### PR TITLE
docs(hosted-private-cloud): port spare-host process update from ovh/d…

### DIFF
--- a/docs/de/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
+++ b/docs/de/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
@@ -1,7 +1,7 @@
 ---
 title: Spare-Host Auslieferung und Rückgabe
 description: Erfahren Sie hier, wie die Bereitstellung eines Spare-Hosts abläuft
-lastUpdated: 2020-06-29
+lastUpdated: 2026-05-22
 ---
 
 ## Ziel
@@ -12,31 +12,30 @@ In den Verträgen von OVHcloud wird der Ersatz eines unzugänglichen Hosts garan
 
 ## Voraussetzungen
 
-- Sie verfügen über eine [Hosted Private Cloud](https://www.ovhcloud.com/de/enterprise/products/hosted-private-cloud/) Infrastruktur.
+- Sie verfügen über eine [Hosted Private Cloud](/links/hosted-private-cloud/vmware) Infrastruktur.
 
 ## In der praktischen Anwendung
 
 ### Lieferung eines Ersatz-Hosts
 
-Wenn einer Ihrer Hosts ausfällt, liefern wir Ihnen automatisch und kostenfrei einen Ersatz-Host in Ihre Infrastruktur, um die Dienstkontinuität zu gewährleisten. 
+Wenn einer Ihrer Hosts ausfällt, liefern wir Ihnen automatisch und kostenfrei einen Ersatz-Host in Ihre Infrastruktur, um die Dienstkontinuität zu gewährleisten.
 
 Sofort nach Lieferung dieses Hosts erhalten Sie eine E-Mail mit allen Informationen zu diesem Host. Sie erhalten auch seine IP-Adresse, mit der Sie ihn leicht in Ihrem vSphere Interface finden können.
 
-Standardmäßig ist der Dienst HA ([High Availability](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability)) von VMware für Ihren Cluster aktiviert. Wenn Sie Ihn aktiviert lassen, werden Ihre virtuellen Maschinen automatisch neu gestartet. Ist der Dienst DRS (Distributed Ressources Scheduler) aktiviert und im Modus „fully automated“, so findet die Lastverteilung zwischen den Hosts Ihres Clusters ebenfalls automatisch statt.
+Standardmäßig ist der Dienst [HA (High Availability)](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability) von VMware für Ihren Cluster aktiviert. Wenn Sie ihn aktiviert lassen, werden Ihre virtuellen Maschinen automatisch neu gestartet. Ist der Dienst [DRS (Distributed Resource Scheduler)](/guides/hosted-private-cloud/powered-by-vmware/drs-distributed-ressource-scheduler) aktiviert und im Modus "Vollautomatisiert", so findet die Lastverteilung zwischen den Hosts Ihres Clusters ebenfalls automatisch statt.
 
 :::warning
-Ist noch ein CD/DVD-Laufwerk auf einer VM installiert oder mit ihr verbunden, so kann der Dienst HA nicht auf dem Ersatz-Host gestartet werden. Es wird empfohlen, das CD/DVD-Laufwerk immer als Clientgerät einzurichten.
+Ist noch ein CD/DVD-Laufwerk auf einer VM installiert oder mit ihr verbunden, so kann der Dienst HA die VM nicht auf dem Ersatz-Host neu starten. Es wird empfohlen, das CD/DVD-Laufwerk immer als Clientgerät einzurichten.
 :::
 
-
-### Vorgehensweise nach Erhalt des Ersatz-Host
-
-Wenn der Original-Host wieder funktioniert (nach der Reparatur), können Sie einen der beiden Hosts (Original oder Ersatz) an uns zurückgeben.
+### Vorgehensweise nach Erhalt des Ersatz-Hosts
 
 Wir empfehlen Ihnen, uns den Original-Host zurückzugeben, damit wir ihn nach dieser Störung einer Reihe von Tests unterziehen (und so zukünftige Störungen vermeiden) können. Sie können dann den Ersatz-Host behalten. Dazu können Sie die Anleitung [Host-Server löschen](/guides/hosted-private-cloud/powered-by-vmware/delete-host) zu Rate ziehen.
 
-OVHcloud kann dann automatisch den Original-Host zurücknehmen, sobald er entfernt ist.
+:::warning
+Im Falle der Nichtrückgabe eines der beiden Hosts (Original oder Ersatz) innerhalb einer Frist von 7 Tagen wird der Ersatz-Host ab dem 8. Tag stundenweise abgerechnet.
+:::
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](https://community.ovhcloud.com/) bei.

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
@@ -1,7 +1,7 @@
 ---
 title: Spare host delivery and return
 description: Find out how the replacement of a host works
-lastUpdated: 2020-06-29
+lastUpdated: 2026-05-22
 ---
 
 ## Objective
@@ -9,6 +9,10 @@ lastUpdated: 2020-06-29
 OVHcloud guarantees in its contracts the replacement of an inaccessible host.
 
 **This guide explains the details of a host replacement procedure.**
+
+## Requirements
+
+- An active [Hosted Private Cloud](/links/hosted-private-cloud/vmware) infrastructure.
 
 ## Instructions
 
@@ -18,21 +22,20 @@ If one of your hosts fails, OVHcloud will automatically deliver a free replaceme
 
 As soon as this host is delivered, you will receive an email providing information about this host and its IP address, allowing you to easily find it in your vSphere interface.
 
-By default, VMware's [High Availability (HA) service](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability) is enabled on your cluster. If you have not disabled it, your virtual machines will automatically restart. If the Distributed Resources Scheduler (DRS) service is enabled and configured in "fully automated" mode, the load distribution on the hosts in your cluster will also be performed automatically.
+By default, VMware's [HA (High Availability)](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability) service is enabled on your cluster. If you have not disabled it, your virtual machines will automatically restart. If the [DRS (Distributed Resource Scheduler)](/guides/hosted-private-cloud/powered-by-vmware/drs-distributed-ressource-scheduler) service is enabled and configured in "Fully Automated" mode, the load distribution on the hosts in your cluster will also be performed automatically.
 
 :::warning
 If a CD/DVD drive is still mounted or connected to a VM, the HA service will not be able to restart it on the spare host. It is recommended that you always have the CD/DVD drive as a client device.
 :::
 
-
 ### What to do after receiving the spare host
-
-Once the original host is functional again, you can return one of the two hosts (the spare host or the original host).
 
 We recommend that you return the original host so that we can run a battery of tests on it (to avoid future failures). You can then keep the spare host. To do this, please follow the [Removing a host server](/guides/hosted-private-cloud/powered-by-vmware/delete-host) guide.
 
-OVHcloud can automatically retrieve the original host as soon as it is removed.
+:::warning
+In the event that one of the two hosts (original or spare) is not returned within 7 days, the spare host will be billed by the hour from the 8th day.
+:::
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/es/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
+++ b/docs/es/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
@@ -1,7 +1,7 @@
 ---
 title: Host de sustitución
 description: Cómo sustituir un host
-lastUpdated: 2020-06-29
+lastUpdated: 2026-05-22
 ---
 
 ## Objetivo
@@ -12,31 +12,30 @@ OVHcloud garantiza en sus contratos la sustitución de los hosts que no están a
 
 ## Requisitos
 
-- Tener una solución [Hosted Private Cloud](https://www.ovhcloud.com/es-es/enterprise/products/hosted-private-cloud/).
+- Tener una solución [Hosted Private Cloud](/links/hosted-private-cloud/vmware).
 
 ## Procedimiento
 
 ### Entrega de un host de sustitución
 
-En caso de fallo en uno de los hosts que componen su infraestructura, OVHcloud entrega automáticamente un host de sustitución gratuito para garantizar la continuidad del servicio en su infraestructura. 
+En caso de fallo en uno de los hosts que componen su infraestructura, OVHcloud entrega automáticamente un host de sustitución gratuito para garantizar la continuidad del servicio en su infraestructura.
 
 Una vez entregado el host, recibirá un mensaje de correo electrónico con toda la información necesaria y su dirección IP, para que así pueda encontrarlo fácilmente en su interfaz vSphere.
 
-Por defecto, el servicio HA ([High Availability](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability)) de VMware está activado en su cluster. Si este servicio permanece activado, las máquinas virtuales se reiniciarán automáticamente. En caso de que el servicio DRS (Distributed Ressources Scheduler) esté activado y configurado en modo «Fully automated», la carga en los hosts del cluster se repartirá de forma automática.
+Por defecto, el servicio [HA (High Availability)](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability) de VMware está activado en su cluster. Si este servicio permanece activado, las máquinas virtuales se reiniciarán automáticamente. En caso de que el servicio [DRS (Distributed Resource Scheduler)](/guides/hosted-private-cloud/powered-by-vmware/drs-distributed-ressource-scheduler) esté activado y configurado en modo "Completamente automático", la carga en los hosts del cluster se repartirá de forma automática.
 
 :::warning
 Si hay montado o conectado un lector de CD/DVD en una MV, el servicio HA no podrá arrancarla en el host de sustitución. Así pues, le recomendamos que siempre conecte estos lectores en un periférico a nivel de cliente.
 :::
 
-
 ### Qué hacer con el host de sustitución
-
-Una vez que el host original vuelva a estar operativo, podrá devolver cualquiera de los dos hosts (el de sustitución o el original).
 
 Le recomendamos que nos devuelva el host original para que podamos realizar un diagnóstico más preciso de la incidencia y evitar así fallos futuros. Si devuelve el host original, podrá conservar el host de sustitución. Para más información, consulte la guía [Eliminar un servidor host](/guides/hosted-private-cloud/powered-by-vmware/delete-host).
 
-Una vez retirado el host original, OVHcloud podrá recuperarlo automáticamente.
+:::warning
+En caso de no devolución de uno de los dos hosts (original o de sustitución) en un plazo de 7 días, el host de sustitución se facturará por hora a partir del 8.º día.
+:::
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/).

--- a/docs/fr/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
+++ b/docs/fr/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
@@ -1,40 +1,41 @@
 ---
 title: Hôte de spare
 description: "Comprendre le mécanisme de remplacement d'hôte"
-lastUpdated: 2020-06-29
+lastUpdated: 2026-05-22
 ---
 
-## Prérequis
-
-- Disposer d'une offre [Hosted Private cloud](https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/).
-
-## Objectifs
+## Objectif
 
 OVHcloud garantit dans ses contrats le remplacement d'un hôte inaccessible.
 
 **Ce guide explique le fonctionnement de ce remplacement.**
 
-## Livraison d’un hôte de spare
+## Prérequis
 
-Si l’un de vos hôtes est victime d’une panne, afin d’assurer la continuité de service, nous vous livrons automatiquement un hôte de remplacement gratuit dans votre infrastructure. 
+- Disposer d'une offre [Hosted Private Cloud](/links/hosted-private-cloud/vmware).
+
+## En pratique
+
+### Livraison d’un hôte de spare
+
+Si l’un de vos hôtes est victime d’une panne, afin d’assurer la continuité de service, nous vous livrons automatiquement un hôte de remplacement gratuit dans votre infrastructure.
 
 Dès que cet hôte est livré, vous recevez un email vous indiquant toutes les informations concernant cet hôte ainsi que son adresse IP vous permettant de le retrouver facilement dans votre interface vSphere.
 
-Par défaut, le service HA ([High Availability)](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability) de VMware est activé sur votre cluster. Si vous l’avez laissé activé, vos machines virtuelles vont redémarrer automatiquement. Si le service DRS (Distributed Ressources Scheduler) est activé et configuré en mode « Entièrement Automatisé », la répartition de charge sur les hôtes de votre cluster sera également effectuée automatiquement.
+Par défaut, le service [HA (High Availability)](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability) de VMware est activé sur votre cluster. Si vous l’avez laissé activé, vos machines virtuelles vont redémarrer automatiquement. Si le service [DRS (Distributed Resource Scheduler)](/guides/hosted-private-cloud/powered-by-vmware/drs-distributed-ressource-scheduler) est activé et configuré en mode « Entièrement automatisé », la répartition de charge sur les hôtes de votre cluster sera également effectuée automatiquement.
 
 :::warning
 Si un lecteur CD/DVD est encore monté ou connecté sur une VM, le service HA ne pourra pas la redémarrer sur l'hôte de spare. Il est recommandé de toujours avoir le lecteur CD/DVD en périphérique client.
 :::
 
+### Que faire après avoir reçu l'hôte de spare
 
-## Que faire après avoir reçu le hôte de spare
+Nous vous recommandons de nous rendre l'hôte original afin que nous puissions lui faire subir une batterie de tests suite à cet incident (pour éviter d’éventuelles futures pannes). Vous pourrez alors conserver l'hôte de spare. Pour cela, suivez le guide « [suppression d’un hôte](/guides/hosted-private-cloud/powered-by-vmware/delete-host) ».
 
-Une fois que l'hôte original est de nouveau fonctionnel (une fois réparé), vous pouvez nous rendre l’un des deux hôtes (l'hôte de spare ou l'hôte original).
-
-Nous vous recommandons de nous rendre l'hôte original afin que nous puissions lui faire subir une batterie de tests suite à cet incident (pour éviter d’éventuelles futures pannes). Vous pourrez alors conserver l'hôte de spare. Pour cela vous pouvez suivre le guide [suppression d’un hôte](/guides/hosted-private-cloud/powered-by-vmware/delete-host)
-
-OVHcloud pourra récupérer automatiquement l'hôte original dès que celui-ci est retiré.
+:::warning
+En cas de non-restitution de l'un des deux hôtes (original ou spare) dans un délai de 7 jours, l'hôte de spare sera facturé à l'heure à compter du 8e jour.
+:::
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/).

