### PR TITLE
docs(bare-metal-cloud): note BYOI deploys image to a single disk only

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-02-10
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -55,6 +55,8 @@ There are some technical limitations linked to the use of physical products such
 **About RAID:**
 
 - Bring Your Own Image (BYOI) does not support software RAID configuration at install-time, but you can use the service [Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux) for that. Choose the custom image method that fits your needs: [Bring Your Own Image (BYOI) / Bring Your Own Linux (BYOLinux), a comparison sheet](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image-versus-bring-your-own-linux).
+
+- BYOI deploys the image to a single disk: the first disk of the target disk group.
 
 - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-05-22
+lastUpdated: 2026-05-25
 ---
 
 import Api from '@components/Api';

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID works on servers with a RAID controller, because the array is presented to the operating system as a single virtual disk.
+- Hardware RAID works on servers with a RAID controller, because the RAID controller presents the array to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID works on servers with a RAID controller, because the RAID controller presents the array to the operating system as a single virtual disk.
+- Hardware RAID works on servers with a RAID controller, because it presents the array to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+- Hardware RAID works on servers with a RAID controller, because the array is presented to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID works on servers with a RAID controller, because the array is presented to the operating system as a single virtual disk.
+- Hardware RAID works on servers with a RAID controller, because the RAID controller presents the array to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-05-22
+lastUpdated: 2026-05-25
 ---
 
 import Api from '@components/Api';

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID works on servers with a RAID controller, because the RAID controller presents the array to the operating system as a single virtual disk.
+- Hardware RAID works on servers with a RAID controller, because it presents the array to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-02-10
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -55,6 +55,8 @@ There are some technical limitations linked to the use of physical products such
 **About RAID:**
 
 - Bring Your Own Image (BYOI) does not support software RAID configuration at install-time, but you can use the service [Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux) for that. Choose the custom image method that fits your needs: [Bring Your Own Image (BYOI) / Bring Your Own Linux (BYOLinux), a comparison sheet](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image-versus-bring-your-own-linux).
+
+- BYOI deploys the image to a single disk: the first disk of the target disk group.
 
 - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+- Hardware RAID works on servers with a RAID controller, because the array is presented to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-02-10
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -55,6 +55,8 @@ There are some technical limitations linked to the use of physical products such
 **About RAID:**
 
 - Bring Your Own Image (BYOI) does not support software RAID configuration at install-time, but you can use the service [Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux) for that. Choose the custom image method that fits your needs: [Bring Your Own Image (BYOI) / Bring Your Own Linux (BYOLinux), a comparison sheet](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image-versus-bring-your-own-linux).
+
+- BYOI deploys the image to a single disk: the first disk of the target disk group.
 
 - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-05-22
+lastUpdated: 2026-05-25
 ---
 
 import Api from '@components/Api';

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID works on servers with a RAID controller, because the array is presented to the operating system as a single virtual disk.
+- Hardware RAID works on servers with a RAID controller, because the RAID controller presents the array to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID works on servers with a RAID controller, because the RAID controller presents the array to the operating system as a single virtual disk.
+- Hardware RAID works on servers with a RAID controller, because it presents the array to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+- Hardware RAID works on servers with a RAID controller, because the array is presented to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI)
 description: Découvrez comment déployer facilement vos propres images sur des serveurs dédiés
-lastUpdated: 2026-05-22
+lastUpdated: 2026-05-25
 ---
 
 import Api from '@components/Api';

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ Certaines limites techniques sont liées à l’utilisation de produits physique
 
 - BYOI déploie l'image sur un seul disque : le premier disque du groupe de disques cible.
 
-- Le RAID matériel est pris en charge, si votre serveur le supporte, car il est configuré avant le déploiement de l'image sur le disque.
+- Le RAID matériel fonctionne sur les serveurs équipés d'un contrôleur RAID, car la matrice RAID est présentée au système d'exploitation comme un seul disque virtuel.
 
 :::
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI)
 description: Découvrez comment déployer facilement vos propres images sur des serveurs dédiés
-lastUpdated: 2026-02-10
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -55,6 +55,8 @@ Certaines limites techniques sont liées à l’utilisation de produits physique
 **À propos du RAID :**
 
 - Bring Your Own Image (BYOI) ne prend pas en charge la configuration RAID logicielle au moment de l'installation, mais vous pouvez utiliser le service [Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux) pour le faire. Choisissez le type d'installation personnalisée le plus adapté : [Comparaison entre Bring Your Own Image (BYOI) et Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image-versus-bring-your-own-linux).
+
+- BYOI déploie l'image sur un seul disque : le premier disque du groupe de disques cible.
 
 - Le RAID matériel est pris en charge, si votre serveur le supporte, car il est configuré avant le déploiement de l'image sur le disque.
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ Certaines limites techniques sont liées à l’utilisation de produits physique
 
 - BYOI déploie l'image sur un seul disque : le premier disque du groupe de disques cible.
 
