### PR TITLE
feat(compute): update to add tabs and add cli

### DIFF
--- a/docs/de/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/de/guides/public-cloud/compute/getting-started.mdx
@@ -1,13 +1,10 @@
 ---
 title: Eine Public Cloud Instanz erstellen und darauf zugreifen
 description: Erfahren Sie hier, wie Sie Public Cloud Instanzen in Ihrem OVHcloud Kundencenter konfigurieren, sowie die ersten Schritte mit Instanzen
-lastUpdated: 2026-02-24
+lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
-
-
-
 
 ## Ziel
 
@@ -15,7 +12,6 @@ Public Cloud Instanzen sind einfach einzurichten und zu verwalten. Als Teil des 
 Danach können Sie Ihr Public Cloud Projekt weiter spezialisieren, je nach Ihren Bedürfnissen.
 
 **Diese Anleitung erklärt die ersten Schritte mit einer Public Cloud Instanz.**
-
 
 ## Voraussetzungen
 
@@ -37,7 +33,6 @@ Profitieren Sie von reduzierten Preisen, indem Sie sich für einen Zeitraum von 
 
 :::
 
-
 ## In der praktischen Anwendung
 
 :::info
@@ -46,7 +41,6 @@ Wenn Sie noch kein Public Cloud Projekt erstellt haben, beginnen Sie mit unserer
 Wichtige **technische Details** zur OVHcloud Public Cloud finden Sie auf [dieser Seite](/guides/public-cloud/cross-functional/compute-essential-information).
 
 :::
-
 
 ### Inhaltsübersicht
 
@@ -58,19 +52,6 @@ Wichtige **technische Details** zur OVHcloud Public Cloud finden Sie auf [dieser
   - [Schritt 2: SSH-Schlüssel importieren](#schritt-2-ssh-schlussel-importieren)
   - [Schritt 3: Netzwerkkonfiguration vorbereiten](#schritt-3-netzwerkkonfiguration-vorbereiten)
   - [Schritt 4: Instanz erstellen](#schritt-4-instanz-erstellen)
-    - [Schritt 4.1: Name der Instanz](#schritt-41-name-der-instanz)
-    - [Schritt 4.2: Standort auswählen](#schritt-42-standort-auswahlen)
-    - [Schritt 4.3: Modell auswählen](#schritt-43-modell-auswahlen)
-      - [Weitere Informationen](#weitere-informationen)
-    - [Schritt 4.4: Image auswählen](#schritt-44-image-auswahlen)
-    - [Schritt 4.5: SSH-Schlüssel auswählen (nicht für Windows-Instanzen)](#schritt-45-ssh-schlussel-auswahlen-nicht-fur-windows-instanzen)
-    - [Schritt 4.6: Backup-Einstellungen konfigurieren](#schritt-46-backup-einstellungen-konfigurieren)
-    - [Schritt 4.7: Netzwerk konfigurieren](#schritt-47-netzwerk-konfigurieren)
-    - [Schritt 4.8: Abrechnungszeitraum auswählen](#schritt-48-abrechnungszeitraum-auswahlen)
-    - [Schritt 4.9: Erweiterte Einstellungen konfigurieren](#schritt-49-erweiterte-einstellungen-konfigurieren)
-      - [Flexible Instanz](#flexible-instanz)
-      - [Post-Installations-Skript](#post-installations-skript)
-    - [Schritt 4.10: Instanz abschließen](#schritt-410-instanz-abschliessen)
   - [Schritt 5: Verbindung mit der Instanz herstellen](#schritt-5-verbindung-mit-der-instanz-herstellen)
     - [5.1: Status der Instanz im OVHcloud Kundencenter überprüfen](#51-status-der-instanz-im-ovhcloud-kundencenter-uberprufen)
     - [5.2: Erste Verbindung mit einer Instanz unter GNU/Linux](#52-erste-verbindung-mit-einer-instanz-unter-gnulinux)
@@ -86,14 +67,12 @@ Wichtige **technische Details** zur OVHcloud Public Cloud finden Sie auf [dieser
     - [6.2: Zusätzliche SSH-Schlüssel](#62-zusatzliche-ssh-schlussel)
 - [Weiterführende Informationen](#weiterfuhrende-informationen)
 
-
 :::info
 **Sie müssen einen öffentlichen SSH-Schlüssel angeben, wenn Sie Public Cloud Instanzen in Ihrem Kundencenter erstellen.** Sobald die Instanz erstellt wurde können Sie Ihren Remote-Zugriff nach eigenem Ermessen konfigurieren.
 
 **Ausnahme**: Die Anmeldeauthentifizierung für Windows-Instanzen erfordert einen Benutzernamen und ein Passwort, da Windows RDP verwendet (**R**emote **D**esktop **P**rotocol).
 
 :::
-
 
 ### Schritt 1: SSH-Schlüsselpaar erstellen
 
@@ -113,10 +92,9 @@ Die meisten aktuellen Desktop-Betriebssysteme enthalten nativ einen **OpenSSH** 
 
 Wenn Sie eine andere Software verwenden, folgen Sie der zugehörigen Benutzerdokumentation. Ein Anwendungsbeispiel für die Open-Source-Lösung `PuTTY` finden Sie in unserer Anleitung: [PuTTY verwenden](/guides/web-cloud/web-hosting/ssh-using-putty-on-windows).
 
-
 ### Schritt 2: SSH-Schlüssel importieren
 
-Sie können Ihre öffentlichen SSH-Schlüssel im Bereich <code className="action">Public Cloud</code> des <ManagerLink to="/">OVHcloud Kundencenters</ManagerLink> speichern. Dies ist nicht zwingend erforderlich, macht die Erstellung einer Instanz jedoch komfortabler.
+Sie können Ihre öffentlichen SSH-Schlüssel in Ihrem Public Cloud Projekt speichern. Dies ist nicht zwingend erforderlich, macht die Erstellung einer Instanz jedoch komfortabler.
 
 :::info
 Mit gespeicherten SSH-Schlüsseln können Sie Ihre Instanzen schneller im OVHcloud Kundencenter erstellen. Informationen zum Austauschen von Schlüsselpaaren und Hinzufügen von Benutzern nach der Erstellung einer Instanz finden Sie in der Anleitung zu [zusätzlichen SSH-Schlüsseln](/guides/public-cloud/compute/configuring-additional-ssh-keys).
@@ -125,16 +103,71 @@ Die in Ihrem OVHcloud Kundencenter hinzugefügten öffentlichen SSH-Schlüssel s
 
 :::
 
+<Tabs>
+  <Tab label="Über das Kundencenter">
+    Loggen Sie sich in das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> ein, navigieren Sie zum Bereich <code className="action">Public Cloud</code> und wählen Sie Ihr Public Cloud Projekt aus.
 
-Öffnen Sie <code className="action">SSH-Schlüssel</code> im linken Menü unter **Einstellungen**. Klicken Sie auf den Button <code className="action">SSH-Schlüssel hinzufügen</code>.
+    Öffnen Sie <code className="action">SSH-Schlüssel</code> im linken Menü unter **Einstellungen**. Klicken Sie auf den Button <code className="action">SSH-Schlüssel hinzufügen</code>.
 
-<img className="thumbnail" alt="SSH-Schlüssel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+    Geben Sie im neuen Fenster einen Namen für den Schlüssel ein. Füllen Sie das Feld `Schlüssel` mit der Zeichenfolge Ihres öffentlichen Schlüssels aus, beispielsweise dem in [Schritt 1](#schritt-1-ssh-schlusselpaar-erstellen) erstellten. Bestätigen Sie, indem Sie auf <code className="action">Hinzufügen</code> klicken.
 
-Geben Sie im neuen Fenster einen Namen für den Schlüssel ein. Füllen Sie das Feld `Schlüssel` mit der Zeichenfolge Ihres öffentlichen Schlüssels aus, beispielsweise dem in [Schritt 1](#schritt-1-ssh-schlusselpaar-erstellen) erstellten. Bestätigen Sie, indem Sie auf <code className="action">Hinzufügen</code> klicken.
+    Sie können diesen Schlüssel nun in [Schritt 4](#schritt-4-instanz-erstellen) auswählen, um ihn einer neuen Instanz hinzuzufügen.
+  </Tab>
+  <Tab label="Über die OVHcloud API">
+    Verwenden Sie den folgenden Aufruf, um Ihren öffentlichen SSH-Schlüssel zu importieren:
 
-<img className="thumbnail" alt="Schlüssel hinzufügen" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
+    > **POST** `/cloud/project/{serviceName}/sshkey`
 
-Sie können diesen Schlüssel nun in [Schritt 4](#schritt-4-instanz-erstellen) auswählen, um ihn einer neuen Instanz hinzuzufügen.
+    Parameter:
+
+    - `serviceName`: die ID Ihres Public Cloud Projekts
+    - `name`: Name des SSH-Schlüssels
+    - `publicKey`: Inhalt Ihres öffentlichen Schlüssels
+
+    Notieren Sie sich die zurückgegebene `id` – sie wird beim Erstellen der Instanz benötigt.
+  </Tab>
+  <Tab label="Über die OVHcloud CLI">
+    Stellen Sie sicher, dass Sie die [OVHcloud CLI](https://github.com/ovh/ovhcloud-cli) installiert und konfiguriert haben, und importieren Sie anschließend Ihren Schlüssel:
+
+    ```bash
+    ovhcloud cloud ssh-key create \
+      --cloud-project <project_id> \
+      --name my-key \
+      --public-key "$(cat ~/.ssh/id_rsa.pub)"
+    ```
+
+    Überprüfen Sie den Import und notieren Sie sich den `name` des Schlüssels für [Schritt 4](#schritt-4-instanz-erstellen):
+
+    ```bash
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="Über die OpenStack CLI">
+    Stellen Sie sicher, dass Sie Ihre OpenStack-Umgebung konfiguriert haben ([zugehörige Anleitung](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)), und importieren Sie anschließend Ihren Schlüssel:
+
+    ```bash
+    openstack keypair create --public-key ~/.ssh/id_rsa.pub my-key
+    ```
+
+    Überprüfen Sie den Import:
+
+    ```bash
+    openstack keypair list
+    ```
+  </Tab>
+  <Tab label="Über Terraform">
+    Deklarieren Sie die Ressource in Ihrer `.tf`-Datei:
+
+    ```hcl
+    resource "openstack_compute_keypair_v2" "my_keypair" {
+      name       = "my-key"
+      public_key = file("~/.ssh/id_rsa.pub")
+    }
+    ```
+
+    Informationen zur initialen Provider-Einrichtung finden Sie in der [Terraform-Anleitung für OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform).
+  </Tab>
+</Tabs>
 
 ### Schritt 3: Netzwerkkonfiguration vorbereiten
 
@@ -148,7 +181,6 @@ Bevor Sie Ihre Instanz erstellen, empfehlen wir, zu überprüfen, wie die Instan
 <details>
 
 <summary>Public Cloud Networking - Modi</summary>
-
 
 **Public Mode**
 
@@ -168,199 +200,205 @@ Weitere Informationen finden Sie auf der [Webseite zu Local Zones](https://www.o
 
 </details>
 
-
 ### Schritt 4: Instanz erstellen
 
-:::info
-Zum Erstellen einer Instanz im OVHcloud Kundencenter ist ein öffentlicher SSH-Schlüssel erforderlich (ausgenommen Windows-Instanzen).
-
-Wenn Sie keine einsatzbereiten SSH-Schlüssel haben, lesen Sie [Schritt 1](#schritt-1-ssh-schlusselpaar-erstellen) und [Schritt 2](#schritt-2-ssh-schlussel-importieren) dieser Anleitung.
-
-:::
-
-
-Klicken Sie auf der **Startseite** auf <code className="action">Instanz erstellen</code>.
-
-#### Schritt 4.1: Name der Instanz
-
-Geben Sie einen vollständigen Namen für Ihre Instanz ein. Der Standardwert ist die kommerzielle Referenz des Instanzmodells. Bei Bedarf können Sie auch die Region und das Datum hinzufügen, um die Identifizierung und Verwaltung Ihrer Instanzen zu erleichtern.
-
-#### Schritt 4.2: Standort auswählen
-
-Wählen Sie einen [Standort](https://www.ovhcloud.com/de/public-cloud/regions-availability/) aus, der Ihren Benutzern oder Kunden am nächsten liegt. Beachten Sie, dass bei Auswahl einer **Local Zone** in diesem Schritt Netzwerkbeschränkungen für die Instanz gelten (siehe [Schritt 3](#networking-modes)).
-
-Weitere Informationen finden Sie auf der [Webseite zu Local Zones](https://www.ovhcloud.com/de/public-cloud/local-zone-compute/) und in der [Dokumentation zur Dienstverfügbarkeit für Local Zones](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-Die Wahl der Region bestimmt die Bereitstellungsart Ihrer Instanz (1-AZ, 3-AZ oder Local Zones). Informationen zu den Unterschieden in Bezug auf Resilienz, Verfügbarkeit und Architektur finden Sie in unserer Anleitung [Vergleich der Bereitstellungsmodi und Resilienz – 3-AZ / 1-AZ / Local Zones verstehen](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details).
-
-#### Schritt 4.3: Modell auswählen
-
-In diesem Schritt wählen Sie das Instanzmodell (auch als Flavor bezeichnet), das die Ihrer Instanz zugewiesenen Ressourcen bestimmt: Prozessor, Arbeitsspeicher und zugehörige Kapazitäten. Öffnen Sie die Dropdown-Liste `Instanzmodell` und wählen Sie den Modelltyp aus, der am besten zu Ihrem Anwendungsfall passt, um auf unsere optimierten Instanzen zuzugreifen.
-
-Der Modelltyp `Discovery` umfasst Instanzen mit geteilten Ressourcen zu günstigen Preisen. Sie eignen sich besonders gut zum Einstieg in die OVHcloud Public Cloud, zum Durchführen von Tests oder zum Hosting leichter Workloads wie Web-Anwendungen.
-
-`Metal Instances`-Modelle bieten vollständig dedizierte physische Ressourcen, die konsistente Leistung und maximale Isolation für die anspruchsvollsten Workloads gewährleisten.
-
-:::info
-Ihre gesamten Public Cloud Ressourcen werden zunächst aus Gründen der Kostenkontrolle und Sicherheit begrenzt. Sie können diese Quotas überprüfen, indem Sie in der linken Navigationsleiste unter **Einstellungen** auf <code className="action">Quota und Regionen</code> klicken. Weitere Informationen finden Sie in der [zugehörigen Dokumentation](/guides/public-cloud/cross-functional/increasing-public-cloud-quota).
-
-Beachten Sie, dass Sie nach der Erstellung ein **Upgrade** Ihrer Instanz durchführen können, um mehr Ressourcen zur Verfügung zu haben. Ein Downgrade auf ein kleineres Modell ist bei einer regulären Instanz jedoch nicht möglich. Weitere Informationen zu diesem Thema finden Sie im nachfolgenden **Schritt 4.9**.
-
-:::
-
-
-##### Weitere Informationen
-
-<details>
-
-<summary>Instanz-Modellkategorien</summary>
-
-
-| Typ | Garantierte Ressourcen | Verwendungshinweise |
-| :---         |     :---:      |          :--- |
-| Best Sellers   | ✓     | Beliebteste Modelle    |
-| General Purpose   | ✓     | Entwicklungsserver, Web- oder Geschäftsanwendungen    |
-| Compute Optimized     | ✓       | Videokodierung oder anderes High Performance Computing      |
-| Memory Optimized    | ✓     | Datenbanken, Analysen und In-Memory-Berechnungen    |
-| GPU     | ✓       | Massive parallele Rechenleistung für spezialisierte Anwendungen (Rendering, Big Data, Deep Learning, etc.)       |
-| Discovery    | -       | Auf geteilten Ressourcen gehostet, für Test- und Entwicklungsumgebungen      |
-| Storage Optimized   | ✓     | Optimiert für Disk-Datentransfer    |
-| Metal Instances | ✓ | Dedizierte Ressourcen mit direktem Zugriff auf Rechen-, Speicher- und Netzwerkressourcen|
-
-</details>
-
-
-<details>
-
-<summary>Regionen und Local Zones</summary>
-
-
-**Regionen**
-
-Eine **Region** ist ein Standort in der Welt, der aus einem oder mehreren Rechenzentren besteht, in denen OVHcloud Dienste gehostet werden. Weitere Informationen zu Regionen, der geografischen Verteilung und der Verfügbarkeit von Diensten finden Sie auf unserer [Webseite zu Regionen](https://www.ovhcloud.com/de/public-cloud/regions-availability/) und der [Webseite zur OVHcloud Infrastruktur](https://www.ovhcloud.com/de/about-us/global-infrastructure/regions/).
-
-**Local Zones**
-
-Local Zones sind eine Erweiterung von **Regionen**, die OVHcloud Dienste näher an bestimmten Standorten platzieren, was zu reduzierten Latenzen und einer verbesserten Anwendungsleistung führt. Weitere Informationen finden Sie auf der [Webseite zu Local Zones](https://www.ovhcloud.com/de/public-cloud/local-zone-compute/) und in der [Dokumentation zur Dienstverfügbarkeit für Local Zones](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-</details>
-
-
-#### Schritt 4.4: Image auswählen
-
-Öffnen Sie die Dropdown-Liste `Distributionstyp`, wählen Sie die Kategorie aus, die Ihren Anforderungen entspricht, und wählen Sie dann über das Dropdown-Menü `Image-Version` das Betriebssystem aus, das auf Ihrer Instanz installiert werden soll.
-
-Welche Images in diesem Schritt verfügbar sind, hängt von den in den vorherigen Schritten getroffenen Entscheidungen ab, also der Kompatibilität mit dem Instanz-Modell und der regionalen Verfügbarkeit. Wenn Sie beispielsweise ein Windows-Betriebssystem auswählen möchten und auf dem Tab für Windows keine Optionen verfügbar sind, müssen Sie die Auswahl in den vorherigen Schritten ändern.
-
-:::info
-Wenn Sie sich für ein Betriebssystem entscheiden, für das eine kostenpflichtige Lizenz erforderlich ist, werden diese Kosten automatisch in der Projektabrechnung berücksichtigt.
-
-:::
-
-
-#### Schritt 4.5: SSH-Schlüssel auswählen (ausgenommen Windows-Instanzen)
-
-Mit Ausnahme von Windows-Instanzen erfordert die Konfiguration Ihrer Instanz auch das **Hinzufügen eines öffentlichen SSH-Schlüssels**. Sie haben zwei Möglichkeiten:
-
-- Einen bereits im OVHcloud Kundencenter gespeicherten öffentlichen Schlüssel verwenden
-- Einen öffentlichen Schlüssel direkt eingeben
-
-Klicken Sie auf die nachfolgenden Tabs, um die Erläuterungen anzuzeigen:
-
 <Tabs>
-  <Tab label="Gespeicherten Schlüssel verwenden">
-    Um einen in Ihrem OVHcloud Kundencenter gespeicherten Schlüssel hinzuzufügen (siehe [Schritt 2](#schritt-2-ssh-schlussel-importieren)), wählen Sie ihn aus der Liste aus.
+  <Tab label="Über das Kundencenter">
+    :::info
+    Beim Erstellen einer Instanz ist ein öffentlicher SSH-Schlüssel erforderlich (ausgenommen Windows-Instanzen). Lesen Sie [Schritt 1](#schritt-1-ssh-schlusselpaar-erstellen) und [Schritt 2](#schritt-2-ssh-schlussel-importieren), wenn Sie keine einsatzbereiten SSH-Schlüssel haben.
+
+    :::
+
+    Loggen Sie sich in das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> ein, navigieren Sie zum Bereich <code className="action">Public Cloud</code> und wählen Sie Ihr Public Cloud Projekt aus. Klicken Sie auf der **Startseite** auf <code className="action">Instanz erstellen</code>.
+
+    **4.1 Name**
+
+    Geben Sie einen vollständigen Namen für Ihre Instanz ein.
+
+    **4.2 Standort**
+
+    Wählen Sie einen [Standort](https://www.ovhcloud.com/de/public-cloud/regions-availability/) aus, der Ihren Benutzern am nächsten liegt. Beachten Sie, dass bei Auswahl einer **Local Zone** Netzwerkbeschränkungen gelten (siehe [Schritt 3](#networking-modes)). Informationen zu den Unterschieden zwischen 3-AZ, 1-AZ und Local Zones finden Sie in der Anleitung [Vergleich der Bereitstellungsmodi](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details).
+
+    **4.3 Modell**
+
+    Öffnen Sie die Dropdown-Liste `Instanzmodell` und wählen Sie den Modelltyp aus, der zu Ihrem Anwendungsfall passt. Das Modell (Flavor) bestimmt die Ihrer Instanz zugewiesenen Ressourcen: Prozessor, Arbeitsspeicher und zugehörige Kapazitäten.
+
+    | Typ | Garantierte Ressourcen | Verwendungshinweise |
+    | :--- | :---: | :--- |
+    | Best Sellers | ✓ | Beliebteste Modelle. |
+    | General Purpose | ✓ | Entwicklungsserver, Web- oder Geschäftsanwendungen. |
+    | Compute Optimized | ✓ | Videokodierung oder anderes High Performance Computing. |
+    | Memory Optimized | ✓ | Datenbanken, Analysen und In-Memory-Berechnungen. |
+    | GPU | ✓ | Massive parallele Rechenleistung für spezialisierte Anwendungen (Rendering, Big Data, Deep Learning, etc.). |
+    | Discovery | - | Geteilte Ressourcen für Test- und Entwicklungsumgebungen. |
+    | Storage Optimized | ✓ | Optimiert für Disk-Datentransfer. |
+    | Metal Instances | ✓ | Dedizierte Ressourcen mit direktem Zugriff auf Rechen-, Speicher- und Netzwerkressourcen. |
+
+    :::info
+    Ihre gesamten Public Cloud Ressourcen werden zunächst begrenzt. Überprüfen Sie Ihre Quotas über <code className="action">Quota und Regionen</code> unter **Einstellungen** in der linken Navigationsleiste. Weitere Informationen finden Sie in der [zugehörigen Dokumentation](/guides/public-cloud/cross-functional/increasing-public-cloud-quota).
+
+    Sie können nach der Erstellung ein **Upgrade** Ihrer Instanz durchführen, um mehr Ressourcen zur Verfügung zu haben. Ein Downgrade auf ein kleineres Modell ist bei einer regulären Instanz jedoch nicht möglich. Weitere Informationen finden Sie unter **Schritt 4.9**.
+
+    :::
+
+    **4.4 Image**
+
+    Wählen Sie das Betriebssystem über die Dropdown-Menüs `Distributionstyp` und `Image-Version` aus. Die verfügbaren Optionen hängen vom gewählten Modell und der gewählten Region ab.
+
+    **4.5 SSH-Schlüssel** *(nicht für Windows-Instanzen)*
+
+    Wählen Sie einen gespeicherten SSH-Schlüssel aus der Liste aus (siehe [Schritt 2](#schritt-2-ssh-schlussel-importieren)) oder klicken Sie auf <code className="action">Neuen SSH-Schlüssel erstellen</code>, um einen öffentlichen Schlüssel direkt einzufügen.
+
+    **4.6 Backup**
+
+    [Automatische Backups](/guides/public-cloud/compute/save-an-instance) sind standardmäßig aktiviert. Wählen Sie den Rotationstyp aus (7 oder 14 Tage).
+
+    **4.7 Netzwerk**
+
+    Der Abschnitt **Netzwerkeinstellungen** ist in zwei Teile gegliedert:
+
+    - **Privates Netzwerk**: Wählen Sie ein bestehendes privates Netzwerk aus oder klicken Sie auf <code className="action">+ Privates Netzwerk erstellen</code>. Wenn ein privates Netzwerk ausgewählt ist, aber kein Gateway besitzt, aktivieren Sie den Schalter <code className="action">Gateway zuweisen</code>, um automatisch ein Gateway anzuhängen.
+    - **Öffentliche Konnektivität zuweisen**: Aktivieren Sie den Schalter, um eine öffentliche IP-Adresse zuzuweisen. Wählen Sie <code className="action">Basic Public IP</code> (kostenlos, an die Lebensdauer der Instanz gebunden, nicht mit einem Gateway kompatibel) oder <code className="action">Eine Floating IP zuweisen (wiederverwendbar)</code> (persistent und wiederverwendbar).
+
+    Eine Übersicht der Netzwerkmodi finden Sie in [Schritt 3](#networking-modes).
+
+    **4.8 Abrechnung**
+
+    Wählen Sie zwischen **monatlicher** Abrechnung (niedrigere Kosten, nicht umkehrbar) und **stündlicher** Abrechnung (flexibel, [auf monatlich umstellbar](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing)). Die stündliche Abrechnung läuft, bis die **Instanz gelöscht wird**. Siehe die [Abrechnungsdokumentation](/guides/public-cloud/cross-functional/analyze-billing).
+
+    **4.9 Erweiterte Einstellungen** *(optional)*
+
+    - **Flexible Instanz**: einzelne 50-GB-Disk, erlaubt die Größenänderung auf höhere oder niedrigere Modelle.
+    - **Post-Installations-Skript**: Fügen Sie Ihr [Post-Installations-Skript](/guides/public-cloud/compute/launching-script-when-creating-instance) hinzu.
+
+    **4.10 Abschließen**
+
+    Überprüfen Sie die Zusammenfassung auf der rechten Seite des Bildschirms und konfigurieren Sie die Anzahl der Instanzen. Klicken Sie auf <code className="action">Instanz starten</code>. Die Bereitstellung kann einige Minuten dauern.
   </Tab>
-  <Tab label="Schlüssel direkt eingeben">
-    Um einen öffentlichen Schlüssel durch Einfügen der Schlüsselzeichenfolge hinzuzufügen, klicken Sie auf den Button <code className="action">Neuen SSH-Schlüssel erstellen</code>.
-    
-    Geben Sie einen Namen für den Schlüssel und die Schlüsselzeichenfolge in die entsprechenden Felder ein. Klicken Sie dann auf <code className="action">Schlüssel bestätigen</code>.
+  <Tab label="Über die OVHcloud API">
+    Rufen Sie die erforderlichen Kennungen ab:
+
+    ```
+    GET /cloud/project/{serviceName}/flavor     → flavorId
+    GET /cloud/project/{serviceName}/image      → imageId
+    GET /cloud/project/{serviceName}/region     → region
+    GET /cloud/project/{serviceName}/sshkey     → sshKeyId
+    ```
+
+    Erstellen Sie die Instanz:
+
+    > **POST** `/cloud/project/{serviceName}/instance`
+
+    Hauptparameter:
+
+    - `name`: Name der Instanz
+    - `flavorId`: Modell-ID
+    - `imageId`: ID des Betriebssystem-Images
+    - `region`: Bereitstellungsregion
+    - `sshKeyId`: SSH-Schlüssel-ID (aus [Schritt 2](#schritt-2-ssh-schlussel-importieren))
+    - `monthlyBilling`: `true` für monatliche Abrechnung
+
+    Informationen zur Konfiguration Ihres API-Zugriffs finden Sie in der [OVHcloud API-Dokumentation](/guides/manage-and-operate/api/first-steps).
+  </Tab>
+  <Tab label="Über die OVHcloud CLI">
+    Rufen Sie die erforderlichen Kennungen ab:
+
+    ```bash
+    ovhcloud cloud reference list-flavors --cloud-project <project_id>
+    ovhcloud cloud reference list-images --cloud-project <project_id>
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+
+    Erstellen Sie die Instanz:
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --name my-instance \
+      --boot-from.image <image_id> \
+      --flavor <flavor_id> \
+      --ssh-key.name my-key \
+      --network.public \
+      --wait
+    ```
+
+    Ersetzen Sie `GRA9` durch Ihre Region. Für eine interaktive Erstellung mit geführter Auswahl:
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --editor \
+      --image-selector \
+      --flavor-selector
+    ```
+
+    Überprüfen Sie den Status nach der Erstellung:
+
+    ```bash
+    ovhcloud cloud instance list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="Über die OpenStack CLI">
+    Rufen Sie die erforderlichen Informationen ab:
+
+    ```bash
+    openstack flavor list
+    openstack image list --property visibility=public
+    openstack keypair list
+    ```
+
+    Erstellen Sie die Instanz:
+
+    ```bash
+    openstack server create \
+      --flavor b2-7 \
+      --image "Ubuntu 24.04" \
+      --key-name my-key \
+      --network Ext-Net \
+      my-instance
+    ```
+
+    Überprüfen Sie den Status:
+
+    ```bash
+    openstack server list
+    openstack server show my-instance
+    ```
+
+    Informationen zur initialen Konfiguration finden Sie in der [Anleitung zur Einrichtung der OpenStack-Umgebung](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment).
+  </Tab>
+  <Tab label="Über Terraform">
+    Vollständiges Konfigurationsbeispiel:
+
+    ```hcl
+    data "openstack_images_image_v2" "ubuntu" {
+      name        = "Ubuntu 24.04"
+      most_recent = true
+    }
+
+    resource "openstack_compute_instance_v2" "my_instance" {
+      name            = "my-instance"
+      flavor_name     = "b2-7"
+      key_pair        = openstack_compute_keypair_v2.my_keypair.name
+      security_groups = ["default"]
+
+      block_device {
+        uuid                  = data.openstack_images_image_v2.ubuntu.id
+        source_type           = "image"
+        destination_type      = "local"
+        boot_index            = 0
+        delete_on_termination = true
+      }
+
+      network {
+        name = "Ext-Net"
+      }
+    }
+    ```
+
+    Informationen zur initialen Provider-Einrichtung und Authentifizierung finden Sie in der [Terraform-Anleitung für OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform).
   </Tab>
 </Tabs>
-
-
-#### Schritt 4.6: Backup-Einstellungen konfigurieren
-
-[Automatische Backups](/guides/public-cloud/compute/save-an-instance) sind standardmäßig aktiviert. Überprüfen Sie die Preisinformationen und weitere Details, bevor Sie fortfahren.
-
-Wählen Sie anschließend den Rotationstyp aus, d.h. die maximale Anzahl der im Verlauf aufbewahrten Backups: 7 oder 14 Tage.
-
-#### Schritt 4.7: Netzwerk konfigurieren
-
-In diesem Schritt konfigurieren Sie das Netzwerk Ihrer Instanz.
-
-**Privates Netzwerk**
-
-Sie können Ihre Instanz mit einem [privaten Netzwerk](#networking-modes) verbinden und ihr eine [Floating IP](https://www.ovhcloud.com/de/public-cloud/floating-ip/) zuweisen.
-
-Durch Klicken auf <code className="action">Privates Netzwerk erstellen</code> können Sie direkt eines erstellen:
-
-- Benennen Sie das Netzwerk.
-- **VLAN-ID auswählen:** Kennung zur Verbindung mehrerer Dienste und Ressourcen innerhalb desselben privaten Netzwerks über eine gemeinsame Netzwerksegmentierungsnummer.
-- **CIDR definieren:** IP-Adressbereich für das Netzwerk.
-- **DHCP durch Aktivieren des entsprechenden Kontrollkästchens einschalten, falls erforderlich:** Aktivieren Sie diese Option, wenn IP-Adressen automatisch zugewiesen werden sollen.
-
-:::info
-Die Instanz kann vollständig privat bleiben, wenn Sie ihr keine öffentliche IP-Adresse zuweisen.
-
-:::
-
-
-**Gateway**
-
-Sie können die Option zur Zuweisung eines Gateways zu Ihrem Netzwerk aktivieren. Das Gateway hat standardmäßig die Größe S, Sie können die Größe jedoch später in den Einstellungen anpassen.
-
-**Öffentliche Konnektivität zuweisen**
-
-Sie können diese Funktion nach Bedarf aktivieren oder deaktivieren. Wenn Sie sie aktivieren, stehen Ihnen zwei Optionen zur Verfügung:
-
-- **Basic Public IP:** eine temporäre öffentliche IP-Adresse, die über die Lebensdauer der Instanz hinaus nicht bestehen bleibt. Beachten Sie, dass die Verwendung einer Basic Public IP nicht mit einem Gateway kompatibel ist.
-- **Floating IP:** Sie können eine neue Floating IP erstellen oder eine bestehende Adresse wiederverwenden, um eine persistente öffentliche IP-Adresse zu erhalten, die von der Instanz getrennt werden kann.
-
-#### Schritt 4.8: Abrechnungszeitraum auswählen
-
-:::info
-Beachten Sie, dass je nach gewähltem Instanz-Modell die **stündliche** Abrechnung als einzige Auswahl erscheinen kann. Dies ist eine vorübergehende Einschränkung; neue Abrechnungsoptionen für die Public Cloud werden demnächst verfügbar sein.
-
-:::
-
-
-<Tabs>
-  <Tab label="Monatliche Abrechnung">
-    Die monatliche Abrechnung führt langfristig zu niedrigeren Kosten, kann jedoch nach der Erstellung der Instanz **nicht** auf stündliche Abrechnung umgestellt werden.
-  </Tab>
-  <Tab label="Stündliche Abrechnung">
-    Die stündliche Abrechnung ist die beste Wahl, wenn die Dauer der Nutzung nicht exakt abschätzbar ist. Wenn Sie sich später entscheiden, die Instanz langfristig zu nutzen, können Sie jederzeit [auf ein monatliches Abonnement umstellen](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing).
-    
-    Die Instanz wird in Rechnung gestellt, solange sie **nicht gelöscht** wird, unabhängig von der produktiven Nutzung der Instanz.
-  </Tab>
-</Tabs>
-
-
-Details hierzu finden Sie in unserer Abrechnungsdokumentation:
-
-- [Public Cloud Abrechnung](/guides/public-cloud/cross-functional/analyze-billing)
-- [FAQ zur monatlichen Abrechnung](/guides/public-cloud/compute/faq-change-of-monthly-billing-method)
-
-Wenn die Konfiguration Ihrer Instanz abgeschlossen ist, können Sie auf den Button <code className="action">Instanz starten</code> klicken oder erweiterte Einstellungen konfigurieren (siehe unten). Die Bereitstellung Ihres Dienstes kann einige Minuten dauern.
-
-#### Schritt 4.9: Erweiterte Einstellungen konfigurieren
-
-##### Flexible Instanz
-
-Eine Flex-Instanz ist eine Instanz mit einer 50-GB-Disk, die eine schnellere Snapshot-Erstellung und -Wiederherstellung ermöglicht.
-
-Sie erlaubt die Größenänderung auf höhere oder niedrigere Modelle bei gleichbleibendem Speicherplatz. Klassische Modelle erlauben dagegen nur die Größenänderung auf höhere Modelle.
-
-##### Post-Installation-Skript
-
-Sie können [Ihr Post-Installation-Skript](/guides/public-cloud/compute/launching-script-when-creating-instance) in diesem Feld hinzufügen.
-
-#### Schritt 4.10: Instanz abschließen
-
-Auf der rechten Seite finden Sie eine Zusammenfassung Ihrer Konfiguration. In diesem Bereich können Sie die Anzahl der zu erstellenden Instanzen konfigurieren. Sie können mehrere Instanzen auf der Grundlage der in den Erstellungsschritten getroffenen Auswahl erstellen; es gelten jedoch [Ressourcenkontingentsgrenzen](/guides/public-cloud/cross-functional/increasing-public-cloud-quota).
-
-Wenn die Konfiguration Ihrer Instanz abgeschlossen ist, klicken Sie auf den Button <code className="action">Instanz starten</code>. Die Bereitstellung Ihres Dienstes kann einige Minuten dauern.
 
 ### Schritt 5: Verbindung mit der Instanz herstellen
 
@@ -376,18 +414,22 @@ Wenn Sie ein **Betriebssystem mit Anwendung** installiert haben, beachten Sie un
 
 :::
 
-
 #### 5.1: Status der Instanz im OVHcloud Kundencenter überprüfen
 
 Wählen Sie <code className="action">Instanzen</code> in der linken Navigationsleiste unter **Compute** aus. Ihre Instanz ist bereit, wenn der Status in der Tabelle `Aktiviert` anzeigt. Wenn die Instanz kürzlich erstellt wurde und einen anderen Status hat, klicken Sie auf den Button „Aktualisieren" neben dem Suchfilter.
-
-<img className="thumbnail" alt="Seite Instanzen" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
 
 Klicken Sie auf den Instanznamen in dieser Tabelle, um das <code className="action">Dashboard</code> zu öffnen, auf dem Sie alle Informationen zur Instanz finden. Weitere Informationen zu den auf dieser Seite verfügbaren Funktionen finden Sie in unserer Anleitung zur [Verwaltung von Instanzen im Kundencenter](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Ein **Benutzer mit erhöhten Rechten (*sudo*) wird automatisch auf der Instanz erstellt**. Der Benutzername entspricht dem installierten Image, z.B. „ubuntu", „debian", „fedora", etc. Sie können dies auf der rechten Seite des <code className="action">Dashboard</code> im Abschnitt **Netzwerke** überprüfen.
 
-<img className="thumbnail" alt="Seite Instanzen" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
+:::info
+Über die OVHcloud CLI können Sie den Status der Instanz überprüfen und ihre IP-Adresse abrufen mit:
+
+```bash
+ovhcloud cloud instance list --cloud-project <project_id>
+```
+
+:::
 
 Wenn Ihr [SSH-Schlüsselpaar korrekt konfiguriert](#schritt-1-ssh-schlusselpaar-erstellen) ist, können Sie sich jetzt mit dem vorkonfigurierten Benutzer und Ihrem SSH-Schlüssel bei der Instanz anmelden. Detailliertere Anweisungen finden Sie in den folgenden Abschnitten.
 
@@ -398,7 +440,6 @@ Diese Anleitung behandelt nicht die Konfiguration privater Netzwerke für Instan
 
 :::
 
-
 #### 5.2: Erste Verbindung mit einer Instanz unter GNU/Linux
 
 :::info
@@ -408,7 +449,6 @@ Wenn Sie weiterhin auf Fehler stoßen, können Sie das Schlüsselpaar mithilfe [
 Wenn Sie eine Instanz ohne SSH-Schlüssel über die [OVHcloud API](/guides/manage-and-operate/api/first-steps) oder das [OpenStack Horizon Interface](/guides/public-cloud/compute/create-instance-in-horizon) erstellt haben, können Sie Ihrer Instanz nur über den [Rescue-Modus](/guides/public-cloud/compute/put-an-instance-in-rescue-mode) einen SSH-Schlüssel hinzufügen, indem Sie den Anweisungen in [dieser Anleitung](/guides/public-cloud/compute/replacing-lost-ssh-key-pair) folgen.
 
 :::
-
 
 Sie können direkt nach der Erstellung über das Kommandozeileninterface Ihres lokalen Geräts (`Terminal`, `Powershell`, etc.) per SSH auf Ihre Instanz zugreifen.
 
@@ -438,29 +478,22 @@ Anschließend müssen Sie die Erstkonfiguration Ihres Windows-Betriebssystems ab
 
 <Tabs>
   <Tab label="1. Lokale Einstellungen">
-    Konfigurieren Sie **Land/Region**, die bevorzugte **Windows-Sprache** und Ihr **Tastaturlayout**. Klicken Sie dann unten rechts auf <code className="action">Next</code>.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" /><br/>
+    Konfigurieren Sie **Land/Region**, die bevorzugte **Windows-Sprache** und Ihr **Tastaturlayout**. Klicken Sie dann unten rechts auf <code className="action">Next</code>.
   </Tab>
   <Tab label="2. Administratorpasswort">
-    Geben Sie ein Passwort für den Windows-Account `Administrator` ein und bestätigen Sie. Klicken Sie dann auf <code className="action">Finish</code>.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" /><br/>
+    Geben Sie ein Passwort für den Windows-Account `Administrator` ein und bestätigen Sie. Klicken Sie dann auf <code className="action">Finish</code>.
   </Tab>
   <Tab label="3. Anmeldebildschirm">
-    Windows wendet Ihre Einstellungen an und zeigt dann den Anmeldebildschirm an. Klicken Sie oben rechts auf <code className="action">Send CtrlAltDel</code>, um sich anzumelden.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" /><br/>
+    Windows wendet Ihre Einstellungen an und zeigt dann den Anmeldebildschirm an. Klicken Sie oben rechts auf <code className="action">Send CtrlAltDel</code>, um sich anzumelden.
   </Tab>
   <Tab label="4. Administrator-Login">
-    Geben Sie das im vorherigen Schritt erstellte Passwort des Accounts `Administrator` ein und klicken Sie auf den `Pfeil`.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
+    Geben Sie das im vorherigen Schritt erstellte Passwort des Accounts `Administrator` ein und klicken Sie auf den `Pfeil`.
   </Tab>
 </Tabs>
-
 
 ##### 5.3.2: Remoteverbindung von Windows aus
 
 Auf Ihrem lokalen Windows-Gerät können Sie sich über die Client-Anwendung `Remote Desktop Connection` mit Ihrer Instanz verbinden.
-
-<img className="thumbnail" alt="RDP-Verbindung" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Geben Sie die IPv4-Adresse Ihrer Instanz sowie Ihren Benutzernamen und Ihr Passwort ein. In der Regel wird eine Warnmeldung angezeigt, die Sie auffordert, die Verbindung aufgrund eines unbekannten Zertifikats zu bestätigen. Klicken Sie auf <code className="action">Ja</code>, um sich anzumelden.
 
@@ -468,7 +501,6 @@ Geben Sie die IPv4-Adresse Ihrer Instanz sowie Ihren Benutzernamen und Ihr Passw
 Wenn bei diesem Verfahren Probleme auftreten, überprüfen Sie, ob Remoteverbindungen (RDP) auf Ihrem Gerät zugelassen sind, indem Sie die Systemeinstellungen, Firewallregeln und mögliche Netzwerkeinschränkungen prüfen.
 
 :::
-
 
 ##### 5.3.3: Remoteverbindung von einem anderen Betriebssystem aus
 
@@ -480,31 +512,23 @@ Unabhängig davon, welchen Client Sie verwenden, benötigen Sie nur die IP-Adres
 
 Die freie Open-Source-Software `Remmina Remote Desktop Client` ist für viele GNU/Linux Desktop-Distributionen verfügbar. Wenn Sie Remmina nicht im Software-Manager Ihrer Desktop-Umgebung finden, können Sie die Anwendung von der [offiziellen Website](https://remmina.org/) beziehen.
 
-<img className="thumbnail" alt="Linux Remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect01.png" loading="lazy" /><br/>
-
 <Tabs>
   <Tab label="1. Verbindung">
-    Öffnen Sie Remmina und stellen Sie sicher, dass das Verbindungsprotokoll auf „RDP" eingestellt ist. Geben Sie die IPv4-Adresse Ihrer Public Cloud Instanz ein und drücken Sie `Enter`.<br/><br/>
-    <img className="thumbnail" alt="Linux Remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" /><br/>
+    Öffnen Sie Remmina und stellen Sie sicher, dass das Verbindungsprotokoll auf „RDP" eingestellt ist. Geben Sie die IPv4-Adresse Ihrer Public Cloud Instanz ein und drücken Sie `Enter`.
   </Tab>
   <Tab label="2. Authentifizierung">
-    Wenn eine Zertifikatwarnung angezeigt wird, klicken Sie auf <code className="action">Yes</code>. Geben Sie den Benutzernamen und Ihr Passwort für Windows ein und klicken Sie auf <code className="action">OK</code>, um die Verbindung herzustellen.<br/><br/>
-    <img className="thumbnail" alt="Linux Remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" /><br/>
+    Wenn eine Zertifikatwarnung angezeigt wird, klicken Sie auf <code className="action">Yes</code>. Geben Sie den Benutzernamen und Ihr Passwort für Windows ein und klicken Sie auf <code className="action">OK</code>, um die Verbindung herzustellen.
   </Tab>
   <Tab label="3. Einstellungen">
-    Sie finden einige nützliche Einstellungsoptionen in der linken Symbolleiste. Klicken Sie beispielsweise auf das Symbol <code className="action">Toggle Dynamic Resolution Update</code>, um die Auflösung des Remote-Fensters zu verbessern.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
+    Sie finden einige nützliche Einstellungsoptionen in der linken Symbolleiste. Klicken Sie beispielsweise auf das Symbol <code className="action">Toggle Dynamic Resolution Update</code>, um die Auflösung des Remote-Fensters zu verbessern.
   </Tab>
 </Tabs>
-
 
 #### 5.4: VNC-Konsolenzugriff
 
 Mit der VNC-Konsole können Sie sich mit Ihren Instanzen verbinden, auch wenn keine anderen Zugriffsmöglichkeiten verfügbar sind.
 
 Wählen Sie <code className="action">Instanzen</code> in der linken Navigationsleiste unter **Compute** aus. Klicken Sie auf den Instanznamen und öffnen Sie den Tab <code className="action">VNC-Konsole</code>.
-
-<img className="thumbnail" alt="VNC-Konsole" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instanz mit GNU/Linux Betriebssystem">
@@ -514,7 +538,6 @@ Wählen Sie <code className="action">Instanzen</code> in der linken Navigationsl
     Melden Sie sich mit Ihren Logindaten der Windows-Instanz an. Bei einer aktiven Sitzung haben Sie unmittelbar Zugriff. Es besteht eine deutliche Latenz im Vergleich zu einer RDP-Verbindung.
   </Tab>
 </Tabs>
-
 
 ### Schritt 6: Erste Schritte mit einer neuen Instanz
 
@@ -527,14 +550,12 @@ Weitere Informationen finden Sie unten im Abschnitt [Weiterführende Information
 
 :::
 
-
 #### 6.1: Benutzerverwaltung
 
 :::info
 Beim Konfigurieren von Benutzer-Accounts und Berechtigungsstufen auf einer Instanz empfehlen wir, die Informationen in unserer Anleitung zu [Benutzer-Accounts](/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds) zu verwenden.
 
 :::
-
 
 ##### 6.1.1: Passwort für den aktuellen Benutzer-Account festlegen
 
@@ -562,7 +583,6 @@ Dieser Schritt ist nicht notwendig und sollte nur ausgeführt werden, wenn Sie e
 Das folgende Beispiel zeigt eine temporäre Lösung auf einer Instanz, auf der Ubuntu installiert ist. Beachten Sie, dass die Befehle möglicherweise an Ihr Betriebssystem angepasst werden müssen. Es wird nicht empfohlen, diese Konfiguration dauerhaft beizubehalten, da sie ein potenzielles Sicherheitsrisiko bedeutet, indem das System für SSH-basierte Angriffe geöffnet wird.
 
 :::
-
 
 Öffnen Sie nach dem [Einloggen auf Ihrer Instanz](#schritt-6-erste-schritte-mit-einer-neuen-instanz) die betreffende Konfigurationsdatei mit einem Texteditor. Beispiel:
 
@@ -620,7 +640,6 @@ Eine detaillierte Erklärung dieser Schritte finden Sie in unserer [zugehörigen
 
 [Erste Schritte mit Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 
-
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](https://community.ovhcloud.com/) bei.

--- a/docs/de/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
@@ -1,8 +1,10 @@
 ---
 title: Aussetzen oder Pausieren einer Instanz
 description: Erfahren Sie, wie Sie eine Public Cloud Instanz aussetzen, pausieren oder anhalten, um vorübergehend Ressourcen freizugeben und dabei Ihre IP-Adresse beizubehalten, sowie die Auswirkungen der einzelnen Optionen auf die Abrechnung
-lastUpdated: 2026-02-27
+lastUpdated: 2026-05-27
 ---
+
+import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Ziel
 
@@ -12,7 +14,6 @@ Bei der Konfiguration einer hochverfügbaren Infrastruktur müssen Sie mögliche
 Die Bezeichnung dieser Optionen im OVHcloud Kundencenter unterscheidet sich von den Namen in OpenStack/Horizon. Wenn Sie Operationen über das OVHcloud Kundencenter durchführen, wählen Sie jeweils die unten beschriebene passende Option aus.
 
 :::
-
 
 **Diese Anleitung erklärt, wie Sie eine Instanz aussetzen, anhalten oder pausieren können.**
 
@@ -44,32 +45,20 @@ Die Bezeichnung dieser Optionen im OVHcloud Kundencenter unterscheidet sich von 
 
 :::
 
-
 In der folgenden Tabelle finden Sie die auf Ihren Instanzen verfügbaren Optionen in der Übersicht. Klicken Sie auf die Option Ihrer Wahl, um zum entsprechenden Teil der Anleitung zu gelangen. Wir setzen die in der **Horizon-Interface** verwendete Terminologie in Klammern.
 
 |Funktion|Beschreibung|Abrechnung|
 |---|---|---|
-|[Aussetzen (*shelve*)](#shelve-instance)|Speichert die Ressourcen und Daten Ihrer Disk, indem ein Snapshot erstellt wird. Alle anderen Ressourcen werden freigegeben.|Ihnen wird nur der Snapshot berechnet.|
-|[Ausschalten (*suspend*)](#stop-suspend-instance)|Speichert den Zustand der VM auf die Disk. Die der Instanz zugewiesenen Ressourcen bleiben reserviert.|An der Abrechnung der Instanz ändert sich nichts.|
-|[Pausieren (*pause*)](#pause-instance)|Speichert den Zustand der VM im RAM. Eine pausierte Instanz wird "eingefroren".|An der Abrechnung der Instanz ändert sich nichts.|
+|[Aussetzen (*shelve*)](#shelve-instance)|Behält die Ressourcen und Daten Ihrer Disk bei, indem ein Snapshot erstellt wird. Alle anderen Ressourcen werden freigegeben. Die Haupt-IP bleibt ebenfalls erhalten.|Ihnen wird nur der Snapshot berechnet.|
+|[Ausschalten (*suspend*)](#stop-suspend-instance)|Speichert den Zustand der VM auf der Disk, die Ressourcen bleiben reserviert.|Die Abrechnung erfolgt zum gleichen Tarif.|
+|[Pausieren (*pause*)](#pause-instance)|Speichert den Zustand der VM im RAM, die Instanz bleibt eingefroren.|Die Abrechnung erfolgt zum gleichen Tarif.|
 
 ### Inhaltsübersicht
 
 - [Aussetzen einer Instanz (*shelve*)](#shelve-instance)
-    - [Im OVHcloud Kundencenter](#control-panel)
-    - [Im Horizon-Interface](#horizon)
-    - [Verwendung der OpenStack/Nova API](#openstack-nova)
 - [Reaktivieren einer Instanz (*unshelve*)](#unshelve-instance)
-    - [Im OVHcloud Kundencenter](#control-panel-unshelve)
-    - [Im Horizon-Interface](#horizon-unshelve)
-    - [Verwendung der OpenStack/Nova API](#openstack-nova-unshelve)
 - [Ausschalten einer Instanz (*suspend*)](#stop-suspend-instance)
-    - [Im OVHcloud Kundencenter](#stop-control-panel)
-    - [Im Horizon-Interface](#stop-horizon)
-    - [Verwendung der OpenStack/Nova API](#stop-openstack-nova)
 - [Pausieren einer Instanz (*pause*)](#pause-instance)
-    - [Im Horizon-Interface](#pause-horizon)
-    - [Verwendung der OpenStack/Nova API](#pause-openstack-nova)
 
 <a name="shelve-instance"></a>
 
@@ -82,79 +71,83 @@ Das Suspendieren dieses Instanztyps führt zur Deaktivierung auf dem Host und so
 
 :::
 
-
 Diese Option erlaubt es Ihnen, die dedizierten Ressourcen Ihrer Public Cloud Instanz freizugeben, während die IP-Adresse bestehen bleibt. Die Daten der lokalen Disk werden in einem automatisch erstellten Snapshot gespeichert, sobald die Instanz den Status *shelved* hat. Die im Arbeitsspeicher und anderswo gespeicherten Daten werden nicht gesichert.
 
-<a name="control-panel"></a>
+<Tabs>
+  <Tab label="Im OVHcloud Kundencenter">
+    Wählen Sie im OVHcloud Kundencenter Ihr Projekt im Bereich <code className="action">Public Cloud</code> aus. Klicken Sie im linken Menü auf <code className="action">Instanzen</code>.
 
-#### Im OVHcloud Kundencenter
+    Klicken Sie auf den Button <code className="action">⋮</code> rechts neben der Instanz, die Sie aussetzen möchten, und klicken Sie anschließend auf <code className="action">Aussetzen</code>.
 
-Loggen Sie sich in Ihr OVHcloud Kundencenter ein und wählen Sie Ihr <code className="action">Public Cloud</code> Projekt aus. Klicken Sie im linken Menü auf <code className="action">Instanzen</code>.
+    <img className="thumbnail" alt="suspend instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
 
-Klicken Sie in der Instanzenverwaltung auf <code className="action">⋮</code> rechts neben der Instanz und wählen Sie <code className="action">Aussetzen</code>.
+    Nehmen Sie die Meldung im Dialogfenster zur Kenntnis und klicken Sie auf <code className="action">Bestätigen</code>.
 
-<img className="thumbnail" alt="suspend instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="confirm suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
 
-Nehmen Sie die Meldung im Dialogfenster zur Kenntnis und klicken Sie auf <code className="action">Bestätigen</code>.
+    Während des Vorgangs wird folgende Meldung angezeigt:
 
-<img className="thumbnail" alt="confirm suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="Operation in progress" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
 
-Während des Vorgangs wird folgende Meldung angezeigt:
+    Sobald der Vorgang abgeschlossen ist, erscheint die Instanz als *Ausgesetzt*.
 
-<img className="thumbnail" alt="Operation in progress" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="suspended status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
 
-Sobald der Vorgang abgeschlossen ist, erscheint die Instanz als *Ausgesetzt*.
+    Um den Snapshot zu sehen, klicken Sie im linken Menü auf <code className="action">Instance Backup</code> im Bereich **Compute**. Ein Snapshot mit dem Namen *xxxxx-shelved* wird dann angezeigt:
 
-<img className="thumbnail" alt="suspended status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="snapshot tab" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+  </Tab>
+  <Tab label="Im Horizon-Interface">
+    Um fortzufahren, müssen Sie sich [in das Horizon-Interface einloggen](https://horizon.cloud.ovh.net/auth/login/):
 
-Um den Snapshot zu sehen, klicken Sie im linken Menü auf <code className="action">Instance Backup</code> im Bereich **Compute**. Ein Snapshot mit dem Namen *xxxxx-shelved* wird dann angezeigt.
+    - Um sich über OVHcloud Single Sign-On zu verbinden: Verwenden Sie den Link <code className="action">Horizon</code> im Menü links unter "Management Interfaces", nachdem Sie Ihr <code className="action">Public Cloud</code> Projekt im <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> geöffnet haben.
 
-<img className="thumbnail" alt="snapshot tab" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+    - Um sich mit einem bestimmten OpenStack-Benutzer anzumelden: Öffnen Sie die [Horizon-Login-Seite](https://horizon.cloud.ovh.net/auth/login/) und geben Sie die zuvor erstellten [OpenStack-Zugangsdaten](/guides/public-cloud/cross-functional/create-and-delete-a-user) ein. Klicken Sie anschließend auf <code className="action">Connect</code>.
 
-<a name="horizon"></a>
+    Wenn Sie Instanzen in verschiedenen Regionen eingerichtet haben, stellen Sie sicher, dass Sie sich in der korrekten Region befinden. Überprüfen Sie es in der oberen linken Ecke des Horizon-Interface.
 
-#### Im Horizon-Interface
+    <img className="thumbnail" alt="horizon interface" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
 
-Um diese Methode zu verwenden, müssen Sie sich [in das Horizon-interface einloggen](https://horizon.cloud.ovh.net/auth/login/).
+    Klicken Sie auf das Menü <code className="action">Compute</code> auf der linken Seite und wählen Sie <code className="action">Instances</code> aus. Wählen Sie <code className="action">Shelve Instance</code> in der Drop-down-Liste für die betreffende Instanz aus.
 
-- Um sich über OVHcloud SSO zu verbinden: Verwenden Sie den Link <code className="action">Horizon</code> im Menü links unter "Management Interfaces", nachdem Sie Ihr <code className="action">Public Cloud</code> Projekt in Ihrem <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> geöffnet haben.
+    <img className="thumbnail" alt="shelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
 
-- Um sich mit einem bestimmten OpenStack-Benutzer anzumelden: Öffnen Sie die Login-Seite für [Horizon](https://horizon.cloud.ovh.net/auth/login/) und geben Sie die zuvor erstellten [OpenStack-Zugangsdaten](/guides/public-cloud/cross-functional/create-and-delete-a-user) ein. Klicken Sie auf <code className="action">Connect</code>.
+    Sobald der Vorgang abgeschlossen ist, hat die Instanz den Status *Shelved Offloaded*.
 
-Wenn Sie Instanzen in verschiedenen Regionen eingerichtet haben, stellen Sie sicher, dass Sie sich in der korrekten Region befinden. Überprüfen Sie es in der oberen linken Ecke des Horizon-Interface.
+    <img className="thumbnail" alt="shelved instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
 
-<img className="thumbnail" alt="horizon interface" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
+    Um den Snapshot anzuzeigen, klicken Sie im Menü <code className="action">Compute</code> auf <code className="action">Images</code>.
 
-Klicken Sie auf das Menü <code className="action">Compute</code> auf der linken Seite und wählen Sie <code className="action">Instances</code> aus. Wählen Sie <code className="action">Shelve Instance</code> in der Drop-down-Liste für die betreffende Instanz aus.
+    <img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+  </Tab>
+  <Tab label="Verwendung der OpenStack/Nova API">
+    Bevor Sie fortfahren, empfehlen wir Ihnen folgende Anleitungen:
 
-<img className="thumbnail" alt="shelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
+    - [Vorbereitung Ihrer Umgebung zur Verwendung der OpenStack API](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
+    - [Konfigurieren der OpenStack-Umgebungsvariablen](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
 
-Sobald der Vorgang abgeschlossen ist, hat die Instanz den Status *Shelved Offloaded*.
+    Sobald Ihre Umgebung bereit ist, geben Sie in der Kommandozeile Folgendes ein:
 
-<img className="thumbnail" alt="shelved instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
+    ```bash
+    openstack server shelve <UUID server>
 
-Um den Snapshot anzuzeigen, klicken Sie im Menü <code className="action">Compute</code> auf <code className="action">Images</code>.
+    =====================================
 
-<img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+    nova shelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="Über die OVHcloud CLI">
+    Bevor Sie fortfahren, empfehlen wir Ihnen folgende Anleitung:
 
-<a name="openstack-nova"></a>
+    - [Erste Schritte mit der OVHcloud CLI](/guides/manage-and-operate/cli/getting-started)
 
-#### Verwendung der OpenStack/Nova API
+    Geben Sie den folgenden Befehl ein:
 
-Bevor Sie fortfahren, empfehlen wir Ihnen folgende Anleitungen:
-
-- [Vorbereitung Ihrer Umgebung zur Verwendung der OpenStack API](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
-- [Konfigurieren der OpenStack-Umgebungsvariablen](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
-
-Sobald Ihre Umgebung bereit ist, geben Sie in der Kommandozeile Folgendes ein:
-
-```bash
-~$ openstack server shelve <UUID server>
- 
-=====================================
-
-~$ nova shelve <UUID server> 
-```
+    ```shell
+    ovhcloud cloud instance shelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="unshelve-instance"></a>
 
@@ -167,151 +160,162 @@ Mit dieser Option können Sie Ihre Instanz aus dem ausgesetzten Zustand entferne
 
 Jede Aktion auf dem Snapshot außer der Reaktivierung (*unshelve*), kann für Ihre Infrastruktur sehr gefährlich sein, wenn sie nicht korrekt ausgeführt wird. Wenn Sie eine Instanz reaktivieren, wird der Snapshot automatisch gelöscht. Es wird nicht empfohlen, eine neue Instanz auf einem Snapshot zu basieren, der beim Aussetzen (*shelve*) der Instanz erzeugt wurde.
 
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren. Wir empfehlen Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovhcloud.com/community/en) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste haben.
+OVHcloud stellt Ihnen Maschinen zur Verfügung, für die Sie verantwortlich sind. Wir haben keinen Zugriff auf diese Maschinen und können sie daher nicht verwalten. Sie sind selbst für die Verwaltung Ihrer Software und Sicherheit verantwortlich. Wenn Sie auf Probleme stoßen oder Zweifel bei der Verwaltung, Nutzung oder Absicherung Ihres Servers haben, empfehlen wir Ihnen, sich an einen [spezialisierten Dienstleister](/links/partner) zu wenden.
 :::
 
-<a name="control-panel-unshelve"></a>
+<Tabs>
+  <Tab label="Im OVHcloud Kundencenter">
+    Wählen Sie im OVHcloud Kundencenter Ihr Projekt im Bereich <code className="action">Public Cloud</code> aus und klicken Sie im linken Menü auf <code className="action">Instanzen</code>.
 
-#### Im OVHcloud Kundencenter
+    Klicken Sie auf den Button <code className="action">⋮</code> rechts neben der Instanz und klicken Sie anschließend auf <code className="action">Reaktivieren</code>.
 
-Loggen Sie sich in Ihr OVHcloud Kundencenter ein. Klicken Sie oben auf der Seite auf <code className="action">Public Cloud</code> und wählen Sie anschließend Ihr Projekt aus. Klicken Sie im linken Menü auf <code className="action">Instanzen</code>.
+    <img className="thumbnail" alt="reactivate instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
 
-Klicken Sie in der Instanzenverwaltung auf <code className="action">⋮</code> rechts neben der Instanz und wählen Sie <code className="action">Reaktivieren</code>.
+    Nehmen Sie die Meldung im Dialogfenster zur Kenntnis und klicken Sie auf <code className="action">Bestätigen</code>.
 
-<img className="thumbnail" alt="reactivate instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
+    Sobald der Vorgang abgeschlossen ist, erscheint der Status Ihrer Instanz als *Aktiviert*.
+  </Tab>
+  <Tab label="Im Horizon-Interface">
+    Klicken Sie im Horizon-Interface auf das Menü <code className="action">Compute</code> auf der linken Seite und wählen Sie anschließend <code className="action">Instances</code> aus. Wählen Sie <code className="action">Unshelve Instance</code> in der Drop-down-Liste für die betreffende Instanz aus.
 
-Nehmen Sie die Meldung im Dialogfenster zur Kenntnis und klicken Sie auf <code className="action">Bestätigen</code>.
+    <img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
 
-Sobald der Vorgang abgeschlossen ist, erscheint Ihre Instanz als *Aktiviert*.
+    Sobald der Vorgang abgeschlossen ist, erscheint Ihre Instanz als *Active*.
+  </Tab>
+  <Tab label="Verwendung der OpenStack/Nova API">
+    Sobald Ihre Umgebung bereit ist, geben Sie in der Kommandozeile Folgendes ein:
 
-<a name="horizon-unshelve"></a>
+    ```bash
+    ~$ openstack server unshelve <UUID server>
 
-#### Im Horizon-Interface
+    =========================================
 
-Klicken Sie auf das Menü <code className="action">Compute</code> auf der linken Seite und wählen Sie <code className="action">Instances</code> aus. Wählen Sie <code className="action">Unshelve Instance</code> in der Drop-down-Liste für die betreffende Instanz aus.
+    ~$ nova unshelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="Über die OVHcloud CLI">
+    Geben Sie den folgenden Befehl ein:
 
-<img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
-
-Sobald der Vorgang abgeschlossen ist, erscheint Ihre Instanz als *Active*.
-
-<a name="openstack-nova-unshelve"></a>
-
-#### Verwendung der OpenStack/Nova APIs
-
-Sobald Ihre Umgebung bereit ist, geben Sie in der Kommandozeile Folgendes ein:
-
-```bash
-~$ openstack server unshelve <UUID server>
-
-=========================================
-
-~$ nova unshelve <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance unshelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="stop-suspend-instance"></a>
 
 ### Ausschalten einer Instanz (*suspend*)
 
-Mit dieser Option können Sie Ihre Instanz ausschalten und den Zustand der virtuellen Maschine auf der Disk sichern. Der Arbeitsspeicher wird ebenfalls auf die Disk geschrieben.
+Mit dieser Option können Sie Ihre Instanz ausschalten und den Zustand der virtuellen Maschine einschließlich des Arbeitsspeichers auf der Disk sichern.
 
-<a name="stop-control-panel"></a>
+<Tabs>
+  <Tab label="Im OVHcloud Kundencenter">
+    Wählen Sie im OVHcloud Kundencenter Ihr Projekt im Bereich <code className="action">Public Cloud</code> aus und klicken Sie im linken Menü auf <code className="action">Instanzen</code>.
 
-#### Im OVHcloud Kundencenter
+    Klicken Sie auf den Button <code className="action">⋮</code> rechts neben der Instanz, die Sie anhalten möchten, und klicken Sie anschließend auf <code className="action">Anhalten</code>.
 
-Loggen Sie sich in Ihr OVHcloud Kundencenter ein. Klicken Sie oben auf der Seite auf <code className="action">Public Cloud</code> und wählen Sie anschließend Ihr Projekt aus. Klicken Sie im linken Menü auf <code className="action">Instanzen</code>.
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
 
-Klicken Sie in der Instanzenverwaltung auf <code className="action">⋮</code> rechts neben der Instanz und wählen Sie <code className="action">Anhalten</code>.
+    Nehmen Sie die Meldung im Dialogfenster zur Kenntnis und klicken Sie auf <code className="action">Bestätigen</code>.
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
 
-Nehmen Sie die Meldung im Dialogfenster zur Kenntnis und klicken Sie auf <code className="action">Bestätigen</code>.
+    Sobald der Vorgang abgeschlossen ist, erscheint die Instanz als *Ausgeschaltet*.
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
+    <img className="thumbnail" alt="off status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_status_off.png" loading="lazy" />
 
-Sobald der Vorgang abgeschlossen ist, erscheint die Instanz als *Ausgeschaltet*.
+    Um die Instanz wieder in Betrieb zu nehmen, führen Sie dieselben Schritte wie oben beschrieben aus. Klicken Sie auf den Button <code className="action">⋮</code> rechts neben der Instanz und wählen Sie <code className="action">Starten</code>. In einigen Fällen müssen Sie möglicherweise einen Kaltstart durchführen.
 
-Um die Instanz wieder in Betrieb zu nehmen (*unsuspend*), klicken Sie in der Instanzenverwaltung auf <code className="action">⋮</code> rechts neben der Instanz und wählen Sie <code className="action">Starten</code>. In einigen Fällen müssen Sie möglicherweise einen Neustart durchführen.
+    <img className="thumbnail" alt="start instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/start_instance_2025.png" loading="lazy" />
 
-<a name="stop-horizon"></a>
+    Sobald der Vorgang abgeschlossen ist, erscheint der Status Ihrer Instanz als *Aktiviert*.
+  </Tab>
+  <Tab label="Im Horizon-Interface">
+    Klicken Sie im Horizon-Interface auf das Menü <code className="action">Compute</code> auf der linken Seite und wählen Sie anschließend <code className="action">Instances</code> aus. Wählen Sie <code className="action">Suspend Instance</code> in der Drop-down-Liste für die betreffende Instanz aus.
 
-#### Im Horizon-Interface
+    <img className="thumbnail" alt="suspend instance Horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
 
-Klicken Sie auf das Menü <code className="action">Compute</code> auf der linken Seite und wählen Sie <code className="action">Instances</code> aus. Wählen Sie <code className="action">Suspend Instance</code> in der Drop-down-Liste für die betreffende Instanz aus.
+    Es erscheint eine Bestätigungsmeldung, die anzeigt, dass die Instanz gestoppt wurde.
 
-<img className="thumbnail" alt="suspend instance Horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
+    Um die Instanz wieder in Betrieb zu nehmen, führen Sie dieselben Schritte wie oben beschrieben aus. Wählen Sie in der Drop-down-Liste für die betreffende Instanz <code className="action">Resume Instance</code> aus.
+  </Tab>
+  <Tab label="Verwendung der OpenStack/Nova API">
+    Sobald Ihre Umgebung bereit ist, geben Sie in der Kommandozeile Folgendes ein:
 
-Es erscheint eine Bestätigungsmeldung, die anzeigt, dass die Instanz gestoppt wurde.
+    ```bash
+    ~$ openstack server suspend <UUID server>
 
-Um die Instanz wieder in Betrieb zu nehmen (*unsuspend*), wählen Sie in der Drop-down-Liste für die entsprechende Instanz <code className="action">Resume Instance</code>.
+    =========================================
 
-<a name="stop-openstack-nova"></a>
+    ~$ nova suspend <UUID server>
+    ```
 
-#### Verwendung der OpenStack/Nova API
+    Um die Instanz wieder in Betrieb zu nehmen, geben Sie in der Kommandozeile Folgendes ein:
 
-Sobald Ihre Umgebung bereit ist, geben Sie in der Kommandozeile Folgendes ein:
+    ```bash
+    ~$ openstack server unsuspend <UUID server>
 
-```bash
-~$ openstack server suspend <UUID server>
+    =========================================
 
-=========================================
+    ~$ nova unsuspend <UUID server>
+    ```
+  </Tab>
+  <Tab label="Über die OVHcloud CLI">
+    Geben Sie den folgenden Befehl ein:
 
-~$ nova suspend <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance stop <instance_id>
+    ```
 
-Um die Instanz wieder in Betrieb zu nehmen, geben Sie in der Kommandozeile Folgendes ein:
+    Um die Instanz wieder in Betrieb zu nehmen, geben Sie den folgenden Befehl ein:
 
-```bash
-~$ openstack server unsuspend <UUID server>
-
-=========================================
-
-~$ nova unsuspend <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance start <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="pause-instance"></a>
 
 ### Pausieren einer Instanz (*pause*)
 
-Diese Aktion ist nur im Horizon-Interface oder über die OpenStack/Nova-API möglich. Damit können Sie eine Instanz "einfrieren".
+Diese Aktion ist **nur** im Horizon-Interface oder über die OpenStack/Nova-API möglich. Damit können Sie Ihre Instanz *einfrieren*.
 
-<a name="pause-horizon"></a>
+<Tabs>
+  <Tab label="Im Horizon-Interface">
+    Klicken Sie im Horizon-Interface auf das Menü <code className="action">Compute</code> auf der linken Seite und wählen Sie anschließend <code className="action">Instances</code> aus. Wählen Sie <code className="action">Pause Instance</code> in der Drop-down-Liste für die betreffende Instanz aus.
 
-#### Im Horizon-Interface
+    <img className="thumbnail" alt="Pause instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
 
-Klicken Sie auf das Menü <code className="action">Compute</code> auf der linken Seite und wählen Sie <code className="action">Instances</code> aus. Wählen Sie <code className="action">Pause Instance</code> in der Drop-down-Liste für die entsprechende Instanz aus.
+    Es erscheint eine Bestätigungsmeldung, die anzeigt, dass die Instanz pausiert wurde.
 
-<img className="thumbnail" alt="Pause instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
+    Um die Pausierung der Instanz aufzuheben, führen Sie dieselben Schritte wie oben beschrieben aus. Wählen Sie in der Drop-down-Liste für die betreffende Instanz <code className="action">Resume Instance</code> aus.
+  </Tab>
+  <Tab label="Verwendung der OpenStack/Nova API">
+    Sobald Ihre Umgebung bereit ist, geben Sie in der Kommandozeile Folgendes ein:
 
-Es erscheint eine Bestätigungsmeldung, die anzeigt, dass die Instanz pausiert wurde.
+    ```bash
+    ~$ openstack server pause <UUID server>
 
-Um die Instanz wieder in Betrieb zu nehmen (*unpause*), wählen Sie in der Dropdown-Liste der entsprechenden Instanz <code className="action">Resume Instance</code>.
+    =========================================
 
-<a name="pause-openstack-nova"></a>
+    ~$ nova pause <UUID server>
+    ```
 
-#### Verwendung der OpenStack/Nova API
+    Um die Pausierung der Instanz aufzuheben, geben Sie in der Kommandozeile Folgendes ein:
 
-Sobald Ihre Umgebung bereit ist, geben Sie in der Kommandozeile Folgendes ein:
+    ```bash
+    ~$ openstack server unpause <UUID server>
 
-```bash
-~$ openstack server pause <UUID server>
+    =========================================
 
-=========================================
-
-~$ nova pause <UUID server>
-```
-
-Um die Instanz **zu reaktivieren**, geben Sie in der Kommandozeile Folgendes ein:
-
-```bash
-~$ openstack server unpause <UUID server>
-
-=========================================
-
-~$ nova unpause <UUID server>
-```
+    ~$ nova unpause <UUID server>
+    ```
+  </Tab>
+</Tabs>
 
 ## Weiterführende Informationen
 
 [OpenStack Dokumentation](https://docs.openstack.org/ocata/user-guide/cli-stop-and-start-an-instance.html).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](https://community.ovhcloud.com/) bei.

--- a/docs/en/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/en/guides/public-cloud/compute/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to create a Public Cloud instance and connect to it
 description: Find out how to configure Public Cloud instances in the OVHcloud Control Panel and the first steps with your instances
-lastUpdated: 2026-02-24
+lastUpdated: 2026-05-25
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -58,19 +58,6 @@ Important **technical details** about the OVHcloud Public Cloud are available on
   - [Step 2: Import SSH keys](#step-2-import-ssh-keys)
   - [Step 3: Prepare the network configuration](#step-3-prepare-the-network-configuration)
   - [Step 4: Create the instance](#step-4-create-the-instance)
-    - [Step 4.1: Instance Name](#step-41-instance-name)
-    - [Step 4.2: Select a location](#step-42-select-a-location)
-    - [Step 4.3: Select a model](#step-43-select-a-model)
-      - [Additional information](#additional-information)
-    - [Step 4.4: Select an image](#step-44-select-an-image)
-    - [Step 4.5: Select an SSH key (not applicable to Windows instances)](#step-45-select-an-ssh-key-not-applicable-to-windows-instances)
-    - [Step 4.6: Configure backup settings](#step-46-configure-backup-settings)
-    - [Step 4.7: Configure the network](#step-47-configure-the-network)
-    - [Step 4.8: Select a billing period](#step-48-select-a-billing-period)
-    - [Step 4.9: Configure advanced settings](#step-49-configure-advanced-settings)
-      - [Flexible instance](#flexible-instance)
-      - [Post-installation script](#post-installation-script)
-    - [Step 4.10: Finalizing your instance](#step-410-finalizing-your-instance)
   - [Step 5: Connect to the instance](#step-5-connect-to-the-instance)
     - [5.1: Verify the instance status in the OVHcloud Control Panel](#51-verify-the-instance-status-in-the-ovhcloud-control-panel)
     - [5.2: First login on an instance with a GNU/Linux OS installed](#52-first-login-on-an-instance-with-a-gnulinux-os-installed)
@@ -125,16 +112,71 @@ Public SSH keys added to your OVHcloud Control Panel will be available for Publi
 
 :::
 
+<Tabs>
+  <Tab label="via the Control Panel">
+    Log in to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, navigate to the <code className="action">Public Cloud</code> section and select your Public Cloud project.
 
-Open <code className="action">SSH Keys</code> in the left-hand menu under **Settings**. Click on the button <code className="action">Add an SSH key</code>.
+    Open <code className="action">SSH Keys</code> in the left-hand menu under **Settings**. Click on the button <code className="action">Add an SSH key</code>.
 
-<img className="thumbnail" alt="ssh keys" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+    In the new window, enter a name for the key. Fill in the `Key` field with your public key string, for example the one created in [Step 1](#step-1-create-an-ssh-key-set). Confirm by clicking <code className="action">Add</code>.
 
-In the new window, enter a name for the key. Fill in the `Key` field with your public key string, for example the one created in [Step 1](#step-1-create-an-ssh-key-set). Confirm by clicking <code className="action">Add</code>.
+    You can now select this key in [Step 4](#step-4-create-the-instance) to add it to a new instance.
+  </Tab>
+  <Tab label="via the OVHcloud API">
+    Use the following call to import your public SSH key:
 
-<img className="thumbnail" alt="add key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
+    > **POST** `/cloud/project/{serviceName}/sshkey`
 
-You can now select this key in [Step 4](#step-4-create-the-instance) to add it to a new instance.
+    Parameters:
+
+    - `serviceName`: your Public Cloud project ID
+    - `name`: name of the SSH key
+    - `publicKey`: content of your public key
+
+    Note the `id` returned — it will be needed when creating the instance.
+  </Tab>
+  <Tab label="via the OVHcloud CLI">
+    Make sure you have installed and configured the [OVHcloud CLI](https://github.com/ovh/ovhcloud-cli), then import your key:
+
+    ```bash
+    ovhcloud cloud ssh-key create \
+      --cloud-project <project_id> \
+      --name my-key \
+      --public-key "$(cat ~/.ssh/id_rsa.pub)"
+    ```
+
+    Verify the import and note the `name` of the key for [Step 4](#step-4-create-the-instance):
+
+    ```bash
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="via the OpenStack CLI">
+    Make sure you have configured your OpenStack environment ([dedicated guide](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)), then import your key:
+
+    ```bash
+    openstack keypair create --public-key ~/.ssh/id_rsa.pub my-key
+    ```
+
+    Verify the import:
+
+    ```bash
+    openstack keypair list
+    ```
+  </Tab>
+  <Tab label="via Terraform">
+    Declare the resource in your `.tf` file:
+
+    ```hcl
+    resource "openstack_compute_keypair_v2" "my_keypair" {
+      name       = "my-key"
+      public_key = file("~/.ssh/id_rsa.pub")
+    }
+    ```
+
+    Refer to the [Terraform guide for OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform) for the initial provider setup.
+  </Tab>
+</Tabs>
 
 ### Step 3: Prepare the network configuration
 
@@ -171,196 +213,203 @@ Find out more on the [Local Zones web page](https://www.ovhcloud.com/en-gb/publi
 
 ### Step 4: Create the instance
 
-:::info
-A public SSH key is required when creating an instance in the OVHcloud Control Panel (except for Windows instances).
-
-Refer to [step 1](#step-1-create-an-ssh-key-set) and [step 2](#step-2-import-ssh-keys) in this guide if you do not have any SSH keys ready to use.
-
-:::
-
-
-On the **Home** page, click <code className="action">Create an instance</code>.
-
-#### Step 4.1: Instance Name
-
-Enter a full name for your instance. The commercial reference of the instance model is the default value. If necessary, you can also add the region and date to facilitate the identification and management of your instances.
-
-#### Step 4.2: Select a location
-
-Select a [location](https://www.ovhcloud.com/en-gb/public-cloud/regions-availability/) closest to your users or customers. Note that if you select a **Local Zone** in this step, network limitations will apply to the instance (see [Step 3](#networking-modes)).
-
-Also refer to the information on the [Local Zones web page](https://www.ovhcloud.com/en-gb/public-cloud/local-zone-compute/) and the [Local Zones capabilities documentation](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-The choice of region determines how your instance is deployed (1-AZ, 3-AZ, or Local Zones). To understand the differences in terms of resilience, availability, and architecture, see our guide [Deployment Mode Comparison and Resilience – Understanding 3-AZ / 1-AZ / Local Zones](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details).
-
-#### Step 4.3: Select a model
-
-At this stage, you choose the instance model (also known as flavor), which determines the resources allocated to your instance: processor, memory, and associated capabilities. Open the `Instance Model` drop-down list, then select the model type that best suits your use case to access our range of optimized instances.
-
-The `Discovery` model type brings together instances with shared resources, offered at competitive prices. They are particularly well suited for discovering the OVHcloud Public Cloud, performing tests, or hosting light workloads such as web applications.
-
-`Metal Instances` models offer fully dedicated physical resources, guaranteeing consistent performance and maximum isolation for the most demanding workloads.
-
-:::info
-Your total Public Cloud resources will initially be limited for cost control and security reasons. You can check these quotas by clicking on <code className="action">Quota & Regions</code> in the left navigation bar under **Settings**. See [the dedicated documentation](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) for more information.
-
-Note that you can **upgrade** your instance after creation to have more resources available. However, downgrading to a smaller model is not possible with a regular instance. You can find more information on this topic in **step 4.9** below.
-
-:::
-
-
-##### Additional information
-
-<details>
-
-<summary>Instance model categories</summary>
-
-
-| Type | Guaranteed Resources | Usage notes |
-| :---         |     :---:      |          :--- |
-| Best Sellers   | ✓     | Most popular models.    |
-| General Purpose   | ✓     | Development servers, web or business applications    |
-| Compute Optimized     | ✓       | Video encoding or other high-performance computing      |
-| Memory Optimized    | ✓     | Databases, analysis, and in-memory calculations    |
-| GPU     | ✓       | Massively parallel processing power for specialized applications (rendering, big data, deep learning, etc.)       |
-| Discovery    | -       | Hosted on shared resources for testing and development environments      |
-| Storage Optimized   | ✓     | Optimized for disk data transfer    |
-| Metal Instances | ✓ | Dedicated resources with direct access to compute, storage and network resources|
-
-</details>
-
-
-<details>
-
-<summary>Regions and Local Zones</summary>
-
-
-**Regions**
-
-A **region** is defined as a location in the world comprised of one or several data centres where OVHcloud services are hosted. You can find more information on regions, geographical division and availability of services on our [region web page](https://www.ovhcloud.com/en-gb/public-cloud/regions-availability/) and our [infrastructure web page](https://www.ovhcloud.com/en-gb/about-us/global-infrastructure/regions/).
-
-**Local Zones**
-
-Local Zones are an extension of **regions** that bring OVHcloud services closer to specific locations, offering reduced latency and improved performances for applications. You can find more information on the [Local Zones web page](https://www.ovhcloud.com/en-gb/public-cloud/local-zone-compute/) and in the [Local Zones capabilities documentation](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-</details>
-
-
-#### Step 4.4: Select an image
-
-Open the `Distribution Type` drop-down list, select the category that corresponds to your needs, then choose the operating system to deploy on your instance using the `Image Version` drop-down menu.
-
-The images available at this stage depend on the choices made in the previous stages, i.e., compatibility with the instance model and regional availability. For example, if you want to select a Windows operating system and there are no options in the Windows tab, you must change your choices from the previous stages.
-
-:::info
-If you choose an operating system that requires a paid license, these costs will be automatically included in the project invoice.
-
-:::
-
-
-#### Step 4.5: Select an SSH key (not applicable to Windows instances)
-
-With the exception of Windows instances, configuring your instance also requires **adding a public SSH key**. You have two options:
-
-- Use a public key already stored in the OVHcloud Control Panel
-- Enter a public key directly
-
-Click on the tabs below to view their presentation:
-
 <Tabs>
-  <Tab label="Using a stored key">
-    To add a key stored in your OVHcloud Control Panel (see [Step 2](#step-2-import-ssh-keys)), select it from the list.
+  <Tab label="via the Control Panel">
+    :::info
+    A public SSH key is required when creating an instance (except for Windows instances). Refer to [Step 1](#step-1-create-an-ssh-key-set) and [Step 2](#step-2-import-ssh-keys) if you do not have SSH keys ready to use.
+
+    :::
+
+    Log in to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, navigate to the <code className="action">Public Cloud</code> section and select your Public Cloud project. On the **Home** page, click <code className="action">Create an instance</code>.
+
+    **4.1 Name**
+
+    Enter a full name for your instance.
+
+    **4.2 Location**
+
+    Select a [location](https://www.ovhcloud.com/en-gb/public-cloud/regions-availability/) closest to your users. Note that selecting a **Local Zone** applies network limitations (see [Step 3](#networking-modes)). Refer to the guide [Deployment Mode Comparison](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details) for differences between 3-AZ, 1-AZ and Local Zones.
+
+    **4.3 Model**
+
+    Open the `Instance Model` drop-down list and select the model type suited to your use case. The model (flavor) determines the resources allocated to your instance: processor, memory, and associated capabilities.
+
+    | Type | Guaranteed Resources | Usage notes |
+    | :--- | :---: | :--- |
+    | Best Sellers | ✓ | Most popular models. |
+    | General Purpose | ✓ | Development servers, web or business applications. |
+    | Compute Optimized | ✓ | Video encoding or other high-performance computing. |
+    | Memory Optimized | ✓ | Databases, analysis, and in-memory calculations. |
+    | GPU | ✓ | Massively parallel processing power for specialised applications (rendering, big data, deep learning, etc.). |
+    | Discovery | - | Shared resources for testing and development environments. |
+    | Storage Optimized | ✓ | Optimised for disk data transfer. |
+    | Metal Instances | ✓ | Dedicated resources with direct access to compute, storage and network resources. |
+
+    :::info
+    Your total Public Cloud resources will initially be limited. Check your quotas via <code className="action">Quota & Regions</code> under **Settings** in the left navigation bar. See [the dedicated documentation](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) for more information.
+
+    You can **upgrade** your instance after creation to have more resources available. However, downgrading to a smaller model is not possible with a regular instance. See **step 4.9** for details.
+
+    :::
+
+    **4.4 Image**
+
+    Select the OS via the `Distribution Type` and `Image Version` drop-down menus. Available options depend on the model and region chosen.
+
+    **4.5 SSH key** *(not applicable to Windows instances)*
+
+    Select a stored SSH key from the list (see [Step 2](#step-2-import-ssh-keys)), or click <code className="action">Create a new SSH key</code> to paste a public key directly.
+
+    **4.6 Backup**
+
+    [Automated backups](/guides/public-cloud/compute/save-an-instance) are enabled by default. Select the rotation type (7 or 14 days).
+
+    **4.7 Network**
+
+    The **Network settings** section is split into two parts:
+
+    - **Private network**: Select an existing private network or click <code className="action">+ Create a private network</code>. If a private network is selected but does not have a gateway, toggle <code className="action">Assign a gateway</code> to attach a gateway automatically.
+    - **Assign public connectivity**: Enable the toggle to assign a public IP. Choose <code className="action">Basic Public IP</code> (free, tied to the instance lifetime, incompatible with a gateway) or <code className="action">Create a Floating IP (Reusable)</code> (persistent and reusable).
+
+    See [Step 3](#networking-modes) for an overview of networking modes.
+
+    **4.8 Billing**
+
+    Choose between **monthly** (lower cost, non-reversible) or **hourly** (flexible, [convertible to monthly](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing)). Hourly billing runs until the **instance is deleted**. See the [billing documentation](/guides/public-cloud/cross-functional/analyze-billing).
+
+    **4.9 Advanced settings** *(optional)*
+
+    - **Flexible instance**: single 50 GB disk, allows resizing to higher or lower models.
+    - **Post-installation script**: add your [post-installation script](/guides/public-cloud/compute/launching-script-when-creating-instance).
+
+    **4.10 Finalize**
+
+    Review the summary on the right side of the screen and configure the number of instances. Click <code className="action">Launch my instance</code>. Delivery may take a few minutes.
   </Tab>
-  <Tab label="Enter a key directly">
-    To add a public key by pasting the key string, click the <code className="action">Create a new SSH Key</code> button.
-    
-    Enter a name for the key and the key string in the respective fields. Then click <code className="action">Validate the key</code>.
+  <Tab label="via the OVHcloud API">
+    Retrieve the required identifiers:
+
+    ```
+    GET /cloud/project/{serviceName}/flavor     → flavorId
+    GET /cloud/project/{serviceName}/image      → imageId
+    GET /cloud/project/{serviceName}/region     → region
+    GET /cloud/project/{serviceName}/sshkey     → sshKeyId
+    ```
+
+    Create the instance:
+
+    > **POST** `/cloud/project/{serviceName}/instance`
+
+    Main parameters:
+
+    - `name`: instance name
+    - `flavorId`: model ID
+    - `imageId`: OS image ID
+    - `region`: deployment region
+    - `sshKeyId`: SSH key ID (from [Step 2](#step-2-import-ssh-keys))
+    - `monthlyBilling`: `true` for monthly billing
+
+    Refer to the [OVHcloud API documentation](/guides/manage-and-operate/api/first-steps) to configure your API access.
+  </Tab>
+  <Tab label="via the OVHcloud CLI">
+    Retrieve the required identifiers:
+
+    ```bash
+    ovhcloud cloud reference list-flavors --cloud-project <project_id>
+    ovhcloud cloud reference list-images --cloud-project <project_id>
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+
+    Create the instance:
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --name my-instance \
+      --boot-from.image <image_id> \
+      --flavor <flavor_id> \
+      --ssh-key.name my-key \
+      --network.public \
+      --wait
+    ```
+
+    Replace `GRA9` with your region. For interactive creation with guided selection:
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --editor \
+      --image-selector \
+      --flavor-selector
+    ```
+
+    Check the status after creation:
+
+    ```bash
+    ovhcloud cloud instance list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="via the OpenStack CLI">
+    Retrieve the required information:
+
+    ```bash
+    openstack flavor list
+    openstack image list --property visibility=public
+    openstack keypair list
+    ```
+
+    Create the instance:
+
+    ```bash
+    openstack server create \
+      --flavor b2-7 \
+      --image "Ubuntu 24.04" \
+      --key-name my-key \
+      --network Ext-Net \
+      my-instance
+    ```
+
+    Check the status:
+
+    ```bash
+    openstack server list
+    openstack server show my-instance
+    ```
+
+    Refer to the [OpenStack environment setup guide](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) for initial configuration.
+  </Tab>
+  <Tab label="via Terraform">
+    Complete configuration example:
+
+    ```hcl
+    data "openstack_images_image_v2" "ubuntu" {
+      name        = "Ubuntu 24.04"
+      most_recent = true
+    }
+
+    resource "openstack_compute_instance_v2" "my_instance" {
+      name            = "my-instance"
+      flavor_name     = "b2-7"
+      key_pair        = openstack_compute_keypair_v2.my_keypair.name
+      security_groups = ["default"]
+
+      block_device {
+        uuid                  = data.openstack_images_image_v2.ubuntu.id
+        source_type           = "image"
+        destination_type      = "local"
+        boot_index            = 0
+        delete_on_termination = true
+      }
+
+      network {
+        name = "Ext-Net"
+      }
+    }
+    ```
+
+    Refer to the [Terraform guide for OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform) for the initial provider setup and authentication.
   </Tab>
 </Tabs>
-
-
-#### Step 4.6: Configure backup settings
-
-[Automated backups](/guides/public-cloud/compute/save-an-instance) are enabled by default. Review the pricing information and additional details before proceeding.
-
-Next, select the rotation type, i.e., the maximum number of backups kept in the history: 7 or 14 days.
-
-#### Step 4.7: Configure the network
-
-In this step, you will configure the network for your instance.
-
-**Private network**
-
-You can connect your instance to a [private network](#networking-modes) and assign it a [floating IP](https://www.ovhcloud.com/en-gb/public-cloud/floating-ip/).
-
-By clicking on <code className="action">Create a private network</code>, you can create one directly:
-
-- Name the network
-- **Select the VLAN ID:** identifier used to interconnect multiple services and resources within the same private network, via a common network segmentation number
-- **Define the CIDR:** range of IP addresses for the network
-- **Enable DHCP by checking the corresponding box, if necessary:** enable this option if you want IP addresses to be assigned automatically
-
-:::info
-The instance can remain fully private if you do not assign it a public IP address.
-
-:::
-
-
-**Gateway**
-
-You can enable the option to assign a gateway to your network. By default, the gateway is size S, but you can adjust its size later in the settings.
-
-**Assign public connectivity**
-
-You can enable or disable this feature as needed. If you choose to enable it, you have two options:
-
-- **Basic Public IP:** a temporary public IP address that does not persist beyond the lifetime of the instance. Note that using a Basic Public IP is not compatible with a gateway.
-- **Floating IP:** You can create a new Floating IP or reuse an existing address, allowing for a persistent public IP that can be detached from the instance.
-
-#### Step 4.8: Select a billing period
-
-:::info
-Please note that, depending on the instance model you choose, **hourly** billing may be the only option displayed. This is a temporary limitation; new Public Cloud billing options will be available soon.
-
-:::
-
-
-<Tabs>
-  <Tab label="Monthly billing">
-    Monthly billing will result in lower costs over time, but **cannot be changed** to hourly billing once the instance has been created.
-  </Tab>
-  <Tab label="Hourly billing">
-    Hourly billing is the best choice if you have not clearly determined the length of the usage period. If you decide to keep the instance for long-term use, you can always [switch to a monthly subscription](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing).
-    
-    The instance will be billed as long as it is **not deleted**, regardless of the actual usage of the instance.
-  </Tab>
-</Tabs>
-
-
-Find details in our dedicated billing documentation:
-
-- [Public Cloud Billing](/guides/public-cloud/cross-functional/analyze-billing)
-- [FAQ on monthly billing](/guides/public-cloud/compute/faq-change-of-monthly-billing-method)
-
-Once you have finished configuring your instance, you can choose to click the <code className="action">Launch my instance</code> button, or configure advanced settings (see below). It may take a few minutes for your service to be delivered.
-
-#### Step 4.9: Configure advanced settings
-
-##### Flexible instance
-
-A Flex instance is a single 50 GB disk instance designed to offer faster snapshot creation and restoration.
-
-It allows resizing to higher or lower models while maintaining fixed storage. Classic models only allow resizing to higher models.
-
-##### Post-installation script
-
-You can add [your post-installation script](/guides/public-cloud/compute/launching-script-when-creating-instance) in this field.
-
-#### Step 4.10: Finalizing your instance
-
-On the right side of your screen, you will find a summary of your configuration. In this section, you can configure the number of instances to be created. You can create multiple instances based on the selections made during the creation steps, but resource [quota limits](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) will apply.
-
-Once you have finished configuring your instance, click the <code className="action">Launch my instance</code> button. Delivery of your service may take a few minutes.
 
 ### Step 5: Connect to the instance
 
@@ -381,13 +430,18 @@ If you have installed an **OS with application**, refer to our [guide on first s
 
 Select <code className="action">Instances</code> in the left-hand navigation bar under **Compute**. Your instance is ready when the status is set to `Enabled` in the table. If the instance was recently created and has a different status, click on the "Refresh" button located next to the search filter.
 
-<img className="thumbnail" alt="instances page" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
-
 Click on the instance's name in this table to open the <code className="action">Dashboard</code> on which you can find all information about the instance. To learn more about the functions available on this page, consult our guide on [managing instances in the Control Panel](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 A **user with elevated permissions (*sudo*) is automatically created** on the instance. The username reflects the image installed, e.g "ubuntu", "debian", "fedora", etc. You can verify this on the right-hand side of the <code className="action">Dashboard</code> in the section **Networks**.
 
-<img className="thumbnail" alt="instances page" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
+:::info
+Via the OVHcloud CLI, check the instance status and retrieve its IP address with:
+
+```bash
+ovhcloud cloud instance list --cloud-project <project_id>
+```
+
+:::
 
 If your [SSH key pair is set up correctly](#step-1-create-an-ssh-key-set), you can now connect to the instance with the preconfigured user and your SSH key. You can find more detailed instructions in the subsequent paragraphs.
 
@@ -438,20 +492,16 @@ You will then need to complete the initial setup of your Windows OS. Follow the 
 
 <Tabs>
   <Tab label="1. Locale settings">
-    Configure your **country/region**, the preferred **Windows language**, and your **keyboard layout**. Then click on the button <code className="action">Next</code> at the bottom right.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" /><br/>
+    Configure your **country/region**, the preferred **Windows language**, and your **keyboard layout**. Then click on the button <code className="action">Next</code> at the bottom right.
   </Tab>
   <Tab label="2. Administrator password">
-    Set a password for your Windows `Administrator` account and confirm it, then click on <code className="action">Finish</code>.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" /><br/>
+    Set a password for your Windows `Administrator` account and confirm it, then click on <code className="action">Finish</code>.
   </Tab>
   <Tab label="3. Login screen">
-    Windows will apply your settings and then display the login screen. Click on the <code className="action">Send CtrlAltDel</code> button in the top right corner to sign in.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" /><br/>
+    Windows will apply your settings and then display the login screen. Click on the <code className="action">Send CtrlAltDel</code> button in the top right corner to sign in.
   </Tab>
   <Tab label="4. Administrator login">
-    Enter the `Administrator` password you have created in the previous step and click on the `Arrow` button.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
+    Enter the `Administrator` password you have created in the previous step and click on the `Arrow` button.
   </Tab>
 </Tabs>
 
@@ -459,8 +509,6 @@ You will then need to complete the initial setup of your Windows OS. Follow the 
 ##### 5.3.2: Log in remotely from Windows
 
 On your local Windows device, you can use the `Remote Desktop Connection` client application to connect to your instance.
-
-<img className="thumbnail" alt="rdp connection" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Enter the IPv4 address of your instance, then your username and passphrase. Usually a warning message will appear, asking to confirm the connection because of an unknown certificate. Click on <code className="action">Yes</code> to log in.
 
@@ -480,20 +528,15 @@ Whichever client you are using, you only need the IP address of your instance an
 
 The free and open-source software `Remmina Remote Desktop Client` is available for many GNU/Linux desktop distributions. If you do not find Remmina in your desktop environment's software manager, you can obtain it from the [official website](https://remmina.org/).
 
-<img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect01.png" loading="lazy" /><br/>
-
 <Tabs>
   <Tab label="1. Connection">
-    Open Remmina and make sure the connection protocol is set to "RDP". Enter the IPv4 address of your Public Cloud instance and press `Enter`.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" /><br/>
+    Open Remmina and make sure the connection protocol is set to "RDP". Enter the IPv4 address of your Public Cloud instance and press `Enter`.
   </Tab>
   <Tab label="2. Authentication">
-    If a certificate warning message appears, click on <code className="action">Yes</code>. Enter the username and your password for Windows and click on <code className="action">OK</code> to establish the connection.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" /><br/>
+    If a certificate warning message appears, click on <code className="action">Yes</code>. Enter the username and your password for Windows and click on <code className="action">OK</code> to establish the connection.
   </Tab>
   <Tab label="3. Settings">
-    You can find some useful items in the left-hand toolbar. For example, click on the icon <code className="action">Toggle dynamic resolution update</code> to improve the window resolution.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
+    You can find some useful items in the left-hand toolbar. For example, click on the icon <code className="action">Toggle dynamic resolution update</code> to improve the window resolution.
   </Tab>
 </Tabs>
 
@@ -503,8 +546,6 @@ The free and open-source software `Remmina Remote Desktop Client` is available f
 The VNC console allows you to connect to your instances even when other means of access are not available.
 
 Select <code className="action">Instances</code> in the left-hand navigation bar under **Compute**. Click on the instance name and open the tab <code className="action">VNC console</code>.
-
-<img className="thumbnail" alt="vnc console" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instance with a GNU/Linux OS installed">

--- a/docs/en/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/en/guides/public-cloud/compute/getting-started.mdx
@@ -1,13 +1,10 @@
 ---
 title: How to create a Public Cloud instance and connect to it
 description: Find out how to configure Public Cloud instances in the OVHcloud Control Panel and the first steps with your instances
-lastUpdated: 2026-05-25
+lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
-
-
-
 
 ## Objective
 
@@ -15,7 +12,6 @@ Public Cloud instances are easy to deploy and manage. However, being part of the
 You can then go further with your Public Cloud project according to your needs.
 
 **This guide explains how to get started with a Public Cloud instance.**
-
 
 ## Requirements
 
@@ -37,7 +33,6 @@ Take advantage of reduced prices by committing to a period of 1 to 36 months on 
 
 :::
 
-
 ## Instructions
 
 :::info
@@ -46,7 +41,6 @@ If you have not created a Public Cloud project yet, start with our [guide on how
 Important **technical details** about the OVHcloud Public Cloud are available on [this guide page](/guides/public-cloud/cross-functional/compute-essential-information).
 
 :::
-
 
 ### Content overview
 
@@ -73,14 +67,12 @@ Important **technical details** about the OVHcloud Public Cloud are available on
     - [6.2: Additional SSH keys](#62-additional-ssh-keys)
 - [Go further](#go-further)
 
-
 :::info
 **You need to provide a public SSH key when creating Public Cloud instances in the OVHcloud Control Panel.** After the instance is created you can configure your remote access at your own discretion.
 
 **Exception**: Login authentication on Windows instances requires username and password because Windows uses RDP (**R**emote **D**esktop **P**rotocol).
 
 :::
-
 
 ### Step 1: Create an SSH key set
 
@@ -100,10 +92,9 @@ Most contemporary desktop operating systems natively include the **OpenSSH** cli
 
 If you use an alternative software, refer to its user documentation. A usage example for the open-source solution `PuTTY` is available in our guide: [How to use PuTTY](/guides/web-cloud/web-hosting/ssh-using-putty-on-windows).
 
-
 ### Step 2: Import SSH keys
 
-You can store your public SSH keys in the <code className="action">Public Cloud</code> section of the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>. This is not mandatory but makes the instance creation process more convenient.
+You can store your public SSH keys in your Public Cloud project. This is not mandatory but makes the instance creation process more convenient.
 
 :::info
 Stored SSH keys help you to create your instances faster in the OVHcloud Control Panel. To change key pairs and add users once an instance is created, please refer to the guide on [additional SSH keys](/guides/public-cloud/compute/configuring-additional-ssh-keys).
@@ -191,7 +182,6 @@ Before creating your instance, we recommend to consider the way the instance wil
 
 <summary>Public Cloud Networking - Modes</summary>
 
-
 **Public Mode**
 
 Instances in Public Mode are exposed to the public Internet directly via IPv4/IPv6. IP addresses cannot be modified but instances can have [Additional IP](https://www.ovhcloud.com/en-gb/network/additional-ip/) addresses attached ([including your own](https://www.ovhcloud.com/en-gb/network/byoip/)) and they can be connected to a [vRack](https://www.ovhcloud.com/en-gb/network/vrack/).
@@ -203,13 +193,12 @@ Instances in Private Mode can only be exposed to the public Internet via a [Gate
 For more information, please consult our guides in the [Public Cloud Network Services](/guides/public-cloud/network-services/overview) section. The [Concepts guide](/guides/public-cloud/network-services/concepts) provides an introduction to Public Cloud Networking.
 
 **Local Private Mode**
- 
+
 Local Private Mode only applies if you create an instance in a **Local Zone**. They can be exposed to the public Internet directly via IPv4/IPv6. Only instances in the same Local Zone can be connected via private networks. Local Zones are not compatible with [vRack](https://www.ovhcloud.com/en-gb/network/vrack/). In this mode, DHCP automatically provides IP addresses to your instances.
 
 Find out more on the [Local Zones web page](https://www.ovhcloud.com/en-gb/public-cloud/local-zone-compute/).
 
 </details>
-
 
 ### Step 4: Create the instance
 
@@ -269,7 +258,7 @@ Find out more on the [Local Zones web page](https://www.ovhcloud.com/en-gb/publi
     The **Network settings** section is split into two parts:
 
     - **Private network**: Select an existing private network or click <code className="action">+ Create a private network</code>. If a private network is selected but does not have a gateway, toggle <code className="action">Assign a gateway</code> to attach a gateway automatically.
-    - **Assign public connectivity**: Enable the toggle to assign a public IP. Choose <code className="action">Basic Public IP</code> (free, tied to the instance lifetime, incompatible with a gateway) or <code className="action">Create a Floating IP (Reusable)</code> (persistent and reusable).
+    - **Assign public connectivity**: Enable the toggle to assign a public IP. Choose <code className="action">Basic Public IP</code> (free, tied to the instance lifetime, incompatible with a gateway) or <code className="action">Assign a Floating IP (Reusable)</code> (persistent and reusable).
 
     See [Step 3](#networking-modes) for an overview of networking modes.
 
@@ -425,7 +414,6 @@ If you have installed an **OS with application**, refer to our [guide on first s
 
 :::
 
-
 #### 5.1: Verify the instance status in the OVHcloud Control Panel
 
 Select <code className="action">Instances</code> in the left-hand navigation bar under **Compute**. Your instance is ready when the status is set to `Enabled` in the table. If the instance was recently created and has a different status, click on the "Refresh" button located next to the search filter.
@@ -452,7 +440,6 @@ This guide does not cover private networking for instances. Please consult our d
 
 :::
 
-
 #### 5.2: First login on an instance with a GNU/Linux OS installed
 
 :::info
@@ -462,7 +449,6 @@ If you still encounter issues, you can replace the key pair with the help of [th
 If you have created an instance without an SSH key, via the [OVHcloud API](/guides/manage-and-operate/api/first-steps) or the [OpenStack Horizon interface](/guides/public-cloud/compute/create-instance-in-horizon), you can only add an SSH key to your instance via [rescue mode](/guides/public-cloud/compute/put-an-instance-in-rescue-mode) by following the instructions set out in [this guide](/guides/public-cloud/compute/replacing-lost-ssh-key-pair).
 
 :::
-
 
 You can access your instance immediately after creation through the command line interface of your local device (`Terminal`, `Command prompt`, `Powershell`, etc.) via SSH.
 
@@ -505,7 +491,6 @@ You will then need to complete the initial setup of your Windows OS. Follow the 
   </Tab>
 </Tabs>
 
-
 ##### 5.3.2: Log in remotely from Windows
 
 On your local Windows device, you can use the `Remote Desktop Connection` client application to connect to your instance.
@@ -516,7 +501,6 @@ Enter the IPv4 address of your instance, then your username and passphrase. Usua
 If you experience any issues with this procedure, verify that remote (RDP) connections are allowed on your device by checking your system settings, firewall rules and possible network restrictions. 
 
 :::
-
 
 ##### 5.3.3: Log in remotely from another OS
 
@@ -540,7 +524,6 @@ The free and open-source software `Remmina Remote Desktop Client` is available f
   </Tab>
 </Tabs>
 
-
 #### 5.4: VNC console access
 
 The VNC console allows you to connect to your instances even when other means of access are not available.
@@ -556,7 +539,6 @@ Select <code className="action">Instances</code> in the left-hand navigation bar
   </Tab>
 </Tabs>
 
-
 ### Step 6: First steps on a new instance
 
 :::info
@@ -568,14 +550,12 @@ You can find more information in the [Go further](#go-further) section below.
 
 :::
 
-
 #### 6.1: User management
 
 :::info
 When configuring user accounts and permission levels on an instance, we recommend to make use of the information in our [user account guide](/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds).
 
 :::
-
 
 ##### 6.1.1: Set a password for the current user account
 
@@ -603,7 +583,6 @@ This step is not necessary and should only be executed if you have a viable reas
 The following example illustrates a temporary solution on an instance with Ubuntu installed. Note that you might need to adjust the commands according to your OS. It is not recommended to keep this configuration permanently because it adds a potential security risk by opening the system to SSH-based attacks.
 
 :::
-
 
 When [logged on to your instance](#step-6-first-steps-on-a-new-instance), open the pertinent configuration file with a text editor. Example:
 
@@ -661,7 +640,6 @@ Use our [dedicated guide](/guides/public-cloud/compute/configuring-additional-ss
 
 [How to get started with Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
-
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/en/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
@@ -1,8 +1,10 @@
 ---
 title: Shelve or pause an instance
 description: Learn how to shelve, pause or suspend a Public Cloud instance to temporarily free resources while keeping your IP address, and understand the billing impact of each option
-lastUpdated: 2026-02-27
+lastUpdated: 2026-05-25
 ---
+
+import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objective
 
@@ -50,26 +52,15 @@ The table below allows you to differentiate the options available on your instan
 |Term|Description|Billing|
 |---|---|---|
 |[Suspend (*shelve*)](#shelve-instance)|Retains the resources and data in your disk by creating a snapshot, all other resources are released. The main IP is also maintained|You are only billed for the snapshot.|
-|[Turn off (*suspend*)](#stop-suspend-instance)|Stores the VM state on disk, the resources dedicated to instance are still reserved.|You will still be billed the same price for your instance.|
-|[Pause](#pause-instance)|Stores the state of the VM in RAM, a paused instance becomes frozen.|You will still be billed the same price for your instance.|
+|[Turn off (*suspend*)](#stop-suspend-instance)|Stores the VM state on disk, the resources remain reserved.|You are billed at the same rate.|
+|[Pause](#pause-instance)|Stores the VM state in RAM, the instance remains frozen.|You are billed at the same rate.|
 
 ### Content overview
 
 - [Suspend (*shelve*) an instance](#shelve-instance)
-    - [From the OVHcloud Control Panel](#control-panel)
-    - [From the Horizon Interface](#horizon)
-    - [Using OpenStack/Nova APIs](#openstack-nova)
 - [Reactivate (*unshelve*) an instance](#unshelve-instance)
-    - [From the OVHcloud Control Panel](#control-panel-unshelve)
-    - [From the Horizon Interface](#horizon-unshelve)
-    - [Using OpenStack/Nova APIs](#openstack-nova-unshelve)
 - [Turn off (*suspend*) an instance](#stop-suspend-instance)
-    - [From the OVHcloud Control Panel](#stop-control-panel)
-    - [From the Horizon Interface](#stop-horizon)
-    - [Using OpenStack/Nova APIs](#stop-openstack-nova)
 - [Pause an instance](#pause-instance)
-    - [From the Horizon Interface](#pause-horizon)
-    - [Using OpenStack/Nova APIs](#pause-openstack-nova)
 
 <a name="shelve-instance"></a>
 
@@ -85,76 +76,81 @@ Suspending this type of instance leads to its decommissioning from the host, and
 
 This option releases the resources dedicated to your Public Cloud instance, but the IP address will remain. The data on your local disk will be stored in a snapshot automatically created once the instance is shelved. Data stored in the memory and elsewhere will not be retained.
 
-<a name="control-panel"></a>
+<Tabs>
+  <Tab label="From the OVHcloud Control Panel">
+    In the OVHcloud Control Panel, select your project from the <code className="action">Public Cloud</code> section. Click on <code className="action">Instances</code> in the left side menu.
 
-#### From the OVHcloud Control Panel
+    Click on the <code className="action">⋮</code> button to the right of the instance you want to suspend, then click on <code className="action">Suspend</code>.
 
-In the OVHcloud Control Panel, select your project from the <code className="action">Public Cloud</code> section. Click on <code className="action">Instances</code> in the left side menu.
+    <img className="thumbnail" alt="suspend instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
 
-Click on the <code className="action">⋮</code> button to the right of the instance you want to suspend, then click on <code className="action">Suspend</code>.
+    In the pop-up window, take note of the message and click on <code className="action">Confirm</code>.
 
-<img className="thumbnail" alt="suspend instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="confirm suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
 
-In the pop-up window, take note of the message and click on <code className="action">Confirm</code>.
+    A message will appear while the operation is in progress:
 
-<img className="thumbnail" alt="confirm suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="Operation in progress" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
 
-A message will appear while the operation is in progress:
+    Once the process is completed, your instance will now appear as *Suspended*.
 
-<img className="thumbnail" alt="Operation in progress" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="suspended status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
 
-Once the process is completed, your instance will now appear as *Suspended*.
+    To view the snapshot, click on <code className="action">Instance Backup</code> underneath the **Compute** tab in the left side menu. A snapshot named *xxxxx-shelved* will now be visible:
 
-<img className="thumbnail" alt="suspended status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="snapshot tab" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+  </Tab>
+  <Tab label="From the Horizon Interface">
+    To proceed, you need to [log in to the Horizon interface](https://horizon.cloud.ovh.net/auth/login/):
 
-To view the snapshot, click on <code className="action">Instance Backup</code> underneath the **Compute** tab in the left side menu. A snapshot named *xxxxx-shelved* will now be visible:
+    - To log in with OVHcloud Single Sign-On: use the <code className="action">Horizon</code> link in the left-hand menu under "Management Interfaces" after opening your <code className="action">Public Cloud</code> project in the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
 
-<img className="thumbnail" alt="snapshot tab" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+    - To log in with a specific OpenStack user: open the [Horizon login page](https://horizon.cloud.ovh.net/auth/login/) and enter the [OpenStack user credentials](/guides/public-cloud/cross-functional/create-and-delete-a-user) previously created, then click on <code className="action">Connect</code>.
 
-<a name="horizon"></a>
+    If you have deployed instances in different regions, make sure you are in the correct region. You can verify this on the top left corner in the Horizon interface.
 
-#### From the Horizon Interface
+    <img className="thumbnail" alt="horizon interface" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
 
-To proceed, you need to [log in to the Horizon interface](https://horizon.cloud.ovh.net/auth/login/):
+    Click on the <code className="action">Compute</code> menu on the left side and select <code className="action">Instances</code>. Select <code className="action">Shelve Instance</code> in the drop list for the corresponding instance.
 
-- To log in with OVHcloud Single Sign-On: use the <code className="action">Horizon</code> link in the left-hand menu under "Management Interfaces" after opening your <code className="action">Public Cloud</code> project in the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
+    <img className="thumbnail" alt="shelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
 
-- To log in with a specific OpenStack user: open the [Horizon login page](https://horizon.cloud.ovh.net/auth/login/) and enter the [OpenStack user credentials](/guides/public-cloud/cross-functional/create-and-delete-a-user) previously created, then click on <code className="action">Connect</code>.
+    Once the process is completed, your instance will now appear as *Shelved Offloaded*.
 
-If you have deployed instances in different regions, make sure you are in the correct region. You can verify this on the top left corner in the Horizon interface.
+    <img className="thumbnail" alt="shelved instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
 
-<img className="thumbnail" alt="horizon interface" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
+    To view the snapshot, in the <code className="action">Compute</code> menu, click on <code className="action">Images</code>.
 
-Click on the <code className="action">Compute</code> menu on the left side and select <code className="action">Instances</code>. Select <code className="action">Shelve Instance</code> in the drop list for the corresponding instance.
+    <img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+  </Tab>
+  <Tab label="Using OpenStack/Nova APIs">
+    Before proceeding, it is recommended that you consult these guides:
 
-<img className="thumbnail" alt="shelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
+    - [Prepare the environment to use the OpenStack API](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
+    - [Set OpenStack environment variables](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
 
-Once the process is completed, your instance will now appear as *Shelved Offloaded*.
+    Once your environment is ready, type the following at the command line:
 
-<img className="thumbnail" alt="shelved instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
+    ```bash
+    openstack server shelve <UUID server>
 
-To view the snapshot, in the <code className="action">Compute</code> menu, click on <code className="action">Images</code>.
+    =====================================
 
-<img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+    nova shelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="From the OVHcloud CLI">
+    Before proceeding, it is recommended that you consult these guides:
 
-<a name="openstack-nova"></a>
+    - [Getting started with the OVHcloud CLI](/guides/manage-and-operate/cli/getting-started)
 
-#### Using OpenStack/Nova APIs
+    Type the following command:
 
-Before proceeding, it is recommended that you consult these guides:
-
-- [Prepare the environment to use the OpenStack API](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
-- [Set OpenStack environment variables](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
-
-Once your environment is ready, type the following at the command line:
-
-```bash
-openstack server shelve <UUID server>
-
-=====================================
-
-nova shelve <UUID server> 
-```
+    ```shell
+    ovhcloud cloud instance shelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="unshelve-instance"></a>
 
@@ -170,43 +166,44 @@ Any actions on the snapshot other than *unshelve* can be very dangerous for your
 OVHcloud is providing you with machines that you are responsible for. We have no access to these machines, and therefore cannot manage them. You are responsible for your own software and security management. If you experience any issues or doubts when it comes to managing, using or securing your server, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/).
 :::
 
-<a name="control-panel-unshelve"></a>
+<Tabs>
+  <Tab label="From the OVHcloud Control Panel">
+    In the OVHcloud Control Panel, select your project from the <code className="action">Public Cloud</code> section and click on <code className="action">Instances</code> in the left side menu.
 
-#### From the OVHcloud Control Panel
+    Click on the <code className="action">⋮</code> button to the right of the instance, then click on <code className="action">Reactivate</code>.
 
-In the OVHcloud Control Panel, select your project from the <code className="action">Public Cloud</code> section and click on <code className="action">Instances</code> in the left side menu.
+    <img className="thumbnail" alt="reactivate instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
 
-Click on the <code className="action">⋮</code> button to the right of the instance, then click on <code className="action">Reactivate</code>.
+    In the pop-up window, take note of the message and click on <code className="action">Confirm</code>.
 
-<img className="thumbnail" alt="reactivate instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
+    Once the process is completed, the status of your instance will now appear as *Enabled*.
+  </Tab>
+  <Tab label="From the Horizon Interface">
+    In the Horizon interface, click on the <code className="action">Compute</code> menu on the left and then select <code className="action">Instances</code>. Select <code className="action">Unshelve Instance</code> in the drop list for the corresponding instance.
 
-In the pop-up window, take note of the message and click on <code className="action">Confirm</code>.
+    <img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
 
-Once the process is completed, the status of your instance will now appear as *Enabled*.
+    Once the process is completed, your instance will now appear as *Active*.
+  </Tab>
+  <Tab label="Using OpenStack/Nova APIs">
+    Once your environment is ready, type the following at the command line:
 
-<a name="horizon-unshelve"></a>
+    ```bash
+    ~$ openstack server unshelve <UUID server>
 
-#### From the Horizon interface
+    =========================================
 
-In the Horizon interface, click on the <code className="action">Compute</code> menu on the left and then select <code className="action">Instances</code>. Select <code className="action">Unshelve Instance</code> in the drop list for the corresponding instance.
+    ~$ nova unshelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="From the OVHcloud CLI">
+    Type the following command:
 
-<img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
-
-Once the process is completed, your instance will now appear as *Active*.
-
-<a name="openstack-nova-unshelve"></a>
-
-#### Using OpenStack/Nova APIs
-
-Once your environment is ready, type the following at the command line:
-
-```bash
-~$ openstack server unshelve <UUID server>
-
-=========================================
-
-~$ nova unshelve <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance shelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="stop-suspend-instance"></a>
 
@@ -214,65 +211,72 @@ Once your environment is ready, type the following at the command line:
 
 This option shuts down your instance and stores the VM state on disk, including memory.
 
-<a name="stop-control-panel"></a>
+<Tabs>
+  <Tab label="From the OVHcloud Control Panel">
+    In the OVHcloud Control Panel, select your project from the <code className="action">Public Cloud</code> section and click on <code className="action">Instances</code> in the left side menu.
 
-#### From the OVHcloud Control Panel
+    Click on the <code className="action">⋮</code> button to the right of the instance you want to stop, then click on <code className="action">Turn off</code>.
 
-In the OVHcloud Control Panel, select your project from the <code className="action">Public Cloud</code> section and click on <code className="action">Instances</code> in the left side menu.
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
 
-Click on the <code className="action">⋮</code> button to the right of the instance you want to stop, then click on <code className="action">Turn off</code>.
+    In the pop-up window, take note of the message and click on <code className="action">Confirm</code>.
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
 
-In the pop-up window, take note of the message and click on <code className="action">Confirm</code>.
+    Once the process is completed, your instance will now appear as *Off*.
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
+    <img className="thumbnail" alt="off status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_status_off.png" loading="lazy" />
 
-Once the process is completed, your instance will now appear as *Off*.
+    To **resume** the instance, perform the same steps as mentioned above. Click on the <code className="action">⋮</code> button to the right of the instance and select <code className="action">Start</code>. In some cases, you might need to do a cold reboot.
 
-<img className="thumbnail" alt="off status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_status_off.png" loading="lazy" />
+    <img className="thumbnail" alt="start instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/start_instance_2025.png" loading="lazy" />
 
-To **resume** the instance, perform the same steps as mentioned above. Click on the <code className="action">⋮</code> button to the right of the instance and select <code className="action">Start</code>. In some cases, you might need to do a cold reboot.
+    Once the process is completed, the status of your instance will now appear as *Enabled*.
+  </Tab>
+  <Tab label="From the Horizon Interface">
+    In the Horizon interface, click on the <code className="action">Compute</code> menu on the left and then select <code className="action">Instances</code>. Select <code className="action">Suspend Instance</code> in the drop list for the corresponding instance.
 
-<img className="thumbnail" alt="start instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/start_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="suspend instance Horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
 
-Once the process is completed, the status of your instance will now appear as *Enabled*.
+    The confirmation message will appear, indicating that the instance has been suspended.
 
-<a name="stop-horizon"></a>
+    To **resume** the instance, perform the same steps as mentioned above. In the drop list for the corresponding instance select <code className="action">Resume Instance</code>.
+  </Tab>
+  <Tab label="Using OpenStack/Nova APIs">
+    Once your environment is ready, type the following at the command line:
 
-#### From the Horizon interface 
+    ```bash
+    ~$ openstack server suspend <UUID server>
 
-In the Horizon interface, click on the <code className="action">Compute</code> menu on the left and then select <code className="action">Instances</code>. Select <code className="action">Suspend Instance</code> in the drop list for the corresponding instance.
+    =========================================
 
-<img className="thumbnail" alt="suspend instance Horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
+    ~$ nova suspend <UUID server>
+    ```
 
-The confirmation message will appear, indicating that the instance has been suspended.
+    To **resume** the instance, type the following at the command line:
 
-To **resume** the instance, perform the same steps as mentioned above. In the drop list for the corresponding instance select <code className="action">Resume Instance</code>.
+    ```bash
+    ~$ openstack server unsuspend <UUID server>
 
-<a name="stop-openstack-nova"></a>
+    =========================================
 
-#### Using OpenStack/Nova API
+    ~$ nova unsuspend <UUID server>
+    ```
+  </Tab>
+  <Tab label="From the OVHcloud CLI">
+    Type the following command:
 
-Once your environment is ready, type the following at the command line:
+    ```shell
+    ovhcloud cloud instance stop <instance_id>
+    ```
 
-```bash
-~$ openstack server suspend <UUID server>
+    To **resume** the instance, type the following command:
 
-=========================================
-
-~$ nova suspend <UUID server>
-```
-
-To **resume** the instance, type the following at the command line:
-
-```bash
-~$ openstack server unsuspend <UUID server>
-
-=========================================
-
-~$ nova unsuspend <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance start <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="pause-instance"></a>
 
@@ -280,41 +284,38 @@ To **resume** the instance, type the following at the command line:
 
 This action is **only** possible in the Horizon interface or via the OpenStack/Nova API. It allows you to *freeze* your instance.
 
-<a name="pause-horizon"></a>
+<Tabs>
+  <Tab label="From the Horizon Interface">
+    In the Horizon interface, click on the <code className="action">Compute</code> menu on the left and then select <code className="action">Instances</code>. Select <code className="action">Pause Instance</code> in the drop list for the corresponding instance.
 
-#### From the Horizon Interface
+    <img className="thumbnail" alt="Pause instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
 
-In the Horizon interface, click on the <code className="action">Compute</code> menu on the left and then select <code className="action">Instances</code>. Select <code className="action">Pause Instance</code> in the drop list for the corresponding instance.
+    The confirmation message will appear, indicating that the instance has been paused.
 
-<img className="thumbnail" alt="Pause instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
+    To **unpause** the instance, perform the same steps as mentioned above. In the drop list for the corresponding instance select <code className="action">Resume Instance</code>.
+  </Tab>
+  <Tab label="Using OpenStack/Nova APIs">
+    Once your environment is ready, type the following at the command line:
 
-The confirmation message will appear, indicating that the instance has been paused.
+    ```bash
+    ~$ openstack server pause <UUID server>
 
-To **unpause** the instance, perform the same steps as mentioned above. In the drop list for the corresponding instance select <code className="action">Resume Instance</code>.
+    =========================================
 
-<a name="pause-openstack-nova"></a>
+    ~$ nova pause <UUID server>
+    ```
 
-#### Using OpenStack/Nova APIs
+    To **unpause** the instance, type the following at the command line:
 
-Once your environment is ready, type the following at the command line:
+    ```bash
+    ~$ openstack server unpause <UUID server>
 
-```bash
-~$ openstack server pause <UUID server>
+    =========================================
 
-=========================================
-
-~$ nova pause <UUID server>
-```
-
-To **unpause** the instance, type the following at the command line:
-
-```bash
-~$ openstack server unpause <UUID server>
-
-=========================================
-
-~$ nova unpause <UUID server>
-```
+    ~$ nova unpause <UUID server>
+    ```
+  </Tab>
+</Tabs>
 
 ## Go further
 

--- a/docs/en/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Shelve or pause an instance
 description: Learn how to shelve, pause or suspend a Public Cloud instance to temporarily free resources while keeping your IP address, and understand the billing impact of each option
-lastUpdated: 2026-05-25
+lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -14,7 +14,6 @@ As part of the configuration of a high-availability infrastructure, you may need
 The naming of these options in the OVHcloud Control Panel is different from the naming in OpenStack/Horizon. If you are doing this via the OVHcloud Control Panel, make sure you select the right option.
 
 :::
-
 
 **This guide explains how to shelve, pause or suspend your instance.**
 
@@ -46,7 +45,6 @@ The naming of these options in the OVHcloud Control Panel is different from the 
 
 :::
 
-
 The table below allows you to differentiate the options available on your instances. Continue reading this guide by clicking on the option of your choice. We put the terminology used in the **Horizon interface** in brackets.
 
 |Term|Description|Billing|
@@ -72,7 +70,6 @@ Please note that suspending an IOPS or T1/T2-180 instance will result in the los
 Suspending this type of instance leads to its decommissioning from the host, and therefore from the disks in passthrough.
 
 :::
-
 
 This option releases the resources dedicated to your Public Cloud instance, but the IP address will remain. The data on your local disk will be stored in a snapshot automatically created once the instance is shelved. Data stored in the memory and elsewhere will not be retained.
 
@@ -163,7 +160,7 @@ This option will allow you to re-up your instance so that you can continue using
 
 Any actions on the snapshot other than *unshelve* can be very dangerous for your infrastructure in case of misuse. Once you *unshelve* an instance, the snapshot is automatically deleted. It is not recommended to deploy a new instance from any snapshot created as a result of shelving (suspending) an instance.
 
-OVHcloud is providing you with machines that you are responsible for. We have no access to these machines, and therefore cannot manage them. You are responsible for your own software and security management. If you experience any issues or doubts when it comes to managing, using or securing your server, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/).
+OVHcloud is providing you with machines that you are responsible for. We have no access to these machines, and therefore cannot manage them. You are responsible for your own software and security management. If you experience any issues or doubts when it comes to managing, using or securing your server, we recommend that you contact a [specialist service provider](/links/partner).
 :::
 
 <Tabs>
@@ -200,7 +197,7 @@ OVHcloud is providing you with machines that you are responsible for. We have no
     Type the following command:
 
     ```shell
-    ovhcloud cloud instance shelve <instance_id>
+    ovhcloud cloud instance unshelve <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -321,4 +318,4 @@ This action is **only** possible in the Horizon interface or via the OpenStack/N
 
 [OpenStack documentation](https://docs.openstack.org/ocata/user-guide/cli-stop-and-start-an-instance.html).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/es/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/es/guides/public-cloud/compute/getting-started.mdx
@@ -1,13 +1,10 @@
 ---
 title: Cómo crear una instancia de Public Cloud y conectarse a ella
 description: Descubra cómo configurar instancias de Public Cloud en el área de cliente de OVHcloud y los primeros pasos con sus instancias
-lastUpdated: 2026-02-24
+lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
-
-
-
 
 ## Objetivo
 
@@ -15,7 +12,6 @@ Las instancias de Public Cloud son fáciles de desplegar y gestionar. Sin embarg
 A continuación, podrá ir más allá con su proyecto de Public Cloud en función de sus necesidades.
 
 **Esta guía explica los primeros pasos con una instancia de Public Cloud.**
-
 
 ## Requisitos
 
@@ -37,7 +33,6 @@ Benefíciese de precios reducidos comprometiéndose por un periodo de 1 a 36 mes
 
 :::
 
-
 ## Procedimiento
 
 :::info
@@ -46,7 +41,6 @@ Si todavía no ha creado ningún proyecto de Public Cloud, comience por nuestra 
 **Los detalles técnicos** importantes relativos al Public Cloud de OVHcloud están disponibles en [esta página](/guides/public-cloud/cross-functional/compute-essential-information).
 
 :::
-
 
 ### Presentación del contenido
 
@@ -58,19 +52,6 @@ Si todavía no ha creado ningún proyecto de Public Cloud, comience por nuestra 
   - [Paso 2: Importar las claves SSH](#paso-2-importar-las-claves-ssh)
   - [Paso 3: preparar la configuración de red](#paso-3-preparar-la-configuracion-de-red)
   - [Paso 4: crear la instancia](#paso-4-crear-la-instancia)
-    - [Paso 4.1: Nombre de la instancia](#paso-41-nombre-de-la-instancia)
-    - [Paso 4.2: Seleccione una localización](#paso-42-seleccione-una-localizacion)
-    - [Paso 4.3: Seleccione un modelo](#paso-43-seleccione-un-modelo)
-      - [Información adicional](#informacion-adicional)
-    - [Paso 4.4: Seleccione una imagen](#paso-44-seleccione-una-imagen)
-    - [Paso 4.5: Seleccione una clave SSH (no aplicable a las instancias Windows)](#paso-45-seleccione-una-clave-ssh-no-aplicable-a-las-instancias-windows)
-    - [Paso 4.6: Configure los parámetros de backup](#paso-46-configure-los-parametros-de-backup)
-    - [Paso 4.7: Configure la red](#paso-47-configure-la-red)
-    - [Paso 4.8: Seleccione un período de facturación](#paso-48-seleccione-un-periodo-de-facturacion)
-    - [Paso 4.9: Configure los parámetros avanzados](#paso-49-configure-los-parametros-avanzados)
-      - [Instancia flexible](#instancia-flexible)
-      - [Script de post-instalación](#script-de-post-instalacion)
-    - [Paso 4.10: Finalización de la instancia](#paso-410-finalizacion-de-la-instancia)
   - [Paso 5: Conectarse a la instancia](#paso-5-conectarse-a-la-instancia)
     - [5.1: Verificar el estado de la instancia en el área de cliente](#51-verificar-el-estado-de-la-instancia-en-el-area-de-cliente)
     - [5.2: Primera conexión a una instancia con sistema operativo GNU/Linux](#52-primera-conexion-a-una-instancia-con-sistema-operativo-gnulinux)
@@ -93,7 +74,6 @@ Si todavía no ha creado ningún proyecto de Public Cloud, comience por nuestra 
 
 :::
 
-
 ### Paso 1: crear un juego de claves SSH
 
 Si ya dispone de un par de claves SSH listo para usar, puede omitir este paso.
@@ -114,7 +94,7 @@ Si utiliza otro software, consulte su documentación de usuario. Las instruccion
 
 ### Paso 2: Importar las claves SSH
 
-Puede almacenar sus claves SSH públicas en la sección <code className="action">Public Cloud</code> de su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>. No es obligatorio, pero hace que el proceso de creación de instancias sea más práctico.
+Puede almacenar sus claves SSH públicas en su proyecto Public Cloud. No es obligatorio, pero hace que el proceso de creación de instancias sea más práctico.
 
 :::info
 Las claves SSH almacenadas le permiten crear sus instancias más rápidamente en el área de cliente. Para cambiar los pares de claves y añadir usuarios una vez creada la instancia, consulte la guía sobre [las claves SSH adicionales](/guides/public-cloud/compute/configuring-additional-ssh-keys).
@@ -123,16 +103,71 @@ Las claves SSH públicas añadidas al área de cliente de OVHcloud estarán disp
 
 :::
 
+<Tabs>
+  <Tab label="Desde el área de cliente">
+    Conéctese al <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, acceda a la sección <code className="action">Public Cloud</code> y seleccione el proyecto Public Cloud correspondiente.
 
-Abra <code className="action">Claves SSH</code> en el menú de la izquierda en **Parámetros**. Haga clic en el botón <code className="action">Añadir una clave SSH</code>.
+    Abra <code className="action">Claves SSH</code> en el menú de la izquierda en **Parámetros**. Haga clic en el botón <code className="action">Añadir una clave SSH</code>.
 
-<img className="thumbnail" alt="ssh keys" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+    En la nueva ventana, introduzca un nombre para la clave. Rellene el campo `Clave` con su cadena de clave pública, por ejemplo, la creada en el [paso 1](#paso-1-crear-un-juego-de-claves-ssh). Confirme haciendo clic en <code className="action">Añadir</code>.
 
-En la nueva ventana, introduzca un nombre para la clave. Rellene el campo `Clave` con su cadena de clave pública, por ejemplo, la creada en el [paso 1](#paso-1-crear-un-juego-de-claves-ssh). Confirme haciendo clic en <code className="action">Añadir</code>.
+    Ahora puede seleccionar esta clave en el [Paso 4](#paso-4-crear-la-instancia) para añadirla a una nueva instancia.
+  </Tab>
+  <Tab label="Desde la API de OVHcloud">
+    Utilice la siguiente llamada para importar su clave SSH pública:
 
-<img className="thumbnail" alt="add key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
+    > **POST** `/cloud/project/{serviceName}/sshkey`
 
-Ahora puede seleccionar esta clave en el [Paso 4](#paso-4-crear-la-instancia) para añadirla a una nueva instancia.
+    Parámetros:
+
+    - `serviceName`: identificador de su proyecto Public Cloud
+    - `name`: nombre de la clave SSH
+    - `publicKey`: contenido de su clave pública
+
+    Anote el `id` devuelto, que será necesario al crear la instancia.
+  </Tab>
+  <Tab label="Desde la CLI de OVHcloud">
+    Asegúrese de haber instalado y configurado la [CLI de OVHcloud](https://github.com/ovh/ovhcloud-cli) y, a continuación, importe su clave:
+
+    ```bash
+    ovhcloud cloud ssh-key create \
+      --cloud-project <project_id> \
+      --name my-key \
+      --public-key "$(cat ~/.ssh/id_rsa.pub)"
+    ```
+
+    Compruebe la importación y anote el `name` de la clave para el [Paso 4](#paso-4-crear-la-instancia):
+
+    ```bash
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="Desde la CLI de OpenStack">
+    Asegúrese de haber configurado su entorno OpenStack ([guía dedicada](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)) y, a continuación, importe su clave:
+
+    ```bash
+    openstack keypair create --public-key ~/.ssh/id_rsa.pub my-key
+    ```
+
+    Compruebe la importación:
+
+    ```bash
+    openstack keypair list
+    ```
+  </Tab>
+  <Tab label="Desde Terraform">
+    Declare el recurso en su archivo `.tf`:
+
+    ```hcl
+    resource "openstack_compute_keypair_v2" "my_keypair" {
+      name       = "my-key"
+      public_key = file("~/.ssh/id_rsa.pub")
+    }
+    ```
+
+    Consulte la [guía de Terraform para el Public Cloud de OVHcloud](/guides/public-cloud/cross-functional/how-to-use-terraform) para la configuración inicial del provider.
+  </Tab>
+</Tabs>
 
 ### Paso 3: preparar la configuración de red
 
@@ -146,7 +181,6 @@ Antes de crear su instancia, le recomendamos que analice cómo se utilizará la 
 <details>
 
 <summary>Public Cloud Networking - Modos</summary>
-
 
 **Modo Público**
 
@@ -166,200 +200,205 @@ Para más información, consulte la [página web de Local Zones](https://www.ovh
 
 </details>
 
-
 ### Paso 4: crear la instancia
 
-:::info
-Se requiere una clave SSH pública al crear una instancia en el área de cliente de OVHcloud (excepto las instancias Windows).
-
-Consulte el [paso 1](#paso-1-crear-un-juego-de-claves-ssh) y el [paso 2](#paso-2-importar-las-claves-ssh) de esta guía si no dispone de claves SSH listas para usar.
-
-:::
-
-
-En la página **Inicio**, haga clic en <code className="action">Crear una instancia</code>.
-
-#### Paso 4.1: Nombre de la instancia
-
-Introduzca un nombre completo para su instancia. La referencia comercial del modelo de instancia es el valor por defecto. Si es necesario, también puede añadir la región y la fecha para facilitar la identificación y la gestión de sus instancias.
-
-#### Paso 4.2: Seleccione una localización
-
-Seleccione una [localización](https://www.ovhcloud.com/es-es/public-cloud/regions-availability/) lo más cercana posible a sus usuarios o clientes. Tenga en cuenta que si selecciona una **Local Zone** en este paso, se aplicarán limitaciones de red a la instancia (ver [Paso 3](#networking-modes)).
-
-Consulte también la información de nuestra [página web sobre las Local Zones](https://www.ovhcloud.com/es-es/public-cloud/local-zone-compute/) y de la [documentación de capacidades de las Local Zones](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-La elección de la región determina el modo de despliegue de su instancia (1-AZ, 3-AZ o Local Zones). Para comprender las diferencias en términos de resiliencia, disponibilidad y arquitectura, consulte nuestra guía [Comparación y resiliencia de los modos de despliegue – Entender las regiones 3-AZ / 1-AZ / Local Zones](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details).
-
-#### Paso 4.3: Seleccione un modelo
-
-En este paso, elegirá el modelo de instancia (también llamado flavour), que determina los recursos asignados a su instancia: procesador, memoria y capacidades asociadas. Abra la lista desplegable `Modelo de instancia` y seleccione el tipo de modelo más adecuado a su caso de uso para acceder a nuestra gama de instancias optimizadas.
-
-El tipo de modelo `Discovery` agrupa instancias con recursos compartidos, ofrecidas a precios competitivos. Son especialmente adecuadas para descubrir el Public Cloud de OVHcloud, realizar pruebas o alojar cargas de trabajo ligeras como aplicaciones web.
-
-Los modelos `Metal Instances` ofrecen recursos físicos totalmente dedicados, garantizando un rendimiento constante y un aislamiento máximo para las cargas de trabajo más exigentes.
-
-:::info
-El total de recursos de Public Cloud se limitará inicialmente por motivos de control de costes y seguridad. Puede comprobar estas cuotas haciendo clic en <code className="action">Cuotas y regiones</code> en la barra de navegación de la izquierda en **Parámetros**. Consulte [la documentación dedicada](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) para obtener más información.
-
-Tenga en cuenta que puede **mejorar** su instancia una vez creada para tener más recursos disponibles. Sin embargo, no es posible cambiar a un modelo más pequeño con una instancia regular. Encontrará más información sobre este tema en el **paso 4.9** a continuación.
-
-:::
-
-
-##### Información adicional
-
-<details>
-
-<summary>Categorías de modelos de instancia</summary>
-
-
-| Tipo | Recursos garantizados | Notas de uso |
-| :---         |     :---:      |          :--- |
-| Best Sellers   | ✓     | Modelos más utilizados.    |
-| General Purpose   | ✓     | Servidores de desarrollo, aplicaciones web o empresariales    |
-| Compute Optimized     | ✓       | Codificación de vídeo u otra computación de alto rendimiento      |
-| Memory Optimized    | ✓     | Bases de datos, análisis y cálculos en memoria    |
-| Storage Optimized   | ✓     | Optimizado para la transferencia de datos en disco    |
-| Discovery    | -       | Alojamiento en recursos compartidos para entornos de prueba y desarrollo      |
-| Cloud GPU     | ✓       | Potencia de procesamiento masivamente paralela para aplicaciones especializadas (renderizado, big data, deep learning, etc.)       |
-| Metal Instances | ✓ | Recursos dedicados con acceso directo a los recursos de cálculo, almacenamiento y red|
-
-</details>
-
-
-<details>
-
-<summary>Regiones y Local Zones</summary>
-
-
-**Regiones**
-
-Una **región** se define como una ubicación en el mundo formada por uno o varios datacenters en los que están alojados los servicios de OVHcloud. Puede encontrar más información sobre las regiones, la distribución geográfica y la disponibilidad de los servicios en nuestra [página web dedicada](https://www.ovhcloud.com/es-es/public-cloud/regions-availability/) y nuestra [página web sobre las localizaciones de las infraestructuras de OVHcloud](https://www.ovhcloud.com/es-es/about-us/global-infrastructure/regions/).
-
-**Local Zones**
-
-Las Local Zones son una extensión de las **regiones** que acercan los servicios de OVHcloud a sitios específicos, ofreciendo una latencia reducida y un rendimiento mejorado para las aplicaciones. Puede encontrar más información en la [página web de Local Zones](https://www.ovhcloud.com/es-es/public-cloud/local-zone-compute/) y en la [documentación de capacidades de las Local Zones](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-</details>
-
-
-#### Paso 4.4: Seleccione una imagen
-
-Abra la lista desplegable `Tipo de distribución`, seleccione la categoría correspondiente a su necesidad y, a continuación, elija el sistema operativo que desea desplegar en su instancia a través del menú desplegable `Versión de la imagen`.
-
-Las imágenes disponibles en este paso dependen de las opciones elegidas en los pasos anteriores, es decir, de la compatibilidad con el modelo de instancia y de la disponibilidad regional. Por ejemplo, si desea seleccionar un sistema operativo Windows y no hay opciones en la pestaña Windows, debe modificar sus opciones de los pasos anteriores.
-
-:::info
-Si elige un sistema operativo que requiera una licencia de pago, estos costes se incluirán automáticamente en la facturación del proyecto.
-
-:::
-
-
-#### Paso 4.5: Seleccione una clave SSH (no aplicable a las instancias Windows)
-
-A excepción de las instancias Windows, la configuración de la instancia también requiere **la adición de una clave SSH pública**. Tiene dos opciones:
-
-- Utilizar una clave pública ya almacenada en el área de cliente de OVHcloud
-- Introducir directamente una clave pública
-
-Haga clic en las pestañas siguientes para ver su presentación:
-
 <Tabs>
-  <Tab label="Utilizar una clave almacenada">
-    Para añadir una clave almacenada en el área de cliente de OVHcloud (consulte [Paso 2](#paso-2-importar-las-claves-ssh)), selecciónela en la lista.
+  <Tab label="Desde el área de cliente">
+    :::info
+    Se requiere una clave SSH pública al crear una instancia (excepto las instancias Windows). Consulte el [paso 1](#paso-1-crear-un-juego-de-claves-ssh) y el [paso 2](#paso-2-importar-las-claves-ssh) si no dispone de claves listas para usar.
+
+    :::
+
+    Conéctese al <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, acceda a la sección <code className="action">Public Cloud</code> y seleccione el proyecto Public Cloud correspondiente. En la página **Inicio**, haga clic en <code className="action">Crear una instancia</code>.
+
+    **4.1 Nombre**
+
+    Introduzca un nombre completo para su instancia.
+
+    **4.2 Localización**
+
+    Seleccione una [localización](https://www.ovhcloud.com/es-es/public-cloud/regions-availability/) cercana a sus usuarios. Si selecciona una **Local Zone**, se aplicarán limitaciones de red (ver [Paso 3](#networking-modes)). Consulte la guía [Comparación de los modos de despliegue](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details) para conocer las diferencias entre 3-AZ, 1-AZ y Local Zones.
+
+    **4.3 Modelo**
+
+    Abra la lista desplegable `Modelo de instancia` y seleccione el tipo adecuado a su caso de uso. El modelo (flavor) determina los recursos asignados a su instancia: procesador, memoria y capacidades asociadas.
+
+    | Tipo | Recursos garantizados | Notas de uso |
+    | :--- | :---: | :--- |
+    | Best Sellers | ✓ | Modelos más utilizados. |
+    | General Purpose | ✓ | Servidores de desarrollo, aplicaciones web o empresariales. |
+    | Compute Optimized | ✓ | Codificación de vídeo u otra computación de alto rendimiento. |
+    | Memory Optimized | ✓ | Bases de datos, análisis y cálculos en memoria. |
+    | GPU | ✓ | Potencia de procesamiento masivamente paralela para aplicaciones especializadas (renderizado, big data, deep learning, etc.). |
+    | Discovery | - | Recursos compartidos para entornos de prueba y desarrollo. |
+    | Storage Optimized | ✓ | Optimizado para la transferencia de datos en disco. |
+    | Metal Instances | ✓ | Recursos dedicados con acceso directo a los recursos de cálculo, almacenamiento y red. |
+
+    :::info
+    El total de recursos de Public Cloud se limitará inicialmente. Compruebe sus cuotas a través de <code className="action">Cuotas y regiones</code> en **Parámetros**, en la barra de navegación de la izquierda. Consulte [la documentación dedicada](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) para obtener más información.
+
+    Puede **mejorar** su instancia una vez creada para disponer de más recursos. Sin embargo, no es posible cambiar a un modelo inferior con una instancia regular. Consulte el **paso 4.9** para obtener más información.
+
+    :::
+
+    **4.4 Imagen**
+
+    Seleccione el sistema operativo a través de los menús `Tipo de distribución` y `Versión de la imagen`. Las opciones disponibles dependen del modelo y de la región elegidos.
+
+    **4.5 Clave SSH** *(no aplicable a las instancias Windows)*
+
+    Seleccione una clave SSH almacenada en la lista (ver [Paso 2](#paso-2-importar-las-claves-ssh)), o haga clic en <code className="action">Crear una nueva llave SSH</code> para introducir directamente una clave pública.
+
+    **4.6 Backup**
+
+    Los [backups automatizados](/guides/public-cloud/compute/save-an-instance) están activados por defecto. Seleccione la rotación deseada (7 o 14 días).
+
+    **4.7 Red**
+
+    La sección **Parámetros de red** se divide en dos partes:
+
+    - **Private network**: seleccione una red privada existente o haga clic en <code className="action">Crear una red privada</code>. Si selecciona una red privada que no dispone de gateway, active el botón conmutador <code className="action">Asignar un servicio Gateway</code> para asociar una gateway automáticamente.
+    - **Asignar una conectividad pública**: active el botón conmutador para asignar una IP pública. Elija <code className="action">Basic Public IP</code> (gratuita, vinculada a la duración de vida de la instancia, incompatible con una gateway) o <code className="action">Asignar una Floating IP (Reutilizable)</code> (persistente y reutilizable).
+
+    Consulte el [Paso 3](#networking-modes) para obtener una visión general de los modos de red.
+
+    **4.8 Facturación**
+
+    Elija entre **mensual** (coste reducido, no reversible) o **por horas** (flexible, [convertible a mensual](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing) más adelante). La facturación por horas se aplica hasta la **eliminación de la instancia**. Consulte la [documentación de facturación](/guides/public-cloud/cross-functional/analyze-billing).
+
+    **4.9 Parámetros avanzados** *(opcional)*
+
+    - **Instancia flexible**: disco único de 50 GB, permite el redimensionamiento hacia modelos superiores o inferiores.
+    - **Script de post-instalación**: añada su [script de post-instalación](/guides/public-cloud/compute/launching-script-when-creating-instance).
+
+    **4.10 Finalización**
+
+    Compruebe el resumen en el lado derecho de la pantalla y configure el número de instancias. Haga clic en <code className="action">Lanzar mi instancia</code>. La entrega puede tardar unos minutos.
   </Tab>
-  <Tab label="Introducir directamente una clave">
-    Para añadir una clave pública pegando la cadena de clave, haga clic en el botón <code className="action">Crear una nueva llave SSH</code>.
-    
-    Introduzca un nombre para la clave y la cadena de clave en los campos respectivos. Haga clic en <code className="action">Validar la clave</code>.
+  <Tab label="Desde la API de OVHcloud">
+    Obtenga los identificadores necesarios:
+
+    ```
+    GET /cloud/project/{serviceName}/flavor     → flavorId
+    GET /cloud/project/{serviceName}/image      → imageId
+    GET /cloud/project/{serviceName}/region     → region
+    GET /cloud/project/{serviceName}/sshkey     → sshKeyId
+    ```
+
+    Cree la instancia:
+
+    > **POST** `/cloud/project/{serviceName}/instance`
+
+    Parámetros principales:
+
+    - `name`: nombre de la instancia
+    - `flavorId`: ID del modelo
+    - `imageId`: ID de la imagen del SO
+    - `region`: región de despliegue
+    - `sshKeyId`: ID de la clave SSH (del [paso 2](#paso-2-importar-las-claves-ssh))
+    - `monthlyBilling`: `true` para una facturación mensual
+
+    Consulte la [documentación de la API de OVHcloud](/guides/manage-and-operate/api/first-steps) para configurar su acceso a la API.
+  </Tab>
+  <Tab label="Desde la CLI de OVHcloud">
+    Obtenga los identificadores necesarios:
+
+    ```bash
+    ovhcloud cloud reference list-flavors --cloud-project <project_id>
+    ovhcloud cloud reference list-images --cloud-project <project_id>
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+
+    Cree la instancia:
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --name my-instance \
+      --boot-from.image <image_id> \
+      --flavor <flavor_id> \
+      --ssh-key.name my-key \
+      --network.public \
+      --wait
+    ```
+
+    Sustituya `GRA9` por su región. Para una creación interactiva con selección guiada:
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --editor \
+      --image-selector \
+      --flavor-selector
+    ```
+
+    Compruebe el estado tras la creación:
+
+    ```bash
+    ovhcloud cloud instance list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="Desde la CLI de OpenStack">
+    Obtenga la información necesaria:
+
+    ```bash
+    openstack flavor list
+    openstack image list --property visibility=public
+    openstack keypair list
+    ```
+
+    Cree la instancia:
+
+    ```bash
+    openstack server create \
+      --flavor b2-7 \
+      --image "Ubuntu 24.04" \
+      --key-name my-key \
+      --network Ext-Net \
+      my-instance
+    ```
+
+    Compruebe el estado:
+
+    ```bash
+    openstack server list
+    openstack server show my-instance
+    ```
+
+    Consulte la [guía de preparación del entorno OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) para la configuración inicial.
+  </Tab>
+  <Tab label="Desde Terraform">
+    Ejemplo de configuración completa:
+
+    ```hcl
+    data "openstack_images_image_v2" "ubuntu" {
+      name        = "Ubuntu 24.04"
+      most_recent = true
+    }
+
+    resource "openstack_compute_instance_v2" "my_instance" {
+      name            = "my-instance"
+      flavor_name     = "b2-7"
+      key_pair        = openstack_compute_keypair_v2.my_keypair.name
+      security_groups = ["default"]
+
+      block_device {
+        uuid                  = data.openstack_images_image_v2.ubuntu.id
+        source_type           = "image"
+        destination_type      = "local"
+        boot_index            = 0
+        delete_on_termination = true
+      }
+
+      network {
+        name = "Ext-Net"
+      }
+    }
+    ```
+
+    Consulte la [guía de Terraform para el Public Cloud de OVHcloud](/guides/public-cloud/cross-functional/how-to-use-terraform) para la configuración inicial del provider y la autenticación.
   </Tab>
 </Tabs>
-
-
-
-#### Paso 4.6: Configure los parámetros de backup
-
-Los [backups automatizados](/guides/public-cloud/compute/save-an-instance) están activados por defecto. Consulte la información sobre precios y los detalles complementarios antes de continuar.
-
-A continuación, seleccione el tipo de rotación, es decir, el número máximo de backups conservados en el historial: 7 o 14 días.
-
-#### Paso 4.7: Configure la red
-
-En este paso, configurará la red de su instancia.
-
-**Red privada**
-
-Puede conectar su instancia a una [red privada](#networking-modes) y asignarle una [Floating IP](https://www.ovhcloud.com/es-es/public-cloud/floating-ip/).
-
-Haciendo clic en <code className="action">Crear una red privada</code>, puede crear una directamente:
-
-- Nombrar la red
-- **Elegir el VLAN ID:** identificador que permite interconectar varios servicios y recursos dentro de una misma red privada, a través de un número de segmentación de red común
-- **Definir el CIDR:** rango de direcciones IP de la red
-- **Activar el DHCP marcando la casilla correspondiente, si es necesario:** active esta opción si desea una asignación automática de direcciones IP
-
-:::info
-La instancia puede permanecer totalmente privada si no le asigna una IP pública.
-
-:::
-
-
-**Gateway**
-
-Puede activar la opción para asignar una gateway a su red. Por defecto, la gateway es de tamaño S, pero podrá ajustar su tamaño más adelante en los parámetros.
-
-**Asignar una conectividad pública**
-
-Puede activar o desactivar esta funcionalidad según sus necesidades. Si decide activarla, tiene dos opciones:
-
-- **Basic Public IP:** una dirección IP pública temporal, que no persiste más allá de la duración de vida de la instancia. Tenga en cuenta que el uso de una Basic Public IP no es compatible con una gateway.
-- **Floating IP:** puede crear una nueva Floating IP o reutilizar una dirección existente, lo que permite una IP pública persistente y desvinculable de la instancia.
-
-#### Paso 4.8: Seleccione un período de facturación
-
-:::info
-Tenga en cuenta que, según el modelo de instancia elegido, la facturación **por horas** puede ser la única opción mostrada. Se trata de una limitación temporal. Pronto estarán disponibles nuevas opciones de facturación de Public Cloud.
-
-:::
-
-
-<Tabs>
-  <Tab label="Facturación mensual">
-    La facturación mensual conlleva una reducción de los costes a lo largo del tiempo, pero **no puede cambiarse** a facturación por horas una vez creada la instancia.
-  </Tab>
-  <Tab label="Facturación por horas">
-    La facturación por horas es la mejor opción si no ha determinado claramente la duración del período de uso. Si decide conservar la instancia para su uso a largo plazo, puede [cambiar a una suscripción mensual](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing).
-    
-    La instancia se facturará mientras no se **elimine**, independientemente del uso real de la instancia.
-  </Tab>
-</Tabs>
-
-
-A continuación se muestra nuestra documentación de facturación dedicada:
-
-- [Facturación de Public Cloud](/guides/public-cloud/cross-functional/analyze-billing)
-- [FAQ sobre la facturación mensual](/guides/public-cloud/compute/faq-change-of-monthly-billing-method)
-
-Una vez finalizada la configuración de su instancia, puede hacer clic en el botón <code className="action">Lanzar mi instancia</code> o configurar los parámetros avanzados (ver a continuación). La entrega del servicio puede tardar unos minutos.
-
-#### Paso 4.9: Configure los parámetros avanzados
-
-##### Instancia flexible
-
-Una instancia Flex es una instancia con un único disco de 50 GB, diseñada para ofrecer un proceso de creación y restauración de snapshots más rápido.
-
-Permite redimensionar la instancia hacia modelos superiores o inferiores, manteniendo un espacio de almacenamiento fijo. Los modelos clásicos solo permiten un redimensionamiento hacia modelos superiores.
-
-##### Script de post-instalación
-
-Puede añadir [su script de post-instalación](/guides/public-cloud/compute/launching-script-when-creating-instance) en este campo.
-
-#### Paso 4.10: Finalización de la instancia
-
-En el lado derecho de su pantalla, se encuentra el resumen de su configuración. En esta sección, podrá configurar el número de instancias a crear. Puede crear varias instancias en función de las selecciones realizadas durante los pasos de creación, pero se aplicarán [los límites de cuota de recursos](/guides/public-cloud/cross-functional/increasing-public-cloud-quota).
-
-Una vez finalizada la configuración de su instancia, haga clic en el botón <code className="action">Lanzar mi instancia</code>. La entrega del servicio puede tardar unos minutos.
 
 ### Paso 5: Conectarse a la instancia
 
@@ -375,18 +414,24 @@ Si ha instalado un **SO con aplicación**, consulte nuestra [guía sobre los pri
 
 :::
 
-
 #### 5.1: Verificar el estado de la instancia en el área de cliente
+
+Conéctese al <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, acceda a la sección <code className="action">Public Cloud</code> y seleccione el proyecto Public Cloud correspondiente.
 
 Seleccione <code className="action">Instancias</code> en la barra de navegación de la izquierda en **Compute**. La instancia está lista cuando el estado se establece en `Activado` en la tabla. Si la instancia se ha creado recientemente y tiene un estado diferente, haga clic en el botón "Actualizar" situado junto al filtro de búsqueda.
 
-<img className="thumbnail" alt="page instances" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
-
 Haga clic en el nombre de la instancia en esta tabla para abrir el <code className="action">Panel de control</code>, donde puede encontrar toda la información relativa a la instancia. Para más información sobre las funciones disponibles en esta página, consulte nuestra guía sobre [la gestión de las instancias en el área de cliente](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
-Se creará automáticamente un **usuario con derechos elevados (*sudo*)** en la instancia. El nombre de usuario refleja la imagen instalada, por ejemplo "ubuntu", "debian", "fedora", etc. Puede comprobarlo en el lado derecho del <code className="action">Panel de control</code> en la sección **Redes**.
+Se creará automáticamente un **usuario con derechos elevados (*sudo*)** en la instancia. El nombre de usuario refleja la imagen instalada, por ejemplo "ubuntu", "debian", "fedora", etc. Puede comprobarlo en el <code className="action">Panel de control</code> en la sección **Redes**.
 
-<img className="thumbnail" alt="page instances" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
+:::info
+A través de la CLI de OVHcloud, compruebe el estado y obtenga la dirección IP de su instancia con:
+
+```bash
+ovhcloud cloud instance list --cloud-project <project_id>
+```
+
+:::
 
 Si su [par de claves SSH está correctamente configurado](#paso-1-crear-un-juego-de-claves-ssh), puede conectarse a la instancia con el usuario preconfigurado y su clave SSH. En los siguientes párrafos encontrará instrucciones más detalladas.
 
@@ -397,7 +442,6 @@ Esta guía no cubre la red privada para las instancias. Para más información, 
 
 :::
 
-
 #### 5.2: Primera conexión a una instancia con sistema operativo GNU/Linux
 
 :::info
@@ -407,7 +451,6 @@ Si sigue teniendo problemas, puede reemplazar el par de claves con [esta guía](
 Si ha creado una instancia sin clave SSH, a través de la [API de OVHcloud](/guides/manage-and-operate/api/first-steps) o de la [interfaz OpenStack Horizon](/guides/public-cloud/compute/create-instance-in-horizon), solo podrá añadir una clave SSH a su instancia a través del [modo rescue](/guides/public-cloud/compute/put-an-instance-in-rescue-mode) siguiendo las instrucciones descritas en [esta guía](/guides/public-cloud/compute/replacing-lost-ssh-key-pair).
 
 :::
-
 
 Puede acceder a su instancia inmediatamente después de su creación a través de la interfaz de línea de comandos de su estación de trabajo local (`Terminal`, `Command prompt`, `Powershell`, etc.) por SSH.
 
@@ -437,29 +480,22 @@ A continuación, complete la configuración inicial del sistema operativo Window
 
 <Tabs>
   <Tab label="1. Configuración regional">
-    Configure su **país/región**, el **idioma preferido de Windows** y su **distribución de teclado**. Haga clic en el botón <code className="action">Siguiente</code> en la esquina inferior derecha.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" /><br/>
+    Configure su **país/región**, el **idioma preferido de Windows** y su **distribución de teclado**. Haga clic en el botón <code className="action">Siguiente</code> en la esquina inferior derecha.
   </Tab>
   <Tab label="2. Contraseña de administrador">
-    Establezca una contraseña para su cuenta Windows `Administrator` y confírmela, y haga clic en <code className="action">Finalizar</code>.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" /><br/>
+    Establezca una contraseña para su cuenta Windows `Administrator` y confírmela, y haga clic en <code className="action">Finalizar</code>.
   </Tab>
   <Tab label="3. Pantalla de conexión">
-    Windows aplicará la configuración y mostrará la pantalla de inicio de sesión. Haga clic en el botón <code className="action">Send CtrlAltDel</code> en la esquina superior derecha para conectarse.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" /><br/>
+    Windows aplicará la configuración y mostrará la pantalla de inicio de sesión. Haga clic en el botón <code className="action">Send CtrlAltDel</code> en la esquina superior derecha para conectarse.
   </Tab>
   <Tab label="4. Inicio de sesión de administrador">
-    Introduzca la contraseña `Administrator` que creó en el paso anterior y haga clic en el botón "Arrow".<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
+    Introduzca la contraseña `Administrator` que creó en el paso anterior y haga clic en el botón "Arrow".
   </Tab>
 </Tabs>
-
 
 ##### 5.3.2: Conéctese de forma remota desde Windows
 
 En su equipo Windows local, puede utilizar la aplicación cliente `Remote Desktop Connection` para conectarse a su instancia.
-
-<img className="thumbnail" alt="rdp connection" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Introduzca la dirección IPv4 de su instancia, su identificador y su contraseña. Normalmente, aparece un mensaje de advertencia solicitándole que confirme la conexión debido a un certificado desconocido. Haga clic en <code className="action">Sí</code> para conectarse.
 
@@ -467,7 +503,6 @@ Introduzca la dirección IPv4 de su instancia, su identificador y su contraseña
 Si tiene problemas con este procedimiento, compruebe que las conexiones remotas (RDP) están permitidas en su dispositivo comprobando la configuración del sistema, las reglas de firewall y las posibles restricciones de red.
 
 :::
-
 
 ##### 5.3.3: Conectarse de forma remota desde otro SO
 
@@ -479,31 +514,23 @@ Independientemente del cliente que utilice, solo necesita la dirección IP de su
 
 El software libre y open source `Remmina Remote Desktop Client` está disponible para muchas distribuciones de escritorio GNU/Linux. Si no encuentra Remmina en el administrador de software de su entorno de escritorio, puede obtenerlo en el [sitio oficial](https://remmina.org/).
 
-<img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect01.png" loading="lazy" /><br/>
-
 <Tabs>
   <Tab label="1. Conexión">
-    Abra Remmina y asegúrese de que el protocolo de conexión está establecido en "RDP". Introduzca la dirección IPv4 de su instancia Public Cloud y pulse "Enter".<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" /><br/>
+    Abra Remmina y asegúrese de que el protocolo de conexión está establecido en "RDP". Introduzca la dirección IPv4 de su instancia Public Cloud y pulse "Enter".
   </Tab>
   <Tab label="2. Autenticación">
-    Si aparece un mensaje de advertencia de certificado, haga clic en <code className="action">Yes</code>. Introduzca el nombre de usuario y la contraseña de Windows y haga clic en <code className="action">OK</code> para establecer la conexión.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" /><br/>
+    Si aparece un mensaje de advertencia de certificado, haga clic en <code className="action">Yes</code>. Introduzca el nombre de usuario y la contraseña de Windows y haga clic en <code className="action">OK</code> para establecer la conexión.
   </Tab>
   <Tab label="3. Parámetros">
-    Puede encontrar elementos útiles en la barra de herramientas de la izquierda. Por ejemplo, haga clic en el icono <code className="action">Toggle dynamic resolution update</code> para mejorar la resolución de la ventana.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
+    Puede encontrar elementos útiles en la barra de herramientas de la izquierda. Por ejemplo, haga clic en el icono <code className="action">Toggle dynamic resolution update</code> para mejorar la resolución de la ventana.
   </Tab>
 </Tabs>
-
 
 #### 5.4: Acceso a la consola VNC
 
 La consola VNC le permite conectarse a sus instancias incluso cuando otros medios de acceso no están disponibles.
 
 Seleccione <code className="action">Instancias</code> en la barra de navegación de la izquierda en **Compute**. Haga clic en el nombre de la instancia y abra la pestaña <code className="action">Consola VNC</code>.
-
-<img className="thumbnail" alt="console vnc" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instancia con un SO GNU/Linux instalado">
@@ -513,7 +540,6 @@ Seleccione <code className="action">Instancias</code> en la barra de navegación
     Inicie sesión con sus credenciales de Windows. Si tiene una sesión activa, dispone de acceso inmediato. Habrá una latencia considerable con respecto a una conexión RDP.
   </Tab>
 </Tabs>
-
 
 ### Paso 6: primeros pasos en una nueva instancia
 
@@ -526,14 +552,12 @@ Encontrará más información en la sección [Más información](#mas-informacio
 
 :::
 
-
 #### 6.1: Gestión de usuarios
 
 :::info
 Al configurar las cuentas de usuario y los niveles de permisos en una instancia, le recomendamos que utilice la información de nuestra [guía de cuentas de usuario](/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds).
 
 :::
-
 
 ##### 6.1.1: Establezca una contraseña para la cuenta de usuario actual
 
@@ -561,7 +585,6 @@ Este paso no es necesario y solo debe realizarse si tiene una razón válida par
 En el ejemplo siguiente se muestra una solución temporal en una instancia en la que está instalado Ubuntu. Tenga en cuenta que es posible que tenga que ajustar los comandos en función del sistema operativo. No se recomienda conservar esta configuración de forma permanente, ya que añade un riesgo potencial de seguridad al abrir el sistema a ataques basados en SSH.
 
 :::
-
 
 Una vez [conectado a su instancia](#paso-6-primeros-pasos-en-una-nueva-instancia), abra el archivo de configuración con un editor de texto. Ejemplo:
 
@@ -621,4 +644,4 @@ Para más información, consulte nuestra [guía dedicada](/guides/public-cloud/c
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/).

--- a/docs/es/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
@@ -1,8 +1,10 @@
 ---
 title: Suspender o poner en pausa una instancia
 description: Cómo suspender, pausar o detener una instancia de Public Cloud para liberar recursos temporalmente conservando su dirección IP, así como el impacto en la facturación de cada opción
-lastUpdated: 2026-02-27
+lastUpdated: 2026-05-27
 ---
+
+import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objetivo
 
@@ -12,7 +14,6 @@ Como parte de la configuración de una infraestructura de alta disponibilidad, p
 El nombre de estas opciones en el área de cliente de OVHcloud es diferente del nombre en OpenStack/Horizon. Si realiza la operación a través del área de cliente, asegúrese de seleccionar la opción correcta.
 
 :::
-
 
 **Esta guía explica cómo suspender, detener o poner en pausa una instancia.**
 
@@ -44,33 +45,20 @@ El nombre de estas opciones en el área de cliente de OVHcloud es diferente del 
 
 :::
 
-
 En la siguiente tabla podrá diferenciar las opciones disponibles en sus instancias. Continúe leyendo esta guía en el apartado correspondiente a su opción. Ponemos entre paréntesis la terminología utilizada en la **interfaz Horizon**.
 
 |Término|Descripción|Facturación|
 |---|---|---|
-|[Suspender (*shelve*)](#shelve-instance)|Conserve su IP, así como los recursos y los datos de su disco creando un snapshot, liberando todos los demás recursos.|Solo se factura el snapshot.|Solo se le facturará por la instantánea (snapshot).|
-|[Apagar (*suspend*)](#stop-suspend-instance)|Almacena el estado de la máquina virtual en el disco. Los recursos dedicados a la instancia están siempre reservados.|La instancia se facturará al mismo precio.|
-|[Pausa](#pause-instance)|Almacena el estado de la máquina virtual en la RAM, una instancia en pausa se convierte en bloqueado.|La instancia se facturará al mismo precio.|
+|[Suspender (*shelve*)](#shelve-instance)|Conserve su IP, así como los recursos y los datos de su disco creando un snapshot, liberando todos los demás recursos.|Solo se factura el snapshot.|
+|[Apagar (*suspend*)](#stop-suspend-instance)|Almacena el estado de la máquina virtual en el disco, los recursos permanecen reservados.|Se le factura al mismo precio.|
+|[Pausa](#pause-instance)|Almacena el estado de la máquina virtual en la RAM, la instancia permanece bloqueada.|Se le factura al mismo precio.|
 
 ### Contenido
 
 - [Suspender (shelve) una instancia](#shelve-instance)
-    - [Desde al área de cliente de OVHcloud](#control-panel)
-    - [Desde la interfaz Horizon](#horizon)
-    - [Utilizando la API de OpenStack/Nova](#openstack-nova)
-- [Reactivar (unshelve) una instancia](#unshelve-instance)
-    - [Desde al área de cliente de OVHcloud](#control-panel-unshelve)
-    - [Desde la interfaz Horizon](#horizon-unshelve)
-    - [Utilizando la API de OpenStack/Nova](#openstack-nova-unshelve)
+- [Reactivar (*unshelve*) una instancia](#unshelve-instance)
 - [Apagar (suspend) una instancia](#stop-suspend-instance)
-    - [Desde al área de cliente de OVHcloud](#stop-control-panel)
-    - [Desde la interfaz Horizon](#stop-horizon)
-    - [Utilizando la API de OpenStack/Nova](#stop-openstack-nova)
-- [Poner en pausa una instancia (*pause*)](#pause-instance)
-    - [Desde la interfaz Horizon](#pause-horizon)
-    - [Utilizando la API de OpenStack/Nova](#pause-openstack-nova)
-
+- [Poner en pausa una instancia](#pause-instance)
 
 <a name="shelve-instance"></a>
 
@@ -83,79 +71,83 @@ La suspensión de este tipo de instancia conlleva su desinstalación del host y,
 
 :::
 
-
 Esta opción le permitirá liberar los recursos dedicados a su instancia de Public Cloud, pero la dirección IP permanecerá. Los datos de su disco local se almacenarán en un snapshot creado automáticamente una vez que la instancia se ponga en reserva. Los datos almacenados en la memoria y en otros sitios no se conservarán.
 
-<a name="control-panel"></a>
+<Tabs>
+  <Tab label="Desde el área de cliente de OVHcloud">
+    En su área de cliente de OVHcloud, haga clic en la pestaña <code className="action">Public Cloud</code>, seleccione su proyecto Public Cloud y haga clic en la sección <code className="action">Instancias</code> en el menú de la izquierda.
 
-#### Desde al área de cliente de OVHcloud
+    Haga clic en el botón <code className="action">⋮</code> a la derecha de la instancia que desea suspender, y luego haga clic en <code className="action">Suspender</code>.
 
-Conéctese al área de cliente de OVHcloud, acceda a la sección Public Cloud y seleccione el proyecto correspondiente. Clic en <code className="action">Instancias</code> en el menú de la izquierda.
+    <img className="thumbnail" alt="suspend instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
 
-Haga clic en el botón <code className="action">⋮</code> a la derecha de la instancia que desea suspender, y luego haga clic en <code className="action">Suspender</code>.
+    En la pantalla que aparece, tome nota de la información proporcionada y haga clic en <code className="action">Confirmar</code>.
 
-<img className="thumbnail" alt="suspend instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="confirm suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
 
-En la pantalla que aparece, tome nota del mensaje y haga clic en <code className="action">Confirmar</code>.
+    Durante la operación se muestra un mensaje:
 
-<img className="thumbnail" alt="confirm suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="Operation in progress" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
 
-Durante la operación se muestra un mensaje:
+    Una vez finalizado el proceso, su instancia tendrá el estado «Suspendida».
 
-<img className="thumbnail" alt="Operation in progress" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="suspended status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
 
-Una vez finalizado el proceso, su instancia se mostrará como *Suspendida*.
+    Para ver el snapshot, haga clic en <code className="action">Instance Backup</code> en la pestaña **Compute** del menú de la izquierda. Aparecerá un snapshot llamado *xxxxx-shelved*:
 
-<img className="thumbnail" alt="suspended status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="snapshot tab" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+  </Tab>
+  <Tab label="Desde la interfaz Horizon">
+    Para utilizar este método, debe [conectarse a la interfaz Horizon](https://horizon.cloud.ovh.net/auth/login/):
 
-El snapshot estará entonces disponible en la sección <code className="action">Instance Backup</code> del menú **Compute** a la izquierda del espacio Public Cloud. Aparecerá un snapshot llamado *xxxxx-shelved*:
+    - Para iniciar sesión con el inicio de sesión único (SSO) de OVHcloud: utilice el enlace <code className="action">Horizon</code> en el menú de la izquierda bajo "Management Interfaces" después de abrir su proyecto <code className="action">Public Cloud</code> en su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>.
 
-<img className="thumbnail" alt="snapshot tab" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+    - Para conectarse con un usuario OpenStack específico: abra la página de conexión a [Horizon](https://horizon.cloud.ovh.net/auth/login/) e introduzca los [identificadores OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user) previamente creados y haga clic en <code className="action">Connect</code>.
 
-<a name="horizon"></a>
+    Si ha desplegado instancias en diferentes regiones, asegúrese de encontrarse en la región adecuada. Puede comprobarlo en la esquina superior izquierda de la interfaz Horizon.
 
-#### Desde la interfaz Horizon
+    <img className="thumbnail" alt="horizon interface" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
 
-Para utilizar este método, conéctese [a Horizon](https://horizon.cloud.ovh.net/auth/login/):
+    Haga clic en el menú <code className="action">Compute</code> a la izquierda y luego en <code className="action">Instances</code>. Seleccione <code className="action">Shelve Instance</code> en la lista desplegable correspondiente a la instancia.
 
-- Para iniciar sesión con el SSO de OVHcloud: utilice el enlace <code className="action">Horizon</code> en el menú izquierdo bajo "Management Interfaces" después de abrir su proyecto <code className="action">Public Cloud</code> en el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>.
+    <img className="thumbnail" alt="instance shelve" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
 
-- Para conectarse con un usuario específico de OpenStack: abra la página de conexión a [Horizon](https://horizon.cloud.ovh.net/auth/login/) e introduzca las [claves OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user) previamente creadas y haga clic en <code className="action">Connect</code>.
+    Una vez finalizado el proceso, su instancia tendrá el estado *Shelved Offloaded*.
 
-Si ha desplegado instancias en diferentes regiones, asegúrese de que se encuentre en la región adecuada. Puede comprobarlo en la esquina superior izquierda de Horizon.
+    <img className="thumbnail" alt="shelved instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
 
-<img className="thumbnail" alt="horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
+    Para ver el snapshot, en el menú <code className="action">Compute</code>, haga clic en <code className="action">Images</code>.
 
-Haga clic en el menú <code className="action">Compute</code> en el lado izquierdo y seleccione <code className="action">Instances</code>. Seleccione <code className="action">Shelve Instance</code> en la lista desplegable de la instancia correspondiente.
+    <img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+  </Tab>
+  <Tab label="Desde las API OpenStack/Nova">
+    Antes de continuar, se recomienda consultar las siguientes guías:
 
-<img className="thumbnail" alt="shelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
+    - [Preparar el entorno para utilizar la API de OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
+    - [Cargar las variables de entorno de OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
 
-Una vez finalizado el proceso, su instancia aparecerá en forma de *Shelved Offloaded*.
+    Una vez que el entorno esté listo, escriba lo siguiente en la línea de comandos:
 
-<img className="thumbnail" alt="shelved instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
+    ```bash
+    ~$ openstack server shelve <UUID server>
 
-Para ver la instantánea (snapshot), haga clic en <code className="action">Images</code> en el menú <code className="action">Compute</code>.
+    =====================================
 
-<img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+    ~$ nova shelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="Desde la CLI de OVHcloud">
+    Antes de continuar, se recomienda consultar las siguientes guías:
 
-<a name="openstack-nova"></a>
+    - [Conocer las bases de la CLI de OVHcloud](/guides/manage-and-operate/cli/getting-started)
 
-#### Utilizando la API de OpenStack/Nova
+    Escriba el siguiente comando:
 
-Antes de continuar, se recomienda consultar las siguientes guías:
-
-- [Preparar el entorno para utilizar la API de OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
-- [Cargar las variables de entorno necesarias para OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
-
-Una vez que el entorno esté listo, escriba lo siguiente en la línea de comandos:
-
-```bash
-~$ openstack server shelve <UUID server>
-
-=====================================
-
-~$ nova shelve <UUID server> 
-```
+    ```shell
+    ovhcloud cloud instance shelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="unshelve-instance"></a>
 
@@ -171,148 +163,153 @@ Cualquier acción en el snapshot que no sea la reactivación (*unshelve*) puede 
 La responsabilidad sobre los servicios que OVHcloud pone a su disposición recae íntegramente en usted. Nuestros técnicos no son los administradores de las máquinas, ya que no tienen acceso a ellas. Por lo tanto, la gestión del software y la seguridad le corresponde a usted. Si tiene problemas o dudas sobre  la administración, la utilización o la seguridad de su servidor, le recomendamos que contacte con un proveedor de [servicios especializado](https://partner.ovhcloud.com/es-es/directory/). Para más información, consulte el apartado «Más información» de esta guía.
 :::
 
-<a name="control-panel-unshelve"></a>
+<Tabs>
+  <Tab label="Desde el área de cliente de OVHcloud">
+    En su área de cliente de OVHcloud, haga clic en la pestaña <code className="action">Public Cloud</code>, seleccione su proyecto Public Cloud y haga clic en la sección <code className="action">Instancias</code> en el menú de la izquierda.
 
-#### Desde al área de cliente de OVHcloud
+    Haga clic en los <code className="action">⋮</code> a la derecha de la instancia y luego haga clic en <code className="action">Reactivar</code>.
 
-Conéctese al área de cliente de OVHcloud, acceda a la sección Public Cloud y seleccione el proyecto correspondiente. Clic en <code className="action">Instancias</code> en el menú de la izquierda.
+    <img className="thumbnail" alt="reactivate instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
 
-Haga clic en el botón <code className="action">⋮</code> a la derecha de la instancia, y luego haga clic en <code className="action">Reactivar</code>.
+    En la pantalla que aparece, tome nota de la información y haga clic en <code className="action">Confirmar</code>.
 
-<img className="thumbnail" alt="reactivate instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
+    Una vez finalizado el proceso, su instancia tendrá el estado «Activada».
+  </Tab>
+  <Tab label="Desde la interfaz Horizon">
+    Haga clic en el menú <code className="action">Compute</code> en el menú de la izquierda y seleccione <code className="action">Instances</code>. Seleccione <code className="action">Unshelve Instance</code> en la lista desplegable correspondiente a la instancia.
 
-En la pantalla que aparece, tome nota del mensaje y haga clic en <code className="action">Confirmar</code>.
+    <img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
 
-Una vez finalizado el proceso, su instancia se mostrará como *Activa*.
+    Una vez finalizado el proceso, su instancia tendrá el estado *Active*.
+  </Tab>
+  <Tab label="Desde las API OpenStack/Nova">
+    Una vez que el entorno esté listo, escriba el siguiente comando en la línea de comandos:
 
-<a name="horizon-unshelve"></a>
+    ```bash
+    ~$ openstack server unshelve <UUID server>
 
-#### Desde la interfaz de Horizon
+    =========================================
 
-En Horizon, haga clic en el menú <code className="action">Compute</code> en el lado izquierdo y seleccione <code className="action">Instances</code>. Seleccione <code className="action">Unshelve Instance</code> en la lista desplegable de la instancia correspondiente.
+    ~$ nova unshelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="Desde la CLI de OVHcloud">
+    Escriba el siguiente comando:
 
-<img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
-
-Una vez finalizado el proceso, la instancia se mostrará como *Active*.
-
-<a name="openstack-nova-unshelve"></a>
-
-#### Utilizando la API de OpenStack/Nova
-
-Una vez que el entorno esté listo, escriba lo siguiente en la línea de comandos:
-
-```bash
-~$ openstack server unshelve <UUID server>
-
-=========================================
-
-~$ nova unshelve <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance unshelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="stop-suspend-instance"></a>
 
 ### Apagar (suspend) una instancia
 
-Esta opción le permitirá detener su instancia y almacenar el estado de la máquina virtual en el disco. La memoria también se escribirá en el disco.
+Esta opción apaga su instancia. El estado de la máquina virtual se almacena en el disco, mientras que la memoria se escribe en el disco.
 
-<a name="stop-control-panel"></a>
+<Tabs>
+  <Tab label="Desde el área de cliente de OVHcloud">
+    En su área de cliente de OVHcloud, haga clic en <code className="action">Public Cloud</code>, seleccione su proyecto Public Cloud y haga clic en <code className="action">Instancias</code> en el menú de la izquierda.
 
-#### Desde al área de cliente de OVHcloud
+    Haga clic en el botón <code className="action">⋮</code> a la derecha de la instancia que desea detener, y luego haga clic en <code className="action">Apagar</code>.
 
-Conéctese al área de cliente de OVHcloud, acceda a la sección Public Cloud y seleccione el proyecto correspondiente. Clic en <code className="action">Instancias</code> en el menú de la izquierda.
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
 
-Haga clic en el botón <code className="action">⋮</code> a la derecha de la instancia, y luego haga clic en <code className="action">Apagar</code>.
+    En la pantalla que aparece, tome nota de la información y haga clic en <code className="action">Confirmar</code>.
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
 
-En la pantalla que aparece, tome nota del mensaje y haga clic en <code className="action">Confirmar</code>.
+    Una vez finalizado el proceso, su instancia tendrá el estado «Apagada».
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
+    Para **reiniciar** la instancia, realice las mismas operaciones indicadas anteriormente. Haga clic en el botón <code className="action">⋮</code> a la derecha de la instancia y seleccione <code className="action">Iniciar</code>. En algunos casos, puede ser necesario realizar un reinicio en frío.
+  </Tab>
+  <Tab label="Desde la interfaz Horizon">
+    En la interfaz Horizon, haga clic en el menú <code className="action">Compute</code> a la izquierda y luego seleccione <code className="action">Instances</code>. Seleccione <code className="action">Suspend Instance</code> en la lista desplegable correspondiente a la instancia.
 
-Una vez finalizado el proceso, la instancia se mostrará como *Apagada*.
+    <img className="thumbnail" alt="suspend instance horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
 
-Para **reactivar** la instancia, siga los pasos que se indican más arriba. Haga clic en el botón <code className="action">⋮</code> a la derecha de la instancia y seleccione <code className="action">Iniciar</code>. En algunos casos, quizá necesite reiniciarse en frío.
+    Se muestra un mensaje de confirmación indicando que la instancia ha sido suspendida.
 
-<a name="stop-horizon"></a>
+    Para **reiniciar** la instancia, realice las mismas operaciones indicadas anteriormente. En la lista desplegable correspondiente a la instancia, seleccione <code className="action">Resume Instance</code>.
+  </Tab>
+  <Tab label="Desde las API OpenStack/Nova">
+    Una vez que el entorno esté listo, escriba el siguiente comando en la línea de comandos:
 
-#### Desde la interfaz de Horizon 
+    ```bash
+    ~$ openstack server suspend <UUID server>
 
-En Horizon, haga clic en el menú <code className="action">Compute</code> en el lado izquierdo y seleccione <code className="action">Instances</code>. Seleccione <code className="action">Suspend Instance</code> en la lista desplegable de la instancia correspondiente.
+    =========================================
 
-<img className="thumbnail" alt="suspend instance horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
+    ~$ nova suspend <UUID server>
+    ```
 
-Se mostrará un mensaje de confirmación indicando que la instancia ha sido suspendida.
+    Para **reiniciar** la instancia, escriba el siguiente comando en la línea de comandos:
 
-Para **reactivar** la instancia, siga los pasos que se indican más arriba. En la lista desplegable correspondiente, seleccione <code className="action">Resume Instance</code>.
+    ```bash
+    ~$ openstack server unsuspend <UUID server>
 
-<a name="stop-openstack-nova"></a>
+    =========================================
 
-#### Utilizando la API de OpenStack/Nova
+    ~$ nova unsuspend <UUID server>
+    ```
+  </Tab>
+  <Tab label="Desde la CLI de OVHcloud">
+    Escriba el siguiente comando:
 
-Una vez que el entorno esté listo, escriba lo siguiente en la línea de comandos:
+    ```shell
+    ovhcloud cloud instance stop <instance_id>
+    ```
 
-```bash
-~$ openstack server suspend <UUID server>
+    Para **reiniciar** la instancia, escriba el siguiente comando:
 
-=========================================
-
-~$ nova suspend <UUID server>
-```
-
-Para **reactivar** la instancia, escriba lo siguiente en la línea de comandos:
-
-```bash
-~$ openstack server unsuspend <UUID server>
-
-=========================================
-
-~$ nova unsuspend <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance start <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="pause-instance"></a>
 
-### Poner en pausa una instancia (*pause*)
+### Poner en pausa una instancia
 
-Esta operación sólo puede realizarse desde la interfaz Horizon o a través de la API OpenStack/Nova. Una instancia en pausa sigue funcionando en un estado bloqueado.
+Esta acción puede realizarse **únicamente** desde la interfaz Horizon o a través de las API OpenStack/Nova. Le permite poner en reposo o «congelar» su instancia.
 
-<a name="pause-horizon"></a>
+<Tabs>
+  <Tab label="Desde la interfaz Horizon">
+    En la interfaz Horizon, haga clic en el menú <code className="action">Compute</code> a la izquierda y luego seleccione <code className="action">Instances</code>. Seleccione <code className="action">Pause Instance</code> en la lista desplegable correspondiente a la instancia.
 
-#### Desde la interfaz de Horizon
+    <img className="thumbnail" alt="Pause instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
 
-En Horizon, haga clic en el menú <code className="action">Compute</code> en el lado izquierdo y seleccione <code className="action">Instances</code>. Seleccione <code className="action">Pause Instance</code> en la lista desplegable de la instancia correspondiente.
+    Aparece el mensaje de confirmación indicando que la instancia ha sido pausada.
 
-<img className="thumbnail" alt="Pause instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
+    Para **reactivar** la instancia, realice las mismas operaciones indicadas anteriormente. En la lista desplegable correspondiente a la instancia, seleccione <code className="action">Resume Instance</code>.
+  </Tab>
+  <Tab label="Desde las API OpenStack/Nova">
+    Una vez que el entorno esté listo, escriba el siguiente comando en la línea de comandos:
 
-Aparecerá el mensaje de confirmación, indicando que la instancia ha sido pausada.
+    ```bash
+    ~$ openstack server pause <UUID server>
 
-Para **reactivar** la instancia, siga los pasos que se indican más arriba. En la lista desplegable correspondiente, seleccione <code className="action">Resume Instance</code>.
+    =========================================
 
-<a name="pause-openstack-nova"></a>
+    ~$ nova pause <UUID server>
+    ```
 
-#### Utilizando la API de OpenStack/Nova
+    Para **reactivar** la instancia, escriba el siguiente comando en la línea de comandos:
 
-Una vez que el entorno esté listo, escriba lo siguiente en la línea de comandos:
+    ```bash
+    ~$ openstack server unpause <UUID server>
 
-```bash
-~$ openstack server pause <UUID server>
+    =========================================
 
-=========================================
-
-~$ nova pause <UUID server>
-```
-
-Para **reactivar** la instancia, escriba lo siguiente en la línea de comandos:
-
-```bash
-~$ openstack server unpause <UUID server>
-
-=========================================
-
-~$ nova unpause <UUID server>
-```
+    ~$ nova unpause <UUID server>
+    ```
+  </Tab>
+</Tabs>
 
 ## Más información
 
 [Documentación OpenStack](https://docs.openstack.org/ocata/user-guide/cli-stop-and-start-an-instance.html).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/).

--- a/docs/fr/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/fr/guides/public-cloud/compute/getting-started.mdx
@@ -1,13 +1,10 @@
 ---
 title: "Comment créer une instance Public Cloud et s'y connecter"
 description: Découvrez comment configurer des instances Public Cloud dans votre espace client OVHcloud ainsi que les premières étapes avec vos instances
-lastUpdated: 2026-05-25
+lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
-
-
-
 
 ## Objectif
 
@@ -15,7 +12,6 @@ Les instances Public Cloud sont faciles à déployer et à gérer. Cependant, en
 Vous pourrez ensuite aller plus loin avec votre projet Public Cloud en fonction de vos besoins.
 
 **Ce guide vous détaille les premiers pas avec une instance Public Cloud.**
-
 
 ## Prérequis
 
@@ -27,7 +23,6 @@ Bénéficiez de prix réduits en vous engageant sur une période de 1 à 36 mois
 
 :::
 
-
 ## En pratique
 
 :::info
@@ -36,7 +31,6 @@ Si vous n'avez pas encore créé de projet Public Cloud, commencez par notre [gu
 **Les détails techniques** importants concernant le Public Cloud d’OVHcloud sont disponibles sur [cette page](/guides/public-cloud/cross-functional/compute-essential-information).
 
 :::
-
 
 ### Présentation du contenu
 
@@ -69,7 +63,6 @@ Si vous n'avez pas encore créé de projet Public Cloud, commencez par notre [gu
 **Exception** : l'authentification de connexion sur les instances Windows nécessite un nom d'utilisateur et un mot de passe car Windows utilise RDP (**R**emote **D**esktop **P**rotocol).
 
 :::
-
 
 ### Étape 1 : créer un jeu de clés SSH
 
@@ -179,7 +172,6 @@ Avant de créer votre instance, nous vous recommandons d'étudier la manière do
 
 <summary>Public Cloud Networking - Modes</summary>
 
-
 **Mode Public**
 
 Les instances en mode public sont exposées à Internet directement via IPv4/IPv6. Les adresses IP ne peuvent pas être modifiées, mais les instances peuvent avoir des adresses [Additional IP](https://www.ovhcloud.com/fr/network/additional-ip/) attachées ([y compris votre propre IP](https://www.ovhcloud.com/fr/network/byoip/)) et elles peuvent être connectées à un [vRack](https://www.ovhcloud.com/fr/network/vrack/).
@@ -197,7 +189,6 @@ Le mode privé local ne s'applique que si vous créez une instance dans une **Lo
 Pour en savoir plus, consultez la [page web des Local Zones](https://www.ovhcloud.com/fr/public-cloud/local-zone-compute/).
 
 </details>
-
 
 ### Étape 4 : créer l'instance
 
@@ -254,10 +245,10 @@ Pour en savoir plus, consultez la [page web des Local Zones](https://www.ovhclou
 
     **4.7 Réseau**
 
-    La section **Network settings** se divise en deux parties :
+    La section **Paramètres de réseaux** se divise en deux parties :
 
-    - **Private network** : sélectionnez un réseau privé existant ou cliquez sur <code className="action">Créer un réseau privé</code>. Si un réseau privé est sélectionné mais ne possède pas de gateway, activez le toggle <code className="action">Attribuer une gateway</code> pour attacher une gateway automatiquement.
-    - **Attribuer une connectivité publique** : activez le toggle pour assigner une IP publique. Choisissez <code className="action">Basic Public IP</code> (gratuite, liée à la durée de vie de l'instance, incompatible avec une gateway) ou <code className="action">Créer une nouvelle</code> (persistante et réutilisable).
+    - **Private network** : sélectionnez un réseau privé existant ou cliquez sur <code className="action">Créer un réseau privé</code>. Si un réseau privé est sélectionné mais ne possède pas de gateway, activez le bouton bascule <code className="action">Attribuer une gateway</code> pour attacher une gateway automatiquement.
+    - **Attribuer une connectivité publique** : activez le bouton bascule pour assigner une IP publique. Choisissez <code className="action">Basic Public IP</code> (gratuite, liée à la durée de vie de l'instance, incompatible avec une gateway) ou <code className="action">Attribuer une Floating IP (Réutilisable)</code> (persistante et réutilisable).
 
     Consultez l'[Étape 3](#networking-modes) pour un aperçu des modes réseau.
 
@@ -413,7 +404,6 @@ Si vous avez installé un **OS avec application**, reportez-vous à notre [guide
 
 :::
 
-
 #### 5.1 : Vérifier l'état de l'instance dans l'espace client
 
 Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section <code className="action">Public Cloud</code> et sélectionnez le projet Public Cloud concerné.
@@ -442,7 +432,6 @@ Ce guide ne couvre pas le réseau privé pour les instances. Veuillez consulter 
 
 :::
 
-
 #### 5.2 : Première connexion sur une instance sous OS GNU/Linux
 
 :::info
@@ -452,7 +441,6 @@ Si vous rencontrez toujours des difficultés, vous pouvez remplacer la paire de 
 Si vous avez créé une instance sans clé SSH, via l’[API OVHcloud](/guides/manage-and-operate/api/first-steps) ou l’[interface OpenStack Horizon](/guides/public-cloud/compute/create-instance-in-horizon), vous ne pouvez ajouter une clé SSH à votre instance que via le [mode rescue](/guides/public-cloud/compute/put-an-instance-in-rescue-mode) en suivant les instructions décrites dans [ce guide](/guides/public-cloud/compute/replacing-lost-ssh-key-pair).
 
 :::
-
 
 Vous pouvez accéder à votre instance immédiatement après sa création via l'interface de ligne de commande de votre poste de travail local (`Terminal`, `Command prompt`, `Powershell`, etc.) via SSH.
 
@@ -495,7 +483,6 @@ Il vous faudra ensuite finaliser la configuration initiale de votre système d�
   </Tab>
 </Tabs>
 
-
 ##### 5.3.2 : Connectez-vous à distance depuis Windows
 
 Sur votre poste Windows local, vous pouvez utiliser l'application cliente `Remote Desktop Connection` pour vous connecter à votre instance.
@@ -506,7 +493,6 @@ Renseignez l'adresse IPv4 de votre instance, puis votre identifiant et votre pas
 Si vous rencontrez des difficultés avec cette procédure, vérifiez que les connexions à distance (RDP) sont autorisées sur votre appareil en vérifiant les paramètres système, les règles de pare-feu et les restrictions réseau possibles.
 
 :::
-
 
 ##### 5.3.3 : Se connecter à distance depuis un autre OS
 
@@ -530,7 +516,6 @@ Le logiciel libre et open source `Remmina Remote Desktop Client` est disponible 
   </Tab>
 </Tabs>
 
-
 #### 5.4 : accès console VNC
 
 La console VNC vous permet de vous connecter à vos instances même lorsque d'autres moyens d'accès ne sont pas disponibles.
@@ -548,7 +533,6 @@ Sélectionnez <code className="action">Instances</code> dans la barre de navigat
   </Tab>
 </Tabs>
 
-
 ### Étape 6 : premiers pas sur une nouvelle instance
 
 :::info
@@ -560,14 +544,12 @@ Retrouvez plus d’informations dans la section [Aller plus loin](#aller-plus-lo
 
 :::
 
-
 #### 6.1 : Gestion des utilisateurs
 
 :::info
 Lors de la configuration des comptes d'utilisateurs et des niveaux d'autorisation sur une instance, nous vous recommandons d'utiliser les informations de notre [guide du compte d'utilisateur](/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds).
 
 :::
-
 
 ##### 6.1.1 : Définissez un mot de passe pour le compte d'utilisateur actuel
 
@@ -595,7 +577,6 @@ Cette étape n'est pas nécessaire et ne doit être exécutée que si vous avez 
 L'exemple suivant illustre une solution temporaire sur une instance sur laquelle Ubuntu est installé. Notez que vous devrez peut-être ajuster les commandes en fonction de votre système d'exploitation. Il n'est pas recommandé de conserver cette configuration en permanence car elle ajoute un risque potentiel de sécurité en ouvrant le système aux attaques basées sur SSH.
 
 :::
-
 
 Une fois [connecté à votre instance](#etape-6-premiers-pas-sur-une-nouvelle-instance), ouvrez le fichier de configuration concerné avec un éditeur de texte. Exemple :
 
@@ -653,6 +634,6 @@ Consultez notre [guide dédié](/guides/public-cloud/compute/configuring-additio
 
 [Comment démarrer avec Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/).

--- a/docs/fr/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/fr/guides/public-cloud/compute/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Comment créer une instance Public Cloud et s'y connecter"
 description: Découvrez comment configurer des instances Public Cloud dans votre espace client OVHcloud ainsi que les premières étapes avec vos instances
-lastUpdated: 2026-02-24
+lastUpdated: 2026-05-25
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -48,19 +48,6 @@ Si vous n'avez pas encore créé de projet Public Cloud, commencez par notre [gu
   - [Étape 2 : Importer les clés SSH](#etape-2-importer-les-cles-ssh)
   - [Étape 3 : préparer la configuration réseau](#etape-3-preparer-la-configuration-reseau)
   - [Étape 4 : créer l'instance](#etape-4-creer-linstance)
-    - [Étape 4.1 : Nom de l'instance](#etape-41-nom-de-linstance)
-    - [Étape 4.2 : Sélectionnez une localisation](#etape-42-selectionnez-une-localisation)
-    - [Étape 4.3 : Sélectionnez un modèle](#etape-43-selectionnez-un-modele)
-      - [Informations complémentaires](#informations-complementaires)
-    - [Étape 4.4 : Sélectionnez une image](#etape-44-selectionnez-une-image)
-    - [Étape 4.5 : Sélectionnez une clé SSH (non applicable aux instances Windows)](#etape-45-selectionnez-une-cle-ssh-non-applicable-aux-instances-windows)
-    - [Étape 4.6 : Configurez les paramètres de sauvegarde](#etape-46-configurez-les-parametres-de-sauvegarde)
-    - [Étape 4.7 : Configurez le réseau](#etape-47-configurez-le-reseau)
-    - [Étape 4.8 : Sélectionnez une période de facturation](#etape-48-selectionnez-une-periode-de-facturation)
-    - [Étape 4.9 : Configurez les paramètres avancés](#etape-49-configurez-les-parametres-avances)
-      - [Instance flexible](#instance-flexible)
-      - [Script de post-installation](#script-de-post-installation)
-    - [Étape 4.10 : Finalisation de votre instance](#etape-410-finalisation-de-votre-instance)
   - [Étape 5 : Se connecter à l'instance](#etape-5-se-connecter-a-linstance)
     - [5.1 : Vérifier l'état de l'instance dans l'espace client](#51-verifier-letat-de-linstance-dans-lespace-client)
     - [5.2 : Première connexion sur une instance sous OS GNU/Linux](#52-premiere-connexion-sur-une-instance-sous-os-gnulinux)
@@ -104,7 +91,7 @@ Si vous utilisez un autre logiciel, reportez-vous à sa documentation utilisateu
 
 ### Étape 2 : Importer les clés SSH
 
-Vous pouvez stocker vos clés SSH publiques dans la section <code className="action">Public Cloud</code> de votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>. Ce n'est pas obligatoire, mais cela rend le processus de création d'instance plus pratique.
+Vous pouvez stocker vos clés SSH publiques dans votre projet Public Cloud. Ce n'est pas obligatoire, mais cela rend le processus de création d'instance plus pratique.
 
 :::info
 Les clés SSH stockées vous permettent de créer vos instances plus rapidement dans votre espace client. Pour changer les paires de clés et ajouter des utilisateurs une fois l'instance créée, reportez-vous au guide sur [les clés SSH supplémentaires](/guides/public-cloud/compute/configuring-additional-ssh-keys).
@@ -113,20 +100,71 @@ Les clés SSH publiques ajoutées à votre espace client OVHcloud seront disponi
 
 :::
 
+<Tabs>
+  <Tab label="Via l’espace client">
+    Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section <code className="action">Public Cloud</code> et sélectionnez le projet Public Cloud concerné.
 
-Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section <code className="action">Public Cloud</code> et sélectionnez le projet Public Cloud concerné.
+    Ouvrez <code className="action">Clés SSH</code> dans le menu de gauche sous **Paramètres**. Cliquez sur le bouton <code className="action">Ajouter une clé SSH</code>.
 
-<img className="thumbnail" alt="control panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/select-project.png" loading="lazy" />
+    Dans la nouvelle fenêtre, entrez un nom pour la clé. Remplissez le champ `Clé` avec votre chaîne de clé publique, par exemple celle créée à l'[étape 1](#etape-1-creer-un-jeu-de-cles-ssh). Confirmez en cliquant sur <code className="action">Ajouter</code>.
 
-Ouvrez <code className="action">Clés SSH</code> dans le menu de gauche sous **Paramètres**. Cliquez sur le bouton <code className="action">Ajouter une clé SSH</code>.
+    Vous pouvez dorénavant sélectionner cette clé à l'[Étape 4](#etape-4-creer-linstance) pour l'ajouter à une nouvelle instance.
+  </Tab>
+  <Tab label="Via l’API OVHcloud">
+    Utilisez l'appel suivant pour importer votre clé SSH publique :
 
-<img className="thumbnail" alt="ssh keys" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+    > **POST** `/cloud/project/{serviceName}/sshkey`
 
-Dans la nouvelle fenêtre, entrez un nom pour la clé. Remplissez le champ `Clé` avec votre chaîne de clé publique, par exemple celle créée à l'[étape 1](#etape-1-creer-un-jeu-de-cles-ssh). Confirmez en cliquant sur <code className="action">Ajouter</code>.
+    Paramètres :
 
-<img className="thumbnail" alt="add key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
+    - `serviceName` : identifiant de votre projet Public Cloud
+    - `name` : nom de la clé SSH
+    - `publicKey` : contenu de votre clé publique
 
-Vous pouvez dorénavant sélectionner cette clé à l'[Étape 4](#etape-4-creer-linstance) pour l'ajouter à une nouvelle instance.
+    Notez l'`id` retourné, il sera nécessaire lors de la création de l'instance.
+  </Tab>
+  <Tab label="Via l’OVHcloud CLI">
+    Assurez-vous d'avoir installé et configuré l'[OVHcloud CLI](https://github.com/ovh/ovhcloud-cli), puis importez votre clé :
+
+    ```bash
+    ovhcloud cloud ssh-key create \
+      --cloud-project <project_id> \
+      --name my-key \
+      --public-key "$(cat ~/.ssh/id_rsa.pub)"
+    ```
+
+    Vérifiez l'import et notez le `name` de la clé pour l'[Étape 4](#etape-4-creer-linstance) :
+
+    ```bash
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="Via le CLI OpenStack">
+    Assurez-vous d'avoir configuré votre environnement OpenStack ([guide dédié](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)), puis importez votre clé :
+
+    ```bash
+    openstack keypair create --public-key ~/.ssh/id_rsa.pub my-key
+    ```
+
+    Vérifiez l'import :
+
+    ```bash
+    openstack keypair list
+    ```
+  </Tab>
+  <Tab label="Via Terraform">
+    Déclarez la ressource dans votre fichier `.tf` :
+
+    ```hcl
+    resource "openstack_compute_keypair_v2" "my_keypair" {
+      name       = "my-key"
+      public_key = file("~/.ssh/id_rsa.pub")
+    }
+    ```
+
+    Consultez le [guide Terraform pour le Public Cloud OVHcloud](/guides/public-cloud/cross-functional/how-to-use-terraform) pour la configuration initiale du provider.
+  </Tab>
+</Tabs>
 
 ### Étape 3 : préparer la configuration réseau
 
@@ -163,199 +201,203 @@ Pour en savoir plus, consultez la [page web des Local Zones](https://www.ovhclou
 
 ### Étape 4 : créer l'instance
 
-:::info
-Une clé SSH publique est obligatoire lors de la création d'une instance dans l'espace client OVHcloud (à l'exception des instances Windows).
-
-Reportez-vous à l'[étape 1](#etape-1-creer-un-jeu-de-cles-ssh) et l'[étape 2](#etape-2-importer-les-cles-ssh) de ce guide si vous n'avez pas de clés SSH prêtes à l'emploi.
-
-:::
-
-
-Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section <code className="action">Public Cloud</code> et sélectionnez le projet Public Cloud concerné.
-
-Sur la page **Accueil**, cliquez sur <code className="action">Créer une instance</code>.
-
-#### Étape 4.1 : Nom de l'instance
-
-Entrez un nom complet pour votre instance. La référence commerciale du modèle d'instance est la valeur par défaut. Si nécessaire, vous pouvez également ajouter la région et la date pour faciliter l’identification et la gestion de vos instances.
-
-#### Étape 4.2 : Sélectionnez une localisation
-
-Sélectionnez une [localisation](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) la plus proche de vos utilisateurs ou clients. Notez que si vous sélectionnez une **Local Zone** à cette étape, des limitations de réseau s'appliqueront à l'instance (voir [Étape 3](#networking-modes)).
-
-Reportez-vous également aux informations de notre [page web sur les Local Zones](https://www.ovhcloud.com/fr/public-cloud/local-zone-compute/) et de la [documentation des capacités des Local Zones](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-Le choix de la région détermine le mode de déploiement de votre instance (1-AZ, 3-AZ ou Local Zones). Pour comprendre les différences en termes de résilience, de disponibilité et d’architecture, consultez notre guide [Comparaison et résilience des modes de déploiement – Comprendre les régions 3-AZ / 1-AZ / Local Zones](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details).
-
-#### Étape 4.3 : Sélectionnez un modèle
-
-À cette étape, vous choisissez le modèle d’instance (également appelé flavour), qui détermine les ressources allouées à votre instance : processeur, mémoire et capacités associées. Ouvrez la liste déroulante `Modèle de l'instance`, puis sélectionnez le type de modèle le plus adapté à votre cas d’usage afin d’accéder à notre gamme d’instances optimisées.
-
-Le type de modèle `Discovery` regroupe des instances à ressources partagées, proposées à des tarifs compétitifs. Elles sont particulièrement adaptées pour découvrir le Public Cloud OVHcloud, réaliser des tests, ou héberger des charges de travail légères comme des applications web.
-
-Les modèles `Metal Instances` offrent quant à eux des ressources physiques entièrement dédiées, garantissant des performances constantes et une isolation maximale pour les workloads les plus exigeants.
-
-:::info
-Le total de vos ressources Public Cloud sera initialement limité pour des raisons de contrôle des coûts et de sécurité. Vous pouvez vérifier ces quotas en cliquant sur <code className="action">Quota & Régions</code> dans la barre de navigation de gauche sous **Paramètres**. Consultez [la documentation dédiée](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) pour plus d'informations.
-
-Notez que vous pouvez **mettre à niveau** votre instance après sa création pour avoir plus de ressources disponibles. Le passage à un modèle plus petit n'est cependant pas possible avec une instance régulière. Vous trouverez plus d'informations sur ce sujet à l'**étape 4.9** ci-dessous.
-
-:::
-
-
-##### Informations complémentaires
-
-<details>
-
-<summary>Catégories de modèles d'instance</summary>
-
-
-| Type | Ressources garanties | Notes d'utilisation |
-| :---         |     :---:      |          :--- |
-| Best Sellers   | ✓     | Modèles les plus utilisés.    |
-| General Purpose   | ✓     | Serveurs de développement, applications web ou métier    |
-| Compute Optimized     | ✓       | Encodage vidéo ou autre calcul haute performance      |
-| Memory Optimized    | ✓     | Bases de données, analyses et calculs en mémoire    |
-| Storage Optimized   | ✓     | Optimisé pour le transfert de données sur disque    |
-| Discovery    | -       | Hébergement sur ressources partagées pour les environnements de test et de développement      |
-| Cloud GPU     | ✓       | Puissance de traitement massivement parallèle pour les applications spécialisées (rendu, big data, deep learning, etc.)       |
-| Metal Instances | ✓ | Ressources dédiées avec accès direct aux ressources de calcul, de stockage et de réseau|
-
-</details>
-
-
-<details>
-
-<summary>Régions et Local Zones</summary>
-
-
-**Régions**
-
-Une **région** est définie comme un emplacement dans le monde composé d'un ou plusieurs datacenters où les services OVHcloud sont hébergés. Vous pouvez trouver plus d'informations sur les régions, la répartition géographique et la disponibilité des services sur notre [page web dédiée](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) et notre [page web sur les localisations des infrastructures OVHcloud](https://www.ovhcloud.com/fr/about-us/global-infrastructure/regions/).
-
-**Local Zones**
-
-Les Local Zones sont une extension des **régions** qui rapprochent les services OVHcloud de sites spécifiques, offrant une latence réduite et des performances améliorées pour les applications. Vous pouvez trouver plus d'informations sur la [page web des Local Zones](https://www.ovhcloud.com/fr/public-cloud/local-zone-compute/) et dans la [documentation des capacités des Local Zones](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-</details>
-
-
-#### Étape 4.4 : Sélectionnez une image
-
-Ouvrez la liste déroulante `Type de distribution`, sélectionnez la catégorie correspondant à votre besoin, puis choisissez le système d’exploitation à déployer sur votre instance à l’aide du menu déroulant `Version de l'image`.
-
-Les images disponibles à cette étape dépendent des choix opérés lors des étapes précédentes, c'est-à-dire de la compatibilité avec le modèle d'instance et de la disponibilité régionale. Par exemple, si vous souhaitez sélectionner un système d'exploitation Windows et qu'il n'y a pas d'options dans l'onglet Windows, vous devez modifier vos choix des étapes précédentes.
-
-:::info
-Si vous choisissez un système d'exploitation nécessitant une licence payante, ces coûts seront automatiquement inclus dans la facturation du projet.
-
-:::
-
-
-#### Étape 4.5 : Sélectionnez une clé SSH (non applicable aux instances Windows)
-
-À l'exception des instances Windows, la configuration de votre instance nécessite également **l'ajout d'une clé SSH publique**. Vous avez deux options :
-
-- Utiliser une clé publique déjà stockée dans l'espace client OVHcloud
-- Saisir directement une clé publique
-
-Cliquez sur les onglets ci-dessous pour afficher leur présentation :
-
 <Tabs>
-  <Tab label="Utiliser une clé stockée">
-    Pour ajouter une clé stockée dans votre espace client OVHcloud (voir [Étape 2](#etape-2-importer-les-cles-ssh)), sélectionnez-la dans la liste.
+  <Tab label="Via l’espace client">
+    :::info
+    Une clé SSH publique est obligatoire lors de la création d'une instance (à l'exception des instances Windows). Reportez-vous à l'[étape 1](#etape-1-creer-un-jeu-de-cles-ssh) et l'[étape 2](#etape-2-importer-les-cles-ssh) si vous n'avez pas de clés prêtes à l'emploi.
+
+    :::
+
+    Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section <code className="action">Public Cloud</code> et sélectionnez le projet Public Cloud concerné. Sur la page **Accueil**, cliquez sur <code className="action">Créer une instance</code>.
+
+    **4.1 Nom**
+
+    Entrez un nom complet pour votre instance.
+
+    **4.2 Localisation**
+
+    Sélectionnez une [localisation](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) proche de vos utilisateurs. Si vous sélectionnez une **Local Zone**, des limitations réseau s'appliquent (voir [Étape 3](#networking-modes)). Consultez le guide [Comparaison des modes de déploiement](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details) pour les différences entre 3-AZ, 1-AZ et Local Zones.
+
+    **4.3 Modèle**
+
+    Ouvrez la liste déroulante `Modèle d'instance` et sélectionnez le type adapté à votre cas d'usage. Le modèle (flavor) détermine les ressources allouées à votre instance : processeur, mémoire et capacités associées.
+
+    | Type | Ressources garanties | Notes d'utilisation |
+    | :--- | :---: | :--- |
+    | Best Sellers | ✓ | Modèles les plus populaires. |
+    | General Purpose | ✓ | Serveurs de développement, applications web ou métier. |
+    | Compute Optimized | ✓ | Encodage vidéo ou autre calcul haute performance. |
+    | Memory Optimized | ✓ | Bases de données, analyses et calculs en mémoire. |
+    | GPU | ✓ | Puissance de traitement massivement parallèle pour applications spécialisées (rendu, big data, deep learning, etc.). |
+    | Discovery | - | Ressources partagées pour les environnements de test et de développement. |
+    | Storage Optimized | ✓ | Optimisé pour le transfert de données disque. |
+    | Metal Instances | ✓ | Ressources dédiées avec accès direct aux ressources de calcul, stockage et réseau. |
+
+    :::info
+    Vos ressources Public Cloud seront initialement limitées. Vérifiez vos quotas via <code className="action">Quota & Régions</code> sous **Paramètres** dans la barre de navigation de gauche. Consultez [la documentation dédiée](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) pour plus d'informations.
+
+    Vous pouvez **mettre à niveau** votre instance après sa création pour disposer de plus de ressources. En revanche, le passage à un modèle inférieur n'est pas possible avec une instance standard. Consultez l'**étape 4.9** pour plus de détails.
+
+    :::
+
+    **4.4 Image**
+
+    Sélectionnez le système d'exploitation via les menus `Type de distribution` et `Version de l'image`. Les options disponibles dépendent du modèle et de la région choisis.
+
+    **4.5 Clé SSH** *(non applicable aux instances Windows)*
+
+    Sélectionnez une clé SSH stockée dans la liste (voir [Étape 2](#etape-2-importer-les-cles-ssh)), ou cliquez sur <code className="action">Créer une nouvelle clé SSH</code> pour saisir directement une clé publique.
+
+    **4.6 Sauvegarde**
+
+    Les [sauvegardes automatisées](/guides/public-cloud/compute/save-an-instance) sont activées par défaut. Sélectionnez la rotation souhaitée (7 ou 14 jours).
+
+    **4.7 Réseau**
+
+    La section **Network settings** se divise en deux parties :
+
+    - **Private network** : sélectionnez un réseau privé existant ou cliquez sur <code className="action">Créer un réseau privé</code>. Si un réseau privé est sélectionné mais ne possède pas de gateway, activez le toggle <code className="action">Attribuer une gateway</code> pour attacher une gateway automatiquement.
+    - **Attribuer une connectivité publique** : activez le toggle pour assigner une IP publique. Choisissez <code className="action">Basic Public IP</code> (gratuite, liée à la durée de vie de l'instance, incompatible avec une gateway) ou <code className="action">Créer une nouvelle</code> (persistante et réutilisable).
+
+    Consultez l'[Étape 3](#networking-modes) pour un aperçu des modes réseau.
+
+    **4.8 Facturation**
+
+    Choisissez entre **mensuelle** (coût réduit, non réversible) ou **à l'heure** (flexible, [convertible en mensuel](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing) ultérieurement). La facturation à l'heure court jusqu'à la **suppression de l'instance**. Consultez la [documentation de facturation](/guides/public-cloud/cross-functional/analyze-billing).
+
+    **4.9 Paramètres avancés** *(optionnel)*
+
+    - **Instance flexible** : disque unique de 50 Go, permet le redimensionnement vers des modèles supérieurs ou inférieurs.
+    - **Script de post-installation** : ajoutez votre [script de post-installation](/guides/public-cloud/compute/launching-script-when-creating-instance).
+
+    **4.10 Finalisation**
+
+    Vérifiez le récapitulatif sur la droite de l'écran et configurez le nombre d'instances. Cliquez sur <code className="action">Lancer mon instance</code>. La livraison peut prendre quelques minutes.
   </Tab>
-  <Tab label="Saisir directement une clé">
-    Pour ajouter une clé publique en collant la chaîne de clé, cliquez sur le bouton <code className="action">Créer une nouvelle clé SSH</code>.
-    
-    Entrez un nom pour la clé et la chaîne de clé dans les champs respectifs. Cliquez ensuite sur <code className="action">Valider la clé</code>.
+  <Tab label="Via l’API OVHcloud">
+    Récupérez les identifiants nécessaires :
+
+    ```
+    GET /cloud/project/{serviceName}/flavor     → flavorId
+    GET /cloud/project/{serviceName}/image      → imageId
+    GET /cloud/project/{serviceName}/region     → region
+    GET /cloud/project/{serviceName}/sshkey     → sshKeyId
+    ```
+
+    Créez l'instance :
+
+    > **POST** `/cloud/project/{serviceName}/instance`
+
+    Paramètres principaux :
+
+    - `name` : nom de l'instance
+    - `flavorId` : ID du modèle
+    - `imageId` : ID de l'image OS
+    - `region` : région de déploiement
+    - `sshKeyId` : ID de la clé SSH (depuis l'[étape 2](#etape-2-importer-les-cles-ssh))
+    - `monthlyBilling` : `true` pour une facturation mensuelle
+
+    Consultez la [documentation API OVHcloud](/guides/manage-and-operate/api/first-steps) pour configurer votre accès à l'API.
+  </Tab>
+  <Tab label="Via l’OVHcloud CLI">
+    Récupérez les identifiants nécessaires :
+
+    ```bash
+    ovhcloud cloud reference list-flavors --cloud-project <project_id>
+    ovhcloud cloud reference list-images --cloud-project <project_id>
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+
+    Créez l'instance :
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --name my-instance \
+      --boot-from.image <image_id> \
+      --flavor <flavor_id> \
+      --ssh-key.name my-key \
+      --network.public \
+      --wait
+    ```
+
+    Remplacez `GRA9` par votre région. Pour une création interactive avec sélection guidée :
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --editor \
+      --image-selector \
+      --flavor-selector
+    ```
+
+    Vérifiez l'état après création :
+
+    ```bash
+    ovhcloud cloud instance list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="Via le CLI OpenStack">
+    Récupérez les informations nécessaires :
+
+    ```bash
+    openstack flavor list
+    openstack image list --property visibility=public
+    openstack keypair list
+    ```
+
+    Créez l'instance :
+
+    ```bash
+    openstack server create \
+      --flavor b2-7 \
+      --image "Ubuntu 24.04" \
+      --key-name my-key \
+      --network Ext-Net \
+      my-instance
+    ```
+
+    Vérifiez l'état :
+
+    ```bash
+    openstack server list
+    openstack server show my-instance
+    ```
+
+    Consultez le [guide de préparation de l'environnement OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) pour la mise en place initiale.
+  </Tab>
+  <Tab label="Via Terraform">
+    Exemple de configuration complète :
+
+    ```hcl
+    data "openstack_images_image_v2" "ubuntu" {
+      name        = "Ubuntu 24.04"
+      most_recent = true
+    }
+
+    resource "openstack_compute_instance_v2" "my_instance" {
+      name            = "my-instance"
+      flavor_name     = "b2-7"
+      key_pair        = openstack_compute_keypair_v2.my_keypair.name
+      security_groups = ["default"]
+
+      block_device {
+        uuid                  = data.openstack_images_image_v2.ubuntu.id
+        source_type           = "image"
+        destination_type      = "local"
+        boot_index            = 0
+        delete_on_termination = true
+      }
+
+      network {
+        name = "Ext-Net"
+      }
+    }
+    ```
+
+    Consultez le [guide Terraform pour le Public Cloud OVHcloud](/guides/public-cloud/cross-functional/how-to-use-terraform) pour la configuration initiale du provider et l'authentification.
   </Tab>
 </Tabs>
-
-
-
-#### Étape 4.6 : Configurez les paramètres de sauvegarde
-
-[Les sauvegardes automatisées](/guides/public-cloud/compute/save-an-instance) sont activées par défaut. Consultez les informations tarifaires et les détails complémentaires avant de poursuivre.
-
-Ensuite, sélectionnez le type de rotation, c’est-à-dire le nombre maximum de sauvegardes conservées en historique : 7 ou 14 jours.
-
-#### Étape 4.7 : Configurez le réseau
-
-Dans cette étape, vous allez configurer le réseau de votre instance.
-
-**Réseau privé**
-
-Vous pouvez connecter votre instance à un [réseau privé](#networking-modes) et lui attribuer une [Floating IP](https://www.ovhcloud.com/fr/public-cloud/floating-ip/).
-
-En cliquant sur <code className="action">Créer un réseau privé</code>, vous pouvez en créer un directement :
-
-- Nommer le réseau
-- **Choisir le VLAN ID:** identifiant permettant d’interconnecter plusieurs services et ressources au sein d’un même réseau privé, via un numéro de segmentation réseau commun
-- **Définir le CIDR:** plage d’adresses IP du réseau
-- **Activer le DHCP en cochant la case correspondante, si nécessaire:** activez cette option si vous souhaitez une attribution automatique des adresses IP
-
-:::info
-L’instance peut rester entièrement privée si vous ne lui attribuez pas d’IP publique.
-
-:::
-
-
-**Gateway**
-
-Vous pouvez activer l’option pour attribuer une gateway à votre réseau. Par défaut, la gateway est de taille S, mais vous pourrez ajuster sa taille ultérieurement dans les paramètres.
-
-**Attribuer une connectivité publique**
-
-Vous pouvez activer ou désactiver cette fonctionnalité selon vos besoins. Si vous choisissez de l’activer, deux options s’offrent à vous :
-
-- **Basic Public IP :** une adresse IP publique temporaire, qui ne persiste pas au-delà de la durée de vie de l’instance. Notez que l’utilisation d’une Basic Public IP n’est pas compatible avec une gateway.
-- **Floating IP :** vous pouvez créer une nouvelle Floating IP ou réutiliser une adresse existante, permettant une IP publique persistante et détachable de l’instance.
-
-#### Étape 4.8 : Sélectionnez une période de facturation
-
-:::info
-Veuillez noter que, selon le modèle d’instance choisi, la facturation **horaire** peut être la seule sélection affichée. Il s’agit d’une limitation temporaire, de nouvelles options de facturation de Public Cloud seront bientôt disponibles.
-
-:::
-
-
-<Tabs>
-  <Tab label="Facturation mensuelle">
-    La facturation mensuelle entraînera une baisse des coûts au fil du temps, mais **ne peut pas être changée** en facturation à l'heure une fois l'instance créée.
-  </Tab>
-  <Tab label="Facturation à l’heure">
-    La facturation à l'heure est le meilleur choix si vous n'avez pas clairement déterminé la durée de la période d'utilisation. Si vous décidez de conserver l’instance pour une utilisation à long terme, vous pouvez toujours [passer à un abonnement mensuel](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing).
-    
-    L'instance sera facturée tant qu'elle n'est **pas supprimée**, quelle que soit l'utilisation réelle de l'instance.
-  </Tab>
-</Tabs>
-
-
-Voici notre documentation de facturation dédiée :
-
-- [Facturation du Public Cloud](/guides/public-cloud/cross-functional/analyze-billing)
-- [FAQ sur la facturation mensuelle](/guides/public-cloud/compute/faq-change-of-monthly-billing-method)
-
-Une fois la configuration de votre instance terminée, vous pouvez choisir de cliquer sur le bouton <code className="action">Lancer mon instance</code> ou de configurer les paramètres avancés (voir ci-dessous). La livraison de votre service peut prendre quelques minutes.
-
-#### Étape 4.9 : Configurez les paramètres avancés
-
-##### Instance flexible
-
-Une instance Flex est une instance à disque unique de 50 Go, conçue pour offrir un processus de création et de restauration de snapshots plus rapide.
-
-Elle permet de redimensionner l’instance vers des modèles supérieurs ou inférieurs, tout en conservant un espace de stockage fixe. Les modèles classiques autorisent uniquement un redimensionnement vers des modèles supérieurs.
-
-##### Script de post-installation
-
-Vous pouvez ajouter [votre script de post-installation](/guides/public-cloud/compute/launching-script-when-creating-instance) dans ce champ.
-
-#### Étape 4.10 : Finalisation de votre instance
-
-Sur le côté droit de votre écran, se trouve le récapitulatif de votre configuration. Dans cette section, vous pourrez configurer le nombre d’instances à créer. Vous pouvez créer plusieurs instances en fonction des sélections effectuées lors des étapes de création, mais [les limites de quota de ressources](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) s’appliqueront.
-
-Une fois la configuration de votre instance terminée, cliquez sur le bouton <code className="action">Lancer mon instance</code>. La livraison de votre service peut prendre quelques minutes.
 
 ### Étape 5 : Se connecter à l'instance
 
@@ -376,17 +418,20 @@ Si vous avez installé un **OS avec application**, reportez-vous à notre [guide
 
 Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section <code className="action">Public Cloud</code> et sélectionnez le projet Public Cloud concerné.
 
-<img className="thumbnail" alt="espace client" src="/images/assets/screens/control-panel/product-selection/public-cloud/select-project.png" loading="lazy" />
-
 Sélectionnez <code className="action">Instances</code> dans la barre de navigation de gauche sous **Compute**. Votre instance est prête lorsque l'état est défini sur `Activé` dans le tableau. Si l'instance a été créée récemment et a un statut différent, cliquez sur le bouton « Actualiser » situé à côté du filtre de recherche.
 
-<img className="thumbnail" alt="page instances" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
+Cliquez sur le nom de l'instance dans ce tableau pour ouvrir le <code className="action">Tableau de bord</code> sur lequel vous pouvez trouver toutes les informations concernant l'instance. Pour en savoir plus sur les fonctions disponibles sur cette page, consultez notre guide sur [la gestion des instances dans l'espace client](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
-Cliquez sur le nom de l'instance dans ce tableau pour ouvrir le <code className="action">Tableau de bord</code> sur lequel vous pouvez trouver toutes les informations concernant l'instance. Pour en savoir plus sur les fonctions disponibles sur cette page, consultez notre guide sur [la gestion des instances dans l’espace client](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
+Un **utilisateur avec des droits élevés (*sudo*) est automatiquement créé** sur l'instance. Le nom d'utilisateur reflète l'image installée, par exemple « ubuntu », « debian », « fedora », etc. Vous pouvez le vérifier dans le <code className="action">Tableau de bord</code> dans la section **Réseaux**.
 
-Un **utilisateur avec des droits élevés (*sudo*) est automatiquement créé** sur l'instance. Le nom d'utilisateur reflète l'image installée, par exemple « ubuntu », « debian », « fedora », etc. Vous pouvez le vérifier sur le côté droit du <code className="action">Tableau de bord</code> dans la section **Réseaux**.
+:::info
+Via l'OVHcloud CLI, vérifiez l'état et récupérez l'adresse IP de votre instance avec :
 
-<img className="thumbnail" alt="page instances" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
+```bash
+ovhcloud cloud instance list --cloud-project <project_id>
+```
+
+:::
 
 Si votre [paire de clés SSH est correctement configurée](#etape-1-creer-un-jeu-de-cles-ssh), vous pouvez maintenant vous connecter à l'instance avec l'utilisateur préconfiguré et votre clé SSH. Vous trouverez des instructions plus détaillées dans les paragraphes suivants.
 
@@ -437,20 +482,16 @@ Il vous faudra ensuite finaliser la configuration initiale de votre système d�
 
 <Tabs>
   <Tab label="1. Paramètres régionaux">
-    Configurez votre **pays/région**, la **langue Windows** préférée et votre **disposition du clavier**. Cliquez ensuite sur le bouton <code className="action">Suivant</code> en bas à droite.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" /><br/>
+    Configurez votre **pays/région**, la **langue Windows** préférée et votre **disposition du clavier**. Cliquez ensuite sur le bouton <code className="action">Suivant</code> en bas à droite.
   </Tab>
   <Tab label="2. Mot de passe administrateur">
-    Définissez un mot de passe pour votre compte Windows `Administrator` et confirmez-le, puis cliquez sur <code className="action">Terminer</code>.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" /><br/>
+    Définissez un mot de passe pour votre compte Windows `Administrator` et confirmez-le, puis cliquez sur <code className="action">Terminer</code>.
   </Tab>
   <Tab label="3. Écran de connexion">
-    Windows appliquera vos paramètres, puis affichera l'écran de connexion. Cliquez sur le bouton <code className="action">Send CtrlAltDel</code> en haut à droite pour vous connecter.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" /><br/>
+    Windows appliquera vos paramètres, puis affichera l'écran de connexion. Cliquez sur le bouton <code className="action">Send CtrlAltDel</code> en haut à droite pour vous connecter.
   </Tab>
   <Tab label="4. Login administrateur">
-    Entrez le mot de passe `Administrator` que vous avez créé à l'étape précédente et cliquez sur le bouton « Arrow ».<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
+    Entrez le mot de passe `Administrator` que vous avez créé à l'étape précédente et cliquez sur le bouton « Arrow ».
   </Tab>
 </Tabs>
 
@@ -458,8 +499,6 @@ Il vous faudra ensuite finaliser la configuration initiale de votre système d�
 ##### 5.3.2 : Connectez-vous à distance depuis Windows
 
 Sur votre poste Windows local, vous pouvez utiliser l'application cliente `Remote Desktop Connection` pour vous connecter à votre instance.
-
-<img className="thumbnail" alt="rdp connection" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Renseignez l'adresse IPv4 de votre instance, puis votre identifiant et votre passphrase. Généralement, un message d'avertissement apparaît, vous demandant de confirmer la connexion en raison d'un certificat inconnu. Cliquez sur <code className="action">Oui</code> pour vous connecter.
 
@@ -479,20 +518,15 @@ Quel que soit le client que vous utilisez, vous n'avez besoin que de l'adresse I
 
 Le logiciel libre et open source `Remmina Remote Desktop Client` est disponible pour de nombreuses distributions de bureau GNU/Linux. Si vous ne trouvez pas Remmina dans le gestionnaire de logiciels de votre environnement de bureau, vous pouvez l'obtenir sur le [site officiel](https://remmina.org/).
 
-<img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect01.png" loading="lazy" /><br/>
-
 <Tabs>
   <Tab label="1. Connexion">
-    Ouvrez Remmina et assurez-vous que le protocole de connexion est défini sur « RDP ». Entrez l'adresse IPv4 de votre instance Public Cloud et appuyez sur « Entrée ».<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" /><br/>
+    Ouvrez Remmina et assurez-vous que le protocole de connexion est défini sur « RDP ». Entrez l'adresse IPv4 de votre instance Public Cloud et appuyez sur « Entrée ».
   </Tab>
   <Tab label="2. Authentification">
-    Si un message d'avertissement de certificat apparaît, cliquez sur <code className="action">Yes</code>. Entrez le nom d'utilisateur et votre mot de passe pour Windows et cliquez sur <code className="action">OK</code> pour établir la connexion.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" /><br/>
+    Si un message d'avertissement de certificat apparaît, cliquez sur <code className="action">Yes</code>. Entrez le nom d'utilisateur et votre mot de passe pour Windows et cliquez sur <code className="action">OK</code> pour établir la connexion.
   </Tab>
   <Tab label="3. Paramètres">
-    Vous pouvez trouver des éléments utiles dans la barre d'outils de gauche. Par exemple, cliquez sur l'icône <code className="action">Toggle dynamic resolution update</code> pour améliorer la résolution de la fenêtre.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
+    Vous pouvez trouver des éléments utiles dans la barre d'outils de gauche. Par exemple, cliquez sur l'icône <code className="action">Toggle dynamic resolution update</code> pour améliorer la résolution de la fenêtre.
   </Tab>
 </Tabs>
 
@@ -503,11 +537,7 @@ La console VNC vous permet de vous connecter à vos instances même lorsque d'au
 
 Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section <code className="action">Public Cloud</code> et sélectionnez le projet Public Cloud concerné.
 
-<img className="thumbnail" alt="espace client" src="/images/assets/screens/control-panel/product-selection/public-cloud/select-project.png" loading="lazy" />
-
 Sélectionnez <code className="action">Instances</code> dans la barre de navigation de gauche sous **Compute**. Cliquez sur le nom de l'instance et ouvrez l'onglet <code className="action">Console VNC</code>.
-
-<img className="thumbnail" alt="console vnc" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instance avec un OS GNU/Linux installé">

--- a/docs/fr/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Suspendre ou mettre en pause une instance
 description: "Découvrez comment suspendre, mettre en pause ou arrêter une instance Public Cloud pour libérer temporairement des ressources tout en conservant votre adresse IP, ainsi que l'impact de chaque option sur la facturation"
-lastUpdated: 2026-05-25
+lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -14,7 +14,6 @@ Dans le cadre de la configuration d’une infrastructure hautement disponible, v
 La dénomination de ces options dans votre espace client OVHcloud est différente de celle dans OpenStack/Horizon. Si vous effectuez cette opération depuis votre espace client OVHcloud, veillez à sélectionner la bonne option.
 
 :::
-
 
 **Ce tutoriel indique comment suspendre, arrêter ou mettre en pause votre instance.**
 
@@ -46,7 +45,6 @@ La dénomination de ces options dans votre espace client OVHcloud est différent
 
 :::
 
-
 Le tableau ci-dessous vous permet de différencier les options disponibles sur vos instances. Poursuivez la lecture de ce guide en cliquant sur l'option de votre choix. Nous mettons entre parenthèses la terminologie utilisée dans l'interface de Horizon.
 
 |Option|Description|Facturation|
@@ -71,7 +69,6 @@ Attention, la suspension d'une instance de type IOPS ou T1/T2-180 entraînera la
 En effet, la suspension de ce type d'instance entraîne la décommission de son hôte et donc des disques en passthrough.
 
 :::
-
 
 Cette option libère les ressources dédiées à votre instance Public Cloud, mais l’adresse IP sera conservée. Les données sur votre disque local seront stockées dans un snapshot créé automatiquement une fois l’instance suspendue. Les données stockées en mémoire et ailleurs ne seront pas sauvegardées.
 
@@ -162,7 +159,7 @@ Cette option réactive votre instance pour continuer à l’utiliser. Veuillez n
 
 Toute action sur le snapshot autre que la réactivation (*unshelve*) peut être très dangereuse pour votre infrastructure en cas de mauvaise utilisation. Lorsqu’une instance est « réactivée » (*unshelved*), le snapshot est automatiquement supprimé. Il est déconseillé de déployer une nouvelle instance à partir d’un snapshot créé suite à la suspension d’une instance.
 
-OVHcloud met à votre disposition des services dont la responsabilité vous incombe. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d’assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien. En cas de difficultés ou de doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/).
+OVHcloud met à votre disposition des services dont la responsabilité vous incombe. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d’assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien. En cas de difficultés ou de doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner).
 :::
 
 <Tabs>
@@ -199,7 +196,7 @@ OVHcloud met à votre disposition des services dont la responsabilité vous inco
     Saisissez la commande suivante :
 
     ```shell
-    ovhcloud cloud instance shelve <instance_id>
+    ovhcloud cloud instance unshelve <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -314,4 +311,4 @@ Cette action est réalisable **uniquement** à partir de l’interface Horizon o
 
 [Documentation OpenStack](https://docs.openstack.org/ocata/user-guide/cli-stop-and-start-an-instance.html).
 
-Échangez avec notre [communauté d’utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](https://community.ovhcloud.com/).

--- a/docs/fr/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
@@ -1,8 +1,10 @@
 ---
 title: Suspendre ou mettre en pause une instance
 description: "Découvrez comment suspendre, mettre en pause ou arrêter une instance Public Cloud pour libérer temporairement des ressources tout en conservant votre adresse IP, ainsi que l'impact de chaque option sur la facturation"
-lastUpdated: 2026-02-27
+lastUpdated: 2026-05-25
 ---
+
+import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objectif
 
@@ -50,26 +52,15 @@ Le tableau ci-dessous vous permet de différencier les options disponibles sur v
 |Option|Description|Facturation|
 |---|---|---|
 |[Suspendre (*shelve*)](#shelve-instance)|Conservez votre IP ainsi que les ressources et les données de votre disque en créant un snapshot, toutes les autres ressources sont libérées.|Seul le snapshot est facturé.|
-|[Éteindre (*suspend*)](#stop-suspend-instance)|Stocke l’état de la VM sur le disque, les ressources dédiées à l’instance sont toujours réservées.|Vous serez toujours facturé au même prix pour votre instance.|
-|[Pause](#pause-instance)|Stocke l’état de la VM dans la mémoire RAM, une instance en pause reste « gelée ».|Vous serez toujours facturé au même prix pour votre instance.|
+|[Éteindre (*suspend*)](#stop-suspend-instance)|Stocke l’état de la VM sur le disque, les ressources restent réservées.|Vous êtes facturé au même tarif.|
+|[Pause](#pause-instance)|Stocke l’état de la VM en RAM, l’instance reste gelée.|Vous êtes facturé au même tarif.|
 
 ### Sommaire
 
 - [Suspendre (shelve) une instance](#shelve-instance)
-    - [Depuis l’espace client OVHcloud](#control-panel)
-    - [Depuis l’interface Horizon](#horizon)
-    - [Depuis les API OpenStack/Nova](#openstack-nova)
 - [Réactiver (*unshelve*) une instance](#unshelve-instance)
-    - [Depuis l’espace client OVHcloud](#control-panel-unshelve)
-    - [Depuis l’interface Horizon](#horizon-unshelve)
-    - [Depuis les API OpenStack/Nova](#openstack-nova-unshelve)
 - [Éteindre (suspend) une instance](#stop-suspend-instance)
-    - [Depuis l’espace client OVHcloud](#stop-control-panel)
-    - [Depuis l’interface Horizon](#stop-horizon)
-    - [Depuis les API OpenStack/Nova](#stop-openstack-nova)
 - [Mettre en pause une instance](#pause-instance)
-    - [Depuis l’interface Horizon](#pause-horizon)
-    - [Depuis les API OpenStack/Nova](#pause-openstack-nova)
 
 <a name="shelve-instance"></a>
 
@@ -84,76 +75,81 @@ En effet, la suspension de ce type d'instance entraîne la décommission de son 
 
 Cette option libère les ressources dédiées à votre instance Public Cloud, mais l’adresse IP sera conservée. Les données sur votre disque local seront stockées dans un snapshot créé automatiquement une fois l’instance suspendue. Les données stockées en mémoire et ailleurs ne seront pas sauvegardées.
 
-<a name="control-panel"></a>
+<Tabs>
+  <Tab label="Depuis l’espace client OVHcloud">
+    Dans votre espace client OVHcloud, cliquez sur l’onglet <code className="action">Public Cloud</code>, sélectionnez votre projet Public Cloud et cliquez sur la rubrique <code className="action">Instances</code> dans le menu de gauche.
 
-#### Depuis l’espace client OVHcloud
+    Cliquez sur le bouton <code className="action">⋮</code> à droite de l’instance que vous souhaitez suspendre puis cliquez sur <code className="action">Suspendre</code>.
 
-Dans votre espace client OVHcloud, cliquez sur l’onglet <code className="action">Public Cloud</code>, sélectionnez votre projet Public Cloud et cliquez sur la rubrique <code className="action">Instances</code> dans le menu de gauche.
+    <img className="thumbnail" alt="suspension instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
 
-Cliquez sur le bouton <code className="action">⋮</code> à droite de l’instance que vous souhaitez suspendre puis cliquez sur <code className="action">Suspendre</code>.
+    Dans la fenêtre qui s’affiche, prenez connaissance des informations données et cliquez sur <code className="action">Confirmer</code>.
 
-<img className="thumbnail" alt="suspension instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="confirmer la suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
 
-Dans la fenêtre qui s’affiche, prenez connaissance des informations données et cliquez sur <code className="action">Confirmer</code>.
+    Un message s'affiche pendant l'opération :
 
-<img className="thumbnail" alt="confirmer la suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="Message de progression de l'opération" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
 
-Un message s'affiche pendant l'opération :
+    Une fois la procédure terminée, votre instance aura le statut « Suspendue ».
 
-<img className="thumbnail" alt="Message de progression de l'opération" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="statut suspendu" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
 
-Une fois la procédure terminée, votre instance aura le statut « Suspendue ».
+    Pour visualiser le snapshot, cliquez sur <code className="action">Instance Backup</code> sous l'onglet **Compute** dans le menu de gauche. Un snapshot nommé *xxxxx-shelved* sera alors visible :
 
-<img className="thumbnail" alt="statut suspendu" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="onglet snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+  </Tab>
+  <Tab label="Depuis l’interface Horizon">
+    Pour utiliser cette méthode, il faut vous [connecter à l’interface Horizon](https://horizon.cloud.ovh.net/auth/login/) :
 
-Pour visualiser le snapshot, cliquez sur <code className="action">Instance Backup</code> sous l'onglet **Compute** dans le menu de gauche. Un snapshot nommé *xxxxx-shelved* sera alors visible :
+    - Pour vous connecter avec l'authentification unique OVHcloud : utilisez le lien <code className="action">Horizon</code> dans le menu de gauche sous « Management Interfaces » après avoir ouvert votre projet <code className="action">Public Cloud</code> dans votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
 
-<img className="thumbnail" alt="onglet snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+    - Pour vous connecter avec un utilisateur OpenStack spécifique : ouvrez la page de connexion à [Horizon](https://horizon.cloud.ovh.net/auth/login/) et renseignez les [identifiants OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user) préalablement créés, puis cliquez sur <code className="action">Connect</code>.
 
-<a name="horizon"></a>
+    Si vous avez déployé des instances dans différentes régions, assurez-vous d’être dans la bonne région. Vous pouvez le vérifier en haut à gauche dans l’interface Horizon.
 
-#### Depuis l’interface Horizon
+    <img className="thumbnail" alt="horizon interface" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
 
-Pour utiliser cette méthode, il faut vous [connecter à l’interface Horizon](https://horizon.cloud.ovh.net/auth/login/):
+    Cliquez sur le menu <code className="action">Compute</code> à gauche puis sur <code className="action">Instances</code>. Sélectionnez <code className="action">Shelve Instance</code> dans la liste déroulante correspondant à l’instance.
 
-- Pour vous connecter avec l'authentification unique OVHcloud : utilisez le lien <code className="action">Horizon</code> dans le menu de gauche sous « Management Interfaces » après avoir ouvert votre projet <code className="action">Public Cloud</code> dans votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
+    <img className="thumbnail" alt="instance shelve" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
 
-- Pour vous connecter avec un utilisateur OpenStack spécifique : ouvrez la page de connexion à [Horizon](https://horizon.cloud.ovh.net/auth/login/) et renseignez les [identifiants OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user) préalablement créés, puis cliquez sur <code className="action">Connect</code>.
+    Une fois la procédure terminée, votre instance aura le statut *Shelved Offloaded*.
 
-Si vous avez déployé des instances dans différentes régions, assurez-vous d’être dans la bonne région. Vous pouvez le vérifier en haut à gauche dans l’interface Horizon.
+    <img className="thumbnail" alt="instance réservée" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
 
-<img className="thumbnail" alt="horizon interface" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
+    Pour visualiser le snapshot, dans le menu <code className="action">Compute</code>, cliquez sur <code className="action">Images</code>.
 
-Cliquez sur le menu <code className="action">Compute</code> à gauche puis sur <code className="action">Instances</code>. Sélectionnez <code className="action">Shelve Instance</code> dans la liste déroulante correspondant à l’instance.
+    <img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+  </Tab>
+  <Tab label="Depuis les API OpenStack/Nova">
+    Avant de poursuivre, il est recommandé de consulter ces guides :
 
-<img className="thumbnail" alt="instance shelve" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
+    - [Préparer l’environnement pour utiliser l’API OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
+    - [Charger les variables d’environnement OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
 
-Une fois la procédure terminée, votre instance aura le statut *Shelved Offloaded*.
+    Une fois votre environnement prêt, saisissez ce qui suit dans la ligne de commande :
 
-<img className="thumbnail" alt="instance réservée" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
+    ```bash
+    ~$ openstack server shelve <UUID server>
 
-Pour visualiser le snapshot, dans le menu <code className="action">Compute</code>, cliquez sur <code className="action">Images</code>.
+    =====================================
 
-<img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+    ~$ nova shelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="Depuis la CLI OVHcloud">
+    Avant de poursuivre, il est recommandé de consulter ces guides :
 
-<a name="openstack-nova"></a>
+    - [Connaître les bases de la CLI OVHcloud](/guides/manage-and-operate/cli/getting-started)
 
-#### Depuis les API OpenStack/Nova
+    Saisissez la commande suivante :
 
-Avant de poursuivre, il est recommandé de consulter ces guides :
-
-- [Préparer l’environnement pour utiliser l’API OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
-- [Charger les variables d’environnement OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
-
-Une fois votre environnement prêt, saisissez ce qui suit dans la ligne de commande :
-
-```bash
-~$ openstack server shelve <UUID server>
-
-=====================================
-
-~$ nova shelve <UUID server> 
-```
+    ```shell
+    ovhcloud cloud instance shelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="unshelve-instance"></a>
 
@@ -169,43 +165,44 @@ Toute action sur le snapshot autre que la réactivation (*unshelve*) peut être 
 OVHcloud met à votre disposition des services dont la responsabilité vous incombe. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d’assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien. En cas de difficultés ou de doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/).
 :::
 
-<a name="control-panel-unshelve"></a>
+<Tabs>
+  <Tab label="Depuis l’espace client OVHcloud">
+    Dans votre espace client OVHcloud, cliquez sur l’onglet <code className="action">Public Cloud</code>, sélectionnez votre projet Public Cloud et cliquez sur la rubrique <code className="action">Instances</code> dans le menu de gauche.
 
-#### Depuis l’espace client OVHcloud 
+    Cliquez sur les <code className="action">⋮</code> à droite de l’instance puis cliquez sur <code className="action">Réactiver</code>.
 
-Dans votre espace client OVHcloud, cliquez sur l’onglet <code className="action">Public Cloud</code>, sélectionnez votre projet Public Cloud et cliquez sur la rubrique <code className="action">Instances</code> dans le menu de gauche.
+    <img className="thumbnail" alt="réactiver instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
 
-Cliquez sur les <code className="action">⋮</code> à droite de l’instance puis cliquez sur <code className="action">Réactiver</code>.
+    Dans la fenêtre qui s’affiche, prenez connaissance des informations et cliquez sur <code className="action">Confirmer</code>.
 
-<img className="thumbnail" alt="réactiver instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
+    Une fois la procédure terminée, votre instance aura le statut « Activée ».
+  </Tab>
+  <Tab label="Depuis l’interface Horizon">
+    Cliquez sur le menu <code className="action">Compute</code> dans le menu de gauche et sélectionnez <code className="action">Instances</code>. Sélectionnez <code className="action">Unshelve Instance</code> dans la liste déroulante correspondant à l’instance.
 
-Dans la fenêtre qui s’affiche, prenez connaissance des informations et cliquez sur <code className="action">Confirmer</code>.
+    <img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
 
-Une fois la procédure terminée, votre instance aura le statut « Activée ».
+    Une fois la procédure terminée, votre instance aura le statut *Active*.
+  </Tab>
+  <Tab label="Depuis les API OpenStack/Nova">
+    Une fois votre environnement prêt, saisissez la commande ci-dessous dans la ligne de commande :
 
-<a name="horizon-unshelve"></a>
+    ```bash
+    ~$ openstack server unshelve <UUID server>
 
-#### Depuis l’interface Horizon
+    =========================================
 
-Cliquez sur le menu <code className="action">Compute</code> dans le menu de gauche et sélectionnez <code className="action">Instances</code>. Sélectionnez <code className="action">Unshelve Instance</code> dans la liste déroulante correspondant à l’instance.
+    ~$ nova unshelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="Depuis la CLI OVHcloud">
+    Saisissez la commande suivante :
 
-<img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
-
-Une fois la procédure terminée, votre instance aura le statut *Active*.
-
-<a name="openstack-nova-unshelve"></a>
-
-#### Depuis les API OpenStack/Nova
-
-Une fois votre environnement prêt, saisissez la commande ci-dessous dans la ligne de commande :
-
-```bash
-~$ openstack server unshelve <UUID server>
-
-=========================================
-
-~$ nova unshelve <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance shelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="stop-suspend-instance"></a>
 
@@ -213,59 +210,66 @@ Une fois votre environnement prêt, saisissez la commande ci-dessous dans la lig
 
 Cette option éteint votre instance. L’état de la VM est stocké sur le disque, tandis que la mémoire est écrite sur le disque.
 
-<a name="stop-control-panel"></a>
+<Tabs>
+  <Tab label="Depuis l’espace client OVHcloud">
+    Dans votre espace client OVHcloud, cliquez sur <code className="action">Public Cloud</code>, sélectionnez votre projet Public Cloud et cliquez sur <code className="action">Instances</code> dans le menu de gauche.
 
-#### Depuis l’espace client OVHcloud
+    Cliquez sur le bouton <code className="action">⋮</code> à droite de l’instance que vous souhaitez arrêter, puis cliquez sur <code className="action">Éteindre</code>.
 
-Dans votre espace client OVHcloud, cliquez sur <code className="action">Public Cloud</code>, sélectionnez votre projet Public Cloud et cliquez sur <code className="action">Instances</code> dans le menu de gauche.
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
 
-Cliquez sur le bouton <code className="action">⋮</code> à droite de l’instance que vous souhaitez arrêter, puis cliquez sur <code className="action">Éteindre</code>.
+    Dans la fenêtre qui s’affiche, prenez connaissance des informations et cliquez sur <code className="action">Confirmer</code>.
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
 
-Dans la fenêtre qui s’affiche, prenez connaissance des informations et cliquez sur <code className="action">Confirmer</code>.
+    Une fois le processus terminé, votre instance aura le statut « Éteinte ».
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
+    Pour **redémarrer** l’instance, effectuez les mêmes démarches que celles indiquées précédemment. Cliquez sur le bouton <code className="action">⋮</code> à droite de l’instance et sélectionnez <code className="action">Démarrer</code>. Dans certains cas, il peut être nécessaire de procéder à un redémarrage à froid.
+  </Tab>
+  <Tab label="Depuis l’interface Horizon">
+    Dans l’interface Horizon, cliquez sur le menu <code className="action">Compute</code> à gauche puis sélectionnez <code className="action">Instances</code>. Sélectionnez <code className="action">Suspend Instance</code> dans la liste déroulante correspondant à l’instance.
 
-Une fois le processus terminé, votre instance aura le statut « Éteinte ».
+    <img className="thumbnail" alt="suspension instance Horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
 
-Pour **redémarrer** l’instance, effectuez les mêmes démarches que celles indiquées précédemment. Cliquez sur le bouton <code className="action">⋮</code> à droite de l’instance et sélectionnez <code className="action">Démarrer</code>. Dans certains cas, il peut être nécessaire de procéder à un redémarrage à froid.
+    Un message de confirmation s’affiche indiquant que l’instance est suspendue.
 
-<a name="stop-horizon"></a>
+    Pour **redémarrer** l’instance, effectuez les mêmes opérations que ci-dessus. Dans la liste déroulante correspondant à l’instance, sélectionnez <code className="action">Resume Instance</code>.
+  </Tab>
+  <Tab label="Depuis les API OpenStack/Nova">
+    Une fois votre environnement prêt, saisissez la commande ci-dessous dans la ligne de commande :
 
-#### Depuis l’interface Horizon 
+    ```bash
+    ~$ openstack server suspend <UUID server>
 
-Dans l’interface Horizon, cliquez sur le menu <code className="action">Compute</code> à gauche puis sélectionnez <code className="action">Instances</code>. Sélectionnez <code className="action">Suspend Instance</code> dans la liste déroulante correspondant à l’instance.
+    =========================================
 
-<img className="thumbnail" alt="suspension instance Horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
+    ~$ nova suspend <UUID server>
+    ```
 
-Un message de confirmation s’affiche indiquant que l’instance est suspendue.
+    Pour **redémarrer** l’instance, saisissez la commande ci-dessous dans la ligne de commande :
 
-Pour **redémarrer** l’instance, effectuez les mêmes opérations que ci-dessus. Dans la liste déroulante correspondant à l’instance, sélectionnez <code className="action">Resume Instance</code>.
+    ```bash
+    ~$ openstack server unsuspend <UUID server>
 
-<a name="stop-openstack-nova"></a>
+    =========================================
 
-#### Depuis les API OpenStack/Nova
+    ~$ nova unsuspend <UUID server>
+    ```
+  </Tab>
+  <Tab label="Depuis la CLI OVHcloud">
+    Saisissez la commande suivante :
 
-Une fois votre environnement prêt, saisissez la commande ci-dessous dans la ligne de commande :
+    ```shell
+    ovhcloud cloud instance stop <instance_id>
+    ```
 
-```bash
-~$ openstack server suspend <UUID server>
+    Pour **redémarrer** l’instance, saisissez la commande suivante :
 
-=========================================
-
-~$ nova suspend <UUID server>
-```
-
-Pour **redémarrer** l’instance, saisissez la commande ci-dessous dans la ligne de commande :
-
-```bash
-~$ openstack server unsuspend <UUID server>
-
-=========================================
-
-~$ nova unsuspend <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance start <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="pause-instance"></a>
 
@@ -273,41 +277,38 @@ Pour **redémarrer** l’instance, saisissez la commande ci-dessous dans la lign
 
 Cette action est réalisable **uniquement** à partir de l’interface Horizon ou via les API OpenStack/Nova. Elle vous permet de mettre en veille ou « geler » votre instance.
 
-<a name="pause-horizon"></a>
+<Tabs>
+  <Tab label="Depuis l’interface Horizon">
+    Dans l’interface Horizon, cliquez sur le menu <code className="action">Compute</code> à gauche puis sélectionnez <code className="action">Instances</code>. Sélectionnez <code className="action">Pause Instance</code> dans la liste déroulante correspondant à l’instance.
 
-#### Depuis l’interface Horizon
+    <img className="thumbnail" alt="Suspendre instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
 
-Dans l’interface Horizon, cliquez sur le menu <code className="action">Compute</code> à gauche puis sélectionnez <code className="action">Instances</code>. Sélectionnez <code className="action">Pause Instance</code> dans la liste déroulante correspondant à l’instance.
+    Le message de confirmation apparait indiquant la mise en pause de l’instance.
 
-<img className="thumbnail" alt="Suspendre instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
+    Pour **réactiver** l’instance, effectuez les mêmes démarches que celles indiquées précédemment. Dans la liste déroulante correspondant à l’instance, sélectionnez <code className="action">Resume Instance</code>.
+  </Tab>
+  <Tab label="Depuis les API OpenStack/Nova">
+    Une fois votre environnement prêt, saisissez la commande ci-dessous dans la ligne de commande :
 
-Le message de confirmation apparait indiquant la mise en pause de l’instance.
+    ```bash
+    ~$ openstack server pause <UUID server>
 
-Pour **réactiver** l’instance, effectuez les mêmes démarches que celles indiquées précédemment. Dans la liste déroulante correspondant à l’instance, sélectionnez <code className="action">Resume Instance</code>.
+    =========================================
 
-<a name="pause-openstack-nova"></a>
+    ~$ nova pause <UUID server>
+    ```
 
-#### Depuis les API OpenStack/Nova
+    Pour **réactiver** l’instance, saisissez la commande ci-dessous dans la ligne de commande :
 
-Une fois votre environnement prêt, saisissez la commande ci-dessous dans la ligne de commande :
+    ```bash
+    ~$ openstack server unpause <UUID server>
 
-```bash
-~$ openstack server pause <UUID server>
+    =========================================
 
-=========================================
-
-~$ nova pause <UUID server>
-```
-
-Pour **réactiver** l’instance, saisissez la commande ci-dessous dans la ligne de commande :
-
-```bash
-~$ openstack server unpause <UUID server>
-
-=========================================
-
-~$ nova unpause <UUID server>
-```
+    ~$ nova unpause <UUID server>
+    ```
+  </Tab>
+</Tabs>
 
 ## Aller plus loin
 

--- a/docs/it/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/it/guides/public-cloud/compute/getting-started.mdx
@@ -1,13 +1,10 @@
 ---
 title: "Come creare un'istanza Public Cloud e connettersi"
 description: Scopri come configurare le istanze Public Cloud nello Spazio Cliente OVHcloud e i primi passaggi con le tue istanze
-lastUpdated: 2026-02-24
+lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
-
-
-
 
 ## Obiettivo
 
@@ -15,7 +12,6 @@ Le istanze Public Cloud sono facili da implementare e gestire. Tuttavia, in quan
 Potrai poi approfondire il tuo progetto Public Cloud in base alle tue esigenze.
 
 **Questa guida ti mostra i primi passi con un'istanza Public Cloud.**
-
 
 ## Prerequisiti
 
@@ -37,7 +33,6 @@ Approfitta dei prezzi ridotti impegnandoti per un periodo da 1 a 36 mesi sulle t
 
 :::
 
-
 ## Procedura
 
 :::info
@@ -46,7 +41,6 @@ Se non hai ancora creato un progetto Public Cloud, inizia con la nostra [guida s
 **I dettagli tecnici** importanti relativi al Public Cloud di OVHcloud sono disponibili su [questa pagina](/guides/public-cloud/cross-functional/compute-essential-information).
 
 :::
-
 
 ### Presentazione del contenuto
 
@@ -58,19 +52,6 @@ Se non hai ancora creato un progetto Public Cloud, inizia con la nostra [guida s
   - [Step 2: Importare le chiavi SSH](#step-2-importare-le-chiavi-ssh)
   - [Step 3: preparare la configurazione di rete](#step-3-preparare-la-configurazione-di-rete)
   - [Step 4: creare l'istanza](#step-4-creare-listanza)
-    - [Step 4.1: Nome dell'istanza](#step-41-nome-dellistanza)
-    - [Step 4.2: Seleziona una localizzazione](#step-42-seleziona-una-localizzazione)
-    - [Step 4.3: Seleziona un modello](#step-43-seleziona-un-modello)
-      - [Informazioni aggiuntive](#informazioni-aggiuntive)
-    - [Step 4.4: Seleziona un'immagine](#step-44-seleziona-unimmagine)
-    - [Step 4.5: Seleziona una chiave SSH (non applicabile alle istanze Windows)](#step-45-seleziona-una-chiave-ssh-non-applicabile-alle-istanze-windows)
-    - [Step 4.6: Configura i parametri di backup](#step-46-configura-i-parametri-di-backup)
-    - [Step 4.7: Configura la rete](#step-47-configura-la-rete)
-    - [Step 4.8: Seleziona un periodo di fatturazione](#step-48-seleziona-un-periodo-di-fatturazione)
-    - [Step 4.9: Configura i parametri avanzati](#step-49-configura-i-parametri-avanzati)
-      - [Istanza flessibile](#istanza-flessibile)
-      - [Script di post-installazione](#script-di-post-installazione)
-    - [Step 4.10: Finalizzazione dell'istanza](#step-410-finalizzazione-dellistanza)
   - [Step 5: Connettersi all'istanza](#step-5-connettersi-allistanza)
     - [5.1: Verificare lo stato dell'istanza nello Spazio Cliente](#51-verificare-lo-stato-dellistanza-nello-spazio-cliente)
     - [5.2: Prima connessione su un'istanza con OS GNU/Linux](#52-prima-connessione-su-unistanza-con-os-gnulinux)
@@ -93,7 +74,6 @@ Se non hai ancora creato un progetto Public Cloud, inizia con la nostra [guida s
 
 :::
 
-
 ### Step 1: creare un set di chiavi SSH
 
 Se disponi già di una coppia di chiavi SSH pronta all'uso, puoi saltare questo step.
@@ -114,7 +94,7 @@ Se utilizzi un altro software, consulta la relativa documentazione utente. Le is
 
 ### Step 2: Importare le chiavi SSH
 
-Puoi archiviare le tue chiavi SSH pubbliche nella sezione <code className="action">Public Cloud</code> del tuo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>. Non è obbligatorio, ma rende più pratico il processo di creazione dell'istanza.
+Puoi archiviare le tue chiavi SSH pubbliche nel tuo progetto Public Cloud. Non è obbligatorio, ma rende più pratico il processo di creazione dell'istanza.
 
 :::info
 Le chiavi SSH archiviate ti permettono di creare le tue istanze più velocemente nello Spazio Cliente. Per modificare le coppie di chiavi e aggiungere utenti dopo aver creato l'istanza, consulta la guida sulle [chiavi SSH aggiuntive](/guides/public-cloud/compute/configuring-additional-ssh-keys).
@@ -123,16 +103,71 @@ Le chiavi SSH pubbliche aggiunte al tuo Spazio Cliente OVHcloud saranno disponib
 
 :::
 
+<Tabs>
+  <Tab label="Tramite lo Spazio Cliente">
+    Accedi allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, vai alla sezione <code className="action">Public Cloud</code> e seleziona il progetto Public Cloud interessato.
 
-Apri <code className="action">Chiavi SSH</code> nel menu a sinistra sotto **Impostazioni**. Clicca sul pulsante <code className="action">Aggiungi una chiave SSH</code>.
+    Apri <code className="action">Chiavi SSH</code> nel menu a sinistra sotto **Impostazioni**. Clicca sul pulsante <code className="action">Aggiungi una chiave SSH</code>.
 
-<img className="thumbnail" alt="ssh keys" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+    Nella nuova finestra, inserisci un nome per la chiave. Compila il campo `Chiave` con la tua stringa di chiave pubblica, ad esempio quella creata allo [step 1](#step-1-creare-un-set-di-chiavi-ssh). Conferma cliccando su <code className="action">Aggiungi</code>.
 
-Nella nuova finestra, inserisci un nome per la chiave. Compila il campo `Chiave` con la tua stringa di chiave pubblica, ad esempio quella creata allo [step 1](#step-1-creare-un-set-di-chiavi-ssh). Conferma cliccando su <code className="action">Aggiungi</code>.
+    Da questo momento puoi selezionare questa chiave allo [Step 4](#step-4-creare-listanza) per aggiungerla a una nuova istanza.
+  </Tab>
+  <Tab label="Tramite l'API OVHcloud">
+    Utilizza la seguente chiamata per importare la tua chiave SSH pubblica:
 
-<img className="thumbnail" alt="add key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
+    > **POST** `/cloud/project/{serviceName}/sshkey`
 
-Da questo momento puoi selezionare questa chiave allo [Step 4](#step-4-creare-listanza) per aggiungerla a una nuova istanza.
+    Parametri:
+
+    - `serviceName`: identificativo del tuo progetto Public Cloud
+    - `name`: nome della chiave SSH
+    - `publicKey`: contenuto della tua chiave pubblica
+
+    Annota l'`id` restituito, sarà necessario durante la creazione dell'istanza.
+  </Tab>
+  <Tab label="Tramite l'OVHcloud CLI">
+    Assicurati di aver installato e configurato l'[OVHcloud CLI](https://github.com/ovh/ovhcloud-cli), poi importa la tua chiave:
+
+    ```bash
+    ovhcloud cloud ssh-key create \
+      --cloud-project <project_id> \
+      --name my-key \
+      --public-key "$(cat ~/.ssh/id_rsa.pub)"
+    ```
+
+    Verifica l'importazione e annota il `name` della chiave per lo [Step 4](#step-4-creare-listanza):
+
+    ```bash
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="Tramite la CLI OpenStack">
+    Assicurati di aver configurato il tuo ambiente OpenStack ([guida dedicata](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)), poi importa la tua chiave:
+
+    ```bash
+    openstack keypair create --public-key ~/.ssh/id_rsa.pub my-key
+    ```
+
+    Verifica l'importazione:
+
+    ```bash
+    openstack keypair list
+    ```
+  </Tab>
+  <Tab label="Tramite Terraform">
+    Dichiara la risorsa nel tuo file `.tf`:
+
+    ```hcl
+    resource "openstack_compute_keypair_v2" "my_keypair" {
+      name       = "my-key"
+      public_key = file("~/.ssh/id_rsa.pub")
+    }
+    ```
+
+    Consulta la [guida Terraform per il Public Cloud OVHcloud](/guides/public-cloud/cross-functional/how-to-use-terraform) per la configurazione iniziale del provider.
+  </Tab>
+</Tabs>
 
 ### Step 3: preparare la configurazione di rete
 
@@ -146,7 +181,6 @@ Prima di creare la tua istanza, ti consigliamo di studiare come l'istanza verrà
 <details>
 
 <summary>Public Cloud Networking - Modalità</summary>
-
 
 **Modalità pubblica**
 
@@ -166,200 +200,205 @@ Per saperne di più, consulta la [pagina web delle Local Zone](https://www.ovhcl
 
 </details>
 
-
 ### Step 4: creare l'istanza
 
-:::info
-Una chiave SSH pubblica è obbligatoria durante la creazione di un'istanza nello Spazio Cliente OVHcloud (ad eccezione delle istanze Windows).
-
-Consulta lo [step 1](#step-1-creare-un-set-di-chiavi-ssh) e lo [step 2](#step-2-importare-le-chiavi-ssh) di questa guida se non disponi di chiavi SSH pronte all'uso.
-
-:::
-
-
-Nella pagina **Home**, clicca su <code className="action">Crea un'istanza</code>.
-
-#### Step 4.1: Nome dell'istanza
-
-Inserisci un nome completo per la tua istanza. Il riferimento commerciale del modello di istanza è il valore predefinito. Se necessario, puoi anche aggiungere la Region e la data per facilitare l'identificazione e la gestione delle tue istanze.
-
-#### Step 4.2: Seleziona una localizzazione
-
-Seleziona una [localizzazione](https://www.ovhcloud.com/it/public-cloud/regions-availability/) più vicina ai tuoi utenti o clienti. Tieni presente che se selezioni una **Local Zone** in questo passaggio, verranno applicate limitazioni di rete all'istanza (vedi [Step 3](#networking-modes)).
-
-Consulta anche le informazioni della nostra [pagina web sulle Local Zone](https://www.ovhcloud.com/it/public-cloud/local-zone-compute/) e della [documentazione sulle capacità delle Local Zone](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-La scelta della Region determina la modalità di deploy della tua istanza (1-AZ, 3-AZ o Local Zones). Per comprendere le differenze in termini di resilienza, disponibilità e architettura, consulta la nostra guida [Confronto e resilienza delle modalità di deploy - Comprendere le regioni 3-AZ / 1-AZ / Local Zones](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details).
-
-#### Step 4.3: Seleziona un modello
-
-In questo step, scegli il modello di istanza (chiamato anche flavour), che determina le risorse assegnate alla tua istanza: processore, memoria e capacità associate. Apri l'elenco a discesa `Modello di istanza`, quindi seleziona il tipo di modello più adatto al tuo caso d'uso per accedere alla nostra gamma di istanze ottimizzate.
-
-Il tipo di modello `Discovery` raggruppa istanze a risorse condivise, proposte a tariffe competitive. Sono particolarmente adatte per scoprire il Public Cloud OVHcloud, effettuare test o ospitare carichi di lavoro leggeri come applicazioni web.
-
-I modelli `Metal Instances` offrono risorse fisiche completamente dedicate, garantendo prestazioni costanti e un isolamento massimo per i workload più esigenti.
-
-:::info
-Il totale delle tue risorse Public Cloud sarà inizialmente limitato per motivi di controllo dei costi e di sicurezza. Puoi verificare queste quote cliccando su <code className="action">Quota e Region</code> nella barra di navigazione a sinistra sotto **Impostazioni**. Consulta [la documentazione dedicata](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) per maggiori informazioni.
-
-Tieni presente che puoi **aggiornare** la tua istanza dopo la sua creazione per avere più risorse disponibili. Tuttavia, il passaggio a un modello più piccolo non è possibile con un'istanza regolare. Per maggiori informazioni su questo argomento, consulta lo **step 4.9** qui sotto.
-
-:::
-
-
-##### Informazioni aggiuntive
-
-<details>
-
-<summary>Categorie di modelli di istanza</summary>
-
-
-| Tipo | Risorse garantite | Note sull'utilizzo |
-| :---         |     :---:      |          :--- |
-| Best Sellers   | ✓     | Modelli più utilizzati.    |
-| General Purpose   | ✓     | Server di sviluppo, applicazioni web o aziendali    |
-| Compute Optimized     | ✓       | Codifica video o altri calcoli ad alte prestazioni      |
-| Memory Optimized    | ✓     | Database, analisi e calcoli in memoria    |
-| Storage Optimized   | ✓     | Ottimizzato per il trasferimento dei dati su disco    |
-| Discovery    | -       | Hosting su risorse condivise per ambienti di test e sviluppo      |
-| Cloud GPU     | ✓       | Potenza di elaborazione massivamente parallela per applicazioni specializzate (rendering, big data, deep learning, ecc.)       |
-| Metal Instances | ✓ | Risorse dedicate con accesso diretto alle risorse di calcolo, storage e rete|
-
-</details>
-
-
-<details>
-
-<summary>Regioni e Local Zone</summary>
-
-
-**Regioni**
-
-Una **Region** è definita come una localizzazione nel mondo composta da uno o più datacenter in cui sono ospitati i servizi OVHcloud. Per maggiori informazioni sulle Region, la distribuzione geografica e la disponibilità dei servizi, consulta la [pagina web dedicata](https://www.ovhcloud.com/it/public-cloud/regions-availability/) e la [pagina web sulle localizzazioni delle infrastrutture OVHcloud](https://www.ovhcloud.com/it/about-us/global-infrastructure/regions/).
-
-**Local Zone**
-
-Le Local Zone sono un'estensione delle **Region** che avvicinano i servizi OVHcloud a siti specifici, offrendo una latenza ridotta e prestazioni migliorate per le applicazioni. Per maggiori informazioni, consulta la [pagina web delle Local Zone](https://www.ovhcloud.com/it/public-cloud/local-zone-compute/) e la [documentazione sulle capacità delle Local Zone](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-</details>
-
-
-#### Step 4.4: Seleziona un'immagine
-
-Apri l'elenco a discesa `Tipo di distribuzione`, seleziona la categoria corrispondente alle tue esigenze, poi scegli il sistema operativo da installare sulla tua istanza tramite il menu a discesa `Versione dell'immagine`.
-
-Le immagini disponibili in questo step dipendono dalle scelte effettuate nei passaggi precedenti, ovvero dalla compatibilità con il modello di istanza e dalla disponibilità regionale. Ad esempio, se desideri selezionare un sistema operativo Windows e non ci sono opzioni nella scheda Windows, devi modificare le scelte dei passaggi precedenti.
-
-:::info
-Se scegli un sistema operativo che richiede una licenza a pagamento, questi costi verranno automaticamente inclusi nella fatturazione del progetto.
-
-:::
-
-
-#### Step 4.5: Seleziona una chiave SSH (non applicabile alle istanze Windows)
-
-Ad eccezione delle istanze Windows, la configurazione della tua istanza richiede anche **l'aggiunta di una chiave SSH pubblica**. Hai due opzioni:
-
-- Utilizzare una chiave pubblica già archiviata nello Spazio Cliente OVHcloud
-- Inserire direttamente una chiave pubblica
-
-Clicca sulle schede qui sotto per visualizzarne la presentazione:
-
 <Tabs>
-  <Tab label="Utilizzare una chiave archiviata">
-    Per aggiungere una chiave archiviata nel tuo Spazio Cliente OVHcloud (vedi [Step 2](#step-2-importare-le-chiavi-ssh)), selezionala dalla lista.
+  <Tab label="Tramite lo Spazio Cliente">
+    :::info
+    Una chiave SSH pubblica è obbligatoria durante la creazione di un'istanza (ad eccezione delle istanze Windows). Consulta lo [step 1](#step-1-creare-un-set-di-chiavi-ssh) e lo [step 2](#step-2-importare-le-chiavi-ssh) se non disponi di chiavi pronte all'uso.
+
+    :::
+
+    Accedi allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, vai alla sezione <code className="action">Public Cloud</code> e seleziona il progetto Public Cloud interessato. Nella pagina **Home**, clicca su <code className="action">Crea un'istanza</code>.
+
+    **4.1 Nome**
+
+    Inserisci un nome completo per la tua istanza.
+
+    **4.2 Localizzazione**
+
+    Seleziona una [localizzazione](https://www.ovhcloud.com/it/public-cloud/regions-availability/) vicina ai tuoi utenti. Se selezioni una **Local Zone**, verranno applicate limitazioni di rete (vedi [Step 3](#networking-modes)). Consulta la guida [Confronto delle modalità di deploy](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details) per le differenze tra 3-AZ, 1-AZ e Local Zones.
+
+    **4.3 Modello**
+
+    Apri l'elenco a discesa `Modello di istanza` e seleziona il tipo più adatto al tuo caso d'uso. Il modello (flavor) determina le risorse assegnate alla tua istanza: processore, memoria e capacità associate.
+
+    | Tipo | Risorse garantite | Note sull'utilizzo |
+    | :--- | :---: | :--- |
+    | Best Sellers | ✓ | Modelli più utilizzati. |
+    | General Purpose | ✓ | Server di sviluppo, applicazioni web o aziendali. |
+    | Compute Optimized | ✓ | Codifica video o altri calcoli ad alte prestazioni. |
+    | Memory Optimized | ✓ | Database, analisi e calcoli in memoria. |
+    | GPU | ✓ | Potenza di elaborazione massivamente parallela per applicazioni specializzate (rendering, big data, deep learning, ecc.). |
+    | Discovery | - | Risorse condivise per gli ambienti di test e sviluppo. |
+    | Storage Optimized | ✓ | Ottimizzato per il trasferimento dei dati su disco. |
+    | Metal Instances | ✓ | Risorse dedicate con accesso diretto alle risorse di calcolo, storage e rete. |
+
+    :::info
+    Il totale delle tue risorse Public Cloud sarà inizialmente limitato. Verifica le tue quote tramite <code className="action">Quota e Region</code> sotto **Impostazioni** nella barra di navigazione a sinistra. Consulta [la documentazione dedicata](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) per maggiori informazioni.
+
+    Puoi **aggiornare** la tua istanza dopo la creazione per avere più risorse. Tuttavia, il passaggio a un modello inferiore non è possibile con un'istanza standard. Consulta lo **step 4.9** per maggiori dettagli.
+
+    :::
+
+    **4.4 Immagine**
+
+    Seleziona il sistema operativo tramite i menu `Tipo di distribuzione` e `Versione dell'immagine`. Le opzioni disponibili dipendono dal modello e dalla Region scelti.
+
+    **4.5 Chiave SSH** *(non applicabile alle istanze Windows)*
+
+    Seleziona una chiave SSH archiviata dalla lista (vedi [Step 2](#step-2-importare-le-chiavi-ssh)), oppure clicca su <code className="action">Crea una nuova chiave SSH</code> per inserire direttamente una chiave pubblica.
+
+    **4.6 Backup**
+
+    I [backup automatizzati](/guides/public-cloud/compute/save-an-instance) sono attivati per impostazione predefinita. Seleziona la rotazione desiderata (7 o 14 giorni).
+
+    **4.7 Rete**
+
+    La sezione **Parametri di rete** si divide in due parti:
+
+    - **Private network**: seleziona una rete privata esistente o clicca su <code className="action">Crea una rete privata</code>. Se viene selezionata una rete privata priva di gateway, attiva il pulsante <code className="action">Assegna un gateway</code> per associare automaticamente un gateway.
+    - **Assegnare una connettività pubblica**: attiva il pulsante per assegnare un IP pubblico. Scegli <code className="action">Basic Public IP</code> (gratuito, legato alla durata di vita dell'istanza, incompatibile con un gateway) oppure <code className="action">Assegnare un Floating IP (riutilizzabile)</code> (persistente e riutilizzabile).
+
+    Consulta lo [Step 3](#networking-modes) per una panoramica delle modalità di rete.
+
+    **4.8 Fatturazione**
+
+    Scegli tra **mensile** (costo ridotto, non reversibile) oppure **oraria** (flessibile, [convertibile in mensile](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing) successivamente). La fatturazione oraria prosegue fino alla **eliminazione dell'istanza**. Consulta la [documentazione sulla fatturazione](/guides/public-cloud/cross-functional/analyze-billing).
+
+    **4.9 Parametri avanzati** *(opzionale)*
+
+    - **Istanza flessibile**: disco unico da 50 GB, permette il ridimensionamento verso modelli superiori o inferiori.
+    - **Script di post-installazione**: aggiungi il tuo [script di post-installazione](/guides/public-cloud/compute/launching-script-when-creating-instance).
+
+    **4.10 Finalizzazione**
+
+    Verifica il riepilogo sul lato destro dello schermo e configura il numero di istanze. Clicca su <code className="action">Avvia l'istanza</code>. La consegna può richiedere qualche minuto.
   </Tab>
-  <Tab label="Inserire direttamente una chiave">
-    Per aggiungere una chiave pubblica incollando la stringa di chiave, clicca sul pulsante <code className="action">Crea una nuova chiave SSH</code>.
-    
-    Inserisci un nome per la chiave e la stringa di chiave nei rispettivi campi. Clicca poi su <code className="action">Conferma la chiave</code>.
+  <Tab label="Tramite l'API OVHcloud">
+    Recupera gli identificativi necessari:
+
+    ```
+    GET /cloud/project/{serviceName}/flavor     → flavorId
+    GET /cloud/project/{serviceName}/image      → imageId
+    GET /cloud/project/{serviceName}/region     → region
+    GET /cloud/project/{serviceName}/sshkey     → sshKeyId
+    ```
+
+    Crea l'istanza:
+
+    > **POST** `/cloud/project/{serviceName}/instance`
+
+    Parametri principali:
+
+    - `name`: nome dell'istanza
+    - `flavorId`: ID del modello
+    - `imageId`: ID dell'immagine OS
+    - `region`: Region di deploy
+    - `sshKeyId`: ID della chiave SSH (dallo [step 2](#step-2-importare-le-chiavi-ssh))
+    - `monthlyBilling`: `true` per una fatturazione mensile
+
+    Consulta la [documentazione API OVHcloud](/guides/manage-and-operate/api/first-steps) per configurare il tuo accesso all'API.
+  </Tab>
+  <Tab label="Tramite l'OVHcloud CLI">
+    Recupera gli identificativi necessari:
+
+    ```bash
+    ovhcloud cloud reference list-flavors --cloud-project <project_id>
+    ovhcloud cloud reference list-images --cloud-project <project_id>
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+
+    Crea l'istanza:
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --name my-instance \
+      --boot-from.image <image_id> \
+      --flavor <flavor_id> \
+      --ssh-key.name my-key \
+      --network.public \
+      --wait
+    ```
+
+    Sostituisci `GRA9` con la tua Region. Per una creazione interattiva con selezione guidata:
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --editor \
+      --image-selector \
+      --flavor-selector
+    ```
+
+    Verifica lo stato dopo la creazione:
+
+    ```bash
+    ovhcloud cloud instance list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="Tramite la CLI OpenStack">
+    Recupera le informazioni necessarie:
+
+    ```bash
+    openstack flavor list
+    openstack image list --property visibility=public
+    openstack keypair list
+    ```
+
+    Crea l'istanza:
+
+    ```bash
+    openstack server create \
+      --flavor b2-7 \
+      --image "Ubuntu 24.04" \
+      --key-name my-key \
+      --network Ext-Net \
+      my-instance
+    ```
+
+    Verifica lo stato:
+
+    ```bash
+    openstack server list
+    openstack server show my-instance
+    ```
+
+    Consulta la [guida sulla preparazione dell'ambiente OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) per la configurazione iniziale.
+  </Tab>
+  <Tab label="Tramite Terraform">
+    Esempio di configurazione completa:
+
+    ```hcl
+    data "openstack_images_image_v2" "ubuntu" {
+      name        = "Ubuntu 24.04"
+      most_recent = true
+    }
+
+    resource "openstack_compute_instance_v2" "my_instance" {
+      name            = "my-instance"
+      flavor_name     = "b2-7"
+      key_pair        = openstack_compute_keypair_v2.my_keypair.name
+      security_groups = ["default"]
+
+      block_device {
+        uuid                  = data.openstack_images_image_v2.ubuntu.id
+        source_type           = "image"
+        destination_type      = "local"
+        boot_index            = 0
+        delete_on_termination = true
+      }
+
+      network {
+        name = "Ext-Net"
+      }
+    }
+    ```
+
+    Consulta la [guida Terraform per il Public Cloud OVHcloud](/guides/public-cloud/cross-functional/how-to-use-terraform) per la configurazione iniziale del provider e l'autenticazione.
   </Tab>
 </Tabs>
-
-
-
-#### Step 4.6: Configura i parametri di backup
-
-I [backup automatizzati](/guides/public-cloud/compute/save-an-instance) sono attivati per impostazione predefinita. Consulta le informazioni tariffarie e i dettagli aggiuntivi prima di proseguire.
-
-Successivamente, seleziona il tipo di rotazione, ovvero il numero massimo di backup conservati nello storico: 7 o 14 giorni.
-
-#### Step 4.7: Configura la rete
-
-In questo step configurerai la rete della tua istanza.
-
-**Rete privata**
-
-Puoi connettere la tua istanza a una [rete privata](#networking-modes) e assegnarle una [Floating IP](https://www.ovhcloud.com/it/public-cloud/floating-ip/).
-
-Cliccando su <code className="action">Crea una rete privata</code>, puoi crearne una direttamente:
-
-- Denominare la rete
-- **Scegliere il VLAN ID:** identificativo che consente di interconnettere più servizi e risorse all'interno della stessa rete privata, tramite un numero di segmentazione di rete comune
-- **Definire il CIDR:** intervallo di indirizzi IP della rete
-- **Attivare il DHCP selezionando la casella corrispondente, se necessario:** attiva questa opzione se desideri un'assegnazione automatica degli indirizzi IP
-
-:::info
-L'istanza può rimanere interamente privata se non le assegni un IP pubblico.
-
-:::
-
-
-**Gateway**
-
-Puoi attivare l'opzione per assegnare un gateway alla tua rete. Per impostazione predefinita, il gateway è di dimensione S, ma potrai modificarne la dimensione successivamente nelle impostazioni.
-
-**Assegnare una connettività pubblica**
-
-Puoi attivare o disattivare questa funzionalità in base alle tue esigenze. Se scegli di attivarla, hai due opzioni:
-
-- **Basic Public IP:** un indirizzo IP pubblico temporaneo, che non persiste oltre la durata di vita dell'istanza. Tieni presente che l'utilizzo di un Basic Public IP non è compatibile con un gateway.
-- **Floating IP:** puoi creare una nuova Floating IP o riutilizzare un indirizzo esistente, consentendo un IP pubblico persistente e scollegabile dall'istanza.
-
-#### Step 4.8: Seleziona un periodo di fatturazione
-
-:::info
-Ti ricordiamo che, in base al modello di istanza scelto, la fatturazione **oraria** potrebbe essere l'unica selezione visualizzata. Si tratta di una limitazione temporanea; nuove opzioni di fatturazione per il Public Cloud saranno presto disponibili.
-
-:::
-
-
-<Tabs>
-  <Tab label="Fatturazione mensile">
-    La fatturazione mensile comporterà una riduzione dei costi nel tempo, ma **non può essere modificata** in fatturazione oraria una volta creata l'istanza.
-  </Tab>
-  <Tab label="Fatturazione oraria">
-    La fatturazione oraria è la scelta migliore se non hai determinato chiaramente la durata del periodo di utilizzo. Se decidi di mantenere l'istanza per un utilizzo a lungo termine, puoi comunque [passare a un abbonamento mensile](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing).
-    
-    L'istanza verrà fatturata fino a quando non verrà **eliminata**, indipendentemente dall'utilizzo effettivo dell'istanza.
-  </Tab>
-</Tabs>
-
-
-Ecco la nostra documentazione dedicata alla fatturazione:
-
-- [Fatturazione del Public Cloud](/guides/public-cloud/cross-functional/analyze-billing)
-- [FAQ sulla fatturazione mensile](/guides/public-cloud/compute/faq-change-of-monthly-billing-method)
-
-Una volta completata la configurazione dell'istanza, puoi cliccare sul pulsante <code className="action">Avvia l'istanza</code> o configurare i parametri avanzati (vedi qui sotto). La consegna del servizio potrebbe richiedere qualche minuto.
-
-#### Step 4.9: Configura i parametri avanzati
-
-##### Istanza flessibile
-
-Un'istanza Flex è un'istanza con un disco unico da 50 GB, progettata per offrire un processo di creazione e ripristino degli snapshot più rapido.
-
-Consente di ridimensionare l'istanza verso modelli superiori o inferiori, mantenendo uno spazio di archiviazione fisso. I modelli classici consentono solo un ridimensionamento verso modelli superiori.
-
-##### Script di post-installazione
-
-Puoi aggiungere [il tuo script di post-installazione](/guides/public-cloud/compute/launching-script-when-creating-instance) in questo campo.
-
-#### Step 4.10: Finalizzazione dell'istanza
-
-Sul lato destro dello schermo si trova il riepilogo della tua configurazione. In questa sezione potrai configurare il numero di istanze da creare. Puoi creare più istanze in base alle selezioni effettuate durante i passaggi di creazione, ma si applicheranno [i limiti di quota delle risorse](/guides/public-cloud/cross-functional/increasing-public-cloud-quota).
-
-Una volta completata la configurazione dell'istanza, clicca sul pulsante <code className="action">Avvia l'istanza</code>. La consegna del servizio potrebbe richiedere qualche minuto.
 
 ### Step 5: Connettersi all'istanza
 
@@ -375,18 +414,24 @@ Se hai installato un **OS con applicazione**, consulta la nostra [guida sui prim
 
 :::
 
-
 #### 5.1: Verificare lo stato dell'istanza nello Spazio Cliente
+
+Accedi allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, vai alla sezione <code className="action">Public Cloud</code> e seleziona il progetto Public Cloud interessato.
 
 Seleziona <code className="action">Istanze</code> nella barra di navigazione a sinistra sotto **Compute**. La tua istanza è pronta quando lo stato è impostato su `Attivato` nella tabella. Se l'istanza è stata creata di recente e ha uno stato diverso, clicca sul pulsante "Aggiorna" accanto al filtro di ricerca.
 
-<img className="thumbnail" alt="pagina istanze" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
-
 Clicca sul nome dell'istanza in questa tabella per aprire il <code className="action">Dashboard</code>, dove puoi trovare tutte le informazioni relative all'istanza. Per maggiori informazioni sulle funzioni disponibili in questa pagina, consulta la nostra guida sulla [gestione delle istanze nello Spazio Cliente](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
-Un **utente con diritti elevati (*sudo*) viene creato automaticamente** sull'istanza. Il nome utente riflette l'immagine installata, ad esempio "ubuntu", "debian", "fedora", ecc. Puoi verificarlo sul lato destro del <code className="action">Dashboard</code> nella sezione **Reti**.
+Un **utente con diritti elevati (*sudo*) viene creato automaticamente** sull'istanza. Il nome utente riflette l'immagine installata, ad esempio "ubuntu", "debian", "fedora", ecc. Puoi verificarlo nel <code className="action">Dashboard</code> nella sezione **Reti**.
 
-<img className="thumbnail" alt="pagina istanze" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
+:::info
+Tramite l'OVHcloud CLI, verifica lo stato e recupera l'indirizzo IP della tua istanza con:
+
+```bash
+ovhcloud cloud instance list --cloud-project <project_id>
+```
+
+:::
 
 Se la tua [coppia di chiavi SSH è configurata correttamente](#step-1-creare-un-set-di-chiavi-ssh), puoi ora connetterti all'istanza con l'utente preconfigurato e la tua chiave SSH. Troverai istruzioni più dettagliate nei paragrafi seguenti.
 
@@ -397,7 +442,6 @@ Questa guida non tratta la rete privata per le istanze. Consulta la nostra docum
 
 :::
 
-
 #### 5.2: Prima connessione su un'istanza con OS GNU/Linux
 
 :::info
@@ -407,7 +451,6 @@ Se riscontri ancora difficoltà, puoi sostituire la coppia di chiavi con l'aiuto
 Se hai creato un'istanza senza chiave SSH, tramite l'[API OVHcloud](/guides/manage-and-operate/api/first-steps) o l'[interfaccia OpenStack Horizon](/guides/public-cloud/compute/create-instance-in-horizon), puoi aggiungere una chiave SSH alla tua istanza solo tramite la [modalità rescue](/guides/public-cloud/compute/put-an-instance-in-rescue-mode) seguendo le istruzioni descritte in [questa guida](/guides/public-cloud/compute/replacing-lost-ssh-key-pair).
 
 :::
-
 
 Puoi accedere alla tua istanza subito dopo la sua creazione tramite l'interfaccia da riga di comando del tuo computer locale (`Terminal`, `Command prompt`, `Powershell`, ecc.) via SSH.
 
@@ -437,29 +480,22 @@ A questo punto dovrai completare la configurazione iniziale del sistema operativ
 
 <Tabs>
   <Tab label="1. Impostazioni regionali">
-    Configura il tuo **paese/area geografica**, la **lingua Windows** preferita e la **disposizione della tastiera**. Clicca poi sul pulsante <code className="action">Avanti</code> in basso a destra.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" /><br/>
+    Configura il tuo **paese/area geografica**, la **lingua Windows** preferita e la **disposizione della tastiera**. Clicca poi sul pulsante <code className="action">Avanti</code> in basso a destra.
   </Tab>
   <Tab label="2. Password amministratore">
-    Definisci una password per il tuo account Windows `Administrator` e confermala, poi clicca su <code className="action">Fine</code>.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" /><br/>
+    Definisci una password per il tuo account Windows `Administrator` e confermala, poi clicca su <code className="action">Fine</code>.
   </Tab>
   <Tab label="3. Schermata di accesso">
-    Windows applicherà le impostazioni, poi visualizzerà la schermata di accesso. Clicca sul pulsante <code className="action">Send CtrlAltDel</code> in alto a destra per accedere.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" /><br/>
+    Windows applicherà le impostazioni, poi visualizzerà la schermata di accesso. Clicca sul pulsante <code className="action">Send CtrlAltDel</code> in alto a destra per accedere.
   </Tab>
   <Tab label="4. Login amministratore">
-    Inserisci la password `Administrator` creata nel passaggio precedente e clicca sul pulsante "Freccia".<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
+    Inserisci la password `Administrator` creata nel passaggio precedente e clicca sul pulsante "Freccia".
   </Tab>
 </Tabs>
-
 
 ##### 5.3.2: Connettersi da remoto da Windows
 
 Sul tuo computer Windows locale, puoi utilizzare l'applicazione client `Remote Desktop Connection` per connetterti alla tua istanza.
-
-<img className="thumbnail" alt="rdp connection" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Inserisci l'indirizzo IPv4 della tua istanza, il tuo identificativo e la tua password. In genere viene visualizzato un messaggio di avviso che richiede di confermare la connessione a causa di un certificato sconosciuto. Clicca su <code className="action">Sì</code> per connetterti.
 
@@ -467,7 +503,6 @@ Inserisci l'indirizzo IPv4 della tua istanza, il tuo identificativo e la tua pas
 Se riscontri difficoltà con questa procedura, verifica che le connessioni remote (RDP) siano consentite sul tuo dispositivo controllando le impostazioni di sistema, le regole del firewall e le eventuali restrizioni di rete.
 
 :::
-
 
 ##### 5.3.3: Connettersi da remoto da un altro OS
 
@@ -479,31 +514,25 @@ Indipendentemente dal client utilizzato, per connetterti hai bisogno solo dell'i
 
 Il software libero e open source `Remmina Remote Desktop Client` è disponibile per numerose distribuzioni desktop GNU/Linux. Se non trovi Remmina nel gestore software del tuo ambiente desktop, puoi ottenerlo dal [sito ufficiale](https://remmina.org/).
 
-<img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect01.png" loading="lazy" /><br/>
-
 <Tabs>
   <Tab label="1. Connessione">
-    Apri Remmina e assicurati che il protocollo di connessione sia impostato su "RDP". Inserisci l'indirizzo IPv4 della tua istanza Public Cloud e premi "Invio".<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" /><br/>
+    Apri Remmina e assicurati che il protocollo di connessione sia impostato su "RDP". Inserisci l'indirizzo IPv4 della tua istanza Public Cloud e premi "Invio".
   </Tab>
   <Tab label="2. Autenticazione">
-    Se appare un messaggio di avviso relativo al certificato, clicca su <code className="action">Yes</code>. Inserisci il nome utente e la password per Windows e clicca su <code className="action">OK</code> per stabilire la connessione.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" /><br/>
+    Se appare un messaggio di avviso relativo al certificato, clicca su <code className="action">Yes</code>. Inserisci il nome utente e la password per Windows e clicca su <code className="action">OK</code> per stabilire la connessione.
   </Tab>
   <Tab label="3. Impostazioni">
-    Puoi trovare elementi utili nella barra degli strumenti a sinistra. Ad esempio, clicca sull'icona <code className="action">Toggle dynamic resolution update</code> per migliorare la risoluzione della finestra.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
+    Puoi trovare elementi utili nella barra degli strumenti a sinistra. Ad esempio, clicca sull'icona <code className="action">Toggle dynamic resolution update</code> per migliorare la risoluzione della finestra.
   </Tab>
 </Tabs>
-
 
 #### 5.4: Accesso console VNC
 
 La console VNC ti permette di connetterti alle tue istanze anche quando altri mezzi di accesso non sono disponibili.
 
-Seleziona <code className="action">Istanze</code> nella barra di navigazione a sinistra sotto **Compute**. Clicca sul nome dell'istanza e apri la scheda <code className="action">Console VNC</code>.
+Accedi allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, vai alla sezione <code className="action">Public Cloud</code> e seleziona il progetto Public Cloud interessato.
 
-<img className="thumbnail" alt="console vnc" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
+Seleziona <code className="action">Istanze</code> nella barra di navigazione a sinistra sotto **Compute**. Clicca sul nome dell'istanza e apri la scheda <code className="action">Console VNC</code>.
 
 <Tabs>
   <Tab label="Istanza con OS GNU/Linux installato">
@@ -513,7 +542,6 @@ Seleziona <code className="action">Istanze</code> nella barra di navigazione a s
     Accedi con le tue credenziali Windows. In caso di sessione attiva, disponi di un accesso immediato. Ci sarà una latenza notevole rispetto a una connessione RDP.
   </Tab>
 </Tabs>
-
 
 ### Step 6: Primi passi su una nuova istanza
 
@@ -526,14 +554,12 @@ Per maggiori informazioni, consulta la sezione [Per saperne di più](#per-sapern
 
 :::
 
-
 #### 6.1: Gestione degli utenti
 
 :::info
 Durante la configurazione degli account utente e dei livelli di autorizzazione su un'istanza, ti consigliamo di utilizzare le informazioni della nostra [guida sull'account utente](/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds).
 
 :::
-
 
 ##### 6.1.1: Definisci una password per l'account utente attuale
 
@@ -561,7 +587,6 @@ Questo step non è necessario e deve essere eseguito solo se hai un motivo valid
 L'esempio seguente illustra una soluzione temporanea su un'istanza su cui è installato Ubuntu. Tieni presente che potrebbe essere necessario adattare i comandi in base al tuo sistema operativo. Non è consigliabile mantenere questa configurazione in modo permanente poiché aggiunge un potenziale rischio di sicurezza esponendo il sistema ad attacchi basati su SSH.
 
 :::
-
 
 Una volta [connesso alla tua istanza](#step-6-primi-passi-su-una-nuova-istanza), apri il file di configurazione con un editor di testo. Esempio:
 
@@ -621,4 +646,4 @@ Consulta la nostra [guida dedicata](/guides/public-cloud/compute/configuring-add
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](https://community.ovhcloud.com/).

--- a/docs/it/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
@@ -1,8 +1,10 @@
 ---
 title: Sospendi o metti in pausa un’istanza
 description: Scopri come sospendere, mettere in pausa o arrestare un’istanza Public Cloud per liberare temporaneamente le risorse conservando il tuo indirizzo IP, nonché l’impatto sulla fatturazione di ciascuna opzione
-lastUpdated: 2026-02-27
+lastUpdated: 2026-05-27
 ---
+
+import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Obiettivo
 
@@ -12,7 +14,6 @@ Durante la configurazione di un'infrastruttura ad alta disponibilità, potresti 
 Il nome di queste opzioni nello Spazio Cliente OVHcloud è diverso dal nome in OpenStack/Horizon. Se effettui questa operazione utilizzando lo Spazio Cliente OVHcloud, assicurati di selezionare l'opzione più adatta.
 
 :::
-
 
 **Questa guida ti mostra come sospendere, arrestare o mettere in pausa un'istanza.**
 
@@ -44,34 +45,20 @@ Il nome di queste opzioni nello Spazio Cliente OVHcloud è diverso dal nome in O
 
 :::
 
-
 La tabella qui sotto ti permette di differenziare le opzioni disponibili sulle tue istanze. Prosegui nella lettura di questa guida cliccando sull'opzione che preferisci. Abbiamo messo tra parentesi la terminologia utilizzata nell'interfaccia di Horizon.
-
 
 |Termine|Descrizione|Fatturazione|
 |---|---|---|
 |[Sospendere (*shelve*)](#shelve-instance)|Conserva il tuo IP e le risorse e i dati del disco creando uno Snapshot. Tutte le altre risorse vengono liberate.|Viene fatturato solo lo Snapshot.|
-|[Spegnere (*suspend*)](#stop-suspend-instance)|Salvare lo stato della macchina virtuale sul disco, le risorse dedicate all'istanza sono sempre riservate.|Riceverai sempre la stessa tariffa per la tua istanza.|
-|[Pausare](#pause-instance)|Salva lo stato della macchina virtuale nella RAM, un'istanza sospesa diventa «bloccata».|Riceverai sempre la stessa tariffa per la tua istanza.|
+|[Spegnere (*suspend*)](#stop-suspend-instance)|Salva lo stato della VM sul disco, le risorse restano riservate.|Vieni fatturato alla stessa tariffa.|
+|[Pausare](#pause-instance)|Salva lo stato della VM nella RAM, l'istanza resta bloccata.|Vieni fatturato alla stessa tariffa.|
 
 ### Sommario
 
 - [Sospendere (shelve) un'istanza](#shelve-instance)
-    - [Nello Spazio Cliente OVHcloud](#control-panel)
-    - [Dall'interfaccia Horizon](#horizon)
-    - [Dalle API OpenStack/Nova](#openstack-nova)
 - [Riattivare (unshelve) un'istanza](#unshelve-instance)
-    - [Nello Spazio Cliente OVHcloud](#control-panel-unshelve)
-    - [Dall'interfaccia Horizon](#horizon-unshelve)
-    - [Dalle API OpenStack/Nova](#openstack-nova-unshelve)
 - [Spegnere (suspend) un'istanza](#stop-suspend-instance)
-    - [Nello Spazio Cliente OVHcloud](#stop-control-panel)
-    - [Dall'interfaccia Horizon](#stop-horizon)
-    - [Dalle API OpenStack/Nova](#stop-openstack-nova)
 - [Mettere in pausa un'istanza](#pause-instance)
-    - [Dall'interfaccia Horizon](#pause-horizon)
-    - [Dalle API OpenStack/Nova](#pause-openstack-nova)
-
 
 <a name="shelve-instance"></a>
 
@@ -84,79 +71,83 @@ La sospensione di questo tipo di istanza comporta la sua disattivazione dall'hos
 
 :::
 
-
 Questa opzione permette di liberare le risorse dedicate all'istanza Public Cloud, ma l'indirizzo IP resta. I dati del disco locale saranno salvati in un snapshot «istantanea» creata automaticamente una volta che l'istanza è sospesa. I dati archiviati nella memoria e altrove non saranno conservati.
 
-<a name="control-panel"></a>
+<Tabs>
+  <Tab label="Dallo Spazio Cliente OVHcloud">
+    Nello Spazio Cliente OVHcloud, vai alla sezione <code className="action">Public Cloud</code>, seleziona il tuo progetto Public Cloud e clicca su <code className="action">Istanze</code> nella barra di navigazione a sinistra.
 
-#### Nello Spazio Cliente OVHcloud
+    Clicca su <code className="action">⋮</code> a destra dell'istanza da sospendere, poi clicca su <code className="action">Sospendere</code>.
 
-Nello Spazio Cliente OVHcloud, vai alla sezione <code className="action">Public Cloud</code>, seleziona il tuo progetto Public Cloud e clicca su <code className="action">Istanze</code> nella barra di navigazione a sinistra. 
+    <img className="thumbnail" alt="suspend instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
 
-Clicca su <code className="action">⋮</code> a destra dell'istanza da sospendere, poi clicca su <code className="action">Sospendere</code>.
+    Nella finestra contestuale, annota il messaggio e clicca su <code className="action">Confermare</code>.
 
-<img className="thumbnail" alt="suspend instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="confirm suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
 
-Nella finestra contestuale, annota il messaggio e clicca su <code className="action">Confermare</code>.
+    Durante l'operazione viene visualizzato un messaggio:
 
-<img className="thumbnail" alt="confirm suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="Operation in progress" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
 
-Durante l'operazione viene visualizzato un messaggio:
+    Una volta completata la procedura, l'istanza si presenta come *Sospesa*.
 
-<img className="thumbnail" alt="Operation in progress" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="sospeso" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
 
-Una volta completata la procedura, l'istanza si presenta come *Sospesa*.
+    Lo snapshot sarà quindi disponibile nella sezione <code className="action">Instance Backup</code> del menu **Compute** a sinistra dello spazio Public Cloud. Sarà quindi visibile uno snapshot denominato *xxxxx-shelved*:
 
-<img className="thumbnail" alt="sospeso" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="snapshot tab" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+  </Tab>
+  <Tab label="Dall'interfaccia Horizon">
+    Per utilizzare questo metodo, è necessario [connettersi all’interfaccia Horizon](https://horizon.cloud.ovh.net/auth/login/):
 
-Lo snapshot sarà quindi disponibile nella sezione <code className="action">Instance Backup</code> del menu **Compute** a sinistra dello spazio Public Cloud. Sarà quindi visibile uno snapshot denominato *xxxxx-shelved*:
+    - Per accedere con il Single Sign-On OVHcloud: utilizza il link <code className="action">Horizon</code> nel menu a sinistra sotto "Management Interfaces" dopo aver aperto il tuo progetto <code className="action">Public Cloud</code> nello <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>.
 
-<img className="thumbnail" alt="snapshot tab" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+    - Per accedere con un utente OpenStack specifico: apri la pagina di accesso a [Horizon](https://horizon.cloud.ovh.net/auth/login/) e inserisci le [credenziali OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user) precedentemente create, poi clicca su <code className="action">Connect</code>.
 
-<a name="horizon"></a>
+    Se hai installato istanze in diverse regioni, assicurati di essere nella localizzazione giusta. Puoi verificarlo nell'angolo superiore sinistro dell'interfaccia Horizon.
 
-#### Dall'interfaccia Horizon
+    <img className="thumbnail" alt="horizon interface" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
 
-Per utilizzare questo metodo, è necessario [connettersi all’interfaccia Horizon](https://horizon.cloud.ovh.net/auth/login/):
+    Clicca su <code className="action">Compute</code> nel menu a sinistra e seleziona <code className="action">Instances</code>. Seleziona <code className="action">Shelve Instance</code> nel menu a tendina dell'istanza.
 
-- Per accedere con il Single Sign-On OVHcloud: utilizza il link <code className="action">Horizon</code> nel menu a sinistra sotto "Management Interfaces" dopo aver aperto il tuo progetto <code className="action">Public Cloud</code> nello <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>.
+    <img className="thumbnail" alt="instance shelve" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
 
-- Per accedere con un utente OpenStack specifico: apri la pagina di accesso a [Horizon](https://horizon.cloud.ovh.net/auth/login/) e inserisci le [credenziali OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user) precedentemente create, poi clicca su <code className="action">Connect</code>.
+    Una volta terminata la procedura, l'istanza apparirà come *Shelved Offloaded*.
 
-Se hai installato istanze in diverse regioni, assicurati di essere nella localizzazione giusta. Puoi verificarlo nell'angolo superiore sinistro dell'interfaccia Horizon.
+    <img className="thumbnail" alt="istanza riservata" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
 
-<img className="thumbnail" alt="horizon interface" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
+    Per visualizzare lo snapshot, nel menu <code className="action">Compute</code>, clicca su <code className="action">Images</code>.
 
-Clicca su <code className="action">Compute</code> nel menu a sinistra e seleziona <code className="action">Instances</code>. Seleziona <code className="action">Shelve Instance</code> nel menu a tendina dell'istanza.
+    <img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+  </Tab>
+  <Tab label="Dalle API OpenStack/Nova">
+    Prima di continuare, si raccomanda di consultare le seguenti guide:
 
-<img className="thumbnail" alt="instance shelve" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
+    - [Preparare l’ambiente per utilizzare l’API OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
+    - [Impostare le variabili d’ambiente OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
 
-Una volta terminata la procedura, l'istanza apparirà come *Shelved Offloaded*.
+    Una volta che l'ambiente è pronto, esegui questo comando:
 
-<img className="thumbnail" alt="istanza riservata" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
+    ```bash
+    ~$ openstack server shelve <UUID server>
 
-Per visualizzare lo snapshot, nel menu <code className="action">Compute</code>, clicca su <code className="action">Images</code>.
+    =====================================
 
-<img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+    ~$ nova shelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="Dalla CLI OVHcloud">
+    Prima di continuare, si raccomanda di consultare queste guide:
 
-<a name="openstack-nova"></a>
+    - [Conoscere le basi della CLI OVHcloud](/guides/manage-and-operate/cli/getting-started)
 
-#### Dalle API OpenStack/Nova
+    Esegui questo comando:
 
-Prima di continuare, si raccomanda di consultare le seguenti guide:
-
-- [Preparare l’ambiente per utilizzare l’API OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
-- [Impostare le variabili d’ambiente OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
-
-Una volta che l'ambiente è pronto, esegui questo comando:
-
-```bash
-~$ openstack server shelve <UUID server>
-
-=====================================
-
-~$ nova shelve <UUID server> 
-```
+    ```shell
+    ovhcloud cloud instance shelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="unshelve-instance"></a>
 
@@ -172,43 +163,44 @@ Qualsiasi azione sullo snapshot diversa dalla riattivazione (*unshelve*) può es
 OVHcloud fornisce i servizi di cui sei responsabile. Non avendo accesso a queste macchine, non siamo noi gli amministratori e pertanto non possiamo fornirti alcuna assistenza. È responsabilità dell’utente garantire ogni giorno la gestione e la sicurezza del software. In caso di difficoltà o dubbi relativi ad amministrazione e sicurezza, ti consigliamo di contattare un [fornitore specializzato](https://partner.ovhcloud.com/it/directory/). Per maggiori informazioni consulta la sezione “Per saperne di più” di questa guida.
 :::
 
-<a name="control-panel-unshelve"></a>
+<Tabs>
+  <Tab label="Dallo Spazio Cliente OVHcloud">
+    Nello Spazio Cliente OVHcloud, vai alla sezione <code className="action">Public Cloud</code>, seleziona il tuo progetto Public Cloud e clicca su <code className="action">Istanze</code> nella barra di navigazione a sinistra.
 
-#### Nello Spazio Cliente OVHcloud
+    Clicca su <code className="action">⋮</code> a destra dell'istanza e poi clicca su <code className="action">Riattivare</code>.
 
-Nello Spazio Cliente OVHcloud, vai alla sezione <code className="action">Public Cloud</code>, seleziona il tuo progetto Public Cloud e clicca su <code className="action">Istanze</code> nella barra di navigazione a sinistra.
+    <img className="thumbnail" alt="reactivate instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
 
-Clicca su <code className="action">⋮</code> a destra dell'istanza e poi clicca su <code className="action">Riattivare</code>.
+    Nella finestra contestuale, annota il messaggio e clicca su <code className="action">Confermare</code>.
 
-<img className="thumbnail" alt="reactivate instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
+    Una volta terminato il processo, l'istanza apparirà come *Attivata*.
+  </Tab>
+  <Tab label="Dall'interfaccia Horizon">
+    Nell'interfaccia Horizon, clicca su <code className="action">Compute</code> nel menu a sinistra e seleziona <code className="action">Instances</code>. Seleziona <code className="action">Unshelve Instance</code> nel menu a tendina dell'istanza.
 
-Nella finestra contestuale, annota il messaggio e clicca su <code className="action">Confermare</code>.
+    <img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
 
-Una volta terminato il processo, l'istanza apparirà come *Attivata*.
+    Una volta terminato il processo, l'istanza apparirà come *Active*.
+  </Tab>
+  <Tab label="Dalle API OpenStack/Nova">
+    Una volta che l'ambiente è pronto, esegui questo comando:
 
-<a name="horizon-unshelve"></a>
+    ```bash
+    ~$ openstack server unshelve <UUID server>
 
-#### Dall'interfaccia Horizon
+    =========================================
 
-Nell'interfaccia Horizon, clicca su <code className="action">Compute</code> nel menu a sinistra e seleziona <code className="action">Instances</code>. Seleziona <code className="action">Unshelve Instance</code> nel menu a tendina dell'istanza.
+    ~$ nova unshelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="Dalla CLI OVHcloud">
+    Esegui questo comando:
 
-<img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
-
-Una volta terminato il processo, l'istanza apparirà come *Active*.
-
-<a name="openstack-nova-unshelve"></a>
-
-#### Dalle API OpenStack/Nova
-
-Una volta che l'ambiente è pronto, esegui questo comando:
-
-```bash
-~$ openstack server unshelve <UUID server>
-
-=========================================
-
-~$ nova unshelve <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance unshelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="stop-suspend-instance"></a>
 
@@ -216,59 +208,66 @@ Una volta che l'ambiente è pronto, esegui questo comando:
 
 Questa opzione ti permette di spegnere la tua istanza e salvare lo stato della macchina virtuale sul disco. La memoria sarà anche scritta sul disco.
 
-<a name="stop-control-panel"></a>
+<Tabs>
+  <Tab label="Dallo Spazio Cliente OVHcloud">
+    Nello Spazio Cliente OVHcloud, vai alla sezione <code className="action">Public Cloud</code>, seleziona il tuo progetto Public Cloud e clicca su <code className="action">Istanze</code> nella barra di navigazione a sinistra.
 
-#### Nello Spazio Cliente OVHcloud
+    Clicca su <code className="action">⋮</code> a destra dell'istanza da arrestare, poi clicca su <code className="action">Spegnere</code>.
 
-Nello Spazio Cliente OVHcloud, vai alla sezione <code className="action">Public Cloud</code>, seleziona il tuo progetto Public Cloud e clicca su <code className="action">Istanze</code> nella barra di navigazione a sinistra.
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
 
-Clicca su <code className="action">⋮</code> a destra dell'istanza da arrestare, poi clicca su <code className="action">Spegnere</code>.
+    Nella finestra contestuale, annota il messaggio e clicca su <code className="action">Confermare</code>.
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
 
-Nella finestra contestuale, annota il messaggio e clicca su <code className="action">Confermare</code>.
+    Una volta completata la procedura, l'istanza apparirà come *Spento*.
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
+    Per **riattivare** l'istanza, effettua gli stessi step indicati in precedenza. Clicca su <code className="action">⋮</code> a destra dell'istanza e seleziona <code className="action">Comincia ora</code>. In alcuni casi, potrebbe essere necessario riavviare a freddo.
+  </Tab>
+  <Tab label="Dall'interfaccia Horizon">
+    Nell'interfaccia Horizon, clicca su <code className="action">Compute</code> nel menu a sinistra e seleziona <code className="action">Instances</code>. Seleziona <code className="action">Suspend Instance</code> nel menu a tendina dell'istanza.
 
-Una volta completata la procedura, l'istanza apparirà come *Spento*.
+    <img className="thumbnail" alt="suspend instance Horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
 
-Per **riattivare** l'istanza, effettua gli stessi step indicati in precedenza. Clicca su <code className="action">⋮</code> a destra dell'istanza e seleziona <code className="action">Comincia ora</code>. In alcuni casi, potrebbe essere necessario riavviare a freddo.
+    Compare il messaggio di conferma che l'istanza è stata sospesa.
 
-<a name="stop-horizon"></a>
+    Per **riattivare** l'istanza, effettua le stesse operazioni indicate in precedenza. Nella lista a tendina dell'istanza corrispondente, seleziona <code className="action">Resume Instance</code>.
+  </Tab>
+  <Tab label="Dalle API OpenStack/Nova">
+    Una volta che l'ambiente è pronto, esegui questo comando:
 
-#### Dall'interfaccia Horizon 
+    ```bash
+    ~$ openstack server suspend <UUID server>
 
-Nell'interfaccia Horizon, clicca su <code className="action">Compute</code> nel menu a sinistra e seleziona <code className="action">Instances</code>. Seleziona <code className="action">Suspend Instance</code> nel menu a tendina dell'istanza.
+    =========================================
 
-<img className="thumbnail" alt="suspend instance Horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
+    ~$ nova suspend <UUID server>
+    ```
 
-Compare il messaggio di conferma che l'istanza è stata sospesa.
+    Per **riattivare** l'istanza, esegui questo comando:
 
-Per **riattivare** l'istanza, effettua le stesse operazioni indicate in precedenza. Nella lista a tendina dell'istanza corrispondente, seleziona <code className="action">Resume Instance</code>.
+    ```bash
+    ~$ openstack server unsuspend <UUID server>
 
-<a name="stop-openstack-nova"></a>
+    =========================================
 
-#### Dalle API OpenStack/Nova
+    ~$ nova unsuspend <UUID server>
+    ```
+  </Tab>
+  <Tab label="Dalla CLI OVHcloud">
+    Esegui questo comando:
 
-Una volta che l'ambiente è pronto, esegui questo comando:
+    ```shell
+    ovhcloud cloud instance stop <instance_id>
+    ```
 
-```bash
-~$ openstack server suspend <UUID server>
+    Per **riattivare** l'istanza, esegui questo comando:
 
-=========================================
-
-~$ nova suspend <UUID server>
-```
-
-Per **riattivare** l'istanza, esegui questo comando:
-
-```bash
-~$ openstack server unsuspend <UUID server>
-
-=========================================
-
-~$ nova unsuspend <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance start <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="pause-instance"></a>
 
@@ -276,44 +275,41 @@ Per **riattivare** l'istanza, esegui questo comando:
 
 Questa operazione è possibile **solo** nell'interfaccia Horizon o tramite l'API Openstack/Nova. Permette di mettere l'istanza in *standby*.
 
-<a name="pause-horizon"></a>
+<Tabs>
+  <Tab label="Dall'interfaccia Horizon">
+    Nell'interfaccia Horizon, clicca su <code className="action">Compute</code> nel menu a sinistra e seleziona <code className="action">Instances</code>. Seleziona <code className="action">Pause Instance</code> nel menu a tendina dell'istanza.
 
-#### Dall'interfaccia Horizon 
+    <img className="thumbnail" alt="Pause instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
 
-Nell'interfaccia Horizon, clicca su <code className="action">Compute</code> nel menu a sinistra e seleziona <code className="action">Instances</code>. Seleziona <code className="action">Pause Instance</code> nel menu a tendina dell'istanza.
+    Compare il messaggio di conferma che l'istanza è stata messa in pausa.
 
-<img className="thumbnail" alt="Pause instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
+    Per **riattivare** l'istanza, segui gli step indicati qui sotto. Nella lista a tendina dell'istanza corrispondente, seleziona <code className="action">Resume Instance</code>.
+  </Tab>
+  <Tab label="Dalle API OpenStack/Nova">
+    Una volta che l'ambiente è pronto, esegui questo comando:
 
-Compare il messaggio di conferma che l'istanza è stata messa in pausa.
+    ```bash
+    ~$ openstack server pause <UUID server>
 
-Per **riattivare** l'istanza, segui gli step indicati qui sotto. Nella lista a tendina dell'istanza corrispondente, seleziona <code className="action">Resume Instance</code>.
+    =========================================
 
-<a name="pause-openstack-nova"></a>
+    ~$ nova pause <UUID server>
+    ```
 
-#### Dalle API OpenStack/Nova
+    Per **riattivare** l'istanza, esegui questo comando:
 
-Una volta che l'ambiente è pronto, esegui questo comando:
+    ```bash
+    ~$ openstack server unpause <UUID server>
 
-```bash
-~$ openstack server pause <UUID server>
+    =========================================
 
-=========================================
-
-~$ nova pause <UUID server>
-```
-
-Per **riattivare** l'istanza, esegui questo comando:
-
-```bash
-~$ openstack server unpause <UUID server>
-
-=========================================
-
-~$ nova unpause <UUID server>
-```
+    ~$ nova unpause <UUID server>
+    ```
+  </Tab>
+</Tabs>
 
 ## Per saperne di più
 
 [Documentazione OpenStack](https://docs.openstack.org/ocata/user-guide/cli-stop-and-start-an-instance.html).
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](https://community.ovhcloud.com/).

--- a/docs/pl/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/pl/guides/public-cloud/compute/getting-started.mdx
@@ -1,13 +1,10 @@
 ---
 title: Jak utworzyć instancję Public Cloud i się z nią połączyć
 description: Dowiedz się, jak skonfigurować instancje Public Cloud w Panelu klienta OVHcloud oraz poznaj pierwsze kroki z instancjami
-lastUpdated: 2026-02-24
+lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
-
-
-
 
 ## Wprowadzenie
 
@@ -15,7 +12,6 @@ Instancje Public Cloud są łatwe do wdrożenia i zarządzania. Jednak jako czę
 W zależności od Twoich potrzeb będziesz mógł dalej rozwijać swój projekt Public Cloud.
 
 **Niniejszy przewodnik przedstawia pierwsze kroki z instancją Public Cloud.**
-
 
 ## Wymagania początkowe
 
@@ -37,7 +33,6 @@ Skorzystaj z obniżonych cen, zobowiązując się do korzystania z zasobów Publ
 
 :::
 
-
 ## W praktyce
 
 :::info
@@ -46,7 +41,6 @@ Jeśli jeszcze nie utworzyłeś projektu Public Cloud, zacznij od naszego [przew
 Ważne **informacje techniczne** na temat OVHcloud Public Cloud są dostępne na [tej stronie przewodnika](/guides/public-cloud/cross-functional/compute-essential-information).
 
 :::
-
 
 ### Prezentacja zawartości
 
@@ -58,19 +52,6 @@ Ważne **informacje techniczne** na temat OVHcloud Public Cloud są dostępne na
   - [Krok 2: Importowanie kluczy SSH](#krok-2-importowanie-kluczy-ssh)
   - [Krok 3: Przygotowanie konfiguracji sieci](#krok-3-przygotowanie-konfiguracji-sieci)
   - [Krok 4: Tworzenie instancji](#krok-4-tworzenie-instancji)
-    - [Krok 4.1: Nazwa instancji](#krok-41-nazwa-instancji)
-    - [Krok 4.2: Wybór lokalizacji](#krok-42-wybor-lokalizacji)
-    - [Krok 4.3: Wybór modelu](#krok-43-wybor-modelu)
-      - [Informacje dodatkowe](#informacje-dodatkowe)
-    - [Krok 4.4: Wybór obrazu](#krok-44-wybor-obrazu)
-    - [Krok 4.5: Wybór klucza SSH (nie dotyczy instancji Windows)](#krok-45-wybor-klucza-ssh-nie-dotyczy-instancji-windows)
-    - [Krok 4.6: Konfiguracja ustawień kopii zapasowych](#krok-46-konfiguracja-ustawien-kopii-zapasowych)
-    - [Krok 4.7: Konfiguracja sieci](#krok-47-konfiguracja-sieci)
-    - [Krok 4.8: Wybór okresu rozliczeniowego](#krok-48-wybor-okresu-rozliczeniowego)
-    - [Krok 4.9: Konfiguracja ustawień zaawansowanych](#krok-49-konfiguracja-ustawien-zaawansowanych)
-      - [Elastyczna instancja](#elastyczna-instancja)
-      - [Skrypt poinstalacyjny](#skrypt-poinstalacyjny)
-    - [Krok 4.10: Finalizacja instancji](#krok-410-finalizacja-instancji)
   - [Krok 5: Połączenie z instancją](#krok-5-polaczenie-z-instancja)
     - [5.1: Sprawdzenie stanu instancji w Panelu klienta OVHcloud](#51-sprawdzenie-stanu-instancji-w-panelu-klienta-ovhcloud)
     - [5.2: Pierwsze logowanie do instancji z zainstalowanym systemem GNU/Linux](#52-pierwsze-logowanie-do-instancji-z-zainstalowanym-systemem-gnulinux)
@@ -86,14 +67,12 @@ Ważne **informacje techniczne** na temat OVHcloud Public Cloud są dostępne na
     - [6.2: Dodatkowe klucze SSH](#62-dodatkowe-klucze-ssh)
 - [Sprawdź również](#sprawdz-rowniez)
 
-
 :::info
 **Podczas tworzenia instancji Public Cloud w Panelu klienta OVHcloud należy podać publiczny klucz SSH.** Po utworzeniu instancji możesz skonfigurować zdalny dostęp w dowolny sposób.
 
 **Wyjątek**: Uwierzytelnianie logowania do instancji Windows wymaga podania nazwy użytkownika i hasła, ponieważ system Windows używa protokołu RDP (**R**emote **D**esktop **P**rotocol).
 
 :::
-
 
 ### Krok 1: Tworzenie zestawu kluczy SSH
 
@@ -113,10 +92,9 @@ Większość współczesnych stacjonarnych systemów operacyjnych zawiera natywn
 
 Jeśli używasz innego oprogramowania, zapoznaj się z jego dokumentacją. Przykład użycia rozwiązania open source `PuTTY` jest dostępny w naszym przewodniku: [Jak korzystać z PuTTY](/guides/web-cloud/web-hosting/ssh-using-putty-on-windows).
 
-
 ### Krok 2: Importowanie kluczy SSH
 
-Publiczne klucze SSH możesz przechowywać w sekcji <code className="action">Public Cloud</code> w <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>. Nie jest to obowiązkowe, ale sprawia, że proces tworzenia instancji jest wygodniejszy.
+Publiczne klucze SSH możesz przechowywać w swoim projekcie Public Cloud. Nie jest to obowiązkowe, ale sprawia, że proces tworzenia instancji jest wygodniejszy.
 
 :::info
 Przechowywane klucze SSH pozwalają na szybsze tworzenie instancji w Panelu klienta OVHcloud. Aby zmienić pary kluczy i dodać użytkowników po utworzeniu instancji, zapoznaj się z przewodnikiem dotyczącym [dodatkowych kluczy SSH](/guides/public-cloud/compute/configuring-additional-ssh-keys).
@@ -125,16 +103,71 @@ Publiczne klucze SSH dodane do Panelu klienta OVHcloud będą dostępne dla usł
 
 :::
 
+<Tabs>
+  <Tab label="W Panelu klienta">
+    Zaloguj się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, przejdź do sekcji <code className="action">Public Cloud</code> i wybierz swój projekt Public Cloud.
 
-Otwórz <code className="action">Klucze SSH</code> w menu po lewej stronie, w sekcji **Ustawienia**. Kliknij przycisk <code className="action">Dodaj klucz SSH</code>.
+    Otwórz <code className="action">Klucze SSH</code> w menu po lewej stronie, w sekcji **Ustawienia**. Kliknij przycisk <code className="action">Dodaj klucz SSH</code>.
 
-<img className="thumbnail" alt="klucze ssh" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+    W nowym oknie wpisz nazwę klucza. Wypełnij pole `Klucz` ciągiem klucza publicznego, na przykład kluczem utworzonym w [Kroku 1](#krok-1-tworzenie-zestawu-kluczy-ssh). Potwierdź, klikając <code className="action">Dodaj</code>.
 
-W nowym oknie wpisz nazwę klucza. Wypełnij pole `Klucz` ciągiem klucza publicznego, na przykład kluczem utworzonym w [Kroku 1](#krok-1-tworzenie-zestawu-kluczy-ssh). Potwierdź, klikając <code className="action">Dodaj</code>.
+    Możesz teraz wybrać ten klucz w [Kroku 4](#krok-4-tworzenie-instancji), aby dodać go do nowej instancji.
+  </Tab>
+  <Tab label="Za pomocą API OVHcloud">
+    Użyj następującego wywołania, aby zaimportować swój publiczny klucz SSH:
 
-<img className="thumbnail" alt="dodaj klucz" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
+    > **POST** `/cloud/project/{serviceName}/sshkey`
 
-Możesz teraz wybrać ten klucz w [Kroku 4](#krok-4-tworzenie-instancji), aby dodać go do nowej instancji.
+    Parametry:
+
+    - `serviceName`: identyfikator Twojego projektu Public Cloud
+    - `name`: nazwa klucza SSH
+    - `publicKey`: zawartość Twojego klucza publicznego
+
+    Zanotuj zwrócony identyfikator `id` — będzie potrzebny podczas tworzenia instancji.
+  </Tab>
+  <Tab label="Za pomocą OVHcloud CLI">
+    Upewnij się, że masz zainstalowane i skonfigurowane [OVHcloud CLI](https://github.com/ovh/ovhcloud-cli), a następnie zaimportuj klucz:
+
+    ```bash
+    ovhcloud cloud ssh-key create \
+      --cloud-project <project_id> \
+      --name my-key \
+      --public-key "$(cat ~/.ssh/id_rsa.pub)"
+    ```
+
+    Sprawdź import i zanotuj `name` klucza na potrzeby [Kroku 4](#krok-4-tworzenie-instancji):
+
+    ```bash
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="Za pomocą OpenStack CLI">
+    Upewnij się, że skonfigurowałeś środowisko OpenStack ([dedykowany przewodnik](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)), a następnie zaimportuj klucz:
+
+    ```bash
+    openstack keypair create --public-key ~/.ssh/id_rsa.pub my-key
+    ```
+
+    Sprawdź import:
+
+    ```bash
+    openstack keypair list
+    ```
+  </Tab>
+  <Tab label="Za pomocą Terraform">
+    Zadeklaruj zasób w pliku `.tf`:
+
+    ```hcl
+    resource "openstack_compute_keypair_v2" "my_keypair" {
+      name       = "my-key"
+      public_key = file("~/.ssh/id_rsa.pub")
+    }
+    ```
+
+    Zapoznaj się z [przewodnikiem Terraform dla OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform), aby skonfigurować dostawcę po raz pierwszy.
+  </Tab>
+</Tabs>
 
 ### Krok 3: Przygotowanie konfiguracji sieci
 
@@ -148,7 +181,6 @@ Przed utworzeniem instancji zalecamy rozważenie sposobu jej wykorzystania w kon
 <details>
 
 <summary>Public Cloud Networking - Tryby</summary>
-
 
 **Public Mode**
 
@@ -168,199 +200,205 @@ Więcej informacji znajdziesz na [stronie internetowej Local Zones](https://www.
 
 </details>
 
-
 ### Krok 4: Tworzenie instancji
 
-:::info
-Publiczny klucz SSH jest wymagany podczas tworzenia instancji w Panelu klienta OVHcloud (z wyjątkiem instancji Windows).
-
-Zapoznaj się z [krokiem 1](#krok-1-tworzenie-zestawu-kluczy-ssh) i [krokiem 2](#krok-2-importowanie-kluczy-ssh) w tym przewodniku, jeśli nie posiadasz gotowych kluczy SSH.
-
-:::
-
-
-Na stronie **Strona główna** kliknij <code className="action">Utwórz instancję</code>.
-
-#### Krok 4.1: Nazwa instancji
-
-Wprowadź pełną nazwę instancji. Domyślną wartością jest oznaczenie handlowe modelu instancji. W razie potrzeby możesz dodać region i datę, aby ułatwić identyfikację i zarządzanie instancjami.
-
-#### Krok 4.2: Wybór lokalizacji
-
-Wybierz [lokalizację](https://www.ovhcloud.com/pl/public-cloud/regions-availability/) najbliższą Twoim użytkownikom lub klientom. Pamiętaj, że wybranie strefy **Local Zone** na tym etapie spowoduje zastosowanie ograniczeń sieciowych dla instancji (patrz [Krok 3](#networking-modes)).
-
-Zapoznaj się również z informacjami na [stronie internetowej Local Zones](https://www.ovhcloud.com/pl/public-cloud/local-zone-compute/) oraz w [dokumentacji możliwości Local Zones](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-Wybór regionu determinuje sposób wdrożenia instancji (1-AZ, 3-AZ lub Local Zones). Aby zrozumieć różnice w zakresie odporności, dostępności i architektury, zapoznaj się z naszym przewodnikiem [Porównanie trybów wdrożenia i odporność – omówienie 3-AZ / 1-AZ / Local Zones](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details).
-
-#### Krok 4.3: Wybór modelu
-
-Na tym etapie wybierz model instancji (znany również jako flavor), który określa zasoby przydzielone do Twojej instancji: procesor, pamięć i powiązane możliwości. Otwórz listę rozwijaną `Model instancji`, a następnie wybierz typ modelu najlepiej odpowiadający Twojemu przypadkowi użycia, aby uzyskać dostęp do naszej gamy zoptymalizowanych instancji.
-
-Typ modelu `Discovery` grupuje instancje ze współdzielonymi zasobami oferowanymi w konkurencyjnych cenach. Są one szczególnie odpowiednie do odkrywania OVHcloud Public Cloud, przeprowadzania testów lub hostingu lekkich obciążeń roboczych, takich jak aplikacje internetowe.
-
-Modele `Metal Instances` oferują w pełni dedykowane zasoby fizyczne, gwarantując stałą wydajność i maksymalną izolację dla najbardziej wymagających obciążeń roboczych.
-
-:::info
-Całkowite zasoby Public Cloud zostaną początkowo ograniczone ze względu na kontrolę kosztów i bezpieczeństwo. Możesz sprawdzić te limity, klikając <code className="action">Limity i regiony</code> na pasku nawigacyjnym po lewej stronie, w sekcji **Ustawienia**. Więcej informacji znajdziesz w [dedykowanej dokumentacji](/guides/public-cloud/cross-functional/increasing-public-cloud-quota).
-
-Pamiętaj, że po utworzeniu instancji możesz ją **uaktualnić**, aby uzyskać więcej zasobów. Jednak przejście na mniejszy model nie jest możliwe w przypadku zwykłej instancji. Więcej informacji na ten temat znajdziesz w **kroku 4.9** poniżej.
-
-:::
-
-
-##### Informacje dodatkowe
-
-<details>
-
-<summary>Kategorie modeli instancji</summary>
-
-
-| Typ | Gwarantowane zasoby | Uwagi dotyczące użycia |
-| :---         |     :---:      |          :--- |
-| Best Sellers   | ✓     | Najpopularniejsze modele.    |
-| General Purpose   | ✓     | Serwery deweloperskie, aplikacje internetowe lub biznesowe    |
-| Compute Optimized     | ✓       | Kodowanie wideo lub inne zastosowania wymagające dużej mocy obliczeniowej      |
-| Memory Optimized    | ✓     | Bazy danych, analizy i obliczenia w pamięci    |
-| GPU     | ✓       | Moc przetwarzania równoległego dla zaawansowanych aplikacji (renderowanie, big data, deep learning, itp.)       |
-| Discovery    | -       | Hosting ze współdzielonymi zasobami dla środowisk testowych i deweloperskich      |
-| Storage Optimized   | ✓     | Zoptymalizowane do przesyłania danych na dysk    |
-| Metal Instances | ✓ | Dedykowane zasoby z bezpośrednim dostępem do zasobów obliczeniowych, pamięci masowej i sieci|
-
-</details>
-
-
-<details>
-
-<summary>Regiony i Local Zones</summary>
-
-
-**Regiony**
-
-**Region** to lokalizacja na świecie składająca się z jednego lub kilku centrów danych, w których hostowane są usługi OVHcloud. Więcej informacji na temat regionów, podziału geograficznego i dostępności usług znajdziesz na naszej [stronie internetowej dotyczącej regionów](https://www.ovhcloud.com/pl/public-cloud/regions-availability/) oraz na naszej [stronie internetowej dotyczącej infrastruktury](https://www.ovhcloud.com/pl/about-us/global-infrastructure/regions/).
-
-**Local Zones**
-
-Local Zones to rozszerzenie **regionów**, które przybliża usługi OVHcloud do określonych lokalizacji, oferując krótszy czas odpowiedzi i lepszą wydajność aplikacji. Więcej informacji znajdziesz na [stronie internetowej Local Zones](https://www.ovhcloud.com/pl/public-cloud/local-zone-compute/) oraz w [dokumentacji możliwości Local Zones](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-</details>
-
-
-#### Krok 4.4: Wybór obrazu
-
-Otwórz listę rozwijaną `Rodzaj dystrybucji`, wybierz kategorię odpowiadającą Twoim potrzebom, a następnie wybierz system operacyjny do wdrożenia na instancji za pomocą rozwijanego menu `Wersja obrazu`.
-
-Obrazy dostępne na tym etapie zależą od wyborów dokonanych na wcześniejszych etapach, tj. kompatybilności z modelem instancji i dostępności regionalnej. Na przykład, jeśli chcesz wybrać system operacyjny Windows i nie ma żadnych opcji na karcie Windows, musisz zmienić wybory na wcześniejszych etapach.
-
-:::info
-Jeśli wybierzesz system operacyjny wymagający płatnej licencji, koszty te zostaną automatycznie uwzględnione na fakturze za projekt.
-
-:::
-
-
-#### Krok 4.5: Wybór klucza SSH (nie dotyczy instancji Windows)
-
-Z wyjątkiem instancji Windows konfiguracja instancji wymaga również **dodania publicznego klucza SSH**. Masz dwie opcje:
-
-- Użycie klucza publicznego już przechowywanego w Panelu klienta OVHcloud
-- Bezpośrednie wprowadzenie klucza publicznego
-
-Kliknij poniższe karty, aby wyświetlić ich opis:
-
 <Tabs>
-  <Tab label="Użycie przechowywanego klucza">
-    Aby dodać klucz przechowywany w Panelu klienta OVHcloud (patrz [Krok 2](#krok-2-importowanie-kluczy-ssh)), wybierz go z listy.
+  <Tab label="W Panelu klienta">
+    :::info
+    Publiczny klucz SSH jest wymagany podczas tworzenia instancji (z wyjątkiem instancji Windows). Zapoznaj się z [Krokiem 1](#krok-1-tworzenie-zestawu-kluczy-ssh) i [Krokiem 2](#krok-2-importowanie-kluczy-ssh), jeśli nie posiadasz gotowych do użycia kluczy SSH.
+
+    :::
+
+    Zaloguj się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, przejdź do sekcji <code className="action">Public Cloud</code> i wybierz swój projekt Public Cloud. Na stronie **Strona główna** kliknij <code className="action">Utwórz instancję</code>.
+
+    **4.1 Nazwa**
+
+    Wprowadź pełną nazwę instancji.
+
+    **4.2 Lokalizacja**
+
+    Wybierz [lokalizację](https://www.ovhcloud.com/pl/public-cloud/regions-availability/) najbliższą Twoim użytkownikom. Pamiętaj, że wybranie strefy **Local Zone** powoduje zastosowanie ograniczeń sieciowych (patrz [Krok 3](#networking-modes)). Zapoznaj się z przewodnikiem [Porównanie trybów wdrożenia](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details), aby poznać różnice między 3-AZ, 1-AZ i Local Zones.
+
+    **4.3 Model**
+
+    Otwórz listę rozwijaną `Model instancji` i wybierz typ modelu odpowiadający Twojemu przypadkowi użycia. Model (flavor) określa zasoby przydzielone do Twojej instancji: procesor, pamięć i powiązane możliwości.
+
+    | Typ | Gwarantowane zasoby | Uwagi dotyczące użycia |
+    | :--- | :---: | :--- |
+    | Best Sellers | ✓ | Najpopularniejsze modele. |
+    | General Purpose | ✓ | Serwery deweloperskie, aplikacje internetowe lub biznesowe. |
+    | Compute Optimized | ✓ | Kodowanie wideo lub inne zastosowania wymagające dużej mocy obliczeniowej. |
+    | Memory Optimized | ✓ | Bazy danych, analizy i obliczenia w pamięci. |
+    | GPU | ✓ | Moc przetwarzania masowo równoległego dla wyspecjalizowanych aplikacji (renderowanie, big data, deep learning, itp.). |
+    | Discovery | - | Współdzielone zasoby dla środowisk testowych i deweloperskich. |
+    | Storage Optimized | ✓ | Zoptymalizowane do przesyłania danych na dysk. |
+    | Metal Instances | ✓ | Dedykowane zasoby z bezpośrednim dostępem do zasobów obliczeniowych, pamięci masowej i sieci. |
+
+    :::info
+    Całkowite zasoby Public Cloud zostaną początkowo ograniczone. Sprawdź swoje limity, klikając <code className="action">Limity i regiony</code> w sekcji **Ustawienia** na pasku nawigacyjnym po lewej stronie. Więcej informacji znajdziesz w [dedykowanej dokumentacji](/guides/public-cloud/cross-functional/increasing-public-cloud-quota).
+
+    Po utworzeniu możesz **uaktualnić** instancję, aby uzyskać więcej zasobów. Jednak przejście na mniejszy model nie jest możliwe w przypadku zwykłej instancji. Więcej informacji znajdziesz w **kroku 4.9**.
+
+    :::
+
+    **4.4 Obraz**
+
+    Wybierz system operacyjny za pomocą rozwijanych menu `Rodzaj dystrybucji` i `Wersja obrazu`. Dostępne opcje zależą od wybranego modelu i regionu.
+
+    **4.5 Klucz SSH** *(nie dotyczy instancji Windows)*
+
+    Wybierz przechowywany klucz SSH z listy (patrz [Krok 2](#krok-2-importowanie-kluczy-ssh)) lub kliknij <code className="action">Utwórz nowy klucz SSH</code>, aby wkleić klucz publiczny bezpośrednio.
+
+    **4.6 Kopia zapasowa**
+
+    [Automatyczne kopie zapasowe](/guides/public-cloud/compute/save-an-instance) są domyślnie włączone. Wybierz typ rotacji (7 lub 14 dni).
+
+    **4.7 Sieć**
+
+    Sekcja **Ustawienia sieci** jest podzielona na dwie części:
+
+    - **Sieć prywatna**: Wybierz istniejącą sieć prywatną lub kliknij <code className="action">+ Utwórz prywatną sieć</code>. Jeśli wybrana sieć prywatna nie posiada bramy, włącz przełącznik <code className="action">Przypisz bramę</code>, aby automatycznie dołączyć bramę.
+    - **Przypisz łączność publiczną**: Włącz przełącznik, aby przypisać publiczny adres IP. Wybierz <code className="action">Basic Public IP</code> (bezpłatny, powiązany z cyklem życia instancji, niekompatybilny z bramą) lub <code className="action">Przypisz Floating IP (wielokrotnego użytku)</code> (trwały i wielokrotnego użytku).
+
+    Zapoznaj się z [Krokiem 3](#networking-modes), aby uzyskać przegląd trybów sieciowych.
+
+    **4.8 Rozliczenia**
+
+    Wybierz między rozliczeniem **miesięcznym** (niższy koszt, nieodwracalne) a **godzinowym** (elastyczne, [konwertowalne na miesięczne](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing)). Rozliczenie godzinowe trwa do **usunięcia instancji**. Zapoznaj się z [dokumentacją dotyczącą rozliczeń](/guides/public-cloud/cross-functional/analyze-billing).
+
+    **4.9 Ustawienia zaawansowane** *(opcjonalnie)*
+
+    - **Elastyczna instancja**: pojedynczy dysk 50 GB, umożliwia zmianę rozmiaru na wyższe lub niższe modele.
+    - **Skrypt poinstalacyjny**: dodaj swój [skrypt poinstalacyjny](/guides/public-cloud/compute/launching-script-when-creating-instance).
+
+    **4.10 Finalizacja**
+
+    Sprawdź podsumowanie po prawej stronie ekranu i skonfiguruj liczbę instancji. Kliknij <code className="action">Uruchom instancję</code>. Dostarczenie usługi może potrwać kilka minut.
   </Tab>
-  <Tab label="Bezpośrednie wprowadzenie klucza">
-    Aby dodać klucz publiczny przez wklejenie ciągu klucza, kliknij przycisk <code className="action">Utwórz nowy klucz SSH</code>.
-    
-    Wprowadź nazwę klucza i ciąg klucza w odpowiednich polach. Następnie kliknij <code className="action">Zatwierdź klucz</code>.
+  <Tab label="Za pomocą API OVHcloud">
+    Pobierz wymagane identyfikatory:
+
+    ```
+    GET /cloud/project/{serviceName}/flavor     → flavorId
+    GET /cloud/project/{serviceName}/image      → imageId
+    GET /cloud/project/{serviceName}/region     → region
+    GET /cloud/project/{serviceName}/sshkey     → sshKeyId
+    ```
+
+    Utwórz instancję:
+
+    > **POST** `/cloud/project/{serviceName}/instance`
+
+    Główne parametry:
+
+    - `name`: nazwa instancji
+    - `flavorId`: identyfikator modelu
+    - `imageId`: identyfikator obrazu systemu operacyjnego
+    - `region`: region wdrożenia
+    - `sshKeyId`: identyfikator klucza SSH (z [Kroku 2](#krok-2-importowanie-kluczy-ssh))
+    - `monthlyBilling`: `true` dla rozliczenia miesięcznego
+
+    Zapoznaj się z [dokumentacją API OVHcloud](/guides/manage-and-operate/api/first-steps), aby skonfigurować dostęp do API.
+  </Tab>
+  <Tab label="Za pomocą OVHcloud CLI">
+    Pobierz wymagane identyfikatory:
+
+    ```bash
+    ovhcloud cloud reference list-flavors --cloud-project <project_id>
+    ovhcloud cloud reference list-images --cloud-project <project_id>
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+
+    Utwórz instancję:
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --name my-instance \
+      --boot-from.image <image_id> \
+      --flavor <flavor_id> \
+      --ssh-key.name my-key \
+      --network.public \
+      --wait
+    ```
+
+    Zastąp `GRA9` swoim regionem. Aby utworzyć instancję interaktywnie z prowadzonym wyborem:
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --editor \
+      --image-selector \
+      --flavor-selector
+    ```
+
+    Sprawdź stan po utworzeniu:
+
+    ```bash
+    ovhcloud cloud instance list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="Za pomocą OpenStack CLI">
+    Pobierz wymagane informacje:
+
+    ```bash
+    openstack flavor list
+    openstack image list --property visibility=public
+    openstack keypair list
+    ```
+
+    Utwórz instancję:
+
+    ```bash
+    openstack server create \
+      --flavor b2-7 \
+      --image "Ubuntu 24.04" \
+      --key-name my-key \
+      --network Ext-Net \
+      my-instance
+    ```
+
+    Sprawdź stan:
+
+    ```bash
+    openstack server list
+    openstack server show my-instance
+    ```
+
+    Zapoznaj się z [przewodnikiem konfiguracji środowiska OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment), aby przeprowadzić wstępną konfigurację.
+  </Tab>
+  <Tab label="Za pomocą Terraform">
+    Pełny przykład konfiguracji:
+
+    ```hcl
+    data "openstack_images_image_v2" "ubuntu" {
+      name        = "Ubuntu 24.04"
+      most_recent = true
+    }
+
+    resource "openstack_compute_instance_v2" "my_instance" {
+      name            = "my-instance"
+      flavor_name     = "b2-7"
+      key_pair        = openstack_compute_keypair_v2.my_keypair.name
+      security_groups = ["default"]
+
+      block_device {
+        uuid                  = data.openstack_images_image_v2.ubuntu.id
+        source_type           = "image"
+        destination_type      = "local"
+        boot_index            = 0
+        delete_on_termination = true
+      }
+
+      network {
+        name = "Ext-Net"
+      }
+    }
+    ```
+
+    Zapoznaj się z [przewodnikiem Terraform dla OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform), aby skonfigurować dostawcę i uwierzytelnianie po raz pierwszy.
   </Tab>
 </Tabs>
-
-
-#### Krok 4.6: Konfiguracja ustawień kopii zapasowych
-
-[Automatyczne kopie zapasowe](/guides/public-cloud/compute/save-an-instance) są domyślnie włączone. Zapoznaj się z cennikiem i dodatkowymi informacjami przed kontynuowaniem.
-
-Następnie wybierz typ rotacji, czyli maksymalną liczbę kopii zapasowych przechowywanych w historii: 7 lub 14 dni.
-
-#### Krok 4.7: Konfiguracja sieci
-
-Na tym etapie skonfigurujesz sieć dla swojej instancji.
-
-**Sieć prywatna**
-
-Możesz podłączyć instancję do [sieci prywatnej](#networking-modes) i przypisać jej adres [Floating IP](https://www.ovhcloud.com/pl/public-cloud/floating-ip/).
-
-Klikając <code className="action">Utwórz prywatną sieć</code>, możesz utworzyć ją bezpośrednio:
-
-- Nadaj sieci nazwę
-- **Wybierz identyfikator VLAN:** identyfikator używany do łączenia wielu usług i zasobów w tej samej sieci prywatnej za pomocą wspólnego numeru segmentacji sieci
-- **Zdefiniuj CIDR:** zakres adresów IP dla sieci
-- **Włącz DHCP, zaznaczając odpowiednie pole, jeśli to konieczne:** włącz tę opcję, jeśli chcesz, aby adresy IP były przypisywane automatycznie
-
-:::info
-Instancja może pozostać w pełni prywatna, jeśli nie przypiszesz jej publicznego adresu IP.
-
-:::
-
-
-**Gateway**
-
-Możesz włączyć opcję przypisania bramy do sieci. Domyślnie brama ma rozmiar S, ale możesz dostosować jej rozmiar później w ustawieniach.
-
-**Przypisanie łączności publicznej**
-
-Możesz włączyć lub wyłączyć tę funkcję w zależności od potrzeb. Jeśli zdecydujesz się ją włączyć, masz dwie opcje:
-
-- **Basic Public IP:** tymczasowy publiczny adres IP, który nie jest zachowywany po zakończeniu cyklu życia instancji. Pamiętaj, że korzystanie z Basic Public IP nie jest kompatybilne z bramą.
-- **Floating IP:** możesz utworzyć nowy adres Floating IP lub ponownie użyć istniejącego adresu, co pozwala na stały publiczny adres IP, który można odłączyć od instancji.
-
-#### Krok 4.8: Wybór okresu rozliczeniowego
-
-:::info
-Pamiętaj, że w zależności od wybranego modelu instancji wyświetlane może być wyłącznie rozliczenie **godzinowe**. Jest to tymczasowe ograniczenie; nowe opcje fakturowania za usługę Public Cloud będą wkrótce dostępne.
-
-:::
-
-
-<Tabs>
-  <Tab label="Płatność miesięczna">
-    Płatność miesięczna pozwala na obniżenie kosztów w dłuższej perspektywie, ale **nie może zostać zmieniona** na rozliczenie godzinowe po utworzeniu instancji.
-  </Tab>
-  <Tab label="Płatność godzinowa">
-    Płatność godzinowa jest najlepszym wyborem, jeśli nie określiłeś jasno okresu użytkowania. Jeśli zdecydujesz się zachować instancję na dłużej, zawsze możesz [zmienić abonament na miesięczny](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing).
-    
-    Opłata za instancję będzie naliczana tak długo, jak instancja **nie zostanie usunięta**, niezależnie od jej faktycznego wykorzystania.
-  </Tab>
-</Tabs>
-
-
-Szczegółowe informacje znajdziesz w naszej dedykowanej dokumentacji dotyczącej rozliczeń:
-
-- [Rozliczenia za usługę Public Cloud](/guides/public-cloud/cross-functional/analyze-billing)
-- [FAQ dotyczący rozliczenia miesięcznego](/guides/public-cloud/compute/faq-change-of-monthly-billing-method)
-
-Po zakończeniu konfiguracji instancji możesz kliknąć przycisk <code className="action">Uruchom instancję</code> lub skonfigurować ustawienia zaawansowane (patrz poniżej). Dostarczenie usługi może potrwać kilka minut.
-
-#### Krok 4.9: Konfiguracja ustawień zaawansowanych
-
-##### Elastyczna instancja
-
-Instancja Flex to instancja z pojedynczym dyskiem 50 GB, zaprojektowana w celu szybszego tworzenia i przywracania migawek.
-
-Umożliwia ona zmianę rozmiaru na wyższe lub niższe modele przy zachowaniu stałej przestrzeni dyskowej. Klasyczne modele pozwalają jedynie na zmianę rozmiaru na wyższe modele.
-
-##### Skrypt poinstalacyjny
-
-W tym polu możesz dodać [swój skrypt poinstalacyjny](/guides/public-cloud/compute/launching-script-when-creating-instance).
-
-#### Krok 4.10: Finalizacja instancji
-
-Po prawej stronie ekranu znajdziesz podsumowanie konfiguracji. W tej sekcji możesz skonfigurować liczbę instancji do utworzenia. Możesz utworzyć wiele instancji na podstawie wyborów dokonanych podczas etapów tworzenia, ale będą obowiązywać [limity przydziału](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) zasobów.
-
-Po zakończeniu konfiguracji instancji kliknij przycisk <code className="action">Uruchom instancję</code>. Dostarczenie usługi może potrwać kilka minut.
 
 ### Krok 5: Połączenie z instancją
 
@@ -376,18 +414,22 @@ Jeśli zainstalowałeś **system OS z aplikacją**, zapoznaj się z naszym [prze
 
 :::
 
-
 #### 5.1: Sprawdzenie stanu instancji w Panelu klienta OVHcloud
 
 Wybierz <code className="action">Instancje</code> na pasku nawigacyjnym po lewej stronie, w sekcji **Compute**. Twoja instancja jest gotowa, gdy w tabeli stan jest ustawiony na `Włączony`. Jeśli instancja została niedawno utworzona i ma inny stan, kliknij przycisk "Odśwież" znajdujący się obok filtru wyszukiwania.
-
-<img className="thumbnail" alt="strona instancji" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
 
 Kliknij nazwę instancji w tej tabeli, aby otworzyć <code className="action">Dashboard</code>, na którym znajdziesz wszystkie informacje dotyczące instancji. Aby dowiedzieć się więcej o funkcjach dostępnych na tej stronie, zapoznaj się z naszym przewodnikiem dotyczącym [zarządzania instancjami w Panelu klienta](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Na instancji **automatycznie tworzony jest użytkownik z podwyższonymi uprawnieniami (*sudo*)**. Nazwa użytkownika odzwierciedla zainstalowany obraz, np. "ubuntu", "debian", "fedora", itp. Możesz to sprawdzić po prawej stronie <code className="action">Dashboard</code> w sekcji **Sieci**.
 
-<img className="thumbnail" alt="strona instancji" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
+:::info
+Za pomocą OVHcloud CLI sprawdź stan instancji i pobierz jej adres IP:
+
+```bash
+ovhcloud cloud instance list --cloud-project <project_id>
+```
+
+:::
 
 Jeśli Twoja [para kluczy SSH jest prawidłowo skonfigurowana](#krok-1-tworzenie-zestawu-kluczy-ssh), możesz teraz połączyć się z instancją za pomocą wstępnie skonfigurowanego użytkownika i Twojego klucza SSH. Bardziej szczegółowe instrukcje znajdziesz w kolejnych akapitach.
 
@@ -398,7 +440,6 @@ Ten przewodnik nie obejmuje sieci prywatnych dla instancji. Zapoznaj się z nasz
 
 :::
 
-
 #### 5.2: Pierwsze logowanie do instancji z zainstalowanym systemem GNU/Linux
 
 :::info
@@ -408,7 +449,6 @@ Jeśli nadal występują problemy, możesz wymienić parę kluczy za pomocą [te
 Jeśli instancja została utworzona bez klucza SSH, za pośrednictwem [API OVHcloud](/guides/manage-and-operate/api/first-steps) lub [interfejsu OpenStack Horizon](/guides/public-cloud/compute/create-instance-in-horizon), możesz dodać klucz SSH do instancji tylko w [trybie Rescue](/guides/public-cloud/compute/put-an-instance-in-rescue-mode), postępując zgodnie z instrukcjami zawartymi w [tym przewodniku](/guides/public-cloud/compute/replacing-lost-ssh-key-pair).
 
 :::
-
 
 Dostęp do instancji jest możliwy zaraz po jej utworzeniu za pomocą interfejsu wiersza poleceń Twojego lokalnego urządzenia (`Terminal`, `Command prompt`, `Powershell`, itp.) przez SSH.
 
@@ -438,29 +478,22 @@ Następnie należy dokończyć wstępną konfigurację systemu operacyjnego Wind
 
 <Tabs>
   <Tab label="1. Ustawienia regionalne">
-    Skonfiguruj swój **kraj/region**, **preferowany język Windows** i **układ klawiatury**. Następnie kliknij przycisk <code className="action">Next</code> w prawym dolnym rogu.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" /><br/>
+    Skonfiguruj swój **kraj/region**, **preferowany język Windows** i **układ klawiatury**. Następnie kliknij przycisk <code className="action">Next</code> w prawym dolnym rogu.
   </Tab>
   <Tab label="2. Hasło administratora">
-    Ustaw hasło dla konta Windows `Administrator` i potwierdź je, następnie kliknij <code className="action">Finish</code>.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" /><br/>
+    Ustaw hasło dla konta Windows `Administrator` i potwierdź je, następnie kliknij <code className="action">Finish</code>.
   </Tab>
   <Tab label="3. Ekran logowania">
-    System Windows zastosuje ustawienia, a następnie wyświetli ekran logowania. Kliknij przycisk <code className="action">Send CtrlAltDel</code> w prawym górnym rogu, aby się zalogować.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" /><br/>
+    System Windows zastosuje ustawienia, a następnie wyświetli ekran logowania. Kliknij przycisk <code className="action">Send CtrlAltDel</code> w prawym górnym rogu, aby się zalogować.
   </Tab>
   <Tab label="4. Logowanie administratora">
-    Wprowadź hasło `Administrator` utworzone na poprzednim etapie i kliknij przycisk `Strzałka`.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
+    Wprowadź hasło `Administrator` utworzone na poprzednim etapie i kliknij przycisk `Strzałka`.
   </Tab>
 </Tabs>
-
 
 ##### 5.3.2: Zdalne logowanie z systemu Windows
 
 Na lokalnym komputerze z systemem Windows możesz zalogować się do instancji za pomocą aplikacji klienckiej `Remote Desktop Connection`.
-
-<img className="thumbnail" alt="połączenie rdp" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Wprowadź adres IPv4 Twojej instancji, następnie swoją nazwę użytkownika i hasło. Zazwyczaj pojawia się komunikat ostrzegawczy z prośbą o potwierdzenie połączenia z powodu nieznanego certyfikatu. Kliknij <code className="action">Tak</code>, aby się zalogować.
 
@@ -468,7 +501,6 @@ Wprowadź adres IPv4 Twojej instancji, następnie swoją nazwę użytkownika i h
 Jeśli masz problemy z tą procedurą, sprawdź, czy połączenia zdalne (RDP) są dozwolone na Twoim urządzeniu, weryfikując ustawienia systemu, reguły zapory i możliwe ograniczenia sieciowe.
 
 :::
-
 
 ##### 5.3.3: Zdalne logowanie z innego systemu operacyjnego
 
@@ -480,31 +512,23 @@ Bez względu na to, którego klienta używasz, do połączenia wymagany jest tyl
 
 Wolne oprogramowanie open source `Remmina Remote Desktop Client` jest dostępne dla wielu dystrybucji GNU/Linux. Jeśli nie znajdziesz Remmina w menedżerze oprogramowania Twojego środowiska graficznego, możesz je pobrać z [oficjalnej strony](https://remmina.org/).
 
-<img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect01.png" loading="lazy" /><br/>
-
 <Tabs>
   <Tab label="1. Połączenie">
-    Otwórz Remmina i upewnij się, że protokół połączenia jest ustawiony na "RDP". Wprowadź adres IPv4 Twojej instancji Public Cloud i naciśnij `Enter`.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" /><br/>
+    Otwórz Remmina i upewnij się, że protokół połączenia jest ustawiony na "RDP". Wprowadź adres IPv4 Twojej instancji Public Cloud i naciśnij `Enter`.
   </Tab>
   <Tab label="2. Uwierzytelnianie">
-    Jeśli pojawi się komunikat ostrzegawczy dotyczący certyfikatu, kliknij <code className="action">Yes</code>. Wprowadź nazwę użytkownika i hasło dla systemu Windows, a następnie kliknij <code className="action">OK</code>, aby nawiązać połączenie.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" /><br/>
+    Jeśli pojawi się komunikat ostrzegawczy dotyczący certyfikatu, kliknij <code className="action">Yes</code>. Wprowadź nazwę użytkownika i hasło dla systemu Windows, a następnie kliknij <code className="action">OK</code>, aby nawiązać połączenie.
   </Tab>
   <Tab label="3. Ustawienia">
-    Przydatne elementy znajdziesz na pasku narzędzi po lewej stronie. Na przykład kliknij ikonę <code className="action">Toggle dynamic resolution update</code>, aby poprawić rozdzielczość okna.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
+    Przydatne elementy znajdziesz na pasku narzędzi po lewej stronie. Na przykład kliknij ikonę <code className="action">Toggle dynamic resolution update</code>, aby poprawić rozdzielczość okna.
   </Tab>
 </Tabs>
-
 
 #### 5.4: Dostęp do konsoli VNC
 
 Konsola VNC pozwala na łączenie się z instancjami, nawet jeśli inne metody dostępu nie są dostępne.
 
 Wybierz <code className="action">Instancje</code> na pasku nawigacyjnym po lewej stronie, w sekcji **Compute**. Kliknij nazwę instancji i otwórz kartę <code className="action">Konsola VNC</code>.
-
-<img className="thumbnail" alt="konsola vnc" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instancja z zainstalowanym systemem GNU/Linux">
@@ -514,7 +538,6 @@ Wybierz <code className="action">Instancje</code> na pasku nawigacyjnym po lewej
     Zaloguj się za pomocą danych logowania Windows. W przypadku aktywnej sesji logowania masz natychmiastowy dostęp. Nastąpi zauważalne opóźnienie w porównaniu z połączeniem RDP.
   </Tab>
 </Tabs>
-
 
 ### Krok 6: Pierwsze kroki z nową instancją
 
@@ -527,14 +550,12 @@ Więcej informacji znajdziesz w sekcji [Sprawdź również](#sprawdz-rowniez) po
 
 :::
 
-
 #### 6.1: Zarządzanie użytkownikami
 
 :::info
 Podczas konfigurowania kont użytkowników i poziomów uprawnień w instancji zalecamy skorzystanie z informacji zawartych w naszym [przewodniku dotyczącym konta użytkownika](/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds).
 
 :::
-
 
 ##### 6.1.1: Ustawienie hasła dla bieżącego konta użytkownika
 
@@ -562,7 +583,6 @@ Ten krok nie jest konieczny i powinien zostać wykonany tylko, jeśli istnieje u
 Poniższy przykład ilustruje tymczasowe rozwiązanie na instancji z zainstalowanym systemem Ubuntu. Pamiętaj, że może być konieczne dostosowanie poleceń w zależności od systemu operacyjnego. Nie zaleca się utrzymywania tej konfiguracji na stałe, ponieważ stanowi ona potencjalne zagrożenie bezpieczeństwa poprzez otwarcie systemu na ataki oparte na SSH.
 
 :::
-
 
 Po [zalogowaniu do instancji](#krok-6-pierwsze-kroki-z-nowa-instancja) otwórz odpowiedni plik konfiguracyjny w edytorze tekstu. Przykład:
 
@@ -620,7 +640,6 @@ Szczegółowe informacje na temat tych kroków znajdziesz w naszym [dedykowanym 
 
 [Jak rozpocząć pracę z Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 
-
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/).

--- a/docs/pl/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
@@ -1,8 +1,10 @@
 ---
 title: Wstrzymanie lub uśpienie instancji
 description: Dowiedz się, jak wstrzymać, uśpić lub zawiesić instancję Public Cloud, aby tymczasowo zwolnić zasoby zachowując adres IP, oraz poznaj wpływ każdej opcji na rozliczenia
-lastUpdated: 2026-02-27
+lastUpdated: 2026-05-27
 ---
+
+import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Wprowadzenie
 
@@ -12,7 +14,6 @@ Częścią konfiguracji infrastruktury o wysokiej dostępności może być konie
 Nazwy tych opcji w Panelu klienta OVHcloud różnią się od nazw w interfejsie Openstack/Horizon. Jeśli przeprowadzasz tę operację w Panelu klienta OVHcloud, pamiętaj o wybraniu odpowiedniej opcji.
 
 :::
-
 
 **Dowiedz się, jak zawiesić, wstrzymać lub zatrzymać swoją instancję.**
 
@@ -44,32 +45,20 @@ Nazwy tych opcji w Panelu klienta OVHcloud różnią się od nazw w interfejsie 
 
 :::
 
-
 Poniższa tabela pozwoli Ci odróżnić opcje dostępne dla Twoich instancji. Kontynuuj lekturę przewodnika, klikając wybraną opcję. W nawiasach umieszczamy terminologię używaną w interfejsie Horizon.
 
 |Nazwa|Opis|Płatności|
 |---|---|---|
 |[Zawieś (*shelve*)](#shelve-instance)|Zachowuje zasoby i dane na dysku przez utworzenie migawki. Wszystkie inne zasoby zostaną zwolnione.|Płatność dotyczy tylko kopii zapasowych snapshot.|
-|[Wyłącz (*suspend*)](#stop-suspend-instance)|Przechowuje stan VM na dysku. Zasoby przeznaczone na instancję są nadal zarezerwowane.|W przypadku Twojej instancji opłata jest taka sama.|
-|[Wstrzymaj](#pause-instance)|Przechowuje stan wirtualnej maszyny w pamięci RAM. Wstrzymana instancja zostaje zablokowana.|W przypadku Twojej instancji opłata jest taka sama.|
+|[Wyłącz (*suspend*)](#stop-suspend-instance)|Przechowuje stan maszyny wirtualnej na dysku, zasoby pozostają zarezerwowane.|Opłata jest naliczana w tej samej stawce.|
+|[Wstrzymaj](#pause-instance)|Przechowuje stan maszyny wirtualnej w pamięci RAM, instancja pozostaje zamrożona.|Opłata jest naliczana w tej samej stawce.|
 
 ### Podsumowanie
 
-- [Zawieś (shelve) instancję](#shelve-instance)
-    - [W Panelu klienta OVHcloud](#control-panel)
-    - [Z poziomu interfejsu Horizon](#horizon)
-    - [Korzystanie z API OpenStack/Nova](#openstack-nova)
+- [Zawieś (*shelve*) instancję](#shelve-instance)
 - [Ponownie aktywuj (*unshelve*) instancję](#unshelve-instance)
-    - [W Panelu klienta OVHcloud](#control-panel-unshelve)
-    - [Z poziomu interfejsu Horizon](#horizon-unshelve)
-    - [Korzystanie z API OpenStack/Nova](#openstack-nova-unshelve)
-- [Wyłącz (suspend) instancję](#stop-suspend-instance)
-    - [W Panelu klienta OVHcloud](#stop-control-panel)
-    - [Z poziomu interfejsu Horizon](#stop-horizon)
-    - [Korzystanie z API OpenStack/Nova](#stop-openstack-nova)
+- [Wyłącz (*suspend*) instancję](#stop-suspend-instance)
 - [Wstrzymaj instancję](#pause-instance)
-    - [Z poziomu interfejsu Horizon](#pause-horizon)
-    - [Korzystanie z API OpenStack/Nova](#pause-openstack-nova)
 
 <a name="shelve-instance"></a>
 
@@ -82,79 +71,83 @@ Zawieszenie tego typu instancji prowadzi do jej wycofania z hosta, a tym samym z
 
 :::
 
-
 Ta opcja pozwoli Ci zwolnić zasoby dedykowane Twojej instancji Public Cloud, ale adres IP pozostanie. Dane z dysku lokalnego będą przechowywane w migawce utworzonej automatycznie po odłożeniu instancji na półkę. Dane przechowywane w pamięci i poza nią nie będą zachowywane.
 
-<a name="control-panel"></a>
+<Tabs>
+  <Tab label="W Panelu klienta OVHcloud">
+    W Panelu klienta OVHcloud wybierz swój projekt z sekcji <code className="action">Public Cloud</code>. Kliknij pozycję <code className="action">Instancje</code> w menu bocznym po lewej stronie.
 
-#### W Panelu klienta OVHcloud
+    Kliknij przycisk <code className="action">⋮</code> po prawej stronie instancji, którą chcesz zawiesić, a następnie <code className="action">Zawieś</code>.
 
-W Panelu klienta OVHcloud kliknij menu sekcji <code className="action">Public Cloud</code>, wybierz projekt Public Cloud i kliknij pozycję <code className="action">Instancje</code> w menu bocznym po lewej stronie.
+    <img className="thumbnail" alt="suspend instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
 
-Kliknij przycisk <code className="action">⋮</code> po prawej stronie instancji, którą chcesz zawiesić, a następnie <code className="action">Zawieś</code>.
+    W oknie, które się wyświetla, zapoznaj się z komunikatem i kliknij przycisk <code className="action">Zatwierdź</code>.
 
-<img className="thumbnail" alt="suspend instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="confirm suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
 
-W oknie, które się wyświetla, zapoznaj się z komunikatem i kliknij przycisk <code className="action">Zatwierdź</code>.
+    Podczas operacji wyświetla się komunikat:
 
-<img className="thumbnail" alt="confirm suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="Operation in progress" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
 
-Podczas operacji wyświetla się komunikat:
+    Po ukończeniu procesu Twoja instancja będzie wyświetlana jako *Suspended*.
 
-<img className="thumbnail" alt="Operation in progress" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="suspended status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
 
-Po ukończeniu procesu Twoja instancja będzie wyświetlana jako *Zawieszona*.
+    Aby wyświetlić migawkę, kliknij pozycję <code className="action">Instance Backup</code> w menu **Compute** po lewej stronie. Migawka o nazwie *xxxxx-shelved* będzie teraz widoczna:
 
-<img className="thumbnail" alt="suspended status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="snapshot tab" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+  </Tab>
+  <Tab label="Z poziomu interfejsu Horizon">
+    Aby kontynuować, należy [zalogować się do interfejsu Horizon](https://horizon.cloud.ovh.net/auth/login/):
 
-Migawka będzie wówczas dostępna w sekcji <code className="action">Instance Backup</code> w menu **Compute** po lewej stronie przestrzeni Public Cloud. Migawka o nazwie *xxxxx-shelved* będzie wtedy widoczna:
+    - Aby zalogować się za pomocą OVHcloud Single Sign-On: użyj linku <code className="action">Horizon</code> w menu po lewej stronie w sekcji "Management Interfaces" po otwarciu projektu <code className="action">Public Cloud</code> w <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>.
 
-<img className="thumbnail" alt="snapshot tab" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+    - Aby zalogować się za pomocą określonego użytkownika OpenStack: otwórz [stronę logowania Horizon](https://horizon.cloud.ovh.net/auth/login/) i wprowadź wcześniej utworzone [dane logowania użytkownika OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user), a następnie kliknij przycisk <code className="action">Connect</code>.
 
-<a name="horizon"></a>
+    Jeśli wdrożyłeś instancje w różnych regionach, upewnij się, że jesteś we właściwym regionie. Weryfikacji dokonujesz w lewym górnym rogu w interfejsie Horizon.
 
-#### Z poziomu interfejsu Horizon
+    <img className="thumbnail" alt="horizon interface" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
 
-Aby skorzystać z tej metody, należy [zalogować się do interfejsu Horizon](https://horizon.cloud.ovh.net/auth/login/):
+    Kliknij menu <code className="action">Compute</code> po lewej stronie i wybierz pozycję <code className="action">Instances</code>. Wybierz pozycję <code className="action">Shelve Instance</code> z listy rozwijanej dla odpowiedniej instancji.
 
-- Aby zalogować się za pomocą OVHcloud SSO: użyj linku <code className="action">Horizon</code> w menu po lewej stronie w sekcji "Management Interfaces" po otwarciu projektu <code className="action">Public Cloud</code> w <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>.
+    <img className="thumbnail" alt="shelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
 
-- Aby zalogować się za pomocą określonego użytkownika OpenStack: otwórz stronę logowania w witrynie [Horizon](https://horizon.cloud.ovh.net/auth/login/) i wprowadź wcześniej utworzone dane [OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user), a następnie kliknij przycisk <code className="action">Connect</code>.
+    Po ukończeniu procesu Twoja instancja będzie wyświetlana jako *Shelved Offloaded*.
 
-Jeśli wdrożyłeś instancje w różnych regionach, upewnij się, że jesteś we właściwym regionie. Weryfikacji dokonujesz w lewym górnym rogu w interfejsie Horizon.
+    <img className="thumbnail" alt="shelved instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
 
-<img className="thumbnail" alt="horizon interface" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
+    Aby wyświetlić migawkę, w menu <code className="action">Compute</code> kliknij pozycję <code className="action">Images</code>.
 
-Kliknij menu <code className="action">Compute</code> po lewej stronie i wybierz pozycję <code className="action">Instances</code>. Wybierz pozycję <code className="action">Shelve Instance</code> z listy rozwijanej dla odpowiedniej instancji.
+    <img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+  </Tab>
+  <Tab label="Korzystanie z API OpenStack/Nova">
+    Przed kontynuowaniem zalecamy zapoznanie się z następującymi przewodnikami:
 
-<img className="thumbnail" alt="shelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
+    - [Przygotowanie środowiska dla API OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
+    - [Ustawianie zmiennych środowiskowych OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
 
-Po ukończeniu procesu Twoja instancja będzie wyświetlana jako odciążona z *Shelved Offloaded*.
+    Kiedy Twoje środowisko jest gotowe, wpisz w wierszu poleceń:
 
-<img className="thumbnail" alt="shelved instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
+    ```bash
+    openstack server shelve <UUID server>
 
-Aby wyświetlić migawkę, w menu <code className="action">Compute</code> kliknij pozycję <code className="action">Images</code>.
+    =====================================
 
-<img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+    nova shelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="Za pomocą OVHcloud CLI">
+    Przed kontynuowaniem zalecamy zapoznanie się z następującymi przewodnikami:
 
-<a name="openstack-nova"></a>
+    - [Pierwsze kroki z OVHcloud CLI](/guides/manage-and-operate/cli/getting-started)
 
-#### Korzystanie z API OpenStack/Nova
+    Wpisz następujące polecenie:
 
-Przed kontynuowaniem zalecamy zapoznanie się z następującymi przewodnikami:
-
-- [Przygotowanie środowiska dla API OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
-- [Ustawianie zmiennych środowiskowych OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
-
-Kiedy Twoje środowisko jest gotowe, wpisz w wierszu poleceń:
-
-```bash
-~$ openstack server shelve <UUID server>
-
-=====================================
-
-~$ nova shelve <UUID server> 
-```
+    ```shell
+    ovhcloud cloud instance shelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="unshelve-instance"></a>
 
@@ -170,148 +163,159 @@ Wszelkie działania na snapshotach inne niż reaktywacja (*unshelve*) mogą być
 OVHcloud oddaje do Twojej dyspozycji usługi, za które przejmujesz odpowiedzialność. Firma OVH nie ma dostępu do Twoich serwerów, nie pełni funkcji administratora i w związku z tym nie będzie mogła udzielić Ci wsparcia. Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku problemów z administrowaniem, użytkowaniem czy zabezpieczeniem serwera rekomendujemy skorzystanie z usług wyspecjalizowanej firmy. Więcej informacji znajduje się w sekcji “Sprawdź również”. 
 :::
 
-<a name="control-panel-unshelve"></a>
+<Tabs>
+  <Tab label="W Panelu klienta OVHcloud">
+    W Panelu klienta OVHcloud wybierz swój projekt z sekcji <code className="action">Public Cloud</code> i kliknij pozycję <code className="action">Instancje</code> w menu bocznym po lewej stronie.
 
-#### W Panelu klienta OVHcloud
+    Kliknij przycisk <code className="action">⋮</code> po prawej stronie instancji, a następnie wybierz opcję <code className="action">Przywróć</code>.
 
-W Panelu klienta OVHcloud kliknij menu sekcji <code className="action">Public Cloud</code>, wybierz projekt Public Cloud i kliknij pozycję <code className="action">Instancje</code> w menu bocznym po lewej stronie.
+    <img className="thumbnail" alt="reactivate instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
 
-Kliknij przycisk <code className="action">⋮</code> po prawej stronie instancji, a następnie wybierz opcję <code className="action">Przywróć</code>.
+    W oknie, które się wyświetla, zapoznaj się z komunikatem i kliknij przycisk <code className="action">Zatwierdź</code>.
 
-<img className="thumbnail" alt="reactivate instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
+    Po ukończeniu procesu stan Twojej instancji będzie widoczny jako *Enabled*.
+  </Tab>
+  <Tab label="Z poziomu interfejsu Horizon">
+    W interfejsie Horizon kliknij menu <code className="action">Compute</code> po lewej stronie, a następnie wybierz pozycję <code className="action">Instances</code>. Wybierz pozycję <code className="action">Unshelve Instance</code> z listy rozwijanej dla odpowiedniej instancji.
 
-W oknie, które się wyświetla, zapoznaj się z komunikatem i kliknij przycisk <code className="action">Zatwierdź</code>.
+    <img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
 
-Po ukończeniu procesu Twoja instancja będzie widoczna jako *Włączona*.
+    Po ukończeniu procesu Twoja instancja będzie widoczna jako *Active*.
+  </Tab>
+  <Tab label="Korzystanie z API OpenStack/Nova">
+    Kiedy Twoje środowisko jest gotowe, wpisz w wierszu poleceń:
 
-<a name="horizon-unshelve"></a>
+    ```bash
+    ~$ openstack server unshelve <UUID server>
 
-#### Z poziomu interfejsu horizon
+    =========================================
 
-W interfejsie Horizon kliknij menu <code className="action">Compute</code> po lewej stronie, a następnie wybierz pozycję <code className="action">Instances</code>. Wybierz pozycję <code className="action">Unshelve Instance</code> z odłożenia z listy rozwijanej dla odpowiedniej instancji.
+    ~$ nova unshelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="Za pomocą OVHcloud CLI">
+    Wpisz następujące polecenie:
 
-<img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
-
-Po ukończeniu procesu Twoja instancja będzie widoczna jako *Active*.
-
-<a name="openstack-nova-unshelve"></a>
-
-#### Korzystanie z API OpenStack/Nova
-
-Kiedy Twoje środowisko jest gotowe, wpisz w wierszu poleceń:
-
-```bash
-~$ openstack server unshelve <UUID server>
-
-=========================================
-
-~$ nova unshelve <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance unshelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="stop-suspend-instance"></a>
 
 ### Wyłącz (suspend) instancję 
 
-Ta opcja pozwala wyłączyć instancję. Stan maszyny wirtualnej jest zapisywany na dysku, a pamięć jest zapisywana na dysku.
+Ta opcja wyłącza instancję i przechowuje stan maszyny wirtualnej na dysku, łącznie z pamięcią.
 
-<a name="stop-control-panel"></a>
+<Tabs>
+  <Tab label="W Panelu klienta OVHcloud">
+    W Panelu klienta OVHcloud wybierz swój projekt z sekcji <code className="action">Public Cloud</code> i kliknij pozycję <code className="action">Instancje</code> w menu bocznym po lewej stronie.
 
-#### W Panelu klienta OVHcloud
+    Kliknij przycisk <code className="action">⋮</code> po prawej stronie instancji, którą chcesz zatrzymać, a następnie <code className="action">Wyłącz</code>.
 
-W Panelu klienta OVHcloud kliknij menu sekcji <code className="action">Public Cloud</code>, wybierz projekt Public Cloud i kliknij pozycję <code className="action">Instancje</code> w menu bocznym po lewej stronie.
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
 
-Kliknij przycisk <code className="action">⋮</code> po prawej stronie instancji, którą chcesz zatrzymać, a następnie <code className="action">Wyłącz</code>.
+    W oknie, które się wyświetla, zapoznaj się z komunikatem i kliknij przycisk <code className="action">Zatwierdź</code>.
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
 
-W oknie, które się wyświetla, zapoznaj się z komunikatem i kliknij przycisk <code className="action">Zatwierdź</code>.
+    Po ukończeniu procesu Twoja instancja będzie wyświetlana jako *Off*.
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
+    <img className="thumbnail" alt="off status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_status_off.png" loading="lazy" />
 
-Po ukończeniu procesu Twoja instancja będzie wyświetlana jako *Wyłączona*.
+    Aby **wznowić** instancję, wykonaj te same kroki, co opisane powyżej. Kliknij przycisk <code className="action">⋮</code> po prawej stronie instancji i wybierz pozycję <code className="action">Uruchom</code>. W niektórych przypadkach może być konieczne wykonanie restartu sprzętowego.
 
-Aby **restartować** instancję, wykonaj kroki opisane powyżej. Kliknij przycisk <code className="action">⋮</code> po prawej stronie instancji i wybierz pozycję <code className="action">Wyślij teraz</code>. W niektórych przypadkach może być konieczne wykonanie restartu sprzętowego.
+    <img className="thumbnail" alt="start instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/start_instance_2025.png" loading="lazy" />
 
-<a name="stop-horizon"></a>
+    Po ukończeniu procesu stan Twojej instancji będzie widoczny jako *Enabled*.
+  </Tab>
+  <Tab label="Z poziomu interfejsu Horizon">
+    W interfejsie Horizon kliknij menu <code className="action">Compute</code> po lewej stronie, a następnie wybierz pozycję <code className="action">Instances</code>. Wybierz pozycję <code className="action">Suspend Instance</code> z listy rozwijanej dla odpowiedniej instancji.
 
-#### Z poziomu interfejsu horizon
+    <img className="thumbnail" alt="suspend instance Horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
 
-W interfejsie Horizon kliknij menu <code className="action">Compute</code> po lewej stronie, a następnie wybierz pozycję <code className="action">Instances</code>. Wybierz pozycję <code className="action">Suspend Instance</code> z listy rozwijanej dla odpowiedniej instancji.
+    Pojawi się komunikat potwierdzenia wskazujący, że instancja została zawieszona.
 
-<img className="thumbnail" alt="suspend instance Horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
+    Aby **wznowić** instancję, wykonaj te same kroki, co opisane powyżej. Z listy rozwijanej odpowiedniej instancji wybierz pozycję <code className="action">Resume Instance</code>.
+  </Tab>
+  <Tab label="Korzystanie z API OpenStack/Nova">
+    Kiedy Twoje środowisko jest gotowe, wpisz w wierszu poleceń:
 
-Pojawi się komunikat potwierdzenia wskazujący, że instancja została zawieszona.
+    ```bash
+    ~$ openstack server suspend <UUID server>
 
-Aby **restartować** instancję, wykonaj kroki opisane powyżej. Z listy rozwijanej odpowiedniej instancji wybierz pozycję <code className="action">Resume Instance</code>.
+    =========================================
 
-<a name="stop-openstack-nova"></a>
+    ~$ nova suspend <UUID server>
+    ```
 
-#### Korzystanie z API OpenStack/Nova
+    Aby **wznowić** instancję, wpisz w wierszu poleceń:
 
-Kiedy Twoje środowisko jest gotowe, wprowadź poniższą komendę w wierszu poleceń:
+    ```bash
+    ~$ openstack server unsuspend <UUID server>
 
-```bash
-~$ openstack server suspend <UUID server>
+    =========================================
 
-=========================================
+    ~$ nova unsuspend <UUID server>
+    ```
+  </Tab>
+  <Tab label="Za pomocą OVHcloud CLI">
+    Wpisz następujące polecenie:
 
-~$ nova suspend <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance stop <instance_id>
+    ```
 
-Aby **restartować** instancję, w wierszu polecenia wpisz następujące polecenie:
+    Aby **wznowić** instancję, wpisz następujące polecenie:
 
-```bash
-~$ openstack server unsuspend <UUID server>
-
-=========================================
-
-~$ nova unsuspend <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance start <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="pause-instance"></a>
 
 ### Wstrzymaj instancję
 
-Operacja ta jest możliwa **tylko** od interfejsie Horizon lub poprzez API OpenStack/Nova. Umożliwia ona *zamrożenie* instancji.
+Operacja ta jest możliwa **tylko** w interfejsie Horizon lub poprzez API OpenStack/Nova. Umożliwia ona *zamrożenie* instancji.
 
-<a name="pause-horizon"></a>
+<Tabs>
+  <Tab label="Z poziomu interfejsu Horizon">
+    W interfejsie Horizon kliknij menu <code className="action">Compute</code> po lewej stronie, a następnie wybierz pozycję <code className="action">Instances</code>. Na liście rozwijanej zaznacz opcję <code className="action">Pause Instance</code> dla odpowiedniej instancji.
 
-#### Korzystanie z programu Horizon
+    <img className="thumbnail" alt="Pause instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
 
-W interfejsie Horizon kliknij menu <code className="action">Compute</code> po lewej stronie, a następnie wybierz pozycję <code className="action">Instances</code>. Na liście rozwijanej zaznacz opcję <code className="action">Pause Instance</code> dla odpowiedniej instancji.
+    Zostanie wyświetlony komunikat potwierdzenia z informacją o wstrzymaniu instancji.
 
-<img className="thumbnail" alt="Pause instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
+    Aby **wznowić** instancję, wykonaj te same kroki, co opisane powyżej. Z listy rozwijanej odpowiedniej instancji wybierz pozycję <code className="action">Resume Instance</code>.
+  </Tab>
+  <Tab label="Korzystanie z API OpenStack/Nova">
+    Kiedy Twoje środowisko jest gotowe, wpisz w wierszu poleceń:
 
-Zostanie wyświetlony komunikat potwierdzenia z informacją o wstrzymaniu instancji.
+    ```bash
+    ~$ openstack server pause <UUID server>
 
-Aby **restartować** instancję, wykonaj kroki opisane powyżej. Z listy rozwijanej odpowiedniej instancji wybierz pozycję <code className="action">Resume Instance</code>.
+    =========================================
 
-<a name="pause-openstack-nova"></a>
+    ~$ nova pause <UUID server>
+    ```
 
-#### Korzystanie z API OpenStack/Nova
+    Aby **wznowić** instancję, wpisz w wierszu poleceń:
 
-Kiedy Twoje środowisko jest gotowe, wpisz w wierszu poleceń:
+    ```bash
+    ~$ openstack server unpause <UUID server>
 
-```bash
-~$ openstack server pause <UUID server>
+    =========================================
 
-=========================================
-
-~$ nova pause <UUID server>
-```
-
-Aby **restartować** instancję, wpisz w wierszu polecenia:
-
-```bash
-~$ openstack server unpause <UUID server>
-
-=========================================
-
-~$ nova unpause <UUID server>
-```
+    ~$ nova unpause <UUID server>
+    ```
+  </Tab>
+</Tabs>
 
 ## Sprawdź również
 
 [Dokumentacja OpenStack](https://docs.openstack.org/ocata/user-guide/cli-stop-and-start-an-instance.html).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/).

--- a/docs/pt/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/pt/guides/public-cloud/compute/getting-started.mdx
@@ -1,13 +1,10 @@
 ---
 title: Como criar uma instância Public Cloud e conectar-se a ela
 description: Descubra como configurar instâncias Public Cloud na sua área de cliente OVHcloud, assim como os primeiros passos com as suas instâncias
-lastUpdated: 2026-02-24
+lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
-
-
-
 
 ## Objetivo
 
@@ -15,7 +12,6 @@ As instâncias Public Cloud são fáceis de implementar e gerir. No entanto, enq
 Poderá depois ir mais longe com o seu projeto Public Cloud em função das suas necessidades.
 
 **Este guia explica os primeiros passos com uma instância Public Cloud.**
-
 
 ## Requisitos
 
@@ -37,7 +33,6 @@ Tire partido de preços reduzidos comprometendo-se com um período de 1 a 36 mes
 
 :::
 
-
 ## Instruções
 
 :::info
@@ -46,7 +41,6 @@ Se ainda não criou nenhum projeto Public Cloud, comece pelo nosso [guia sobre a
 **Os detalhes técnicos** importantes relativos ao Public Cloud da OVHcloud estão disponíveis em [esta página](/guides/public-cloud/cross-functional/compute-essential-information).
 
 :::
-
 
 ### Apresentação do conteúdo
 
@@ -58,19 +52,6 @@ Se ainda não criou nenhum projeto Public Cloud, comece pelo nosso [guia sobre a
   - [Etapa 2: Importar as chaves SSH](#etapa-2-importar-as-chaves-ssh)
   - [Etapa 3: preparar a configuração de rede](#etapa-3-preparar-a-configuracao-de-rede)
   - [Etapa 4: criar a instância](#etapa-4-criar-a-instancia)
-    - [Etapa 4.1: Nome da instância](#etapa-41-nome-da-instancia)
-    - [Etapa 4.2: Selecione uma localização](#etapa-42-selecione-uma-localizacao)
-    - [Etapa 4.3: Selecione um modelo](#etapa-43-selecione-um-modelo)
-      - [Informações complementares](#informacoes-complementares)
-    - [Etapa 4.4: Selecione uma imagem](#etapa-44-selecione-uma-imagem)
-    - [Etapa 4.5: Selecione uma chave SSH (não aplicável às instâncias Windows)](#etapa-45-selecione-uma-chave-ssh-nao-aplicavel-as-instancias-windows)
-    - [Etapa 4.6: Configure os parâmetros de backup](#etapa-46-configure-os-parametros-de-backup)
-    - [Etapa 4.7: Configure a rede](#etapa-47-configure-a-rede)
-    - [Etapa 4.8: Selecione um período de faturação](#etapa-48-selecione-um-periodo-de-faturacao)
-    - [Etapa 4.9: Configure os parâmetros avançados](#etapa-49-configure-os-parametros-avancados)
-      - [Instância flexível](#instancia-flexivel)
-      - [Script de pós-instalação](#script-de-pos-instalacao)
-    - [Etapa 4.10: Finalização da instância](#etapa-410-finalizacao-da-instancia)
   - [Etapa 5: Conectar-se à instância](#etapa-5-conectar-se-a-instancia)
     - [5.1: Verificar o estado da instância na área de cliente](#51-verificar-o-estado-da-instancia-na-area-de-cliente)
     - [5.2: Primeira ligação numa instância com OS GNU/Linux](#52-primeira-ligacao-numa-instancia-com-os-gnulinux)
@@ -93,7 +74,6 @@ Se ainda não criou nenhum projeto Public Cloud, comece pelo nosso [guia sobre a
 
 :::
 
-
 ### Etapa 1: criar um conjunto de chaves SSH
 
 Se já tiver um par de chaves SSH pronto a utilizar, pode ignorar esta etapa.
@@ -114,7 +94,7 @@ Se utilizar outro software, consulte a documentação do utilizador. As instruç
 
 ### Etapa 2: Importar as chaves SSH
 
-Pode armazenar as suas chaves SSH públicas na secção <code className="action">Public Cloud</code> da sua <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>. Não é obrigatório, mas torna o processo de criação de instâncias mais prático.
+Pode armazenar as suas chaves SSH públicas no seu projeto Public Cloud. Não é obrigatório, mas torna o processo de criação de instâncias mais prático.
 
 :::info
 As chaves SSH armazenadas permitem-lhe criar as suas instâncias mais rapidamente na sua área de cliente. Para alterar os pares de chaves e adicionar utilizadores depois de criar a instância, consulte o guia [chaves SSH adicionais](/guides/public-cloud/compute/configuring-additional-ssh-keys).
@@ -123,16 +103,71 @@ As chaves SSH públicas adicionadas à sua área de cliente OVHcloud estarão di
 
 :::
 
+<Tabs>
+  <Tab label="Através da área de cliente">
+    Ligue-se à <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>, aceda à secção <code className="action">Public Cloud</code> e selecione o projeto Public Cloud em questão.
 
-Abra <code className="action">Chaves SSH</code> no menu à esquerda em **Parâmetros**. Clique no botão <code className="action">Adicionar chave SSH</code>.
+    Abra <code className="action">Chaves SSH</code> no menu à esquerda em **Parâmetros**. Clique no botão <code className="action">Adicionar chave SSH</code>.
 
-<img className="thumbnail" alt="ssh keys" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+    Na nova janela, introduza um nome para a chave. Preencha o campo `Chave` com a sua cadeia de chave pública, por exemplo, a criada na [etapa 1](#etapa-1-criar-um-conjunto-de-chaves-ssh). Confirme clicando em <code className="action">Adicionar</code>.
 
-Na nova janela, introduza um nome para a chave. Preencha o campo `Chave` com a sua cadeia de chave pública, por exemplo, a criada na [etapa 1](#etapa-1-criar-um-conjunto-de-chaves-ssh). Confirme clicando em <code className="action">Adicionar</code>.
+    Agora pode selecionar esta chave na [Etapa 4](#etapa-4-criar-a-instancia) para a adicionar a uma nova instância.
+  </Tab>
+  <Tab label="Através da API OVHcloud">
+    Utilize a chamada seguinte para importar a sua chave SSH pública:
 
-<img className="thumbnail" alt="add key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
+    > **POST** `/cloud/project/{serviceName}/sshkey`
 
-Agora pode selecionar esta chave na [Etapa 4](#etapa-4-criar-a-instancia) para a adicionar a uma nova instância.
+    Parâmetros:
+
+    - `serviceName`: identificador do seu projeto Public Cloud
+    - `name`: nome da chave SSH
+    - `publicKey`: conteúdo da sua chave pública
+
+    Tome nota do `id` devolvido, será necessário aquando da criação da instância.
+  </Tab>
+  <Tab label="Através do OVHcloud CLI">
+    Certifique-se de que instalou e configurou o [OVHcloud CLI](https://github.com/ovh/ovhcloud-cli), depois importe a sua chave:
+
+    ```bash
+    ovhcloud cloud ssh-key create \
+      --cloud-project <project_id> \
+      --name my-key \
+      --public-key "$(cat ~/.ssh/id_rsa.pub)"
+    ```
+
+    Verifique a importação e tome nota do `name` da chave para a [Etapa 4](#etapa-4-criar-a-instancia):
+
+    ```bash
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="Através do CLI OpenStack">
+    Certifique-se de que configurou o seu ambiente OpenStack ([guia dedicado](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)), depois importe a sua chave:
+
+    ```bash
+    openstack keypair create --public-key ~/.ssh/id_rsa.pub my-key
+    ```
+
+    Verifique a importação:
+
+    ```bash
+    openstack keypair list
+    ```
+  </Tab>
+  <Tab label="Através do Terraform">
+    Declare o recurso no seu ficheiro `.tf`:
+
+    ```hcl
+    resource "openstack_compute_keypair_v2" "my_keypair" {
+      name       = "my-key"
+      public_key = file("~/.ssh/id_rsa.pub")
+    }
+    ```
+
+    Consulte o [guia Terraform para o Public Cloud OVHcloud](/guides/public-cloud/cross-functional/how-to-use-terraform) para a configuração inicial do provider.
+  </Tab>
+</Tabs>
 
 ### Etapa 3: preparar a configuração de rede
 
@@ -146,7 +181,6 @@ Antes de criar a sua instância, recomendamos que estude a forma como a instânc
 <details>
 
 <summary>Public Cloud Networking - Modos</summary>
-
 
 **Modo Público**
 
@@ -166,200 +200,205 @@ Para saber mais, consulte a [página Web das Local Zones](https://www.ovhcloud.c
 
 </details>
 
-
 ### Etapa 4: criar a instância
 
-:::info
-É obrigatória uma chave SSH pública aquando da criação de uma instância na área de cliente OVHcloud (exceto nas instâncias Windows).
-
-Consulte a [etapa 1](#etapa-1-criar-um-conjunto-de-chaves-ssh) e a [etapa 2](#etapa-2-importar-as-chaves-ssh) deste guia se não tiver chaves SSH prontas a utilizar.
-
-:::
-
-
-Na página **Página Inicial**, clique em <code className="action">Criar uma instância</code>.
-
-#### Etapa 4.1: Nome da instância
-
-Introduza um nome completo para a sua instância. A referência comercial do modelo de instância é o valor predefinido. Se necessário, pode também adicionar a região e a data para facilitar a identificação e a gestão das suas instâncias.
-
-#### Etapa 4.2: Selecione uma localização
-
-Selecione uma [localização](https://www.ovhcloud.com/pt/public-cloud/regions-availability/) mais próxima dos seus utilizadores ou clientes. Tenha em conta que se selecionar uma **Local Zone** nesta etapa, as limitações de rede serão aplicadas à instância (ver [Etapa 3](#networking-modes)).
-
-Consulte também as informações da nossa [página Web das Local Zones](https://www.ovhcloud.com/pt/public-cloud/local-zone-compute/) e da [documentação das capacidades das Local Zones](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-A escolha da região determina o modo de implementação da sua instância (1-AZ, 3-AZ ou Local Zones). Para compreender as diferenças em termos de resiliência, disponibilidade e arquitetura, consulte o nosso guia [Comparação e resiliência dos modos de implementação – Compreender as regiões 3-AZ / 1-AZ / Local Zones](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details).
-
-#### Etapa 4.3: Selecione um modelo
-
-Nesta etapa, escolherá o modelo de instância (também chamado flavour), que determina os recursos alocados à sua instância: processador, memória e capacidades associadas. Abra a lista pendente `Modelo da instância`, selecione o tipo de modelo mais adaptado ao seu caso de utilização para aceder à nossa gama de instâncias otimizadas.
-
-O tipo de modelo `Discovery` reúne instâncias com recursos partilhados, propostas a preços competitivos. São particularmente adequadas para descobrir o Public Cloud OVHcloud, realizar testes ou alojar cargas de trabalho ligeiras como aplicações web.
-
-Os modelos `Metal Instances` oferecem recursos físicos inteiramente dedicados, garantindo desempenhos constantes e um isolamento máximo para os workloads mais exigentes.
-
-:::info
-O total dos seus recursos Public Cloud será inicialmente limitado por razões de controlo de custos e de segurança. Pode verificar estas quotas clicando em <code className="action">Quota e Regiões</code> na barra de navegação à esquerda em **Parâmetros**. Consulte [a documentação dedicada](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) para mais informações.
-
-Tenha em atenção que pode **atualizar** a sua instância após a sua criação para dispor de mais recursos disponíveis. No entanto, a mudança para um modelo mais pequeno não é possível com uma instância regular. Consulte a **etapa 4.9** abaixo para mais informações sobre este assunto.
-
-:::
-
-
-##### Informações complementares
-
-<details>
-
-<summary>Categorias de modelos de instâncias</summary>
-
-
-| Tipo | Recursos garantidos | Notas de utilização |
-| :---         |     :---:      |          :--- |
-| Best Sellers   | ✓     | Modelos mais utilizados.    |
-| General Purpose   | ✓     | Servidores de desenvolvimento, aplicações web ou profissionais    |
-| Compute Optimized     | ✓       | Codificação de vídeo ou outro cálculo de alta performance      |
-| Memory Optimized    | ✓     | Bases de dados, análises e cálculos em memória    |
-| Storage Optimized   | ✓     | Otimizado para transferência de dados para disco    |
-| Discovery    | -       | Alojamento em recursos partilhados para os ambientes de teste e de desenvolvimento      |
-| Cloud GPU     | ✓       | Potência de processamento massivamente paralelo para aplicações especializadas (renderização, big data, deep learning, etc.)       |
-| Metal Instances | ✓ | Recursos dedicados com acesso direto aos recursos de computação, armazenamento e rede|
-
-</details>
-
-
-<details>
-
-<summary>Regiões e Local Zones</summary>
-
-
-**Regiões**
-
-Uma **região** é definida como uma localização no mundo composta por um ou vários datacenters onde os serviços da OVHcloud estão alojados. Pode encontrar mais informações sobre as regiões, a distribuição geográfica e a disponibilidade dos serviços na nossa [página Web dedicada](https://www.ovhcloud.com/pt/public-cloud/regions-availability/) e na nossa [página Web sobre as localizações das infraestruturas OVHcloud](https://www.ovhcloud.com/pt/about-us/global-infrastructure/regions/).
-
-**Local Zones**
-
-As Local Zones são uma extensão das **regiões** que aproximam os serviços da OVHcloud de sites específicos, oferecendo uma latência reduzida e desempenhos melhorados para as aplicações. Pode encontrar mais informações na [página Web das Local Zones](https://www.ovhcloud.com/pt/public-cloud/local-zone-compute/) e na [documentação das capacidades das Local Zones](/guides/public-cloud/compute/local-zones-capabilities-limitations).
-
-</details>
-
-
-#### Etapa 4.4: Selecione uma imagem
-
-Abra a lista pendente `Tipo de distribuição`, selecione a categoria correspondente à sua necessidade e escolha o sistema operativo a implementar na sua instância através do menu pendente `Versão da imagem`.
-
-As imagens disponíveis nesta etapa dependem das escolhas efetuadas nas etapas anteriores, ou seja, da compatibilidade com o modelo de instância e da disponibilidade regional. Por exemplo, se deseja selecionar um sistema operativo Windows e não existem opções no separador Windows, deve alterar as suas escolhas das etapas anteriores.
-
-:::info
-Se selecionar um sistema operativo que exija uma licença paga, estes custos serão automaticamente incluídos na faturação do projeto.
-
-:::
-
-
-#### Etapa 4.5: Selecione uma chave SSH (não aplicável às instâncias Windows)
-
-Com exceção das instâncias Windows, a configuração da sua instância requer também **a adição de uma chave SSH pública**. Tem duas opções:
-
-- Utilizar uma chave pública já armazenada na área de cliente OVHcloud
-- Introduzir diretamente uma chave pública
-
-Clique nos separadores abaixo para visualizar a apresentação:
-
 <Tabs>
-  <Tab label="Utilizar uma chave armazenada">
-    Para adicionar uma chave armazenada na sua área de cliente OVHcloud (consulte [Etapa 2](#etapa-2-importar-as-chaves-ssh)), selecione-a na lista.
+  <Tab label="Através da área de cliente">
+    :::info
+    É obrigatória uma chave SSH pública aquando da criação de uma instância (exceto nas instâncias Windows). Consulte a [etapa 1](#etapa-1-criar-um-conjunto-de-chaves-ssh) e a [etapa 2](#etapa-2-importar-as-chaves-ssh) se não tiver chaves prontas a utilizar.
+
+    :::
+
+    Ligue-se à <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>, aceda à secção <code className="action">Public Cloud</code> e selecione o projeto Public Cloud em questão. Na página **Página Inicial**, clique em <code className="action">Criar uma instância</code>.
+
+    **4.1 Nome**
+
+    Introduza um nome completo para a sua instância.
+
+    **4.2 Localização**
+
+    Selecione uma [localização](https://www.ovhcloud.com/pt/public-cloud/regions-availability/) próxima dos seus utilizadores. Se selecionar uma **Local Zone**, aplicam-se limitações de rede (ver [Etapa 3](#networking-modes)). Consulte o guia [Comparação dos modos de implementação](/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details) para as diferenças entre 3-AZ, 1-AZ e Local Zones.
+
+    **4.3 Modelo**
+
+    Abra a lista pendente `Modelo da instância` e selecione o tipo adaptado ao seu caso de utilização. O modelo (flavour) determina os recursos alocados à sua instância: processador, memória e capacidades associadas.
+
+    | Tipo | Recursos garantidos | Notas de utilização |
+    | :--- | :---: | :--- |
+    | Best Sellers | ✓ | Modelos mais populares. |
+    | General Purpose | ✓ | Servidores de desenvolvimento, aplicações web ou profissionais. |
+    | Compute Optimized | ✓ | Codificação de vídeo ou outro cálculo de alta performance. |
+    | Memory Optimized | ✓ | Bases de dados, análises e cálculos em memória. |
+    | GPU | ✓ | Potência de processamento massivamente paralelo para aplicações especializadas (renderização, big data, deep learning, etc.). |
+    | Discovery | - | Recursos partilhados para os ambientes de teste e de desenvolvimento. |
+    | Storage Optimized | ✓ | Otimizado para transferência de dados para disco. |
+    | Metal Instances | ✓ | Recursos dedicados com acesso direto aos recursos de computação, armazenamento e rede. |
+
+    :::info
+    Os seus recursos Public Cloud serão inicialmente limitados. Verifique as suas quotas através de <code className="action">Limite e regiões</code> em **Parâmetros** na barra de navegação à esquerda. Consulte [a documentação dedicada](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) para mais informações.
+
+    Pode **atualizar** a sua instância após a sua criação para dispor de mais recursos. Em contrapartida, a mudança para um modelo inferior não é possível com uma instância regular. Consulte a **etapa 4.9** para mais detalhes.
+
+    :::
+
+    **4.4 Imagem**
+
+    Selecione o sistema operativo através dos menus `Tipo de distribuição` e `Versão da imagem`. As opções disponíveis dependem do modelo e da região escolhidos.
+
+    **4.5 Chave SSH** *(não aplicável às instâncias Windows)*
+
+    Selecione uma chave SSH armazenada na lista (ver [Etapa 2](#etapa-2-importar-as-chaves-ssh)), ou clique em <code className="action">Criar uma nova chave SSH</code> para introduzir diretamente uma chave pública.
+
+    **4.6 Backup**
+
+    Os [backups automatizados](/guides/public-cloud/compute/save-an-instance) são ativados por predefinição. Selecione a rotação pretendida (7 ou 14 dias).
+
+    **4.7 Rede**
+
+    A secção **Parâmetros de rede** divide-se em duas partes:
+
+    - **Rede privada**: selecione uma rede privada existente ou clique em <code className="action">Criar uma rede privada</code>. Se uma rede privada estiver selecionada mas não possuir gateway, ative o botão de alternância <code className="action">Atribuir uma gateway</code> para associar uma gateway automaticamente.
+    - **Atribuir conectividade pública**: ative o botão de alternância para atribuir um IP público. Escolha <code className="action">Basic Public IP</code> (gratuito, ligado à duração de vida da instância, incompatível com uma gateway) ou <code className="action">Atribuir uma Floating IP (Reutilizável)</code> (persistente e reutilizável).
+
+    Consulte a [Etapa 3](#networking-modes) para uma vista geral dos modos de rede.
+
+    **4.8 Faturação**
+
+    Escolha entre **mensal** (custo reduzido, não reversível) ou **à hora** (flexível, [convertível em mensal](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing) posteriormente). A faturação à hora aplica-se até à **eliminação da instância**. Consulte a [documentação de faturação](/guides/public-cloud/cross-functional/analyze-billing).
+
+    **4.9 Parâmetros avançados** *(opcional)*
+
+    - **Instância flexível**: disco único de 50 GB, permite o redimensionamento para modelos superiores ou inferiores.
+    - **Script de pós-instalação**: adicione o seu [script de pós-instalação](/guides/public-cloud/compute/launching-script-when-creating-instance).
+
+    **4.10 Finalização**
+
+    Verifique o resumo no lado direito do ecrã e configure o número de instâncias. Clique em <code className="action">Lançar a minha instância</code>. O fornecimento pode demorar alguns minutos.
   </Tab>
-  <Tab label="Introduzir diretamente uma chave">
-    Para adicionar uma chave pública colando a cadeia de chaves, clique no botão <code className="action">Criar uma nova chave SSH</code>.
-    
-    Introduza um nome para a chave e a cadeia de chaves nos respetivos campos. A seguir, clique em <code className="action">Validar a chave</code>.
+  <Tab label="Através da API OVHcloud">
+    Recupere os identificadores necessários:
+
+    ```
+    GET /cloud/project/{serviceName}/flavor     → flavorId
+    GET /cloud/project/{serviceName}/image      → imageId
+    GET /cloud/project/{serviceName}/region     → region
+    GET /cloud/project/{serviceName}/sshkey     → sshKeyId
+    ```
+
+    Crie a instância:
+
+    > **POST** `/cloud/project/{serviceName}/instance`
+
+    Parâmetros principais:
+
+    - `name`: nome da instância
+    - `flavorId`: ID do modelo
+    - `imageId`: ID da imagem do SO
+    - `region`: região de implementação
+    - `sshKeyId`: ID da chave SSH (da [etapa 2](#etapa-2-importar-as-chaves-ssh))
+    - `monthlyBilling`: `true` para uma faturação mensal
+
+    Consulte a [documentação API OVHcloud](/guides/manage-and-operate/api/first-steps) para configurar o seu acesso à API.
+  </Tab>
+  <Tab label="Através do OVHcloud CLI">
+    Recupere os identificadores necessários:
+
+    ```bash
+    ovhcloud cloud reference list-flavors --cloud-project <project_id>
+    ovhcloud cloud reference list-images --cloud-project <project_id>
+    ovhcloud cloud ssh-key list --cloud-project <project_id>
+    ```
+
+    Crie a instância:
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --name my-instance \
+      --boot-from.image <image_id> \
+      --flavor <flavor_id> \
+      --ssh-key.name my-key \
+      --network.public \
+      --wait
+    ```
+
+    Substitua `GRA9` pela sua região. Para uma criação interativa com seleção guiada:
+
+    ```bash
+    ovhcloud cloud instance create GRA9 \
+      --cloud-project <project_id> \
+      --editor \
+      --image-selector \
+      --flavor-selector
+    ```
+
+    Verifique o estado após a criação:
+
+    ```bash
+    ovhcloud cloud instance list --cloud-project <project_id>
+    ```
+  </Tab>
+  <Tab label="Através do CLI OpenStack">
+    Recupere as informações necessárias:
+
+    ```bash
+    openstack flavor list
+    openstack image list --property visibility=public
+    openstack keypair list
+    ```
+
+    Crie a instância:
+
+    ```bash
+    openstack server create \
+      --flavor b2-7 \
+      --image "Ubuntu 24.04" \
+      --key-name my-key \
+      --network Ext-Net \
+      my-instance
+    ```
+
+    Verifique o estado:
+
+    ```bash
+    openstack server list
+    openstack server show my-instance
+    ```
+
+    Consulte o [guia de preparação do ambiente OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) para a configuração inicial.
+  </Tab>
+  <Tab label="Através do Terraform">
+    Exemplo de configuração completa:
+
+    ```hcl
+    data "openstack_images_image_v2" "ubuntu" {
+      name        = "Ubuntu 24.04"
+      most_recent = true
+    }
+
+    resource "openstack_compute_instance_v2" "my_instance" {
+      name            = "my-instance"
+      flavor_name     = "b2-7"
+      key_pair        = openstack_compute_keypair_v2.my_keypair.name
+      security_groups = ["default"]
+
+      block_device {
+        uuid                  = data.openstack_images_image_v2.ubuntu.id
+        source_type           = "image"
+        destination_type      = "local"
+        boot_index            = 0
+        delete_on_termination = true
+      }
+
+      network {
+        name = "Ext-Net"
+      }
+    }
+    ```
+
+    Consulte o [guia Terraform para o Public Cloud OVHcloud](/guides/public-cloud/cross-functional/how-to-use-terraform) para a configuração inicial do provider e a autenticação.
   </Tab>
 </Tabs>
-
-
-
-#### Etapa 4.6: Configure os parâmetros de backup
-
-Os [backups automatizados](/guides/public-cloud/compute/save-an-instance) são ativados por predefinição. Consulte as informações tarifárias e os detalhes complementares antes de prosseguir.
-
-Em seguida, selecione o tipo de rotação, ou seja, o número máximo de backups conservados em histórico: 7 ou 14 dias.
-
-#### Etapa 4.7: Configure a rede
-
-Nesta etapa, vai configurar a rede da sua instância.
-
-**Rede privada**
-
-Pode ligar a sua instância a uma [rede privada](#networking-modes) e atribuir-lhe um endereço [Floating IP](https://www.ovhcloud.com/pt/public-cloud/floating-ip/).
-
-Ao clicar em <code className="action">Criar uma rede privada</code>, pode criar uma diretamente:
-
-- Dar um nome à rede
-- **Escolher o VLAN ID:** identificador que permite interligar vários serviços e recursos dentro de uma mesma rede privada, através de um número de segmentação de rede comum
-- **Definir o CIDR:** intervalo de endereços IP da rede
-- **Ativar o DHCP selecionando a caixa correspondente, se necessário:** ative esta opção se pretender uma atribuição automática dos endereços IP
-
-:::info
-A instância pode permanecer inteiramente privada se não lhe atribuir um IP público.
-
-:::
-
-
-**Gateway**
-
-Pode ativar a opção para atribuir uma gateway à sua rede. Por predefinição, a gateway é de tamanho S, mas poderá ajustar o seu tamanho posteriormente nos parâmetros.
-
-**Atribuir conectividade pública**
-
-Pode ativar ou desativar esta funcionalidade em função das suas necessidades. Se optar por ativá-la, duas opções estão disponíveis:
-
-- **Basic Public IP:** um endereço IP público temporário, que não persiste para além da duração de vida da instância. Note que a utilização de um Basic Public IP não é compatível com uma gateway.
-- **Floating IP:** pode criar um novo Floating IP ou reutilizar um endereço existente, permitindo um IP público persistente e desassociável da instância.
-
-#### Etapa 4.8: Selecione um período de faturação
-
-:::info
-Tenha em conta que, consoante o modelo de instância escolhido, a faturação **à hora** pode ser a única seleção apresentada. Trata-se de uma limitação temporária e, em breve, estarão disponíveis novas opções de faturação do Public Cloud.
-
-:::
-
-
-<Tabs>
-  <Tab label="Faturação mensal">
-    A faturação mensal irá reduzir os custos ao longo do tempo, mas **não pode ser alterada** para uma faturação à hora, após a instância ter sido criada.
-  </Tab>
-  <Tab label="Faturação à hora">
-    A faturação à hora é a melhor escolha se não definiu claramente a duração do período de utilização. Se decidir conservar a instância para uma utilização a longo prazo, poderá sempre [passar para uma subscrição mensal](/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing).
-    
-    A instância será faturada enquanto não for **eliminada**, independentemente da utilização real da instância.
-  </Tab>
-</Tabs>
-
-
-Consulte a nossa documentação de faturação dedicada:
-
-- [Faturação do Public Cloud](/guides/public-cloud/cross-functional/analyze-billing)
-- [FAQ sobre a faturação mensal](/guides/public-cloud/compute/faq-change-of-monthly-billing-method)
-
-Uma vez terminada a configuração da instância, poderá optar por clicar no botão <code className="action">Iniciar a minha instância</code> ou configurar os parâmetros avançados (ver abaixo). O fornecimento do seu serviço pode demorar alguns minutos.
-
-#### Etapa 4.9: Configure os parâmetros avançados
-
-##### Instância flexível
-
-Uma instância Flex é uma instância com um único disco de 50 GB, concebida para oferecer um processo de criação e restauro de snapshots mais rápido.
-
-Permite redimensionar a instância para modelos superiores ou inferiores, mantendo um espaço de armazenamento fixo. Os modelos clássicos autorizam apenas um redimensionamento para modelos superiores.
-
-##### Script de pós-instalação
-
-Pode adicionar [o seu script de pós-instalação](/guides/public-cloud/compute/launching-script-when-creating-instance) neste campo.
-
-#### Etapa 4.10: Finalização da instância
-
-No lado direito do ecrã, encontra-se o resumo da sua configuração. Nesta secção, poderá configurar o número de instâncias a criar. Pode criar várias instâncias em função das seleções efetuadas nas etapas de criação, mas [os limites de quota de recursos](/guides/public-cloud/cross-functional/increasing-public-cloud-quota) serão aplicados.
-
-Uma vez terminada a configuração da instância, clique no botão <code className="action">Iniciar a minha instância</code>. O fornecimento do seu serviço pode demorar alguns minutos.
 
 ### Etapa 5: Conectar-se à instância
 
@@ -375,18 +414,24 @@ Se instalou um **SO com aplicação**, consulte o nosso [guia de primeiros passo
 
 :::
 
-
 #### 5.1: Verificar o estado da instância na área de cliente
+
+Ligue-se à <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>, aceda à secção <code className="action">Public Cloud</code> e selecione o projeto Public Cloud em questão.
 
 Selecione <code className="action">Instâncias</code> na barra de navegação à esquerda em **Compute**. A sua instância está pronta quando o estado está definido em `Ativado` na tabela. Se a instância tiver sido criada recentemente e tiver um estado diferente, clique no botão "Atualizar" junto do filtro de pesquisa.
 
-<img className="thumbnail" alt="page instâncias" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
-
 Clique no nome da instância nesta tabela para abrir o <code className="action">Dashboard</code> no qual pode encontrar todas as informações relativas à instância. Para saber mais sobre as funções disponíveis nesta página, consulte o guia [Gestão das instâncias na área de cliente](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
-Um **utilizador com permissões elevadas (*sudo*) é automaticamente criado** na instância. O nome de utilizador reflete a imagem instalada, por exemplo "ubuntu", "debian", "fedora", etc. Pode verificá-lo no lado direito do <code className="action">Dashboard</code> na secção **Redes**.
+Um **utilizador com permissões elevadas (*sudo*) é automaticamente criado** na instância. O nome de utilizador reflete a imagem instalada, por exemplo "ubuntu", "debian", "fedora", etc. Pode verificá-lo no <code className="action">Dashboard</code> na secção **Redes**.
 
-<img className="thumbnail" alt="page instâncias" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
+:::info
+Através do OVHcloud CLI, verifique o estado e recupere o endereço IP da sua instância com:
+
+```bash
+ovhcloud cloud instance list --cloud-project <project_id>
+```
+
+:::
 
 Se o seu [par de chaves SSH estiver corretamente configurado](#etapa-1-criar-um-conjunto-de-chaves-ssh), pode agora ligar-se à instância com o utilizador pré-configurado e a sua chave SSH. Consulte os parágrafos seguintes para obter instruções mais detalhadas.
 
@@ -397,7 +442,6 @@ Este guia não cobre a rede privada para as instâncias. Consulte a nossa docume
 
 :::
 
-
 #### 5.2: Primeira ligação numa instância com OS GNU/Linux
 
 :::info
@@ -407,7 +451,6 @@ Se continuar a ter problemas, pode substituir o par de chaves utilizando [este g
 Se criou uma instância sem chave SSH através da [API OVHcloud](/guides/manage-and-operate/api/first-steps) ou da [interface OpenStack Horizon](/guides/public-cloud/compute/create-instance-in-horizon), só pode adicionar uma chave SSH à sua instância através do [modo rescue](/guides/public-cloud/compute/put-an-instance-in-rescue-mode) seguindo as instruções descritas em [este guia](/guides/public-cloud/compute/replacing-lost-ssh-key-pair).
 
 :::
-
 
 Pode aceder à sua instância imediatamente após a sua criação através da interface de linha de comandos da sua estação de trabalho local (`Terminal`, `Command prompt`, `Powershell`, etc.) via SSH.
 
@@ -437,29 +480,22 @@ De seguida, terá de finalizar a configuração inicial do seu sistema operativo
 
 <Tabs>
   <Tab label="1. Parâmetros regionais">
-    Configure o seu **país/região**, o **idioma preferido do Windows** e a sua **configuração do teclado**. A seguir, clique no botão <code className="action">Seguinte</code> no canto inferior direito.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" /><br/>
+    Configure o seu **país/região**, o **idioma preferido do Windows** e a sua **configuração do teclado**. A seguir, clique no botão <code className="action">Seguinte</code> no canto inferior direito.
   </Tab>
   <Tab label="2. Palavra-passe de administrador">
-    Defina uma palavra-passe para a sua conta Windows `Administrator` e confirme-a e clique em <code className="action">Terminar</code>.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" /><br/>
+    Defina uma palavra-passe para a sua conta Windows `Administrator` e confirme-a e clique em <code className="action">Terminar</code>.
   </Tab>
   <Tab label="3. Ecrã de ligação">
-    O Windows aplicará as suas definições e, em seguida, apresentará o ecrã de ligação. Clique no botão <code className="action">Send CtrlAltDel</code> no canto superior direito para iniciar sessão.<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" /><br/>
+    O Windows aplicará as suas definições e, em seguida, apresentará o ecrã de ligação. Clique no botão <code className="action">Send CtrlAltDel</code> no canto superior direito para iniciar sessão.
   </Tab>
   <Tab label="4. Login de administrador">
-    Introduza a palavra-passe `Administrator` que criou na etapa anterior e clique no botão "Seta".<br/><br/>
-    <img className="thumbnail" alt="VNC" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
+    Introduza a palavra-passe `Administrator` que criou na etapa anterior e clique no botão "Seta".
   </Tab>
 </Tabs>
-
 
 ##### 5.3.2: Ligue-se remotamente a partir do Windows
 
 No seu computador Windows local, pode utilizar a aplicação cliente `Remote Desktop Connection` para se ligar à sua instância.
-
-<img className="thumbnail" alt="rdp connection" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Introduza o endereço IPv4 da sua instância, depois o seu identificador e a sua passphrase. Normalmente, é apresentada uma mensagem de aviso a pedir-lhe para confirmar a ligação devido a um certificado desconhecido. Clique em <code className="action">Sim</code> para se ligar.
 
@@ -467,7 +503,6 @@ Introduza o endereço IPv4 da sua instância, depois o seu identificador e a sua
 Se encontrar dificuldades com este procedimento, verifique se as ligações remotas (RDP) são permitidas no seu dispositivo, verificando as definições do sistema, as regras da firewall e as possíveis restrições de rede.
 
 :::
-
 
 ##### 5.3.3: Ligar-se remotamente a partir de outro SO
 
@@ -479,31 +514,25 @@ Independentemente do cliente que utiliza, só precisa do endereço IP da instân
 
 O software livre e open source `Remmina Remote Desktop Client` está disponível para várias distribuições de desktop GNU/Linux. Se não encontrar o Remmina no gestor de software do seu ambiente de trabalho, poderá obtê-lo no [site oficial](https://remmina.org/).
 
-<img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect01.png" loading="lazy" /><br/>
-
 <Tabs>
   <Tab label="1. Ligação">
-    Abra o Remmina e certifique-se de que o protocolo de ligação está definido como "RDP". Introduza o endereço IPv4 da sua instância Public Cloud e prima "Enter".<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" /><br/>
+    Abra o Remmina e certifique-se de que o protocolo de ligação está definido como "RDP". Introduza o endereço IPv4 da sua instância Public Cloud e prima "Enter".
   </Tab>
   <Tab label="2. Autenticação">
-    Se aparecer uma mensagem de aviso de certificado, clique em <code className="action">Yes</code>. Introduza o nome de utilizador e a palavra-passe para o Windows e clique em <code className="action">OK</code> para estabelecer a ligação.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" /><br/>
+    Se aparecer uma mensagem de aviso de certificado, clique em <code className="action">Yes</code>. Introduza o nome de utilizador e a palavra-passe para o Windows e clique em <code className="action">OK</code> para estabelecer a ligação.
   </Tab>
   <Tab label="3. Parâmetros">
-    Pode encontrar elementos úteis na barra de ferramentas à esquerda. Por exemplo, clique no ícone <code className="action">Toggle dynamic resolution update</code> para melhorar a resolução da janela.<br/><br/>
-    <img className="thumbnail" alt="linux remote" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
+    Pode encontrar elementos úteis na barra de ferramentas à esquerda. Por exemplo, clique no ícone <code className="action">Toggle dynamic resolution update</code> para melhorar a resolução da janela.
   </Tab>
 </Tabs>
-
 
 #### 5.4: Acesso consola VNC
 
 A consola VNC permite-lhe ligar-se às suas instâncias mesmo quando não estão disponíveis outros meios de acesso.
 
-Selecione <code className="action">Instâncias</code> na barra de navegação à esquerda em **Compute**. Clique no nome da instância e abra o separador <code className="action">Consola VNC</code>.
+Ligue-se à <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>, aceda à secção <code className="action">Public Cloud</code> e selecione o projeto Public Cloud em questão.
 
-<img className="thumbnail" alt="consola vnc" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
+Selecione <code className="action">Instâncias</code> na barra de navegação à esquerda em **Compute**. Clique no nome da instância e abra o separador <code className="action">Consola VNC</code>.
 
 <Tabs>
   <Tab label="Instância com um SO GNU/Linux instalado">
@@ -513,7 +542,6 @@ Selecione <code className="action">Instâncias</code> na barra de navegação à
     Ligue-se com as suas credenciais Windows. Com uma sessão ativa, tem acesso imediato. Haverá uma latência notável em relação a uma ligação RDP.
   </Tab>
 </Tabs>
-
 
 ### Etapa 6: Primeiros passos numa nova instância
 
@@ -526,14 +554,12 @@ Encontre mais informações na secção [Quer saber mais?](#quer-saber-mais) aba
 
 :::
 
-
 #### 6.1: Gestão de utilizadores
 
 :::info
 Ao configurar as contas de utilizadores e os níveis de autorização numa instância, recomendamos que utilize as informações do nosso [guia da conta de utilizador](/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds).
 
 :::
-
 
 ##### 6.1.1: Defina uma palavra-passe para a conta de utilizador atual
 
@@ -561,7 +587,6 @@ Esta etapa não é necessária e só deve ser executada se tiver um motivo váli
 O exemplo seguinte ilustra uma solução temporária numa instância na qual o Ubuntu está instalado. Tenha em conta que poderá ser necessário ajustar os comandos em função do seu sistema operativo. Não é recomendado manter esta configuração permanentemente, pois adiciona um risco potencial de segurança ao abrir o sistema aos ataques baseados em SSH.
 
 :::
-
 
 Depois de [aceder à instância](#etapa-6-primeiros-passos-numa-nova-instancia), abra o ficheiro de configuração em questão com um editor de texto. Exemplo:
 
@@ -621,4 +646,4 @@ Consulte o nosso [guia dedicado](/guides/public-cloud/compute/configuring-additi
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projeto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/).

--- a/docs/pt/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/suspend-or-pause-an-instance.mdx
@@ -1,18 +1,19 @@
 ---
 title: Suspender ou colocar em pausa uma instância
 description: Saiba como suspender ou colocar em pausa uma instância Public Cloud para libertar temporariamente recursos mantendo o seu endereço IP, bem como o impacto na faturação de cada opção
-lastUpdated: 2026-02-27
+lastUpdated: 2026-05-27
 ---
+
+import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objetivo
 
-No âmbito da configuração de uma infraestrutura de alta disponibilidade, é possível que tenha de reduzir o acesso às suas instâncias para efetuar alguns testes. OpenStack que suspenda, parar ou coloque em pausa as suas instâncias. Em cada caso, o seu endereço IP é mantido.
+No âmbito da configuração de uma infraestrutura de alta disponibilidade, é possível que tenha de reduzir o acesso às suas instâncias para efetuar alguns testes. O OpenStack permite-lhe suspender, parar ou colocar em pausa a sua instância. Em cada caso, o seu endereço IP é mantido.
 
 :::warning
 O nome destas opções na Área de Cliente OVHcloud é diferente do nome no Openstack/Horizon. Se efetuar esta operação através da Área de Cliente OVHcloud, certifique-se de que selecionou a opção adequada.
 
 :::
-
 
 **Este guia explica como suspender, parar ou colocar em pausa sua instância.**
 
@@ -44,32 +45,20 @@ O nome destas opções na Área de Cliente OVHcloud é diferente do nome no Open
 
 :::
 
-
 A tabela abaixo permite-lhe diferenciar as opções disponíveis nas suas instâncias. Consulte este manual clicando na opção que preferir. Colocámos entre parênteses a terminologia utilizada na interface Horizon.
 
 |Termo|Descrição|Faturação|
 |---|---|---|
 |[Suspender (*shelve*)](#shelve-instance)|Conserve o seu IP, bem como os recursos e os dados no seu disco, criando uma imagem instantânea; todos os outros recursos são libertados.|Só é faturado por snapshot.|
-|[Desativar (*suspend*)](#stop-suspend-instance)|Armazena o estado da máquina virtual no disco, os recursos dedicados à instância estão sempre reservados.|Será sempre faturado ao mesmo preço para a sua instância.|
-|[Pausa](#pause-instance)|Armazena o estado da máquina virtual na memória RAM, uma instância suspensa torna se « gelada ».|Será sempre faturado ao mesmo preço para a sua instância.|
+|[Desativar (*suspend*)](#stop-suspend-instance)|Armazena o estado da VM no disco, os recursos permanecem reservados.|É faturado ao mesmo preço.|
+|[Pausa](#pause-instance)|Armazena o estado da VM na RAM, a instância permanece gelada.|É faturado ao mesmo preço.|
 
 ### Índice
 
 - [Suspender (shelve) uma instância](#shelve-instance)
-    - [Da Área de Cliente OVHcloud](#control-panel)
-    - [Da interface Horizon](#horizon)
-    - [Utilização das API OpenStack/Nova](#openstack-nova)
 - [Reativar (unshelve) uma instância](#unshelve-instance)
-    - [Da Área de Cliente OVHcloud](#control-panel-unshelve)
-    - [Da interface Horizon](#horizon-unshelve)
-    - [Utilização das API OpenStack/Nova](#openstack-nova-unshelve)
 - [Desativar (suspend) uma instância](#stop-suspend-instance)
-    - [Da Área de Cliente OVHcloud](#stop-control-panel)
-    - [Da interface Horizon](#stop-horizon)
-    - [Utilização das API OpenStack/Nova](#stop-openstack-nova)
 - [Colocar em pausa uma instância (*pause*)](#pause-instance)
-    - [Da interface Horizon](#pause-horizon)
-    - [Utilização das API OpenStack/Nova](#pause-openstack-nova)
 
 <a name="shelve-instance"></a>
 
@@ -82,79 +71,83 @@ Suspender este tipo de instância leva à sua desativação do anfitrião e, por
 
 :::
 
-
 Esta opção permite libertar os recursos dedicados à sua instância de Public Cloud, mas o endereço IP fica. Os dados do seu disco local serão armazenados numa imagem instantânea criada automaticamente após a instância estar reservada. Os dados armazenados na memória e noutros locais não serão conservados.
 
-<a name="control-panel"></a>
+<Tabs>
+  <Tab label="A partir da área de cliente OVHcloud">
+    Na sua área de cliente OVHcloud, clique no separador <code className="action">Public Cloud</code>, selecione o seu projeto Public Cloud e clique na rubrica <code className="action">Instâncias</code> no menu à esquerda.
 
-#### Da Área de Cliente OVHcloud
+    Clique no botão <code className="action">⋮</code> à direita da instância que pretende suspender, depois clique em <code className="action">Suspender</code>.
 
-Na Área de Cliente OVHcloud, clique no menu da secção <code className="action">Public Cloud</code>, selecione o seu projeto Public Cloud e clique em <code className="action">Instâncias</code> no menu à esquerda.
+    <img className="thumbnail" alt="suspend instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
 
-Clique então nas <code className="action">⋮</code> à direita da instância a suspender, e clique em <code className="action">Suspender</code>.
+    Na janela que aparece, tome conhecimento das informações apresentadas e clique em <code className="action">Confirmar</code>.
 
-<img className="thumbnail" alt="suspend instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspend_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="confirm suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
 
-Na janela contextual, tome nota da mensagem e clique em <code className="action">Confirmar</code>.
+    Uma mensagem é exibida durante a operação:
 
-<img className="thumbnail" alt="confirm suspension" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_suspension_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="Operation in progress" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
 
-Uma mensagem é exibida durante a operação:
+    Uma vez terminado o processo, a sua instância terá o estado "Suspensa".
 
-<img className="thumbnail" alt="Operation in progress" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspension_message_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="suspended status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
 
-Uma vez terminado o processo, a instância parece *Suspensa*.
+    Para visualizar o snapshot, clique em <code className="action">Instance Backup</code> no separador **Compute** no menu à esquerda. Um snapshot chamado *xxxxx-shelved* estará então visível:
 
-<img className="thumbnail" alt="suspended status" src="/images/public-cloud/compute/suspend-or-pause-an-instance/instance_suspended_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="snapshot tab" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+  </Tab>
+  <Tab label="A partir da interface Horizon">
+    Para utilizar este método, é necessário [ligar-se à interface Horizon](https://horizon.cloud.ovh.net/auth/login/):
 
-O snapshot estará então disponível na secção <code className="action">Instance Backup</code> do menu **Compute** à esquerda do espaço Public Cloud. Um snapshot chamado *xxxxx-shelved* estará então visível:
+    - Para se ligar com a autenticação única OVHcloud: utilize o link <code className="action">Horizon</code> no menu à esquerda em "Management Interfaces" após abrir o seu projeto <code className="action">Public Cloud</code> na sua <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>.
 
-<img className="thumbnail" alt="snapshot tab" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelved_backup_2025.png" loading="lazy" />
+    - Para se ligar com um utilizador OpenStack específico: abra a página de ligação ao [Horizon](https://horizon.cloud.ovh.net/auth/login/) e introduza os [identificadores OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user) previamente criados, depois clique em <code className="action">Connect</code>.
 
-<a name="horizon"></a>
+    Se implementou instâncias em regiões diferentes, certifique-se de que se encontra na região apropriada. Pode verificá-lo no canto superior esquerdo da interface Horizon.
 
-#### Da interface Horizon
+    <img className="thumbnail" alt="horizon interface" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
 
-Para utilizar este método, é necessário [ligar à interface Horizon](https://horizon.cloud.ovh.net/auth/login/):
+    Clique no menu <code className="action">Compute</code> à esquerda e depois em <code className="action">Instances</code>. Selecione <code className="action">Shelve Instance</code> na lista pendente correspondente à instância.
 
-- Para iniciar sessão com o SSO da OVHcloud: utilize o link <code className="action">Horizon</code> no menu à esquerda em "Management Interfaces" após abrir o seu projeto <code className="action">Public Cloud</code> na <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>.
+    <img className="thumbnail" alt="shelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
 
-- Para se ligar a um utilizador OpenStack específico: abra a página de ligação ao [Horizon](https://horizon.cloud.ovh.net/auth/login/) e introduza os [identificadores OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user) previamente criados, depois clique em <code className="action">Connect</code>.
+    Uma vez terminado o processo, a sua instância terá o estado *Shelved Offloaded*.
 
-Se criou instâncias em regiões diferentes, certifique-se de que se encontra na região apropriada. Pode verificá-lo no canto superior esquerdo da interface Horizon.
+    <img className="thumbnail" alt="shelved instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
 
-<img className="thumbnail" alt="horizon interface" src="/images/public-cloud/compute/suspend-or-pause-an-instance/firstaccesshorizon.png" loading="lazy" />
+    Para visualizar o snapshot, no menu <code className="action">Compute</code>, clique em <code className="action">Images</code>.
 
-Clique no menu <code className="action">Compute</code> no lado esquerdo e selecione <code className="action">Instances</code>. Selecione <code className="action">Shelve Instance</code> na lista pendente para a instância correspondente.
+    <img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+  </Tab>
+  <Tab label="A partir das API OpenStack/Nova">
+    Antes de continuar, recomendamos que consulte os seguintes guias:
 
-<img className="thumbnail" alt="shelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/shelveinstancehorizon.png" loading="lazy" />
+    - [Preparar o ambiente para utilizar a API OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
+    - [Carregar as variáveis de ambiente OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
 
-Uma vez terminado o processo, a sua instância aparece como *Shelved Offloaded* reservada.
+    Quando o ambiente estiver pronto, introduza o seguinte na linha de comandos:
 
-<img className="thumbnail" alt="shelved instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/newinstancestatushorizon.png" loading="lazy" />
+    ```bash
+    ~$ openstack server shelve <UUID server>
 
-Para ver o snapshot, no menu <code className="action">Compute</code>, clique em <code className="action">Images</code>.
+    =====================================
 
-<img className="thumbnail" alt="snapshot" src="/images/public-cloud/compute/suspend-or-pause-an-instance/snapshothorizon.png" loading="lazy" />
+    ~$ nova shelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="A partir do CLI OVHcloud">
+    Antes de continuar, recomendamos que consulte os seguintes guias:
 
-<a name="openstack-nova"></a>
+    - [Conhecer as bases do CLI OVHcloud](/guides/manage-and-operate/cli/getting-started)
 
-#### Utilização das API OpenStack/Nova
+    Introduza o seguinte comando:
 
-Antes de continuar, recomendamos que consulte os seguintes guias:
-
-- [Preparar o ambiente para utilizar a API OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
-- [Carregar as variáveis de ambiente OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
-
-Quando o ambiente estiver pronto, utilize o seguinte comando:
-
-```bash
-~$ openstack server shelve <UUID server>
-
-=====================================
-
-~$ nova shelve <UUID server> 
-```
+    ```shell
+    ovhcloud cloud instance shelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="unshelve-instance"></a>
 
@@ -165,48 +158,49 @@ Esta opção permite-lhe reativar a sua instância para que a possa continuar a 
 :::danger
 **Ações no snapshot**
 
-Qualquer ação no snapshot que não a reativação *unshelve* pode ser muito perigosa para a sua infraestrutura em em caso de mau uso. Uma vez « reactivada » (*unshelved*) uma instância, a snapshot é automaticamente eliminada. Não é recomendado criar uma nova instância a partir de uma snapshot criada após a suspensão (*shelve*) de uma instância.
+Qualquer ação no snapshot que não a reativação (*unshelve*) pode ser muito perigosa para a sua infraestrutura em caso de mau uso. Quando uma instância é "reativada" (*unshelved*), o snapshot é automaticamente eliminado. Não é recomendado implementar uma nova instância a partir de um snapshot criado na sequência da suspensão de uma instância.
 
-A utilização e a gestão dos serviços OVHcloud são da responsabilidade do cliente. Como não temos acesso a estas máquinas, não podemos administrá-las nem fornecer-lhe assistência. O cliente é o único responsável pela gestão e pela segurança do serviço. Se encontrar alguma dificuldade relacionada com o processo, deverá contactar um [serviço especializado](https://partner.ovhcloud.com/pt/directory/). Para mais informações, aceda à secção deste manual intitulada: “Quer saber mais?”. 
+A OVHcloud disponibiliza-lhe serviços cuja responsabilidade lhe incumbe. Com efeito, não tendo qualquer acesso a estas máquinas, não somos os seus administradores e não poderemos fornecer-lhe assistência. Cabe-lhe, por conseguinte, assegurar a gestão de software e a segurança no quotidiano. Em caso de dificuldades ou de dúvidas relativas à administração, à utilização ou à segurança de um servidor, recomendamos que recorra a um [prestador especializado](/links/partner).
 :::
 
-<a name="control-panel-unshelve"></a>
+<Tabs>
+  <Tab label="A partir da área de cliente OVHcloud">
+    Na sua área de cliente OVHcloud, clique no separador <code className="action">Public Cloud</code>, selecione o seu projeto Public Cloud e clique na rubrica <code className="action">Instâncias</code> no menu à esquerda.
 
-#### Da Área de Cliente OVHcloud
+    Clique nos <code className="action">⋮</code> à direita da instância, depois clique em <code className="action">Reativar</code>.
 
-Na Área de Cliente OVHcloud, clique no menu da secção <code className="action">Public Cloud</code>, selecione o seu projeto Public Cloud e clique em <code className="action">Instâncias</code> no menu à esquerda.
+    <img className="thumbnail" alt="reactivate instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
 
-Clique então nas <code className="action">⋮</code> à direita da instância, clique em <code className="action">Reativar</code>.
+    Na janela que aparece, tome conhecimento das informações e clique em <code className="action">Confirmar</code>.
 
-<img className="thumbnail" alt="reactivate instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/reactivate_instance_2025.png" loading="lazy" />
+    Uma vez terminado o processo, a sua instância terá o estado "Ativada".
+  </Tab>
+  <Tab label="A partir da interface Horizon">
+    Clique no menu <code className="action">Compute</code> no menu à esquerda e selecione <code className="action">Instances</code>. Selecione <code className="action">Unshelve Instance</code> na lista pendente correspondente à instância.
 
-Na janela contextual, tome nota da mensagem e clique em <code className="action">Confirmar</code>.
+    <img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
 
-Uma vez terminado o processo, a sua instância aparece como *Ativada*.
+    Uma vez terminado o processo, a sua instância terá o estado *Active*.
+  </Tab>
+  <Tab label="A partir das API OpenStack/Nova">
+    Quando o ambiente estiver pronto, introduza o comando abaixo na linha de comandos:
 
-<a name="horizon-unshelve"></a>
+    ```bash
+    ~$ openstack server unshelve <UUID server>
 
-#### Da interface Horizon
+    =========================================
 
-Na interface Horizon, clique no menu <code className="action">Compute</code> no lado esquerdo e selecione <code className="action">Instances</code>. Selecione <code className="action">Unshelve Instance</code> na lista pendente para a instância correspondente.
+    ~$ nova unshelve <UUID server>
+    ```
+  </Tab>
+  <Tab label="A partir do CLI OVHcloud">
+    Introduza o seguinte comando:
 
-<img className="thumbnail" alt="unshelve instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/unshelveinstancehorizon.png" loading="lazy" />
-
-Uma vez terminado o processo, a sua instância aparecerá como *Active*.
-
-<a name="openstack-nova-unshelve"></a>
-
-#### Utilização das API OpenStack/Nova
-
-Quando o ambiente estiver pronto, utilize o seguinte comando:
-
-```bash
-~$ openstack server unshelve <UUID server>
-
-=========================================
-
-~$ nova unshelve <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance unshelve <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="stop-suspend-instance"></a>
 
@@ -214,104 +208,108 @@ Quando o ambiente estiver pronto, utilize o seguinte comando:
 
 Esta opção permite desligar a sua instância. O estado da VM é armazenado no disco, enquanto a memória é gravada no disco.
 
-<a name="stop-control-panel"></a>
+<Tabs>
+  <Tab label="A partir da área de cliente OVHcloud">
+    Na sua área de cliente OVHcloud, clique em <code className="action">Public Cloud</code>, selecione o seu projeto Public Cloud e clique em <code className="action">Instâncias</code> no menu à esquerda.
 
-#### Da Área de Cliente OVHcloud
+    Clique no botão <code className="action">⋮</code> à direita da instância que pretende parar, depois clique em <code className="action">Desativar</code>.
 
-Na Área de Cliente OVHcloud, clique no menu da secção <code className="action">Public Cloud</code>, selecione o seu projeto Public Cloud e clique em <code className="action">Instâncias</code> no menu à esquerda.
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
 
-Clique então nas <code className="action">⋮</code> à direita da instância a parar, e clique em <code className="action">Desativar</code>.
+    Na janela que aparece, tome conhecimento das informações e clique em <code className="action">Confirmar</code>.
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/turn_off_instance_2025.png" loading="lazy" />
+    <img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
 
-Na janela contextual, tome nota da mensagem e clique em <code className="action">Confirmar</code>.
+    Uma vez terminado o processo, a sua instância terá o estado "Desativada".
 
-<img className="thumbnail" alt="stop instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/confirm_turn_off.png" loading="lazy" />
+    Para **reiniciar** a instância, efetue as mesmas etapas que as indicadas anteriormente. Clique no botão <code className="action">⋮</code> à direita da instância e selecione <code className="action">Iniciar</code>. Em alguns casos, poderá ser necessário efetuar um reinício a frio.
+  </Tab>
+  <Tab label="A partir da interface Horizon">
+    Na interface Horizon, clique no menu <code className="action">Compute</code> à esquerda e depois selecione <code className="action">Instances</code>. Selecione <code className="action">Suspend Instance</code> na lista pendente correspondente à instância.
 
-Uma vez terminado o processo, a instância aparece como *Apagada*.
+    <img className="thumbnail" alt="instance suspension horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
 
-Para **reativar** a instância, efetue as mesmas etapas que as acima mencionadas. Clique então nas <code className="action">⋮</code> à direita da instânciae selecione o <code className="action">Iniciar</code>. Em alguns casos, poderá ter de efetuar uma Reboot a frio.
+    Aparece uma mensagem de confirmação a indicar que a instância foi suspensa.
 
-<a name="stop-horizon"></a>
+    Para **reiniciar** a instância, efetue as mesmas operações que as indicadas acima. Na lista pendente correspondente à instância, selecione <code className="action">Resume Instance</code>.
+  </Tab>
+  <Tab label="A partir das API OpenStack/Nova">
+    Quando o ambiente estiver pronto, introduza o comando abaixo na linha de comandos:
 
-#### Da interface Horizon 
+    ```bash
+    ~$ openstack server suspend <UUID server>
 
-Na interface Horizon, clique no menu <code className="action">Compute</code> no lado esquerdo e selecione <code className="action">Instances</code>. Selecione <code className="action">Suspend Instance</code> na lista pendente para a instância correspondente.
+    =========================================
 
-<img className="thumbnail" alt="instance suspension horizon" src="/images/public-cloud/compute/suspend-or-pause-an-instance/suspendinstancehorizon.png" loading="lazy" />
+    ~$ nova suspend <UUID server>
+    ```
 
-Aparecerá a mensagem de confirmação indicando que a instância foi suspensa.
+    Para **reiniciar** a instância, introduza o comando abaixo na linha de comandos:
 
-Para **reactivar** a instância, efetue as mesmas operações que as acima mencionadas. Na lista pendente da instância correspondente, selecione <code className="action">Resume Instance</code>.
+    ```bash
+    ~$ openstack server unsuspend <UUID server>
 
-<a name="stop-openstack-nova"></a>
+    =========================================
 
-#### Utilização da API OpenStack/Nova
+    ~$ nova unsuspend <UUID server>
+    ```
+  </Tab>
+  <Tab label="A partir do CLI OVHcloud">
+    Introduza o seguinte comando:
 
-Quando o ambiente estiver pronto, utilize o seguinte comando
+    ```shell
+    ovhcloud cloud instance stop <instance_id>
+    ```
 
-```bash
-~$ openstack server suspend <UUID server>
+    Para **reiniciar** a instância, introduza o seguinte comando:
 
-=========================================
-
-~$ nova suspend <UUID server>
-```
-
-Para **reactivar** a instância, utilize o seguinte comando
-
-```bash
-~$ openstack server unsuspend <UUID server>
-
-=========================================
-
-~$ nova unsuspend <UUID server>
-```
+    ```shell
+    ovhcloud cloud instance start <instance_id>
+    ```
+  </Tab>
+</Tabs>
 
 <a name="pause-instance"></a>
 
-### Colocar em pausa uma instância (*pause*) 
+### Colocar em pausa uma instância (*pause*)
 
-Esta ação só é possível através da interface Horizon ou da API Openstack/Nova. A instância tem um estado de « gelado » ou de « espera »
+Esta ação só é possível **a partir** da interface Horizon ou através das API OpenStack/Nova. Permite-lhe colocar em espera ou "gelar" a sua instância.
 
-<a name="pause-horizon"></a>
+<Tabs>
+  <Tab label="A partir da interface Horizon">
+    Na interface Horizon, clique no menu <code className="action">Compute</code> à esquerda e depois selecione <code className="action">Instances</code>. Selecione <code className="action">Pause Instance</code> na lista pendente correspondente à instância.
 
-#### Da interface Horizon 
+    <img className="thumbnail" alt="Pause instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
 
-Na interface Horizon, clique no menu <code className="action">Compute</code> no lado esquerdo e selecione <code className="action">Instances</code>. Selecione <code className="action">Pause Instance</code> na lista pendente para a instância correspondente.
+    Aparece a mensagem de confirmação a indicar a colocação em pausa da instância.
 
-<img className="thumbnail" alt="Pause instance" src="/images/public-cloud/compute/suspend-or-pause-an-instance/pauseinstancehorizon.png" loading="lazy" />
+    Para **reativar** a instância, efetue as mesmas etapas que as indicadas anteriormente. Na lista pendente correspondente à instância, selecione <code className="action">Resume Instance</code>.
+  </Tab>
+  <Tab label="A partir das API OpenStack/Nova">
+    Quando o ambiente estiver pronto, introduza o comando abaixo na linha de comandos:
 
-Aparecerá a mensagem de confirmação indicando que a instância foi pausada.
+    ```bash
+    ~$ openstack server pause <UUID server>
 
-Para **reactivar** a instância, efetue as mesmas etapas que as mencionadas acima. Na lista pendente da instância correspondente, selecione <code className="action">Resume Instance</code>.
+    =========================================
 
-<a name="pause-openstack-nova"></a>
+    ~$ nova pause <UUID server>
+    ```
 
-#### Utilização das API OpenStack/Nova
+    Para **reativar** a instância, introduza o comando abaixo na linha de comandos:
 
-Quando o ambiente estiver pronto, utilize o seguinte comando:
+    ```bash
+    ~$ openstack server unpause <UUID server>
 
-```bash
-~$ openstack server pause <UUID server>
+    =========================================
 
-=========================================
-
-~$ nova pause <UUID server>
-```
-
-Para **reactivar** a instância, utilize o seguinte comando:
-
-```bash
-~$ openstack server unpause <UUID server>
-
-=========================================
-
-~$ nova unpause <UUID server>
-```
+    ~$ nova unpause <UUID server>
+    ```
+  </Tab>
+</Tabs>
 
 ## Quer saber mais?
 
 [Documentação OpenStack](https://docs.openstack.org/ocata/user-guide/cli-stop-and-start-an-instance.html).
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/).


### PR DESCRIPTION
Restructures Public Cloud Compute getting-started and shelve/pause guides into multi-tool tabs (Control Panel, API, OVHcloud CLI, OpenStack CLI, Terraform). Adds OVHcloud CLI coverage to every procedural section. EN + FR only.

Original-URL: https://github.com/ovh/docs/pull/9249
Original-author: @OvhValentin 

To do: proofreading and translation