### PR TITLE
chore(cp-steps): strip markers from non-en locales of getting-started-cloud-web

### DIFF
--- a/docs/de/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
@@ -55,7 +55,6 @@ Aktuell sind folgende Programmiersprachen verfügbar:
 - Python
 - Ruby
 
-{/* CP-STEPS-START:access-runtime-software */}
 Um zu den Runtime Engines Ihres [Cloud Web](https://www.ovhcloud.com/de/web-hosting/cloud-web-offer/) Hostings zu gelangen, klicken Sie auf die Tabs, um nacheinander jeden der **3** Schritte anzuzeigen.
 
 <Tabs>
@@ -74,11 +73,9 @@ Um zu den Runtime Engines Ihres [Cloud Web](https://www.ovhcloud.com/de/web-host
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:access-runtime-software */}
 
 Überprüfen Sie daher, bevor Sie fortfahren, dass Sie über die für Ihr Projekt notwendigen Runtime Engines verfügen.
 
-{/* CP-STEPS-START:check-cloud-web-vcores */}
 Um zu überprüfen, dass Sie über 2 vCores für Ihr Cloud Web Hosting verfügen, klicken Sie auf die Tabs, um nacheinander jeden der **2** Schritte anzuzeigen.
 
 <Tabs>
@@ -92,7 +89,6 @@ Um zu überprüfen, dass Sie über 2 vCores für Ihr Cloud Web Hosting verfügen
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:check-cloud-web-vcores */}
 
 ### 3 - Umgebungsvariablen erstellen (optional)
 
@@ -100,7 +96,6 @@ Wenn Sie Ihr Projekt mehrfach in verschiedenen Umgebungen einrichten möchten (z
 
 Dadurch ist es zum Beispiel möglich, keine .env-Datei im PHP-Framework Laravel festzulegen, wie es in der zugehörigen Dokumentation beschrieben ist: [https://laravel.com/docs/master/configuration](https://laravel.com/docs/master/configuration).
 
-{/* CP-STEPS-START:add-environment-variable */}
 Um eine Umgebungsvariable hinzuzufügen, klicken Sie auf die Tabs, um nacheinander jeden der **3** Schritte anzuzeigen.
 
 <Tabs>
@@ -119,7 +114,6 @@ Um eine Umgebungsvariable hinzuzufügen, klicken Sie auf die Tabs, um nacheinand
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:add-environment-variable */}
 
 Wenn Sie kein Entwicklungsframework mit Umgebungsvariablen verwenden oder überprüfen möchten, ob Ihre Umgebungsvariablen funktionieren, können Sie hierfür ein Skript erstellen. Im Folgenden finden Sie zwei Beispiele, um Ihnen bei diesem Vorgang zu helfen. Sie ersetzen allerdings nicht die Hilfe eines Webmasters.
 
@@ -147,7 +141,6 @@ Vergessen Sie nicht, die allgemeinen Angaben in diesen Skripten ("DB_DATABASE") 
 
 ### 4 - Zusätzliche Domains und Multisite konfigurieren (optional)
 
-{/* CP-STEPS-START:configure-multisite */}
 Nun da die technische Umgebung Ihres Cloud Web Hostings fertig ist, können Sie zusätzliche Domains konfigurieren und als Multisite einrichten. So können Sie Ihren Bereich aufteilen und beispielsweise mehrere Websites darauf hosten. Wenn Sie dies für Ihr Projekt einrichten möchten, klicken Sie auf die Tabs, um nacheinander jeden der **3** Schritte anzuzeigen.
 
 <Tabs>
@@ -174,7 +167,6 @@ Nun da die technische Umgebung Ihres Cloud Web Hostings fertig ist, können Sie 
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:configure-multisite */}
 
 Wiederholen Sie diesen Schritt, falls Sie mehrere Domains zu Ihrem Cloud Web Hosting hinzufügen möchten. Weitere Informationen zum Hinzufügen einer Domain als Multisite finden Sie in unserer Anleitung: ["Mehrere Websites auf einem Webhosting einrichten"](/guides/web-cloud/web-hosting/multisites-configure-multisite).
 
