### PR TITLE
Edge Network Firewall - QUIC support clarification

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aktivieren und Konfigurieren der Edge Network Firewall
 description: Erfahren Sie, wie Sie die Edge Network Firewall für Ihre Dienste konfigurieren
-lastUpdated: 2026-03-10
+lastUpdated: 2026-05-28
 ---
 
 ## Ziel
@@ -44,7 +44,8 @@ Weitere Informationen finden Sie auf unserer [Vergleichsseite](https://eco.ovhcl
 
 
 :::warning
-Die Edge Network Firewall unterstützt das QUIC-Protokoll nicht.
+Das QUIC-Protokoll wird derzeit am Rand des OVHcloud Netzwerks verworfen, unabhängig von Ihren Edge Network Firewall-Einstellungen.
+Verwenden Sie für HTTP-Traffic stattdessen HTTP/2, das auf Standard-TCP basiert.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Enabling and configuring the Edge Network Firewall
 description: Find out how to configure the Edge Network Firewall for your services
-lastUpdated: 2026-03-10
+lastUpdated: 2026-05-26
 ---
 
 ## Objective
@@ -44,7 +44,8 @@ Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for 
 
 
 :::warning
-The Edge Network Firewall does not support QUIC protocol.
+The QUIC protocol is currently dropped at the OVHcloud network edge, regardless of your Edge Network Firewall settings.
+For HTTP traffic, please use HTTP/2, which instead relies on standard TCP.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Enabling and configuring the Edge Network Firewall
 description: Find out how to configure the Edge Network Firewall for your services
-lastUpdated: 2026-05-26
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Activar y configurar el Edge Network Firewall
 description: Descubra cómo configurar el Edge Network Firewall para sus servicios
-lastUpdated: 2026-03-10
+lastUpdated: 2026-05-28
 ---
 
 ## Objetivo
@@ -44,7 +44,8 @@ Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/
 
 
 :::warning
-El Edge Network Firewall no es compatible con el protocolo QUIC.
+Actualmente, el protocolo QUIC se bloquea en el perímetro de la red de OVHcloud, independientemente de la configuración del Edge Network Firewall.
+Para el tráfico HTTP, utilice HTTP/2, que se basa en el protocolo TCP estándar.
 
 :::
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Activer et configurer le Edge Network Firewall
 description: Découvrez comment configurer le Edge Network Firewall pour vos services
-lastUpdated: 2026-05-26
+lastUpdated: 2026-05-28
 ---
 
 ## Objectif

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Activer et configurer le Edge Network Firewall
 description: Découvrez comment configurer le Edge Network Firewall pour vos services
-lastUpdated: 2026-03-10
+lastUpdated: 2026-05-26
 ---
 
 ## Objectif
@@ -44,7 +44,8 @@ Consultez notre [comparatif](https://eco.ovhcloud.com/fr/compare/) pour plus d�
 
 
 :::warning
-Le Edge Network Firewall ne prend pas en charge le protocole QUIC.
+Le protocole QUIC est actuellement bloqué à l'entrée du réseau OVHcloud, quels que soient les paramètres de votre Edge Network Firewall. 
+Pour le trafic HTTP, veuillez utiliser HTTP/2, qui s'appuie plutôt sur le protocole TCP standard.
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attivare e configurare Edge Network Firewall
 description: Scopri come configurare Edge Network Firewall per i tuoi servizi
-lastUpdated: 2026-03-10
+lastUpdated: 2026-05-28
 ---
 
 ## Obiettivo
@@ -44,7 +44,8 @@ Per maggiori informazioni, consulta la nostra [pagina di confronto](https://eco.
 
 
 :::warning
-Edge Network Firewall non supporta il protocollo QUIC.
+Attualmente, il protocollo QUIC viene bloccato al perimetro della rete OVHcloud, indipendentemente dalle impostazioni di Edge Network Firewall.
+Per il traffico HTTP, utilizza HTTP/2, che si basa sul protocollo TCP standard.
 
 :::
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aktywacja i konfiguracja Edge Network Firewall
 description: Dowiedz się, jak skonfigurować Edge Network Firewall dla Twoich usług
-lastUpdated: 2026-03-10
+lastUpdated: 2026-05-28
 ---
 
 ## Wprowadzenie
@@ -44,7 +44,8 @@ Aby uzyskać więcej informacji, odwiedź naszą [stronę porównawczą](https:/
 
 
 :::warning
-Edge Network Firewall nie obsługuje protokołu QUIC.
+Protokół QUIC jest obecnie blokowany na brzegu sieci OVHcloud, niezależnie od ustawień Edge Network Firewall.
+W przypadku ruchu HTTP zalecamy użycie protokołu HTTP/2, który opiera się na standardowym protokole TCP.
 
 :::
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ativar e configurar o Edge Network Firewall
 description: Saiba como configurar o Edge Network Firewall para os seus serviços
-lastUpdated: 2026-03-10
+lastUpdated: 2026-05-28
 ---
 
 ## Objetivo
@@ -44,7 +44,8 @@ Consulte a nossa [página de comparação](https://eco.ovhcloud.com/pt/compare/)
 
 
 :::warning
-O Edge Network Firewall não suporta o protocolo QUIC.
+Atualmente, o protocolo QUIC encontra-se bloqueado na periferia da rede OVHcloud, independentemente das definições do Edge Network Firewall.
+Para o tráfego HTTP, utilize o HTTP/2, que se baseia no protocolo TCP padrão.
 
 :::
 


### PR DESCRIPTION
Changed the warning to clarify where QUIC isn't supported, and provide an alternative.

- Update of existing guide(s)
- Manual translation
- Can be merged immediately