### PR TITLE
docs: vRack 3-AZ failover priorities (port of legacy #9365)

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Einen Additional-IPv6-Block in einem vRack konfigurieren
 description: Erfahren Sie, wie Sie einen Block öffentlicher IPv6-Adressen für die Verwendung in einem OVHcloud vRack-Netzwerk konfigurieren
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -270,7 +270,57 @@ Das ausgewählte Bandbreiten-Upgrade wird auf alle IP-Adressen in dieser Region 
 </details>
 
 
-#### Host-seitige Befehle
+### 3-AZ Failover-Prioritäten verwalten
+
+Einige OVHcloud-Regionen erstrecken sich über drei Availability Zones (AZs), die in physisch unabhängigen Standorten innerhalb derselben Region gehostet werden. Wenn eine solche Region am Public-IP-Routing Ihres vRacks beteiligt ist, wird sie im OVHcloud Kundencenter durch ein **3-AZ**-Badge neben dem Regionsnamen im Tab <code className="action">Public IP Routing</code> gekennzeichnet.
+
+:::info
+Wenn eine Region in den 3-AZ-Modus übergegangen ist, während Sie bereits IPs über das vRack in dieser Region geroutet hatten, bleiben diese IPs im 1-AZ-Modus und profitieren nicht automatisch von der 3-AZ-Routing-Konfiguration.
+
+Um den 3-AZ-Modus für IP-Blöcke zu aktivieren, die in solchen Regionen über das vRack geroutet werden, entfernen Sie den IP-Block aus dem vRack und fügen Sie ihn anschließend wieder hinzu.
+
+**IP-Blöcke, die weiterhin im 1-AZ-Modus geroutet werden, sind durch ein graues `1-AZ`-Badge gekennzeichnet.**
+
+:::
+
+
+#### Vorteile
+
+- **Eingebaute Resilienz**: Über das vRack geroutete öffentliche IP-Datenströme bleiben verfügbar, wenn eine einzelne Availability Zone nicht erreichbar ist, da das Routing automatisch auf die nächste AZ in der Prioritätenreihenfolge umgeleitet wird.
+- **Vorhersehbares Failover-Verhalten**: Jede 3-AZ-Region weist Ihrem vRack eine primäre Availability Zone und zwei geordnete Failover-Positionen zu, wodurch die Failover-Reihenfolge deterministisch wird.
+- **Workload-Ausrichtung**: Wenn weitere OVHcloud-Services in derselben 3-AZ-Region bereitgestellt sind, können die Prioritäten so abgestimmt werden, dass die aktive AZ des vRacks der AZ entspricht, in der Ihre Services laufen. So bleibt Ihr öffentlicher Datenverkehr im Normalbetrieb in derselben AZ wie Ihre Workload.
+
+#### Funktionsweise und Verwaltung der Prioritäten
+
+Wenn ein vRack erstmals mit einer 3-AZ-Region verknüpft wird, weist OVHcloud seinen Availability Zones eine zufällige Prioritätenreihenfolge zu. Die Zonen **Primary**, **Secondary** und **Last resort** werden in dieser Reihenfolge auf der entsprechenden Regionskachel im Tab <code className="action">Public IP Routing</code> innerhalb des Unterabschnitts `3-AZ failover priorities` angezeigt, direkt über der Schaltfläche <code className="action">Konfigurieren</code>.
+
+Sie können diese zufällige Zuweisung jederzeit überschreiben, beispielsweise um die Failover-Prioritäten am AZ-Layout der weiteren mit Ihrer Infrastruktur verbundenen Komponenten auszurichten.
+
+<details>
+
+<summary>Die Prioritäten der Availability Zones anpassen</summary>
+
+
+So passen Sie die Failover-Prioritäten einer 3-AZ-Region an:
+
+- Öffnen Sie <code className="action">Network</code> in der linken Seitenleiste Ihres Kundencenters.
+- Wählen Sie <code className="action">Privates vRack Netzwerk</code> aus.
+- Klicken Sie in der Spalte "Public IP & bandwidth" auf die Schaltfläche <code className="action">Verwalten</code> für das entsprechende vRack.
+- Öffnen Sie den Tab <code className="action">Public IP Routing</code>.
+- Suchen Sie die Kachel der 3-AZ-Region, die Sie konfigurieren möchten, anschließend den Unterabschnitt `3-AZ failover priorities`, und klicken Sie auf <code className="action">Konfigurieren</code>.
+- Weisen Sie im erscheinenden Panel jede Availability Zone einem der drei Slots zu: **Primary Zone**, **Secondary Zone** und **Last resort Zone**.
+- Bestätigen Sie Ihre Auswahl.
+
+:::info
+Prioritätsänderungen gelten für alle Additional-IP-Blöcke, die für das ausgewählte vRack in die entsprechende 3-AZ-Region geroutet werden, unabhängig von ihrer IP-Version.
+
+:::
+
+
+</details>
+
+
+### Host-seitige Befehle
 
 <details>
 
@@ -335,7 +385,7 @@ Nach einem Moment (die Konfiguration muss sich propagieren) sollte eine spezifis
 </details>
 
 
-#### Einrichtungsüberprüfung
+### Einrichtungsüberprüfung
 
 <details>
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguration eines Additional IP-Blocks in einem vRack
 description: In dieser Anleitung erfahren Sie, wie Sie einen Block öffentlicher IP-Adressen für die Verwendung mit dem vRack konfigurieren.
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 
@@ -144,6 +144,56 @@ Die Gebühren für den ersten Monat werden anteilig auf der Grundlage der verble
 
 
 Das ausgewählte Bandbreiten-Upgrade gilt für alle IP-Adressen in dieser Region für das gewählte vRack.
+
+</details>
+
+
+### 3-AZ Failover-Prioritäten verwalten
+
+Einige OVHcloud-Regionen erstrecken sich über drei Availability Zones (AZs), die in physisch unabhängigen Standorten innerhalb derselben Region gehostet werden. Wenn eine solche Region am Public-IP-Routing Ihres vRacks beteiligt ist, wird sie im OVHcloud Kundencenter durch ein **3-AZ**-Badge neben dem Regionsnamen im Tab <code className="action">Public IP Routing</code> gekennzeichnet.
+
+:::info
+Wenn eine Region in den 3-AZ-Modus übergegangen ist, während Sie bereits IPs über das vRack in dieser Region geroutet hatten, bleiben diese IPs im 1-AZ-Modus und profitieren nicht automatisch von der 3-AZ-Routing-Konfiguration.
+
+Um den 3-AZ-Modus für IP-Blöcke zu aktivieren, die in solchen Regionen über das vRack geroutet werden, entfernen Sie den IP-Block aus dem vRack und fügen Sie ihn anschließend wieder hinzu.
+
+**IP-Blöcke, die weiterhin im 1-AZ-Modus geroutet werden, sind durch ein graues `1-AZ`-Badge gekennzeichnet.**
+
+:::
+
+
+#### Vorteile
+
+- **Eingebaute Resilienz**: Über das vRack geroutete öffentliche IP-Datenströme bleiben verfügbar, wenn eine einzelne Availability Zone nicht erreichbar ist, da das Routing automatisch auf die nächste AZ in der Prioritätenreihenfolge umgeleitet wird.
+- **Vorhersehbares Failover-Verhalten**: Jede 3-AZ-Region weist Ihrem vRack eine primäre Availability Zone und zwei geordnete Failover-Positionen zu, wodurch die Failover-Reihenfolge deterministisch wird.
+- **Workload-Ausrichtung**: Wenn weitere OVHcloud-Services in derselben 3-AZ-Region bereitgestellt sind, können die Prioritäten so abgestimmt werden, dass die aktive AZ des vRacks der AZ entspricht, in der Ihre Services laufen. So bleibt Ihr öffentlicher Datenverkehr im Normalbetrieb in derselben AZ wie Ihre Workload.
+
+#### Funktionsweise und Verwaltung der Prioritäten
+
+Wenn ein vRack erstmals mit einer 3-AZ-Region verknüpft wird, weist OVHcloud seinen Availability Zones eine zufällige Prioritätenreihenfolge zu. Die Zonen **Primary**, **Secondary** und **Last resort** werden in dieser Reihenfolge auf der entsprechenden Regionskachel im Tab <code className="action">Public IP Routing</code> innerhalb des Unterabschnitts `3-AZ failover priorities` angezeigt, direkt über der Schaltfläche <code className="action">Konfigurieren</code>.
+
+Sie können diese zufällige Zuweisung jederzeit überschreiben, beispielsweise um die Failover-Prioritäten am AZ-Layout der weiteren mit Ihrer Infrastruktur verbundenen Komponenten auszurichten.
+
+<details>
+
+<summary>Die Prioritäten der Availability Zones anpassen</summary>
+
+
+So passen Sie die Failover-Prioritäten einer 3-AZ-Region an:
+
+- Öffnen Sie <code className="action">Network</code> in der linken Seitenleiste Ihres Kundencenters.
+- Wählen Sie <code className="action">Privates vRack Netzwerk</code> aus.
+- Klicken Sie in der Spalte "Public IP & bandwidth" auf die Schaltfläche <code className="action">Verwalten</code> für das entsprechende vRack.
+- Öffnen Sie den Tab <code className="action">Public IP Routing</code>.
+- Suchen Sie die Kachel der 3-AZ-Region, die Sie konfigurieren möchten, anschließend den Unterabschnitt `3-AZ failover priorities`, und klicken Sie auf <code className="action">Konfigurieren</code>.
+- Weisen Sie im erscheinenden Panel jede Availability Zone einem der drei Slots zu: **Primary Zone**, **Secondary Zone** und **Last resort Zone**.
+- Bestätigen Sie Ihre Auswahl.
+
+:::info
+Prioritätsänderungen gelten für alle Additional-IP-Blöcke, die für das ausgewählte vRack in die entsprechende 3-AZ-Region geroutet werden, unabhängig von ihrer IP-Version.
+
+:::
+
 
 </details>
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring an Additional IPv6 block in a vRack
 description: Find out how to configure a block of public IPv6 addresses for use with an OVHcloud vRack network
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -271,7 +271,57 @@ The selected bandwidth upgrade will apply to all IP addresses in that region for
 </details>
 
 
-#### Host-side commands
+### Managing 3-AZ failover priorities
+
+Some OVHcloud regions span three Availability Zones (AZs) hosted in physically independent locations within the same region. When such a region is involved in your vRack public IP routing, it is identified in the OVHcloud Control Panel by a **3-AZ** badge displayed next to the region name in the <code className="action">Public IP routing</code> tab.
+
+:::info
+If a region transitioned to 3-AZ while you already had IPs routed via the vRack in that region, those IPs will remain in 1-AZ mode and will not automatically benefit from the 3-AZ routing configuration.
+
+To enable 3-AZ mode for IP blocks routed via the vRack in such regions, remove the IP block from the vRack, then re-add it.
+
+**IP blocks that are still routed in 1-AZ mode are identified by a grey `1-AZ` badge.**
+
+:::
+
+
+#### Benefits
+
+- **Built-in resilience**: public IP traffic routed via the vRack remains available if a single Availability Zone becomes unavailable, as routing automatically fails over to the next AZ in the priority order.
+- **Predictable failover behaviour**: each 3-AZ region gives your vRack a Primary Availability Zone and two ordered failover positions, making the failover sequence deterministic.
+- **Workload alignment**: when other OVHcloud services are deployed in the same 3-AZ region, priorities can be aligned so that the vRack's active AZ matches the AZ hosting your services. This keeps your public traffic in the same AZ as your workload during normal operation.
+
+#### Mechanics and priority management
+
+When a vRack is first associated with a 3-AZ region, OVHcloud assigns a random priority order to its availability zones. The **Primary**, **Secondary**, and **Last resort** zones are displayed in order of priority in the corresponding region tile on the <code className="action">Public IP routing</code> tab, within the `3-AZ failover priorities` subsection, right above a <code className="action">Configure</code> button.
+
+You can override this random assignment at any time, for example to align failover priorities with the AZ layout of other components attached to your infrastructure.
+
+<details>
+
+<summary>Modify the Availability Zone priorities</summary>
+
+
+To adjust the failover priorities of a 3-AZ region:
+
+- Open <code className="action">Network</code> in the left-hand sidebar of your Control Panel.
+- Select <code className="action">vRack private network</code>.
+- In the "Public IP & bandwidth" column, click the <code className="action">Manage</code> button for the corresponding vRack.
+- Open the <code className="action">Public IP routing</code> tab.
+- Locate the tile of the 3-AZ region you want to configure, then the `3-AZ failover priorities` subsection, and click <code className="action">Configure</code>.
+- In the panel that opens, assign each Availability Zone to one of the three slots: **Primary Zone**, **Secondary Zone** and **Last resort Zone**.
+- Confirm your selection.
+
+:::info
+Priority changes apply to all Additional IP blocks routed to the corresponding 3-AZ region for the selected vRack, regardless of their IP version.
+
+:::
+
+
+</details>
+
+
+### Host-side commands
 
 <details>
 
@@ -336,7 +386,7 @@ After a moment (the configuration must propagate), specific IPv6 address (with t
 </details>
 
 
-#### Setup verification
+### Setup verification
 
 <details>
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring an Additional IP block in a vRack
 description: This guide will show you how to configure a block of public IP addresses for use with the vRack.
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 
@@ -144,6 +144,56 @@ Charges for the initial month are pro-rated based on the remaining days, with th
 
 
 The selected bandwidth upgrade will apply to all IP addresses in that region for the chosen vRack.
+
+</details>
+
+
+### Managing 3-AZ failover priorities
+
+Some OVHcloud regions span three Availability Zones (AZs) hosted in physically independent locations within the same region. When such a region is involved in your vRack public IP routing, it is identified in the OVHcloud Control Panel by a **3-AZ** badge displayed next to the region name in the <code className="action">Public IP routing</code> tab.
+
+:::info
+If a region transitioned to 3-AZ while you already had IPs routed via the vRack in that region, those IPs will remain in 1-AZ mode and will not automatically benefit from the 3-AZ routing configuration.
+
+To enable 3-AZ mode for IP blocks routed via the vRack in such regions, remove the IP block from the vRack, then re-add it.
+
+**IP blocks that are still routed in 1-AZ mode are identified by a grey `1-AZ` badge.**
+
+:::
+
+
+#### Benefits
+
+- **Built-in resilience**: public IP traffic routed via the vRack remains available if a single Availability Zone becomes unavailable, as routing automatically fails over to the next AZ in the priority order.
+- **Predictable failover behaviour**: each 3-AZ region gives your vRack a Primary Availability Zone and two ordered failover positions, making the failover sequence deterministic.
+- **Workload alignment**: when other OVHcloud services are deployed in the same 3-AZ region, priorities can be aligned so that the vRack's active AZ matches the AZ hosting your services. This keeps your public traffic in the same AZ as your workload during normal operation.
+
+#### Mechanics and priority management
+
+When a vRack is first associated with a 3-AZ region, OVHcloud assigns a random priority order to its availability zones. The **Primary**, **Secondary**, and **Last resort** zones are displayed in order of priority in the corresponding region tile on the <code className="action">Public IP routing</code> tab, within the `3-AZ failover priorities` subsection, right above a <code className="action">Configure</code> button.
+
+You can override this random assignment at any time, for example to align failover priorities with the AZ layout of other components attached to your infrastructure.
+
+<details>
+
+<summary>Modify the Availability Zone priorities</summary>
+
+
+To adjust the failover priorities of a 3-AZ region:
+
+- Open <code className="action">Network</code> in the left-hand sidebar of your Control Panel.
+- Select <code className="action">vRack private network</code>.
+- In the "Public IP & bandwidth" column, click the <code className="action">Manage</code> button for the corresponding vRack.
+- Open the <code className="action">Public IP routing</code> tab.
+- Locate the tile of the 3-AZ region you want to configure, then the `3-AZ failover priorities` subsection, and click <code className="action">Configure</code>.
+- In the panel that opens, assign each Availability Zone to one of the three slots: **Primary Zone**, **Secondary Zone** and **Last resort Zone**.
+- Confirm your selection.
+
+:::info
+Priority changes apply to all Additional IP blocks routed to the corresponding 3-AZ region for the selected vRack, regardless of their IP version.
+
+:::
+
 
 </details>
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar un bloque Additional IPv6 en un vRack
 description: Descubra cómo configurar un bloque de direcciones IPv6 públicas para su uso en un vRack
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -269,7 +269,57 @@ El aumento del ancho de banda se aplicará a todas las direcciones IP de esa reg
 </details>
 
 
-#### Comandos en el host
+### Gestionar las prioridades de failover 3-AZ
+
+Algunas regiones de OVHcloud se extienden por tres zonas de disponibilidad (AZ) alojadas en ubicaciones físicamente independientes dentro de la misma región. Cuando este tipo de región interviene en el enrutamiento de las IP públicas de su vRack, se identifica en el área de cliente de OVHcloud mediante una etiqueta **3-AZ** que aparece junto al nombre de la región en la pestaña <code className="action">Conectividad IP pública</code>.
+
+:::info
+Si una región ha pasado al modo 3-AZ cuando usted ya tenía IP enrutadas a través del vRack en esa región, esas IP permanecerán en modo 1-AZ y no se beneficiarán automáticamente de la configuración de enrutamiento 3-AZ.
+
+Para activar el modo 3-AZ en los bloques de IP enrutados a través del vRack en estas regiones, debe retirar el bloque de IP del vRack y, a continuación, volver a añadirlo.
+
+**Los bloques de IP que siguen enrutándose en modo 1-AZ se identifican mediante una etiqueta gris `1-AZ`.**
+
+:::
+
+
+#### Ventajas
+
+- **Resiliencia integrada**: el tráfico IP público enrutado a través del vRack permanece disponible si una zona de disponibilidad deja de estarlo, ya que el enrutamiento conmuta automáticamente a la siguiente AZ según el orden de prioridad.
+- **Comportamiento de failover predecible**: cada región 3-AZ asigna a su vRack una zona de disponibilidad principal y dos posiciones de failover ordenadas, lo que hace determinista la secuencia de failover.
+- **Alineación con la carga de trabajo**: cuando otros servicios de OVHcloud están desplegados en la misma región 3-AZ, las prioridades pueden alinearse para que la AZ activa del vRack coincida con la AZ que aloja sus servicios. De este modo, su tráfico público permanece en la misma AZ que su carga de trabajo durante el funcionamiento normal.
+
+#### Mecánica y gestión de las prioridades
+
+Cuando un vRack se asocia por primera vez a una región 3-AZ, OVHcloud asigna aleatoriamente un orden de prioridad a sus zonas de disponibilidad. Las zonas **principal, secundaria y de último recurso** se muestran en este orden en el recuadro correspondiente a la región dentro de la pestaña <code className="action">Conectividad IP pública</code>, en la subsección `Prioridades de failover 3-AZ`, justo encima del botón <code className="action">Configurar</code>.
+
+Puede modificar esta asignación aleatoria en cualquier momento, por ejemplo, para alinear las prioridades de failover con la disposición AZ de otros componentes asociados a su infraestructura.
+
+<details>
+
+<summary>Modificar las prioridades de las zonas de disponibilidad</summary>
+
+
+Para ajustar las prioridades de failover de una región 3-AZ:
+
+- En la barra lateral izquierda del área de cliente, acceda a <code className="action">Network</code>.
+- Seleccione <code className="action">Red privada vRack</code>.
+- En la columna "Dirección IP pública y ancho de banda", haga clic en el botón <code className="action">Gestionar</code> correspondiente al vRack deseado.
+- Vaya a la pestaña <code className="action">Conectividad IP pública</code>.
+- En el recuadro de la región 3-AZ que desee configurar, localice la subsección `Prioridades de failover 3-AZ` y haga clic en <code className="action">Configurar</code>.
+- En el panel que se abre, asigne cada zona de disponibilidad a una de las tres posiciones: **Zona principal**, **Zona secundaria** y **Zona de último recurso**.
+- Confirme su selección.
+
+:::info
+Los cambios de prioridad se aplican a todos los bloques de Additional IP enrutados a la región 3-AZ correspondiente para el vRack seleccionado, sea cual sea su versión de IP.
+
+:::
+
+
+</details>
+
+
+### Comandos en el host
 
 <details>
 
@@ -335,7 +385,7 @@ Tras un breve período de tiempo (el tiempo de propagación de la configuración
 </details>
 
 
-#### Verificación de la instalación
+### Verificación de la instalación
 
 <details>
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar un bloque de Additional IP en un vRack
 description: Descubra cómo configurar un bloque de direcciones IP públicas en el vRack.
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 
@@ -144,6 +144,56 @@ El primer mes suscrito se factura de forma proporcional a los días restantes. L
 
 
 El aumento de ancho de banda se aplicará a todas las direcciones IP de esa región para el vRack seleccionado.
+
+</details>
+
+
+### Gestionar las prioridades de failover 3-AZ
+
+Algunas regiones de OVHcloud se extienden por tres zonas de disponibilidad (AZ) alojadas en ubicaciones físicamente independientes dentro de la misma región. Cuando este tipo de región interviene en el enrutamiento de las IP públicas de su vRack, se identifica en el área de cliente de OVHcloud mediante una etiqueta **3-AZ** que aparece junto al nombre de la región en la pestaña <code className="action">Conectividad IP pública</code>.
+
+:::info
+Si una región ha pasado al modo 3-AZ cuando usted ya tenía IP enrutadas a través del vRack en esa región, esas IP permanecerán en modo 1-AZ y no se beneficiarán automáticamente de la configuración de enrutamiento 3-AZ.
+
+Para activar el modo 3-AZ en los bloques de IP enrutados a través del vRack en estas regiones, debe retirar el bloque de IP del vRack y, a continuación, volver a añadirlo.
+
+**Los bloques de IP que siguen enrutándose en modo 1-AZ se identifican mediante una etiqueta gris `1-AZ`.**
+
+:::
+
+
+#### Ventajas
+
+- **Resiliencia integrada**: el tráfico IP público enrutado a través del vRack permanece disponible si una zona de disponibilidad deja de estarlo, ya que el enrutamiento conmuta automáticamente a la siguiente AZ según el orden de prioridad.
+- **Comportamiento de failover predecible**: cada región 3-AZ asigna a su vRack una zona de disponibilidad principal y dos posiciones de failover ordenadas, lo que hace determinista la secuencia de failover.
+- **Alineación con la carga de trabajo**: cuando otros servicios de OVHcloud están desplegados en la misma región 3-AZ, las prioridades pueden alinearse para que la AZ activa del vRack coincida con la AZ que aloja sus servicios. De este modo, su tráfico público permanece en la misma AZ que su carga de trabajo durante el funcionamiento normal.
+
+#### Mecánica y gestión de las prioridades
+
+Cuando un vRack se asocia por primera vez a una región 3-AZ, OVHcloud asigna aleatoriamente un orden de prioridad a sus zonas de disponibilidad. Las zonas **principal, secundaria y de último recurso** se muestran en este orden en el recuadro correspondiente a la región dentro de la pestaña <code className="action">Conectividad IP pública</code>, en la subsección `Prioridades de failover 3-AZ`, justo encima del botón <code className="action">Configurar</code>.
+
+Puede modificar esta asignación aleatoria en cualquier momento, por ejemplo, para alinear las prioridades de failover con la disposición AZ de otros componentes asociados a su infraestructura.
+
+<details>
+
+<summary>Modificar las prioridades de las zonas de disponibilidad</summary>
+
+
+Para ajustar las prioridades de failover de una región 3-AZ:
+
+- En la barra lateral izquierda del área de cliente, acceda a <code className="action">Network</code>.
+- Seleccione <code className="action">Red privada vRack</code>.
+- En la columna "Dirección IP pública y ancho de banda", haga clic en el botón <code className="action">Gestionar</code> correspondiente al vRack deseado.
+- Vaya a la pestaña <code className="action">Conectividad IP pública</code>.
+- En el recuadro de la región 3-AZ que desee configurar, localice la subsección `Prioridades de failover 3-AZ` y haga clic en <code className="action">Configurar</code>.
+- En el panel que se abre, asigne cada zona de disponibilidad a una de las tres posiciones: **Zona principal**, **Zona secundaria** y **Zona de último recurso**.
+- Confirme su selección.
+
+:::info
+Los cambios de prioridad se aplican a todos los bloques de Additional IP enrutados a la región 3-AZ correspondiente para el vRack seleccionado, sea cual sea su versión de IP.
+
+:::
+
 
 </details>
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer un bloc Additional IPv6 dans un vRack
 description: "Découvrez comment configurer un bloc d'adresses IPv6 publiques à utiliser dans un vRack"
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -269,7 +269,57 @@ L'augmentation de bande passante s'appliquera à toutes les adresses IP de cette
 </details>
 
 
-#### Commandes sur l'hôte
+### Gérer les priorités de basculement 3-AZ
+
+Certaines régions OVHcloud s'étendent sur trois zones de disponibilité (AZ) hébergées dans des emplacements physiquement indépendants au sein d'une même région. Lorsqu'une telle région est utilisée pour le routage des IP publiques de votre vRack, elle est identifiée dans l'espace client OVHcloud par un badge **3-AZ** affiché à côté du nom de la région dans l'onglet <code className="action">Connectivité IP publique</code>.
+
+:::info
+Si une région est passée en mode 3-AZ alors que vous aviez déjà des adresses IP routées via le vRack dans cette région, ces IP resteront en mode 1-AZ et ne bénéficieront pas automatiquement de la configuration de routage 3-AZ.
+
+Pour activer le mode 3-AZ pour les blocs d'adresses IP routés via le vRack dans ces régions, vous devez retirer le bloc IP du vRack, puis le réajouter.
+
+**Les blocs d'adresses IP qui sont toujours routés en mode 1-AZ sont identifiés par un badge gris `1-AZ`.**
+
+:::
+
+
+#### Avantages
+
+- **Résilience intégrée** : le trafic IP public routé via le vRack reste disponible si une zone de disponibilité devient indisponible, le routage basculant automatiquement vers l'AZ suivante dans l'ordre de priorité.
+- **Comportement de basculement prévisible** : chaque région 3-AZ attribue à votre vRack une zone de disponibilité principale et deux positions de basculement ordonnées, ce qui rend la séquence de basculement déterministe.
+- **Alignement avec la charge de travail** : lorsque d'autres services OVHcloud sont déployés dans la même région 3-AZ, les priorités peuvent être alignées pour que l'AZ active du vRack corresponde à l'AZ qui héberge vos services. Votre trafic public reste ainsi dans la même AZ que votre charge de travail en fonctionnement normal.
+
+#### Mécanique et gestion des priorités
+
+Lorsqu'un vRack est rattaché pour la première fois à une région 3-AZ, OVHcloud attribue aléatoirement un ordre de priorité à ses zones de disponibilité. Les **zones principale, secondaire et de dernier recours** sont affichées dans cet ordre sous l'onglet <code className="action">Connectivité IP publique</code>, sur la tuile correspondant à la région 3-AZ, dans la sous-section `Priorités de basculement 3-AZ`, juste au-dessus du bouton <code className="action">Configurer</code>.
+
+Vous pouvez modifier cette attribution à tout moment, par exemple pour aligner les priorités de basculement sur la disposition AZ des autres composants de votre infrastructure.
+
+<details>
+
+<summary>Modifier les priorités des zones de disponibilité</summary>
+
+
+Pour ajuster les priorités de basculement d'une région 3-AZ :
+
+- Dans la barre latérale gauche de votre espace client, ouvrez <code className="action">Network</code>.
+- Sélectionnez <code className="action">Réseau Privé vRack</code>.
+- Dans la colonne « Adresse IP publique et bande passante », cliquez sur le bouton <code className="action">Gérer</code> correspondant au vRack souhaité.
+- Ouvrez l'onglet <code className="action">Connectivité IP publique</code>.
+- Dans la tuile de la région 3-AZ à configurer, localisez la sous-section `Priorités de basculement 3-AZ`, puis cliquez sur <code className="action">Configurer</code>.
+- Dans le panneau qui s'ouvre à droite, attribuez chaque zone de disponibilité à l'un des trois emplacements : **Zone principale**, **Zone secondaire** et **Zone de dernier recours**.
+- Validez votre sélection.
+
+:::info
+Les modifications de priorité s'appliquent à tous les blocs d'Additional IP routés vers la région 3-AZ correspondante pour le vRack sélectionné, quelle que soit leur version d'IP.
+
+:::
+
+
+</details>
+
+
+### Commandes sur l'hôte
 
 <details>
 
@@ -335,7 +385,7 @@ Après une courte durée (le temps de la propagation de la configuration), une a
 </details>
 
 
-#### Vérification de l'installation
+### Vérification de l'installation
 
 <details>
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer un bloc Additional IP dans le vRack
 description: "Découvrez comment configurer un bloc d'adresses IP publiques dans le vRack"
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 
@@ -144,6 +144,56 @@ Le premier mois souscrit est facturé au prorata des jours restants. Le tarif co
 
 
 L'augmentation de bande passante s'appliquera à toutes les adresses IP de cette région pour le vRack sélectionné.
+
+</details>
+
+
+### Gérer les priorités de basculement 3-AZ
+
+Certaines régions OVHcloud s'étendent sur trois zones de disponibilité (AZ) hébergées dans des emplacements physiquement indépendants au sein d'une même région. Lorsqu'une telle région est utilisée pour le routage des IP publiques de votre vRack, elle est identifiée dans l'espace client OVHcloud par un badge **3-AZ** affiché à côté du nom de la région dans l'onglet <code className="action">Connectivité IP publique</code>.
+
+:::info
+Si une région est passée en mode 3-AZ alors que vous aviez déjà des adresses IP routées via le vRack dans cette région, ces IP resteront en mode 1-AZ et ne bénéficieront pas automatiquement de la configuration de routage 3-AZ.
+
+Pour activer le mode 3-AZ pour les blocs d'adresses IP routés via le vRack dans ces régions, vous devez retirer le bloc IP du vRack, puis le réajouter.
+
+**Les blocs d'adresses IP qui sont toujours routés en mode 1-AZ sont identifiés par un badge gris `1-AZ`.**
+
+:::
+
+
+#### Avantages
+
+- **Résilience intégrée** : le trafic IP public routé via le vRack reste disponible si une zone de disponibilité devient indisponible, le routage basculant automatiquement vers l'AZ suivante dans l'ordre de priorité.
+- **Comportement de basculement prévisible** : chaque région 3-AZ attribue à votre vRack une zone de disponibilité principale et deux positions de basculement ordonnées, ce qui rend la séquence de basculement déterministe.
+- **Alignement avec la charge de travail** : lorsque d'autres services OVHcloud sont déployés dans la même région 3-AZ, les priorités peuvent être alignées pour que l'AZ active du vRack corresponde à l'AZ qui héberge vos services. Votre trafic public reste ainsi dans la même AZ que votre charge de travail en fonctionnement normal.
+
+#### Mécanique et gestion des priorités
+
+Lorsqu'un vRack est rattaché pour la première fois à une région 3-AZ, OVHcloud attribue aléatoirement un ordre de priorité à ses zones de disponibilité. Les **zones principale, secondaire et de dernier recours** sont affichées dans cet ordre sous l'onglet <code className="action">Connectivité IP publique</code>, sur la tuile correspondant à la région 3-AZ, dans la sous-section `Priorités de basculement 3-AZ`, juste au-dessus du bouton <code className="action">Configurer</code>.
+
+Vous pouvez modifier cette attribution à tout moment, par exemple pour aligner les priorités de basculement sur la disposition AZ des autres composants de votre infrastructure.
+
+<details>
+
+<summary>Modifier les priorités des zones de disponibilité</summary>
+
+
+Pour ajuster les priorités de basculement d'une région 3-AZ :
+
+- Dans la barre latérale gauche de votre espace client, ouvrez <code className="action">Network</code>.
+- Sélectionnez <code className="action">Réseau Privé vRack</code>.
+- Dans la colonne « Adresse IP publique et bande passante », cliquez sur le bouton <code className="action">Gérer</code> correspondant au vRack souhaité.
+- Ouvrez l'onglet <code className="action">Connectivité IP publique</code>.
+- Dans la tuile de la région 3-AZ à configurer, localisez la sous-section `Priorités de basculement 3-AZ`, puis cliquez sur <code className="action">Configurer</code>.
+- Dans le panneau qui s'ouvre à droite, attribuez chaque zone de disponibilité à l'un des trois emplacements : **Zone principale**, **Zone secondaire** et **Zone de dernier recours**.
+- Validez votre sélection.
+
+:::info
+Les modifications de priorité s'appliquent à tous les blocs d'Additional IP routés vers la région 3-AZ correspondante pour le vRack sélectionné, quelle que soit leur version d'IP.
+
+:::
+
 
 </details>
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurare un blocco Additional IPv6 in un vRack
 description: Scopri come configurare un blocco di indirizzi IPv6 pubblici da utilizzare in un vRack
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -269,7 +269,57 @@ L'aumento della larghezza di banda si applicherà a tutti gli indirizzi IP di qu
 </details>
 
 
-#### Comandi sull'host
+### Gestire le priorità di failover 3-AZ
+
+Alcune regioni OVHcloud si estendono su tre zone di disponibilità (AZ) ospitate in posizioni fisicamente indipendenti all'interno della stessa regione. Quando una di queste regioni interviene nel routing degli IP pubblici del vRack, viene identificata nello Spazio Cliente OVHcloud da un badge **3-AZ** visualizzato accanto al nome della regione nella scheda <code className="action">Connettività IP pubblica</code>.
+
+:::info
+Se una regione è passata alla modalità 3-AZ mentre erano già presenti IP indirizzati tramite il vRack in quella regione, questi IP rimarranno in modalità 1-AZ e non beneficeranno automaticamente della configurazione di routing 3-AZ.
+
+Per attivare la modalità 3-AZ sui blocchi di IP indirizzati tramite il vRack in queste regioni, rimuovi il blocco IP dal vRack e poi aggiungilo di nuovo.
+
+**I blocchi IP ancora indirizzati in modalità 1-AZ sono identificati da un badge grigio `1-AZ`.**
+
+:::
+
+
+#### Vantaggi
+
+- **Resilienza integrata**: il traffico IP pubblico instradato attraverso il vRack rimane disponibile se una singola zona di disponibilità diventa non raggiungibile, poiché il routing passa automaticamente alla AZ successiva nell'ordine di priorità.
+- **Comportamento di failover prevedibile**: ogni regione 3-AZ assegna al vRack una zona di disponibilità principale e due posizioni di failover ordinate, rendendo deterministica la sequenza di failover.
+- **Allineamento con il carico di lavoro**: quando altri servizi OVHcloud sono installati nella stessa regione 3-AZ, le priorità possono essere allineate in modo che la AZ attiva del vRack corrisponda alla AZ che ospita i servizi. In questo modo, il traffico pubblico rimane nella stessa AZ del carico di lavoro durante il normale funzionamento.
+
+#### Meccanica e gestione delle priorità
+
+Quando un vRack viene associato per la prima volta a una regione 3-AZ, OVHcloud assegna in modo casuale un ordine di priorità alle sue zone di disponibilità. Le zone **principale, secondaria e di ultima istanza** vengono visualizzate in questo ordine nel riquadro della regione corrispondente, all'interno della scheda <code className="action">Connettività IP pubblica</code>, nella sottosezione `Priorità di failover 3-AZ`, subito sopra il pulsante <code className="action">Configura</code>.
+
+È possibile modificare questa assegnazione casuale in qualsiasi momento, ad esempio per allineare le priorità di failover alla disposizione delle AZ di altri componenti collegati alla tua infrastruttura.
+
+<details>
+
+<summary>Modificare le priorità delle zone di disponibilità</summary>
+
+
+Per regolare le priorità di failover di una regione 3-AZ:
+
+- Nella barra laterale sinistra dello Spazio Cliente, apri <code className="action">Network</code>.
+- Seleziona <code className="action">Rete privata vRack</code>.
+- Nella colonna "Indirizzo IP pubblico e larghezza di banda", clicca sul pulsante <code className="action">Gestisci</code> corrispondente al vRack desiderato.
+- Apri la scheda <code className="action">Connettività IP pubblica</code>.
+- Nel riquadro della regione 3-AZ da configurare, individua la sottosezione `Priorità di failover 3-AZ` e clicca su <code className="action">Configura</code>.
+- Nel pannello che si apre, assegna ogni zona di disponibilità a una delle tre posizioni: **Zona principale**, **Zona secondaria** e **Zona di ultima istanza**.
+- Conferma la selezione.
+
+:::info
+Le modifiche di priorità si applicano a tutti i blocchi di Additional IP indirizzati alla regione 3-AZ corrispondente per il vRack selezionato, indipendentemente dalla versione IP.
+
+:::
+
+
+</details>
+
+
+### Comandi sull'host
 
 <details>
 
@@ -335,7 +385,7 @@ Dopo un breve periodo (il tempo di propagazione della configurazione), un indiri
 </details>
 
 
-#### Verifica dell'installazione
+### Verifica dell'installazione
 
 <details>
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurare un blocco Additional IP in un vRack
 description: Scopri come configurare un blocco di indirizzi IP pubblici nel vRack.
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 
@@ -144,6 +144,56 @@ Il primo mese sottoscritto viene fatturato in modo proporzionale ai giorni riman
 
 
 L'aumento di larghezza di banda si applicherà a tutti gli indirizzi IP di quella regione per il vRack selezionato.
+
+</details>
+
+
+### Gestire le priorità di failover 3-AZ
+
+Alcune regioni OVHcloud si estendono su tre zone di disponibilità (AZ) ospitate in posizioni fisicamente indipendenti all'interno della stessa regione. Quando una di queste regioni interviene nel routing degli IP pubblici del vRack, viene identificata nello Spazio Cliente OVHcloud da un badge **3-AZ** visualizzato accanto al nome della regione nella scheda <code className="action">Connettività IP pubblica</code>.
+
+:::info
+Se una regione è passata alla modalità 3-AZ mentre erano già presenti IP indirizzati tramite il vRack in quella regione, questi IP rimarranno in modalità 1-AZ e non beneficeranno automaticamente della configurazione di routing 3-AZ.
+
+Per attivare la modalità 3-AZ sui blocchi di IP indirizzati tramite il vRack in queste regioni, rimuovi il blocco IP dal vRack e poi aggiungilo di nuovo.
+
+**I blocchi IP ancora indirizzati in modalità 1-AZ sono identificati da un badge grigio `1-AZ`.**
+
+:::
+
+
+#### Vantaggi
+
+- **Resilienza integrata**: il traffico IP pubblico instradato attraverso il vRack rimane disponibile se una singola zona di disponibilità diventa non raggiungibile, poiché il routing passa automaticamente alla AZ successiva nell'ordine di priorità.
+- **Comportamento di failover prevedibile**: ogni regione 3-AZ assegna al vRack una zona di disponibilità principale e due posizioni di failover ordinate, rendendo deterministica la sequenza di failover.
+- **Allineamento con il carico di lavoro**: quando altri servizi OVHcloud sono installati nella stessa regione 3-AZ, le priorità possono essere allineate in modo che la AZ attiva del vRack corrisponda alla AZ che ospita i servizi. In questo modo, il traffico pubblico rimane nella stessa AZ del carico di lavoro durante il normale funzionamento.
+
+#### Meccanica e gestione delle priorità
+
+Quando un vRack viene associato per la prima volta a una regione 3-AZ, OVHcloud assegna in modo casuale un ordine di priorità alle sue zone di disponibilità. Le zone **principale, secondaria e di ultima istanza** vengono visualizzate in questo ordine nel riquadro della regione corrispondente, all'interno della scheda <code className="action">Connettività IP pubblica</code>, nella sottosezione `Priorità di failover 3-AZ`, subito sopra il pulsante <code className="action">Configura</code>.
+
+È possibile modificare questa assegnazione casuale in qualsiasi momento, ad esempio per allineare le priorità di failover alla disposizione delle AZ di altri componenti collegati alla tua infrastruttura.
+
+<details>
+
+<summary>Modificare le priorità delle zone di disponibilità</summary>
+
+
+Per regolare le priorità di failover di una regione 3-AZ:
+
+- Nella barra laterale sinistra dello Spazio Cliente, apri <code className="action">Network</code>.
+- Seleziona <code className="action">Rete privata vRack</code>.
+- Nella colonna "Indirizzo IP pubblico e larghezza di banda", clicca sul pulsante <code className="action">Gestisci</code> corrispondente al vRack desiderato.
+- Apri la scheda <code className="action">Connettività IP pubblica</code>.
+- Nel riquadro della regione 3-AZ da configurare, individua la sottosezione `Priorità di failover 3-AZ` e clicca su <code className="action">Configura</code>.
+- Nel pannello che si apre, assegna ogni zona di disponibilità a una delle tre posizioni: **Zona principale**, **Zona secondaria** e **Zona di ultima istanza**.
+- Conferma la selezione.
+
+:::info
+Le modifiche di priorità si applicano a tutti i blocchi di Additional IP indirizzati alla regione 3-AZ corrispondente per il vRack selezionato, indipendentemente dalla versione IP.
+
+:::
+
 
 </details>
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja bloku Additional IPv6 w sieci vRack
 description: Dowiedz się, jak skonfigurować blok publicznych adresów IPv6 do użytku w sieci vRack OVHcloud
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -271,7 +271,57 @@ Wybrane ulepszenie przepustowości zostanie zastosowane do wszystkich adresów I
 </details>
 
 
-#### Polecenia po stronie hosta
+### Zarządzanie priorytetami przełączania awaryjnego 3-AZ
+
+Niektóre regiony OVHcloud obejmują trzy strefy dostępności (AZ) zlokalizowane w fizycznie niezależnych miejscach w obrębie tego samego regionu. Jeśli taki region uczestniczy w routingu publicznych adresów IP Twojej sieci vRack, jest oznaczony w Panelu klienta OVHcloud etykietą **3-AZ** wyświetlaną obok nazwy regionu na zakładce <code className="action">Publiczny routing IP</code>.
+
+:::info
+Jeżeli region został przełączony w tryb 3-AZ, gdy adresy IP były już routowane przez vRack w tym regionie, te adresy pozostaną w trybie 1-AZ i nie skorzystają automatycznie z konfiguracji routingu 3-AZ.
+
+Aby aktywować tryb 3-AZ dla bloków IP routowanych przez vRack w takich regionach, usuń blok IP z sieci vRack, a następnie dodaj go ponownie.
+
+**Bloki IP, które są nadal routowane w trybie 1-AZ, są oznaczone szarą etykietą `1-AZ`.**
+
+:::
+
+
+#### Korzyści
+
+- **Wbudowana odporność**: publiczny ruch IP routowany przez vRack pozostaje dostępny, jeśli pojedyncza strefa dostępności staje się niedostępna, ponieważ routing automatycznie przełącza się na kolejną strefę AZ w ustalonej kolejności priorytetów.
+- **Przewidywalne zachowanie podczas przełączania awaryjnego**: każdy region 3-AZ przypisuje sieci vRack główną strefę dostępności oraz dwie uporządkowane pozycje przełączania awaryjnego, dzięki czemu kolejność przełączania jest deterministyczna.
+- **Dopasowanie do obciążenia**: jeśli inne usługi OVHcloud są wdrożone w tym samym regionie 3-AZ, priorytety można dopasować tak, aby aktywna strefa AZ vRacka odpowiadała strefie hostującej Twoje usługi. W ten sposób publiczny ruch pozostaje w tej samej strefie AZ co Twoje obciążenie podczas normalnej pracy.
+
+#### Zasady działania i zarządzanie priorytetami
+
+Gdy vRack jest po raz pierwszy powiązany z regionem 3-AZ, OVHcloud losowo przypisuje kolejność priorytetów jego strefom dostępności. Strefy **główna**, **pomocnicza** i **ostatniej szansy** są wyświetlane w tej kolejności w kafelku odpowiadającego regionu na zakładce <code className="action">Publiczny routing IP</code>, w podsekcji `Priorytety przełączania awaryjnego 3-AZ`, tuż nad przyciskiem <code className="action">Konfiguruj</code>.
+
+W każdej chwili możesz zmienić tę losową kolejność, na przykład w celu dostosowania priorytetów przełączania do układu stref AZ innych komponentów Twojej infrastruktury.
+
+<details>
+
+<summary>Zmiana priorytetów stref dostępności</summary>
+
+
+Aby dostosować priorytety przełączania awaryjnego regionu 3-AZ:
+
+- Z lewego menu Panelu klienta otwórz sekcję <code className="action">Network</code>.
+- Wybierz <code className="action">Prywatna sieć vRack</code>.
+- W kolumnie "Publiczny adres IP i przepustowość" kliknij przycisk <code className="action">Zarządzaj</code> przy odpowiednim vRack.
+- Otwórz zakładkę <code className="action">Publiczny routing IP</code>.
+- W kafelku regionu 3-AZ, który chcesz skonfigurować, znajdź podsekcję `Priorytety przełączania awaryjnego 3-AZ` i kliknij <code className="action">Konfiguruj</code>.
+- W otwartym panelu przypisz każdą strefę dostępności do jednego z trzech slotów: **Strefa główna**, **Strefa pomocnicza** oraz **Strefa ostatniej szansy**.
+- Potwierdź wybór.
+
+:::info
+Zmiany priorytetów są stosowane do wszystkich bloków Additional IP routowanych do odpowiedniego regionu 3-AZ dla wybranej sieci vRack, niezależnie od wersji IP.
+
+:::
+
+
+</details>
+
+
+### Polecenia po stronie hosta
 
 <details>
 
@@ -336,7 +386,7 @@ Po chwili (konfiguracja musi się rozpropagować) na interfejsie powinien być w
 </details>
 
 
-#### Weryfikacja konfiguracji
+### Weryfikacja konfiguracji
 
 <details>
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja bloku Additional IP w sieci vRack
 description: Ten przewodnik pokazuje, jak skonfigurować blok publicznych adresów IP do użytku z siecią vRack.
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 
@@ -144,6 +144,56 @@ Opłaty za pierwszy miesiąc są naliczane proporcjonalnie do liczby pozostałyc
 
 
 Wybrany upgrade przepustowości zostanie zastosowany do wszystkich adresów IP w tym regionie dla wybranego vRack.
+
+</details>
+
+
+### Zarządzanie priorytetami przełączania awaryjnego 3-AZ
+
+Niektóre regiony OVHcloud obejmują trzy strefy dostępności (AZ) zlokalizowane w fizycznie niezależnych miejscach w obrębie tego samego regionu. Jeśli taki region uczestniczy w routingu publicznych adresów IP Twojej sieci vRack, jest oznaczony w Panelu klienta OVHcloud etykietą **3-AZ** wyświetlaną obok nazwy regionu na zakładce <code className="action">Publiczny routing IP</code>.
+
+:::info
+Jeżeli region został przełączony w tryb 3-AZ, gdy adresy IP były już routowane przez vRack w tym regionie, te adresy pozostaną w trybie 1-AZ i nie skorzystają automatycznie z konfiguracji routingu 3-AZ.
+
+Aby aktywować tryb 3-AZ dla bloków IP routowanych przez vRack w takich regionach, usuń blok IP z sieci vRack, a następnie dodaj go ponownie.
+
+**Bloki IP, które są nadal routowane w trybie 1-AZ, są oznaczone szarą etykietą `1-AZ`.**
+
+:::
+
+
+#### Korzyści
+
+- **Wbudowana odporność**: publiczny ruch IP routowany przez vRack pozostaje dostępny, jeśli pojedyncza strefa dostępności staje się niedostępna, ponieważ routing automatycznie przełącza się na kolejną strefę AZ w ustalonej kolejności priorytetów.
+- **Przewidywalne zachowanie podczas przełączania awaryjnego**: każdy region 3-AZ przypisuje sieci vRack główną strefę dostępności oraz dwie uporządkowane pozycje przełączania awaryjnego, dzięki czemu kolejność przełączania jest deterministyczna.
+- **Dopasowanie do obciążenia**: jeśli inne usługi OVHcloud są wdrożone w tym samym regionie 3-AZ, priorytety można dopasować tak, aby aktywna strefa AZ vRacka odpowiadała strefie hostującej Twoje usługi. W ten sposób publiczny ruch pozostaje w tej samej strefie AZ co Twoje obciążenie podczas normalnej pracy.
+
+#### Zasady działania i zarządzanie priorytetami
+
+Gdy vRack jest po raz pierwszy powiązany z regionem 3-AZ, OVHcloud losowo przypisuje kolejność priorytetów jego strefom dostępności. Strefy **główna**, **pomocnicza** i **ostatniej szansy** są wyświetlane w tej kolejności w kafelku odpowiadającego regionu na zakładce <code className="action">Publiczny routing IP</code>, w podsekcji `Priorytety przełączania awaryjnego 3-AZ`, tuż nad przyciskiem <code className="action">Konfiguruj</code>.
+
+W każdej chwili możesz zmienić tę losową kolejność, na przykład w celu dostosowania priorytetów przełączania do układu stref AZ innych komponentów Twojej infrastruktury.
+
+<details>
+
+<summary>Zmiana priorytetów stref dostępności</summary>
+
+
+Aby dostosować priorytety przełączania awaryjnego regionu 3-AZ:
+
+- Z lewego menu Panelu klienta otwórz sekcję <code className="action">Network</code>.
+- Wybierz <code className="action">Prywatna sieć vRack</code>.
+- W kolumnie "Publiczny adres IP i przepustowość" kliknij przycisk <code className="action">Zarządzaj</code> przy odpowiednim vRack.
+- Otwórz zakładkę <code className="action">Publiczny routing IP</code>.
+- W kafelku regionu 3-AZ, który chcesz skonfigurować, znajdź podsekcję `Priorytety przełączania awaryjnego 3-AZ` i kliknij <code className="action">Konfiguruj</code>.
+- W otwartym panelu przypisz każdą strefę dostępności do jednego z trzech slotów: **Strefa główna**, **Strefa pomocnicza** oraz **Strefa ostatniej szansy**.
+- Potwierdź wybór.
+
+:::info
+Zmiany priorytetów są stosowane do wszystkich bloków Additional IP routowanych do odpowiedniego regionu 3-AZ dla wybranej sieci vRack, niezależnie od wersji IP.
+
+:::
+
 
 </details>
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar um bloco Additional IPv6 num vRack
 description: Saiba como configurar um bloco de endereços IPv6 públicos para utilização num vRack
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -269,7 +269,57 @@ O aumento da largura de banda aplicar-se-á a todos os endereços IP dessa regi�
 </details>
 
 
-#### Comandos no host
+### Gerir as prioridades de failover 3-AZ
+
+Algumas regiões OVHcloud estendem-se por três zonas de disponibilidade (AZ) alojadas em locais fisicamente independentes dentro da mesma região. Quando uma região deste tipo intervém no encaminhamento dos IP públicos do seu vRack, é identificada na área de cliente OVHcloud através de uma etiqueta **3-AZ** apresentada junto ao nome da região no separador <code className="action">Conectividade IP pública</code>.
+
+:::info
+Se uma região passou para o modo 3-AZ enquanto já tinha endereços IP encaminhados através do vRack nessa região, esses IP permanecerão no modo 1-AZ e não beneficiarão automaticamente da configuração de encaminhamento 3-AZ.
+
+Para ativar o modo 3-AZ nos blocos de IP encaminhados através do vRack nessas regiões, deve retirar o bloco IP do vRack e, em seguida, voltar a adicioná-lo.
+
+**Os blocos de IP que continuam a ser encaminhados no modo 1-AZ são identificados por uma etiqueta cinzenta `1-AZ`.**
+
+:::
+
+
+#### Vantagens
+
+- **Resiliência integrada**: o tráfego IP público encaminhado através do vRack permanece disponível se uma zona de disponibilidade ficar indisponível, uma vez que o encaminhamento comuta automaticamente para a AZ seguinte na ordem de prioridade.
+- **Comportamento de failover previsível**: cada região 3-AZ atribui ao seu vRack uma zona de disponibilidade principal e duas posições de failover ordenadas, tornando determinista a sequência de failover.
+- **Alinhamento com a carga de trabalho**: quando outros serviços OVHcloud estão implementados na mesma região 3-AZ, as prioridades podem ser alinhadas para que a AZ ativa do vRack corresponda à AZ que aloja os seus serviços. Desta forma, o seu tráfego público mantém-se na mesma AZ que a sua carga de trabalho durante o funcionamento normal.
+
+#### Mecânica e gestão das prioridades
+
+Quando um vRack é associado pela primeira vez a uma região 3-AZ, a OVHcloud atribui aleatoriamente uma ordem de prioridade às suas zonas de disponibilidade. As zonas **principal, secundária e de último recurso** são apresentadas por esta ordem no bloco da região correspondente no separador <code className="action">Conectividade IP pública</code>, dentro da subsecção `Prioridades de failover 3-AZ`, mesmo por cima do botão <code className="action">Configurar</code>.
+
+Pode alterar esta atribuição aleatória a qualquer momento, por exemplo para alinhar as prioridades de failover com a disposição AZ de outros componentes associados à sua infraestrutura.
+
+<details>
+
+<summary>Alterar as prioridades das zonas de disponibilidade</summary>
+
+
+Para ajustar as prioridades de failover de uma região 3-AZ:
+
+- Na barra lateral esquerda da área de cliente, abra <code className="action">Network</code>.
+- Selecione <code className="action">Rede privada vRack</code>.
+- Na coluna "Endereço IP público e largura de banda", clique no botão <code className="action">Gerir</code> correspondente ao vRack pretendido.
+- Vá ao separador <code className="action">Conectividade IP pública</code>.
+- No bloco da região 3-AZ que pretende configurar, localize a subsecção `Prioridades de failover 3-AZ` e clique em <code className="action">Configurar</code>.
+- No painel apresentado, atribua cada zona de disponibilidade a uma das três posições: **Zona principal**, **Zona secundária** e **Zona de último recurso**.
+- Confirme a sua seleção.
+
+:::info
+As alterações de prioridade aplicam-se a todos os blocos de Additional IP encaminhados para a região 3-AZ correspondente para o vRack selecionado, independentemente da sua versão de IP.
+
+:::
+
+
+</details>
+
+
+### Comandos no host
 
 <details>
 
@@ -335,7 +385,7 @@ Após um curto período de tempo (o tempo de propagação da configuração), um
 </details>
 
 
-#### Verificação da instalação
+### Verificação da instalação
 
 <details>
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar um bloco de Additional IP num vRack
 description: Saiba como configurar um bloco de endereços IP públicos num vRack.
-lastUpdated: 2026-03-13
+lastUpdated: 2026-05-22
 ---
 
 
@@ -144,6 +144,56 @@ O primeiro mês subscrito é faturado de forma proporcional aos dias restantes. 
 
 
 O aumento de largura de banda será aplicado a todos os endereços IP dessa região para o vRack selecionado.
+
+</details>
+
+
+### Gerir as prioridades de failover 3-AZ
+
+Algumas regiões OVHcloud estendem-se por três zonas de disponibilidade (AZ) alojadas em locais fisicamente independentes dentro da mesma região. Quando uma região deste tipo intervém no encaminhamento dos IP públicos do seu vRack, é identificada na área de cliente OVHcloud através de uma etiqueta **3-AZ** apresentada junto ao nome da região no separador <code className="action">Conectividade IP pública</code>.
+
+:::info
+Se uma região passou para o modo 3-AZ enquanto já tinha endereços IP encaminhados através do vRack nessa região, esses IP permanecerão no modo 1-AZ e não beneficiarão automaticamente da configuração de encaminhamento 3-AZ.
+
+Para ativar o modo 3-AZ nos blocos de IP encaminhados através do vRack nessas regiões, deve retirar o bloco IP do vRack e, em seguida, voltar a adicioná-lo.
+
+**Os blocos de IP que continuam a ser encaminhados no modo 1-AZ são identificados por uma etiqueta cinzenta `1-AZ`.**
+
+:::
+
+
+#### Vantagens
+
+- **Resiliência integrada**: o tráfego IP público encaminhado através do vRack permanece disponível se uma zona de disponibilidade ficar indisponível, uma vez que o encaminhamento comuta automaticamente para a AZ seguinte na ordem de prioridade.
+- **Comportamento de failover previsível**: cada região 3-AZ atribui ao seu vRack uma zona de disponibilidade principal e duas posições de failover ordenadas, tornando determinista a sequência de failover.
+- **Alinhamento com a carga de trabalho**: quando outros serviços OVHcloud estão implementados na mesma região 3-AZ, as prioridades podem ser alinhadas para que a AZ ativa do vRack corresponda à AZ que aloja os seus serviços. Desta forma, o seu tráfego público mantém-se na mesma AZ que a sua carga de trabalho durante o funcionamento normal.
+
+#### Mecânica e gestão das prioridades
+
+Quando um vRack é associado pela primeira vez a uma região 3-AZ, a OVHcloud atribui aleatoriamente uma ordem de prioridade às suas zonas de disponibilidade. As zonas **principal, secundária e de último recurso** são apresentadas por esta ordem no bloco da região correspondente no separador <code className="action">Conectividade IP pública</code>, dentro da subsecção `Prioridades de failover 3-AZ`, mesmo por cima do botão <code className="action">Configurar</code>.
+
+Pode alterar esta atribuição aleatória a qualquer momento, por exemplo para alinhar as prioridades de failover com a disposição AZ de outros componentes associados à sua infraestrutura.
+
+<details>
+
+<summary>Alterar as prioridades das zonas de disponibilidade</summary>
+
+
+Para ajustar as prioridades de failover de uma região 3-AZ:
+
+- Na barra lateral esquerda da área de cliente, abra <code className="action">Network</code>.
+- Selecione <code className="action">Rede privada vRack</code>.
+- Na coluna "Endereço IP público e largura de banda", clique no botão <code className="action">Gerir</code> correspondente ao vRack pretendido.
+- Vá ao separador <code className="action">Conectividade IP pública</code>.
+- No bloco da região 3-AZ que pretende configurar, localize a subsecção `Prioridades de failover 3-AZ` e clique em <code className="action">Configurar</code>.
+- No painel apresentado, atribua cada zona de disponibilidade a uma das três posições: **Zona principal**, **Zona secundária** e **Zona de último recurso**.
+- Confirme a sua seleção.
+
+:::info
+As alterações de prioridade aplicam-se a todos os blocos de Additional IP encaminhados para a região 3-AZ correspondente para o vRack selecionado, independentemente da sua versão de IP.
+
+:::
+
 
 </details>
 


### PR DESCRIPTION
Ports legacy PR https://github.com/ovh/docs/pull/9365 by @SlimJ4 — *vRack — 3-AZ Failover priorities*.

## Summary

Documents the new vRack 3-AZ failover priorities feature in two dedicated-server guides:

- `configure-ipv6-in-vrack`
- `configuring-an-ip-block-in-a-vrack`

Adds a new section "Managing 3-AZ failover priorities" with benefits, mechanics, and a step-by-step procedure for adjusting the AZ priority order from the Control Panel. In the IPv6 guide, also promotes the "Host-side commands" and "Setup verification" subsections from h4 to h3 (they are no longer logically nested under the bandwidth section).

## Files ported (EN + FR — matches legacy PR)

| Legacy | New-docs |
|---|---|
| `pages/bare_metal_cloud/dedicated_servers/configure-an-ipv6-in-a-vrack/guide.en-gb.md` | `docs/en/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx` |
| `pages/bare_metal_cloud/dedicated_servers/configure-an-ipv6-in-a-vrack/guide.fr-fr.md` | `docs/fr/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack.mdx` |
| `pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-gb.md` | `docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx` |
| `pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.fr-fr.md` | `docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx` |

**Slug rename:** `configure-an-ipv6-in-a-vrack` (legacy) → `configure-ipv6-in-vrack` (new-docs). Not present in `slug-regression-report.txt`; resolved via filesystem search.

## Locales added beyond the legacy PR

The legacy PR only updated EN and FR. On new-docs, every locale tree has its own real translated file (no symlinks to EN), so the 3-AZ content was additionally translated into the five remaining locales for parity. Source routing: DE/PL from EN, ES/IT/PT from FR.

| Locale | configure-ipv6-in-vrack | configuring-an-ip-block-in-a-vrack |
|---|---|---|
| DE | ✓ section + heading promotions + date | ✓ section + date |
| ES | ✓ section + heading promotions + date | ✓ section + date |
| IT | ✓ section + heading promotions + date | ✓ section + date |
| PL | ✓ section + heading promotions + date | ✓ section + date |
| PT | ✓ section + heading promotions + date | ✓ section + date |

Action-button labels in the translated sections were verified with `/verify-buttons`:

- `Network`, `vRack private network`, `Public IP Routing` — reuse the established translations already present elsewhere in each target guide.
- `Configure`, `Manage` — matched 10/10 against `common_configure` / `common_manage` in `web/client/app/core/translations/Messages_{lang}.json` (DE Konfigurieren/Verwalten, ES Configurar/Gestionar, IT Configura/Gestisci, PL Konfiguruj/Zarządzaj, PT Configurar/Gerir).

## Date update

Frontmatter `lastUpdated:` bumped from `2026-03-13` to **`2026-05-22`** across all 14 files. The legacy PR used a forward-dated value (`2026-05-26`); today's date is used instead.

## Syntax conversions

| Legacy → New | Where |
|---|---|
| `` `Btn`{.action} `` → `<code className="action">Btn</code>` | All action-button labels in the new section |
| `> [!primary] …` → `:::info … :::` | Both callouts in the new section |
| `/// details \| Title … ///` → `<details><summary>Title</summary>…</details>` | The "Modify the Availability Zone priorities" block |

## Notes

- No divergence between legacy-base and new-docs current for the affected sections.
- No `meta.yaml`, infra files, or images touched.

Commits:
1. `docs(i18n): add 3-AZ failover priorities section to vRack guides (EN+FR)` — 4 files (direct port).
2. `docs(i18n): translate 3-AZ failover priorities section into DE/ES/IT/PL/PT` — 10 files (parity).

Both commits carry `Original-URL:` and `Original-author: @SlimJ4` trailers.