@@ -186,7 +178,6 @@ Es gibt zwei mögliche Vorgehensweisen, um Ihr Projekt einzurichten. Wenn Sie me
 
 Mit dieser Lösung können Sie auf einer gebrauchsfertigen Websitestruktur aufbauen und diese nach Belieben anpassen (Themes, Texte usw.). OVHcloud stellt Ihnen 4 verschiedene 1-Klick-Module zur Verfügung. Nähere Informationen finden Sie auf der Webseite ["Erstellen Sie Ihre Website mit 1-Klick-Modulen"](https://www.ovhcloud.com/de/web-hosting/uc-website/).
 
-{/* CP-STEPS-START:install-1-click-module */}
 Wenn Sie sich für die Verwendung eines unserer 1-Klick-Module entscheiden, klicken Sie auf die Tabs, um nacheinander jeden der **3** Schritte anzuzeigen.
 
 <Tabs>
@@ -203,7 +194,6 @@ Wenn Sie sich für die Verwendung eines unserer 1-Klick-Module entscheiden, klic
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:install-1-click-module */}
 
 Wenn Sie mehr über die 1-Klick-Module von OVHcloud wissen möchten, werfen Sie einen Blick in unsere Dokumentation: ["Installation Ihrer Website mit 1-Klick-Modulen"](/guides/web-cloud/web-hosting/cms-install-1-click-modules).
 

--- a/docs/es/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
@@ -55,7 +55,6 @@ Los lenguajes disponibles actualmente son:
 - Python
 - Ruby
 
-{/* CP-STEPS-START:access-runtime-software */}
 Para acceder a los motores de ejecución de su hosting [Cloud Web](https://www.ovhcloud.com/es-es/web-hosting/cloud-web-offer/), haga clic en las pestañas siguientes para visualizar cada una de las **3** etapas.
 
 <Tabs>
@@ -74,11 +73,9 @@ Para acceder a los motores de ejecución de su hosting [Cloud Web](https://www.o
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:access-runtime-software */}
 
 Por lo tanto, asegúrese de disponer del motor o motores de ejecución necesarios para su proyecto antes de continuar.
 
-{/* CP-STEPS-START:check-cloud-web-vcores */}
 Para comprobar que dispone de 2 vCores con su hosting Cloud Web, haga clic en las pestañas siguientes para visualizar cada una de las **2** etapas.
 
 <Tabs>
@@ -92,7 +89,6 @@ Para comprobar que dispone de 2 vCores con su hosting Cloud Web, haga clic en la
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:check-cloud-web-vcores */}
 
 ### 3 - Crear variables de entorno (opcional)
 
@@ -100,7 +96,6 @@ Si desea desplegar su proyecto en varios entornos (por ejemplo, en desarrollo, t
 
 Esto permite, por ejemplo, no definir un archivo «.env» en el framework PHP Laravel, tal como indica la documentación de Laravel: [https://laravel.com/docs/master/configuration](https://laravel.com/docs/master/configuration).
 
-{/* CP-STEPS-START:add-environment-variable */}
 Para añadir una variable de entorno, haga clic en las pestañas siguientes para visualizar cada una de las **3** etapas.
 
 <Tabs>
@@ -119,7 +114,6 @@ Para añadir una variable de entorno, haga clic en las pestañas siguientes para
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:add-environment-variable */}
 
 Si no utiliza ningún framework de desarrollo que incluya las variables de entorno, o si simplemente quiere comprobar que las variables funcionen correctamente, puede crear un script que realice dicha comprobación. A continuación ofrecemos dos ejemplos que le ayudarán en esta tarea (sin que estos sustituyan la ayuda de un webmaster).
 
@@ -147,7 +141,6 @@ No olvide sustituir el valor «DB_DATABASE» por la variable de entorno correspo
 
 ### 4 - Configurar dominios adicionales como multisitio (opcional)
 
-{/* CP-STEPS-START:configure-multisite */}
 Con el entorno técnico del hosting Cloud Web ya listo, es posible configurar dominios adicionales como multisitio para poder alojar varios sitios web en el mismo alojamiento. Si esto se ajusta a su proyecto, haga clic en las pestañas siguientes para visualizar cada una de las **3** etapas.
 
 <Tabs>
@@ -174,7 +167,6 @@ Con el entorno técnico del hosting Cloud Web ya listo, es posible configurar do
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:configure-multisite */}
 
 Repita la operación para cada dominio que quiera añadir a su hosting Cloud Web, en su caso. Para más información sobre cómo añadir un dominio como multisitio, consulte la guía [Alojar varios sitios web en un mismo hosting](/guides/web-cloud/web-hosting/multisites-configure-multisite).
 
