### PR TITLE
chore(seo): allow search engine indexing of production builds

### DIFF
--- a/rspress.config.build.ts
+++ b/rspress.config.build.ts
@@ -39,9 +39,6 @@ export default defineConfig({
     logLevel: 'error',
     plugins: [pluginSass()],
     html: {
-      meta: {
-        robots: 'noindex, nofollow',
-      },
       // jQuery loaded statically so window.jQuery is available globally
       // before ovh_delta.js runs. ovh_delta.js itself is loaded dynamically
       // from a useEffect inside AnalyticsBootstrap (see components/Analytics)


### PR DESCRIPTION
Remove the noindex, nofollow meta tag from the production build config so the site can be crawled and indexed by search engines.