### PR TITLE
docs(port): adapt legacy PRs #9392/#9393/#9394/#9400 — PCI grammar pass

### DIFF
--- a/docs/de/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -95,6 +95,6 @@ sudo cat /etc/hosts
 127.0.0.1 localhost
 ```
 
-## Weiterführende Informationen 
+## Weiterführende Informationen
 
 Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.

--- a/docs/de/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/de/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -25,7 +25,7 @@ You'll need an [OVHcloud Public Cloud project](/guides/public-cloud/cross-functi
 
 ### Install Packer
 
-Packer can be downloaded from the official website (curently [here](https://www.packer.io/downloads.html) ) and you'll need to `unzip` it.
+Packer can be downloaded from the official website (currently [here](https://www.packer.io/downloads.html) ) and you'll need to `unzip` it.
 
 For Linux 64bits
 
@@ -92,7 +92,7 @@ export NETWORK_ID=`openstack network list -f json | jq -r '.[] | select(.Name ==
 
 **INFO**: for `FLAVOR_ID`, you can directly use the name, ie `b2-7`
 
-Finaly, create a `packer.json` file
+Finally, create a `packer.json` file
 
 ```shell
 cat > packer.json <<EOF
@@ -129,7 +129,7 @@ cat > packer.json <<EOF
 EOF
 ```
 
-In the last selection of the configuration file, we specify a `setup_vm.sh` shell script to be ran.
+In the last selection of the configuration file, we specify a `setup_vm.sh` shell script to be run.
 
 ```sh
 #!/bin/sh
@@ -149,7 +149,7 @@ git clone ...
 
 ## Building the image
 
-Using the configuration file create above, check it and build the image with
+Using the configuration file created above, check it and build the image with
 
 ```shell
 packer validate packer.json

--- a/docs/de/guides/public-cloud/compute/creating-ssh-keys.mdx
+++ b/docs/de/guides/public-cloud/compute/creating-ssh-keys.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2024-12-09
 
 ## Ziel
 
-SSH ermöglicht einen sicheren Kommunikationskanal über öffentliche Netzwerke in einer Client-Server-Architektur. Diese SSH-Verbindungen zwischen zwei vertrauenswürdigen Hosts, etwa zwischen einem Desktop-Client und einem Remote-Server, können mithilfe von Schlüsselpaaren authentifiziert werden, 
+SSH ermöglicht einen sicheren Kommunikationskanal über öffentliche Netzwerke in einer Client-Server-Architektur. Diese SSH-Verbindungen zwischen zwei vertrauenswürdigen Hosts, etwa zwischen einem Desktop-Client und einem Remote-Server, können mithilfe von Schlüsselpaaren authentifiziert werden. 
 
 Ein Schlüsselsatz besteht aus einem öffentlichen Schlüssel, der weitergegeben werden kann, und einem privaten Schlüssel, der geheim bleibt. Wenn der öffentliche Schlüssel auf einem Server gespeichert wird, kann sich jeder Client, der über den zugehörigen privaten Schlüssel verfügt, ohne Eingabe eines Kennworts anmelden.
 

--- a/docs/de/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/de/guides/public-cloud/compute/image-life-cycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud & VPS - Image and OS life cycle and end of life/support announcements
 description: Discover the lifecycle and end-of-life/end-of-support announcements for distributions and softwares for your VPS or Public Cloud instance
-lastUpdated: 2025-02-11
+lastUpdated: 2025-11-12
 ---
 
 ## Objective