@@ -186,7 +178,6 @@ Existen dos formas de instalar un proyecto. Si quiere instalar más de uno, debe
 
 Los módulos en un clic permiten tener la estructura de un sitio web lista para usar, que podrá personalizar a su gusto (diseño, contenido, etc.). OVHcloud ofrece cuatro módulos en un clic, que puede consultar en la página [Crear un sitio web con los CMS más populares](https://www.ovhcloud.com/es-es/web-hosting/uc-website/).
 
-{/* CP-STEPS-START:install-1-click-module */}
 Si elige esta opción, haga clic en las pestañas siguientes para visualizar cada una de las **3** etapas.
 
 <Tabs>
@@ -203,7 +194,6 @@ Si elige esta opción, haga clic en las pestañas siguientes para visualizar cad
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:install-1-click-module */}
 
 Si desea más información sobre los módulos en un clic de OVHcloud, consulte la guía [Instalar un sitio web con un módulo en un clic](/guides/web-cloud/web-hosting/cms-install-1-click-modules).
 

--- a/docs/fr/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
@@ -55,7 +55,6 @@ Les langages actuellement disponibles sont :
 - Python
 - Ruby
 
-{/* CP-STEPS-START:access-runtime-software */}
 Pour accéder aux moteurs d'exécution de votre hébergement [Cloud Web](https://www.ovhcloud.com/fr/web-hosting/cloud-web-offer/), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
 <Tabs>
@@ -74,11 +73,9 @@ Pour accéder aux moteurs d'exécution de votre hébergement [Cloud Web](https:/
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:access-runtime-software */}
 
 Dès lors, assurez-vous de disposer du ou des moteurs d'exécution nécessaires à votre projet avant de poursuivre.
 
-{/* CP-STEPS-START:check-cloud-web-vcores */}
 Pour vérifier que vous disposez bien de 2 vCores avec votre hébergement Cloud Web, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
 <Tabs>
@@ -92,7 +89,6 @@ Pour vérifier que vous disposez bien de 2 vCores avec votre hébergement Cloud 
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:check-cloud-web-vcores */}
 
 ### 3 - Créer des variables d'environnement (facultatif)
 
@@ -100,7 +96,6 @@ Lorsque vous souhaitez déployer plusieurs fois votre projet dans des environnem
 
 Par exemple, cela permet de ne pas définir de fichier « .env » dans le framework, comme sur PHP Laravel : [https://laravel.com/docs/master/configuration](https://laravel.com/docs/master/configuration).
 
-{/* CP-STEPS-START:add-environment-variable */}
 Pour ajouter une variable d'environnement, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
 <Tabs>
@@ -119,7 +114,6 @@ Pour ajouter une variable d'environnement, cliquez sur les onglets ci-dessous po
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:add-environment-variable */}
 
 Si vous n’utilisez pas de framework de développement intégrant les variables d’environnement ou si vous souhaitez simplement vérifier le bon fonctionnement de vos variables, vous pouvez créer un script qui effectuera cette vérification. Vous trouverez, ci-dessous, deux exemples pouvant vous aider dans votre démarche, mais ils ne se substituent pas à l’aide d’un webmaster.
 
@@ -147,7 +141,6 @@ Prenez soin de remplacer l'information générique présente dans ces scripts «
 
 ### 4 - Configurer des domaines additionnels en tant que Multisite (facultatif)
 
