### PR TITLE
docs(vps): fix Nextcloud Docker Compose connectivity and persistence

### DIFF
--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to install Nextcloud on an OVHcloud VPS with Docker and Traefik
 description: Find out how to deploy Nextcloud on an OVHcloud VPS with automatic HTTPS via Traefik, MariaDB and Redis
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-22
 ---
 
 ## Objective
@@ -156,11 +156,15 @@ services:
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
     volumes:
-      - db_data:/var/lib/MySQL
+      - db_data:/var/lib/mysql
+    networks:
+      - internal
 
   Redis:
-    image: Redis:7-alpine
+    image: redis:7-alpine
     restart: unless-stopped
+    networks:
+      - internal
 
   app:
     image: nextcloud:apache
@@ -179,11 +183,14 @@ services:
       NEXTCLOUD_TRUSTED_DOMAINS: ${NC_DOMAIN}
     volumes:
       - nextcloud_html:/var/www/html
+      - config:/var/www/html/config
       - nextcloud_data:/var/www/html/data
     networks:
+      - internal
       - proxy
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.nextcloud.rule=Host(`${NC_DOMAIN}`)
       - traefik.http.routers.nextcloud.entrypoints=websecure
       - traefik.http.routers.nextcloud.tls.certresolver=letsencrypt
@@ -192,8 +199,10 @@ volumes:
   db_data:
   nextcloud_html:
   nextcloud_data:
+  config:
 
 networks:
+  internal:
   proxy:
     external: true
 ```

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to install Nextcloud on an OVHcloud VPS with Docker and Traefik
 description: Find out how to deploy Nextcloud on an OVHcloud VPS with automatic HTTPS via Traefik, MariaDB and Redis
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-22
 ---
 
 ## Objective
@@ -156,11 +156,15 @@ services:
       MYSQL_PASSWORD: $&#123;DB_PASSWORD&#125;
       MYSQL_ROOT_PASSWORD: $&#123;DB_ROOT_PASSWORD&#125;
     volumes:
-      - db_data:/var/lib/MySQL
+      - db_data:/var/lib/mysql
+    networks:
+      - internal
 
   Redis:
-    image: Redis:7-alpine
+    image: redis:7-alpine
     restart: unless-stopped
+    networks:
+      - internal
 
   app:
     image: nextcloud:apache
@@ -179,11 +183,14 @@ services:
       NEXTCLOUD_TRUSTED_DOMAINS: $&#123;NC_DOMAIN&#125;
     volumes:
       - nextcloud_html:/var/www/html
+      - config:/var/www/html/config
       - nextcloud_data:/var/www/html/data
     networks:
+      - internal
       - proxy
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.nextcloud.rule=Host(`${NC_DOMAIN}`)
       - traefik.http.routers.nextcloud.entrypoints=websecure
       - traefik.http.routers.nextcloud.tls.certresolver=letsencrypt
@@ -192,8 +199,10 @@ volumes:
   db_data:
   nextcloud_html:
   nextcloud_data:
+  config:
 
 networks:
+  internal:
   proxy:
     external: true
 ```

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to install Nextcloud on an OVHcloud VPS with Docker and Traefik
 description: Find out how to deploy Nextcloud on an OVHcloud VPS with automatic HTTPS via Traefik, MariaDB and Redis
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-22
 ---
 
 ## Objective
@@ -156,11 +156,15 @@ services:
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
     volumes:
-      - db_data:/var/lib/MySQL
+      - db_data:/var/lib/mysql
+    networks:
+      - internal
 
   Redis:
-    image: Redis:7-alpine
+    image: redis:7-alpine
     restart: unless-stopped
+    networks:
+      - internal
 
   app:
     image: nextcloud:apache
@@ -179,11 +183,14 @@ services:
       NEXTCLOUD_TRUSTED_DOMAINS: ${NC_DOMAIN}
     volumes:
       - nextcloud_html:/var/www/html
+      - config:/var/www/html/config
       - nextcloud_data:/var/www/html/data
     networks:
+      - internal
       - proxy
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.nextcloud.rule=Host(`${NC_DOMAIN}`)
       - traefik.http.routers.nextcloud.entrypoints=websecure
       - traefik.http.routers.nextcloud.tls.certresolver=letsencrypt
@@ -192,8 +199,10 @@ volumes:
   db_data:
   nextcloud_html:
   nextcloud_data:
+  config:
 
 networks:
+  internal:
   proxy:
     external: true
 ```

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -1,7 +1,7 @@
 ---
 title: Installer Nextcloud sur un VPS OVHcloud avec Docker et Traefik
 description: Découvrez comment déployer Nextcloud sur un VPS OVHcloud avec HTTPS automatique via Traefik, MariaDB et Redis
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-22
 ---
 
 ## Objectif
@@ -157,10 +157,14 @@ services:
       MYSQL_ROOT_PASSWORD: $&#123;DB_ROOT_PASSWORD&#125;
     volumes:
       - db_data:/var/lib/mysql
+    networks:
+      - internal
 
   redis:
     image: redis:7-alpine
     restart: unless-stopped
+    networks:
+      - internal
 
   app:
     image: nextcloud:apache
@@ -179,11 +183,14 @@ services:
       NEXTCLOUD_TRUSTED_DOMAINS: $&#123;NC_DOMAIN&#125;
     volumes:
       - nextcloud_html:/var/www/html
+      - config:/var/www/html/config
       - nextcloud_data:/var/www/html/data
     networks:
+      - internal
       - proxy
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.nextcloud.rule=Host(`${NC_DOMAIN}`)
       - traefik.http.routers.nextcloud.entrypoints=websecure
       - traefik.http.routers.nextcloud.tls.certresolver=letsencrypt
@@ -192,8 +199,10 @@ volumes:
   db_data:
   nextcloud_html:
   nextcloud_data:
+  config:
 
 networks:
+  internal:
   proxy:
     external: true
 ```

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to install Nextcloud on an OVHcloud VPS with Docker and Traefik
 description: Find out how to deploy Nextcloud on an OVHcloud VPS with automatic HTTPS via Traefik, MariaDB and Redis
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-22
 ---
 
 ## Objective
