### PR TITLE
fix(theme): restore mobile burger-menu links and drop Beta badge

### DIFF
--- a/theme/components/NavHamburger/NavScreen.tsx
+++ b/theme/components/NavHamburger/NavScreen.tsx
@@ -1,4 +1,4 @@
-import { useNav } from '@rspress/core/runtime';
+import type { NavItem } from '@rspress/core';
 import { SocialLinks } from '@rspress/core/theme';
 import { clearAllBodyScrollLocks, disableBodyScroll } from 'body-scroll-lock';
 import clsx from 'clsx';
@@ -7,6 +7,7 @@ import '@rspress/core/dist/theme/components/NavScreen/index.css';
 import { NavScreenAppearance } from '@rspress/core/dist/theme/components/NavScreen/NavScreenAppearance.js';
 import { NavScreenMenu } from '@rspress/core/dist/theme/components/NavScreen/NavScreenMenu.js';
 import { NavScreenVersions } from '@rspress/core/dist/theme/components/NavScreen/NavScreenVersions.js';
+import { useLocalizedNav } from '../Nav/hooks';
 import { NavScreenLangs } from './NavScreenLangs';
 
 export function NavScreenDivider() {
@@ -20,7 +21,7 @@ interface NavScreenProps {
 
 export function NavScreen({ isScreenOpen, toggleScreen }: NavScreenProps) {
   const screen = useRef<HTMLDivElement>(null);
-  const menuItems = useNav();
+  const menuItems = useLocalizedNav() as unknown as NavItem[];
 
   useEffect(() => {
     if (screen.current && isScreenOpen) {

--- a/theme/components/Sidebar/SidebarSectionHeader.tsx
+++ b/theme/components/Sidebar/SidebarSectionHeader.tsx
@@ -8,22 +8,10 @@ export function SidebarSectionHeader({
   sectionHeaderText: string;
   tag?: string;
 }) {
-  const isDocHeader =
-    sectionHeaderText === 'sidebar.documentation' ||
-    sectionHeaderText === 'Documentation';
-
   return (
     <div className="rp-sidebar-section-header">
       <div className="rp-sidebar-section-header__left">
         <span {...renderInlineMarkdown(sectionHeaderText)}></span>
-        {isDocHeader && (
-          <span
-            className="rp-badge rp-badge--info"
-            style={{ marginLeft: '0.5rem', fontSize: '0.7rem' }}
-          >
-            Beta
-          </span>
-        )}
       </div>
       <div className="rp-sidebar-section-header__right">
         <Tag tag={tag} />


### PR DESCRIPTION
- NavScreen used rspress's stock useNav() which expects link:string, but our nav config uses links:Record<Locale,string>. The cast in rspress.config.ts hid the mismatch and the mobile menu rendered Webmail / customer account / support as inert items with no href. Switch to useLocalizedNav() so mobile resolves the same translated text + locale-specific URL the desktop nav does.
- Remove the hardcoded "Beta" badge next to the Documentation sidebar header now that the new docs platform is live and indexed.