-{/* CP-STEPS-START:configure-multisite */}
 Maintenant que l’environnement technique de votre hébergement Cloud Web est prêt, vous pouvez configurer des noms de domaine additionnels à celui-ci en tant que Multisite. Ceci vous permet de partager votre espace afin d’y héberger plusieurs sites internet par exemple. Si cela correspond à votre projet, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
 <Tabs>
@@ -174,7 +167,6 @@ Maintenant que l’environnement technique de votre hébergement Cloud Web est p
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:configure-multisite */}
 
 Répétez cette manipulation si vous souhaitez ajouter plusieurs noms de domaine à votre hébergement Cloud Web. Pour obtenir plus d'informations sur l'ajout d'un nom de domaine en tant que Multisite, consultez notre documentation : [« Partager son hébergement entre plusieurs sites »](/guides/web-cloud/web-hosting/multisites-configure-multisite).
 
@@ -186,7 +178,6 @@ Deux démarches sont possibles pour réaliser l'installation de votre projet. R�
 
 Cette solution vous permet de bénéficier d’une structure de site prête à l’emploi à personnaliser (thème, textes, etc.). OVHcloud en propose quatre avec ses modules en 1 clic à découvrir sur la page [« Créer un site internet avec les modules en 1 clic »](https://www.ovhcloud.com/fr/web-hosting/uc-website/).
 
-{/* CP-STEPS-START:install-1-click-module */}
 Si votre choix se porte sur l'utilisation de nos modules en 1 clic, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
 <Tabs>
@@ -203,7 +194,6 @@ Si votre choix se porte sur l'utilisation de nos modules en 1 clic, cliquez sur 
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:install-1-click-module */}
 
 Si vous désirez obtenir plus d'informations sur les modules en 1 clic OVHcloud, consultez notre documentation : [« Installer son site avec les modules en 1 clic »](/guides/web-cloud/web-hosting/cms-install-1-click-modules).
 

--- a/docs/it/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
@@ -55,7 +55,6 @@ I linguaggi di programmazione disponibili sono:
 - Python
 - Ruby
 
-{/* CP-STEPS-START:access-runtime-software */}
 Per accedere ai programmi d'esecuzione del tuo hosting [Cloud Web](https://www.ovhcloud.com/it/web-hosting/cloud-web-offer/), clicca sulle schede seguenti per visualizzare ciascuno dei **3** passaggi.
 
 <Tabs>
@@ -74,11 +73,9 @@ Per accedere ai programmi d'esecuzione del tuo hosting [Cloud Web](https://www.o
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:access-runtime-software */}
 
 Da questo momento, prima di proseguire, assicurati di disporre del programma o più programmi d'esecuzione necessari al tuo progetto.
 
-{/* CP-STEPS-START:check-cloud-web-vcores */}
 Per verificare di disporre di 2 vCore con il tuo hosting Cloud Web, clicca sulle schede seguenti per visualizzare ciascuno dei **2** passaggi.
 
 <Tabs>
@@ -92,7 +89,6 @@ Per verificare di disporre di 2 vCore con il tuo hosting Cloud Web, clicca sulle
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:check-cloud-web-vcores */}
 
 ### 3 - Crea alcune variabili d'ambiente (facoltativo)
 
@@ -100,7 +96,6 @@ Se hai intenzione di distribuire il tuo progetto più volte in ambienti diversi 
 
 Per esempio, questo consente di non definire file ".env" nel framework PHP Laravel come indicato nella documentazione del framework: [https://laravel.com/docs/master/configuration](https://laravel.com/docs/master/configuration).
 
-{/* CP-STEPS-START:add-environment-variable */}
 Per aggiungere una variabile d'ambiente, clicca sulle schede seguenti per visualizzare ciascuno dei **3** passaggi.
 
 <Tabs>
@@ -119,7 +114,6 @@ Per aggiungere una variabile d'ambiente, clicca sulle schede seguenti per visual
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:add-environment-variable */}
 
 Se non utilizzi framework di sviluppo che includono variabili d'ambiente o se semplicemente vuoi verificare il corretto funzionamento delle tue variabili, puoi creare uno script per effettuare queste funzioni. Di seguito trovi due esempi che possono esserti d'aiuto nel tuo percorso, ma non sostituiscono l'assistenza di un webmaster.
 