@@ -156,11 +156,15 @@ services:
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
     volumes:
-      - db_data:/var/lib/MySQL
+      - db_data:/var/lib/mysql
+    networks:
+      - internal
 
   Redis:
-    image: Redis:7-alpine
+    image: redis:7-alpine
     restart: unless-stopped
+    networks:
+      - internal
 
   app:
     image: nextcloud:apache
@@ -179,11 +183,14 @@ services:
       NEXTCLOUD_TRUSTED_DOMAINS: ${NC_DOMAIN}
     volumes:
       - nextcloud_html:/var/www/html
+      - config:/var/www/html/config
       - nextcloud_data:/var/www/html/data
     networks:
+      - internal
       - proxy
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.nextcloud.rule=Host(`${NC_DOMAIN}`)
       - traefik.http.routers.nextcloud.entrypoints=websecure
       - traefik.http.routers.nextcloud.tls.certresolver=letsencrypt
@@ -192,8 +199,10 @@ volumes:
   db_data:
   nextcloud_html:
   nextcloud_data:
+  config:
 
 networks:
+  internal:
   proxy:
     external: true
 ```

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to install Nextcloud on an OVHcloud VPS with Docker and Traefik
 description: Find out how to deploy Nextcloud on an OVHcloud VPS with automatic HTTPS via Traefik, MariaDB and Redis
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-22
 ---
 
 ## Objective
@@ -156,11 +156,15 @@ services:
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
     volumes:
-      - db_data:/var/lib/MySQL
+      - db_data:/var/lib/mysql
+    networks:
+      - internal
 
   Redis:
-    image: Redis:7-alpine
+    image: redis:7-alpine
     restart: unless-stopped
+    networks:
+      - internal
 
   app:
     image: nextcloud:apache
@@ -179,11 +183,14 @@ services:
       NEXTCLOUD_TRUSTED_DOMAINS: ${NC_DOMAIN}
     volumes:
       - nextcloud_html:/var/www/html
+      - config:/var/www/html/config
       - nextcloud_data:/var/www/html/data
     networks:
+      - internal
       - proxy
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.nextcloud.rule=Host(`${NC_DOMAIN}`)
       - traefik.http.routers.nextcloud.entrypoints=websecure
       - traefik.http.routers.nextcloud.tls.certresolver=letsencrypt
@@ -192,8 +199,10 @@ volumes:
   db_data:
   nextcloud_html:
   nextcloud_data:
+  config:
 
 networks:
+  internal:
   proxy:
     external: true
 ```

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to install Nextcloud on an OVHcloud VPS with Docker and Traefik
 description: Find out how to deploy Nextcloud on an OVHcloud VPS with automatic HTTPS via Traefik, MariaDB and Redis
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-22
 ---
 
 ## Objective
@@ -156,11 +156,15 @@ services:
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
     volumes:
-      - db_data:/var/lib/MySQL
+      - db_data:/var/lib/mysql
+    networks:
+      - internal
 
   Redis:
-    image: Redis:7-alpine
+    image: redis:7-alpine
     restart: unless-stopped
+    networks:
+      - internal
 
   app:
     image: nextcloud:apache
@@ -179,11 +183,14 @@ services:
       NEXTCLOUD_TRUSTED_DOMAINS: ${NC_DOMAIN}
     volumes:
       - nextcloud_html:/var/www/html
+      - config:/var/www/html/config
       - nextcloud_data:/var/www/html/data
     networks:
+      - internal
       - proxy
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.nextcloud.rule=Host(`${NC_DOMAIN}`)
       - traefik.http.routers.nextcloud.entrypoints=websecure
       - traefik.http.routers.nextcloud.tls.certresolver=letsencrypt
@@ -192,8 +199,10 @@ volumes:
   db_data:
   nextcloud_html:
   nextcloud_data:
+  config:
 
 networks:
+  internal:
   proxy:
     external: true
 ```


### PR DESCRIPTION
Port of legacy PR https://github.com/ovh/docs/pull/9343.

- Add dedicated `internal` network for db / redis / app services (fixes `getaddrinfo for db failed`).
- Lowercase Redis image tag (`redis:7-alpine`) for registry compliance.
- Correct MariaDB volume path to `/var/lib/mysql` (case-sensitive FS).
- Persist Nextcloud `/config` so config.php survives container recreation.
- Add `traefik.docker.network=proxy` label on app for correct routing.

Legacy PR only touched en-gb + fr-fr; propagated to all 7 locales since the change is inside a language-agnostic Docker Compose code block.

Original-URL: https://github.com/ovh/docs/pull/9343
Original-author: @afiand