### PR TITLE
docs(i18n): k8s ip-allocation — use 3-AZ payload example (region, availabilityZones, plan)

### DIFF
--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Personnaliser l'allocation IP sur un cluster OVHcloud Managed Kubernetes"
 description: "Découvrez comment configurer la politique d'allocation IP pour vos pods et services sur un cluster OVHcloud Managed Kubernetes avec le plan Standard"
-lastUpdated: 2026-03-17
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -72,13 +72,17 @@ Pour définir une politique d'allocation IP personnalisée sur les pods et/ou se
   "nodepool": {
     "desiredNodes": 3,
     "flavorName": "b3-8",
-    "name": "my-nodepool"
+    "name": "my-nodepool-zone-b",
+    "availabilityZones": ["eu-west-par-b"]
   },
-  "region": "GRA11",
+  "region": "EU-WEST-PAR",
   "ipAllocationPolicy": {
     "podsIpv4Cidr": "172.16.0.0/12",
     "servicesIpv4Cidr": "10.100.0.0/16"
-  }
+  },
+  "privateNetworkId": "a60144a6-5ec1-4fe5-af79-31032f37876a",
+  "nodesSubnetId": "ca2809f6-b7ef-40d8-8ef1-4b64c1a1ffae",
+  "plan": "standard"
 }
 ```
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
@@ -1,7 +1,7 @@
 ---
 title: Customising IP allocation on an OVHcloud Managed Kubernetes cluster
 description: Find out how to configure the IP allocation policy for your pods and services on an OVHcloud Managed Kubernetes cluster with Standard plan
-lastUpdated: 2026-03-17
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -70,13 +70,17 @@ To set a custom IP allocation policy on pods and/or services, you can use the fo
   "nodepool": {
     "desiredNodes": 3,
     "flavorName": "b3-8",
-    "name": "my-nodepool"
+    "name": "my-nodepool-zone-b",
+    "availabilityZones": ["eu-west-par-b"]
   },
-  "region": "GRA11",
+  "region": "EU-WEST-PAR",
   "ipAllocationPolicy": {
     "podsIpv4Cidr": "172.16.0.0/12",
     "servicesIpv4Cidr": "10.100.0.0/16"
-  }
+  },
+  "privateNetworkId": "a60144a6-5ec1-4fe5-af79-31032f37876a",
+  "nodesSubnetId": "ca2809f6-b7ef-40d8-8ef1-4b64c1a1ffae",
+  "plan": "standard"
 }
 ```
 

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Personnaliser l'allocation IP sur un cluster OVHcloud Managed Kubernetes"
 description: "Découvrez comment configurer la politique d'allocation IP pour vos pods et services sur un cluster OVHcloud Managed Kubernetes avec le plan Standard"
-lastUpdated: 2026-03-17
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -72,13 +72,17 @@ Pour définir une politique d'allocation IP personnalisée sur les pods et/ou se
   "nodepool": {
     "desiredNodes": 3,
     "flavorName": "b3-8",
-    "name": "my-nodepool"
+    "name": "my-nodepool-zone-b",
+    "availabilityZones": ["eu-west-par-b"]
   },
-  "region": "GRA11",
+  "region": "EU-WEST-PAR",
   "ipAllocationPolicy": {
     "podsIpv4Cidr": "172.16.0.0/12",
     "servicesIpv4Cidr": "10.100.0.0/16"
-  }
+  },
+  "privateNetworkId": "a60144a6-5ec1-4fe5-af79-31032f37876a",
+  "nodesSubnetId": "ca2809f6-b7ef-40d8-8ef1-4b64c1a1ffae",
+  "plan": "standard"
 }
 ```
 

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Personnaliser l'allocation IP sur un cluster OVHcloud Managed Kubernetes"
 description: "Découvrez comment configurer la politique d'allocation IP pour vos pods et services sur un cluster OVHcloud Managed Kubernetes avec le plan Standard"
-lastUpdated: 2026-03-17
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -70,13 +70,17 @@ Pour définir une politique d'allocation IP personnalisée sur les pods et/ou se
   "nodepool": {
     "desiredNodes": 3,
     "flavorName": "b3-8",
-    "name": "my-nodepool"
+    "name": "my-nodepool-zone-b",
+    "availabilityZones": ["eu-west-par-b"]
   },
-  "region": "GRA11",
+  "region": "EU-WEST-PAR",
   "ipAllocationPolicy": {
     "podsIpv4Cidr": "172.16.0.0/12",
     "servicesIpv4Cidr": "10.100.0.0/16"
-  }
+  },
+  "privateNetworkId": "a60144a6-5ec1-4fe5-af79-31032f37876a",
+  "nodesSubnetId": "ca2809f6-b7ef-40d8-8ef1-4b64c1a1ffae",
+  "plan": "standard"
 }
 ```
 

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Personnaliser l'allocation IP sur un cluster OVHcloud Managed Kubernetes"
 description: "Découvrez comment configurer la politique d'allocation IP pour vos pods et services sur un cluster OVHcloud Managed Kubernetes avec le plan Standard"