-- Le RAID matériel fonctionne sur les serveurs équipés d'un contrôleur RAID, car la matrice RAID est présentée au système d'exploitation comme un seul disque virtuel.
+- Le RAID matériel fonctionne sur les serveurs équipés d'un contrôleur RAID, car le contrôleur RAID présente la matrice au système d'exploitation comme un seul disque virtuel.
 
 :::
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ Certaines limites techniques sont liées à l’utilisation de produits physique
 
 - BYOI déploie l'image sur un seul disque : le premier disque du groupe de disques cible.
 
-- Le RAID matériel fonctionne sur les serveurs équipés d'un contrôleur RAID, car le contrôleur RAID présente la matrice au système d'exploitation comme un seul disque virtuel.
+- Le RAID matériel fonctionne sur les serveurs équipés d'un contrôleur RAID, car il présente la matrice au système d'exploitation comme un seul disque virtuel.
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-02-10
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -55,6 +55,8 @@ There are some technical limitations linked to the use of physical products such
 **About RAID:**
 
 - Bring Your Own Image (BYOI) does not support software RAID configuration at install-time, but you can use the service [Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux) for that. Choose the custom image method that fits your needs: [Bring Your Own Image (BYOI) / Bring Your Own Linux (BYOLinux), a comparison sheet](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image-versus-bring-your-own-linux).
+
+- BYOI deploys the image to a single disk: the first disk of the target disk group.
 
 - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-05-22
+lastUpdated: 2026-05-25
 ---
 
 import Api from '@components/Api';

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID works on servers with a RAID controller, because the array is presented to the operating system as a single virtual disk.
+- Hardware RAID works on servers with a RAID controller, because the RAID controller presents the array to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID works on servers with a RAID controller, because the RAID controller presents the array to the operating system as a single virtual disk.
+- Hardware RAID works on servers with a RAID controller, because it presents the array to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+- Hardware RAID works on servers with a RAID controller, because the array is presented to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-02-10
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -55,6 +55,8 @@ There are some technical limitations linked to the use of physical products such
 **About RAID:**
 
 - Bring Your Own Image (BYOI) does not support software RAID configuration at install-time, but you can use the service [Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux) for that. Choose the custom image method that fits your needs: [Bring Your Own Image (BYOI) / Bring Your Own Linux (BYOLinux), a comparison sheet](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image-versus-bring-your-own-linux).
+
+- BYOI deploys the image to a single disk: the first disk of the target disk group.
 
 - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-05-22
+lastUpdated: 2026-05-25
 ---
 
 import Api from '@components/Api';

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID works on servers with a RAID controller, because the array is presented to the operating system as a single virtual disk.
+- Hardware RAID works on servers with a RAID controller, because the RAID controller presents the array to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID works on servers with a RAID controller, because the RAID controller presents the array to the operating system as a single virtual disk.
+- Hardware RAID works on servers with a RAID controller, because it presents the array to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+- Hardware RAID works on servers with a RAID controller, because the array is presented to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-02-10
+lastUpdated: 2026-05-22
 ---
 
 import Api from '@components/Api';
@@ -55,6 +55,8 @@ There are some technical limitations linked to the use of physical products such
 **About RAID:**
 
 - Bring Your Own Image (BYOI) does not support software RAID configuration at install-time, but you can use the service [Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux) for that. Choose the custom image method that fits your needs: [Bring Your Own Image (BYOI) / Bring Your Own Linux (BYOLinux), a comparison sheet](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image-versus-bring-your-own-linux).
+
+- BYOI deploys the image to a single disk: the first disk of the target disk group.
 
 - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-05-22
+lastUpdated: 2026-05-25
 ---
 
 import Api from '@components/Api';

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID works on servers with a RAID controller, because the array is presented to the operating system as a single virtual disk.
+- Hardware RAID works on servers with a RAID controller, because the RAID controller presents the array to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID works on servers with a RAID controller, because the RAID controller presents the array to the operating system as a single virtual disk.
+- Hardware RAID works on servers with a RAID controller, because it presents the array to the operating system as a single virtual disk.
 
 :::
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -58,7 +58,7 @@ There are some technical limitations linked to the use of physical products such
 
 - BYOI deploys the image to a single disk: the first disk of the target disk group.
 
-- Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+- Hardware RAID works on servers with a RAID controller, because the array is presented to the operating system as a single virtual disk.
 
 :::
 


### PR DESCRIPTION
* docs(bare-metal-cloud): note BYOI deploys image to a single disk only

    Adds a bullet to the BYOI guide's RAID warning clarifying that the
    image is deployed to a single disk: the first disk of the target
    disk group.
    
    Original-URL: https://github.com/ovh/docs/pull/8837
    Original-author: @outtersg

    
* docs(bare-metal-cloud): explain why BYOI works with hardware RAID

    Rewords the hardware RAID bullet to say why it works: the array is
    presented to the operating system as a single virtual disk. This
    connects to the preceding bullet ("BYOI deploys the image to a single
    disk"), so the reader can see why both statements hold at once.
    
