### PR TITLE
fix(theme): persist SurveyWidget dismissal across reloads

### DIFF
--- a/theme/components/SurveyWidget/SurveyWidget.tsx
+++ b/theme/components/SurveyWidget/SurveyWidget.tsx
@@ -1,25 +1,50 @@
 import { useI18n, useLang } from '@rspress/core/runtime';
 import { trackClick } from '@components/Analytics';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import './SurveyWidget.scss';
 
 const SURVEY_URL = 'https://s.elq.fr/ovhabp/LfDet1p?%23+Version=';
+const STORAGE_KEY = 'surveyWidget:dismissed';
+
+function hasBeenDismissed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
+function markAsDismissed(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, Date.now().toString());
+  } catch {
+    // localStorage unavailable
+  }
+}
 
 export function SurveyWidget() {
-  const [dismissed, setDismissed] = useState(false);
+  const [dismissed, setDismissed] = useState(true);
   const t = useI18n();
   const lang = useLang();
+
+  useEffect(() => {
+    if (!hasBeenDismissed()) {
+      setDismissed(false);
+    }
+  }, []);
 
   if (dismissed) return null;
 
   const handleRespond = (e: React.MouseEvent<HTMLButtonElement>) => {
     trackClick('cta-answer-survey', e.currentTarget);
     window.open(`${SURVEY_URL}${lang}`, '_blank', 'noopener,noreferrer');
+    markAsDismissed();
     setDismissed(true);
   };
 
   const handleDismiss = (e: React.MouseEvent<HTMLButtonElement>) => {
     trackClick('cta-dismiss-survey', e.currentTarget);
+    markAsDismissed();
     setDismissed(true);
   };
 


### PR DESCRIPTION
Store a flag in localStorage when the user dismisses or responds to the survey, so refreshing the page no longer re-displays the widget.