### PR TITLE
docs(port): apply legacy PR #9388 — VMware lifecycle GA dates

### DIFF
--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/lifecycle-policy.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/lifecycle-policy.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hosted Private Cloud VMware Lifecycle Policy
 description: Discover the lifecycle policy for VMware on OVHcloud services, including maintenance, sunset, and end of support phases
-lastUpdated: 2026-05-06
+lastUpdated: 2026-05-21
 ---
 
 :::warning
@@ -90,10 +90,10 @@ For the Managed VMware vSphere product, a specific hardware lifecycle applies:
 
 |                   Hardware Generation                 | General Availability |     Sales    |    Growth     | End of Support |
 |:-----------------------------------------------------:|:--------------------:|:------------:|:-------------:|:-----------:|
-| SDDC2014 & SDDC2016 (Intel Ivy Bridge, Intel Haswell) |          2016        |  2017-04-30  |  2026-06-01   | 2027-05-31  |
-|              SDDC2018 (Intel Broadwell)               |          2018        |  2018-11-30  |  2026-06-01   | 2027-05-31  |
-|             Essentials (Intel Broadwell)              |          2020        |  2026-06-01  |  2026-06-01   | 2027-05-31  |
-|               Premier (Intel Xeon Gold)               |          2020        |  2026-05-29  |  2027-03-30   | 2027-10-31  |
+| SDDC2014 & SDDC2016 (Intel Ivy Bridge, Intel Haswell) |          2016        |  2017-04-30  |  2026-06-30   | 2027-06-30  |
+|              SDDC2018 (Intel Broadwell)               |          2018        |  2018-11-30  |  2026-06-30   | 2027-06-30  |
+|             Essentials (Intel Broadwell)              |          2020        |  2026-06-01  |  2026-06-30   | 2027-06-30  |
+|               Premier (Intel Xeon Gold)               |          2020        |  2026-05-28  |  2027-03-31   | 2027-10-31  |
 |           Premier2026 (Intel Emerald Rapids)          |          2026        |  2027-06-30  |               |             |
 |           Premier2027 (Intel Granite Rapids)          |          2027        |              |               |             |
 

--- a/docs/fr/guides/hosted-private-cloud/powered-by-vmware/lifecycle-policy.mdx
+++ b/docs/fr/guides/hosted-private-cloud/powered-by-vmware/lifecycle-policy.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cycle de vie de la solution VMware on OVHcloud
 description: Découvrez la politique de cycle de vie des services VMware on OVHcloud, incluant les phases de maintenance, sunset et fin de support
-lastUpdated: 2026-05-06
+lastUpdated: 2026-05-21
 ---
 
 :::warning
@@ -88,10 +88,10 @@ Pour le produit Managed VMware vSphere, un cycle de vie matériel spécifique s�
 
 |                   Génération matérielle               | General Availability |    Sales    |     Growth     | Fin de Support |
 |:-----------------------------------------------------:|:--------------------:|:------------:|:-------------:|:-----------:|
-| SDDC2014 & SDDC2016 (Intel Ivy Bridge, Intel Haswell) |          2016        |  2017-04-30  |  2026-06-01   | 2027-05-31  |
-|              SDDC2018 (Intel Broadwell)               |          2018        |  2018-11-30  |  2026-06-01   | 2027-05-31  |
-|             Essentials (Intel Broadwell)              |          2020        |  2026-06-01  |  2026-06-01   | 2027-05-31  |
-|               Premier (Intel Xeon Gold)               |          2020        |  2026-05-29  |  2027-03-30   | 2027-10-31  |
+| SDDC2014 & SDDC2016 (Intel Ivy Bridge, Intel Haswell) |          2016        |  2017-04-30  |  2026-06-30   | 2027-06-30  |
+|              SDDC2018 (Intel Broadwell)               |          2018        |  2018-11-30  |  2026-06-30   | 2027-06-30  |
+|             Essentials (Intel Broadwell)              |          2020        |  2026-06-01  |  2026-06-30   | 2027-06-30  |
+|               Premier (Intel Xeon Gold)               |          2020        |  2026-05-28  |  2027-03-31   | 2027-10-31  |
 |           Premier2026 (Intel Emerald Rapids)          |          2026        |  2027-06-30  |               |             |
 |           Premier2027 (Intel Granite Rapids)          |          2027        |              |               |             |
 


### PR DESCRIPTION
Updates the Managed VMware vSphere hardware lifecycle table with the new GA dates for SDDC2014/2016, SDDC2018, Essentials, and Premier rows. DE/ES/IT/PL/PT serve EN via symlink, so this single edit propagates.

Original-URL: https://github.com/ovh/docs/pull/9388 from @P13K 