@@ -147,7 +141,6 @@ Ricorda di sostituire l'informazione generica presente in questi script "DB_DATA
 
 ### 4 - Configura domini aggiuntivi come Multisito (facoltativo)
 
-{/* CP-STEPS-START:configure-multisite */}
 Adesso che l'ambiente tecnico del tuo hosting Cloud Web è pronto, puoi configurare domini aggiuntivi come Multisito. Questo ti permette di condividere il tuo spazio al fine di ospitare più siti Internet. Se questo è il tuo caso, clicca sulle schede seguenti per visualizzare ciascuno dei **3** passaggi.
 
 <Tabs>
@@ -174,7 +167,6 @@ Adesso che l'ambiente tecnico del tuo hosting Cloud Web è pronto, puoi configur
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:configure-multisite */}
 
 Ripeti questa operazione per ciascun dominio che vuoi aggiungere al tuo Cloud Web. Per ottenere maggiori informazioni sull'aggiunta di un dominio come Multisito, consulta la seguente guida: [Ospitare più siti su uno stesso hosting](/guides/web-cloud/web-hosting/multisites-configure-multisite).
 
@@ -186,7 +178,6 @@ Per realizzare l'installazione del tuo progetto ci sono due possibilità. Ripeti
 
 Questa soluzione ti permette di usufruire di un CMS pronto all'uso e personalizzabile (tema, contenuti, ecc.). OVHcloud propone 4 moduli in 1 click che permettono di installare un CMS in modo semplice e veloce. Per saperne di più accedi alla pagina [Crea il tuo sito con i moduli in 1 click](https://www.ovhcloud.com/it/web-hosting/uc-website/).
 
-{/* CP-STEPS-START:install-1-click-module */}
 Se vuoi optare per l'utilizzo di uno dei nostri moduli, clicca sulle schede seguenti per visualizzare ciascuno dei **3** passaggi.
 
 <Tabs>
@@ -203,7 +194,6 @@ Se vuoi optare per l'utilizzo di uno dei nostri moduli, clicca sulle schede segu
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:install-1-click-module */}
 
 Per maggiori informazioni sui moduli in 1 click, consulta la nostra guida: [Installare i moduli in 1 click OVHcloud](/guides/web-cloud/web-hosting/cms-install-1-click-modules).
 

--- a/docs/pl/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
@@ -55,7 +55,6 @@ Aktualnie dostępne języki to:
 - Python
 - Ruby
 
-{/* CP-STEPS-START:access-runtime-software */}
 Aby uzyskać dostęp do frameworków Twojego hostingu [Cloud Web](https://www.ovhcloud.com/pl/web-hosting/cloud-web-offer/), kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
 
 <Tabs>
@@ -74,11 +73,9 @@ Aby uzyskać dostęp do frameworków Twojego hostingu [Cloud Web](https://www.ov
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:access-runtime-software */}
 
 Zanim przejdziesz do kolejnych kroków, upewnij się, że posiadasz framework lub frameworki niezbędne do Twojego projektu.
 
-{/* CP-STEPS-START:check-cloud-web-vcores */}
 Aby sprawdzić, czy w ramach hostingu Cloud Web dysponujesz 2 vCores, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **2** kroków.
 
 <Tabs>
@@ -92,7 +89,6 @@ Aby sprawdzić, czy w ramach hostingu Cloud Web dysponujesz 2 vCores, kliknij na
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:check-cloud-web-vcores */}
 
 ### 3 - Utworzenie zmiennych środowiskowych (opcjonalnie)
 
