### PR TITLE
docs(i18n): refresh Kafka supported-versions list (3.8 deprecated, ad…

### DIFF
--- a/docs/de/guides/public-cloud/databases/kafka-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/kafka-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka
 description: Discover the capabilities and limitations of Analytics for Kafka
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -35,7 +35,10 @@ The Public Cloud Analytics offer is available in the following regions:
 
 The Public Cloud Analytics offer supports the following Kafka version:
 
-- Kafka 3.8
+- Kafka 3.8 (Soon deprecated)
+- Kafka 3.9
+- Kafka 4.0
+- Kafka 4.1
 
 Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data-analytics/analytics/lifecycle-policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Kafka Release Cycle on their official page: [https://kafka.apache.org/downloads](https://kafka.apache.org/downloads)
 

--- a/docs/en/guides/public-cloud/databases/kafka-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/kafka-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka
 description: Discover the capabilities and limitations of Analytics for Kafka
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -35,7 +35,10 @@ The Public Cloud Analytics offer is available in the following regions:
 
 The Public Cloud Analytics offer supports the following Kafka version:
 
-- Kafka 3.8
+- Kafka 3.8 (Soon deprecated)
+- Kafka 3.9
+- Kafka 4.0
+- Kafka 4.1
 
 Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data-analytics/analytics/lifecycle-policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Kafka Release Cycle on their official page: [https://kafka.apache.org/downloads](https://kafka.apache.org/downloads)
 

--- a/docs/es/guides/public-cloud/databases/kafka-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/kafka-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka
 description: Discover the capabilities and limitations of Analytics for Kafka
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -35,7 +35,10 @@ The Public Cloud Analytics offer is available in the following regions:
 
 The Public Cloud Analytics offer supports the following Kafka version:
 
-- Kafka 3.8
+- Kafka 3.8 (Soon deprecated)
+- Kafka 3.9
+- Kafka 4.0
+- Kafka 4.1
 
 Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data-analytics/analytics/lifecycle-policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Kafka Release Cycle on their official page: [https://kafka.apache.org/downloads](https://kafka.apache.org/downloads)
 

--- a/docs/fr/guides/public-cloud/databases/kafka-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/kafka-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capacités et limitations pour Analytics avec Kafka (EN)
 description: Discover the capabilities and limitations of Analytics for Kafka
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -35,7 +35,10 @@ The Public Cloud Analytics offer is available in the following regions:
 
 The Public Cloud Analytics offer supports the following Kafka version:
 
-- Kafka 3.8
+- Kafka 3.8 (Soon deprecated)
+- Kafka 3.9
+- Kafka 4.0
+- Kafka 4.1
 
 Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data-analytics/analytics/lifecycle-policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Kafka Release Cycle on their official page: [https://kafka.apache.org/downloads](https://kafka.apache.org/downloads)
 

--- a/docs/it/guides/public-cloud/databases/kafka-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/kafka-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka
 description: Discover the capabilities and limitations of Analytics for Kafka
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -35,7 +35,10 @@ The Public Cloud Analytics offer is available in the following regions:
 
 The Public Cloud Analytics offer supports the following Kafka version:
 
-- Kafka 3.8
+- Kafka 3.8 (Soon deprecated)
+- Kafka 3.9
+- Kafka 4.0
+- Kafka 4.1
 
 Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data-analytics/analytics/lifecycle-policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Kafka Release Cycle on their official page: [https://kafka.apache.org/downloads](https://kafka.apache.org/downloads)
 

--- a/docs/pl/guides/public-cloud/databases/kafka-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/kafka-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka
 description: Discover the capabilities and limitations of Analytics for Kafka
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -35,7 +35,10 @@ The Public Cloud Analytics offer is available in the following regions:
 
 The Public Cloud Analytics offer supports the following Kafka version:
 
-- Kafka 3.8
+- Kafka 3.8 (Soon deprecated)
+- Kafka 3.9
+- Kafka 4.0
+- Kafka 4.1
 
 Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data-analytics/analytics/lifecycle-policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Kafka Release Cycle on their official page: [https://kafka.apache.org/downloads](https://kafka.apache.org/downloads)
 

--- a/docs/pt/guides/public-cloud/databases/kafka-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/kafka-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka
 description: Discover the capabilities and limitations of Analytics for Kafka
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -35,7 +35,10 @@ The Public Cloud Analytics offer is available in the following regions:
 
 The Public Cloud Analytics offer supports the following Kafka version:
 
-- Kafka 3.8
+- Kafka 3.8 (Soon deprecated)
+- Kafka 3.9
+- Kafka 4.0
+- Kafka 4.1
 
 Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data-analytics/analytics/lifecycle-policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Kafka Release Cycle on their official page: [https://kafka.apache.org/downloads](https://kafka.apache.org/downloads)
 


### PR DESCRIPTION
…d 3.9/4.0/4.1)

Mark Kafka 3.8 as soon-to-be-deprecated and add 3.9 / 4.0 / 4.1 to the supported-versions list of the Public Cloud Analytics Kafka capabilities guide, across all 7 locales.

Ports legacy PR https://github.com/ovh/docs/pull/9397 (branch public_cloud_analytics_kafka_versions).

Original-URL: https://github.com/ovh/docs/pull/9397
Original-author: @thild42