@@ -70,7 +70,7 @@ Please note that:
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
 | 14 | [Forky](https://wiki.debian.org/DebianForky) | | | |
-| 13 | [Trixie](https://wiki.debian.org/DebianTrixie) | | | |
+| 13 | [Trixie](https://wiki.debian.org/DebianTrixie) | August 2025 | August 2028 | June 2030 |
 | 12 | [Bookworm](https://wiki.debian.org/DebianBookworm) | June 2023 | June 2026 | June 2028 |
 | 11 | [Bullseye](https://wiki.debian.org/DebianBullseye) | August 2021 | August 2024 | August 2026 |
 | 10 | [Buster](https://wiki.debian.org/DebianBuster) | July 2019 | September 2022 | June 2024 |

--- a/docs/de/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/de/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -220,7 +220,7 @@ Nachdem dies abgeschlossen ist, trennen Sie das Volume von der Instanz und häng
 
 ### Partition erweitern (Windows-Instanz)
 
-Bevor Sie fortfahren, hängen Sie das Volume erneut an die Instanz an. Klicken Sie auf <code className="action">...</code> in der Zeile des Volumes und wählen Sie <code className="action">Mit Instanz verbiden</code> aus.
+Bevor Sie fortfahren, hängen Sie das Volume erneut an die Instanz an. Klicken Sie auf <code className="action">...</code> in der Zeile des Volumes und wählen Sie <code className="action">Mit Instanz verbinden</code> aus.
 
 Stellen Sie eine RDP-Verbindung (Remote Desktop) zu Ihrer Windows-Instanz her.
 

--- a/docs/de/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/de/guides/public-cloud/compute/install-wordpress.mdx
@@ -83,7 +83,7 @@ debian@instance:~$ sudo mariadb-secure-installation
 
 Bestätigen Sie den ersten Prompt, indem Sie <code className="action">Enter</code> drücken.
 
-Sie können dann eine Methode auswählen, um den Zugang zu Ihrem Datenbankserver zu abzusichern.
+Sie können dann eine Methode auswählen, um den Zugang zu Ihrem Datenbankserver abzusichern.
 
 ```console
 Switch to unix_socket authentication [Y/n]
@@ -275,7 +275,7 @@ debian@instance:~$ sudo certbot --apache -d domainname.ovh -d www.domainname.ovh
 
 Geben Sie eine gültige E-Mail-Adresse ein und akzeptieren Sie die Nutzungsbedingungen.
 
-Certbot verlängert die Zertifikate automatisch; es sind keine weitereren Schritte erforderlich. Sie können jedoch in der Dokumentation zu den verfügbaren Optionen von Certbot nachlesen, um mehr zu dessen Einsatzmöglichkeiten zu erfahren.
+Certbot verlängert die Zertifikate automatisch; es sind keine weiteren Schritte erforderlich. Sie können jedoch in der Dokumentation zu den verfügbaren Optionen von Certbot nachlesen, um mehr zu dessen Einsatzmöglichkeiten zu erfahren.
 
 ## Weiterführende Informationen
 

--- a/docs/de/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
+++ b/docs/de/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
@@ -27,7 +27,7 @@ Während des Betriebs können Sie jederzeit eine Sicherung Ihrer Daten, der Konf
 
 ### Snapshot erstellen
 
-Loggen Sie sich ins [Horizon-Interface](https://horizon.cloud.ovh.net/auth/login/) ein wählen Sie oben links die korrekte Region aus.
+Loggen Sie sich ins [Horizon-Interface](https://horizon.cloud.ovh.net/auth/login/) ein und wählen Sie oben links die korrekte Region aus.
 
 <img className="thumbnail" alt="Region" src="/images/public-cloud/compute/managing-snapshots-in-horizon/region2021.png" loading="lazy" />
 

--- a/docs/de/guides/public-cloud/compute/share-images-between-projects.mdx
+++ b/docs/de/guides/public-cloud/compute/share-images-between-projects.mdx
@@ -14,7 +14,7 @@ Diese Funktion bietet viele Möglichkeiten, birgt aber auch Risiken. Es ist also
 
 Wenn Sie z.B. ein Image aus Projekt A für Projekt B freigeben möchten (unter demselben oder einem anderen Account), gelten die folgenden Regeln:
 
-- Ein Image kamm nur innerhalb einer Region freigegeben werden. Ein in Projekt A in der Region GRA11 erstelltes Image ist beispielsweise nur für Projekt B in derselben Region (GRA11) verfügbar.
+- Ein Image kann nur innerhalb einer Region freigegeben werden. Ein in Projekt A in der Region GRA11 erstelltes Image ist beispielsweise nur für Projekt B in derselben Region (GRA11) verfügbar.
 - Das Image bleibt physisch an Projekt A angehängt. Das Projekt B verfügt nur über eine Zugriffsberechtigung (*access authorization*) für dieses Image.
 - Wenn Projekt A den Zugriff auf das Image unterdrückt (Löschen der ACL, Löschen des Images, Löschen des Projekts aufgrund ausstehender Zahlungen, etc.), funktionieren Instanzen, die von diesem Image aus in Projekt B ausgeführt werden, möglicherweise wegen Problemen bei Migration oder Rebuild nicht mehr.
 

--- a/docs/de/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
+++ b/docs/de/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
@@ -37,7 +37,7 @@ Hier die wichtigsten Befehle im Überblick:
 |volume create|Neues Volume erstellen|
 |volume delete|Volume löschen|
 |list volume|Volumes auflisten|
-|volume snapshot create|Snaspshot eines Volumes erstellen|
+|volume snapshot create|Snapshot eines Volumes erstellen|
 
 Sie können die Erklärung zu einem speziellen Swift-Befehl aufrufen, indem Sie "help" einfügen:
 
@@ -164,7 +164,7 @@ Für die meisten der nachfolgenden Befehle muss die Volume-ID statt des Namens a
 - Volume mit dem OpenStack-Client auf einer Instanz mounten:
 
 ```bash
-admin@server-1: openstack server add volume 46aec29f-fe50-4562-b3f9-2e6665a7270a f75db60b-4179-b-8-3ca-4-e9e e faf ef
+admin@server-1:~$ openstack server add volume 46aec29f-fe50-4562-b3f9-2e6665a7270d f75d60b3-4179-4ca9-8bc7-8e5f7a1682f8
 ```
 
 - Überprüfen Sie mit dem OpenStack-Client, ob das Volume korrekt an die Instanz angehängt wurde:

--- a/docs/de/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/de/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -24,7 +24,7 @@ Dies kann in folgenden Fällen nützlich sein:
 
 ## Voraussetzungen
 
-- Sie verfügen über eine [Public Cloud Instanz](https://www.ovhcloud.com/de/public-cloud).
+- Sie verfügen über eine [Public Cloud Instanz](/links/public-cloud/public-cloud).
 - Sie verfügen über einen Volume Snapshot in der gleichen OpenStack-Region.
 - Sie haben administrativen Zugriff (sudo) über SSH oder RDP auf Ihre Instanzen.
 
@@ -69,7 +69,8 @@ Der Vorgang zur Anbindung der Festplatte an Ihre Instanz beginnt und kann einige
 <img className="thumbnail" alt="volume" src="/images/public-cloud/compute/create-volume-from-snapshot/volume05.png" loading="lazy" />
 
 :::warning
-Achten Sie darauf, den aktuell angezeigten Bereich des Kundencenters während der Festplattenbindung nicht zu verlassen. Der laufende Prozess könnte unterbrochen werden.
+>
+> Achten Sie darauf, den aktuell angezeigten Bereich des Kundencenters während der Festplattenbindung nicht zu verlassen. Der laufende Prozess könnte unterbrochen werden.
 :::
 
 Sobald der Vorgang abgeschlossen ist, können Sie für die nächsten Schritte unsere Konfigurationsanleitung verwenden, für [Linux](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#unter-linux)- oder [Windows](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#unter-windows)-Instanzen.

--- a/docs/de/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
@@ -278,7 +278,7 @@ Diese Aktion ist nur im Horizon-Interface oder über die OpenStack/Nova-API mög
 
 #### Im Horizon-Interface
 
-Klicken Sie auf das Menü <code className="action">Compute</code> auf der linken Seite und wählen Sie <code className="action">Instances</code> aus. Wählen Sie <code className="action">Pause Instance</code> Drop-down-Liste für die entsprechende Instanz aus.
+Klicken Sie auf das Menü <code className="action">Compute</code> auf der linken Seite und wählen Sie <code className="action">Instances</code> aus. Wählen Sie <code className="action">Pause Instance</code> in der Drop-down-Liste für die entsprechende Instanz aus.
 
 <img className="thumbnail" alt="Pause instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
 

--- a/docs/de/guides/public-cloud/compute/test-disk-speed.mdx
+++ b/docs/de/guides/public-cloud/compute/test-disk-speed.mdx
@@ -13,7 +13,7 @@ Es kann aus verschiedenen Gründen vorkommen, dass Sie die Geschwindigkeit Ihrer
 ## Voraussetzungen
 
 - Sie verfügen über eine [Public Cloud Instanz](https://www.ovhcloud.com/de/public-cloud/compute/).
-- SIe haven administrativen Zugriff (sudo) auf Ihre Instanz über SSH (Linux) oder RDP (Windows).
+- Sie haben administrativen Zugriff (sudo) auf Ihre Instanz über SSH (Linux) oder RDP (Windows).
 
 ## In der praktischen Anwendung
 

--- a/docs/de/guides/public-cloud/compute/upgrading-operating-system.mdx
+++ b/docs/de/guides/public-cloud/compute/upgrading-operating-system.mdx
@@ -101,13 +101,13 @@ $ sudo apt-get update
 Danach führen Sie ein Update Ihrer installierten Pakete auf deren aktuellste Versionen durch:
 
 ```sh
-$ sudo apt get upgrade -y
+$ sudo apt-get upgrade -y
 ```
 
 Wenn Sie diese Operation abgeschlossen haben, führen Sie ein Distributionsupgrade durch, bei dem weitere Aktualisierungen durchgeführt werden, die eventuell notwendig sind:
 
 ```sh
-$ sudo apt-get dist upgrade -y
+$ sudo apt-get dist-upgrade -y
 ```
 
 Die neue Version kann anschließend installiert werden. Ubuntu stellt ein Tool namens *do-release-upgrade* zur Verfügung, das dieses Update sicherer und einfacher macht. Starten Sie das Update mit folgendem Befehl:

--- a/docs/de/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/de/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -67,7 +67,7 @@ A state is composed of several files inside a `.pulumi` folder:
 - `meta.yaml`: This is the metadata file. It does not hold information about the stacks but rather information about the backend itself.
 - `stacks/`: Active state files for each stack (e.g. `dev.json`).
 - `locks/`: Optional lock files for each stack if the stack is currently being operated on by a Pulumi operation (e.g. `dev/$lock.json`).
-- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json`vwhere $timestamp records the time the history file was created).
+- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json` where $timestamp records the time the history file was created).
 
 ## Instructions
 

--- a/docs/de/guides/public-cloud/cross-functional/api-rate-limits.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/api-rate-limits.mdx
@@ -13,7 +13,7 @@ Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In 
 
 Ein Durchsatzlimit ist eine Einschränkung, die von der API auf die Anzahl der Anforderungen angewendet wird, die ein Client über einen bestimmten Zeitraum an die API stellen kann.
 
-## Warum Nuzungsbeschränkungen?
+## Warum Nutzungsbeschränkungen?
 
 Durchsatzlimits sind gängige Praxis für APIs. Sie werden aus verschiedenen Gründen eingerichtet:
 

--- a/docs/de/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
@@ -68,7 +68,7 @@ Wenn die CLIs schon installiert sind, überprüfen Sie deren Funktion wie folgt:
 
 Die *OpenRC*-Datei ist nicht dazu vorgesehen, unter Windows geladen zu werden.
 
-Für das Laden der Umgebungsvariablen gitb es zwei Lösungen:
+Für das Laden der Umgebungsvariablen gibt es zwei Lösungen:
 
 - Die Datei kann mittels entsprechender Änderungen angepasst werden. Sie können **export** durch **set** ersetzen:
 

--- a/docs/de/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -31,7 +31,7 @@ Das Erstellen eines Projekts ist die Voraussetzung, um [Public Cloud Instanzen](
 
 ## In der praktischen Anwendung
 
-Nachdem Sie die Vertragsbedingungen gelesen haben, bestätigen Sie diese, indem Sie das entsprechende Kästchen ankreuzen und auf <code className="action">Das Public-Cloud-Universun entdecken</code> klicken.
+Nachdem Sie die Vertragsbedingungen gelesen haben, bestätigen Sie diese, indem Sie das entsprechende Kästchen ankreuzen und auf <code className="action">Das Public-Cloud-Universum entdecken</code> klicken.
 
 <img className="thumbnail" alt="Projekt erstellen" src="/images/public-cloud/cross-functional/create-a-public-cloud-project/firstproject2024.png" loading="lazy" style={{ maxWidth: '400px' }} />
 

--- a/docs/de/guides/public-cloud/cross-functional/delete-a-project.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/delete-a-project.mdx
@@ -58,4 +58,4 @@ Beachten Sie, dass ein Projekt, das in die Löschphase eintritt, 7 Tage lang im 
 
 [Die ersten Schritte mit Ihrer Public Cloud Instanz](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/cross-functional/security-group-private-network.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/security-group-private-network.mdx
@@ -71,7 +71,7 @@ True
 
 #### Für ein neues privates Netzwerk:
 
-Die Aktualisierungen auf die Stein-Version in den OpenStack-Regionen und auf die neue Version von Open vSwitch werden zum 6. September 2022 durchgeführt ([Private network port default configuration change](https://public-cloud.status-ovhcloud.com/incidents/z6qq4bcvsn11)). Damit wird der Parameter "port pecurity" in jedem neu erstellten privaten Netzwerk standardmäßig auf "True" festgelegt.
+Die Aktualisierungen auf die Stein-Version in den OpenStack-Regionen und auf die neue Version von Open vSwitch werden zum 6. September 2022 durchgeführt ([Private network port default configuration change](https://public-cloud.status-ovhcloud.com/incidents/z6qq4bcvsn11)). Damit wird der Parameter "port security" in jedem neu erstellten privaten Netzwerk standardmäßig auf "True" festgelegt.
 
 Damit wird sichergestellt, dass die Standardeinstellung "True" als Richtlinie konsistent mit Vanilla-Deployments von OpenStack ist.
 

--- a/docs/de/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
@@ -133,7 +133,7 @@ export OS_TOKEN=$(openstack token issue -f value -c id)
 
 ### Schritt 3: Unnötige Variable löschen
 
-Um den Token für Aktionen mit Ihrem Benutzer zu verwenden, muss die Variable `OS_USER_DOMAIN_NAME` enfernt werden.
+Um den Token für Aktionen mit Ihrem Benutzer zu verwenden, muss die Variable `OS_USER_DOMAIN_NAME` entfernt werden.
 
 Führen Sie hierzu folgenden Befehl aus:
 

--- a/docs/de/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/de/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2024-01-22
 
 ## Objective
 
-This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the pre requisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
+This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the prerequisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
 
 For this example, we will use a private network and a subnet with the following properties:
 
@@ -44,7 +44,7 @@ Click the `Subnets` tab: the subnets from the private network are listed.
 
 Click on your `Edit Subnet`. For this guide, our target is to add a gateway IP:
 
-- Click untick the  `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
+- Untick the `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
 
 <img className="thumbnail" alt="gateway IP" src="/images/public-cloud/network-services/configuration-04-update-subnet/add_gateway_ip.png" loading="lazy" />
 

--- a/docs/en/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
+++ b/docs/en/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
@@ -155,7 +155,7 @@ openstack server add port <server_id> <port_id>
 
 #### Activate your Windows licence
 
-To activate Windows, you must go through Powershell.
+To activate Windows, you must go through PowerShell.
 
 Once you have logged in to your Windows instance, right click on the <code className="action">Start</code> menu and select <code className="action">Windows PowerShell</code>.
 

--- a/docs/en/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -95,6 +95,6 @@ sudo cat /etc/hosts
 127.0.0.1 localhost
 ```
 
-## Go further 
+## Go further
 
 Join our [community of users](https://community.ovhcloud.com/community/en).

--- a/docs/en/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/en/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -25,7 +25,7 @@ You'll need an [OVHcloud Public Cloud project](/guides/public-cloud/cross-functi
 
 ### Install Packer
 
-Packer can be downloaded from the official website (curently [here](https://www.packer.io/downloads.html) ) and you'll need to `unzip` it.
+Packer can be downloaded from the official website (currently [here](https://www.packer.io/downloads.html) ) and you'll need to `unzip` it.
 
 For Linux 64bits
 
@@ -92,7 +92,7 @@ export NETWORK_ID=`openstack network list -f json | jq -r '.[] | select(.Name ==
 
 **INFO**: for `FLAVOR_ID`, you can directly use the name, ie `b2-7`
 
-Finaly, create a `packer.json` file
+Finally, create a `packer.json` file
 
 ```shell
 cat > packer.json <<EOF
@@ -129,7 +129,7 @@ cat > packer.json <<EOF
 EOF
 ```
 
-In the last selection of the configuration file, we specify a `setup_vm.sh` shell script to be ran.
+In the last selection of the configuration file, we specify a `setup_vm.sh` shell script to be run.
 
 ```sh
 #!/bin/sh
@@ -149,7 +149,7 @@ git clone ...
 
 ## Building the image
 
-Using the configuration file create above, check it and build the image with
+Using the configuration file created above, check it and build the image with
 
 ```shell
 packer validate packer.json

--- a/docs/en/guides/public-cloud/compute/create-server-group-horizon-cli.mdx
+++ b/docs/en/guides/public-cloud/compute/create-server-group-horizon-cli.mdx
@@ -95,7 +95,7 @@ A Server Group with the policy of `soft anti affinity` will **try to** make sure
 
 If you subsequently launch more instances referencing the same Server Group, the scheduler concentrates or distributes them according to the Server Group's policy.
 
-### Modifiying a Server Group
+### Modifying a Server Group
 
 <img className="thumbnail" alt="List Server Groups OpenStack" src="/images/public-cloud/compute/create-server-group-horizon-cli/list_server_groups_openStack_dashboard.png" loading="lazy" />
 

--- a/docs/en/guides/public-cloud/compute/creating-ssh-keys.mdx
+++ b/docs/en/guides/public-cloud/compute/creating-ssh-keys.mdx
@@ -314,7 +314,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-Vou can open the key file with a text editor (Notepad, Notepad++, etc.). From the Windows File Explorer, right-click on the file and select `Open with`.  
+You can open the key file with a text editor (Notepad, Notepad++, etc.). From the Windows File Explorer, right-click on the file and select `Open with`.  
 You can also use one of the following commands (when in the directory `\Users\WindowsUsername\.ssh`):
 
 - `cmd`

--- a/docs/en/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -24,7 +24,7 @@ We have provided you with this guide in order to help you with common tasks. How
 
 ## Instructions
 
-### Step 1: Install Plesk.
+### Step 1: Install Plesk
 
 Plesk can be installed easily via an SSH connection. To do this, download and launch the Plesk installation script using the command that best suits your situation below.
 

--- a/docs/en/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/en/guides/public-cloud/compute/install-wordpress.mdx
@@ -241,7 +241,7 @@ In the next step, you can pre-configure your website's general information and c
 
 <img className="thumbnail" alt="wordpress" src="/images/public-cloud/compute/install-wordpress-on-an-instance/wp_install2.png" loading="lazy" />
 
-Once this is confirmed, you will be able to log in to your website's administation panel with the user credentials defined in the previous step.
+Once this is confirmed, you will be able to log in to your website's administration panel with the user credentials defined in the previous step.
 
 :::info
 In order to establish secure connections (`https`), the web server has to be secured via a Certificate Authority such as "[Let’s Encrypt](https://letsencrypt.org/)" which offers free certificates. You will need to install a client tool (such as "Certbot") and configure Apache. Without this step, your website can only accept `http` requests. 

--- a/docs/en/guides/public-cloud/compute/key-concepts.mdx
+++ b/docs/en/guides/public-cloud/compute/key-concepts.mdx
@@ -62,7 +62,7 @@ When creating an instance, you select an image that includes the operating syste
 
 - **Linux Distributions:** Ubuntu, Debian, CentOS, AlmaLinux, Rocky Linux, and others. These images are ready to use for web servers, development environments, and general-purpose workloads.
 - **Windows Server:** Versions with integrated licenses, allowing immediate deployment for Microsoft-based applications and enterprise workloads.
-- **Pre-configured Applications:** Images that come with softwares such as cPanel, Plesk, Docker, or NVIDIA GPU Cloud (NGC). They simplify deployment and accelerate time-to-production.
+- **Pre-configured Applications:** Images that come with software such as cPanel, Plesk, Docker, or NVIDIA GPU Cloud (NGC). They simplify deployment and accelerate time-to-production.
 - **[Custom Images](/guides/public-cloud/compute/upload-own-image):** You can import your own images in QCOW2 or RAW format, providing full control over your environment and enabling migrations, standardized templates, or specialized configurations.
 
 **Lifecycle and Support:** OVHcloud regularly updates the image catalog. Always consult the lifecycle and end-of-support announcements to ensure your images remain secure and supported. See [here](/guides/public-cloud/compute/image-life-cycle).
@@ -139,7 +139,7 @@ Once you are familiar with the core concepts of OVHcloud Public Cloud Compute, y
 
 - [How to create a Public Cloud instance and connect to it](/guides/public-cloud/compute/getting-started)
 - [Managing your Public Cloud instances](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
-- [Starting an instance on an bootable volume](/guides/public-cloud/compute/start-instance-on-attached-volume)
+- [Starting an instance on a bootable volume](/guides/public-cloud/compute/start-instance-on-attached-volume)
 - [Shelve or pause an instance](/guides/public-cloud/compute/suspend-or-pause-an-instance)
 - [First steps with preinstalled applications](/guides/public-cloud/compute/apps-first-steps)
 - [Adding cloud credit](/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project)

--- a/docs/en/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -47,7 +47,7 @@ service ssh restart
 
 With this script, you can modify the default SSH port (22 -> 2211) and block the connection using the **root** user privileges.
 
-- Update packets and set up a web server:
+- Update packages and set up a web server:
 
 ```bash
 #!/bin/bash
@@ -89,7 +89,7 @@ user.
 
 ### Create the instance
 
-After you have retrieved the list of images and instance templates, you can launch the script with Cloud-init via the **--user- data** argument:
+After you have retrieved the list of images and instance templates, you can launch the script with Cloud-init via the **--user-data** argument:
 
 ```bash
 root@server:~# nova boot --key_name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1

--- a/docs/en/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume.mdx
+++ b/docs/en/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume.mdx
@@ -55,7 +55,7 @@ lsblk
 
 ```bash
 /dev/vdb # volume source
-/dev/vdc # volume cible LUKS
+/dev/vdc # LUKS target volume
 ```
 
 ### Step 3: Prepare the LUKS (encrypted) volume

--- a/docs/en/guides/public-cloud/compute/responsibility-model-instances.mdx
+++ b/docs/en/guides/public-cloud/compute/responsibility-model-instances.mdx
@@ -31,8 +31,8 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 | **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Produce, route, deliver and maintain physical Instances and hosting buldings | I | RA |
-| Install internal functionnal bricks needed to maintain in operational and security conditions the Service (firmware, BIOS) | I | RA |
+| Produce, route, deliver and maintain physical Instances and hosting buildings | I | RA |
+| Install internal functional bricks needed to maintain in operational and security conditions the Service (firmware, BIOS) | I | RA |
 | Deploy the first network configuration on the Service  | I | RA |
 | Buy and hold licences and usage rights for Microsoft OS available on OVHcloud catalog | CI | RA |
 | Buy and hold licences and usage rights for others OS used | RA |  |
@@ -65,7 +65,7 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 | Install security bricks and tools needed following needs | RA |  |
 | Administrate applications installed on Instances | RA |   |
 | Manage backups | RA |  |
-| Manage backups following Customer request (optionnal) | CI | RA |
+| Manage backups following Customer request (optional) | CI | RA |
 
 ##### **3.1.2. Access management**
 
@@ -81,7 +81,7 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 | --- | --- | --- |
 | Manage and monitor physical servers capacity in support of Public Cloud services |  | RA |
 | Manage and monitor Public Cloud services capacity | RA |  |
-| Monitor the functionning of softwares installed on Instances | RA |  |
+| Monitor the functioning of softwares installed on Instances | RA |  |
 | Retain logs of control plane for Instances monitoring (API, hypervisor) |  | RA |
 | Retain logs of Information System hosted on Instances| RA |  |
 | Monitor the proper functioning of physical devices (utilities) in support of the service | I | RA |

--- a/docs/en/guides/public-cloud/compute/storage-classic-multi-attach-3az.mdx
+++ b/docs/en/guides/public-cloud/compute/storage-classic-multi-attach-3az.mdx
@@ -33,7 +33,7 @@ In the OVHcloud Control Panel, simply select the classic volume available in the
 
 <img className="thumbnail" alt="classic 3az block volume" src="/images/public-cloud/compute/classic-block-multi-az-limitations/create_volume_type.png" loading="lazy" />
 
-##  Considerations
+## Considerations
 
 When working with Classic Multi-Attach in 3AZ regions, the following points should be taken into account:
 

--- a/docs/en/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/en/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -66,7 +66,8 @@ The process of attaching the disk to your instance will then begin, and this may
 <img className="thumbnail" alt="attaching volume" src="/images/public-cloud/compute/create-volume-from-snapshot/volume05.png" loading="lazy" />
 
 :::warning
-Make sure to not leave the current page in your OVHcloud Control Panel while the disk is being attached. This may interrupt the process.
+>
+> Make sure to not leave the current page in your OVHcloud Control Panel while the disk is being attached. This may interrupt the process.
 :::
 
 Once the attachment is complete, you can follow these steps on how to configure the additional disk [using Linux](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#using-linux) or [using Windows](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#using-windows).

--- a/docs/en/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/en/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -67,7 +67,7 @@ A state is composed of several files inside a `.pulumi` folder:
 - `meta.yaml`: This is the metadata file. It does not hold information about the stacks but rather information about the backend itself.
 - `stacks/`: Active state files for each stack (e.g. `dev.json`).
 - `locks/`: Optional lock files for each stack if the stack is currently being operated on by a Pulumi operation (e.g. `dev/$lock.json`).
-- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json`vwhere $timestamp records the time the history file was created).
+- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json` where $timestamp records the time the history file was created).
 
 ## Instructions
 

--- a/docs/en/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
@@ -192,7 +192,7 @@ Each Local Zone operates as a single availability zone with a limited set of ser
 
 - **Reduced latency:** Local Zones ensure fast response times to users close to them, ideal for real-time applications such as online gaming or video conferencing.
 - **Local compliance:** Data can be processed and stored in specific locations, making it easier to comply with location and regulatory requirements.
-- **Regional extension:** Local Zones can be used as an extension of the 1-AZ or 3-AZ regions to complete critical workloads locally, while benefiting from additionnal services available in the regions.
+- **Regional extension:** Local Zones can be used as an extension of the 1-AZ or 3-AZ regions to complete critical workloads locally, while benefiting from additional services available in the regions.
 
 #### Limits
 

--- a/docs/en/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -132,7 +132,7 @@ Once your infrastructure is deployed, two possibilities:
 - Use Ansible playbooks to automatically install and configure your applications.
 - Set up your services manually on each instance.
 
-Be sure to use the same applications versions as in your source environment to ensure compatibility with your existing data.
+Be sure to use the same application versions as in your source environment to ensure compatibility with your existing data.
 
 Once configuration is complete, migrate your data using tools like rsync, scp, or database utilities, and validate that everything is working as expected.
 
@@ -166,7 +166,7 @@ After migrating, update all your applications to use the new endpoints, includin
 
 Make sure every connection points to the correct OVHcloud resources.
 
-Then, thoroughly test your entire workflow and run all integration tests to verify that your applications works correctly in the new environment.
+Then, thoroughly test your entire workflow and run all integration tests to verify that your applications work correctly in the new environment.
 
 ### 10. Update DNS records
 

--- a/docs/en/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
+++ b/docs/en/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
@@ -57,7 +57,7 @@ This solution preserves the flexibility of a single stretched VLAN while enforci
 
 ## Use case examples
 
-Here are some practical scenarios where extending a OVHcloud private network across regions or integrating with other OVHcloud products can solve real-world challenges.
+Here are some practical scenarios where extending an OVHcloud private network across regions or integrating with other OVHcloud products can solve real-world challenges.
 
 - **Database on Bare Metal & Application on Public Cloud:** Connect a Bare Metal database server with applications running in Public Cloud regions using the same VLAN without IP conflicts.
 - **DHCP as a Service for Bare Metal Servers:** Assign IPs from Public Cloud networks to Bare Metal servers via DHCP for seamless integration.

--- a/docs/en/guides/public-cloud/network-services/loadbalancer-update-size.mdx
+++ b/docs/en/guides/public-cloud/network-services/loadbalancer-update-size.mdx
@@ -43,7 +43,7 @@ Once you are logged in, go to the <code className="action">Load Balancer</code> 
 
 ### Step 3 - Edit the Load Balancer
 
-Click the down arrow button on the right side of your load Balancer entry.
+Click the down arrow button on the right side of your Load Balancer entry.
 
 Select <code className="action">Edit Load Balancer</code> in the dropdown menu.
 

--- a/docs/en/guides/public-cloud/network-services/migrate-additional-ip.mdx
+++ b/docs/en/guides/public-cloud/network-services/migrate-additional-ip.mdx
@@ -60,7 +60,7 @@ Click on the drop-down menu to choose the destination instance from the list.
 
 Confirm by clicking on <code className="action">Attach</code>.
 
-After a few seconds, the Control Panel will be updated and a confirmation message will be displayed if the migration was done sucessfully.
+After a few seconds, the Control Panel will be updated and a confirmation message will be displayed if the migration was done successfully.
 
 <img className="thumbnail" alt="migrating Additional IP" src="/images/public-cloud/network-services/additional-ip-migrate/migrateip_03.png" loading="lazy" />
 

--- a/docs/en/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/en/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2024-01-22
 
 ## Objective
 
-This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the pre requisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
+This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the prerequisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
 
 For this example, we will use a private network and a subnet with the following properties:
 
@@ -44,7 +44,7 @@ Click the `Subnets` tab: the subnets from the private network are listed.
 
 Click on your `Edit Subnet`. For this guide, our target is to add a gateway IP:
 
-- Click untick the  `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
+- Untick the `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
 
 <img className="thumbnail" alt="gateway IP" src="/images/public-cloud/network-services/configuration-04-update-subnet/add_gateway_ip.png" loading="lazy" />
 

--- a/docs/en/guides/public-cloud/network-services/weight-load-balancer-member.mdx
+++ b/docs/en/guides/public-cloud/network-services/weight-load-balancer-member.mdx
@@ -246,7 +246,7 @@ If having a final **DRAINED** status is critical for your operations, it is reco
 
 ### Step 4 - Confirm Traffic is directed to the active member
 
-The member whose weight is 0 will have an	Operating Status `Draining`. Run the test script again:
+The member whose weight is 0 will have an Operating Status `Draining`. Run the test script again:
 
 ```bash
 #!/bin/sh

--- a/docs/es/guides/public-cloud/compute/apps-first-steps.mdx
+++ b/docs/es/guides/public-cloud/compute/apps-first-steps.mdx
@@ -77,7 +77,7 @@ Si su dominio está registrado en OVHcloud, puede seguir [esta guía](/guides/we
 
 <ol start="2">
   <li>Tal vez tengan que esperar 24 horas antes de que ambos registros se propaguen por completo. Todavía puede comprobarlo con <a href="https://mxtoolbox.com/DnsLookup.aspx">mxtoolbox</a>. Si la dirección IP de su dominio aparece en mxtoolbox del mismo modo que la de su servidor, puede pasar a la siguiente etapa.</li>
-  <li>Conéctese al servidor por SSH con el usuario CentOS y ejecute los siguientes comandos para instalar Cura:</li>
+  <li>Conéctese al servidor por SSH con el usuario CentOS y ejecute los siguientes comandos para instalar Certbot:</li>
 </ol>
 
 :::warning
@@ -95,7 +95,7 @@ systemctl restart httpd
 ```
 
 <ol start="4">
-  <li> Genere su certificado SSL utilizando Cura (siga las indicaciones en pantalla).</li>
+  <li> Genere su certificado SSL utilizando Certbot (siga las indicaciones en pantalla).</li>
 </ol>
 
 ```sh
@@ -104,7 +104,7 @@ certbot certonly -d personaldomain.ovh --webroot
 
 Al introducir "Input the webroot", debe introducir una variable del tipo "/var/www/wordpress". Si instala Joomla!, debe sustituir "wordpress" por "joomla".
 
-Ahora debe asegurarse de que Cierbot también sitúe esta variable en el archivo ssl.conf. Para ello, introduzca:
+Ahora debe asegurarse de que Certbot también sitúe esta variable en el archivo ssl.conf. Para ello, introduzca:
 
 ```sh
 certbot -d personaldomain.ovh —apache

--- a/docs/es/guides/public-cloud/compute/change-project-contacts.mdx
+++ b/docs/es/guides/public-cloud/compute/change-project-contacts.mdx
@@ -50,7 +50,7 @@ En la nueva ventana, indique el ID de cliente que quiera modificar para cada con
 
 <img className="thumbnail" alt="change-contacts" src="/images/public-cloud/compute/change-project-contacts/contactchange1.png" loading="lazy" />
 
-Una vez que haga clic en el botón <code className="action">Aceptar</code>, las dos cuentas de OVHcloud afectadas por la modificación recibirán un mensaje de correo electrónico de confirmación. Este mensaje de correo electrónico contiene un código(token) que permite confirmar el cambio de contacto en la pestaña <code className="action">Mis solicitudes</code> de la sección **Gestión de contactos**.
+Una vez que haga clic en el botón <code className="action">Aceptar</code>, las dos cuentas de OVHcloud afectadas por la modificación recibirán un mensaje de correo electrónico de confirmación. Este mensaje de correo electrónico contiene un código (token) que permite confirmar el cambio de contacto en la pestaña <code className="action">Mis solicitudes</code> de la sección **Gestión de contactos**.
 
 Para más información, consulte nuestra guía [Gestionar los contactos de los servicios](/guides/account-and-service-management/account-information/managing-contacts).
 

--- a/docs/es/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -96,6 +96,6 @@ sudo cat /etc/hosts
 127.0.0.1 localhost
 ```
 
-## Más información 
+## Más información
 
 Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).

--- a/docs/es/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
+++ b/docs/es/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
@@ -133,7 +133,7 @@ Por motivos de seguridad y buenas prácticas, no es necesario que varios usuario
 sudo nano /home/user2/.ssh/authorized_keys
 ```
 
-Pegue **cadena de clave pública** en este archivo. Guarde el archivo y salga del editor.
+Pegue la **cadena de clave pública** en este archivo. Guarde el archivo y salga del editor.
 
 Reinicie su instancia (`sudo reboot`) o reinicie únicamente el servicio OpenSSH con uno de los siguientes comandos (el comando adecuado puede variar en función del sistema operativo):
 

--- a/docs/es/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/es/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -25,7 +25,7 @@ You'll need an [OVHcloud Public Cloud project](/guides/public-cloud/cross-functi
 
 ### Install Packer
 
-Packer can be downloaded from the official website (curently [here](https://www.packer.io/downloads.html) ) and you'll need to `unzip` it.
+Packer can be downloaded from the official website (currently [here](https://www.packer.io/downloads.html) ) and you'll need to `unzip` it.
 
 For Linux 64bits
 
@@ -92,7 +92,7 @@ export NETWORK_ID=`openstack network list -f json | jq -r '.[] | select(.Name ==
 
 **INFO**: for `FLAVOR_ID`, you can directly use the name, ie `b2-7`
 
-Finaly, create a `packer.json` file
+Finally, create a `packer.json` file
 
 ```shell
 cat > packer.json <<EOF
@@ -129,7 +129,7 @@ cat > packer.json <<EOF
 EOF
 ```
 
-In the last selection of the configuration file, we specify a `setup_vm.sh` shell script to be ran.
+In the last selection of the configuration file, we specify a `setup_vm.sh` shell script to be run.
 
 ```sh
 #!/bin/sh
@@ -149,7 +149,7 @@ git clone ...
 
 ## Building the image
 
-Using the configuration file create above, check it and build the image with
+Using the configuration file created above, check it and build the image with
 
 ```shell
 packer validate packer.json

--- a/docs/es/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/es/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -97,7 +97,7 @@ Introduzca la información solicitada. Si necesita ayuda para completar los dist
 |---|---|
 |Boot Source|Haga clic en la flecha desplegable para seleccionar el origen de inicio de una instancia (por ejemplo, "Image" o "Instance snapshot* (Instantánea de instancia)").|
 |Create New Volume|Puede marcar esta opción si desea crear un volumen en el que se copie la imagen de sistema operativo especificada.|
-|Volumen size (GB)|Si ha elegido crear un volumen, deje que el sistema determine el tamaño por usted.|
+|Volume size (GB)|Si ha elegido crear un volumen, deje que el sistema determine el tamaño por usted.|
 |Delete Volume on Instance Delete|Puede conservar la opción por defecto **No**. Si se selecciona **Yes**, al eliminar la instancia también se eliminará el volumen.|
 |Image name|Seleccione la imagen de la instancia (solo en el caso de un arranque desde una imagen) haciendo clic en la flecha arriba situada junto a la imagen que desee. En nuestro ejemplo, utilizamos una selección de CentOS 7.|
 |Instance snapshot|Elija una instantánea de una instancia (solo en caso de haber iniciado un snapshot) haciendo clic en la flecha arriba situada junto a la imagen de instantánea de instancia que desee.|

--- a/docs/es/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
+++ b/docs/es/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
@@ -35,7 +35,7 @@ Puede lanzar una imagen desde una URL o crear una personal haciendo clic en el b
 Cumplimente el formulario. Los campos marcados con asterisco (*) son obligatorios:
 
 - Image name (Nombre de la imagen) (\*) 
-- Image description (Descripción de la image)
+- Image description (Descripción de la imagen)
 - Image file (Fichero de imagen: seleccione el archivo en el equipo local)
 - Image format (Formato de la imagen) (\*):
 

--- a/docs/es/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/es/guides/public-cloud/compute/image-life-cycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud & VPS - Image and OS life cycle and end of life/support announcements
 description: Discover the lifecycle and end-of-life/end-of-support announcements for distributions and softwares for your VPS or Public Cloud instance
-lastUpdated: 2025-02-11
+lastUpdated: 2025-11-12
 ---
 
 ## Objective
@@ -70,7 +70,7 @@ Please note that:
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
 | 14 | [Forky](https://wiki.debian.org/DebianForky) | | | |
-| 13 | [Trixie](https://wiki.debian.org/DebianTrixie) | | | |
+| 13 | [Trixie](https://wiki.debian.org/DebianTrixie) | August 2025 | August 2028 | June 2030 |
 | 12 | [Bookworm](https://wiki.debian.org/DebianBookworm) | June 2023 | June 2026 | June 2028 |
 | 11 | [Bullseye](https://wiki.debian.org/DebianBullseye) | August 2021 | August 2024 | August 2026 |
 | 10 | [Buster](https://wiki.debian.org/DebianBuster) | July 2019 | September 2022 | June 2024 |

--- a/docs/es/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -55,7 +55,7 @@ Una vez completada la instalación, la interfaz de línea de comandos (CLI) most
 
 - Se generan dos URL:
     - Una con la dirección IP del servidor (en HTTPS con un certificado SSL autofirmado, que puede activar una alerta de seguridad en algunos navegadores).
-    - El otro con un dominio Plesk (en HTTPS con un certificado SSL firmado, sin alerta de seguridad).
+    - La otra con un dominio Plesk (en HTTPS con un certificado SSL firmado, sin alerta de seguridad).
     - Ambas son seguras, pero se recomienda usar la segunda.
 - Un mensaje dice: "También puede conectarse como 'root' con su contraseña 'root'." Sin embargo, por defecto no se genera ninguna contraseña root. Si es necesario, los clientes pueden seguir [esta guía](/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds) para activar el usuario root y establecer una contraseña.
 
@@ -70,8 +70,7 @@ OVHcloud no comercializa licencias de Plesk para la solución Public Cloud. No o
 :::
 
 
-¿Desea cambiar su licencia, por ejemplo para sustituir una llave de prueba o para cambiar su oferta? Desde el interfaz de Plesk, vaya a <code className="action">Tools & Settings</code>. En la sección **Plesk**, seleccione <code className="action">License information</code>.
-Para añadir su licencia de Plesk, necesitará 
+¿Desea cambiar su licencia, por ejemplo para sustituir una llave de prueba o para cambiar su oferta? Desde la interfaz de Plesk, vaya a <code className="action">Tools & Settings</code>. En la sección **Plesk**, seleccione <code className="action">License information</code>.
 
 
 ## Más información

--- a/docs/es/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/es/guides/public-cloud/compute/install-wordpress.mdx
@@ -87,7 +87,7 @@ Para ejecutarlo, introduzca el siguiente comando:
 debian@instance:~$ sudo mariadb-secure-installation
 ```
 
-Confirme el primer salto pulsando <code className="action">Entrar</code>.
+Confirme el primer prompt pulsando <code className="action">Entrar</code>.
 
 A continuación, seleccione una forma de proteger los accesos al servidor de bases de datos.
 
@@ -97,13 +97,13 @@ Switch to unix_socket authentication [Y/n]
 
 Le recomendamos que utilice el método de autenticación propuesto en lugar del acceso mediante contraseña root. Pulse <code className="action">y</code> y, a continuación, <code className="action">Entrar</code>. (Si decide utilizar el acceso de usuario root, escriba <code className="action">n</code> y establezca una contraseña root).
 
-Introduzca <code className="action">n</code> en el siguiente comando:
+Introduzca <code className="action">n</code> en el siguiente aviso:
 
 ```console
 Change the root password? [Y/n]
 ```
 
-Las siguientes visitas relativas a las medidas de seguridad, confírmelas todas con <code className="action">y</code> hasta el final del script.
+Los siguientes avisos relativos a las medidas de seguridad, confírmelos todos con <code className="action">y</code> hasta el final del script.
 
 Si ha configurado el acceso MariaDB como se recomienda (*unix_socket*), dispondrá de un acceso de administrador automático (*root*) cada vez que se conecte al servidor como usuario con altos permisos (*sudo*).
 
@@ -215,7 +215,7 @@ También puede abrir `http://IP_de_su_instancia` en un navegador web. Se abrirá
 
 Los siguientes pasos instalarán WordPress sustituyendo la carpeta Apache predeterminada para las páginas web.
 
-En lugar de utilizar la carpeta predeterminada, también puede crear un nuevo *Virtual Host* para instalar WordPress. Este tutorial es útil para alojar varios sitios web, lo que no es relevante para este tutorial.
+En lugar de utilizar la carpeta predeterminada, también puede crear un nuevo *Virtual Host* para instalar WordPress. Esta opción es útil para alojar varios sitios web, lo que no es relevante para este tutorial.
 
 Elimine la carpeta existente:
 
@@ -259,7 +259,7 @@ Como alternativa, OVHcloud le ofrece la solución [SSL Gateway](https://www.ovhc
 :::
 
 
-### Paso 6: (opcional): activar conexiones seguras con Let's Encrypt
+### Paso 6 (opcional): activar conexiones seguras con Let's Encrypt
 
 En primer lugar, compruebe que el dominio dispone de los registros adecuados en la zona DNS, es decir, que apunta a la dirección IP de la instancia.
 
@@ -283,7 +283,7 @@ debian@instance:~$ sudo certbot --apache -d domainname.ovh -d www.domainname.ovh
 
 Introduzca una dirección de correo electrónico válida y acepte las condiciones de uso.
 
-Algunos renovarán automáticamente los certificados. No es necesario realizar ninguna otra etapa. No obstante, puede consultar las opciones disponibles para saber más sobre las funcionalidades de Certbot.
+Certbot renovará automáticamente los certificados. No es necesario realizar ninguna otra etapa. No obstante, puede consultar las opciones disponibles para saber más sobre las funcionalidades de Certbot.
 
 ## Más información
 

--- a/docs/es/guides/public-cloud/compute/key-concepts.mdx
+++ b/docs/es/guides/public-cloud/compute/key-concepts.mdx
@@ -10,7 +10,7 @@ Esta guía tiene como objetivo brindarle una comprensión clara de los conceptos
 
 ## ¿Qué es una instancia (Máquina Virtual)?
 
-Una instancia, o Máquina Virtual (VM), es un servidor completamente aislado que se ejecuta en la infraestructura física compartida de OVHcloud. Funciona como un servidor tradicional, pero ofrece la flexibilidad y escalabilidad de la nube. Usted elige el sistema operativo, define los recursos de CPU, RAM y Almacenamiento, y despliega sus aplicaciones, sitios web o entornos de desarrollo.
+Una instancia, o Máquina Virtual (VM), es un servidor completamente aislado que se ejecuta en la infraestructura física compartida de OVHcloud. Funciona como un servidor tradicional, pero ofrece la flexibilidad y escalabilidad de la nube. Usted elige el sistema operativo, define los recursos de CPU, RAM y almacenamiento, y despliega sus aplicaciones, sitios web o entornos de desarrollo.
 
 Las instancias de Public Cloud Compute ofrecen:
 
@@ -27,9 +27,9 @@ OVHcloud ofrece varias familias de instancias diseñadas para satisfacer diferen
 | Tipos de instancias  | Descripción                      | Casos de uso típicos                                                                                                                                                        |
 | ------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | General            | Equilibrio entre CPU y Memoria         | Adecuado para servidores de desarrollo, aplicaciones web y cargas de trabajo empresariales generales. Proporciona una relación equilibrada entre CPU y RAM.                                            |
-| CPU optimizada     | Alta rendimiento del procesador     | Ideal para aplicaciones intensivas en cálculo, tareas de procesamiento paralelo, pipelines CI/CD o microservicios que requieren una alta frecuencia de CPU.                                     |
+| CPU optimizada     | Alto rendimiento del procesador     | Ideal para aplicaciones intensivas en cálculo, tareas de procesamiento paralelo, pipelines CI/CD o microservicios que requieren una alta frecuencia de CPU.                                     |
 | Memoria optimizada | Alta capacidad de memoria          | Diseñado para análisis de datos, cargas de trabajo de big data y caché de bases de datos. Presenta altas relaciones memoria/CPU y IOPS acelerados. Los núcleos virtuales están a 2 GHz o más.       |
-| Almacenamiento optimizado | Alta rendimiento IOPS           | Equipado con almacenamiento NVMe para E/S de disco ultrarrápidas, ideal para bases de datos y aplicaciones de big data.                                                                     |
+| Almacenamiento optimizado | Alto rendimiento IOPS           | Equipado con almacenamiento NVMe para E/S de disco ultrarrápidas, ideal para bases de datos y aplicaciones de big data.                                                                     |
 | GPU                | Gráficos acelerados por hardware      | Proporciona un rendimiento de cálculo paralelo excepcional, hasta 1000 veces más rápido que la CPU para ciertas cargas de trabajo. Adecuado para IA, aprendizaje profundo y renderizado 3D.               |
 | Descubrimiento     | Recursos compartidos, económico | Instancias de entrada con recursos compartidos, ofreciendo un rendimiento estable a un precio asequible. Ideal para entornos de prueba, formación o proyectos de demostración. | 
 
@@ -123,7 +123,7 @@ Los Savings Plans le permiten reducir sus costos de Public Cloud Compute a cambi
 **Ventajas clave:**
 
 - **Costos reducidos**: Más económico que la facturación en *pay-as-you-go*.
-- **Aplicación automática**: Las ahorros se aplican automáticamente a todas las instancias compatibles.
+- **Aplicación automática**: Los ahorros se aplican automáticamente a todas las instancias compatibles.
 - **Flexible**: Puede cambiar los tipos o tamaños de instancias manteniendo los beneficios de su plan.
 
 **Casos de uso ideales:**

--- a/docs/es/guides/public-cloud/compute/migration-between-regions.mdx
+++ b/docs/es/guides/public-cloud/compute/migration-between-regions.mdx
@@ -9,7 +9,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objetivo
 
-Este guía explica cómo migrar una instancia de Public Cloud de una zona de disponibilidad (AZ) a otra, de 1AZ a 3AZ o viceversa. Centraliza los pasos clave (backup, transferencia y recreación) y redirige a los guías detallados para cada elemento.
+Esta guía explica cómo migrar una instancia de Public Cloud de una zona de disponibilidad (AZ) a otra, de 1AZ a 3AZ o viceversa. Centraliza los pasos clave (backup, transferencia y recreación) y redirige a las guías detalladas para cada elemento.
 
 ## Requisitos
 
@@ -60,7 +60,7 @@ El backup de una instancia puede realizarse:
 - a través de la CLI OpenStack.
 - a través de Horizon.
 
-Encuentre toda la información detallada en la sección **Crear una copia de seguridad de una instancia** de nuestro guía "[Guardar una instancia](/guides/public-cloud/compute/save-an-instance)".
+Encuentre toda la información detallada en la sección **Crear una copia de seguridad de una instancia** de nuestra guía "[Guardar una instancia](/guides/public-cloud/compute/save-an-instance)".
 
 ### Paso 2. Migrar el backup a otra región
 
@@ -86,7 +86,7 @@ La restauración de la instancia en la nueva región puede realizarse:
 - a través de la CLI OpenStack.
 - a través de Horizon.
 
-Encuentre toda la información detallada en la sección **Crear o restaurar un servidor virtual a partir de un snapshot** de nuestro guía "[Restaurar una instancia desde una copia de seguridad](/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup)".
+Encuentre toda la información detallada en la sección **Crear o restaurar un servidor virtual a partir de un snapshot** de nuestra guía "[Restaurar una instancia desde una copia de seguridad](/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup)".
 
 ## Más información
 

--- a/docs/es/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/es/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -89,7 +89,7 @@ EEFFFFFFFFFFFFFGGGGGGGGGGGGGhhhhhhhhhhhhhhhhhhhhhhhhhh== new@sshkey
 
 Por motivos de seguridad, quite la cadena de clave obsoleta "old" del archivo. Guarde los cambios y salga del editor.
 
-Reinicie la instancia en modo normal desde su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>. Consulte las instrucciones de [guide sur le mode rescue](/guides/public-cloud/compute/put-an-instance-in-rescue-mode) si es necesario.
+Reinicie la instancia en modo normal desde su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>. Consulte las instrucciones de [guía sobre el modo rescue](/guides/public-cloud/compute/put-an-instance-in-rescue-mode) si es necesario.
 
 Ya puede acceder a la instancia con su nuevo par de claves SSH.
 

--- a/docs/es/guides/public-cloud/compute/resize-instance-openstack.mdx
+++ b/docs/es/guides/public-cloud/compute/resize-instance-openstack.mdx
@@ -59,7 +59,7 @@ $ openstack server list
 
 ### Lista de modelos <a name="flavorlist"></a>
 
-A continuación, deberá ver la lista de modelos (*flavors*) disponibles en su región para recuperar el ID de la nueva plantilla. En nuestro ejemplo, queremos redimensionar nuestra instancia en un modelo b2-30 con ID `09889e6-d1fc-4967-baea-19fd97fd83a8`.
+A continuación, deberá ver la lista de modelos (*flavors*) disponibles en su región para recuperar el ID de la nueva plantilla. En nuestro ejemplo, queremos redimensionar nuestra instancia en un modelo b2-30 con ID `098889e6-d1fc-4967-baea-19fd97fd83a8`.
 
 ```bash
 $ openstack flavor list

--- a/docs/es/guides/public-cloud/compute/share-images-between-projects.mdx
+++ b/docs/es/guides/public-cloud/compute/share-images-between-projects.mdx
@@ -20,7 +20,7 @@ Por ejemplo, si desea compartir una imagen de un proyecto A con un proyecto B (e
 
 Por lo tanto, es importante tener esto en cuenta antes de comprometerse con esta configuración.
 
-Para más informaciónes, consulte la [documentación oficial de OpenStack](https://docs.openstack.org/image-guide/share-images.html).
+Para más información, consulte la [documentación oficial de OpenStack](https://docs.openstack.org/image-guide/share-images.html).
 
 **Esta guía explica cómo compartir imágenes entre uno o varios proyectos, conservando al mismo tiempo la configuración y el estado de la imagen.**
 

--- a/docs/es/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/es/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -69,7 +69,8 @@ El proceso de vinculación del disco a la instancia comenzará en ese momento y 
 <img className="thumbnail" alt="adjunto" src="/images/public-cloud/compute/create-volume-from-snapshot/volume05.png" loading="lazy" />
 
 :::warning
-Debe evitar la navegación fuera de la pestaña en curso al asociar el disco. Esto puede interrumpir el proceso.
+>
+> Debe evitar la navegación fuera de la pestaña en curso al asociar el disco. Esto puede interrumpir el proceso.
 :::
 
 Una vez realizado el apego, puede seguir los siguientes pasos [en Linux](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#con-linux) o [Windows](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#con-windows).

--- a/docs/es/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
+++ b/docs/es/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
@@ -55,7 +55,7 @@ Le recomendamos que realice los snapshots fuera de su horario de producción.
 
 Estas son algunas de las buenas prácticas:
 
-- Evite crear snapshots en las horas punta (entre las 04:00 y las 22:00, hora de París).
+- evite crear snapshots en las horas punta (entre las 04:00 y las 22:00, hora de París).
 - instale el agente qemu-guest si no lo ha hecho o intente desactivarlo si es necesario;
 - intente no "solicitar" demasiado al servidor durante la fase de creación del snapshot (limitación de I/O, consumo de RAM, etc.).
 

--- a/docs/es/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/es/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -67,7 +67,7 @@ A state is composed of several files inside a `.pulumi` folder:
 - `meta.yaml`: This is the metadata file. It does not hold information about the stacks but rather information about the backend itself.
 - `stacks/`: Active state files for each stack (e.g. `dev.json`).
 - `locks/`: Optional lock files for each stack if the stack is currently being operated on by a Pulumi operation (e.g. `dev/$lock.json`).
-- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json`vwhere $timestamp records the time the history file was created).
+- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json` where $timestamp records the time the history file was created).
 
 ## Instructions
 

--- a/docs/es/guides/public-cloud/cross-functional/compute-essential-information.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/compute-essential-information.mdx
@@ -137,7 +137,7 @@ En la práctica, a continuación le ofrecemos algunas guías que le ayudarán en
 |[Crear la primera instancia](/guides/public-cloud/compute/getting-started)|Esta es la primera guía práctica para iniciar un servidor cloud desde el área de cliente de OVHcloud.|
 |[Uso de una llave SSH](/guides/public-cloud/compute/creating-ssh-keys)| Para conectarse a una instancia Linux, necesitará utilizar una conexión SSH en esta guía.|
 |[Configuración de la red privada](/guides/public-cloud/network-services/vrack)|En OVHcloud, la tecnología vRack utiliza las redes privadas. Esta guía le ayudará a realizar esta operación.|
-|[Asociar un disco adicional a una instancia](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)|Esta guía explica cómo añadir almacenamiento adicional a la primera instancia de OVH.|
+|[Asociar un disco adicional a una instancia](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)|Esta guía explica cómo añadir almacenamiento adicional a la primera instancia de OVHcloud.|
 |[Conectarse a Horizon](/guides/public-cloud/cross-functional/introducing-horizon)|La interfaz Horizon de OpenStack permite realizar determinadas acciones avanzadas. Así es como conectarse a ella.|
 |[Crear un cluster Kubernetes](/guides/public-cloud/containers-orchestration/managed-kubernetes/create-cluster) (EN)|Esta guía le ayudará paso a paso a la creación de su primer cluster Kubernetes.|
 |[Configurar una Additional IP](/guides/public-cloud/network-services/configure-additional-ip)|Las Additional IP permiten cambiar el tráfico de una instancia a otra. Esta guía explica cómo configurar esta opción.|

--- a/docs/es/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
@@ -42,7 +42,7 @@ Esta sección permite almacenar y gestionar pares de claves SSH. Simplemente pue
 
 <img className="thumbnail" alt="horizon - llaves SSH" src="/images/public-cloud/cross-functional/access-and-security-in-horizon/key_pairs.png" loading="lazy" />
 
-Si desea añadir una llave preexistente, haga clic en <code className="action">Importar Public Key</code>. Se abrirá una ventana en la que podrá introducir una clave o seleccionar un archivo de claves.
+Si desea añadir una llave preexistente, haga clic en <code className="action">Import Public Key</code>. Se abrirá una ventana en la que podrá introducir una clave o seleccionar un archivo de claves.
 
 Esta sección de la interfaz contiene instrucciones básicas. Para más información sobre las llaves SSH, consulte [esta guía](/guides/public-cloud/compute/creating-ssh-keys).
 

--- a/docs/es/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
@@ -157,7 +157,7 @@ brew install openstackclient
 Para acceder a las herramientas de ayuda, ejecute el siguiente comando:
 
 ```sh
-openstack —-help
+openstack --help
 nova help
 ```
 

--- a/docs/es/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
@@ -87,7 +87,7 @@ A continuación, haga clic en el botón <code className="action">Change</code> p
 
 <img className="thumbnail" alt="Configuración de la contraseña" src="/images/public-cloud/cross-functional/create-and-delete-a-user/3_H_set_new_passord.png" loading="lazy" />
 
-Tenga en cuenta que, al cambiar la contraseña de una cuenta de usuario, se cancela inmediatamente lla contraseña anteriormente utilizada.
+Tenga en cuenta que, al cambiar la contraseña de una cuenta de usuario, se cancela inmediatamente la contraseña anteriormente utilizada.
 
 ### Eliminación del usuario OpenStack
 

--- a/docs/es/guides/public-cloud/cross-functional/managing-tokens.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/managing-tokens.mdx
@@ -24,7 +24,7 @@ Keystone.
 
 ### Principio global
 
-La mayoría de las solicitudes presentadas a las API de OpenStack deben responder a un mecanismo de autorización. Este mecanismo funciona mediante la obtención de token (jeon en francés) y validación de este. A continuación explicamos cómo funciona una llamada desde la autenticación hasta la ejecución de la llamada.
+La mayoría de las solicitudes presentadas a las API de OpenStack deben responder a un mecanismo de autorización. Este mecanismo funciona mediante la obtención de token (jeton en francés) y validación de este. A continuación explicamos cómo funciona una llamada desde la autenticación hasta la ejecución de la llamada.
 
 - Solicitud de creación de token en el punto de autenticación con los credentials
 - Consulta sobre el punto del servicio deseado (almacenamiento, compute, network...) proporcionando el token como parámetro
@@ -145,7 +145,7 @@ curl -X GET $endpoint/photos/fullsize/ovh-summit-2014-backstage-DS.jpg -H "X-Aut
 
 - -X GET: Método HTTP GET
 - $endpoint/photos/fullsize/ovh-summit-2014-backstage-DS.jpg: dirección del objeto
-- -H "X-Auth-Token": $token": elemento de autenticación
+- -H "X-Auth-Token: $token": elemento de autenticación
 - -I: opción curl para obtener solo las metadatas
 
 La respuesta es:

--- a/docs/es/guides/public-cloud/network-services/migrate-additional-ip.mdx
+++ b/docs/es/guides/public-cloud/network-services/migrate-additional-ip.mdx
@@ -56,7 +56,7 @@ En la columna izquierda, haga clic en **Network** y abra la sección <code class
 
 En este ejemplo, la dirección Additional IP enrutada a "Instancia_A" será migrada a "Instancia_B".
 
-Haga clic en <code className="action">...</code> en la línea de la Directorial IP y seleccione <code className="action">Editar la instancia asociada</code>.
+Haga clic en <code className="action">...</code> en la línea de la Additional IP y seleccione <code className="action">Editar la instancia asociada</code>.
 
 <img className="thumbnail" alt="Migrating Additional IP" src="/images/public-cloud/network-services/additional-ip-migrate/migrateip_01.png" loading="lazy" />
 

--- a/docs/es/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/es/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2024-01-22
 
 ## Objective
 
-This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the pre requisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
+This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the prerequisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
 
 For this example, we will use a private network and a subnet with the following properties:
 
@@ -44,7 +44,7 @@ Click the `Subnets` tab: the subnets from the private network are listed.
 
 Click on your `Edit Subnet`. For this guide, our target is to add a gateway IP:
 
-- Click untick the  `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
+- Untick the `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
 
 <img className="thumbnail" alt="gateway IP" src="/images/public-cloud/network-services/configuration-04-update-subnet/add_gateway_ip.png" loading="lazy" />
 

--- a/docs/fr/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
+++ b/docs/fr/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
@@ -45,7 +45,7 @@ Dirigez-vous ensuite dans <code className="action">Compute</code>, puis <code cl
 
 <img className="thumbnail" alt="compute et instance" src="/images/public-cloud/compute/activate-windows-license-private-mode/horizon2.png" loading="lazy" />
 
-Pour ajouter une interface, dans la colonne « Actions », cliquez sur la flèche permettant d’accéder aux actions possible sur l’instance. Cliquez alors sur <code className="action">Attach Interface</code> :
+Pour ajouter une interface, dans la colonne « Actions », cliquez sur la flèche permettant d’accéder aux actions possibles sur l’instance. Cliquez alors sur <code className="action">Attach Interface</code> :
 
 <img className="thumbnail" alt="attach interface" src="/images/public-cloud/compute/activate-windows-license-private-mode/horizon3.png" loading="lazy" />
 
@@ -155,9 +155,9 @@ openstack server add port <server_id> <port_id>
 
 #### Activer votre système Windows
 
-Pour pourvoir activer votre système Windows, vous devez passer par Powershell.
+Pour pouvoir activer votre système Windows, vous devez passer par PowerShell.
 
-Une fois connecté à votre instance Windows, faites un clic droit sur le menu <code className="action">Démarrer</code> et sélectionnez <code className="action">Windows Powershell</code>.
+Une fois connecté à votre instance Windows, faites un clic droit sur le menu <code className="action">Démarrer</code> et sélectionnez <code className="action">Windows PowerShell</code>.
 
 Renseignez la commande suivante :
 

--- a/docs/fr/guides/public-cloud/compute/apps-first-steps.mdx
+++ b/docs/fr/guides/public-cloud/compute/apps-first-steps.mdx
@@ -98,7 +98,7 @@ certbot certonly -d personaldomain.ovh --webroot
 
 Lorsque vous êtes invité à saisir « Input the webroot », vous devez saisir une variable du type « /var/www/wordpress ». Si vous installez Joomla!, vous devez remplacer « wordpress » par « joomla ».
 
-Vous devez maintenant faire en sorte que Certbot place également cette variable dans le fichier ssl.conf. Pour cela, entrez:
+Vous devez maintenant faire en sorte que Certbot place également cette variable dans le fichier ssl.conf. Pour cela, entrez :
 
 ```sh
 certbot -d personaldomain.ovh --apache
@@ -228,7 +228,7 @@ Vous trouverez ci-dessous les premières étapes relatives à la mise en service
 
 Aucune autre étape n'est nécessaire pour terminer la première configuration de cette application.
 
-## Allez plus loin
+## Aller plus loin
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 

--- a/docs/fr/guides/public-cloud/compute/change-project-contacts.mdx
+++ b/docs/fr/guides/public-cloud/compute/change-project-contacts.mdx
@@ -7,7 +7,7 @@ lastUpdated: 2025-04-28
 ## Objectif
 
 Vous pouvez modifier les contacts administrateur et facturation d'un projet Public Cloud dans votre espace client.<br/>
-La modification de ces contacts permet de dissocier la gestion technique de la gestion facturation, pour les services d'un projet .
+La modification de ces contacts permet de dissocier la gestion technique de la gestion facturation, pour les services d'un projet.
 
 **Ce guide vous explique comment modifier les contacts d'un projet Public Cloud dans votre espace client.**
 

--- a/docs/fr/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -95,6 +95,6 @@ sudo cat /etc/hosts
 127.0.0.1 localhost
 ```
 
-## Aller plus loin 
+## Aller plus loin
 
 Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).

--- a/docs/fr/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -365,7 +365,7 @@ Dans cet exemple, `vda` fait référence au disque par défaut de l'instance. Le
 
 Créez une partition sur le disque supplémentaire via les commandes ci-dessous.
 
-Si votre disque additionnel est inférieur à 2TB:
+Si votre disque additionnel est inférieur à 2TB :
 
 ```bash
 sudo fdisk /dev/vdb
@@ -399,7 +399,7 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Si votre disque additionnel est supérieur à 2TB:
+Si votre disque additionnel est supérieur à 2TB :
 
 ```bash
 sudo parted /dev/vdb

--- a/docs/fr/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
+++ b/docs/fr/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
@@ -40,7 +40,7 @@ Les opérations de **création** et de **restauration** d'une instance depuis un
 :::
 
 
-### Créer une instance a partir d'une sauvegarde
+### Créer une instance à partir d'une sauvegarde
 
 <Tabs>
   <Tab label="Via l'espace client OVHcloud">

--- a/docs/fr/guides/public-cloud/compute/create-server-group-horizon-cli.mdx
+++ b/docs/fr/guides/public-cloud/compute/create-server-group-horizon-cli.mdx
@@ -110,7 +110,7 @@ Dans les deux cas, cela est dû au fait que le déplacement de l'instance pourra
 
 ### Résolution des problèmes courants
 
-Si vous continuez à créer des instances au sein d'un groupe de serveurs avec une polique `anti affinity`, vous finirez par dépasser la quantité totale de nœuds compute dans la région.
+Si vous continuez à créer des instances au sein d'un groupe de serveurs avec une politique `anti affinity`, vous finirez par dépasser la quantité totale de nœuds compute dans la région.
 
 La commande réussira toujours, mais l'instance ne sera plus planifiée sur un nœud compute.
 

--- a/docs/fr/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
+++ b/docs/fr/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
@@ -9,7 +9,7 @@ L'ajout d'images personnalisées est possible via l'interface OpenStack Horizon.
 
 **Ce guide vous explique les différentes étapes de la création, du lancement et de la suppression d'images dans l'interface Horizon, depuis laquelle vous gérez vos services OVHcloud.**
 
-### Prérequis
+## Prérequis
 
 - [Créer un accès à Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 - Se rendre dans le menu Images de l'interface OpenStack Horizon

--- a/docs/fr/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -55,7 +55,7 @@ Certaines de ces opérations sont aussi accessibles depuis la page de gestion de
 
 Cliquez sur <code className="action">Modifier l’image</code> ou <code className="action">Modifier le modèle</code>.
 
-Vous pouvez également ouvrir <code className="action">Actions supplémentaires</code>, puis sélectionner <code className="action">Editer</code>.
+Vous pouvez également ouvrir <code className="action">Actions supplémentaires</code>, puis sélectionner <code className="action">Éditer</code>.
 
 La nouvelle page présente une version modifiée des options [de création d'instance](/guides/public-cloud/compute/first-steps-with-public-cloud-instance), dans laquelle vous pouvez modifier les éléments suivants :
 

--- a/docs/fr/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/fr/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -34,7 +34,7 @@ Si vous avez atteint la capacité maximale de votre disque supplémentaire, vous
 
 ## En pratique
 
-Les étapes suivantes supposent que vous avez déjà configuré un disque supplémentaire selon les intrusctions de [notre guide](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
+Les étapes suivantes supposent que vous avez déjà configuré un disque supplémentaire selon les instructions de [notre guide](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
 
 ## Monitorer l'utilisation du disque avant le redimensionnement
 
@@ -120,7 +120,7 @@ Cliquez sur <code className="action">Block Storage</code> dans le menu de gauche
 
 Si le volume est attaché à une **instance Windows**, cliquez sur le bouton <code className="action">...</code> à droite du volume concerné et sélectionnez <code className="action">Détacher de l'instance</code>.
 
-Cliquez sur le bouton <code className="action">...</code> à droite du volume concerné et sélectionnez <code className="action">Editer</code>.
+Cliquez sur le bouton <code className="action">...</code> à droite du volume concerné et sélectionnez <code className="action">Éditer</code>.
 
 <img className="thumbnail" alt="tableau de bord" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-02.png" loading="lazy" />
 
@@ -128,7 +128,7 @@ Dans la fenêtre qui apparaît, indiquez la nouvelle taille du volume et cliquez
 
 <img className="thumbnail" alt="tableau de bord" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-03.png" loading="lazy" />
 
-### Etendre la partition (instance Linux)
+### Étendre la partition (instance Linux)
 
 Ouvrez une connexion SSH à votre instance pour ajuster la partition au disque redimensionné.
 
@@ -222,7 +222,7 @@ tmpfs 982M 0 982M 0% /sys/fs/cgroup
 
 Une fois cette opération terminée, détachez le volume de l'instance et rattachez-le afin de vous assurer que les paramètres QoS mis à jour (IOPS et bande passante) soient correctement appliqués.
 
-### Etendre la partition (instance Windows)
+### Étendre la partition (instance Windows)
 
 Avant de continuer, rattachez le volume à l'instance. Cliquez sur <code className="action">...</code> dans la ligne du volume et sélectionnez <code className="action">Attacher à l'instance</code>.
 

--- a/docs/fr/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -49,7 +49,7 @@ sudo sh <(curl https://autoinstall.plesk.com/plesk-installer || wget -O - https:
 
 Patientez ensuite le temps de l'installation. 
 
-### Étape 2 : finaliser la configuration et ajouter une license
+### Étape 2 : finaliser la configuration et ajouter une licence
 
 Une fois l’installation terminée, l’interface en ligne de commande (CLI) affichera les informations suivantes :
 

--- a/docs/fr/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/fr/guides/public-cloud/compute/install-wordpress.mdx
@@ -179,7 +179,7 @@ Vous pouvez aller plus loin avec l’UFW, par exemple si vous souhaitez restrein
 
 ### Étape 4 : installation de WordPress
 
-Rendez-vous sur le [site officiel de WordPress](https://wordpress.org/download/) afin de récupérer **l’URL de téléchargement** de la dernière version (au format « tar.gz ). Téléchargez ensuite le fichier :
+Rendez-vous sur le [site officiel de WordPress](https://wordpress.org/download/) afin de récupérer **l’URL de téléchargement** de la dernière version (au format « tar.gz »). Téléchargez ensuite le fichier :
 
 ```bash
 debian@instance:~$ wget https://wordpress.org/latest.tar.gz
@@ -255,7 +255,7 @@ La commande suivante installe une version de Certbot qui fonctionne mais est obs
 :::
 
 
-Installez les paquers nécessaires pour le client Certbot :
+Installez les paquets nécessaires pour le client Certbot :
 
 ```bash
 debian@instance:~$ sudo apt install certbot python3-certbot-apache

--- a/docs/fr/guides/public-cloud/compute/key-concepts.mdx
+++ b/docs/fr/guides/public-cloud/compute/key-concepts.mdx
@@ -6,11 +6,11 @@ lastUpdated: 2025-12-05
 
 ## Objectif
 
-Ce guide vise à vous donner une compréhension claire des concepts fondamentaux nécessaires à la création, à la configuration et à la gestion de vos premières instances OVHcloud Public Cloud Compute. Vous apprendrez comment fonctionnent les instances, comment choisir le bon type d'instance, et comment les éléments-clés tels que les images, les zones de disponibilité, le réseau, la Sécurité et les sauvegardes s'articulent au sein de l'écosystème OVHcloud.
+Ce guide vise à vous donner une compréhension claire des concepts fondamentaux nécessaires à la création, à la configuration et à la gestion de vos premières instances OVHcloud Public Cloud Compute. Vous apprendrez comment fonctionnent les instances, comment choisir le bon type d'instance, et comment les éléments-clés tels que les images, les zones de disponibilité, le réseau, la sécurité et les sauvegardes s'articulent au sein de l'écosystème OVHcloud.
 
 ## Qu'est-ce qu'une instance (Machine Virtuelle) ?
 
-Une instance, ou Machine Virtuelle (VM), est un serveur entièrement isolé s'exécutant sur l'infrastructure physique partagée d'OVHcloud. Elle fonctionne comme un serveur traditionnel, mais offre la flexibilité et l'évolutivité du cloud. Vous choisissez le système d'exploitation, définissez les ressources CPU, RAM et Stockage, et déployez vos applications, sites web ou environnements de développement.
+Une instance, ou Machine Virtuelle (VM), est un serveur entièrement isolé s'exécutant sur l'infrastructure physique partagée d'OVHcloud. Elle fonctionne comme un serveur traditionnel, mais offre la flexibilité et l'évolutivité du cloud. Vous choisissez le système d'exploitation, définissez les ressources CPU, RAM et stockage, et déployez vos applications, sites web ou environnements de développement.
 
 Les instances Public Cloud Compute offrent :
 

--- a/docs/fr/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,5 +1,5 @@
 ---
-title: Lancer un script lors de la creation d’une instance
+title: Lancer un script lors de la création d’une instance
 lastUpdated: 2022-03-18
 ---
 
@@ -17,7 +17,7 @@ Dans certaines situations, il vous sera nécessaire de lancer un script lors de 
 
 ## En pratique
 
-### Creation d'un script
+### Création d'un script
 
 Il existe plusieurs possibilités de scripts utiles à lancer lors de la création d'une instance. Vous pouvez par exemple utiliser des  **scripts shell**  :
 
@@ -33,7 +33,7 @@ mkdir /home/ovh/.ssh
 echo "VOTRE_CLE_SSH_PUBLIQUE" > /home/ovh/.ssh/authorized_keys
 ```
 
-Ce script vous permet de créer un utilisateur nommé "**ovh**". On lui donne ensuite les accés **sudo** et on ajoute sa clé ssh.
+Ce script vous permet de créer un utilisateur nommé "**ovh**". On lui donne ensuite les accès **sudo** et on ajoute sa clé ssh.
 
 - Modification de la configuration SSH :
 
@@ -47,7 +47,7 @@ service ssh restart
 
 Ce script permet de modifier le port SSH par défaut (22 -> 2211) et d'interdire la connexion à l'aide de l'utilisateur "**root**".
 
-- Mise à jour des packets et installation d'un serveur WEB :
+- Mise à jour des paquets et installation d'un serveur WEB :
 
 ```bash
 #!/bin/bash
@@ -87,9 +87,9 @@ utilisateur.
 :::
 
 
-### Creation de l'instance
+### Création de l'instance
 
-Après avoir récupéré la liste des images et des modèles d'instance, il est possible de lancer le script avec Cloud-init grâce à l'argument **--user- data** :
+Après avoir récupéré la liste des images et des modèles d'instance, il est possible de lancer le script avec Cloud-init grâce à l'argument **--user-data** :
 
 ```bash
 root@server:~# nova boot --key_name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1

--- a/docs/fr/guides/public-cloud/compute/managing-instances-horizon.mdx
+++ b/docs/fr/guides/public-cloud/compute/managing-instances-horizon.mdx
@@ -50,9 +50,9 @@ Ce menu vous permet d'exécuter les actions suivantes sur une ou plusieurs insta
 
 - Start Instances : cette option permet de redémarrer une ou plusieurs instances en statut *shutoff* ou *off*.
 - Shut Off Instances : cette option permet de suspendre une ou plusieurs instances.
-- Soft Reboot Instances : cette option vous permet de faire un rédemarrage logiciel sur une ou plusieurs instances.
+- Soft Reboot Instances : cette option vous permet de faire un redémarrage logiciel sur une ou plusieurs instances.
 
-**Create Snapshot** : Cette option permet de créé un snapshot (instantané) de votre instance. Consultez [ce guide](/guides/public-cloud/compute/managing-snapshots-in-horizon) pour plus d'informations.
+**Create Snapshot** : Cette option permet de créer un snapshot (instantané) de votre instance. Consultez [ce guide](/guides/public-cloud/compute/managing-snapshots-in-horizon) pour plus d'informations.
 
 ### Modifier une instance
 
@@ -101,7 +101,7 @@ Sélectionnez <code className="action">Rebuild Instance</code> dans la liste dé
 
 Sélectionnez l'image pour la reconstruction.<br/>
 Sélectionnez le type de partitionnement (« Automatique » ou « Manuel »). Ceci est facultatif.<br/>
-Pour finir, cliquez sur <code className="action">Rebuild Instance</code>. Cette operation peut prendre quelques minutes.
+Pour finir, cliquez sur <code className="action">Rebuild Instance</code>. Cette opération peut prendre quelques minutes.
 
 ### Suspendre ou mettre en pause une instance (Shelve or pause an instance)
 

--- a/docs/fr/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
+++ b/docs/fr/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
@@ -72,9 +72,9 @@ Dans la fenêtre contextuelle, un certain nombre d'options doivent être sélect
 
 Une fois cela fait, cliquez sur <code className="action">Launch Instance</code> pour commencer la création de votre instance.
 
-### Supression d'un snapshot
+### Suppression d'un snapshot
 
-Dans l'inteface horizon, cliquez sur le menu <code className="action">Compute</code> à gauche puis sur <code className="action">Images</code>.
+Dans l'interface horizon, cliquez sur le menu <code className="action">Compute</code> à gauche puis sur <code className="action">Images</code>.
 
 Cliquez ensuite sur la flèche déroulante à côté du snapshot à supprimer et cliquez sur <code className="action">Delete Image</code>. Confirmez la suppression du snapshot.
 

--- a/docs/fr/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume.mdx
+++ b/docs/fr/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume.mdx
@@ -29,7 +29,7 @@ Ce guide explique comment migrer vos données d’un volume Block Storage standa
 
 ## En pratique
 
-### Etape 1 : Créer un volume LUKS
+### Étape 1 : Créer un volume LUKS
 
 Depuis votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, créez un nouveau volume Block Storage et sélectionnez le type `LUKS`.
 
@@ -111,7 +111,7 @@ sudo umount /mnt/luks_target
 
 Si le volume LUKS doit être utilisé de manière permanente, ajoutez une entrée dans `/etc/fstab` pour qu’il soit monté automatiquement au démarrage :
 
-Exemple:
+Exemple :
 
 ```bash
 UUID=<UUID_of_volume> /mnt/data ext4 defaults 0 2

--- a/docs/fr/guides/public-cloud/compute/migration-between-regions.mdx
+++ b/docs/fr/guides/public-cloud/compute/migration-between-regions.mdx
@@ -11,7 +11,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Ce guide explique comment migrer une instance Public Cloud d’une zone de disponibilité (AZ) à une autre, de 1AZ vers 3AZ ou inversement. Il centralise les étapes clés (sauvegarde, transfert et recréation) et redirige vers les guides détaillés pour chaque élément.
 
-## prérequis
+## Prérequis
 
 - Avoir une [instance Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
@@ -86,7 +86,7 @@ La restauration de l'instance dans la nouvelle région peut être réalisée :
 - via la CLI Openstack.
 - via Horizon.
 
-Retrouvez toutes les informations détaillées dans la partie **Créer une instance a partir d'une sauvegarde** de notre guide « [Créer / restaurer un serveur virtuel a partir d’une sauvegarde](/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup) ».
+Retrouvez toutes les informations détaillées dans la partie **Créer une instance à partir d'une sauvegarde** de notre guide « [Créer / restaurer un serveur virtuel a partir d’une sauvegarde](/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup) ».
 
 ## Aller plus loin
 

--- a/docs/fr/guides/public-cloud/compute/resize-instance-openstack.mdx
+++ b/docs/fr/guides/public-cloud/compute/resize-instance-openstack.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2025-08-25
 
 En raison d'une activité accrue, ou simplement pour répondre à de nouveaux besoins, votre instance peut manquer de ressources et se retrouver incapable de répondre à une nouvelle charge. Grâce au Public Cloud d’OVHcloud, vous pouvez augmenter les ressources disponibles pour votre instance en quelques étapes seulement.
 
-**Découvez comment redimensionner votre instance Public Cloud à l'aide du CLI OpenStack.**
+**Découvrez comment redimensionner votre instance Public Cloud à l'aide du CLI OpenStack.**
 
 :::info
 **Limites :**

--- a/docs/fr/guides/public-cloud/compute/responsibility-model-instances.mdx
+++ b/docs/fr/guides/public-cloud/compute/responsibility-model-instances.mdx
@@ -34,7 +34,7 @@ Le RACI ci-dessous détaille le partage des responsabilités entre OVHcloud et l
 | Produire, acheminer, livrer et maintenir les instances physiques et les bâtiments d’hébergement | I | RA |
 | Installer les briques fonctionnelles internes à l'instance nécessaires au maintien en conditions opérationnelles et au maintien en conditions de sécurité (firmware, BIOS) | I | RA |
 | Déployer la configuration réseau initiale du service | I | RA |
-| Acheter et détenir les licences et droits d’utilisation pour les OS Microsoft proposés au cathalogue d'OVHcloud | CI | RA |
+| Acheter et détenir les licences et droits d’utilisation pour les OS Microsoft proposés au catalogue d'OVHcloud | CI | RA |
 | Acheter et détenir les licences et droits d'utilisation pour les autres types d'OS utilisés | RA |  |
 
 #### 2.2. Modèle de réversibilité
@@ -102,7 +102,7 @@ Le RACI ci-dessous détaille le partage des responsabilités entre OVHcloud et l
 | Gérer le plan d’adressage IP et choisir les protocoles réseaux adéquats | RA | I |
 | Filtrer les accès réseau à l'instance | RA | I |
 | Filtrer les connexions réseaux et déployer une architecture sécurisée en fonction des besoins (FW, WAF, IPS/IDS, protocoles sécurisés, etc) | RA |   |
-| Assurer le fonctionnement des systèmes automatiques de gestion du réseau (architecture, mise en oeuvre, maintenance logicielle et matérielle pour les réseaux publics et privés déployés) | I | RA |
+| Assurer le fonctionnement des systèmes automatiques de gestion du réseau (architecture, mise en œuvre, maintenance logicielle et matérielle pour les réseaux publics et privés déployés) | I | RA |
 
 
 ##### **3.1.6. Gestion**
@@ -113,7 +113,7 @@ Le RACI ci-dessous détaille le partage des responsabilités entre OVHcloud et l
 | Assurer la sécurité des infrastructures de gestion (API, control plane) |   | RA |
 | Assurer la sécurité des OS, softwares et middlewares installés sur les instances | RA |  |
 | Gérer la sécurité physique des équipements et infrastructures hébergés | I | RA |
-| Gérer la sécurité des données herbergées sur les instances | RA |  |
+| Gérer la sécurité des données hébergées sur les instances | RA |  |
 
 ##### **3.1.7. Continuité d'activité**
 | **Activité** | **Client** | **OVHcloud** |

--- a/docs/fr/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
+++ b/docs/fr/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
@@ -32,7 +32,7 @@ Voici la liste des commandes principales :
 |volume create|Crée un nouveau volume|
 |volume delete|Supprime un volume|
 |volume list|Liste les volumes|
-|volume snapshot create|Crée un snaspshot d'un volume|
+|volume snapshot create|Crée un snapshot d'un volume|
 
 Vous pouvez également obtenir des informations concernant une commande spécifique en ajoutant `help` devant celle ci :
 

--- a/docs/fr/guides/public-cloud/compute/storage-classic-multi-attach-3az.mdx
+++ b/docs/fr/guides/public-cloud/compute/storage-classic-multi-attach-3az.mdx
@@ -48,6 +48,6 @@ Les volumes Classic Multi-attach sont assortis de limitations spécifiques qu'il
 - La réécriture du volume n'est pas prise en charge lorsque le volume est en cours d'utilisation - le passage d'un type compatible avec le multi-attach à un type non compatible avec le multi-attach (ou vice-versa) n'est pas autorisé.
 - Le chiffrement n'est pas disponible pour les volumes Classic Multi-attach.
 
-## Aller plus loin 
+## Aller plus loin
 
 Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).

--- a/docs/fr/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/fr/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -10,7 +10,7 @@ Vous pouvez créer des disques supplémentaires pour vos instances Public Cloud 
 
 Cela peut être utile dans les cas suivants :
 
-- Si vous souhaitez restaurer les données du disque supplémentaires.
+- Si vous souhaitez restaurer les données du disque supplémentaire.
 - Si vous souhaitez disposer d’un espace de stockage hautement disponible et performant avec vos données.
 - Si vous souhaitez déplacer vos données vers une autre instance.
 
@@ -66,7 +66,8 @@ Le processus d’attachement du disque à votre instance va alors commencer et p
 <img className="thumbnail" alt="attacher volume" src="/images/public-cloud/compute/create-volume-from-snapshot/volume05.png" loading="lazy" />
 
 :::warning
-Vous devez éviter la navigation en dehors de l’onglet en cours pendant l’attachement du disque. Cela peut interrompre le processus.
+>
+> Vous devez éviter la navigation en dehors de l’onglet en cours pendant l’attachement du disque. Cela peut interrompre le processus.
 :::
 
 Une fois l'attachement effectué, vous pouvez suivre les étapes suivantes pour configurer votre disque supplémentaire [sous Linux](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#sous-linux) ou [sous Windows](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#sous-windows).

--- a/docs/fr/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
+++ b/docs/fr/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
@@ -41,7 +41,7 @@ Ouvrez le menu <code className="action">Block Storage</code> dans la barre de na
 
 <img className="thumbnail" alt="Volume Snapshot" src="/images/public-cloud/compute/creating-a-volume-snapshot/volume_snapshot01.png" loading="lazy" />
 
-A droite du volume concerné, cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Créer une sauvegarde</code> (il n'est pas nécessaire de détacher d'abord le volume de son instance). Cependant, si vous souhaitez détacher votre volume, nous vous invitons à consulter la section « Détacher un volume » de [ce guide](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
+À droite du volume concerné, cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Créer une sauvegarde</code> (il n'est pas nécessaire de détacher d'abord le volume de son instance). Cependant, si vous souhaitez détacher votre volume, nous vous invitons à consulter la section « Détacher un volume » de [ce guide](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
 
 Il faut ensuite sélectionner <code className="action">Volume Snapshot</code>, le nommer et cliquer sur <code className="action">Créer la sauvegarde</code>.
 
@@ -73,7 +73,7 @@ Cliquez sur le bouton <code className="action">...</code> pour <code className="
 
 [Créer un volume à partir d’une sauvegarde](/guides/public-cloud/compute/storage-create-volume-from-backup)
 
-[Créer et configurer un disque supplementaire sur une instance](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
+[Créer et configurer un disque supplémentaire sur une instance](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
 
 [Augmenter la taille d’un disque supplémentaire](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 

--- a/docs/fr/guides/public-cloud/compute/switch-volume-type.mdx
+++ b/docs/fr/guides/public-cloud/compute/switch-volume-type.mdx
@@ -31,7 +31,7 @@ L'objectif de ce guide est de vous montrer comment changer un type de volume Blo
 
 Lors de la modification d'un type de volume Block Storage en un volume « High speed gen2 », la politique de migration doit être modifiée de `Never` à `On Demand`.
 
-Par défaut, la politque de migration est définie sur `Never` car le volume reste sur le même cluster CEPH. Cependant, pour le « High speed gen2 », le volume devra être migré vers un nouveau cluster.
+Par défaut, la politique de migration est définie sur `Never` car le volume reste sur le même cluster CEPH. Cependant, pour le « High speed gen2 », le volume devra être migré vers un nouveau cluster.
 
 Cette modification peut être réalisée via Horizon ou via l’interface de ligne de commande OpenStack.
 

--- a/docs/fr/guides/public-cloud/compute/upgrading-operating-system.mdx
+++ b/docs/fr/guides/public-cloud/compute/upgrading-operating-system.mdx
@@ -152,7 +152,7 @@ Une fois le serveur redémarré, installez le paquet de mise à jour :
 $ sudo dnf install dnf-plugin-system-upgrade
 ```
 
-Maintenant que vous disposez du paquet requis, vous pouvez effectuer la mise à jour. Les mises à jur du système ne sont officiellement prises en charge et testées que sur 2 versions au maximum (par exemple, de 32 à 34).
+Maintenant que vous disposez du paquet requis, vous pouvez effectuer la mise à jour. Les mises à jour du système ne sont officiellement prises en charge et testées que sur 2 versions au maximum (par exemple, de 32 à 34).
 Dans cet exemple, nous allons passer de Fedora 32 à 33 :
 
 ```sh

--- a/docs/fr/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/fr/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -67,7 +67,7 @@ A state is composed of several files inside a `.pulumi` folder:
 - `meta.yaml`: This is the metadata file. It does not hold information about the stacks but rather information about the backend itself.
 - `stacks/`: Active state files for each stack (e.g. `dev.json`).
 - `locks/`: Optional lock files for each stack if the stack is currently being operated on by a Pulumi operation (e.g. `dev/$lock.json`).
-- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json`vwhere $timestamp records the time the history file was created).
+- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json` where $timestamp records the time the history file was created).
 
 ## Instructions
 

--- a/docs/fr/guides/public-cloud/cross-functional/api-rate-limits.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/api-rate-limits.mdx
@@ -90,7 +90,7 @@ Cette approche présente de nombreux avantages :
 
 - les nouvelles tentatives automatiques vous permettent de récupérer des erreurs de limite de débit sans blocage ou perte de données ;
 - la désactivation exponentielle vous permet d’effectuer vos premières tentatives rapidement, tout en bénéficiant de délais plus longs en cas d’échec de vos premières tentatives ;
-- l'ajout d'un délai aléatoire évite que toutes les tentatives ne soient effecutées en même temps.
+- l'ajout d'un délai aléatoire évite que toutes les tentatives ne soient effectuées en même temps.
 
 Sachez que les demandes infructueuses ne rentrent pas dans le calcul de votre limite de débit. Par conséquent, le renvoi continu d'une demande pourrait fonctionner, mais nous pourrions modifier ce comportement à l'avenir. Nous vous recommandons de ne pas vous fier à ce mécanisme.
 

--- a/docs/fr/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
@@ -7,7 +7,7 @@ lastUpdated: 2021-05-26
 ## Objectif
 
 L'interface OpenStack Horizon fournit des options pour configurer l'accès à vos instances et à d'autres services.<br/>
-Vous pouvez par exemple configurer des groupes de sécurité pour filtrer les connexions entrantes et sortantes, ou bien encore télécharger le fichier OpenRC contenantvos identifiants afin d'utiliser les API OpenStack.
+Vous pouvez par exemple configurer des groupes de sécurité pour filtrer les connexions entrantes et sortantes, ou bien encore télécharger le fichier OpenRC contenant vos identifiants afin d'utiliser les API OpenStack.
 
 **Découvrez comment gérer et sécuriser l'accès à vos instances**
 

--- a/docs/fr/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -30,7 +30,7 @@ Après en avoir pris connaissance, validez les termes des contrats en cochant la
 <img className="thumbnail" alt="création de projet" src="/images/public-cloud/cross-functional/create-a-public-cloud-project/firstproject2024.png" loading="lazy" style={{ maxWidth: '400px' }} />
 
 - Si vous n'avez pas encore de moyen de paiement valide dans votre compte OVHcloud, le processus de création du projet Public Cloud commence. Votre projet sera alors créé en [Mode découverte](#discovery).
-- Si vous avez déjà renseigné un moyen de paiement dans votre compte OVHcloud, vous devez d'abord nommer votre projet Public Cloud puis sélectionner votre moyen de paiment.
+- Si vous avez déjà renseigné un moyen de paiement dans votre compte OVHcloud, vous devez d'abord nommer votre projet Public Cloud puis sélectionner votre moyen de paiement.
 
 <img className="thumbnail" alt="création de projet" src="/images/public-cloud/cross-functional/create-a-public-cloud-project/project-creation.png" loading="lazy" style={{ maxWidth: '400px' }} />
 

--- a/docs/fr/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -234,7 +234,7 @@ Ces protections, associées à celles que vous pouvez mettre en place sur vos se
 <summary>Comment vérifier si mon instance est vulnérable a la faille MDS ?</summary>
 
 
-La vulnérabilité à la [faille MDS](https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html) peut etre vérifiée avec la commande suivante:
+La vulnérabilité à la [faille MDS](https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html) peut être vérifiée avec la commande suivante:
 
 ```bash
 cat /sys/devices/system/cpu/vulnerabilities/mds
@@ -255,13 +255,13 @@ openstack server reboot --hard $serverID
 <summary>Mon instance est-elle toujours vulnérable a la faille SSBD ?</summary>
 
 
-La vulnérabilité à la [faille SSBD](https://www.kernel.org/doc/html/latest/userspace-api/spec_ctrl.html) peut etre vérifiée avec la commande suivante :
+La vulnérabilité à la [faille SSBD](https://www.kernel.org/doc/html/latest/userspace-api/spec_ctrl.html) peut être vérifiée avec la commande suivante :
 
 ```bash
 cat /sys/devices/system/cpu/vulnerabilities/ssbd
 ```
 
-Même si le résultat est `Vulnerable`, votre instance est tout de meme protegée face a cette faille.
+Même si le résultat est `Vulnerable`, votre instance est tout de même protégée face à cette faille.
 
 En effet, le *flag CPU SSBD* n'est pas disponible pour votre instance car il peut provoquer des instabilités sur certains OS.
 

--- a/docs/fr/guides/public-cloud/cross-functional/managing-tokens.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/managing-tokens.mdx
@@ -35,11 +35,11 @@ De la même manière, si un token doit être révoqué avant sa date d'expiratio
 
 Pour plus d'information, consultez la documentation d'[OpenStack de l'API](https://docs.openstack.org/keystone/train/api_curl_examples.html).
 
-### Operations manuelles
+### Opérations manuelles
 
 Les opérations qui suivent peuvent être effectuées manuellement, elles sont généralement utilisées à des fins pédagogiques ou de dépannage.
 
-Il est nécessaire de charger l'environnement à l'aide du fichier openRC. Pour cela, nous vous recommandons de télécharger et utiliser le fichier openrc.sh que vous trouverez dans l'interface Horizon. Ce dernier disposera de l’ensemble des variables d’environnement nécessaires â la construction des commandes qui vont suivre.
+Il est nécessaire de charger l'environnement à l'aide du fichier openRC. Pour cela, nous vous recommandons de télécharger et utiliser le fichier openrc.sh que vous trouverez dans l'interface Horizon. Ce dernier disposera de l’ensemble des variables d’environnement nécessaires à la construction des commandes qui vont suivre.
 
 Pour vous connecter à Horizon et télécharger le fichier, consultez [ce guide](/guides/public-cloud/cross-functional/introducing-horizon).
 

--- a/docs/fr/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -55,7 +55,7 @@ Veuillez noter que seules les **instances** de troisième génération (B3, C3, 
 
 Les Savings Plans pour Managed Rancher Service reposent sur l'engagement d’une quantité de vCPUs sur une durée définie, ce qui permet de réaliser des économies sur le service Managed Rancher. Ce modèle offre une flexibilité accrue, car les vCPUs engagés peuvent être partagés entre tous vos environnements Rancher, optimisant la facturation des ressources utilisées d'une manière flexible et évolutive.
 
-En souscrivant à un Savings PLan pour Rancher, vous vous engagez à utiliser une certaine quantité de vCPU, qui est ensuite répartie entre vos clusters Rancher, ce qui garantit la rentabilité même si votre utilisation fluctue au fil du temps.
+En souscrivant à un Savings Plan pour Rancher, vous vous engagez à utiliser une certaine quantité de vCPU, qui est ensuite répartie entre vos clusters Rancher, ce qui garantit la rentabilité même si votre utilisation fluctue au fil du temps.
 
 :::info
 Les Savings Plans pour Managed Rancher Service ne s'appliquent qu'aux vCPU. Les autres ressources, telles que le stockage, les instances et les autres services, ne sont pas couvertes par ce Savings Plan et seront toujours facturées séparément. Veillez à prendre en compte ces coûts supplémentaires lors de la planification de vos ressources Rancher.

--- a/docs/fr/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
@@ -45,7 +45,7 @@ Le [guide de gestion des mots de passe](/guides/account-and-service-management/a
 
 #### Ajouter une adresse e-mail de secours
 
-- **Importance** : Aide à récupérer l'accès à votre compte si votre em-ail principal est inaccessible.
+- **Importance** : Aide à récupérer l'accès à votre compte si votre e-mail principal est inaccessible.
 - **Configuration** : Ajoutez une adresse e-mail de secours dans le tableau de bord OVHcloud sous les paramètres de votre profil, en vous assurant qu'elle diffère de votre adresse e-mail principale. Voir le [guide sur la gestion des informations personnelles](/guides/account-and-service-management/account-information/all-about-username).
 
 ### Étape 2 : Comprendre la gestion des identités et des accès (IAM) et créer des identités

--- a/docs/fr/guides/public-cloud/cross-functional/whats-is-landing-zone.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/whats-is-landing-zone.mdx
@@ -121,7 +121,7 @@ Le cycle de vie d'un log comprend 4 phases distinctes :
 - **Stockage :** après leur ingestion, vos logs sont stockés dans la Logs Data Platform. Les données peuvent être stockées de deux manières : sous forme de données indexées accessibles via des API et d'autres outils, ou sous forme de données archivées.
 - **Consommation :** il existe de nombreuses façons d'utiliser vos logs. Les utilisateurs de la Logs Data Platform peuvent visualiser les logs en temps réel, créer des tableaux de bord, créer et exécuter des requêtes détaillées à l'aide de l'interface utilisateur ou de l'API, et également configurer des alertes.
 
-## OVHcloud Landing Zone: un guide étape par étape
+## OVHcloud Landing Zone : un guide étape par étape
 
 Pour créer une Landing Zone qui fonctionne bien, il est important d'évaluer les composants nécessaires à sa construction. La Landing Zone idéale doit être suffisamment flexible pour s'adapter à divers besoins, permettant un déploiement automatisé, agile et simple de l'architecture cible.
 
@@ -164,7 +164,7 @@ Pour créer une Landing Zone qui fonctionne bien, il est important d'évaluer le
         - Les réseaux et vRack
         - Les instances de calcul
         - Les rôles IAM
-        - Le DNS (via OVH DNS)
+        - Le DNS (via OVHcloud DNS)
         - Le Bastion Host pour l'accès SSH
         - La surveillance et les alertes centralisées
         - Le stockage d'objets partagé (pour les journaux ou les sauvegardes)
@@ -201,6 +201,6 @@ Intégrez plutôt la documentation et les mises à jour continues dans votre pro
 
 Considérez votre Landing Zone comme un produit : itérez, documentez et optimisez-la au fil du temps.
 
-## Allez plus loin
+## Aller plus loin
 
 Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).

--- a/docs/fr/guides/public-cloud/network-services/buy-additional-ip.mdx
+++ b/docs/fr/guides/public-cloud/network-services/buy-additional-ip.mdx
@@ -64,7 +64,7 @@ Les pays suivants sont disponibles pour la géolocalisation des IP :
 |          |          |          |           |                |
 |:--------:|:--------:|:--------:|:---------:|:--------------:|
 | Belgique  | Finlande  | France   | Allemagne   | République Tchèque |
-| Irelande  |  Italie   | Lituanie | Pays-bas | Royaume-Uni    |
+| Irlande   |  Italie   | Lituanie | Pays-bas | Royaume-Uni    |
 | Portugal |  Espagne   |  Pologne |  Suisse |                 |
 
 :::info
@@ -85,7 +85,7 @@ Si vous avez besoin de vérifier la géolocalisation d'une autre manière, conta
 
 Une fois le pays sélectionné, cliquez sur <code className="action">Suivant</code>.
 
-A la dernière étape, sélectionnez votre instance dans le menu déroulant. Cliquez ensuite sur <code className="action">Générer le bon de commande</code>.
+À la dernière étape, sélectionnez votre instance dans le menu déroulant. Cliquez ensuite sur <code className="action">Générer le bon de commande</code>.
 
 <img className="thumbnail" alt="Ajout IP" src="/images/public-cloud/network-services/additional-ip-buy/buyaddIP_04.png" loading="lazy" />
 

--- a/docs/fr/guides/public-cloud/network-services/loadbalancer-update-size.mdx
+++ b/docs/fr/guides/public-cloud/network-services/loadbalancer-update-size.mdx
@@ -43,7 +43,7 @@ Une fois connecté, allez dans la section <code className="action">Load Balancer
 
 ### Étape 3 - Modifier le Load Balancer
 
-A droite de votre Load Balancer, cliquez sur la flèche pointant vers le bas. Sélectionnez <code className="action">Modifier le Load Balancer</code> dans le menu déroulant.
+À droite de votre Load Balancer, cliquez sur la flèche pointant vers le bas. Sélectionnez <code className="action">Modifier le Load Balancer</code> dans le menu déroulant.
 
 <img className="thumbnail" alt="Bouton Modifier le Load Balancer" src="/images/public-cloud/network-services/update-load-balancer-size/editButtonLoadBalancer.png" loading="lazy" />
 

--- a/docs/fr/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/fr/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2024-01-22
 
 ## Objective
 
-This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the pre requisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
+This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the prerequisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
 
 For this example, we will use a private network and a subnet with the following properties:
 
@@ -44,7 +44,7 @@ Click the `Subnets` tab: the subnets from the private network are listed.
 
 Click on your `Edit Subnet`. For this guide, our target is to add a gateway IP:
 
-- Click untick the  `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
+- Untick the `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
 
 <img className="thumbnail" alt="gateway IP" src="/images/public-cloud/network-services/configuration-04-update-subnet/add_gateway_ip.png" loading="lazy" />
 

--- a/docs/it/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
+++ b/docs/it/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
@@ -37,7 +37,7 @@ Per familiarizzare con Horizon, consulta la guida [Accedere all'interfaccia Hori
 
 ## Procedura
 
-### Associa uno porto pubblico "Ext-Net" a un'istanza
+### Associa un porto pubblico "Ext-Net" a un'istanza
 
 #### Dall'interfaccia Horizon
 

--- a/docs/it/guides/public-cloud/compute/apps-first-steps.mdx
+++ b/docs/it/guides/public-cloud/compute/apps-first-steps.mdx
@@ -78,7 +78,7 @@ Se il tuo dominio è registrato in OVHcloud, consulta [questa guida](/guides/web
 <ol start="2">
   <li>Forse dovrai aspettare 24 ore prima che le due registrazioni si propaghino completamente. È sempre possibile verificarlo con <a href="https://mxtoolbox.com/DnsLookup.aspx">mxtoolbox</a>. Se l'indirizzo IP del tuo dominio viene visualizzato su mxtoolbox nello stesso modo del tuo server, passa allo step successivo.</li>
 
-  <li>Accedi in SSH al tuo server con l'utente CentOS ed esegui questi comandi per installare Cerbot:</li>
+  <li>Accedi in SSH al tuo server con l'utente CentOS ed esegui questi comandi per installare Certbot:</li>
 </ol>
 
 :::warning
@@ -96,7 +96,7 @@ systemctl restart httpd
 ```
 
 <ol start="4">
-  <li> Genera il tuo certificato SSL utilizzando Cerbot (segui le istruzioni sullo schermo).</li>
+  <li> Genera il tuo certificato SSL utilizzando Certbot (segui le istruzioni sullo schermo).</li>
 </ol>
 
 ```sh
@@ -105,7 +105,7 @@ certbot certonly -d personaldomain.ovh --webroot
 
 Quando ti viene chiesto di inserire "Input the webroot", inserisci una variabile del tipo "/var/www/wordpress". Se installa Joomla!, sostituisci "wordpress" con "joomla".
 
-Assicurati che Cerbot inserisca questa variabile nel file ssl.conf. Per farlo, inserisci:
+Assicurati che Certbot inserisca questa variabile nel file ssl.conf. Per farlo, inserisci:
 
 ```sh
 certbot -d personaldomain.ovh —apache

--- a/docs/it/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -26,7 +26,7 @@ Questa guida è destinata alle istanze basate su distribuzioni Linux **esclusiva
 
 ## Prerequisiti
 
-- Aver creato un’[istanza Public Cloud](/guides/account-and-service-management/account-information/ovhcloud-account-creation)
+- Aver creato un’[istanza Public Cloud](/guides/public-cloud/compute/public-cloud-first-steps)
 - [Essere connessi in SSH](/guides/public-cloud/compute/getting-started) (sudo) all’istanza
 
 ## Procedura
@@ -100,6 +100,6 @@ sudo cat /etc/hosts
 127.0.0.1 localhost
 ```
 
-## Per saperne di più 
+## Per saperne di più
 
 Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).

--- a/docs/it/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -26,7 +26,7 @@ Questa guida è destinata alle istanze basate su distribuzioni Linux **esclusiva
 
 ## Prerequisiti
 
-- Aver creato un’[istanza Public Cloud](/guides/public-cloud/compute/public-cloud-first-steps)
+- Aver creato un’[istanza Public Cloud](/guides/public-cloud/compute/getting-started)
 - [Essere connessi in SSH](/guides/public-cloud/compute/getting-started) (sudo) all’istanza
 
 ## Procedura

--- a/docs/it/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/it/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -25,7 +25,7 @@ You'll need an [OVHcloud Public Cloud project](/guides/public-cloud/cross-functi
 
 ### Install Packer
 
-Packer can be downloaded from the official website (curently [here](https://www.packer.io/downloads.html) ) and you'll need to `unzip` it.
+Packer can be downloaded from the official website (currently [here](https://www.packer.io/downloads.html) ) and you'll need to `unzip` it.
 
 For Linux 64bits
 
@@ -92,7 +92,7 @@ export NETWORK_ID=`openstack network list -f json | jq -r '.[] | select(.Name ==
 
 **INFO**: for `FLAVOR_ID`, you can directly use the name, ie `b2-7`
 
-Finaly, create a `packer.json` file
+Finally, create a `packer.json` file
 
 ```shell
 cat > packer.json <<EOF
@@ -129,7 +129,7 @@ cat > packer.json <<EOF
 EOF
 ```
 
-In the last selection of the configuration file, we specify a `setup_vm.sh` shell script to be ran.
+In the last selection of the configuration file, we specify a `setup_vm.sh` shell script to be run.
 
 ```sh
 #!/bin/sh
@@ -149,7 +149,7 @@ git clone ...
 
 ## Building the image
 
-Using the configuration file create above, check it and build the image with
+Using the configuration file created above, check it and build the image with
 
 ```shell
 packer validate packer.json

--- a/docs/it/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
+++ b/docs/it/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
@@ -21,7 +21,7 @@ La fatturazione delle tue istanze mensili è ora raggruppata in un'unica fattura
 
 ### Quando è necessario pagare un’istanza con fatturazione mensile?
 
-Ogni istanza dichiarata mensile ed esistente il 1° del mese in corso sarà fatturata per un mese intero. e apparirà sulla prossima fattura il primo giorno del mese successivo, insieme agli altri utilizzi Public Cloud.
+Ogni istanza dichiarata mensile ed esistente il 1° del mese in corso sarà fatturata per un mese intero. E apparirà sulla prossima fattura il primo giorno del mese successivo, insieme agli altri utilizzi Public Cloud.
 
 ### Se avvii un’istanza mensile a metà mese, come paghi?
 

--- a/docs/it/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/it/guides/public-cloud/compute/image-life-cycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud & VPS - Image and OS life cycle and end of life/support announcements
 description: Discover the lifecycle and end-of-life/end-of-support announcements for distributions and softwares for your VPS or Public Cloud instance
-lastUpdated: 2025-02-11
+lastUpdated: 2025-11-12
 ---
 
 ## Objective
@@ -70,7 +70,7 @@ Please note that:
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
 | 14 | [Forky](https://wiki.debian.org/DebianForky) | | | |
-| 13 | [Trixie](https://wiki.debian.org/DebianTrixie) | | | |
+| 13 | [Trixie](https://wiki.debian.org/DebianTrixie) | August 2025 | August 2028 | June 2030 |
 | 12 | [Bookworm](https://wiki.debian.org/DebianBookworm) | June 2023 | June 2026 | June 2028 |
 | 11 | [Bullseye](https://wiki.debian.org/DebianBullseye) | August 2021 | August 2024 | August 2026 |
 | 10 | [Buster](https://wiki.debian.org/DebianBuster) | July 2019 | September 2022 | June 2024 |

--- a/docs/it/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/it/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -34,7 +34,7 @@ Se hai raggiunto la capacità massima del tuo disco aggiuntivo, aggiungi spazio 
 
 ## Procedura
 
-Per gli step successivi, è necessario aver già configurato un disco aggiuntivo in base alle intrusioni della [nostra guida](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
+Per gli step successivi, è necessario aver già configurato un disco aggiuntivo in base alle istruzioni della [nostra guida](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
 
 ## Monitoraggio dell'utilizzo del disco prima del ridimensionamento
 
@@ -132,7 +132,7 @@ Nella nuova finestra, indica la nuova dimensione del volume e clicca su <code cl
 
 Apri una connessione SSH alla tua istanza per adattare la partizione al disco ridimensionato.
 
-Per prima cosa, esegui il mount del disco utilizzando questo comando:
+Per prima cosa, smonta il disco utilizzando questo comando:
 
 ```bash
 admin@server:~$ sudo umount /mnt/disk
@@ -222,7 +222,7 @@ Una volta completata questa operazione, scollegate il volume dall'istanza e rico
 
 Prima di procedere, ricollegate il volume all'istanza. Cliccate su <code className="action">...</code> nella riga del volume e selezionate <code className="action">Associa all'istanza</code>.
 
-Installa una connessione RDP (Remote Desktop) sulla tua istanza Windows.
+Stabilisci una connessione RDP (Remote Desktop) sulla tua istanza Windows.
 
 Una volta connesso, clicca con il tasto destro sul pulsante <code className="action">Inizia</code> e apri la <code className="action">Gestione dei dischi</code>.
 

--- a/docs/it/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -55,7 +55,7 @@ Attendi il completamento dell’operazione.
 Una volta completata l’installazione, l’interfaccia da riga di comando (CLI) visualizzerà le seguenti informazioni:
 
 - Vengono generati due URL:
-    - una con l'indirizzo IP del server (in HTTPS con un certificato SSL autofirmato, che può attivare un alert di sicurezza in alcuni browser).
+    - Una con l'indirizzo IP del server (in HTTPS con un certificato SSL autofirmato, che può attivare un alert di sicurezza in alcuni browser).
     - L'altra con dominio Plesk (in HTTPS con certificato SSL firmato, senza alert di sicurezza).
     - Entrambi sono sicuri, ma si consiglia di utilizzare il secondo.
 - Un messaggio recita: "Puoi accedere come ‘root’ con la tua password ‘root’." Tuttavia, per impostazione predefinita, non viene generata alcuna password di root. Se necessario, i clienti possono seguire [questa guida](/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds) per attivare l'utente root e impostare una password.
@@ -71,7 +71,7 @@ OVHcloud non fornisce licenze Plesk per le soluzioni Public Cloud. È possibile 
 :::
 
 
-Vuoi modificare la tua licenza, ad esempio per sostituire una chiave di test o cambiare offerta? Accedi all’interfaccia Plesk e, nella sezione <code className="action">Tools & Settings</code>. Nella sezione **Plesk**, seleziona <code className="action">License information</code>.
+Vuoi modificare la tua licenza, ad esempio per sostituire una chiave di test o cambiare offerta? Accedi all’interfaccia Plesk, vai nella sezione <code className="action">Tools & Settings</code>. Nella sezione **Plesk**, seleziona <code className="action">License information</code>.
 
 ## Per saperne di più
 

--- a/docs/it/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/it/guides/public-cloud/compute/install-wordpress.mdx
@@ -87,7 +87,7 @@ Per eseguirlo, esegui questo comando:
 debian@instance:~$ sudo mariadb-secure-installation
 ```
 
-Conferma il primo invito cliccando su <code className="action">Entrata</code>.
+Conferma il primo prompt premendo <code className="action">Invio</code>.
 
 In seguito scegli un metodo per proteggere gli accessi al tuo server di database.
 
@@ -95,9 +95,9 @@ In seguito scegli un metodo per proteggere gli accessi al tuo server di database
 Switch to unix_socket authentication [Y/n]
 ```
 
-Si raccomanda di utilizzare il metodo di autenticazione proposto al posto dell'accesso tramite password root. Premi su <code className="action">y</code> e poi su <code className="action">Entrata</code>. (Se decidi di utilizzare l'accesso utente root, digita <code className="action">n</code> e poi definisci una password di root.)
+Si raccomanda di utilizzare il metodo di autenticazione proposto al posto dell'accesso tramite password root. Premi su <code className="action">y</code> e poi su <code className="action">Invio</code>. (Se decidi di utilizzare l'accesso utente root, digita <code className="action">n</code> e poi definisci una password di root.)
 
-Inserisci <code className="action">il seguente</code> invito:
+Inserisci <code className="action">n</code> al prompt successivo:
 
 ```console
 Change the root password? [Y/n]
@@ -146,7 +146,7 @@ MariaDB [(none)]> exit;
 
 ### Step 3: configurare il firewall
 
-La configurazione di un firewall (*iptables*) permette di migliorare la sicurezza della tua istanza WordPress. Questo processo può essere semplificato utilizzando il front end "Uncomplicated Firewall" (UFW) e la sua serie di profili predefiniti. Installate UFW:
+La configurazione di un firewall (*iptables*) permette di migliorare la sicurezza della tua istanza WordPress. Questo processo può essere semplificato utilizzando il front end "Uncomplicated Firewall" (UFW) e la sua serie di profili predefiniti. Installa UFW:
 
 ```bash
 debian@instance:~$ sudo apt install ufw
@@ -164,7 +164,7 @@ debian@instance:~$ sudo ufw app list | grep WWW # o grep Apache
 
 Scegliendo "WWW Full", le connessioni protette (porta 443) e le richieste http non sicure (porta 80) al server web saranno autorizzate.
 
-Per visualizzare quali porti sono interessati da un profilo particolare, accedi `sudo ufw app info "profilo"`.
+Per visualizzare quali porte sono interessate da un profilo particolare, accedi `sudo ufw app info "profilo"`.
 
 Inserendo il seguente comando, le porte definite dal profilo "WWW Full" saranno aperte:
 
@@ -198,7 +198,7 @@ Accedi al [sito ufficiale di WordPress](https://wordpress.org/download/) per rec
 debian@instance:~$ wget https://wordpress.org/latest.tar.gz
 ```
 
-Elimina l'archivio scaricato:
+Decomprimi l'archivio scaricato:
 
 ```bash
 debian@instance:~$ tar zxvf latest.tar.gz
@@ -222,7 +222,7 @@ Elimina la cartella esistente:
 debian@instance:~$ sudo rm -R /var/www/html/
 ```
 
-Sostituisci di default la cartella del server Web con la cartella WordPress:
+Sostituisci la cartella predefinita del server Web con la cartella WordPress:
 
 ```bash
 debian@instance:~$ sudo mv wordpress /var/www/html
@@ -238,7 +238,7 @@ Il server Web è pronto per la configurazione iniziale di WordPress.
 
 ### Step 5: configurare WordPress
 
-Apri un browser Web e accedi al sito WordPress inserendo l'indirizzo IP della tua istanza (o il dominio se ne hai già [collegato uno all'istanza](/guides/web-cloud/domains/dns-zone-edit)). Scegliete una lingua sulla prima pagina.
+Apri un browser Web e accedi al sito WordPress inserendo l'indirizzo IP della tua istanza (o il dominio se ne hai già [collegato uno all'istanza](/guides/web-cloud/domains/dns-zone-edit)). Scegli una lingua sulla prima pagina.
 
 Utilizza la configurazione assistita WordPress per accedere al database. Inserisci le informazioni [configurate precedentemente](#sqlconf).
 
@@ -268,7 +268,7 @@ Il comando successivo installa una versione di Cerbot che funziona ma è obsolet
 :::
 
 
-Installate le scartoffie necessarie per il cliente Cerbot:
+Installa i pacchetti necessari per il client Certbot:
 
 ```bash
 debian@instance:~$ sudo apt install certbot python3-certbot-apache
@@ -282,7 +282,7 @@ debian@instance:~$ sudo certbot --apache -d domainname.ovh -d www.domainname.ovh
 
 Inserisci un indirizzo email valido e accetta le condizioni di utilizzo.
 
-Cerbot rinnova automaticamente i certificati. Non sono necessarie ulteriori fasi. Per maggiori informazioni sulle funzionalità di Cerbot, consulta le opzioni disponibili.
+Certbot rinnova automaticamente i certificati. Non sono necessarie ulteriori fasi. Per maggiori informazioni sulle funzionalità di Certbot, consulta le opzioni disponibili.
 
 ## Per saperne di più
 

--- a/docs/it/guides/public-cloud/compute/key-concepts.mdx
+++ b/docs/it/guides/public-cloud/compute/key-concepts.mdx
@@ -27,7 +27,7 @@ OVHcloud offre diverse famiglie di istanze progettate per rispondere a diversi t
 | Tipi di istanze  | Descrizione                      | Caso d'uso tipico                                                                                                                                                        |
 | ------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Generale           | Equilibrio CPU e Memoria         | Adatto a server di sviluppo, applicazioni web e carichi di lavoro aziendali generali. Fornisce un rapporto bilanciato tra CPU e RAM.                                            |
-| CPU ottimizzata      | Alta prestazione del processore     | Ideale per applicazioni intensiva di calcolo, attività di elaborazione parallela, pipeline CI/CD o microservizi che richiedono una frequenza CPU elevata.                                     |
+| CPU ottimizzata      | Alta prestazione del processore     | Ideale per applicazioni intensive di calcolo, attività di elaborazione parallela, pipeline CI/CD o microservizi che richiedono una frequenza CPU elevata.                                     |
 | Memoria ottimizzata  | Capacità di memoria elevata          | Progettata per l'analisi dei dati, carichi di lavoro big data e cache di database. Presenta rapporti memoria/CPU elevati e IOPS accelerati. I core virtuali sono clockati a 2 GHz o più.       |
 | Archiviazione ottimizzata | Alta prestazione IOPS           | Dotata di archiviazione NVMe per I/O disco ultra veloci, ideale per database e applicazioni big data.                                                                     |
 | GPU                | Grafica accelerata hardware      | Fornisce un'eccezionale prestazione di calcolo parallelo, fino a 1000 volte più veloce della CPU per alcuni carichi di lavoro. Adatta all'IA, al machine learning e al rendering 3D.               |
@@ -62,7 +62,7 @@ Durante la creazione di un'istanza, selezioni un'immagine che include il sistema
 
 - **Distribuzioni Linux**: Ubuntu, Debian, CentOS, AlmaLinux, Rocky Linux e altre. Queste immagini sono pronte all'uso per i server web, gli ambienti di sviluppo e i carichi di lavoro generali.
 - **Windows Server**: Versioni con licenze integrate, permettendo un immediato deployment per applicazioni basate su Microsoft e carichi di lavoro aziendali.
-- **Applicazioni preconfigurate**: Immagini che includono software come cPanel, Plesk, Docker o NVIDIA GPU Cloud (NGC). Semplicizzano il deployment e accelerano il passaggio alla produzione.
+- **Applicazioni preconfigurate**: Immagini che includono software come cPanel, Plesk, Docker o NVIDIA GPU Cloud (NGC). Semplificano il deployment e accelerano il passaggio alla produzione.
 - **[Immagini personalizzate](/guides/public-cloud/compute/upload-own-image)**: Puoi importare le tue immagini in formato QCOW2 o RAW, offrendo un controllo completo sul tuo ambiente e permettendo migrazioni, modelli standardizzati o configurazioni specializzate.
 
 **Ciclo di vita e supporto**: OVHcloud aggiorna regolarmente il catalogo delle immagini. Consulta sempre le notifiche sul ciclo di vita e la fine del supporto per assicurarti che le tue immagini rimangano sicure e supportate. Vedi [qui](/guides/public-cloud/compute/image-life-cycle).
@@ -80,7 +80,7 @@ Buone pratiche:
 
 - Non condividere mai la tua chiave privata.
 - Utilizzare una chiave unica per ogni utente.
-- Archiviare le tue chiavi in un gestore o in un fortezza sicuro.
+- Archiviare le tue chiavi in un gestore o in una fortezza sicura.
 
 Per istruzioni dettagliate sulla creazione e sull'utilizzo delle chiavi SSH, consulta la guida [OVHcloud su SSH](/guides/public-cloud/compute/creating-ssh-keys).
 

--- a/docs/it/guides/public-cloud/compute/local-zones-capabilities-limitations.mdx
+++ b/docs/it/guides/public-cloud/compute/local-zones-capabilities-limitations.mdx
@@ -35,7 +35,7 @@ Per maggiori informazioni, accedi alla nostra [pagina dedicata alle istanze Loca
 | Archiviazione         | Object Storage             | Sì | 1. Non sono supportate le politiche utente. tutte le chiavi di accesso all'interno di un progetto possono accedere a tutti i bucket in tutte le Local Zones. <br/> 2. Supportato solo il livello di archiviazione Standard. <br/> 3. Funzionalità S3<sup>1</sup> non supportate: tag S3, Legal Hold, SSE-OMK, replica S3, accesso log server. |
 |                       | Archiviazione su disco     | Sì | Nessun supporto per la crittografia. I volumi classici non possono essere multi-attaccati. I volumi classici limitati a 250 IOPS (contro 500 IOPS nelle regioni 1AZ e 3AZ). Dimensione massima 4 TB (contro 12 TB). |
 |                       | File Storage         | No | |
-| Container.            | Managed Kubernetes Service         | No | |
+| Container             | Managed Kubernetes Service         | No | |
 |                       | Managed Rancher Service   | No | |
 |                       | Managed Private Registry   | No | |
 | DBaas                 | DBaas                      | No | |

--- a/docs/it/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
+++ b/docs/it/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
@@ -44,7 +44,7 @@ Nella nuova finestra inserisci le informazioni richieste:
 
 Lo Snapshot sarà successivamente elencato nella sezione <code className="action">Images</code>. Ti consigliamo di assegnare un nome esplicito a ogni Snapshot.
 
-### Ripristino uno snapshot
+### Ripristino di uno snapshot
 
 È possibile ripristinare uno snapshot creando una nuova istanza a partire da essa.
 

--- a/docs/it/guides/public-cloud/compute/migration-between-regions.mdx
+++ b/docs/it/guides/public-cloud/compute/migration-between-regions.mdx
@@ -9,7 +9,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Obiettivi
 
-Questa guida spiega come migrare un'istanza Public Cloud da una zona di disponibilità (AZ) a un'altra, da 1AZ a 3AZ o viceversa. Centralizza le fasi chiave (backup, trasferimento e ricreazione) e rimanda ai guide dettagliate per ogni elemento.
+Questa guida spiega come migrare un'istanza Public Cloud da una zona di disponibilità (AZ) a un'altra, da 1AZ a 3AZ o viceversa. Centralizza le fasi chiave (backup, trasferimento e ricreazione) e rimanda alle guide dettagliate per ogni elemento.
 
 ## Prerequisiti
 
@@ -21,7 +21,7 @@ Questa guida spiega come migrare un'istanza Public Cloud da una zona di disponib
 ### Accesso allo Spazio Cliente OVHcloud
 
 - **Link diretto:** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Public Cloud</code> > Seleziona il tuo project
+- **Percorso di navigazione:** <code className="action">Public Cloud</code> > Seleziona il tuo progetto
 
 ---
 {/* CP-NAV-END:publiccloud-projects */}

--- a/docs/it/guides/public-cloud/compute/resize-instance-openstack.mdx
+++ b/docs/it/guides/public-cloud/compute/resize-instance-openstack.mdx
@@ -44,7 +44,7 @@ Durante il ridimensionamento, l'istanza viene arrestata per tutta la durata dell
 
 ### Elenca le istanze
 
-Il primo step consiste nell’elencare le istanze per recuperare il nome dell’istanza che vuoi ridimensionare. Nel nostro esempio, vogliamo ridimensionare l’istanza denominata "OVHcloudistance".
+Il primo step consiste nell’elencare le istanze per recuperare il nome dell’istanza che vuoi ridimensionare. Nel nostro esempio, vogliamo ridimensionare l’istanza denominata "OVHcloudinstance".
 
 ```bash
 $ openstack server list

--- a/docs/it/guides/public-cloud/compute/revert-a-flex-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/revert-a-flex-instance.mdx
@@ -43,7 +43,7 @@ Clicca sul menu <code className="action">Compute</code> a sinistra e seleziona <
 
 Questa sezione indica il template attuale (*old flavor*) e ti permette di selezionare un nuovo template (*new flavor*) per la risorsa dell'istanza.
 
-Nel nostro esempio, il nostro template è « b2-15-flex ». Possiamo tornare a un template classico « b2-15 » o aggiornare l'istanza verso il template « b2-30 » per avere più spazio di storage. Nel nostro caso, vorremmo aggiornare la nostra istanza verso il modello classico « b2-30 x per aumentare lo spazio di storage.
+Nel nostro esempio, il nostro template è « b2-15-flex ». Possiamo tornare a un template classico « b2-15 » o aggiornare l'istanza verso il template « b2-30 » per avere più spazio di storage. Nel nostro caso, vorremmo aggiornare la nostra istanza verso il modello classico « b2-30 » per aumentare lo spazio di storage.
 
 <img className="thumbnail" alt="Scegli un nuovo flavor" src="/images/public-cloud/compute/revert-a-flex-instance/confirmflavor.png" loading="lazy" />
 

--- a/docs/it/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
+++ b/docs/it/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
@@ -37,7 +37,7 @@ Ecco la lista dei comandi principali:
 |volume create|Crea un nuovo volume|
 |volume delete|Elimina un volume|
 |volume list|Lista i volumi|
-|create volume snapshot|Crea uno snaspshot di un volume|
+|create volume snapshot|Crea uno snapshot di un volume|
 
 Per ottenere informazioni su un comando specifico, aggiungi `help` davanti a questo comando:
 
@@ -190,7 +190,7 @@ admin@server-1:~$ openstack server remove volume 46aec29f-fe50-4562-b3f9-2e6665a
 - Elimina il volume:
 
 ```bash
-admin@server-1:~$ opesntack volume delete f75d60b3-4179-4ca9-8bc7-8e5f7a1682f8
+admin@server-1:~$ openstack volume delete f75d60b3-4179-4ca9-8bc7-8e5f7a1682f8
 ```
 
 ## Per saperne di più

--- a/docs/it/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/it/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -54,7 +54,7 @@ La creazione del disco potrebbe richiedere alcuni minuti, a seconda della sua di
 
 ### Associa il disco a un'istanza
 
-Una volta creato il disco, puoi decidere di associarlo a un'istanza. clicca su <code className="action">Block Storage</code> nella barra di navigazione di sinistra su **Storage e Backup**.
+Una volta creato il disco, puoi decidere di associarlo a un'istanza. Clicca su <code className="action">Block Storage</code> nella barra di navigazione di sinistra su **Storage e Backup**.
 
 A destra del volume scelto, clicca sul pulsante <code className="action">...</code> e poi su <code className="action">Associa all'istanza</code>.
 
@@ -69,7 +69,8 @@ Il processo di associazione del disco all'istanza sta per iniziare e potrebbe ri
 <img className="thumbnail" alt="associare volume" src="/images/public-cloud/compute/create-volume-from-snapshot/volume05.png" loading="lazy" />
 
 :::warning
-Evitare la navigazione fuori dalla scheda in corso durante l'associazione del disco. Ciò può interrompere il processo.
+>
+> Evitare la navigazione fuori dalla scheda in corso durante l'associazione del disco. Ciò può interrompere il processo.
 :::
 
 Una volta effettuato l'associazione, puoi seguire gli step successivi [con Linux](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#da-linux) o [Windows](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#da-windows).

--- a/docs/it/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
+++ b/docs/it/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
@@ -75,6 +75,6 @@ Clicca sul pulsante <code className="action">...</code> per eliminare uno Snapsh
 
 [Crea e configura un disco aggiuntivo sulla tua istanza](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
 
-[Aumenta la spazio del tuo disco aggiuntivo](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
+[Aumenta lo spazio del tuo disco aggiuntivo](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
 Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).

--- a/docs/it/guides/public-cloud/compute/switch-volume-type.mdx
+++ b/docs/it/guides/public-cloud/compute/switch-volume-type.mdx
@@ -22,7 +22,7 @@ L’obiettivo di questa guida è mostrarti come modificare un tipo di volume Blo
 ### Accesso allo Spazio Cliente OVHcloud
 
 - **Link diretto:** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Public Cloud</code> > Seleziona il tuo project
+- **Percorso di navigazione:** <code className="action">Public Cloud</code> > Seleziona il tuo progetto
 
 ---
 {/* CP-NAV-END:publiccloud-projects */}

--- a/docs/it/guides/public-cloud/compute/test-disk-speed.mdx
+++ b/docs/it/guides/public-cloud/compute/test-disk-speed.mdx
@@ -19,7 +19,7 @@ Eseguire un test della velocità dei tuoi dischi è necessario per confrontare l
 
 ### Installare il comando di test
 
-Il comando necessario per verificare la velocità del disco si chiama `fio` Non è presente di default sul tuo server.
+Il comando necessario per verificare la velocità del disco si chiama `fio`. Non è presente di default sul tuo server.
 
 Per installare `fio`, connettiti all'istanza in SSH ed esegui il comando:
 

--- a/docs/it/guides/public-cloud/compute/upload-own-image.mdx
+++ b/docs/it/guides/public-cloud/compute/upload-own-image.mdx
@@ -58,7 +58,7 @@ Consigliamo di utilizzare immagini in formato RAW o QCOW2. Ottimizza la dimensio
 
 ### Importa la tua immagine
 
-OpenStack ci sono due modi per importare la tua immagine. Puoi farlo tramite l'interfaccia da riga di comando OpenStack o con [l'interfaccia Horizon](https://horizon.cloud.ovh.net/auth/login/).
+Con OpenStack ci sono due modi per importare la tua immagine. Puoi farlo tramite l'interfaccia da riga di comando OpenStack o con [l'interfaccia Horizon](https://horizon.cloud.ovh.net/auth/login/).
 
 #### Da riga di comando OpenStack
 

--- a/docs/it/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/it/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -67,7 +67,7 @@ A state is composed of several files inside a `.pulumi` folder:
 - `meta.yaml`: This is the metadata file. It does not hold information about the stacks but rather information about the backend itself.
 - `stacks/`: Active state files for each stack (e.g. `dev.json`).
 - `locks/`: Optional lock files for each stack if the stack is currently being operated on by a Pulumi operation (e.g. `dev/$lock.json`).
-- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json`vwhere $timestamp records the time the history file was created).
+- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json` where $timestamp records the time the history file was created).
 
 ## Instructions
 

--- a/docs/it/guides/public-cloud/compute/volume-backup.mdx
+++ b/docs/it/guides/public-cloud/compute/volume-backup.mdx
@@ -61,10 +61,10 @@ A destra del volume, clicca sul pulsante <code className="action">...</code> e p
 
 Seleziona il volume da cui desideri creare un backup.
 
-Seleziona quindi il tipo di backup che vuoi creare: **Volume Snapshot** ou **Volume Backup**.
+Seleziona quindi il tipo di backup che vuoi creare: **Volume Snapshot** o **Volume Backup**.
 
 - Scegliendo **Volume Snapshot**, hai la possibilità di modificare il nome del Volume Snapshot da creare prima di confermare cliccando su <code className="action">Creare il backup</code>.
-- Selezionando **Volume Backup**, ti verrà chiesto di scollegare il volume dall'istanza per poter continuare. È possibile modificare il nome del Volume Snapshot da creare prima di confermare il mount <code className="action">Creare il backup</code>.
+- Selezionando **Volume Backup**, ti verrà chiesto di scollegare il volume dall'istanza per poter continuare. È possibile modificare il nome del Volume Snapshot da creare prima di confermare cliccando su <code className="action">Creare il backup</code>.
 
 <img className="thumbnail" alt="Volume Backup o Snapshot - creazione" src="/images/public-cloud/compute/volume-backup/volumebackup02.png" loading="lazy" />
 

--- a/docs/it/guides/public-cloud/cross-functional/activate-hds-certification.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/activate-hds-certification.mdx
@@ -24,7 +24,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ### Accesso allo Spazio Cliente OVHcloud
 
 - **Link diretto:** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Public Cloud</code> > Seleziona il tuo project
+- **Percorso di navigazione:** <code className="action">Public Cloud</code> > Seleziona il tuo progetto
 
 ---
 {/* CP-NAV-END:publiccloud-projects */}

--- a/docs/it/guides/public-cloud/cross-functional/compute-essential-information.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/compute-essential-information.mdx
@@ -50,7 +50,7 @@ Il catalogo Public Cloud propone risorse a basso livello come istanze o reti pri
 Quando la risorsa proposta è "gestita", si parla spesso di una risorsa negli strati alti, già vicina all'applicazione, come un cluster di database, un cluster Kubernetes, una soluzione di training modello per l'IA...
 <br/>Per "gestita" si intende il fatto che la piattaforma è sviluppata, monitorata, mantenuta (upgrade) da OVHcloud. Non dovete preoccuparvi di questa gestione e approfittate direttamente del servizio.
 
-Queste risorse sono disponibili nei diversi datacenter localizzati nel mondo OVHcloud offre servizi Public Cloud in Europa, America del Nord, Asia e Oceania.
+Queste risorse sono disponibili nei diversi datacenter localizzati nel mondo. OVHcloud offre servizi Public Cloud in Europa, America del Nord, Asia e Oceania.
 <br/>È possibile avviare una risorsa in ciascuno di questi punti selezionando semplicemente la localizzazione desiderata.
 
 <img className="thumbnail" alt="Public Cloud geolocation" src="/images/public-cloud/cross-functional/00-essential-info-to-get-started-on-public-cloud/geolocation.png" loading="lazy" />

--- a/docs/it/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -24,7 +24,7 @@ La creazione di un progetto è il primo passo nella distribuzione delle [istanze
 ### Accesso allo Spazio Cliente OVHcloud
 
 - **Link diretto:** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Public Cloud</code> > Seleziona il tuo project
+- **Percorso di navigazione:** <code className="action">Public Cloud</code> > Seleziona il tuo progetto
 
 ---
 {/* CP-NAV-END:publiccloud-projects */}

--- a/docs/it/guides/public-cloud/cross-functional/delete-a-project.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/delete-a-project.mdx
@@ -33,7 +33,7 @@ Una volta eliminato un progetto, le risorse in esso contenute vengono definitiva
 ### Accesso allo Spazio Cliente OVHcloud
 
 - **Link diretto:** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Public Cloud</code> > Seleziona il tuo project
+- **Percorso di navigazione:** <code className="action">Public Cloud</code> > Seleziona il tuo progetto
 
 ---
 {/* CP-NAV-END:publiccloud-projects */}

--- a/docs/it/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
@@ -22,7 +22,7 @@ Per creare di più, è necessario aumentare la quota disponibile.
 ### Accesso allo Spazio Cliente OVHcloud
 
 - **Link diretto:** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Public Cloud</code> > Seleziona il tuo project
+- **Percorso di navigazione:** <code className="action">Public Cloud</code> > Seleziona il tuo progetto
 
 ---
 {/* CP-NAV-END:publiccloud-projects */}

--- a/docs/it/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
@@ -164,7 +164,7 @@ Per effettuare questa operazione, utilizza il comando:
 ```bash
 openstack --os-auth-type token token revoke <token_id>
 
-# ou 
+# o 
 
 openstack --os-auth-type token token revoke $OS_TOKEN
 ```

--- a/docs/it/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/it/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2024-01-22
 
 ## Objective
 
-This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the pre requisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
+This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the prerequisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
 
 For this example, we will use a private network and a subnet with the following properties:
 
@@ -44,7 +44,7 @@ Click the `Subnets` tab: the subnets from the private network are listed.
 
 Click on your `Edit Subnet`. For this guide, our target is to add a gateway IP:
 
-- Click untick the  `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
+- Untick the `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
 
 <img className="thumbnail" alt="gateway IP" src="/images/public-cloud/network-services/configuration-04-update-subnet/add_gateway_ip.png" loading="lazy" />
 

--- a/docs/pl/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -103,6 +103,6 @@ sudo cat /etc/hosts
 127.0.0.1 localhost
 ```
 
-## Sprawdź również 
+## Sprawdź również
 
 Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).

--- a/docs/pl/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
+++ b/docs/pl/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
@@ -91,7 +91,7 @@ Więcej informacji na temat uprawnień użytkowników i powiązanych z nimi tema
 
 Jeśli stworzyłeś pary kluczy SSH w systemie opartym na GNU/Linux, macOS lub BSD, możesz użyć komendy `ssh-copy-id`, aby dodać publiczne klucze do Twojego serwera.
 
-Narzędzie `ssh-copy-id` kopiuje klucze publiczne do pliku`~/.ssh/authorized_keys` na określonym serwerze zdalnym i w razie potrzeby automatycznie tworzy plik w tym katalogu.
+Narzędzie `ssh-copy-id` kopiuje klucze publiczne do pliku `~/.ssh/authorized_keys` na określonym serwerze zdalnym i w razie potrzeby automatycznie tworzy plik w tym katalogu.
 
 ```bash
 ssh-copy-id username@IP_ADDRESS

--- a/docs/pl/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/pl/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -25,7 +25,7 @@ You'll need an [OVHcloud Public Cloud project](/guides/public-cloud/cross-functi
 
 ### Install Packer
 
-Packer can be downloaded from the official website (curently [here](https://www.packer.io/downloads.html) ) and you'll need to `unzip` it.
+Packer can be downloaded from the official website (currently [here](https://www.packer.io/downloads.html) ) and you'll need to `unzip` it.
 
 For Linux 64bits
 
@@ -92,7 +92,7 @@ export NETWORK_ID=`openstack network list -f json | jq -r '.[] | select(.Name ==
 
 **INFO**: for `FLAVOR_ID`, you can directly use the name, ie `b2-7`
 
-Finaly, create a `packer.json` file
+Finally, create a `packer.json` file
 
 ```shell
 cat > packer.json <<EOF
@@ -129,7 +129,7 @@ cat > packer.json <<EOF
 EOF
 ```
 
-In the last selection of the configuration file, we specify a `setup_vm.sh` shell script to be ran.
+In the last selection of the configuration file, we specify a `setup_vm.sh` shell script to be run.
 
 ```sh
 #!/bin/sh
@@ -149,7 +149,7 @@ git clone ...
 
 ## Building the image
 
-Using the configuration file create above, check it and build the image with
+Using the configuration file created above, check it and build the image with
 
 ```shell
 packer validate packer.json

--- a/docs/pl/guides/public-cloud/compute/creating-ssh-keys.mdx
+++ b/docs/pl/guides/public-cloud/compute/creating-ssh-keys.mdx
@@ -98,7 +98,7 @@ Dla większej wygody i bezpieczeństwa, przechowuj tajne hasła w menedżerze ha
 :::
 
 
-Domyślnie wszystkie klucze SSH są przechowywane w katalogu `.ssh`. Pliki klucza publicznego będą miały '.pub` dodane do nazwy pliku.
+Domyślnie wszystkie klucze SSH są przechowywane w katalogu `.ssh`. Pliki klucza publicznego będą miały `.pub` dodane do nazwy pliku.
 
 ```console
 Your identification has been saved in /home/user/.ssh/id_rsa.

--- a/docs/pl/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
+++ b/docs/pl/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
@@ -36,7 +36,7 @@ Należy wypełnić pola. Niektóre są obowiązkowe (*), inne opcjonalne:
 
 - Image name (Nazwa obrazu) (*)
 - Image description (Opis obrazu)
-- Image file (Plik obrazu) (*) (wysyłka z lokalnego komputer)
+- Image file (Plik obrazu) (*) (wysyłka z lokalnego komputera)
 - Image format (Format obrazu) (*) :
 
 |||

--- a/docs/pl/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/pl/guides/public-cloud/compute/image-life-cycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud & VPS - Image and OS life cycle and end of life/support announcements
 description: Discover the lifecycle and end-of-life/end-of-support announcements for distributions and softwares for your VPS or Public Cloud instance
-lastUpdated: 2025-02-11
+lastUpdated: 2025-11-12
 ---
 
 ## Objective
@@ -70,7 +70,7 @@ Please note that:
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
 | 14 | [Forky](https://wiki.debian.org/DebianForky) | | | |
-| 13 | [Trixie](https://wiki.debian.org/DebianTrixie) | | | |
+| 13 | [Trixie](https://wiki.debian.org/DebianTrixie) | August 2025 | August 2028 | June 2030 |
 | 12 | [Bookworm](https://wiki.debian.org/DebianBookworm) | June 2023 | June 2026 | June 2028 |
 | 11 | [Bullseye](https://wiki.debian.org/DebianBullseye) | August 2021 | August 2024 | August 2026 |
 | 10 | [Buster](https://wiki.debian.org/DebianBuster) | July 2019 | September 2022 | June 2024 |

--- a/docs/pl/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/pl/guides/public-cloud/compute/install-wordpress.mdx
@@ -51,7 +51,7 @@ Poniższe instrukcje są sprawdzane dla dystrybucji Debian 11. Ubuntu opiera si�
 :::
 
 
-Aby uzyskać dostęp do Twojej instalacji za pomocą nazwy domeny, powiąż ją z Twoją instancją. W tym celu edytuj strefę DNS dostępną w <ManagerLink to="/">Panelu client OVHcloud</ManagerLink>, pod warunkiem, że OVHcloud jest Twoim operatorem, a nazwa domeny wykorzystuje serwery DNS OVHcloud.
+Aby uzyskać dostęp do Twojej instalacji za pomocą nazwy domeny, powiąż ją z Twoją instancją. W tym celu edytuj strefę DNS dostępną w <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, pod warunkiem, że OVHcloud jest Twoim operatorem, a nazwa domeny wykorzystuje serwery DNS OVHcloud.
 
 Aby dowiedzieć się więcej, zapoznaj się z przewodnikiem [Modyfikacja strefy DNS](/guides/web-cloud/domains/dns-zone-edit). Jeśli domena jest aktualnie używana, skonfiguruj DNS dopiero po zainstalowaniu nowego WordPress i uruchomieniu Twojej strony WWW.
 
@@ -92,12 +92,12 @@ Potwierdź pierwszą prośbę, naciskając <code className="action">Enter</code>
 Następnie wybierz metodę zabezpieczenia dostępu do serwera baz danych.
 
 ```console
-Switch to unix_socket authinfo [Y/n]
+Switch to unix_socket authentication [Y/n]
 ```
 
 Zaleca się stosowanie proponowanej metody uwierzytelniania zamiast dostępu za pomocą hasła root. Kliknij <code className="action">y</code>, a następnie <code className="action">Enter</code>. (Jeśli zdecydujesz się korzystać z dostępu użytkownika root, wpisz <code className="action">n</code>, następnie zdefiniuj hasło root.)
 
-Wpisz <code className="action">n</code> na poniższy adres e-mail:
+Wpisz <code className="action">n</code> przy następnym pytaniu:
 
 ```console
 Change the root password? [Y/n]
@@ -145,7 +145,7 @@ MariaDB [(none)]> exit;
 
 ### Etap 3: skonfiguruj firewall
 
-Konfiguracja zapory sieciowej (iptables* *) pozwala poprawić bezpieczeństwo Twojej instancji WordPress. Proces ten można uprościć, korzystając z front-endu "Uncomplicated Firewall" (UFW) oraz zestawu wstępnie zdefiniowanych profili. Zainstaluj UFW:
+Konfiguracja zapory sieciowej (*iptables*) pozwala poprawić bezpieczeństwo Twojej instancji WordPress. Proces ten można uprościć, korzystając z front-endu "Uncomplicated Firewall" (UFW) oraz zestawu wstępnie zdefiniowanych profili. Zainstaluj UFW:
 
 ```bash
 debian@instance:~$ sudo apt install ufw
@@ -197,7 +197,7 @@ Przejdź do oficjalnej [strony WordPress](https://wordpress.org/download/), aby 
 debian@instance:~$ wget https://wordpress.org/latest.tar.gz
 ```
 
-Odłącz pobrany archiwum:
+Rozpakuj pobrane archiwum:
 
 ```bash
 debian@instance:~$ tar zxvf latest.tar.gz
@@ -211,7 +211,7 @@ debian@instance:~$ sudo systemctl status apache2
 
 Można również otworzyć `http://IP_twojej_instancji` w przeglądarce internetowej. Należy wyświetlić stronę "Apache2 Debian Default Page".
 
-Kolejne etapy instalacji WordPress zastępując domyślny folder Apache dla stron www.
+Kolejne etapy instalują WordPress, zastępując domyślny folder Apache dla stron WWW.
 
 Zamiast używać domyślnego folderu, możesz również utworzyć nowy *Virtual Host* do instalacji WordPress. Aplikacja ta jest przydatna do hostowania kilku stron WWW, co nie jest istotne dla tego tutoriala.
 

--- a/docs/pl/guides/public-cloud/compute/key-concepts.mdx
+++ b/docs/pl/guides/public-cloud/compute/key-concepts.mdx
@@ -22,14 +22,14 @@ Instancje można zarządzać za pomocą Panelu klienta OVHcloud, interfejsu Hori
 
 ## Typy instancji
 
-OVHcloud oferuje wiele rodziny instancji zaprojektowanych w celu spełnienia różnych wymagań dotyczących obciążenia. Każda rodzina oferuje zakres rozmiarów (flavorów), aby dokładnie dopasować potrzeby zasobowe.
+OVHcloud oferuje wiele rodzin instancji zaprojektowanych w celu spełnienia różnych wymagań dotyczących obciążenia. Każda rodzina oferuje zakres rozmiarów (flavorów), aby dokładnie dopasować potrzeby zasobowe.
 
 | Typy instancji | Opis | Typowe przypadki użycia |
 | ------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | General Purpose | Zrównoważone CPU i pamięć | Nadaje się do serwerów deweloperskich, aplikacji internetowych i ogólnych obciążeń biznesowych. Zapewnia zrównoważony stosunek CPU do RAM. |
 | CPU Optimized | Wysoka wydajność procesora | Idealne dla aplikacji intensywnie obliczeniowych, zadań przetwarzania równoległego, potoków CI/CD lub mikroserwisów wymagających wysokiej częstotliwości CPU. |
 | Memory Optimized | Duża pojemność pamięci | Dostosowane do analizy danych, dużych obciążeń danych i buforowania baz danych. Zapewnia wysokie stosunki RAM do CPU i przyspieszone IOPS. vCores są zegarowane z częstotliwością 2 GHz lub wyższą. |
-| Storage Optimized | Wysoka wydajność IOPS | Wyposaży w magazyn NVMe, zapewniając ultra szybkie operacje wejścia/wyjścia z dysku, idealne do baz danych i dużych aplikacji danych. |
+| Storage Optimized | Wysoka wydajność IOPS | Wyposażona w magazyn NVMe, zapewniając ultra szybkie operacje wejścia/wyjścia z dysku, idealne do baz danych i dużych aplikacji danych. |
 | GPU | Grafika przyspieszona sprzętowo | Oferuje wyjątkową wydajność obliczeń równoległych, nawet do 1000 razy szybszą niż CPU dla niektórych obciążeń. Nadaje się do AI, uczenia głębokiego i renderowania 3D. |
 | Discovery | Niskie koszty, udostępnione zasoby | Instancje wstępne z udostępnionymi zasobami, oferujące stabilną wydajność po atrakcyjnej cenie. Idealne do środowisk testowych, szkoleń lub projektów dowodowych. |
 
@@ -108,7 +108,7 @@ Instancje OVHcloud Compute mogą być podłączone do różnych typów sieci w z
 | Typy sieci | Opis | Przypadki użycia |
 | ------------------------ | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | Sieć publiczna | Instancje są podłączone do Internetu za pomocą publicznego adresu IP. | Gospodarowanie witrynami internetowymi, API lub udostępnianie zdalnego dostępu do Twoich serwerów. |
-| Sieć prywatna (vRack) | Prywatna interkoneksja między Twoimi zasobami OVHcloud, izolowana od Internetu publicznego. | Łączenie baz danych, usług backendowych lub komunikacji wewnętrznego między instancjami. |
+| Sieć prywatna (vRack) | Prywatna interkoneksja między Twoimi zasobami OVHcloud, izolowana od Internetu publicznego. | Łączenie baz danych, usług backendowych lub komunikacji wewnętrznej między instancjami. |
 
 vRack umożliwia utworzenie bezpiecznej, izolowanej sieci, nawet w różnych regionach lub projektach.
 
@@ -122,7 +122,7 @@ Savings Plans pozwalają Ci obniżyć koszty Public Cloud Compute w zamian za zo
 
 **Główne korzyści:**
 
-- **Niższe koszty**: Więcej opłacalne niż rozliczanie za rzeczywiste użycie.
+- **Niższe koszty**: Bardziej opłacalne niż rozliczanie za rzeczywiste użycie.
 - **Automatyczne stosowanie**: Zyski są automatycznie stosowane do wszystkich kompatybilnych instancji.
 - **Elastyczne**: Możesz zmieniać typy lub rozmiary instancji, zachowując korzyści z planu.
 

--- a/docs/pl/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
+++ b/docs/pl/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
@@ -28,7 +28,7 @@ Możliwe jest tworzenie zrzutów instancji, które będą mogły zostać wykorzy
 
 ### Tworzenie snapshota
 
-Zaloguj się do interfejsu Horizon i upewnij się, czy jesteś w odpowiednim regionie. I możecie to sprawdzić w lewym górnym rogu. 
+Zaloguj się do interfejsu Horizon i upewnij się, czy jesteś w odpowiednim regionie. Możecie to sprawdzić w lewym górnym rogu. 
 
 <img className="thumbnail" alt="Wybór regionu" src="/images/public-cloud/compute/managing-snapshots-in-horizon/region2021.png" loading="lazy" />
 
@@ -81,7 +81,7 @@ Następnie kliknij <code className="action">Launch Instance</code>, aby rozpocz�
 
 ### Usunięcie snapshota
 
-W interfejsie horizon kliknij menu <code className="action">Compute</code> po lewej stronie, a następnie kliknij <code className="action">Image</code>.
+W interfejsie horizon kliknij menu <code className="action">Compute</code> po lewej stronie, a następnie kliknij <code className="action">Images</code>.
 
 Następnie kliknij rozwijaną strzałkę obok snapshota, który chcesz usunąć i kliknij <code className="action">Delete Image</code>. Potwierdź usunięcie snapshota.
 

--- a/docs/pl/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/pl/guides/public-cloud/compute/setup-security-group.mdx
@@ -89,7 +89,7 @@ Po dodaniu nowej reguły odczekaj kilka minut, aż zostanie ona uwzględniona.
 root@serveur:~$ ssh admin@149.xxx.xxx.177
 
 Last login: Tue Oct 13 13:56:30 2015 from proxy-109-190-254-35.ovh.net
-admin@serveur1:~
+admin@serveur1:~$
 ```
 
 ### Konfiguracja grupy zabezpieczeń na instancji <a name="instance-security-group"></a>
@@ -106,7 +106,7 @@ Możesz zastosować nową grupę zabezpieczeń dla instancji, która została ju
 
 ### Usuń grupę zabezpieczeń
 
-Aby usunąć grupę zabezpieczeń, zaznacz ją w odpowiednim polu po lewej stronie, następnie kliknij Delete <code className="action">Security Groups</code>
+Aby usunąć grupę zabezpieczeń, zaznacz ją w odpowiednim polu po lewej stronie, następnie kliknij <code className="action">Delete Security Groups</code>
 
 <img className="thumbnail" alt="usuń grupę zabezpieczeń" src="/images/public-cloud/compute/setup-security-group/security-group7.png" loading="lazy" />
 

--- a/docs/pl/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/pl/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -69,7 +69,8 @@ Proces łączenia dysku z Twoją instancją rozpocznie się i może zająć kilk
 <img className="thumbnail" alt="przywiąż wolumen" src="/images/public-cloud/compute/create-volume-from-snapshot/volume05.png" loading="lazy" />
 
 :::warning
-Podczas łączenia dysku unikaj przeglądania strony poza zakładką w trakcie. Może to zakłócić proces.
+>
+> Podczas łączenia dysku unikaj przeglądania strony poza zakładką w trakcie. Może to zakłócić proces.
 :::
 
 Po podłączeniu możesz przejść do kolejnych etapów [w systemie Linux](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#w-systemie-linux) lub [Windows](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#w-systemie-windows).

--- a/docs/pl/guides/public-cloud/compute/upgrading-operating-system.mdx
+++ b/docs/pl/guides/public-cloud/compute/upgrading-operating-system.mdx
@@ -142,7 +142,7 @@ Sprawdź, czy Twoje aplikacje działają zgodnie z planem. W przypadku problemu 
 Przed rozpoczęciem aktualizacji głównej wersji systemu operacyjnego upewnij się, że aktualizujesz najnowsze wersje wszystkich pakietów zainstalowanych w jego obecnej wersji. Wprowadź to polecenie:
 
 ```sh
-$ sudo dnf upgrade —refresh
+$ sudo dnf upgrade --refresh
 ```
 
 Następnie zrestartuj serwer:

--- a/docs/pl/guides/public-cloud/compute/upload-own-image.mdx
+++ b/docs/pl/guides/public-cloud/compute/upload-own-image.mdx
@@ -4,7 +4,7 @@ description: Dowiedz się, jak zaimportować własny obraz do Public Cloud
 lastUpdated: 2020-10-27
 ---
 
-## Ziel
+## Cel
 
 OVHcloud oferuje klientom Public Cloud obrazy gotowe do użycia, a także możliwość korzystania z własnych obrazów.
 

--- a/docs/pl/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/pl/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -67,7 +67,7 @@ A state is composed of several files inside a `.pulumi` folder:
 - `meta.yaml`: This is the metadata file. It does not hold information about the stacks but rather information about the backend itself.
 - `stacks/`: Active state files for each stack (e.g. `dev.json`).
 - `locks/`: Optional lock files for each stack if the stack is currently being operated on by a Pulumi operation (e.g. `dev/$lock.json`).
-- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json`vwhere $timestamp records the time the history file was created).
+- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json` where $timestamp records the time the history file was created).
 
 ## Instructions
 

--- a/docs/pl/guides/public-cloud/compute/volume-backup.mdx
+++ b/docs/pl/guides/public-cloud/compute/volume-backup.mdx
@@ -95,7 +95,7 @@ Po otrzymaniu wniosku o utworzenie wolumenu Backup zostaje on dodany do listy.
 
 <img className="thumbnail" alt="Kopia zapasowa - lista" src="/images/public-cloud/compute/volume-backup/volumebackup04.png" loading="lazy" />
 
-Kliknij przycisk <code className="action">...</code>, aby <code className="action">usun</code> lub <code className="action">Utwórz wolumen</code> na podstawie wolumenu Snapshot lub odpowiedniego wolumenu Backup.
+Kliknij przycisk <code className="action">...</code>, aby <code className="action">Usuń</code> lub <code className="action">Utwórz wolumen</code> na podstawie wolumenu Snapshot lub odpowiedniego wolumenu Backup.
 
 Więcej informacji na ten temat znajdziesz w [naszym przewodniku dotyczącym tworzenia wolumenu z kopii zapasowej](/guides/public-cloud/compute/storage-create-volume-from-backup).
 

--- a/docs/pl/guides/public-cloud/cross-functional/api-rate-limits.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/api-rate-limits.mdx
@@ -104,6 +104,6 @@ Oto przykłady znanych bibliotek implementujących funkcję *retry backoff* w py
 - tenacity: [https://pypi.org/project/tenacity/](https://pypi.org/project/tenacity/)
 - backoff: [https://pypi.org/project/backoff/](https://pypi.org/project/backoff/)
 
-## Sprawdź
+## Sprawdź również
 
 Przyłącz się do społeczności naszych użytkowników na [https://community.ovh.com/en/](https://community.ovh.com/en/).

--- a/docs/pl/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
@@ -38,7 +38,7 @@ Kliknij przycisk <code className="action">Download OpenStack RC File</code>, aby
 
 - **Key Pairs** (w <code className="action">Projekcie</code> i <code className="action">Compute</code>)
 
-W tej sekcji możesz przechowywać pary kluczy SSH i zarządzać nimi. Możesz po prostu utworzyć i dodać klucz publiczny i prywatny klikając przycisk <code className="action">Create Key Au Pair</code>.
+W tej sekcji możesz przechowywać pary kluczy SSH i zarządzać nimi. Możesz po prostu utworzyć i dodać klucz publiczny i prywatny klikając przycisk <code className="action">Create Key Pair</code>.
 
 <img className="thumbnail" alt="horizon - klucze SSH" src="/images/public-cloud/cross-functional/access-and-security-in-horizon/key_pairs.png" loading="lazy" />
 
@@ -46,7 +46,7 @@ Jeśli chcesz dodać istniejący klucz, kliknij przycisk <code className="action
 
 Ta część interfejsu zawiera podstawowe instrukcje. Więcej informacji na temat kluczy SSH znajdziesz w [tym przewodniku](/guides/public-cloud/compute/creating-ssh-keys).
 
-- **Security Groups** (w <code className="action">ramach projektu</code>, a następnie <code className="action">Network</code>)
+- **Security Groups** (w <code className="action">Project</code> / <code className="action">Network</code>)
 
 Grupy zabezpieczeń to zbiory reguł filtrowania stosowanych do interfejsów sieciowych. Można z nich korzystać, aby ograniczyć dostęp do instancji do adresów IP i portów.
 

--- a/docs/pl/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -10,7 +10,7 @@ Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera S
 :::
 
 
-## Objective
+## Cel
 
 Utworzenie projekt jest pierwszym krokiem we wdrażaniu [instancji Public Cloud](https://www.ovhcloud.com/pl/public-cloud/).
 

--- a/docs/pl/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -113,7 +113,7 @@ Zapoznaj się z przewodnikiem [Zmiana klucza SSH w przypadku utraty](/guides/pub
 </details>
 
 
-### Kopii zapasowych
+### Kopie zapasowe
 
 <details>
 <summary>Czy można wykonać kopię zapasową serwerów Public Cloud?</summary>

--- a/docs/pl/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
@@ -14,7 +14,7 @@ Jeśli chcesz utworzyć więcej zasobów, musisz zwiększyć limit.
 
 ## Wymagania początkowe
 
-- [Posiadanie ważnego](/guides/account-and-service-management/managing-billing-payments-and-services/manage-payment-methods) sposobu płatności w Panelu klienta OVHcloud.
+- [Posiadanie ważnego sposobu płatności](/guides/account-and-service-management/managing-billing-payments-and-services/manage-payment-methods) w Panelu klienta OVHcloud.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---

--- a/docs/pl/guides/public-cloud/cross-functional/managing-tokens.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/managing-tokens.mdx
@@ -144,7 +144,7 @@ curl -X GET $endpoint/photos/fullsize/ovh-summit-2014-backstage-DS.jpg -H "X-Aut
 ```
 
 - -X GET: metoda HTTP GET
-- $endpoint/photos/fullsize/ovh-summit-2014-backstage-DS.jpg adres obiektu
+- $endpoint/photos/fullsize/ovh-summit-2014-backstage-DS.jpg: adres obiektu
 - -H "X-Auth-Token: $token": element uwierzytelniania
 - -I: opcja curl w celu uzyskania wyłącznie metadanych
 

--- a/docs/pl/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
@@ -53,7 +53,7 @@ Więcej informacji o tym narzędziu znajdziesz w [dokumentacji OpenStack CLI](ht
 :::
 
 
-Można to uzyskać z interfejsu zarządzania pakietami apt (dla dystrybucji opartych na Debianie) lub ium (dla dystrybucji opartych na RHEL/CentOS):
+Można to uzyskać z interfejsu zarządzania pakietami apt (dla dystrybucji opartych na Debianie) lub yum (dla dystrybucji opartych na RHEL/CentOS):
 
 ```bash
 # Dystrybucje Debian 

--- a/docs/pl/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/pl/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2024-01-22
 
 ## Objective
 
-This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the pre requisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
+This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the prerequisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
 
 For this example, we will use a private network and a subnet with the following properties:
 
@@ -44,7 +44,7 @@ Click the `Subnets` tab: the subnets from the private network are listed.
 
 Click on your `Edit Subnet`. For this guide, our target is to add a gateway IP:
 
-- Click untick the  `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
+- Untick the `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
 
 <img className="thumbnail" alt="gateway IP" src="/images/public-cloud/network-services/configuration-04-update-subnet/add_gateway_ip.png" loading="lazy" />
 

--- a/docs/pt/guides/public-cloud/compute/change-project-contacts.mdx
+++ b/docs/pt/guides/public-cloud/compute/change-project-contacts.mdx
@@ -46,11 +46,11 @@ Aparecerão os contactos do seu projeto Public Cloud na tabela. Clique no botão
 
 <img className="thumbnail" alt="alteracao-contactos" src="/images/public-cloud/compute/change-project-contacts/contactchange.png" loading="lazy" />
 
-Na nova janela, indique o identificador de cliente desejado para cada contacto que pretende alterar. Tenha em conta que as contas OVHcloud para os `Contact administrador` e `Contact Faturation` devem ser obrigatoriamente indicadas na mesma filial OVHcloud.
+Na nova janela, indique o identificador de cliente desejado para cada contacto que pretende alterar. Tenha em conta que as contas OVHcloud para os `Contacto administrador` e `Contacto de faturação` devem ser obrigatoriamente indicadas na mesma filial OVHcloud.
 
 <img className="thumbnail" alt="alteracao-contactos" src="/images/public-cloud/compute/change-project-contacts/contactchange1.png" loading="lazy" />
 
-Depois de clicar no botão <code className="action">Validar</code>, as duas contas OVHcloud afetadas pela alteração receberão um e-mail de confirmação. Este e-mail contém um código(token) que permite validar a alteração de contacto no separador <code className="action">Os meus pedidos</code> na secção **Gestão dos contactos**.
+Depois de clicar no botão <code className="action">Validar</code>, as duas contas OVHcloud afetadas pela alteração receberão um e-mail de confirmação. Este e-mail contém um código (token) que permite validar a alteração de contacto no separador <code className="action">Os meus pedidos</code> na secção **Gestão dos contactos**.
 
 Para uma explicação mais detalhada deste procedimento, consulte o nosso guia "[Como gerir os contactos dos serviços OVHcloud](/guides/account-and-service-management/account-information/managing-contacts)".
 

--- a/docs/pt/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -9,7 +9,7 @@ Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certo
 :::
 
 
-## Sumário
+## Objetivo
 
 O módulo Cloud-init permite configurar a [instância Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) quando é criada, mas também em cada reinicialização. Por isso, se pretender reconfigurar o hostname devido a um erro durante a criação da instância ou para reconfigurar o seu servidor de e-mail, terá de desativar o módulo Cloud-init. Este último encarrega-se de configurar o hostname de modo que não seja restabelecido.
 

--- a/docs/pt/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
+++ b/docs/pt/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
@@ -89,7 +89,7 @@ Pode obter mais informações sobre as permissões dos utilizadores e tópicos r
 
 Se criou os seus pares de chaves SSH num sistema baseado em GNU/Linux, macOS ou BSD, pode utilizar o comando `ssh-copy-id` para adicionar as chaves públicas ao seu servidor.
 
-O utilitário `ssh-copy-id` copia as chaves públicas no arquivo `~/.ssh/authorized_keys` no servidor remoto especificado e cria automaticamente o arquivo neste diretório, se necessário.
+O utilitário `ssh-copy-id` copia as chaves públicas no ficheiro `~/.ssh/authorized_keys` no servidor remoto especificado e cria automaticamente o arquivo neste diretório, se necessário.
 
 ```bash
 ssh-copy-id username@IP_ADDRESS
@@ -131,7 +131,7 @@ Por razões de segurança e de boas práticas, um par de chaves não deve ser ut
 sudo nano /home/user2/.ssh/authorized_keys
 ```
 
-Cole a **cadeia de chaves públicas** neste ficheiro. Salve o arquivo e saia do editor.
+Cole a **cadeia de chaves públicas** neste ficheiro. Guarde o ficheiro e saia do editor.
 
 Reinicie a sua instância (`sudo reboot`) ou reinicie apenas o serviço OpenSSH com um dos seguintes comandos (o comando apropriado pode variar em função do seu sistema operativo):
 

--- a/docs/pt/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -535,7 +535,7 @@ Faça novamente um clique direito e selecione <code className="action">Iniciar o
 
 <img className="thumbnail" alt="offline disk" src="/images/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance/disk-management-03.png" loading="lazy" />
 
-Em seguida, seleccione <code className="action">MBR</code> se o disco adicional tiver menos de 2 TB, ou <code className="action">GPT</code> se tiver mais de 2 TB e, em seguida, clique em <code className="action">OK</code>.
+Em seguida, selecione <code className="action">MBR</code> se o disco adicional tiver menos de 2 TB, ou <code className="action">GPT</code> se tiver mais de 2 TB e, em seguida, clique em <code className="action">OK</code>.
 
 <img className="thumbnail" alt="inicializa disk" src="/images/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance/initialize_disk.png" loading="lazy" />
 

--- a/docs/pt/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/pt/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -25,7 +25,7 @@ You'll need an [OVHcloud Public Cloud project](/guides/public-cloud/cross-functi
 
 ### Install Packer
 
-Packer can be downloaded from the official website (curently [here](https://www.packer.io/downloads.html) ) and you'll need to `unzip` it.
+Packer can be downloaded from the official website (currently [here](https://www.packer.io/downloads.html) ) and you'll need to `unzip` it.
 
 For Linux 64bits
 
@@ -92,7 +92,7 @@ export NETWORK_ID=`openstack network list -f json | jq -r '.[] | select(.Name ==
 
 **INFO**: for `FLAVOR_ID`, you can directly use the name, ie `b2-7`
 
-Finaly, create a `packer.json` file
+Finally, create a `packer.json` file
 
 ```shell
 cat > packer.json <<EOF
@@ -129,7 +129,7 @@ cat > packer.json <<EOF
 EOF
 ```
 
-In the last selection of the configuration file, we specify a `setup_vm.sh` shell script to be ran.
+In the last selection of the configuration file, we specify a `setup_vm.sh` shell script to be run.
 
 ```sh
 #!/bin/sh
@@ -149,7 +149,7 @@ git clone ...
 
 ## Building the image
 
-Using the configuration file create above, check it and build the image with
+Using the configuration file created above, check it and build the image with
 
 ```shell
 packer validate packer.json

--- a/docs/pt/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/pt/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -12,7 +12,7 @@ Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certo
 :::
 
 
-## Sumário
+## Objetivo
 
 Tem a possibilidade de criar instâncias diretamente a partir da interface Horizon. Isto permite-lhe, por exemplo, criar múltiplas instâncias ou ainda configurar um grupo de segurança e aplicá-lo às suas instâncias.
 
@@ -99,7 +99,7 @@ Deverá preencher as diferentes informações. Caso seja necessário, consulte a
 |Volume size (GB)|Se optou por criar um volume, deixe o sistema determinar o tamanho em seu lugar.|
 |Delete Volume on Instance Delete|Pode conservar a opção predefinida **No**. Se **Yes** for selecionado, quando a instância for eliminada o volume também será eliminado.|
 |Image name|Selecione a imagem da instância (apenas em caso de arranque a partir de uma imagem) clicando na seta para cima junto à imagem à sua escolha. No nosso exemplo, utilizamos uma seleção de CentOS 7.|
-|Instance snapshot|Escolha um instantâneo de uma instância (apenas em caso de arranque a partir de uma snapshot) clicando na seta para cima ao lado da imagem de instantâneo de uma instância à sua escolha|.
+|Instance snapshot|Escolha um instantâneo de uma instância (apenas em caso de arranque a partir de uma snapshot) clicando na seta para cima ao lado da imagem de instantâneo de uma instância à sua escolha.|
 
 **Flavor**
 

--- a/docs/pt/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
+++ b/docs/pt/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
@@ -204,6 +204,6 @@ Preencha as variáveis:
 
 [Criação e ligação a uma primeira instância Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-[Efetuar um backup de uma instância](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[Efetuar um backup de uma instância](/guides/public-cloud/compute/save-an-instance)
 
 Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).

--- a/docs/pt/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
+++ b/docs/pt/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
@@ -12,7 +12,7 @@ Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certo
 ## Objetivo
 
 A adição de imagens personalizadas é possível através do manager OpenStack Horizon
-Esta operação permite-lhe, por exemplo, importar as suas imagens das antigas máquinas virtuais para o Public Cloud, com a condição que o seu formato ser compatível.
+Esta operação permite-lhe, por exemplo, importar as suas imagens das antigas máquinas virtuais para o Public Cloud, com a condição de que o seu formato seja compatível.
 
 **Este guia explica as diferentes etapas para a criação, para dar inicio e eliminar imagens na interface Horizon onde gere os seus serviços OVHcloud.**
 

--- a/docs/pt/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/pt/guides/public-cloud/compute/image-life-cycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud & VPS - Image and OS life cycle and end of life/support announcements
 description: Discover the lifecycle and end-of-life/end-of-support announcements for distributions and softwares for your VPS or Public Cloud instance
-lastUpdated: 2025-02-11
+lastUpdated: 2025-11-12
 ---
 
 ## Objective
@@ -70,7 +70,7 @@ Please note that:
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
 | 14 | [Forky](https://wiki.debian.org/DebianForky) | | | |
-| 13 | [Trixie](https://wiki.debian.org/DebianTrixie) | | | |
+| 13 | [Trixie](https://wiki.debian.org/DebianTrixie) | August 2025 | August 2028 | June 2030 |
 | 12 | [Bookworm](https://wiki.debian.org/DebianBookworm) | June 2023 | June 2026 | June 2028 |
 | 11 | [Bullseye](https://wiki.debian.org/DebianBullseye) | August 2021 | August 2024 | August 2026 |
 | 10 | [Buster](https://wiki.debian.org/DebianBuster) | July 2019 | September 2022 | June 2024 |

--- a/docs/pt/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/pt/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -34,7 +34,7 @@ Se atingiu a capacidade máxima do seu disco suplementar, pode adicionar armazen
 
 ## Instruções
 
-Os passos seguintes pressupõem que já configurou um disco suplementar de acordo com as intrusões do [nosso guia](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
+Os passos seguintes pressupõem que já configurou um disco suplementar de acordo com as instruções do [nosso guia](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
 
 ## Monitorização do consumo dos discos antes do redimensionamento
 

--- a/docs/pt/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -4,7 +4,7 @@ description: Saiba como instalar o Plesk na sua instância Public Cloud
 lastUpdated: 2025-04-08
 ---
 
-## Sumário
+## Objetivo
 
 O Plesk é uma interface de gestão de servidores simples de utilizar. Pode instalá-la e utilizá-la nas suas instâncias Public Cloud da OVHcloud.
 
@@ -49,7 +49,7 @@ sudo sh <(curl https://autoinstall.plesk.com/plesk-installer || wget -O - https:
 
 De seguida, aguarde até a instalação ficar concluída. 
 
-### 2 - finalizar a configuração e adicionar uma licença
+### 2 - Finalizar a configuração e adicionar uma licença
 
 Uma vez concluída a instalação, a interface de linha de comandos (CLI) apresentará as seguintes informações:
 
@@ -57,7 +57,7 @@ Uma vez concluída a instalação, a interface de linha de comandos (CLI) aprese
     - Um com o endereço IP do servidor (em HTTPS com um certificado SSL autoassinado, o que pode ativar um alerta de segurança em certos browsers).
     - O outro com um domínio Plesk (em HTTPS com um certificado SSL assinado, sem alerta de segurança).
     - Ambos são seguros, mas é recomendado que utilize o segundo.
-- Uma mensagem indica: "Você também pode se conectar como um ‘root’ com sua palavra-passe ‘root’." No entanto, não é gerada nenhuma palavra-passe root por predefinição. Se necessário, os clientes podem seguir [este guia](/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds) para ativar o utilizador root e definir uma palavra-passe.
+- Uma mensagem indica: "Você também pode se conectar como um ‘root’ com a sua palavra-passe ‘root’." No entanto, não é gerada nenhuma palavra-passe root por predefinição. Se necessário, os clientes podem seguir [este guia](/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds) para ativar o utilizador root e definir uma palavra-passe.
 
 Uma vez na página Plesk, siga as instruções apresentadas no ecrã para finalizar a instalação.
 

--- a/docs/pt/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/pt/guides/public-cloud/compute/install-wordpress.mdx
@@ -51,7 +51,7 @@ As seguintes instruções são verificadas para Debian 11. O Ubuntu é baseado e
 :::
 
 
-Para aceder à sua instalação através de um nome de domínio, deve ligá-la à sua instância. Para isso, deve editar a zona DNS acessível a partir do seu <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, desde que a OVHcloud seja o seu agente de registo **e** que o nome de domínio utilize os servidores DNS da OVHcloud.
+Para aceder à sua instalação através de um nome de domínio, deve ligá-la à sua instância. Para isso, deve editar a zona DNS acessível a partir da sua <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, desde que a OVHcloud seja o seu agente de registo **e** que o nome de domínio utilize os servidores DNS da OVHcloud.
 
 Para mais informações, consulte o guia [Editar a sua zona DNS](/guides/web-cloud/domains/dns-zone-edit). Se o domínio estiver a ser utilizado atualmente, só pode configurar os DNS após a instalação do novo WordPress e o arranque do seu website.
 
@@ -87,7 +87,7 @@ Para o executar, insira o seguinte comando:
 debian@instance:~$ sudo mariadb-secure-installation
 ```
 
-Confirme a primeira chamada apoiando-se na <code className="action">Enter</code>.
+Confirme o primeiro aviso premindo <code className="action">Enter</code>.
 
 De seguida, selecione um método para proteger os acessos ao seu servidor de bases de dados.
 
@@ -97,7 +97,7 @@ Switch to unix_socket authentication [Y/n]
 
 Recomenda-se a utilização do método de autenticação proposto em vez do acesso por palavra-passe root. Carregue <code className="action">y</code> e depois em <code className="action">Enter</code>. (Se optar por utilizar o acesso root ao utilizador, introduza <code className="action">n</code> e defina uma palavra-passe root.)
 
-Introduza <code className="action">n</code> convite:
+Introduza <code className="action">n</code> no convite seguinte:
 
 ```console
 Change the root password? [Y/n]
@@ -145,13 +145,13 @@ MariaDB [(none)]> exit;
 
 ### Etapa 3: configurar a firewall
 
-A configuração de uma firewall (*iptables*) permite melhorar a segurança da sua instância WordPress. Este processo pode ser simplificado utilizando o Frontend "Uncomplated Firewall" (UFW) e o seu conjunto de perfis pré-definidos. Instale o UFW:
+A configuração de uma firewall (*iptables*) permite melhorar a segurança da sua instância WordPress. Este processo pode ser simplificado utilizando o Frontend "Uncomplicated Firewall" (UFW) e o seu conjunto de perfis pré-definidos. Instale o UFW:
 
 ```bash
 debian@instance:~$ sudo apt install ufw
 ```
 
-Na lista de aplicações disponíveis para o UFW, os perfis que correspondem a um servidor web são nomeados "WWW" em uma instância Debian e "Apache" em uma instância Ubuntu. Esses perfis permitem abrir as portas necessárias para o tráfego HTTP e HTTPS de forma simples e segura.
+Na lista de aplicações disponíveis para o UFW, os perfis que correspondem a um servidor web são nomeados "WWW" numa instância Debian e "Apache" numa instância Ubuntu. Esses perfis permitem abrir as portas necessárias para o tráfego HTTP e HTTPS de forma simples e segura.
 
 ```bash
 debian@instance:~$ sudo ufw app list | grep WWW # ou grep Apache

--- a/docs/pt/guides/public-cloud/compute/key-concepts.mdx
+++ b/docs/pt/guides/public-cloud/compute/key-concepts.mdx
@@ -10,7 +10,7 @@ Este guia visa dar-lhe uma compreensão clara dos conceitos fundamentais necess�
 
 ## O que é uma instância (Máquina Virtual)?
 
-Uma instância, ou Máquina Virtual (VM), é um servidor totalmente isolado a executar-se na infraestrutura física partilhada da OVHcloud. Funciona como um servidor tradicional, mas oferece a flexibilidade e a escalabilidade do cloud. Pode escolher o sistema operativo, definir os recursos CPU, RAM e Armazenamento e implantar as suas aplicações, sites web ou ambientes de desenvolvimento.
+Uma instância, ou Máquina Virtual (VM), é um servidor totalmente isolado a executar-se na infraestrutura física partilhada da OVHcloud. Funciona como um servidor tradicional, mas oferece a flexibilidade e a escalabilidade do cloud. Pode escolher o sistema operativo, definir os recursos CPU, RAM e armazenamento e implantar as suas aplicações, sites web ou ambientes de desenvolvimento.
 
 As instâncias Public Cloud Compute oferecem:
 
@@ -26,7 +26,7 @@ A OVHcloud oferece várias famílias de instâncias concebidas para responder a 
 
 | Tipos de instâncias  | Descrição                      | Casos de utilização típicos                                                                                                                                                        |
 | ------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Geral           | Equilíbrio CPU e Memória         | Adequada para servidores de desenvolvimento, aplicações web e cargas de trabalho empresariais gerais. Fornecer um ratio equilibrado entre CPU e RAM.                                            |
+| Geral           | Equilíbrio CPU e Memória         | Adequada para servidores de desenvolvimento, aplicações web e cargas de trabalho empresariais gerais. Fornece um ratio equilibrado entre CPU e RAM.                                            |
 | CPU otimizada      | Alta performance do processador     | Ideal para aplicações intensivas em cálculo, tarefas de processamento paralelo, pipelines CI/CD ou microserviços que necessitam de uma alta frequência CPU.                                     |
 | Memória otimizada  | Capacidade de memória elevada          | Concebida para análise de dados, cargas de trabalho big data e cache de bases de dados. Apresenta altas taxas de memória/CPU e IOPS acelerados. Os núcleos virtuais são clockados a 2 GHz ou mais.       |
 | Armazenamento otimizado | Alta performance IOPS           | Equipada com armazenamento NVMe para E/S de disco ultra rápidas, ideal para bases de dados e aplicações big data.                                                                     |
@@ -61,11 +61,11 @@ As instâncias Public Cloud da OVHcloud são implantadas em [vários centros de 
 Ao criar uma instância, seleciona uma imagem que inclui o sistema operativo e, opcionalmente, aplicações pré-instaladas. A OVHcloud oferece uma variedade de imagens para responder a necessidades diversas:
 
 - **Distribuições Linux**: Ubuntu, Debian, CentOS, AlmaLinux, Rocky Linux e outras. Estas imagens estão prontas para uso em servidores web, ambientes de desenvolvimento e cargas de trabalho gerais.
-- **Windows Server**: Versões com licenças integradas, permitindo um implantação imediata para aplicações baseadas em Microsoft e cargas de trabalho empresariais.
+- **Windows Server**: Versões com licenças integradas, permitindo uma implantação imediata para aplicações baseadas em Microsoft e cargas de trabalho empresariais.
 - **Aplicações pré-configuradas**: Imagens que incluem software como cPanel, Plesk, Docker ou NVIDIA GPU Cloud (NGC). Simplificam a implantação e aceleram a transição para a produção.
 - **[Imagens personalizadas](/guides/public-cloud/compute/upload-own-image)**: Pode importar as suas próprias imagens nos formatos QCOW2 ou RAW, oferecendo um controlo total sobre o seu ambiente e permitindo migrações, modelos padronizados ou configurações especializadas.
 
-**Ciclo de vida e suporte**: A OVHcloud atualiza regularmente o catálogo de imagens. Consulte sempre as anúncios sobre o ciclo de vida e o fim do suporte para assegurar que as suas imagens permaneçam seguras e suportadas. Veja [aqui](/guides/public-cloud/compute/image-life-cycle).
+**Ciclo de vida e suporte**: A OVHcloud atualiza regularmente o catálogo de imagens. Consulte sempre os anúncios sobre o ciclo de vida e o fim do suporte para assegurar que as suas imagens permaneçam seguras e suportadas. Veja [aqui](/guides/public-cloud/compute/image-life-cycle).
 
 ## Chaves SSH
 

--- a/docs/pt/guides/public-cloud/compute/local-zones-capabilities-limitations.mdx
+++ b/docs/pt/guides/public-cloud/compute/local-zones-capabilities-limitations.mdx
@@ -35,7 +35,7 @@ Encontre mais informações na nossa [página dedicada às instâncias Local Zon
 | Armazenamento         | Object Storage             | Sim | 1. Políticas de utilizador não suportadas. todas as chaves de acesso dentro de um projeto podem aceder a todos os baldees em todas as Local Zones. <br/> 2. Apenas a classe de armazenamento Standard é suportada. <br/> 3. Características S3<sup>1</sup> não suportadas: etiquetas S3, Legal Hold, SSE-OMK, replicação S3, registo de acesso ao servidor. |
 |                       | Block Storage     | Sim | Sem suporte de encriptação. Volumes clássicos não podem ser multi-anexados. Volumes clássicos limitados a 250 IOPS (vs 500 IOPS nas regiões 1AZ e 3AZ). Tamanho máximo 4 TB (vs 12 TB). |
 |                       | File Storage | Não | |
-| Container.            | Managed Kubernetes Service | Não | |
+| Container             | Managed Kubernetes Service | Não | |
 |                       | Managed Rancher Service  | Não | |
 |                       | Managed Private Registry | Não | |
 | DBaas                 | DBaas                      | Não | |

--- a/docs/pt/guides/public-cloud/compute/resize-instance-openstack.mdx
+++ b/docs/pt/guides/public-cloud/compute/resize-instance-openstack.mdx
@@ -88,15 +88,15 @@ Tenga en cuenta que sólo puede cambiar el tamaño de una instancia de un modelo
 :::
 
 
-### Redimensionar la instancia
+### Redimensionar uma instância
 
-Una vez que haya recuperado la información, ya puede redimensionar su instancia:
+Depois de ter recuperado as informações necessárias, pode agora redimensionar a sua instância:
 
 ```bash
 $  openstack server resize --flavor `<FLAVOR-ID>` `<INSTANCE-NAME>`
 ```
 
-Por ejemplo, para redimensionar nuestra instancia "OVHcloudInstance":
+Por exemplo, para redimensionar a nossa instância "OVHcloudinstance":
 
 ```bash
 $ openstack server resize --flavor 098889e6-d1fc-4967-baea-19fd97fd83a8 OVHcloudinstance

--- a/docs/pt/guides/public-cloud/compute/resize-of-an-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/resize-of-an-instance.mdx
@@ -95,7 +95,7 @@ A seguir, clique em <code className="action">Finish</code> para validar a sua es
 
 <img className="thumbnail" alt="public-cloud" src="/images/public-cloud/compute/resize-of-an-instance/2979.png" loading="lazy" />
 
-## Quer saiba mais?
+## Quer saber mais?
 
 Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
 

--- a/docs/pt/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/pt/guides/public-cloud/compute/setup-security-group.mdx
@@ -88,8 +88,8 @@ Depois de adicionar a nova regra, aguarde alguns minutos para que esta seja toma
 ```bash
 root@serveur:~$ ssh admin@149.xxx.xxx.177
 
-Last login: Tue Out 13 13:56:30 2015 from proxy-109-190-254-35.ovh.net
-admin@serveur1
+Last login: Tue Oct 13 13:56:30 2015 from proxy-109-190-254-35.ovh.net
+admin@serveur1:~$
 ```
 
 ### Configurar um grupo de segurança numa instância <a name="instance-security-group"></a>

--- a/docs/pt/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
+++ b/docs/pt/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
@@ -113,4 +113,4 @@ Para os utilizadores de nível mais avançado que pretendem gerar endereços tem
 
 ## Quer saber mais?
 
-Fale com a nossa comunidade de utilizadores em https://community.ovh.com/en/.
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
+++ b/docs/pt/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
@@ -34,7 +34,7 @@ Eis a lista dos comandos principais:
 
 |Comando|Descrição|
 |---|---|
-|volume creme|Criar um novo volume|
+|volume create|Criar um novo volume|
 |volume delete|Eliminar um volume|
 |volume list|Lista dos volumes|
 |volume snapshot create|Criar uma snapshot de um volume|

--- a/docs/pt/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/pt/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -16,7 +16,7 @@ Pode criar discos suplementares para as suas instâncias Public Cloud a partir d
 
 Tal pode ser útil nos seguintes casos:
 
-- Se deseja restaurar os dados do disco suplementares.
+- Se deseja restaurar os dados do disco suplementar.
 - Se deseja dispor de um espaço de armazenamento de alta disponibilidade e de alta performance com os seus dados.
 - Se pretender mover os seus dados para outra instância.
 
@@ -69,7 +69,8 @@ O processo de conexão do disco à sua instância vai então começar e pode lev
 <img className="thumbnail" alt="associar volume" src="/images/public-cloud/compute/create-volume-from-snapshot/volume05.png" loading="lazy" />
 
 :::warning
-Deve evitar a navegação fora do separador em curso durante a conexão do disco. Isto pode interromper o processo.
+>
+> Deve evitar a navegação fora do separador em curso durante a conexão do disco. Isto pode interromper o processo.
 :::
 
 Uma vez efetuada a associação, pode seguir os passos indicados [em Linux](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#utilizando-o-linux) ou [em Windows](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#utilizando-o-windows).

--- a/docs/pt/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
+++ b/docs/pt/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
@@ -41,7 +41,7 @@ Clique em <code className="action">Block Storage</code> na barra de navegação 
 
 <img className="thumbnail" alt="Volume Snapshot" src="/images/public-cloud/compute/creating-a-volume-snapshot/volume_snapshot01.png" loading="lazy" />
 
-À direita do volume em causa, clique no botão <code className="action">...</code> e, a seguir, em <code className="action">Criar uma cópia de segurança</code> (não é necessário desassociar primeiro o volume da sua instância). No entanto, se pretender desassociar o seu volume, sugerimos que consulte a secção "Desassociar um volume"de [este manual](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
+À direita do volume em causa, clique no botão <code className="action">...</code> e, a seguir, em <code className="action">Criar uma cópia de segurança</code> (não é necessário desassociar primeiro o volume da sua instância). No entanto, se pretender desassociar o seu volume, sugerimos que consulte a secção "Desassociar um volume" de [este manual](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
 
 De seguida, selecione <code className="action">Volume Snapshot</code>, dê-lhe um nome e clique em <code className="action">Criar o backup</code>.
 

--- a/docs/pt/guides/public-cloud/compute/test-disk-speed.mdx
+++ b/docs/pt/guides/public-cloud/compute/test-disk-speed.mdx
@@ -13,7 +13,7 @@ Quer seja para comparar as performances entre os diferentes discos, quer seja pa
 ## Requisitos
 
 - Dispor de uma [instância Public Cloud](https://www.ovhcloud.com/pt/public-cloud/compute/).
-- Dispor de um Ter acesso administrativo (sudo) à sua instância através de SSH (Linux) ou RDP (Windows).
+- Ter acesso administrativo (sudo) à sua instância através de SSH (Linux) ou RDP (Windows).
 
 ## Instruções
 

--- a/docs/pt/guides/public-cloud/compute/upgrading-operating-system.mdx
+++ b/docs/pt/guides/public-cloud/compute/upgrading-operating-system.mdx
@@ -142,7 +142,7 @@ Verifique que as suas aplicações funcionam como previsto. Em caso de problema,
 Antes de começar a atualização da versão principal do SO, certifique-se de que atualiza as versões mais recentes de todos os pacotes instalados na sua versão atual. Introduza esta encomenda:
 
 ```sh
-$ sudo dnf upgrade —refresh
+$ sudo dnf upgrade --refresh
 ```
 
 A seguir, reinicie o servidor:

--- a/docs/pt/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/pt/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -67,7 +67,7 @@ A state is composed of several files inside a `.pulumi` folder:
 - `meta.yaml`: This is the metadata file. It does not hold information about the stacks but rather information about the backend itself.
 - `stacks/`: Active state files for each stack (e.g. `dev.json`).
 - `locks/`: Optional lock files for each stack if the stack is currently being operated on by a Pulumi operation (e.g. `dev/$lock.json`).
-- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json`vwhere $timestamp records the time the history file was created).
+- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json` where $timestamp records the time the history file was created).
 
 ## Instructions
 

--- a/docs/pt/guides/public-cloud/cross-functional/api-rate-limits.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/api-rate-limits.mdx
@@ -28,7 +28,7 @@ Ao estabelecer limites de débito, garantimos que a API possa manter uma experi�
 
 ### Keystone (API de identidade OpenStack)
 
-Aplicamos limites de débito ao nível do**utilizador** OpenStack.
+Aplicamos limites de débito ao nível do **utilizador** OpenStack.
 
 Um utilizador pode efetuar **60 pedidos por minuto** antes de receber uma resposta HTTP 429.
 
@@ -104,6 +104,6 @@ Aqui estão alguns exemplos de livrarias bem conhecidas para implementar a funç
 - tenacity: [https://pypi.org/project/tenacity/](https://pypi.org/project/tenacity/)
 - backoff: [https://pypi.org/project/backoff/](https://pypi.org/project/backoff/)
 
-## Quer mais?
+### Quer saber mais?
 
 Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).

--- a/docs/pt/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -31,7 +31,7 @@ A criação de um projeto é a primeira etapa na implantação de [instâncias P
 
 ## Instruções
 
-Após ter tomado conhecimento, valide os termos dos contratos selecionando a casa correspondente e clique em <code className="action">Descobrir o universo Public Cloud</code>.
+Após ter tomado conhecimento, valide os termos dos contratos selecionando a caixa correspondente e clique em <code className="action">Descobrir o universo Public Cloud</code>.
 
 <img className="thumbnail" alt="criação de projeto" src="/images/public-cloud/cross-functional/create-a-public-cloud-project/firstproject2024.png" loading="lazy" style={{ maxWidth: '400px' }} />
 

--- a/docs/pt/guides/public-cloud/cross-functional/managing-tokens.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/managing-tokens.mdx
@@ -144,7 +144,7 @@ curl -X GET $endpoint/photos/fullsize/ovh-summit-2014-backstage-DS.jpg -H "X-Aut
 ```
 
 - -X GET: método HTTP GET
-- endpoint/photos/fullsize/ovh-summit-2014-backstage-DS.jpg endereço do objeto
+- $endpoint/photos/fullsize/ovh-summit-2014-backstage-DS.jpg: endereço do objeto
 - -H "X-Auth-Token: $token": elemento de autenticação
 - -I: opção curl para recuperar apenas os metadados
 

--- a/docs/pt/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/pt/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2024-01-22
 
 ## Objective
 
-This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the pre requisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
+This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the prerequisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
 
 For this example, we will use a private network and a subnet with the following properties:
 
@@ -44,7 +44,7 @@ Click the `Subnets` tab: the subnets from the private network are listed.
 
 Click on your `Edit Subnet`. For this guide, our target is to add a gateway IP:
 
-- Click untick the  `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
+- Untick the `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
 
 <img className="thumbnail" alt="gateway IP" src="/images/public-cloud/network-services/configuration-04-update-subnet/add_gateway_ip.png" loading="lazy" />
 


### PR DESCRIPTION
Bundled port of four legacy PRs by @Jessica41 that together form a single grammar-and-punctuation pass over Public Cloud guides. Each legacy PR was a review-sized slice of one effort; combined here because they share an author, theme, base commit, and a non-overlapping file set.

Applies 186 small grammar / punctuation / whitespace fixes across all 7 primary locales (compute, network services, cross-functional).

Legacy-specific changes (community URL standardisation to /links/, .thumbnail modifiers, Going Further footer rewrites) are intentionally NOT ported — they are no-ops on new-docs, which addresses them differently through migration-time normalisation.

See cp-extraction/pr-port/bundle-pr-9392-9393-9394-9400.md (in the tools repo) for the full per-PR breakdown and per-file report.

Original-URL: https://github.com/ovh/docs/pull/9392
Original-URL: https://github.com/ovh/docs/pull/9393
Original-URL: https://github.com/ovh/docs/pull/9394
Original-URL: https://github.com/ovh/docs/pull/9400
Original-author: @Jessica41