@@ -100,7 +96,6 @@ Jeśli chcesz wdrożyć kilka projektów w różnych środowiskach (na przykład
 
 Dzięki temu nie jest na przykład konieczne określanie pliku ".env" we frameworku PHP Laravel, jak wskazuje dokumentacja: [https://laravel.com/docs/master/configuration](https://laravel.com/docs/master/configuration).
 
-{/* CP-STEPS-START:add-environment-variable */}
 Aby dodać zmienną środowiskową, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
 
 <Tabs>
@@ -119,7 +114,6 @@ Aby dodać zmienną środowiskową, kliknij na poniższe karty, aby wyświetlić
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:add-environment-variable */}
 
 Jeśli nie używasz środowiska deweloperskiego zawierającego zmienne środowiskowe lub jeśli chcesz sprawdzić, czy zmienne działają poprawnie, możesz utworzyć skrypt, który przeprowadzi weryfikację. Poniżej przykład skryptu, który może być pomocny w przeprowadzanej przez Ciebie operacji, nie zastąpi on jednak pomocy technicznej webmastera.
 
@@ -147,7 +141,6 @@ Pamiętaj, aby zastąpić informację "DB_DATABASE", zapisaną w powyższych skr
 
 ### 4 - Konfiguracja dodatkowych domen jako MultiSite (opcjonalnie)
 
-{/* CP-STEPS-START:configure-multisite */}
 Teraz, kiedy środowisko Twojego hostingu Cloud Web jest gotowe, możesz skonfigurować dodatkowe domeny w opcji MultiSite. Dzięki temu będziesz mógł podzielić Twoją przestrzeń i hostować na niej kilka stron WWW. Jeśli opcja ta jest niezbędna dla Twojego projektu, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
 
 <Tabs>
@@ -174,7 +167,6 @@ Teraz, kiedy środowisko Twojego hostingu Cloud Web jest gotowe, możesz skonfig
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:configure-multisite */}
 
 Powtórz tę operację, jeśli chcesz dodać kilka domen do Twojego hostingu Cloud Web. Aby uzyskać więcej informacji o dodawaniu domeny w opcji MultiSite, zapoznaj się z naszą dokumentacją: [Instalacja kilku stron WWW na jednym hostingu](/guides/web-cloud/web-hosting/multisites-configure-multisite).
 
@@ -186,7 +178,6 @@ Aby zainstalować Twój projekt, masz do dyspozycji dwie możliwości. Powtarzaj
 
 W tej opcji wybierasz gotowe do użycia rozwiązanie, które dowolnie personalizujesz pod względem struktury strony (szablon, teksty itd.). OVHcloud proponuje cztery moduły CMS, o których możesz dowiedzieć się więcej na stronie ["Twoja strona WWW dzięki modułom CMS"](https://www.ovhcloud.com/pl/web-hosting/uc-website/).
 
-{/* CP-STEPS-START:install-1-click-module */}
 Jeśli decydujesz się na skorzystanie z modułów CMS OVHcloud, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
 
 <Tabs>
@@ -203,7 +194,6 @@ Jeśli decydujesz się na skorzystanie z modułów CMS OVHcloud, kliknij na poni
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:install-1-click-module */}
 
 Jeśli chcesz uzyskać więcej informacji o modułach CMS OVHcloud, zapoznaj się z dokumentacją: [Automatyczna instalacja strony WWW za pomocą modułu CMS](/guides/web-cloud/web-hosting/cms-install-1-click-modules).
 

--- a/docs/pt/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
@@ -55,7 +55,6 @@ As linguagens atualmente disponíveis são:
 - Python
 - Ruby
 
-{/* CP-STEPS-START:access-runtime-software */}
 Para aceder aos motores de execução do seu alojamento [Cloud Web](https://www.ovhcloud.com/pt/web-hosting/cloud-web-offer/), clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 <Tabs>
@@ -74,11 +73,9 @@ Para aceder aos motores de execução do seu alojamento [Cloud Web](https://www.
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:access-runtime-software */}
 
 Assim, antes de prosseguir, certifique-se de que dispõe do ou dos motores de execução necessários ao seu projeto.
 
-{/* CP-STEPS-START:check-cloud-web-vcores */}
 Para verificar que dispõe de 2 vCores com o seu alojamento Cloud Web, clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
 <Tabs>
@@ -92,7 +89,6 @@ Para verificar que dispõe de 2 vCores com o seu alojamento Cloud Web, clique no
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:check-cloud-web-vcores */}
 
 ### 3 - Criar variáveis de ambiente (facultativo)
 
