### PR TITLE
docs(i18n): announce PG15 / MariaDB 10.11 EOL dates, update PG14 EOS/EOL

### DIFF
--- a/docs/de/guides/web-cloud/databases/db-eos-eol.mdx
+++ b/docs/de/guides/web-cloud/databases/db-eos-eol.mdx
@@ -1,6 +1,6 @@
 ---
 title: Web Cloud Databases - EOL und EOS Ankündigungen
-lastUpdated: 2026-03-06
+lastUpdated: 2026-05-22
 ---
 
 ## Ziel
@@ -12,13 +12,13 @@ Weitere Informationen erhalten Sie auf der Seite zur [EOL Policy für Managed Da
 |Version|EOL Ankündigung|End-of-Sale|End-of-Support|
 |---|---|---|---|
 |MariaDB 10.6|2025-02-12|2026-01-04|2026-07-06|
-|MariaDB 10.11|Noch festzulegen|Noch festzulegen|Noch festzulegen|
+|MariaDB 10.11|2026-05-22|2027-08-17|2028-02-16|
 |MariaDB 11.4|Noch festzulegen|Noch festzulegen|Noch festzulegen|
 |MariaDB 11.8|Noch festzulegen|Noch festzulegen|Noch festzulegen|
 |MySQL 8.0|2025-03-17|2025-09-30|2026-04-01|
 |MySQL 8.4|Noch festzulegen|Noch festzulegen|Noch festzulegen|
-|PostgreSQL 14|2025-02-12|2026-05-13|2026-11-12|
-|PostgreSQL 15|Noch festzulegen|Noch festzulegen|Noch festzulegen|
+|PostgreSQL 14|2025-02-12|2026-08-22|2026-11-21|
+|PostgreSQL 15|2026-05-22|2027-05-12|2027-11-11|
 |PostgreSQL 16|Noch festzulegen|Noch festzulegen|Noch festzulegen|
 |PostgreSQL 17|Noch festzulegen|Noch festzulegen|Noch festzulegen|
 |PostgreSQL 18|Noch festzulegen|Noch festzulegen|Noch festzulegen|

--- a/docs/en/guides/web-cloud/databases/db-eos-eol.mdx
+++ b/docs/en/guides/web-cloud/databases/db-eos-eol.mdx
@@ -1,6 +1,6 @@
 ---
 title: Web Cloud Databases EOS and EOL announcements
-lastUpdated: 2026-03-06
+lastUpdated: 2026-05-22
 ---
 
 ## Objective
@@ -10,13 +10,13 @@ The products covered by those End Of Sale (EOS) and End Of Life (EOL) announceme
 |Version|EOL announcement|End-of-Sale|End-of-Support|
 |---|---|---|---|
 |MariaDB 10.6|2025-02-12|2026-01-04|2026-07-06|
-|MariaDB 10.11|To be defined|To be defined|To be defined|
+|MariaDB 10.11|2026-05-22|2027-08-17|2028-02-16|
 |MariaDB 11.4|To be defined|To be defined|To be defined|
 |MariaDB 11.8|To be defined|To be defined|To be defined|
 |MySQL 8.0|2025-03-17|2025-09-30|2026-04-01|
 |MySQL 8.4|To be defined|To be defined|To be defined|
-|PostgreSQL 14|2025-02-12|2026-05-13|2026-11-12|
-|PostgreSQL 15|To be defined|To be defined|To be defined|
+|PostgreSQL 14|2025-02-12|2026-08-22|2026-11-21|
+|PostgreSQL 15|2026-05-22|2027-05-12|2027-11-11|
 |PostgreSQL 16|To be defined|To be defined|To be defined|
 |PostgreSQL 17|To be defined|To be defined|To be defined|
 |PostgreSQL 18|To be defined|To be defined|To be defined|

--- a/docs/es/guides/web-cloud/databases/db-eos-eol.mdx
+++ b/docs/es/guides/web-cloud/databases/db-eos-eol.mdx
@@ -1,6 +1,6 @@
 ---
 title: Anuncios de fin de venta/vida Web Cloud Databases
-lastUpdated: 2026-03-06
+lastUpdated: 2026-05-22
 ---
 
 ## Objetivo
@@ -11,13 +11,13 @@ Para más información, consulte la [política de fin de vida de las bases de da
 |Versión|Anuncio de fin de vida|Fin de venta|Fin de soporte|
 |---|---|---|---|
 |MariaDB 10.6|2025-02-12|2026-01-04|2026-07-06|
-|MariaDB 10.11|Por determinar|Por determinar|Por determinar|
+|MariaDB 10.11|2026-05-22|2027-08-17|2028-02-16|
 |MariaDB 11.4|Por determinar|Por determinar|Por determinar|
 |MariaDB 11.8|Por determinar|Por determinar|Por determinar|
 |MySQL 8.0|2025-03-17|2025-09-30|2026-04-01|
 |MySQL 8.4|Por determinar|Por determinar|Por determinar|
-|PostgreSQL 14|2025-02-12|2026-05-13|2026-11-12|
-|PostgreSQL 15|Por determinar|Por determinar|Por determinar|
+|PostgreSQL 14|2025-02-12|2026-08-22|2026-11-21|
+|PostgreSQL 15|2026-05-22|2027-05-12|2027-11-11|
 |PostgreSQL 16|Por determinar|Por determinar|Por determinar|
 |PostgreSQL 17|Por determinar|Por determinar|Por determinar|
 |PostgreSQL 18|Por determinar|Por determinar|Por determinar|

--- a/docs/fr/guides/web-cloud/databases/db-eos-eol.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-eos-eol.mdx
@@ -1,6 +1,6 @@
 ---
 title: Annonces de fin de vente/vie Web Cloud Databases
-lastUpdated: 2026-03-06
+lastUpdated: 2026-05-22
 ---
 
 ## Objectif
@@ -10,13 +10,13 @@ Les produits couverts par ces annonces de fin de vente et de fin de vie sont les
 |Version|Annonce de fin de vie|Fin de vente|Fin de support|
 |---|---|---|---|
 |MariaDB 10.6|2025-02-12|2026-01-04|2026-07-06|
-|MariaDB 10.11|À définir|À définir|À définir|
+|MariaDB 10.11|2026-05-22|2027-08-17|2028-02-16|
 |MariaDB 11.4|À définir|À définir|À définir|
 |MariaDB 11.8|À définir|À définir|À définir|
 |MySQL 8.0|2025-03-17|2025-09-30|2026-04-01|
 |MySQL 8.4|À définir|À définir|À définir|
-|PostgreSQL 14|2025-02-12|2026-05-13|2026-11-12|
-|PostgreSQL 15|À définir|À définir|À définir|
+|PostgreSQL 14|2025-02-12|2026-08-22|2026-11-21|
+|PostgreSQL 15|2026-05-22|2027-05-12|2027-11-11|
 |PostgreSQL 16|À définir|À définir|À définir|
 |PostgreSQL 17|À définir|À définir|À définir|
 |PostgreSQL 18|À définir|À définir|À définir|

--- a/docs/it/guides/web-cloud/databases/db-eos-eol.mdx
+++ b/docs/it/guides/web-cloud/databases/db-eos-eol.mdx
@@ -1,6 +1,6 @@
 ---
 title: Annunci di fine vendita/vita Web Cloud Databases
-lastUpdated: 2026-03-06
+lastUpdated: 2026-05-22
 ---
 
 ## Obiettivo
@@ -11,13 +11,13 @@ Per maggiori informazioni, consulta la [politica di fine vita dei database gesti
 |Versione|Annuncio di fine vita|Fine vendita|Fine supporto|
 |---|---|---|---|
 |MariaDB 10.6|2025-02-12|2026-01-04|2026-07-06|
-|MariaDB 10.11|Da definire|Da definire|Da definire|
+|MariaDB 10.11|2026-05-22|2027-08-17|2028-02-16|
 |MariaDB 11.4|Da definire|Da definire|Da definire|
 |MariaDB 11.8|Da definire|Da definire|Da definire|
 |MySQL 8.0|2025-03-17|2025-09-30|2026-04-01|
 |MySQL 8.4|Da definire|Da definire|Da definire|
-|PostgreSQL 14|2025-02-12|2026-05-13|2026-11-12|
-|PostgreSQL 15|Da definire|Da definire|Da definire|
+|PostgreSQL 14|2025-02-12|2026-08-22|2026-11-21|
+|PostgreSQL 15|2026-05-22|2027-05-12|2027-11-11|
 |PostgreSQL 16|Da definire|Da definire|Da definire|
 |PostgreSQL 17|Da definire|Da definire|Da definire|
 |PostgreSQL 18|Da definire|Da definire|Da definire|

--- a/docs/pl/guides/web-cloud/databases/db-eos-eol.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-eos-eol.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ogłoszenia dotyczące końca umowy sprzedaży/usługi Web Cloud Databases
-lastUpdated: 2026-03-06
+lastUpdated: 2026-05-22
 ---
 
 ## Wprowadzenie
@@ -11,13 +11,13 @@ Więcej informacji na ten temat znajdziesz w [polityce wycofania zarządzanych](
 |Wersja|Ogłoszenie o zakończeniu życia|Koniec sprzedaży|Zakończenie pomocy|
 |---|---|---|---|
 |MariaDB 10.6|2025-02-12|2026-01-04|2026-07-06|
-|MariaDB 10.11|Do określenia|Do określenia|Do określenia|
+|MariaDB 10.11|2026-05-22|2027-08-17|2028-02-16|
 |MariaDB 11.4|Do określenia|Do określenia|Do określenia|
 |MariaDB 11.8|Do określenia|Do określenia|Do określenia|
 |MySQL 8.0|2025-03-17|2025-09-30|2026-04-01|
 |MySQL 8.4|Do określenia|Do określenia|Do określenia|
-|PostgreSQL 14|2025-02-12|2026-05-13|2026-11-12|
-|PostgreSQL 15|Do określenia|Do określenia|Do określenia|
+|PostgreSQL 14|2025-02-12|2026-08-22|2026-11-21|
+|PostgreSQL 15|2026-05-22|2027-05-12|2027-11-11|
 |PostgreSQL 16|Do określenia|Do określenia|Do określenia|
 |PostgreSQL 17|Do określenia|Do określenia|Do określenia|
 |PostgreSQL 18|Do określenia|Do określenia|Do określenia|

--- a/docs/pt/guides/web-cloud/databases/db-eos-eol.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-eos-eol.mdx
@@ -1,6 +1,6 @@
 ---
 title: Anúncios de fim de venda/vida Web Cloud Databases
-lastUpdated: 2026-03-06
+lastUpdated: 2026-05-22
 ---
 
 ## Objetivo
@@ -11,13 +11,13 @@ Para mais informações, consulte a [política de fim de vida das bases de dados
 |Versão|Anúncio de fim de vida|Fim da venda|Fim do suporte|
 |---|---|---|---|
 |MariaDB 10.6|2025-02-12|2026-01-04|2026-07-06|
-|MariaDB 10.11|A definir|A definir|A definir|
+|MariaDB 10.11|2026-05-22|2027-08-17|2028-02-16|
 |MariaDB 11.4|A definir|A definir|A definir|
 |MariaDB 11.8|A definir|A definir|A definir|
 |MySQL 8.0|2025-03-17|2025-09-30|2026-04-01|
 |MySQL 8.4|A definir|A definir|A definir|
-|PostgreSQL 14|2025-02-12|2026-05-13|2026-11-12|
-|PostgreSQL 15|A definir|A definir|A definir|
+|PostgreSQL 14|2025-02-12|2026-08-22|2026-11-21|
+|PostgreSQL 15|2026-05-22|2027-05-12|2027-11-11|
 |PostgreSQL 16|A definir|A definir|A definir|
 |PostgreSQL 17|A definir|A definir|A definir|
 |PostgreSQL 18|A definir|A definir|A definir|


### PR DESCRIPTION
Update the Web Cloud Databases EOS/EOL announcement table across all 7 locales:
- MariaDB 10.11: announced (EOL 2026-05-22, EOS 2027-08-17, EoSupport 2028-02-16)
- PostgreSQL 14: EOS bumped to 2026-08-22, EoSupport to 2026-11-21
- PostgreSQL 15: announced (EOL 2026-05-22, EOS 2027-05-12, EoSupport 2027-11-11)

Ports legacy PR https://github.com/ovh/docs/pull/9399 (branch dev/fabien.bagard/clouddb-eol-eos).

Original-URL: https://github.com/ovh/docs/pull/9399
Original-author: @Meuh-42