### PR TITLE
fix(config): point GitHub links at ovhcloud-docs instead of legacy repo

### DIFF
--- a/rspress.config.build.ts
+++ b/rspress.config.build.ts
@@ -144,7 +144,7 @@ export default defineConfig({
     // See node_modules/@rspress/core/dist/theme/logic/useRedirect4FirstVisit.js
     localeRedirect: 'never',
     editLink: {
-      docRepoBaseUrl: `https://github.com/ovh/docs/tree/develop-beta/docs/${locale}`,
+      docRepoBaseUrl: `https://github.com/ovh/ovhcloud-docs/tree/develop/docs/${locale}`,
     },
     nav: nav as Parameters<typeof defineConfig>[0]['themeConfig']['nav'],
     sidebar,
@@ -152,7 +152,7 @@ export default defineConfig({
       {
         icon: 'github',
         mode: 'link',
-        content: 'https://github.com/ovh/docs',
+        content: 'https://github.com/ovh/ovhcloud-docs',
       },
     ],
     footer: {

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -166,7 +166,7 @@ export default defineConfig({
     // See rspress.config.build.ts for rationale — disabled here too for dev parity
     localeRedirect: 'never',
     editLink: {
-      docRepoBaseUrl: 'https://github.com/ovh/docs/tree/develop-beta/docs',
+      docRepoBaseUrl: 'https://github.com/ovh/ovhcloud-docs/tree/develop/docs',
     },
     // Nav uses custom format with localized links, processed by useLocalizedNav() hook
     nav: nav as unknown as NavItem[],
@@ -175,7 +175,7 @@ export default defineConfig({
       {
         icon: 'github',
         mode: 'link',
-        content: 'https://github.com/ovh/docs',
+        content: 'https://github.com/ovh/ovhcloud-docs',
       },
     ],
     footer: {


### PR DESCRIPTION
The per-guide "Edit this page" link and the navbar GitHub icon both pointed at github.com/ovh/docs (now a deprecated branch on the legacy repo). Retarget both editLink.docRepoBaseUrl and socialLinks at github.com/ovh/ovhcloud-docs (develop branch) so contributors land on the active repo.