--- a/docs/it/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
+++ b/docs/it/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
@@ -1,38 +1,41 @@
 ---
 title: Host sostitutivo
 description: Come avviene la sostituzione di un host malfunzionante
-lastUpdated: 2020-06-29
+lastUpdated: 2026-05-22
 ---
 
-## Prerequisiti
-
-- Disporre di una soluzione [Hosted Private Cloud](https://www.ovhcloud.com/it/enterprise/products/hosted-private-cloud/)
-
-## Obiettivi
+## Obiettivo
 
 In caso di irraggiungibilità di un server host, OVHcloud ne garantisce la sostituzione a livello contrattuale.
 
 **Questa guida ti mostra come funziona la procedura di sostituzione di una macchina malfunzionante.**
 
-## Consegna dello spare host
+## Prerequisiti
 
-Per garantire la continuità di servizio anche in caso di malfunzionamento di uno degli host, OVHcloud mette automaticamente a disposizione nell’infrastruttura un host sostitutivo gratuito. 
+- Disporre di una soluzione [Hosted Private Cloud](/links/hosted-private-cloud/vmware).
+
+## Procedura
+
+### Consegna dello spare host
+
+Per garantire la continuità di servizio anche in caso di malfunzionamento di uno degli host, OVHcloud mette automaticamente a disposizione nell’infrastruttura un host sostitutivo gratuito.
 
 Al momento della consegna di questa macchina, viene inviata un’email con tutte le informazioni associate e l’indirizzo IP che permette di individuarla facilmente nell’interfaccia vSphere.
 
-Il servizio [High Availability (HA)](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability) di VMware è abilitato di default sul cluster. Nel caso in cui sia stato lasciato attivo, le macchine virtuali si riavvieranno automaticamente. Se il servizio DRS (Distributed Ressources Scheduler) è attivo e configurato in modalità “fully automated”, anche la distribuzione del carico sugli host del cluster verrà eseguita in modo automatico.
+Il servizio [HA (High Availability)](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability) di VMware è abilitato di default sul cluster. Nel caso in cui sia stato lasciato attivo, le macchine virtuali si riavvieranno automaticamente. Se il servizio [DRS (Distributed Resource Scheduler)](/guides/hosted-private-cloud/powered-by-vmware/drs-distributed-ressource-scheduler) è attivo e configurato in modalità "Completamente automatizzata", anche la distribuzione del carico sugli host del cluster verrà eseguita in modo automatico.
 
 :::warning
 Se un lettore CD/DVD risulta ancora montato o connesso su una VM, il servizio HA non potrà riavviarlo sull’host sostitutivo. Consigliamo quindi di assicurarsi che il lettore sia sempre una periferica a livello client.
 :::
 
+### Cosa fare dopo aver ricevuto lo spare host
 
-## Cosa fare dopo aver ricevuto lo spare host
+Consigliamo di rendere il server originale, per permetterci di eseguire una serie di test in seguito all’incidente ed evitare eventuali malfunzionamenti futuri. In questo caso è possibile quindi conservare l’host sostitutivo. Per eseguire questa operazione, consulta la guida sulla [rimozione di un server host](/guides/hosted-private-cloud/powered-by-vmware/delete-host).
 
-Una volta che l’host originale è nuovamente operativo, è possibile restituire uno degli host (la macchina sostitutiva o quella originale).
-
-Consigliamo di rendere il server originale, per permetterci di eseguire una serie di test in seguito all’incidente ed evitare eventuali malfunzionamenti futuri. In questo caso è possibile quindi conservare l’host sostitutivo. Per eseguire questa operazione, consulta la guida sulla [rimozione di un server host](/guides/hosted-private-cloud/powered-by-vmware/delete-host): una volta eliminato l’host originale, OVHcloud potrà recuperarlo automaticamente.
+:::warning
+In caso di mancata restituzione di uno dei due host (originale o spare) entro un termine di 7 giorni, lo spare host sarà fatturato a ore a partire dall’8° giorno.
+:::
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](https://community.ovhcloud.com/).

--- a/docs/pl/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
+++ b/docs/pl/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
@@ -1,12 +1,8 @@
 ---
 title: Host zapasowy
 description: Mechanizm wymiany hosta
-lastUpdated: 2020-06-29
+lastUpdated: 2026-05-22
 ---
-
-## Wymagania początkowe
-
-- Wykupienie usługi [Hosted Private Cloud](https://www.ovhcloud.com/pl/enterprise/products/hosted-private-cloud/).
 
 ## Wprowadzenie
 
@@ -14,27 +10,32 @@ OVHcloud w swoich umowach gwarantuje wymianę niedostępnego hosta.
 
 **Ten przewodnik wyjaśnia, na czym polega wymiana hosta.**
 
-## Dostarczenie zapasowego hosta
+## Wymagania początkowe
 
-W przypadku awarii jednego z hostów automatycznie dostarczamy bezpłatny host zapasowy, aby zapewnić ciągłość usług. 
+- Wykupienie usługi [Hosted Private Cloud](/links/hosted-private-cloud/vmware).
+
+## W praktyce
+
+### Dostarczenie zapasowego hosta
+
+W przypadku awarii jednego z hostów automatycznie dostarczamy bezpłatny host zapasowy, aby zapewnić ciągłość usług.
 
 Gdy tylko host zostanie dostarczony, otrzymasz wiadomość e-mail ze wszystkimi potrzebnymi informacjami oraz adresem IP hosta, dzięki czemu łatwo go znajdziesz w interfejsie vSphere.
 
-Usługa VMware [High Availability](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability)(HA) jest domyślnie aktywowana w klastrze. Jeśli pozostawisz ją włączoną, Twoje wirtualne maszyny zostaną automatycznie zrestartowane. Jeśli usługa Distributed Resources Scheduler (DRS) jest włączona i skonfigurowana w trybie "Pełna automatyzacja", równoważenie obciążeń na hostach w klastrze będzie również wykonywane automatycznie.
+Usługa VMware [HA (High Availability)](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability) jest domyślnie aktywowana w klastrze. Jeśli pozostawisz ją włączoną, Twoje wirtualne maszyny zostaną automatycznie zrestartowane. Jeśli usługa [DRS (Distributed Resource Scheduler)](/guides/hosted-private-cloud/powered-by-vmware/drs-distributed-ressource-scheduler) jest włączona i skonfigurowana w trybie "Całkowicie automatycznym", równoważenie obciążeń na hostach w klastrze będzie również wykonywane automatycznie.
 
 :::warning
 Jeśli napęd CD/DVD jest nadal zamontowany lub podłączony do wirtualnej maszyny, usługa HA nie będzie w stanie uruchomić go ponownie na zapasowym hoście. Zalecamy, aby napęd CD/DVD zawsze był podłączony jako urządzenie klienckie.
 :::
 
+### Jakie kroki należy wykonać po otrzymaniu hosta zapasowego
 
-## Jakie kroki należy wykonać po otrzymaniu hosta zapasowego
+Rekomendujemy zwrócenie oryginalnego hosta, abyśmy mogli przeprowadzić testy diagnozujące przyczynę incydentu w celu uniknięcia potencjalnych awarii w przyszłości. W tym przypadku zachowasz host zapasowy. Zapoznaj się z przewodnikiem [Usunięcie hosta](/guides/hosted-private-cloud/powered-by-vmware/delete-host)
 
-Po przywróceniu działania oryginalnego hosta możesz nam zwrócić jeden z hostów (host zapasowy lub oryginalny).
-
-Rekomendujemy zwrócenie oryginalnego hosta, abyśmy mogli przeprowadzić testy diagnozujące przyczynę incydentu w celu uniknięcia potencjalnych awarii w przyszłości. W tym przypadku zachowasz host zapasowy. Zapoznaj się z przewodnikiem [Usunięcie hosta](/guides/hosted-private-cloud/powered-by-vmware/delete-host)
-
-OVHcloud automatycznie odzyska oryginalny host, gdy tylko zostanie on usunięty.
+:::warning
+W przypadku braku zwrotu jednego z dwóch hostów (oryginalny lub zapasowy) w terminie 7 dni, za host zapasowy będzie naliczana opłata godzinowa począwszy od 8. dnia.
+:::
 
 ## Sprawdź również
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/).

--- a/docs/pt/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
+++ b/docs/pt/guides/hosted-private-cloud/powered-by-vmware/spare-hosts.mdx
@@ -1,41 +1,41 @@
 ---
 title: Host de substituição
 description: Descubra o mecanismo de substituição de um host
-lastUpdated: 2020-06-29
+lastUpdated: 2026-05-22
 ---
 
-## Requisitos
-
-- Dispor de uma oferta [Hosted Private Cloud](https://www.ovhcloud.com/pt/enterprise/products/hosted-private-cloud/).
-
-## Sumário
+## Objetivo
 
 A OVHcloud garante nos seus contratos a substituição de um host inacessível.
 
 **Este manual explica o funcionamento desta substituição.**
 
-## Entrega de um host de substituição
+## Requisitos
 
-Para garantir a continuidade de serviço em caso de avaria de um dos hosts, a OVHcloud disponibiliza automaticamente na infraestrutura um host de substituição gratuito. 
+- Dispor de uma oferta [Hosted Private Cloud](/links/hosted-private-cloud/vmware).
+
+## Instruções
+
+### Entrega de um host de substituição
+
+Para garantir a continuidade de serviço em caso de avaria de um dos hosts, a OVHcloud disponibiliza automaticamente na infraestrutura um host de substituição gratuito.
 
 Assim que este host for entregue, receberá um e-mail indicando-lhe todas as informações sobre este host, assim como o seu endereço IP que lhe permite encontrá-lo facilmente na sua interface vSphere.
 
-Por predefinição, o serviço HA ([High Availability](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability)) de VMware é ativado no seu cluster. Se o tiver deixado ativo, as suas máquinas virtuais irão reiniciar automaticamente. Se o serviço DRS (Distributed Ressources Scheduler) for ativado e configurado em modo “fully automated”, a repartição da carga nos hosts do seu cluster será igualmente efetuada de forma automática.
+Por predefinição, o serviço [HA (High Availability)](/guides/hosted-private-cloud/powered-by-vmware/vmware-ha-high-availability) de VMware é ativado no seu cluster. Se o tiver deixado ativo, as suas máquinas virtuais irão reiniciar automaticamente. Se o serviço [DRS (Distributed Resource Scheduler)](/guides/hosted-private-cloud/powered-by-vmware/drs-distributed-ressource-scheduler) for ativado e configurado em modo "Inteiramente automatizado", a repartição da carga nos hosts do seu cluster será igualmente efetuada de forma automática.
 
 :::warning
 Se um leitor CD/DVD ainda estiver montado ou ligado numa VM, o serviço HA não a poderá reiniciar no host de substituição. Recomenda-se ter sempre o leitor CD/DVD em periférico cliente.
 :::
 
+### O que fazer depois de receber o host de substituição
 
-## O que fazer depois de receber o host de substituição
+Recomendamos que nos devolva o host original para que lhe possamos aplicar uma série de testes após esse incidente (para evitar eventuais novas avarias). Assim, poderá conservar o host de substituição. Para isso, pode consultar o manual [Eliminar um servidor host](/guides/hosted-private-cloud/powered-by-vmware/delete-host).
 
-Uma vez o host original novamente funcional (depois de reparado), poderá devolver um dos dois hosts (host de substituição ou host original).
-
-Recomendamos que nos devolva o host original para que lhe possamos aplicar uma série de testes após esse incidente (para evitar eventuais novas avarias). Assim, poderá conservar o host de substituição. Para isso, pode consultar o manual [Eliminar um servidor host](/guides/hosted-private-cloud/powered-by-vmware/delete-host)
-
-A OVHcloud poderá recuperar automaticamente o host original assim que este for retirado.
+:::warning
+Em caso de não devolução de um dos dois hosts (original ou de substituição) no prazo de 7 dias, o host de substituição será faturado à hora a partir do 8.º dia.
+:::
 
 ## Quer saber mais?
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
-
+Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/).


### PR DESCRIPTION
…ocs#9382

Restructures the spare-host delivery/return guide (Hosted Private Cloud / VMware) across all 7 locales: promotes Delivery and Return to subsections under Instructions, adds a Prerequisites section, tightens HA/DRS link labels, drops the redundant "you can return one of the two hosts" sentence, and adds a 7-day non-return billing warning. Bumps lastUpdated to today.

Original-URL: https://github.com/ovh/docs/pull/9382
Original-author: @CelineMa59