-lastUpdated: 2026-03-17
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -72,13 +72,17 @@ Pour définir une politique d'allocation IP personnalisée sur les pods et/ou se
   "nodepool": {
     "desiredNodes": 3,
     "flavorName": "b3-8",
-    "name": "my-nodepool"
+    "name": "my-nodepool-zone-b",
+    "availabilityZones": ["eu-west-par-b"]
   },
-  "region": "GRA11",
+  "region": "EU-WEST-PAR",
   "ipAllocationPolicy": {
     "podsIpv4Cidr": "172.16.0.0/12",
     "servicesIpv4Cidr": "10.100.0.0/16"
-  }
+  },
+  "privateNetworkId": "a60144a6-5ec1-4fe5-af79-31032f37876a",
+  "nodesSubnetId": "ca2809f6-b7ef-40d8-8ef1-4b64c1a1ffae",
+  "plan": "standard"
 }
 ```
 

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Personnaliser l'allocation IP sur un cluster OVHcloud Managed Kubernetes"
 description: "Découvrez comment configurer la politique d'allocation IP pour vos pods et services sur un cluster OVHcloud Managed Kubernetes avec le plan Standard"
-lastUpdated: 2026-03-17
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -72,13 +72,17 @@ Pour définir une politique d'allocation IP personnalisée sur les pods et/ou se
   "nodepool": {
     "desiredNodes": 3,
     "flavorName": "b3-8",
-    "name": "my-nodepool"
+    "name": "my-nodepool-zone-b",
+    "availabilityZones": ["eu-west-par-b"]
   },
-  "region": "GRA11",
+  "region": "EU-WEST-PAR",
   "ipAllocationPolicy": {
     "podsIpv4Cidr": "172.16.0.0/12",
     "servicesIpv4Cidr": "10.100.0.0/16"
-  }
+  },
+  "privateNetworkId": "a60144a6-5ec1-4fe5-af79-31032f37876a",
+  "nodesSubnetId": "ca2809f6-b7ef-40d8-8ef1-4b64c1a1ffae",
+  "plan": "standard"
 }
 ```
 

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Personnaliser l'allocation IP sur un cluster OVHcloud Managed Kubernetes"
 description: "Découvrez comment configurer la politique d'allocation IP pour vos pods et services sur un cluster OVHcloud Managed Kubernetes avec le plan Standard"
-lastUpdated: 2026-03-17
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -72,13 +72,17 @@ Pour définir une politique d'allocation IP personnalisée sur les pods et/ou se
   "nodepool": {
     "desiredNodes": 3,
     "flavorName": "b3-8",
-    "name": "my-nodepool"
+    "name": "my-nodepool-zone-b",
+    "availabilityZones": ["eu-west-par-b"]
   },
-  "region": "GRA11",
+  "region": "EU-WEST-PAR",
   "ipAllocationPolicy": {
     "podsIpv4Cidr": "172.16.0.0/12",
     "servicesIpv4Cidr": "10.100.0.0/16"
-  }
+  },
+  "privateNetworkId": "a60144a6-5ec1-4fe5-af79-31032f37876a",
+  "nodesSubnetId": "ca2809f6-b7ef-40d8-8ef1-4b64c1a1ffae",
+  "plan": "standard"
 }
 ```
 


### PR DESCRIPTION
Refresh the JSON payload example in the Managed Kubernetes "Configure pods/services IP allocation policy" guide across all 7 locales:
- Switch example region from GRA11 to EU-WEST-PAR (multi-AZ-capable)
- Add availabilityZones to the nodepool block
- Add privateNetworkId, nodesSubnetId, and plan (required for the standard plan with multi-AZ)

Ports legacy PR https://github.com/ovh/docs/pull/9398 (branch fix/pedro/k8s-ip-allocation-example). Extends to DE/ES/IT/PL/PT since the JSON example is data, not language-specific content.

Original-URL: https://github.com/ovh/docs/pull/9398
Original-author: @pgaxatte