@@ -100,7 +96,6 @@ Quando deseja implementar várias vezes o seu projeto em ambientes diferentes (p
 
 Por exemplo, desta forma pode deixar de fora um ficheiro ".env" no framework PHP Laravel, como indica a documentação do framework: [https://laravel.com/docs/master/configuration](https://laravel.com/docs/master/configuration).
 
-{/* CP-STEPS-START:add-environment-variable */}
 Para adicionar uma variável de ambiente, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 <Tabs>
@@ -119,7 +114,6 @@ Para adicionar uma variável de ambiente, clique nos separadores abaixo para vis
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:add-environment-variable */}
 
 Se não utiliza um framework de desenvolvimento que integre as variáveis de ambiente, ou se deseja simplesmente verificar o bom funcionamento das suas variáveis, pode criar um script para efetuar esta verificação. Encontrará abaixo dois exemplos que podem ser-lhe úteis, mas que não substituem a ajuda de um webmaster:
 
@@ -147,7 +141,6 @@ Tenha o cuidado de substituir a informação genérica presentes nestes scripts 
 
 ### 4 - Configurar domínios adicionais enquanto Multisite (facultativo)
 
-{/* CP-STEPS-START:configure-multisite */}
 Agora que o ambiente técnico do seu alojamento [Cloud Web](https://www.ovhcloud.com/pt/web-hosting/cloud-web-offer/) está pronto, pode configurar domínios adicionais enquanto Multisite. Isto permite-lhe partilhar o seu espaço, de forma a alojar nele vários sites, por exemplo. Se isto se adequa ao seu projeto, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 <Tabs>
@@ -174,7 +167,6 @@ Agora que o ambiente técnico do seu alojamento [Cloud Web](https://www.ovhcloud
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:configure-multisite */}
 
 Repita esta manipulação se deseja adicionar vários domínios ao seu alojamento Cloud Web. Para obter mais informação acerca da adição de um domínio enquanto Multisite, consulte o guia: [Partilhar o alojamento entre vários sites](/guides/web-cloud/web-hosting/multisites-configure-multisite).
 
@@ -186,7 +178,6 @@ Tem ao dispor duas formas de efetuar a instalação do seu projeto. Repita o pro
 
 Esta solução permite-lhe beneficiar de uma estrutura de site pronta a usar ainda por personalizar (tema, textos, etc.). A OVHcloud disponibiliza quatro com os módulos em 1 clique, a descobrir na página [Criar um site com os módulos em 1 clique](https://www.ovhcloud.com/pt/web-hosting/uc-website/).
 
-{/* CP-STEPS-START:install-1-click-module */}
 Se optar pela utilização dos nossos módulos em 1 clique, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 <Tabs>
@@ -203,7 +194,6 @@ Se optar pela utilização dos nossos módulos em 1 clique, clique nos separador
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:install-1-click-module */}
 
 Para mais informações sobre os módulos, consulte o guia: [Instalar um site com os módulos em 1 clique](/guides/web-cloud/web-hosting/cms-install-1-click-modules).
 


### PR DESCRIPTION
Port of legacy PR https://github.com/ovh/docs/pull/9377.

The legacy PR strips `CP-STEPS-START`/`CP-STEPS-END` markers from all non-en-gb locales across 86 guides. On new-docs, 85 of those guides already had markers removed entirely (prior NM migration cleaned up EN too). Only `getting-started-cloud-web` still carried markers in every locale, and all 7 locales there are real files (not symlinks), so each non-EN locale needed its own strip.

EN is left untouched (still holds its CP-STEPS markers), consistent with the legacy PR keeping en-gb intact.

Original-URL: https://github.com/ovh/docs/pull/9377
Original-author: @benchbzh