### PR TITLE
[SK-2651] -WEB- Emails - Lock for SPAM - Add Zimbra

### DIFF
--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Zimbra FAQ
 description: Hier finden Sie die häufigsten Fragen zur Migration der OVHcloud MX Plan Dienste nach Zimbra
-lastUpdated: 2025-12-05
+lastUpdated: 2026-05-28
 ---
 
 
@@ -43,6 +43,52 @@ Es bestehen Funktionsunterschiede zwischen der im MX Plan Angebot verwendeten Zi
 
 
 Eine Anleitung zur Verwendung von Zimbra finden Sie bereits unter [dieser Adresse](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</details>
+
+
+<details>
+
+<summary>Ich kann nicht mehr auf mein Zimbra E-Mail-Konto zugreifen und verstehe nicht warum: Was soll ich tun?</summary>
+
+
+Wenn Sie einen vollständigen Zugriffsverlust auf Ihr Zimbra E-Mail-Konto feststellen (Anmeldung am Zimbra Webmail abgelehnt, Versand und Empfang ausgesetzt, Zugangsdaten scheinbar korrekt), ist die häufigste Ursache eine **automatische Sperrung der Adresse aufgrund von Spam**.
+
+Diese Maßnahme gilt für alle drei Zimbra Angebote:
+
+- **MX Plan - Zimbra**
+- **Zimbra Starter**
+- **Zimbra Pro**
+
+**Wie erkennen Sie diesen Fall:**
+
+- Der Zugriff auf das Zimbra Webmail ist vollständig ausgesetzt (und nicht nur der Versand).
+- In Ihrem OVHcloud Kundencenter wurde im Gegensatz zu anderen E-Mail-Technologien kein Support-Ticket automatisch erstellt.
+- Möglicherweise wurde kürzlich eine ungewöhnliche Versandaktivität auf dem Konto festgestellt (Massenversand, verdächtige Inhalte, potenziell infizierter Arbeitsplatz des Nutzers, kompromittierte Zugangsdaten, Weiterleitung an eine schädliche Adresse).
+
+**Warum erhalten Sie keine eindeutige Benachrichtigung:**
+
+Bei Zimbra Konten setzt die Anti-Spam-Sperrung den gesamten Zugriff auf das Konto aus und löst kein automatisches Support-Ticket aus. Der Kunde kann den Zugriffsverlust daher feststellen, ohne sofort eine Erklärung zu erhalten.
+
+**Was tun?**
+
+1. Beachten Sie die Anleitung "[Was tun, wenn Ihre E-Mail-Adresse wegen Spamversands gesperrt wurde](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam)" und führen Sie die in Schritt 1 beschriebenen Prüfungen (Arbeitsplatz, Drittanbieter-Software, Weiterleitungen, Filter, automatische Antworten) anhand der noch zugänglichen Elemente durch.
+2. **Erstellen Sie manuell ein Support-Ticket** über Ihr OVHcloud Kundencenter. Geben Sie im Ticket Folgendes an:
+    - Die betroffene E-Mail-Adresse;
+    - Den zugehörigen Dienst (MX Plan, Zimbra Starter oder Zimbra Pro) sowie dessen Identifikator;
+    - Die bereits durchgeführten Korrekturmaßnahmen.
+3. Sobald das Ticket vom Support bearbeitet wurde, wird Ihre Adresse entsperrt und der Zugriff auf das Zimbra Webmail wiederhergestellt.
+
+:::info
+**Weitere mögliche Ursachen für den Zugriffsverlust** (vor oder nach der Kontaktaufnahme mit dem Support auszuschließen):
+
+- Kürzlich geändertes Passwort (durch Sie selbst oder einen Plattform-Administrator).
+- Dienst befindet sich derzeit in administrativer Sperrung (unbezahlte Rechnung, Kündigung, Vertragsende).
+- Kürzlich durchgeführte Dienstmigration (prüfen Sie eventuelle Benachrichtigungs-E-Mails, die 2 Wochen und 1 Tag vor der Migration versendet wurden).
+- Einmaliger Infrastrukturvorfall: Prüfen Sie den [Status der OVHcloud Dienste](https://status.ovhcloud.com).
+
+:::
+
 
 </details>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
-title: Was tun, wenn ein Account wegen Spamversands gesperrt wurde?
-description: Erfahren Sie, wie Sie vorgehen, wenn Ihre E-Mail-Adresse wegen Spamversands gesperrt wurde
-lastUpdated: 2026-03-05
+title: Was tun, wenn Ihre E-Mail-Adresse wegen Spamversands gesperrt wurde
+description: "Eine wegen Spamversands gesperrte E-Mail-Adresse entsperren: Ursache der verdächtigen Aktivität identifizieren, beheben und den OVHcloud Support kontaktieren."
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -16,8 +16,10 @@ Wenn Ihre E-Mail-Adresse wegen Spamversands gesperrt ist, bedeutet dies, dass be
 ## Voraussetzungen
 
 - Sie verfügen über eine [OVHcloud E-Mail-Lösung](https://www.ovhcloud.com/de/emails/).
+- Sie sind in Ihrem <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> angemeldet.
 
 {/* CP-NAV-START:web-mx-plan */}
+{/* CP-NAV-START:web-zimbra */}
 {/* CP-NAV-START:web-email-pro */}
 {/* CP-NAV-START:web-exchange */}
 ---
@@ -28,6 +30,11 @@ Wenn Ihre E-Mail-Adresse wegen Spamversands gesperrt ist, bedeutet dies, dass be
 
 - **Direkter Link:** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
 - **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Wählen Sie Ihren MX Plan Dienst aus
+
+**Zimbra (Starter / Pro):**
+
+- **Direkter Link:** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
+- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Wählen Sie Ihren Zimbra-Dienst aus
 
 **E-Mail Pro:**
 
@@ -42,93 +49,150 @@ Wenn Ihre E-Mail-Adresse wegen Spamversands gesperrt ist, bedeutet dies, dass be
 ---
 {/* CP-NAV-END:web-exchange */}
 {/* CP-NAV-END:web-email-pro */}
+{/* CP-NAV-END:web-zimbra */}
 {/* CP-NAV-END:web-mx-plan */}
 
 ## In der praktischen Anwendung <a name="instructions"></a>
 
-Bevor Sie fortfahren: Falls die Sperrung eine E-Mail-Adresse vom Typ MX Plan betrifft, identifizieren Sie zunächst die verwendete E-Mail-Technologie Ihres Dienstes, um den richtigen Entsperrungsvorgang durchzuführen.
+Bevor Sie fortfahren: Falls die Sperrung eine MX Plan E-Mail-Adresse betrifft, identifizieren Sie zunächst die von Ihrer Lösung verwendete E-Mail-Technologie, um den richtigen Entsperrvorgang zu befolgen. Für die Lösungen **Zimbra Starter** und **Zimbra Pro** wechseln Sie direkt zum Tab **Zimbra** in Schritt 2, ohne dabei die Prüfungen aus Schritt 1 zu überspringen.
 
 :::info
-**Die E-Mail-Technologie Ihres MX Plan Dienstes identifizieren.**
+**Identifizieren Sie die E-Mail-Technologie Ihrer MX Plan Lösung.**
 
-Je nach Aktivierungsdatum Ihres MX Plan Dienstes oder einer kürzlich durchgeführten Migration kann die zugehörige E-Mail-Technologie unterschiedlich sein. Diese Version wird durch die Oberfläche Ihres Webmails charakterisiert. So identifizieren Sie sie:
+Je nach Aktivierungsdatum Ihrer MX Plan Lösung oder nach einer kürzlich erfolgten Migration kann sich die zugehörige E-Mail-Technologie unterscheiden. Diese Version erkennen Sie an ihrer Webmail-Oberfläche. So identifizieren Sie sie:
 
-- Im Tab <code className="action">Allgemeine Informationen</code> finden Sie die verwendete Technologie unter dem Eintrag **Webmail** im Rahmen <code className="action">Abo</code>.
+- Prüfen Sie im Tab <code className="action">Allgemeine Informationen</code> die im Bereich <code className="action">Abonnement</code> unter dem Label **Webmail** angegebene Technologie.
 
-<img className="thumbnail" alt="E-Mail-Technologie im OVHcloud Kundencenter MX Plan identifizieren" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
+<img className="thumbnail" alt="Identifizierung der E-Mail-Technologie im Kundencenter des MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
 
-- Wenn die angezeigte Technologie **RoundCube** ist, folgen Sie den Anweisungen im Tab **MX Plan - RoundCube**.
-- Wenn die angezeigte Technologie **OWA** oder **Zimbra** ist, folgen Sie den Anweisungen im Tab **MX Plan - OWA / Zimbra**.
+- Wird **Roundcube** angezeigt, folgen Sie den Anweisungen im Tab **MX Plan - Roundcube**.
+- Wird **OWA** (Outlook Web App) angezeigt, folgen Sie den Anweisungen im Tab **MX Plan - OWA**.
+- Wird **Zimbra** angezeigt, folgen Sie den Anweisungen im Tab **Zimbra** (das Verfahren ist für MX Plan - Zimbra, Zimbra Starter und Zimbra Pro identisch).
 
 :::
 
 
-### Schritt 1: Warum wurde Ihre E-Mail-Adresse wegen Spamversands gesperrt? <a name="step1"></a>
+### Schritt 1: Die Ursache der Sperrung verstehen und beheben <a name="step1"></a>
 
-Wenn beim Versand von E-Mails verdächtige Aktivitäten festgestellt werden, wird die betroffene Adresse automatisch gesperrt. In diesem Fall können Sie über diese E-Mail-Adresse keine E-Mails mehr versenden.
+Wenn verdächtige Aktivitäten bei ausgehenden E-Mails erkannt werden, wird die betroffene Adresse automatisch gesperrt. In diesem Fall können Sie über diese E-Mail-Adresse keine E-Mails mehr versenden.
 
 :::warning
 "Verdächtige Aktivität" bedeutet, dass:
 
-- Der Anti-Spam-Server, der E-Mails beim Versand scannt, ein oder mehrere Elemente der E-Mail als verdächtig eingestuft hat und diese als Spam-E-Mail betrachtet werden können.
-- Die Häufigkeit des Versands und die Anzahl der Empfänger zu hoch sind und als Spamming gewertet werden. Für Massenversand ist es erforderlich, einen Mailinglisten-Dienst zu verwenden und keine Standard-E-Mail-Adresse.
+- der Anti-Spam-Server, der E-Mails beim Versand prüft, festgestellt hat, dass ein oder mehrere Elemente der E-Mail als verdächtig gelten und möglicherweise Spam darstellen.
+- die Versandhäufigkeit und die Anzahl der Empfänger zu hoch sind und dazu beitragen, dass die Aktivität als Spamming eingestuft wird. Für Massensendungen müssen Sie einen Mailinglisten-Dienst anstelle einer Standard-E-Mail-Adresse verwenden.
 
-Die genauen Gründe für eine Sperrung können nicht offengelegt werden, um Versuche zur Umgehung des Spam-Erkennungssystems zu verhindern. Um den Inhalt einer E-Mail zu testen, können Sie ein externes Tool wie [Mailtester](https://www.mail-tester.com/) verwenden.
+Die genauen Gründe für eine Sperrung können nicht offengelegt werden, um zu verhindern, dass das Spam-Erkennungssystem umgangen wird. Um den Inhalt einer E-Mail zu testen, können Sie ein externes Tool wie [Mailtester](https://www.mail-tester.com/) verwenden.
 
 :::
 
 
-Stellen Sie zunächst bei den Benutzern der gesperrten E-Mail-Adresse sicher, dass diese die Sperrung nicht selbst durch eine ungewöhnliche Nutzung der E-Mail-Adresse verursacht haben (z. B. durch Massenversand von E-Mails). Ist dies der Fall, müssen Sie die Situation korrigieren, bevor Sie die Adresse entsperren.
+Prüfen Sie zunächst mit den Nutzern der gesperrten E-Mail-Adresse, ob diese nicht selbst für die Sperrung verantwortlich sind, etwa durch eine ungewöhnliche Nutzung der E-Mail-Adresse (zum Beispiel Massenversand von E-Mails). Sollte dies der Fall sein, müssen Sie die Situation bereinigen, bevor Sie die Adresse entsperren lassen.
 
-Wenn die vom Anti-Spam-System erkannte verdächtige Aktivität nicht von einem legitimen Benutzer der E-Mail-Adresse verursacht wurde, führen Sie die folgenden Maßnahmen durch:
+Wurde die vom Anti-Spam-System erkannte verdächtige Aktivität nicht von den rechtmäßigen Nutzern der E-Mail-Adresse veranlasst, ergreifen Sie folgende Maßnahmen:
 
-- Führen Sie eine Virenprüfung aller Geräte durch, die die wegen Spamversands gesperrte E-Mail-Adresse verwenden, und wenden Sie Korrekturen an, falls diese infiziert sind.
+- Führen Sie auf jedem Gerät, das die wegen Spamversands gesperrte E-Mail-Adresse verwendet, einen Virenscan durch und beheben Sie eine Infektion, falls vorhanden.
 
-- Überprüfen Sie alle Programme, die die Zugangsdaten der wegen Spamversands gesperrten E-Mail-Adresse verwenden (z. B. Faxgerät, Unternehmenssoftware, E-Mail-Client).
+- Überprüfen Sie sämtliche Software, die mit den Zugangsdaten der wegen Spamversands gesperrten E-Mail-Adresse arbeitet (zum Beispiel: Faxgerät, Branchensoftware, E-Mail-Client).
 
-- Überprüfen Sie die Weiterleitungen, die auf der wegen Spamversands gesperrten E-Mail-Adresse konfiguriert sind.
+- Überprüfen Sie die auf der wegen Spamversands gesperrten E-Mail-Adresse eingerichteten Weiterleitungen.
 
-- Überprüfen Sie die Filter, die über einen E-Mail-Client oder das Webmail auf der wegen Spamversands gesperrten E-Mail-Adresse konfiguriert sind.
+- Überprüfen Sie die auf der wegen Spamversands gesperrten E-Mail-Adresse eingerichteten Filter über einen E-Mail-Client oder das Webmail.
 
-- Überprüfen Sie die automatischen Antworten, die über einen E-Mail-Client oder das Webmail auf der wegen Spamversands gesperrten E-Mail-Adresse konfiguriert sind.
+- Überprüfen Sie die auf der wegen Spamversands gesperrten E-Mail-Adresse konfigurierten Abwesenheitsbenachrichtigungen über einen E-Mail-Client oder das Webmail.
 
-### Schritt 2: Den Status der E-Mail-Adresse überprüfen und auf das zugehörige Support-Ticket zugreifen
+:::info
+Filter, Weiterleitungen und Abwesenheitsbenachrichtigungen, die direkt im Webmail (Zimbra, OWA) oder in Ihrem E-Mail-Client konfiguriert wurden, sind für den OVHcloud Support nicht zugänglich: Der Support kann sie nicht für Sie überprüfen. Diese Prüfungen müssen Sie selbst durchführen, entweder über das Webmail oder über ein bereits mit der Adresse konfiguriertes Gerät.
 
-Wählen Sie den betroffenen E-Mail-Dienst in den folgenden Tabs aus:
+:::
+
+:::warning
+Wenn die Sperrung eine Adresse mit der Technologie **Zimbra** betrifft (MX Plan - Zimbra, Zimbra Starter oder Zimbra Pro), ist die Adresse **nicht mehr zugänglich**: Zusätzlich zum E-Mail-Versand wird auch die Anmeldung am Zimbra-Webmail gesperrt. Filter, Weiterleitungen und Abwesenheitsbenachrichtigungen können daher nicht mehr über das Webmail eingesehen werden.
+
+:::
+
+#### Einen Filter einrichten, um SPAM- / DCE-Nachrichten zu isolieren
+
+Um das Risiko einer erneuten Sperrung nach dem Entsperren zu verringern, empfehlen wir, einen Filter auf der E-Mail-Adresse einzurichten:
+
+- Der Filter soll E-Mails, deren Betreff die Kennzeichnung **"SPAM"** oder **"DCE"** (*Dirty Commercial Email*) enthält, **isolieren**, beispielsweise indem er sie in einen eigens dafür vorgesehenen Ordner verschiebt. **Löschen Sie diese E-Mails nicht automatisch**: Durch eine Löschung gingen mögliche Falschmeldungen (zu Unrecht markierte legitime Nachrichten) verloren.
+- **Behalten** Sie bestehende **Weiterleitungsregeln** bei: Löschen Sie diese nicht, wenn Sie den Filter hinzufügen.
+
+Dieser Filter wird über das Webmail oder einen E-Mail-Client konfiguriert.
+
+### Schritt 2: Status prüfen und auf das Support-Ticket zugreifen
+
+Wählen Sie in den folgenden Tabs die betroffene E-Mail-Lösung aus:
 
 <Tabs>
   <Tab label="Exchange">
-    Gehen Sie zum Tab <code className="action">E-Mail-Accounts</code> Ihrer Plattform. Wenn in der Spalte "Status" der betroffenen E-Mail-Adresse "Gesperrt" angezeigt wird, klicken Sie auf <code className="action">...</code> rechts neben dem Account und dann auf <code className="action">Entsperren</code>. Die E-Mail-Adresse wird nicht automatisch entsperrt. Kontaktieren Sie den Support über das Support-Ticket, indem Sie die 3 gestellten Fragen beantworten.<br/>
+    Wechseln Sie in den Tab <code className="action">E-Mail-Accounts</code> Ihrer Plattform. Zeigt die Spalte "Status" für die betroffene E-Mail-Adresse "Blockiert" an, klicken Sie auf <code className="action">...</code> rechts neben dem Account und anschließend auf <code className="action">Sperrung aufheben</code>. Die E-Mail-Adresse wird nicht automatisch entsperrt. Kontaktieren Sie den Support über das Support-Ticket, indem Sie die drei dort gestellten Fragen beantworten.<br/>
 
-Fahren Sie mit [Schritt 3](#step3) der Anleitung fort.
-    
-    <img className="thumbnail" alt="Status gesperrt im Tab E-Mail-Accounts Exchange" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-01.png" loading="lazy" />
+    Fahren Sie mit [Schritt 3](#step3) dieser Anleitung fort.
+
+    <img className="thumbnail" alt="Spalte Status auf Blockiert im Tab E-Mail-Accounts für Exchange" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-01.png" loading="lazy" />
   </Tab>
   <Tab label="E-Mail Pro">
-    Gehen Sie zum Tab <code className="action">E-Mail-Accounts</code> Ihrer Plattform. Wenn in der Spalte "Status" rechts neben der betroffenen E-Mail-Adresse "Spam" angezeigt wird, klicken Sie auf diesen Hinweis und dann auf <code className="action">Ticket beantworten</code>. Die E-Mail-Adresse wird nicht automatisch entsperrt. Kontaktieren Sie den Support über das Support-Ticket, indem Sie die 3 gestellten Fragen beantworten. <br/>
+    Wechseln Sie in den Tab <code className="action">E-Mail-Accounts</code> Ihrer Plattform. Zeigt die Spalte "Status" rechts neben der betroffenen E-Mail-Adresse "Spam" an, klicken Sie darauf und anschließend auf <code className="action">Auf das Ticket antworten</code>. Die E-Mail-Adresse wird nicht automatisch entsperrt. Kontaktieren Sie den Support über das Support-Ticket, indem Sie die drei dort gestellten Fragen beantworten.<br/>
 
-Fahren Sie mit [Schritt 3](#step3) der Anleitung fort.
-    
-    <img className="thumbnail" alt="Status Spam im Tab E-Mail-Accounts E-Mail Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
-  </Tab>
-  <Tab label="MX Plan - OWA / Zimbra">
-    Gehen Sie zum Tab <code className="action">E-Mail-Accounts</code> Ihrer Plattform. Wenn in der Spalte "Status" rechts neben der betroffenen E-Mail-Adresse "Spam" angezeigt wird, klicken Sie auf diesen Hinweis und dann auf <code className="action">Ticket beantworten</code>. Die E-Mail-Adresse wird nicht automatisch entsperrt. Kontaktieren Sie den Support über das Support-Ticket, indem Sie die 3 gestellten Fragen beantworten.<br/>
+    Fahren Sie mit [Schritt 3](#step3) dieser Anleitung fort.
 
-Fahren Sie mit [Schritt 3](#step3) der Anleitung fort.
-    
-    <img className="thumbnail" alt="Status Spam im Tab E-Mail-Accounts MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
+    <img className="thumbnail" alt="Spalte Status auf Spam im Tab E-Mail-Accounts für E-Mail Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan - RoundCube">
-    Wenn die Sperrung eine MX Plan E-Mail-Adresse mit dem Webmail **RoundCube** betrifft, gibt es kein Support-Ticket. Bitte lesen Sie [Schritt 1](#step1) dieser Anleitung, bevor Sie den folgenden Anweisungen folgen.
-    
-    Gehen Sie zum Tab <code className="action">E-Mails</code> Ihrer Plattform. Wenn in der Spalte "Blockiert wegen SPAM" der Wert "Ja" angezeigt wird, klicken Sie auf diesen Hinweis und dann auf <code className="action">Passwort ändern</code>. Ihre E-Mail-Adresse ist jetzt entsperrt, Sie müssen [Schritt 3](#step3) nicht ausführen.
-    
-    <img className="thumbnail" alt="Blockiert wegen SPAM im Tab E-Mails MX Plan RoundCube" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-04.png" loading="lazy" />
-    
+  <Tab label="MX Plan - OWA">
+    Wechseln Sie in den Tab <code className="action">E-Mail-Accounts</code> Ihrer Plattform. Zeigt die Spalte "Status" rechts neben der betroffenen E-Mail-Adresse "Spam" an, klicken Sie darauf und anschließend auf <code className="action">Auf das Ticket antworten</code>. Die E-Mail-Adresse wird nicht automatisch entsperrt. Kontaktieren Sie den Support über das Support-Ticket, indem Sie die drei dort gestellten Fragen beantworten.<br/>
+
+    Fahren Sie mit [Schritt 3](#step3) dieser Anleitung fort.
+
+    <img className="thumbnail" alt="Spalte Status auf Spam im Tab E-Mail-Accounts für MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
+  </Tab>
+  <Tab label="Zimbra">
+    Dieser Tab gilt für alle Adressen, die die Technologie **Zimbra** verwenden: **MX Plan - Zimbra**, **Zimbra Starter** und **Zimbra Pro**. Der Entsperrvorgang ist für diese drei Lösungen identisch.
+
+    Wenn die Sperrung greift, wird **kein Support-Ticket automatisch erzeugt**, und die Adresse ist nicht mehr zugänglich (sowohl das Zimbra-Webmail als auch der E-Mail-Versand sind deaktiviert).
+
+    Um die Adresse entsperren zu lassen:
+
+    1. Führen Sie die in [Schritt 1](#step1) beschriebenen Prüfungen anhand der Elemente durch, auf die Sie zugreifen können (Geräte der Nutzer, Drittanbieter-Software, Weiterleitungen, die über einen anderen Zugang sichtbar sind).
+    2. **Erstellen Sie manuell ein Support-Ticket** über Ihr OVHcloud Kundencenter.
+    3. Geben Sie im Ticket Folgendes an:
+        - die von der Sperrung betroffene E-Mail-Adresse;
+        - den zugehörigen Dienst (MX Plan, Zimbra Starter oder Zimbra Pro) sowie dessen Kennung;
+        - die bereits durchgeführten Abhilfemaßnahmen (Virenscans, Entfernung nicht legitimer Absender, Hinzufügen des SPAM/DCE-Filters usw.).
+
+    Sobald das Ticket vom Support bearbeitet wurde, wird die Adresse entsperrt. [Schritt 3](#step3) ist in diesem Fall nicht anwendbar.
+  </Tab>
+  <Tab label="MX Plan - Roundcube">
+    Wenn die Sperrung eine MX Plan E-Mail-Adresse mit dem Webmail **Roundcube** betrifft, wird kein Support-Ticket erzeugt.
+
+    Bevor Sie Maßnahmen ergreifen, ist es **unerlässlich, die Ursache der Sperrung zu identifizieren**, indem Sie die Prüfungen aus [Schritt 1](#step1) durchführen (möglicherweise infizierte Geräte, Drittanbieter-Software, Weiterleitungen, Filter, Abwesenheitsbenachrichtigungen).
+
+    Im Tab <code className="action">E-Mails</code> Ihrer Plattform zeigt die Spalte "Blockiert wegen SPAM" den Wert "Ja" an, wenn die Adresse gesperrt ist.
+
+    <img className="thumbnail" alt="Spalte Blockiert wegen SPAM im Tab E-Mails für MX Plan Roundcube" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-04.png" loading="lazy" />
+
     :::warning
-    In seltenen Fällen kann in der Spalte "Blockiert wegen SPAM" der Wert "Nein" angezeigt werden, obwohl die E-Mail-Adresse gesperrt ist. Wenn Sie die erforderlichen Maßnahmen zur Absicherung der E-Mail-Adresse ergriffen haben, bleibt die Lösung wie oben beschrieben.
+    **Entsperren Sie die Adresse nicht selbst.** Auch wenn die Oberfläche dies zulässt, müssen Sie **den OVHcloud Support kontaktieren**, indem Sie über Ihr Kundencenter ein Support-Ticket erstellen, damit die Ursache der Sperrung vor jeder Entsperrung überprüft werden kann. Eine vorzeitige Entsperrung ohne Behebung der Ursache setzt die Adresse einer sofortigen erneuten Sperrung aus.
 
     :::
+
+    :::warning
+    Das Ändern des Passworts ist **nicht zwingend erforderlich**. Es sollte nur erfolgen, **wenn eine Kompromittierung vermutet wird** (infiziertes Gerät, geleakte oder geteilte Zugangsdaten, unbefugter Zugriff). Ein Passwortwechsel ohne identifizierte Ursache verdeckt das eigentliche Problem und setzt die Adresse einer erneuten Sperrung aus.
+
+    :::
+
+    :::info
+    In seltenen Fällen kann die Spalte "Blockiert wegen SPAM" den Wert "Nein" anzeigen, obwohl die E-Mail-Adresse gesperrt ist. Der Vorgang bleibt derselbe: Kontaktieren Sie den OVHcloud Support.
+
+    :::
+
+    Um die Adresse entsperren zu lassen, **erstellen Sie manuell ein Support-Ticket** über Ihr OVHcloud Kundencenter und geben Sie Folgendes an:
+
+    - die von der Sperrung betroffene E-Mail-Adresse;
+    - den zugehörigen MX Plan Dienst sowie dessen Kennung;
+    - die bereits durchgeführten Abhilfemaßnahmen (Virenscans, Entfernung nicht legitimer Absender, Hinzufügen des SPAM/DCE-Filters usw.).
+
+    Sobald das Ticket vom Support bearbeitet wurde, wird die Adresse entsperrt. [Schritt 3](#step3) ist in diesem Fall nicht anwendbar.
 
   </Tab>
 </Tabs>
@@ -136,50 +200,52 @@ Fahren Sie mit [Schritt 3](#step3) der Anleitung fort.
 
 ### Schritt 3: Auf das Support-Ticket zugreifen <a name="step3"></a>
 
-Nach Schritt 2 werden Sie zum Fenster "Meine Support-Anfragen" weitergeleitet. Klicken Sie auf den Button <code className="action">...</code> rechts neben dem Ticket mit dem Betreff "Account locked for spam." und dann auf <code className="action">Details anzeigen</code>.
+Nach Schritt 2 werden Sie zum Fenster "Meine Support-Anfragen" weitergeleitet. Klicken Sie auf die Schaltfläche <code className="action">...</code> rechts neben dem Ticket mit dem Betreff "Account locked for spam." und anschließend auf <code className="action">Details anzeigen</code>.
 
-<img className="thumbnail" alt="Meine Support-Anfragen mit dem Spam-Sperrungsticket" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-02.png" loading="lazy" />
+<img className="thumbnail" alt="Fenster Meine Support-Anfragen mit dem Ticket zur Sperrung wegen Spam" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-02.png" loading="lazy" />
 
-Sie finden hier die an Sie gesendete E-Mail, die gleichzeitig ein Support-Ticket beim Kundendienst generiert hat.
+Hier finden Sie die E-Mail, die Ihnen zugesendet wurde und ein Support-Ticket erzeugt.
 
-Das Support-Ticket sieht wie folgt aus:
+Das Support-Ticket lautet wie folgt:
 
->
 > Sehr geehrter Kunde,
 >
-> Unser System hat festgestellt, dass die Adresse **Ihre.Adresse@example.com**, die auf unseren Systemen unter **Dienstreferenz** gehostet wird, eine Quelle für den Versand von Spam (Junk-E-Mails) darstellt.
-> Das Senden von E-Mails wurde daher vorübergehend deaktiviert.
+> unser System hat festgestellt, dass die Adresse **ihreadresse@example.com**, die auf unseren Systemen unter dem Dienst **servicename** gehostet wird, eine Spamquelle ist.
+> Der Versand von E-Mails wurde daher vorübergehend deaktiviert.
 >
-> Wir haben derzeit **X** verdächtige Nachrichten erkannt.
+> Wir haben derzeit **X** verdächtige Nachricht(en) festgestellt.
 >
-> Damit wir den Versand von E-Mails für folgende Adresse wieder aktivieren können: **Ihre.Adresse@example.com**,
-> beantworten Sie diese E-Mail mit den folgenden Fragen:
+> Damit wir den Versand für die Adresse: **adresse@example.com** wieder freigeben können,
+> beantworten Sie bitte die folgenden Fragen in Ihrer Antwort auf diese E-Mail:
 >
-> - Sind Sie der Absender der betreffenden E-Mail (siehe nachstehender Header)?
+> - Sind Sie der Absender der betreffenden E-Mail (siehe Header unten)?
 >
-> - Haben Sie eine Weiterleitungsregel zu einer anderen E-Mail-Adresse?
+> - Verfügen Sie über eine Weiterleitungsregel an eine andere E-Mail-Adresse?
 >
 > - Haben Sie auf eine Spam-Nachricht geantwortet?
-> 
-> Diese Antworten helfen uns, Ihr Konto schnell wieder zu aktivieren.
-> <br/>
-> <br/>
-> 
+>
+> Ihre Antworten helfen uns dabei, Ihren Account schnell wieder freizugeben.
 
-Im Anschluss an diese Nachricht wird Ihnen ein Auszug der Header der versendeten E-Mails bereitgestellt.
+Nach dieser Nachricht wird Ihnen ein Auszug aus den Headern der versendeten E-Mails bereitgestellt.
 
-Diese Header ermöglichen es, den Weg und den Ursprung der versendeten E-Mails zu bestimmen.
+Diese Header helfen dabei, den Versandweg und den Ursprung der versendeten E-Mails zu ermitteln.
 
 :::info
-Sobald Ihr Ticket vom Kundendienst bearbeitet und Ihre E-Mail-Adresse entsperrt wurde, ändern Sie das Passwort der E-Mail-Adresse und achten Sie darauf, dass es ausreichend stark ist. Sie können dazu den [Passwort-Generator der CNIL](https://www.cnil.fr/fr/generer-un-mot-de-passe-solide) verwenden. Weitere Informationen finden Sie auch unter [Tipps der CNIL für ein gutes Passwort](https://www.cnil.fr/fr/les-conseils-de-la-cnil-pour-un-bon-mot-de-passe).
+Sobald Ihr Ticket vom Kundensupport bearbeitet und Ihre E-Mail-Adresse entsperrt wurde, ändern Sie das Passwort nur dann, **wenn anhand der in [Schritt 1](#step1) durchgeführten Prüfungen eine Kompromittierung vermutet wird** (infiziertes Gerät, geteilte oder geleakte Zugangsdaten, unbefugter Zugriff). Das Ändern des Passworts ist **nicht zwingend erforderlich**.
+
+Wenn ein neues Passwort erforderlich ist, achten Sie darauf, dass es ausreichend stark ist. Verwenden Sie einen vertrauenswürdigen Passwort-Generator und wählen Sie eine lange, komplexe Passphrase, die für diese Adresse einzigartig ist.
 
 :::
 
 
 ## Weiterführende Informationen
 
-Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](https://partner.ovhcloud.com/de/directory/).
+Informationen zur Verwaltung von Aliassen und Weiterleitungen Ihrer E-Mail-Adresse finden Sie in der Anleitung [E-Mail-Aliasse und Weiterleitungen verwenden](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
-Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
+Informationen dazu, wie Sie Ihre Filter und Abwesenheitsbenachrichtigungen über das Webmail einsehen können, finden Sie in den Anleitungen [E-Mail-Adresse über das Roundcube Webmail nutzen](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) und [Das Zimbra Webmail nutzen](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Für spezialisierte Dienstleistungen (SEO, Entwicklung usw.) wenden Sie sich an die [OVHcloud Partner](https://partner.ovhcloud.com/de/directory/).
+
+Wenn Sie Unterstützung bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen wünschen, lesen Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
+
+Treten Sie unserer [User Community](https://community.ovhcloud.com/community/de) bei.

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Zimbra FAQ
 description: Here you will find the most frequently asked questions about the migration of OVHcloud MX Plan solution to Zimbra
-lastUpdated: 2025-12-05
+lastUpdated: 2026-05-28
 ---
 
 
@@ -43,6 +43,52 @@ There are differences in functionality between the Zimbra solution used in the M
 
 
 A user guide for Zimbra is now available at [this address](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</details>
+
+
+<details>
+
+<summary>I can no longer access my Zimbra email account and I do not understand why: what should I do?</summary>
+
+
+If you notice a complete loss of access to your Zimbra email account (Zimbra webmail login refused, sending and receiving suspended, credentials apparently correct), the most common cause is an **automatic blocking of the address for spam**.
+
+This measure applies to all three Zimbra offers:
+
+- **MX Plan - Zimbra**
+- **Zimbra Starter**
+- **Zimbra Pro**
+
+**How to recognise this case:**
+
+- Access to Zimbra webmail is entirely suspended (and not only sending).
+- No support ticket has been automatically generated in your OVHcloud Control Panel, unlike with other email technologies.
+- Unusual sending activity may have been detected on the account recently (mass sending, suspicious content, potentially infected user workstation, compromised credentials, redirection to a malicious address).
+
+**Why you do not receive a clear notification:**
+
+For Zimbra accounts, the anti-spam blocking suspends the entire account access and does not trigger an automatic support ticket. The customer can therefore notice the loss of access without receiving an immediate explanation.
+
+**What to do?**
+
+1. Refer to the guide ["What to do if your email address is blocked for spam"](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam) and carry out the checks described in step 1 (workstation, third-party software, redirections, filters, automatic replies) based on the elements still accessible.
+2. **Manually create a support ticket** from your OVHcloud Control Panel. In the ticket, indicate:
+    - The email address concerned;
+    - The associated service (MX Plan, Zimbra Starter or Zimbra Pro) and its identifier;
+    - The corrective actions already undertaken.
+3. Once the ticket is processed by support, your address is unblocked and access to Zimbra webmail is restored.
+
+:::info
+**Other possible causes of loss of access** (to rule out before or after contacting support):
+
+- Password recently changed (by yourself or by a platform administrator).
+- Service currently undergoing administrative suspension (unpaid invoice, termination, end of contract).
+- Service migration recently performed (check any notification emails sent 2 weeks then 1 day before migration).
+- One-off infrastructure incident: check the [OVHcloud services status](https://status.ovhcloud.com).
+
+:::
+
 
 </details>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
-title: What to do if your account is blocked for spam
-description: Find out what to do if your email address has been blocked for spam
-lastUpdated: 2026-03-05
+title: What to do if your email address is blocked for spam
+description: "Unblock an email address blocked for spam: identify the cause of the suspicious activity, fix it and contact OVHcloud support."
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -9,71 +9,80 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objective
 
-When your email address is blocked for spam, it means that suspicious activity has been detected when sending emails from this address. In this situation, you can no longer send emails from this email address. You must then understand why suspicious activity was detected and take action to prevent this situation from recurring.
+When your email address is blocked for spam, this means that suspicious activity has been detected when sending emails from that address. In this situation, you can no longer send emails from this email address. You then need to understand why suspicious activity was detected and take action to prevent this situation from recurring.
 
-**Find out what to do when your address is blocked for spam.**
+**Find out how to respond when your address is blocked for spam.**
 
 ## Requirements
 
-- An [OVHcloud email solution](https://www.ovhcloud.com/en-gb/emails/)
+- An [OVHcloud email solution](https://www.ovhcloud.com/en/emails/).
+- You are logged in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
 
 {/* CP-NAV-START:web-mx-plan */}
+{/* CP-NAV-START:web-zimbra */}
 {/* CP-NAV-START:web-email-pro */}
 {/* CP-NAV-START:web-exchange */}
 ---
 
-### OVHcloud Control Panel Access
+### Access to the OVHcloud Control Panel
 
 **MX Plan:**
 
 - **Direct link:** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Select your MX Plan service
+- **To access your services:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Select your MX Plan service
+
+**Zimbra (Starter / Pro):**
+
+- **Direct link:** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
+- **To access your services:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Select your Zimbra service
 
 **Email Pro:**
 
 - **Direct link:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Select your platform
+- **To access your services:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Select your platform
 
 **Exchange:**
 
 - **Direct link:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Select your platform
+- **To access your services:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Select your platform
 
 ---
 {/* CP-NAV-END:web-exchange */}
 {/* CP-NAV-END:web-email-pro */}
+{/* CP-NAV-END:web-zimbra */}
 {/* CP-NAV-END:web-mx-plan */}
 
 ## Instructions <a name="instructions"></a>
 
-Before continuing, if the block concerns an MX Plan email address, identify the email technology used by your solution in order to follow the correct unblocking process.
+Before continuing, if the block concerns an MX Plan email address, identify the email technology used by your solution in order to follow the correct unblocking process. For **Zimbra Starter** and **Zimbra Pro** solutions, go directly to the **Zimbra** tab in step 2, without skipping the checks in step 1.
 
 :::info
 **Identify the email technology of your MX Plan solution.**
 
-Depending on the activation date of your MX Plan solution or if it has been recently migrated, the associated email technology may differ. This version is characterised by its webmail interface. To identify it:
+Depending on the activation date of your MX Plan solution or following a recent migration, the associated email technology may differ. This version is characterised by its webmail interface. To identify it:
 
 - From the <code className="action">General information</code> tab, check the technology used under the **Webmail** label in the <code className="action">Subscription</code> section.
 
-<img className="thumbnail" alt="Identify the email technology in the MX Plan Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
+<img className="thumbnail" alt="Identifying the email technology in the MX Plan Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
 
-- If the technology displayed is **RoundCube**, follow the instructions in the **MX Plan - RoundCube** tab.
-- If the technology displayed is **OWA** or **Zimbra**, follow the instructions in the **MX Plan - OWA / Zimbra** tab.
+- If the technology displayed is **Roundcube**, follow the instructions in the **MX Plan - Roundcube** tab.
+- If the technology displayed is **OWA** (Outlook Web App), follow the instructions in the **MX Plan - OWA** tab.
+- If the technology displayed is **Zimbra**, follow the instructions in the **Zimbra** tab (the procedure is common to MX Plan - Zimbra, Zimbra Starter and Zimbra Pro).
 
 :::
 
 
-### Step 1: Why is your email address blocked for spam? <a name="step1"></a>
+### Step 1: Understand and address the cause of the block <a name="step1"></a>
 
-When suspicious activity is detected at the email sending level, the address concerned is automatically blocked. In this situation, you can no longer send emails from this email address.
+When suspicious activity is detected on outgoing emails, the address concerned is automatically blocked. In this situation, you can no longer send emails from this email address.
 
 :::warning
 "Suspicious activity" means that:
 
-- The anti-spam server, which scans emails when they are sent, has found that one or more elements of the email are considered suspicious and may constitute spam.
-- The sending frequency and the number of recipients are too high and contribute to considering the sending as spamming. Indeed, to carry out mass mailings, you need to use a mailing list service rather than a standard email address.
+- The anti-spam server, which scans emails as they are sent, has found that one or more elements of the email are considered suspicious and may constitute spam.
+- The sending frequency and the number of recipients are too high and contribute to the activity being considered as spamming. To carry out mass mailings, you need to use a mailing list service rather than a standard email address.
 
-The precise reasons for a block cannot be disclosed in order to prevent any attempt to bypass the spam detection system. To test the content of an email, you can use a tool external to OVHcloud such as [Mailtester](https://www.mail-tester.com/).
+The precise reasons for a block cannot be disclosed, in order to prevent any attempt to bypass the spam detection system. To test the content of an email, you can use a tool external to OVHcloud such as [Mailtester](https://www.mail-tester.com/).
 
 :::
 
@@ -82,9 +91,9 @@ First of all, check with the user(s) of the blocked email address that they are 
 
 If the suspicious activity detected by the anti-spam system was not initiated by the legitimate user(s) of the email address, take the following measures:
 
-- Run an antivirus scan on each device that uses the email address blocked for spam, and apply a fix if they are infected.
+- Run an antivirus scan on each device that uses the email address blocked for spam, and apply a fix if any are infected.
 
-- Check all software using the credentials of the email address blocked for spam (e.g. fax machine, business software, email client).
+- Check all software using the credentials of the email address blocked for spam (for example: fax machine, business software, email client).
 
 - Check the redirections applied to the email address blocked for spam.
 
@@ -92,43 +101,98 @@ If the suspicious activity detected by the anti-spam system was not initiated by
 
 - Check the auto-replies configured on the email address blocked for spam, via an email client or webmail.
 
-### Step 2: Check the status of the email address and access the associated support ticket
+:::info
+Filters, redirections and auto-replies configured directly on the webmail (Zimbra, OWA) or in your email client are not accessible to OVHcloud support: support cannot check them on your behalf. These checks must be carried out by you, from the webmail or from a device already configured with the address.
 
-Select the relevant email solution in the following tabs:
+:::
+
+:::warning
+If the block concerns an address using the **Zimbra** technology (MX Plan - Zimbra, Zimbra Starter or Zimbra Pro), the address is **no longer accessible**: the Zimbra webmail login is suspended in addition to email sending. Filters, redirections and auto-replies can therefore no longer be consulted from the webmail.
+
+:::
+
+#### Set up a filter to isolate SPAM / DCE messages
+
+To reduce the risk of recurrence after unblocking, we recommend adding a filter on the email address:
+
+- The filter must **isolate** emails whose subject contains the labels **"SPAM"** or **"DCE"** (*Dirty Commercial Email*), for example by moving them to a dedicated folder. **Do not delete them automatically**: deletion would cause any false positives (legitimate messages wrongly flagged) to be lost.
+- **Keep** any existing **redirection rules** in place: do not delete them when adding the filter.
+
+This filter is configured from the webmail or an email client.
+
+### Step 2: Check the status and access the support ticket
+
+Select the email solution concerned in the following tabs:
 
 <Tabs>
   <Tab label="Exchange">
     Go to the <code className="action">Email accounts</code> tab of your platform. If the "Status" column for the email address concerned shows "Blocked", click <code className="action">...</code> to the right of the account, then <code className="action">Unblock</code>. The email address is not unblocked automatically. Contact the support team via the support ticket by answering the 3 questions asked.<br/>
 
-Proceed to [step 3](#step3) of the guide.
+    Proceed to [step 3](#step3) of the guide.
     
-    <img className="thumbnail" alt="Status column Blocked in the Email accounts tab Exchange" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Status column Blocked in the Email accounts tab for Exchange" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-01.png" loading="lazy" />
   </Tab>
   <Tab label="Email Pro">
-    Go to the <code className="action">Email accounts</code> tab of your platform. If the "Status" column to the right of the email address concerned shows "Spam", click on it, then <code className="action">Reply to the ticket</code>. The email address is not unblocked automatically. Contact the support team via the support ticket by answering the 3 questions asked.<br/>
+    Go to the <code className="action">Email accounts</code> tab of your platform. If the "Status" column to the right of the email address concerned shows "Spam", click on it, then on <code className="action">Reply to the ticket</code>. The email address is not unblocked automatically. Contact the support team via the support ticket by answering the 3 questions asked. <br/>
 
-Proceed to [step 3](#step3) of the guide.
+    Proceed to [step 3](#step3) of the guide.
     
-    <img className="thumbnail" alt="Status column Spam in the Email accounts tab Email Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
+    <img className="thumbnail" alt="Status column Spam in the Email accounts tab for Email Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan - OWA / Zimbra">
-    Go to the <code className="action">Email accounts</code> tab of your platform. If the "Status" column to the right of the email address concerned shows "Spam", click on it, then <code className="action">Reply to the ticket</code>. The email address is not unblocked automatically. Contact the support team via the support ticket by answering the 3 questions asked.<br/>
+  <Tab label="MX Plan - OWA">
+    Go to the <code className="action">Email accounts</code> tab of your platform. If the "Status" column to the right of the email address concerned shows "Spam", click on it, then on <code className="action">Reply to the ticket</code>. The email address is not unblocked automatically. Contact the support team via the support ticket by answering the 3 questions asked.<br/>
 
-Proceed to [step 3](#step3) of the guide.
+    Proceed to [step 3](#step3) of the guide.
     
-    <img className="thumbnail" alt="Status column Spam in the Email accounts tab MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
+    <img className="thumbnail" alt="Status column Spam in the Email accounts tab for MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan - RoundCube">
-    If the block concerns an MX Plan email address with **RoundCube** webmail, there is no support ticket. Please ensure you read [step 1](#step1) of this guide before following the instructions below.
+  <Tab label="Zimbra">
+    This tab applies to all addresses using the **Zimbra** technology: **MX Plan - Zimbra**, **Zimbra Starter** and **Zimbra Pro**. The unblocking process is identical for these three solutions.
+
+    When the block is applied, **no support ticket is generated automatically** and the address is no longer accessible (Zimbra webmail and email sending are both disabled).
+
+    To get the address unblocked:
+
+    1. Carry out the checks described in [step 1](#step1), based on the elements you can access (user devices, third-party software, redirections visible from another access).
+    2. **Manually create a support ticket** from your OVHcloud Control Panel.
+    3. In the ticket, specify:
+        - The email address affected by the block;
+        - The associated service (MX Plan, Zimbra Starter or Zimbra Pro) and its identifier;
+        - The corrective actions already taken (antivirus scans, removal of non-legitimate senders, addition of the SPAM/DCE filter, etc.).
+
+    Once the ticket has been processed by support, the address is unblocked. [Step 3](#step3) does not apply in this case.
+  </Tab>
+  <Tab label="MX Plan - Roundcube">
+    If the block concerns an MX Plan email address with **Roundcube** webmail, no support ticket is generated.
+
+    Before taking any action, it is **essential to identify the cause of the block** by carrying out the checks in [step 1](#step1) (potentially infected devices, third-party software, redirections, filters, auto-replies).
+
+    In the <code className="action">Emails</code> tab of your platform, the "Blocked for SPAM" column shows "Yes" when the address is blocked.
     
-    Go to the <code className="action">Emails</code> tab of your platform. If the "Blocked for SPAM" column shows "Yes", click on it, then <code className="action">Change password</code>. Your email address is now unblocked, you do not need to follow [step 3](#step3).
-    
-    <img className="thumbnail" alt="Blocked for SPAM column in the Emails tab MX Plan Roundcube" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-04.png" loading="lazy" />
+    <img className="thumbnail" alt="Blocked for SPAM column in the Emails tab for MX Plan Roundcube" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-04.png" loading="lazy" />
     
     :::warning
-    In rare cases, the "Blocked for SPAM" column may show "No" despite the fact that the email address is blocked. If you have taken the necessary measures to secure the email address, the solution remains the same as above.
+    **Do not unblock the address yourself.** Even if the interface allows it, you must **contact OVHcloud support** by creating a support ticket from your Control Panel, so that the origin of the block can be verified before any unblocking. Premature unblocking, without addressing the cause, exposes the address to immediate recurrence.
 
     :::
+
+    :::warning
+    Changing the password is **not systematic**. It should only be done **if a compromise is suspected** (infected device, leaked or shared credentials, unauthorised access). Changing the password without an identified cause masks the real problem and exposes the address to recurrence.
+
+    :::
+
+    :::info
+    In rare cases, the "Blocked for SPAM" column may show "No" even though the email address is blocked. The procedure remains the same: contact OVHcloud support.
+
+    :::
+
+    To get the address unblocked, **manually create a support ticket** from your OVHcloud Control Panel, specifying:
+
+    - The email address affected by the block;
+    - The associated MX Plan service and its identifier;
+    - The corrective actions already taken (antivirus scans, removal of non-legitimate senders, addition of the SPAM/DCE filter, etc.).
+
+    Once the ticket has been processed by support, the address is unblocked. [Step 3](#step3) does not apply in this case.
 
   </Tab>
 </Tabs>
@@ -140,15 +204,14 @@ Following step 2, you will be redirected to the "My support requests" window. Cl
 
 <img className="thumbnail" alt="My support requests window with the spam block ticket" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-02.png" loading="lazy" />
 
-Here you will find the email that was sent to you, which generated a support ticket.
+Here you will find the email that was sent to you, which generates a support ticket.
 
 The support ticket reads as follows:
 
->
 > Dear Customer,
 >
-> Our system has detected that the address **address@example.com** hosted on our systems under the **service name** service is a source of spam.
-> The sending of emails has been temporarily disabled.
+> Our system has detected that the address **youraddress@example.com**, hosted on our systems under the **servicename** service, is a source of spam.
+> The sending of emails has therefore been temporarily disabled.
 >
 > We have currently detected **X** suspicious message(s).
 >
@@ -159,27 +222,30 @@ The support ticket reads as follows:
 >
 > - Do you have a redirection rule to another email address?
 >
-> - Have you responded to spam?
-> 
+> - Have you responded to a Spam?
+>
 > These answers will help us re-enable your account quickly.
-> <br/>
-> <br/>
-> 
 
 Following this message, a sample of headers from the sent emails has been provided to you.
 
 These headers help determine the routing and origin of the sent emails.
 
 :::info
-Once your ticket has been processed by customer support and your email address has been unblocked, change the password of the email address, ensuring that it is sufficiently strong. You can use [CNIL's strong password generator](https://www.cnil.fr/fr/generer-un-mot-de-passe-solide). You can also refer to [CNIL's tips for a good password](https://www.cnil.fr/fr/les-conseils-de-la-cnil-pour-un-bon-mot-de-passe).
+Once your ticket has been processed by customer support and your email address has been unblocked, only change the password **if a compromise is suspected** based on the checks carried out in [step 1](#step1) (infected device, shared or leaked credentials, unauthorised access). Changing the password is **not systematic**.
+
+If a new password is needed, make sure it is sufficiently strong. Use a reputable password generator and choose a long, complex passphrase that is unique to this address.
 
 :::
 
 
 ## Go further
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
+To manage the aliases and redirections of your email address, see the guide [Using email aliases and redirections](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-gb/support-levels/).
+To view your filters and auto-replies from the webmail, see the guides [Using your email address from the Roundcube webmail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) and [Using the Zimbra webmail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en/directory/).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en/support-levels/).
 
 Join our [community of users](https://community.ovhcloud.com/community/en).

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ sobre la solución Zimbra OVHcloud
 description: Encuentre las preguntas sobre la migración a Zimbra para la solución MX Plan de OVHcloud
-lastUpdated: 2025-12-05
+lastUpdated: 2026-05-28
 ---
 
 
@@ -43,6 +43,52 @@ Existen diferencias de funcionalidad entre la solución Zimbra utilizada en la s
 
 
 Ya está disponible una guía del usuario de Zimbra en [esta dirección](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</details>
+
+
+<details>
+
+<summary>Ya no tengo acceso a mi cuenta de correo Zimbra y no entiendo por qué: ¿qué puedo hacer?</summary>
+
+
+Si constata una pérdida total de acceso a su cuenta de correo Zimbra (conexión al webmail Zimbra rechazada, envío y recepción suspendidos, identificadores aparentemente correctos), la causa más frecuente es un **bloqueo automático de la dirección por spam**.
+
+Esta medida se aplica a las tres ofertas Zimbra:
+
+- **MX Plan - Zimbra**
+- **Zimbra Starter**
+- **Zimbra Pro**
+
+**Cómo reconocer este caso:**
+
+- El acceso al webmail Zimbra está totalmente suspendido (y no solo el envío).
+- No se ha generado automáticamente ningún ticket de asistencia en su área de cliente de OVHcloud, a diferencia de otras tecnologías de correo electrónico.
+- Es posible que se haya detectado una actividad de envío inusual en la cuenta recientemente (envíos masivos, contenido sospechoso, puesto de usuario potencialmente infectado, identificadores comprometidos, redirección hacia una dirección malintencionada).
+
+**Por qué no recibo una notificación clara:**
+
+Para las cuentas Zimbra, el bloqueo antispam suspende la totalidad del acceso a la cuenta y no activa ningún ticket de asistencia automático. Por lo tanto, el cliente puede constatar la pérdida de acceso sin recibir una explicación inmediata.
+
+**¿Qué hacer?**
+
+1. Consulte la guía ["¿Qué hacer si una dirección de correo electrónico está bloqueada por spam?"](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam) y realice las verificaciones descritas en el paso 1 (puesto, programas de terceros, redirecciones, filtros, respuestas automáticas) a partir de los elementos aún accesibles.
+2. **Cree manualmente un ticket de asistencia** desde su área de cliente de OVHcloud. En el ticket, indique:
+    - La dirección de correo electrónico afectada;
+    - El servicio asociado (MX Plan, Zimbra Starter o Zimbra Pro) y su identificador;
+    - Las acciones correctivas ya emprendidas.
+3. Una vez que el soporte haya tratado el ticket, su dirección se desbloqueará y se restablecerá el acceso al webmail Zimbra.
+
+:::info
+**Otras causas posibles de pérdida de acceso** (a descartar antes o después de contactar con el soporte):
+
+- Contraseña modificada recientemente (por usted mismo o por un administrador de la plataforma).
+- Servicio en proceso de suspensión administrativa (impago, rescisión, fin de contrato).
+- Migración de servicio realizada recientemente (compruebe los posibles correos de notificación enviados 2 semanas y 1 día antes de la migración).
+- Incidencia puntual de infraestructura: consulte el [estado de los servicios de OVHcloud](https://status.ovhcloud.com).
+
+:::
+
 
 </details>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
-title: ¿Qué hacer en caso de cuenta bloqueada por spam?
-description: Cómo actuar cuando su dirección ha sido bloqueada por spam
-lastUpdated: 2026-03-05
+title: ¿Qué hacer si una dirección de correo electrónico está bloqueada por spam?
+description: "Desbloquee una dirección de correo electrónico bloqueada por spam: identifique la causa de la actividad sospechosa, corríjala y contacte con el soporte de OVHcloud."
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -9,15 +9,17 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objetivo
 
-Cuando su dirección de correo electrónico está bloqueada por spam, significa que se ha detectado una actividad sospechosa en el envío de mensajes de correo electrónico desde esta dirección. En este caso, ya no podrá enviar mensajes de correo electrónico desde esta dirección. A continuación, debe comprender por qué se ha detectado una actividad sospechosa y tomar medidas para evitar que esta situación vuelva a producirse.
+Cuando su dirección de correo electrónico está bloqueada por spam, significa que se ha detectado una actividad sospechosa durante el envío de mensajes desde dicha dirección. En esta situación, ya no podrá enviar correos electrónicos desde esa dirección. Debe entonces comprender por qué se ha detectado una actividad sospechosa y actuar para evitar que esta situación se repita.
 
-**Cómo actuar cuando su dirección está bloqueada por spam.**
+**Descubra cómo reaccionar cuando su dirección está bloqueada por spam.**
 
 ## Requisitos
 
-- Disponer de un [plan de correo en OVHcloud](https://www.ovhcloud.com/es-es/emails/).
+- Disponer de un [plan de correo electrónico de OVHcloud](https://www.ovhcloud.com/es-es/emails/).
+- Haber iniciado sesión en su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>.
 
 {/* CP-NAV-START:web-mx-plan */}
+{/* CP-NAV-START:web-zimbra */}
 {/* CP-NAV-START:web-email-pro */}
 {/* CP-NAV-START:web-exchange */}
 ---
@@ -27,64 +29,71 @@ Cuando su dirección de correo electrónico está bloqueada por spam, significa 
 **MX Plan:**
 
 - **Enlace directo:** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Seleccione su servicio MX Plan
+- **Para acceder a sus servicios:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Seleccione su servicio MX Plan
+
+**Zimbra (Starter / Pro):**
+
+- **Enlace directo:** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
+- **Para acceder a sus servicios:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Seleccione su servicio Zimbra
 
 **Email Pro:**
 
 - **Enlace directo:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Seleccione su plataforma
+- **Para acceder a sus servicios:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Seleccione su plataforma
 
 **Exchange:**
 
 - **Enlace directo:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Seleccione su plataforma
+- **Para acceder a sus servicios:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Seleccione su plataforma
 
 ---
 {/* CP-NAV-END:web-exchange */}
 {/* CP-NAV-END:web-email-pro */}
+{/* CP-NAV-END:web-zimbra */}
 {/* CP-NAV-END:web-mx-plan */}
 
 ## Procedimiento <a name="instructions"></a>
 
-Antes de continuar, y si el bloqueo afecta a una dirección de correo electrónico de tipo MX Plan, identifique la tecnología de correo electrónico utilizada por su plan para seguir el proceso de desbloqueo adecuado.
+Antes de continuar, y si el bloqueo afecta a una dirección de correo electrónico de tipo MX Plan, identifique la tecnología de correo electrónico utilizada por su plan para seguir el proceso de desbloqueo adecuado. Para los planes **Zimbra Starter** y **Zimbra Pro**, vaya directamente a la pestaña **Zimbra** de la etapa 2, sin omitir las comprobaciones de la etapa 1.
 
 :::info
 **Identificar la tecnología de correo electrónico de su plan MX Plan.**
 
 En función de la fecha de activación de su plan MX Plan o de una migración reciente, la tecnología de correo electrónico asociada puede variar. Esta versión se caracteriza por la interfaz de su webmail. Para identificarla:
 
-- Desde la pestaña <code className="action">Información general</code>, compruebe la tecnología utilizada bajo la mención **Webmail** en el recuadro <code className="action">Suscripción</code>.
+- Desde la pestaña <code className="action">Información general</code>, consulte la tecnología utilizada bajo la mención **Webmail** presente en el recuadro <code className="action">Suscripción</code>.
 
 <img className="thumbnail" alt="Identificar la tecnología de correo electrónico en el área de cliente MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
 
-- Si la tecnología que se muestra es **RoundCube**, siga las instrucciones de la pestaña **MX Plan - RoundCube**.
-- Si la tecnología que se muestra es **OWA** o **Zimbra**, siga las instrucciones de la pestaña **MX Plan - OWA / Zimbra**.
+- Si la tecnología que se muestra es **Roundcube**, siga las instrucciones de la pestaña **MX Plan - Roundcube**.
+- Si la tecnología que se muestra es **OWA** (Outlook Web App), siga las instrucciones de la pestaña **MX Plan - OWA**.
+- Si la tecnología que se muestra es **Zimbra**, siga las instrucciones de la pestaña **Zimbra** (procedimiento común a MX Plan - Zimbra, Zimbra Starter y Zimbra Pro).
 
 :::
 
 
-### Etapa 1: ¿por qué su dirección de correo electrónico está bloqueada por spam? <a name="step1"></a>
+### Etapa 1: comprender y tratar la causa del bloqueo <a name="step1"></a>
 
-Cuando se detecta una actividad sospechosa en el envío de mensajes de correo electrónico, la dirección en cuestión se bloquea automáticamente. En ese caso, no podrá enviar mensajes de correo electrónico desde esta dirección.
+Cuando se detecta una actividad sospechosa en el envío de correos electrónicos, la dirección afectada se bloquea automáticamente. En esta situación, ya no podrá enviar mensajes desde dicha dirección.
 
 :::warning
 Una "actividad sospechosa" significa que:
 
-- El servidor antispam, que analiza los mensajes de correo electrónico durante el envío, ha detectado que uno o varios elementos del mensaje se consideran sospechosos y pueden constituir un correo spam.
-- La frecuencia de envío y el número de destinatarios son demasiado elevados y contribuyen a que el envío se considere spam. Para realizar envíos masivos, es necesario utilizar un servicio de listas de correo y no una dirección de correo electrónico estándar.
+- El servidor antispam, que analiza los mensajes durante el envío, ha detectado que uno o varios elementos del mensaje se consideran sospechosos y pueden constituir un correo spam.
+- La frecuencia de envío y el número de destinatarios son demasiado elevados y contribuyen a que el envío se considere spam. Para realizar envíos masivos es necesario utilizar un servicio de listas de correo y no una dirección de correo electrónico estándar.
 
-Las razones concretas de un bloqueo no pueden ser divulgadas para evitar cualquier intento de eludir el sistema de detección de spam. Para probar el contenido de un mensaje de correo electrónico, puede utilizar una herramienta externa a OVHcloud como [Mailtester](https://www.mail-tester.com/).
+Las razones concretas de un bloqueo no pueden ser divulgadas para evitar cualquier intento de eludir el sistema de detección de spam. Para probar el contenido de un mensaje, puede utilizar una herramienta externa a OVHcloud como [Mailtester](https://www.mail-tester.com/).
 
 :::
 
 
-En primer lugar, asegúrese, con los usuarios de la dirección de correo electrónico bloqueada, de que no son los causantes directos del bloqueo, debido a un uso inusual de la dirección de correo electrónico (por ejemplo, tras el envío masivo de mensajes de correo electrónico). Si es así, debe corregir la situación antes de desbloquear la dirección.
+En primer lugar, asegúrese, con el o los usuarios de la dirección de correo electrónico bloqueada, de que no son los causantes directos del bloqueo debido a un uso inusual de la dirección (por ejemplo, tras envíos masivos de correos electrónicos). Si es así, debe corregir la situación antes de desbloquear la dirección.
 
 Si la actividad sospechosa detectada por el antispam no ha sido iniciada por los usuarios legítimos de la dirección de correo electrónico, tome las siguientes medidas:
 
-- Realice un análisis antivirus de cada uno de los equipos que utilicen la dirección de correo electrónico bloqueada por spam y aplique un correctivo si estos están infectados.
+- Realice un análisis antivirus de cada uno de los equipos que utilicen la dirección de correo electrónico bloqueada por spam y aplique un correctivo si están infectados.
 
-- Compruebe todos los programas que utilicen las credenciales de la dirección de correo electrónico bloqueada por spam (por ejemplo: fax, software de gestión empresarial, software de mensajería).
+- Compruebe todos los programas que utilicen las credenciales de la dirección bloqueada por spam (por ejemplo: fax, software de gestión empresarial, software de mensajería).
 
 - Compruebe las redirecciones aplicadas a la dirección de correo electrónico bloqueada por spam.
 
@@ -92,94 +101,151 @@ Si la actividad sospechosa detectada por el antispam no ha sido iniciada por los
 
 - Compruebe las respuestas automáticas configuradas en la dirección de correo electrónico bloqueada por spam, mediante un software de mensajería o el webmail.
 
-### Etapa 2: comprobar el estado de la dirección de correo electrónico y acceder al tíquet de asistencia asociado
+:::info
+Los filtros, redirecciones y respuestas automáticas configurados directamente en el webmail (Zimbra, OWA) o en su software de mensajería no son accesibles para el soporte de OVHcloud: no puede verificarlos en su lugar. Estas comprobaciones deben realizarse por su cuenta, desde el webmail o un equipo ya configurado con la dirección.
 
-Seleccione el plan de correo electrónico en las siguientes pestañas:
+:::
+
+:::warning
+Si el bloqueo afecta a una dirección que utiliza la tecnología **Zimbra** (MX Plan - Zimbra, Zimbra Starter o Zimbra Pro), la dirección **deja de ser accesible**: además del envío, se suspende la conexión al webmail Zimbra. Los filtros, redirecciones y respuestas automáticas dejan de ser consultables desde el webmail.
+
+:::
+
+#### Configurar un filtro para aislar los mensajes SPAM / DCE
+
+Para reducir el riesgo de reincidencia tras el desbloqueo, recomendamos añadir un filtro en la dirección de correo electrónico:
+
+- El filtro debe **aislar** los correos cuyo asunto contenga las menciones **"SPAM"** o **"DCE"** (*Dirty Commercial Email*), por ejemplo, moviéndolos a una carpeta dedicada. **No los elimine automáticamente**: una eliminación haría perder posibles falsos positivos (mensajes legítimos marcados por error).
+- **Conserve**, en cambio, las posibles **reglas de redirección** ya existentes: no las elimine al añadir el filtro.
+
+Este filtro se configura desde el webmail o un software de mensajería.
+
+### Etapa 2: comprobar el estado y acceder al tique de asistencia
+
+Seleccione el plan de correo electrónico correspondiente en las siguientes pestañas:
 
 <Tabs>
   <Tab label="Exchange">
-    Acceda a la pestaña <code className="action">Cuentas de correo</code> de su plataforma. Si la columna "estado" de la dirección de correo electrónico correspondiente indica "bloqueado", haga clic en <code className="action">...</code> a la derecha de la cuenta y, seguidamente, en <code className="action">Desbloquear</code>. El desbloqueo de la dirección de correo electrónico no se realiza automáticamente. Contacte con el soporte a través del tíquet de asistencia respondiendo a las 3 preguntas formuladas.<br/>
+    Acceda a la pestaña <code className="action">Cuentas de correo</code> de su plataforma. Si la columna "estado" de la dirección de correo electrónico correspondiente indica "bloqueado", haga clic en <code className="action">...</code> a la derecha de la cuenta y, seguidamente, en <code className="action">Desbloquear</code>. La dirección de correo electrónico no se desbloquea automáticamente. Contacte con el soporte a través del tique de asistencia respondiendo a las 3 preguntas formuladas.<br/>
 
-Continúe con la [etapa 3](#step3) de la guía.
+    Pase a la [etapa 3](#step3) de la guía.
     
     <img className="thumbnail" alt="Columna estado bloqueado en la pestaña Cuentas de correo Exchange" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-01.png" loading="lazy" />
   </Tab>
   <Tab label="Email Pro">
-    Acceda a la pestaña <code className="action">Cuentas de correo</code> de su plataforma. Si la columna "estado" a la derecha de la dirección de correo electrónico correspondiente indica "Spam", haga clic en esta mención y, seguidamente, en <code className="action">Responder al tíquet</code>. El desbloqueo de la dirección de correo electrónico no se realiza automáticamente. Contacte con el soporte a través del tíquet de asistencia respondiendo a las 3 preguntas formuladas. <br/>
+    Acceda a la pestaña <code className="action">Cuentas de correo</code> de su plataforma. Si la columna "estado" a la derecha de la dirección de correo electrónico correspondiente indica "Spam", haga clic en esta mención y, seguidamente, en <code className="action">Responder al tique</code>. La dirección de correo electrónico no se desbloquea automáticamente. Contacte con el soporte a través del tique de asistencia respondiendo a las 3 preguntas formuladas. <br/>
 
-Continúe con la [etapa 3](#step3) de la guía.
+    Pase a la [etapa 3](#step3) de la guía.
     
     <img className="thumbnail" alt="Columna estado Spam en la pestaña Cuentas de correo Email Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan - OWA / Zimbra">
-    Acceda a la pestaña <code className="action">Cuentas de correo</code> de su plataforma. Si la columna "estado" a la derecha de la dirección de correo electrónico correspondiente indica "Spam", haga clic en esta mención y, seguidamente, en <code className="action">Responder al tíquet</code>. El desbloqueo de la dirección de correo electrónico no se realiza automáticamente. Contacte con el soporte a través del tíquet de asistencia respondiendo a las 3 preguntas formuladas.<br/>
+  <Tab label="MX Plan - OWA">
+    Acceda a la pestaña <code className="action">Cuentas de correo</code> de su plataforma. Si la columna "estado" a la derecha de la dirección de correo electrónico correspondiente indica "Spam", haga clic en esta mención y, seguidamente, en <code className="action">Responder al tique</code>. La dirección de correo electrónico no se desbloquea automáticamente. Contacte con el soporte a través del tique de asistencia respondiendo a las 3 preguntas formuladas.<br/>
 
-Continúe con la [etapa 3](#step3) de la guía.
+    Pase a la [etapa 3](#step3) de la guía.
     
     <img className="thumbnail" alt="Columna estado Spam en la pestaña Cuentas de correo MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan - RoundCube">
-    Si el bloqueo afecta a una dirección de correo electrónico MX Plan con el webmail **RoundCube**, no hay tíquet de asistencia. Asegúrese de consultar la [etapa 1](#step1) de esta guía antes de seguir las instrucciones a continuación.
-    
-    Acceda a la pestaña <code className="action">Emails</code> de su plataforma. Si la columna "Bloqueado por SPAM" indica "Sí", haga clic en esta mención y, seguidamente, en <code className="action">Cambiar la contraseña</code>. Su dirección de correo electrónico se ha desbloqueado. No necesita seguir la [etapa 3](#step3).
+  <Tab label="Zimbra">
+    Esta pestaña se aplica a todas las direcciones que utilizan la tecnología **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** y **Zimbra Pro**. El proceso de desbloqueo es idéntico para estos tres planes.
+
+    En el momento del bloqueo, **no se genera ningún tique de asistencia automáticamente** y la dirección deja de ser accesible (webmail Zimbra y envío desactivados).
+
+    Para desbloquear la dirección:
+
+    1. Realice las comprobaciones descritas en la [etapa 1](#step1), a partir de los elementos accesibles (equipos de usuario, programas de terceros, redirecciones visibles desde otro acceso).
+    2. **Cree manualmente un tique de asistencia** desde su área de cliente de OVHcloud.
+    3. En el tique, indique:
+        - La dirección de correo electrónico afectada por el bloqueo.
+        - El servicio asociado (MX Plan, Zimbra Starter o Zimbra Pro) y su identificador.
+        - Las acciones correctivas ya emprendidas (análisis antivirus, eliminación de remitentes no legítimos, adición del filtro SPAM/DCE, etc.).
+
+    Una vez que el soporte tramite el tique, la dirección se desbloqueará. La [etapa 3](#step3) no se aplica en este caso.
+  </Tab>
+  <Tab label="MX Plan - Roundcube">
+    Si el bloqueo afecta a una dirección de correo electrónico MX Plan con el webmail **Roundcube**, no se genera ningún tique de asistencia.
+
+    Antes de cualquier acción, es **imprescindible identificar la causa del bloqueo** realizando las comprobaciones de la [etapa 1](#step1) (equipos potencialmente infectados, programas de terceros, redirecciones, filtros, respuestas automáticas).
+
+    En la pestaña <code className="action">Emails</code> de su plataforma, la columna "Bloqueado por SPAM" indica "Sí" cuando la dirección está bloqueada.
     
     <img className="thumbnail" alt="Columna Bloqueado por SPAM en la pestaña Emails MX Plan Roundcube" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-04.png" loading="lazy" />
     
     :::warning
-    En algunos casos, la columna "Bloqueado por SPAM" puede indicar "No", a pesar de que la dirección de correo electrónico esté bloqueada. Si ha tomado las medidas necesarias para proteger la dirección de correo electrónico, la solución es la misma que la anterior.
+    **No desbloquee la dirección usted mismo.** Aunque la interfaz lo permita, debe **contactar con el soporte de OVHcloud** creando un tique de asistencia desde su área de cliente, para que el origen del bloqueo sea verificado antes de cualquier desbloqueo. Un desbloqueo prematuro, sin tratar la causa, expone a una reincidencia inmediata.
 
     :::
+
+    :::warning
+    El **cambio de contraseña no es sistemático**. Solo debe realizarse **si se sospecha que ha habido un compromiso** (equipo infectado, credenciales divulgadas o compartidas, acceso no autorizado). Cambiar la contraseña sin una causa identificada oculta el verdadero problema y expone a una reincidencia.
+
+    :::
+
+    :::info
+    En casos excepcionales, la columna "Bloqueado por SPAM" puede indicar "No" aunque la dirección de correo electrónico esté bloqueada. El procedimiento es el mismo: contacte con el soporte de OVHcloud.
+
+    :::
+
+    Para desbloquear la dirección, **cree manualmente un tique de asistencia** desde su área de cliente de OVHcloud indicando:
+
+    - La dirección de correo electrónico afectada por el bloqueo.
+    - El servicio MX Plan asociado y su identificador.
+    - Las acciones correctivas ya emprendidas (análisis antivirus, eliminación de remitentes no legítimos, adición del filtro SPAM/DCE, etc.).
+
+    Una vez que el soporte tramite el tique, la dirección se desbloqueará. La [etapa 3](#step3) no se aplica en este caso.
 
   </Tab>
 </Tabs>
 
 
-### Etapa 3: acceder al tíquet de asistencia <a name="step3"></a>
+### Etapa 3: acceder al tique de asistencia <a name="step3"></a>
 
-Tras la etapa 2, será redirigido a la ventana "Mis solicitudes de asistencia". Haga clic en el botón <code className="action">...</code> a la derecha del tíquet con el asunto "Account locked for spam." y, seguidamente, en <code className="action">Ver toda la información</code>.
+Tras la etapa 2, será redirigido a la ventana "Mis solicitudes de asistencia". Haga clic en el botón <code className="action">...</code> a la derecha del tique con el asunto "Account locked for spam." y, seguidamente, en <code className="action">Ver el detalle</code>.
 
-<img className="thumbnail" alt="Ventana Mis solicitudes de asistencia con el tíquet de bloqueo por spam" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-02.png" loading="lazy" />
+<img className="thumbnail" alt="Ventana Mis solicitudes de asistencia con el tique de bloqueo por spam" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-02.png" loading="lazy" />
 
-Encontrará el mensaje de correo electrónico que se le ha enviado, el cual genera un tíquet de asistencia ante el soporte.
+Encontrará así el mensaje de correo electrónico que se le ha enviado, el cual genera un tique de asistencia ante el soporte.
 
-El tíquet de asistencia se presenta de la siguiente manera:
+El tique de asistencia se presenta de la siguiente manera:
 
->
 > Estimado/a cliente:
 >
-> Nuestro sistema ha hallado que la dirección **sudirección@dominio.com** alojada en nuestros sistemas en el servicio **servicename** origina el envío de correos no deseados (spam).
-> Por consiguiente, se ha desactivado el envío de mensajes de correo electrónico temporalmente.
+> Nuestro sistema ha detectado que la dirección **sudirección@dominio.com** alojada en nuestros sistemas en el servicio **servicename** es origen del envío de correos no deseados (spam).
+> Por consiguiente, se ha desactivado temporalmente el envío de mensajes de correo electrónico.
 >
-> Actualmente, hemos encontrado **X** mensaje/s sospecho/s.
+> Hemos detectado actualmente **X** mensaje(s) sospechoso(s).
 >
-> Con el fin de ayudarnos a reactivar el envío de mensajes de correo electrónico de la dirección: **dirección@dominio.com**,
-> responda este mensaje de correo electrónico contestando las siguientes preguntas:
+> Para ayudarnos a reactivar el envío de mensajes de la dirección: **dirección@dominio.com**,
+> responda a este mensaje completando las siguientes preguntas:
 >
-> - ¿Es usted el remitente del mensaje de correo electrónico en cuestión (véase el encabezado a continuación)?
+> - ¿Es usted el remitente del mensaje en cuestión (consulte el encabezado a continuación)?
 >
-> - ¿Dispone de una regla de redirección a otra dirección de correo electrónico?
+> - ¿Dispone de una regla de redirección hacia otra dirección de correo electrónico?
 >
-> - ¿Ha respondido a algún correo no deseado?
-> 
+> - ¿Ha respondido a un Spam?
+>
 > Estas respuestas nos ayudarán a reactivar su cuenta rápidamente.
-> <br/>
-> <br/>
-> 
 
-A continuación de este mensaje, se le ha enviado una muestra de los encabezados de los mensajes de correo electrónico transmitidos.
+A continuación de este mensaje, se le ha enviado una muestra de los encabezados de los correos electrónicos enviados.
 
-Estos encabezados permiten determinar el recorrido y el origen de los mensajes de correo electrónico enviados.
+Estos encabezados permiten determinar el recorrido y el origen de los mensajes enviados.
 
 :::info
-Una vez que el soporte haya tratado su tíquet y se haya desbloqueado su dirección de correo electrónico, cambie la contraseña de la dirección de correo electrónico, asegurándose de que sea lo suficientemente segura. Puede utilizar la [herramienta de generación de contraseñas seguras](https://www.cnil.fr/fr/generer-un-mot-de-passe-solide) de la CNIL. También puede consultar los [consejos de la CNIL para una buena contraseña](https://www.cnil.fr/fr/les-conseils-de-la-cnil-pour-un-bon-mot-de-passe).
+Una vez que el soporte haya tramitado su tique y su dirección de correo electrónico esté desbloqueada, realice un **cambio de contraseña únicamente si se sospecha que ha habido un compromiso** a la vista de las comprobaciones realizadas en la [etapa 1](#step1) (equipo infectado, credenciales compartidas o divulgadas, acceso no autorizado). El cambio de contraseña **no es sistemático**.
+
+Si es necesario establecer una nueva contraseña, asegúrese de que sea lo suficientemente robusta. Puede consultar las recomendaciones de la [Agencia Española de Protección de Datos (AEPD)](https://www.aepd.es/) sobre buenas prácticas de seguridad y contraseñas.
 
 :::
 
 
 ## Más información
 
-Para servicios especializados (posicionamiento web, desarrollo, etc.), contacte con los [partners de OVHcloud](https://partner.ovhcloud.com/es-es/directory/).
+Para gestionar los alias y las redirecciones de su dirección de correo electrónico, consulte la guía [Utilizar alias y redirecciones de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
-Si desea disfrutar de ayuda para el uso y la configuración de sus soluciones de OVHcloud, consulte nuestras distintas [ofertas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
+Para consultar sus filtros y respuestas automáticas desde el webmail, consulte las guías [Utilizar su dirección de correo electrónico desde el webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) y [Utilizar el webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Para prestaciones especializadas (posicionamiento web, desarrollo, etc.), contacte con los [partners de OVHcloud](https://partner.ovhcloud.com/es/directory/).
+
+Para recibir asistencia en el uso y la configuración de sus soluciones de OVHcloud, consulte nuestras [ofertas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
+
+Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/es).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ sur la solution Zimbra OVHcloud
 description: "Retrouvez les questions concernant la migration vers Zimbra pour l'offre MX Plan OVHcloud"
-lastUpdated: 2026-05-18
+lastUpdated: 2026-05-28
 ---
 
 
@@ -72,7 +72,7 @@ Pour les comptes Zimbra, le blocage anti-spam suspend l'intégralité de l'accè
 
 **Que faire ?**
 
-1. Consultez le guide [« Que faire en cas de compte bloqué pour spam ? »](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam) et réalisez les vérifications décrites à l'étape 1 (poste, logiciels tiers, redirections, filtres, réponses automatiques) à partir des éléments encore accessibles.
+1. Consultez le guide [« Que faire en cas d'adresse e-mail bloquée pour spam ? »](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam) et réalisez les vérifications décrites à l'étape 1 (poste, logiciels tiers, redirections, filtres, réponses automatiques) à partir des éléments encore accessibles.
 2. **Créez manuellement un ticket d'assistance** depuis votre espace client OVHcloud. Dans le ticket, indiquez :
     - L'adresse e-mail concernée ;
     - Le service associé (MX Plan, Zimbra Starter ou Zimbra Pro) et son identifiant ;

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ sur la solution Zimbra OVHcloud
 description: "Retrouvez les questions concernant la migration vers Zimbra pour l'offre MX Plan OVHcloud"
-lastUpdated: 2025-12-05
+lastUpdated: 2026-05-18
 ---
 
 
@@ -43,6 +43,52 @@ Il existe des différences de fonctionnalités entre la solution Zimbra utilisé
 
 
 Un guide d'utilisation de Zimbra est disponible à [cette adresse](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</details>
+
+
+<details>
+
+<summary>Je n'ai plus accès à mon compte e-mail Zimbra et je ne comprends pas pourquoi : que faire ?</summary>
+
+
+Si vous constatez une perte totale d'accès à votre compte e-mail Zimbra (connexion au webmail Zimbra refusée, envoi et réception suspendus, identifiants apparemment corrects), la cause la plus fréquente est un **blocage automatique de l'adresse pour spam**.
+
+Cette mesure s'applique aux trois offres Zimbra :
+
+- **MX Plan - Zimbra**
+- **Zimbra Starter**
+- **Zimbra Pro**
+
+**Comment reconnaître ce cas :**
+
+- L'accès au webmail Zimbra est entièrement suspendu (et pas seulement l'envoi).
+- Aucun ticket d'assistance n'a été généré automatiquement dans votre espace client OVHcloud, contrairement aux autres technologies e-mail.
+- Une activité d'envoi inhabituelle a pu être détectée sur le compte récemment (envois massifs, contenu suspect, poste utilisateur potentiellement infecté, identifiants compromis, redirection vers une adresse malveillante).
+
+**Pourquoi je ne reçois pas de notification claire :**
+
+Pour les comptes Zimbra, le blocage anti-spam suspend l'intégralité de l'accès au compte et ne déclenche pas de ticket d'assistance automatique. Le client peut donc constater la perte d'accès sans recevoir d'explication immédiate.
+
+**Que faire ?**
+
+1. Consultez le guide [« Que faire en cas de compte bloqué pour spam ? »](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam) et réalisez les vérifications décrites à l'étape 1 (poste, logiciels tiers, redirections, filtres, réponses automatiques) à partir des éléments encore accessibles.
+2. **Créez manuellement un ticket d'assistance** depuis votre espace client OVHcloud. Dans le ticket, indiquez :
+    - L'adresse e-mail concernée ;
+    - Le service associé (MX Plan, Zimbra Starter ou Zimbra Pro) et son identifiant ;
+    - Les actions correctives déjà engagées.
+3. Une fois le ticket traité par le support, votre adresse est débloquée et l'accès au webmail Zimbra est rétabli.
+
+:::info
+**Autres causes possibles de perte d'accès** (à écarter avant ou après contact du support) :
+
+- Mot de passe modifié récemment (par vous-même ou par un administrateur de la plateforme).
+- Service en cours de suspension administrative (impayé, résiliation, fin de contrat).
+- Migration de service récemment effectuée (vérifier les éventuels e-mails de notification envoyés 2 semaines puis 1 jour avant migration).
+- Incident d'infrastructure ponctuel : consultez le [statut des services OVHcloud](https://status.ovhcloud.com).
+
+:::
+
 
 </details>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: Que faire en cas de compte bloqué pour spam ?
 description: Découvrez comment réagir lorsque votre adresse a été bloquée pour spam
-lastUpdated: 2026-03-05
+lastUpdated: 2026-05-18
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -18,6 +18,7 @@ Lorsque votre adresse e-mail est bloquée pour spam, cela signifie qu'une activi
 - Disposer d'une [offre e-mail OVHcloud](https://www.ovhcloud.com/fr/emails/).
 
 {/* CP-NAV-START:web-mx-plan */}
+{/* CP-NAV-START:web-zimbra */}
 {/* CP-NAV-START:web-email-pro */}
 {/* CP-NAV-START:web-exchange */}
 ---
@@ -28,6 +29,11 @@ Lorsque votre adresse e-mail est bloquée pour spam, cela signifie qu'une activi
 
 - **Lien direct :** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
 - **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Sélectionnez votre service MX Plan
+
+**Zimbra (Starter / Pro) :**
+
+- **Lien direct :** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
+- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Sélectionnez votre service Zimbra
 
 **Email Pro :**
 
@@ -42,11 +48,12 @@ Lorsque votre adresse e-mail est bloquée pour spam, cela signifie qu'une activi
 ---
 {/* CP-NAV-END:web-exchange */}
 {/* CP-NAV-END:web-email-pro */}
+{/* CP-NAV-END:web-zimbra */}
 {/* CP-NAV-END:web-mx-plan */}
 
 ## En pratique <a name="instructions"></a>
 
-Avant de poursuivre et si le blocage concerne une adresse e-mail de type MX Plan, identifiez la technologie e-mail utilisée par votre offre pour suivre le bon processus de déblocage.
+Avant de poursuivre et si le blocage concerne une adresse e-mail de type MX Plan, identifiez la technologie e-mail utilisée par votre offre pour suivre le bon processus de déblocage. Pour les offres **Zimbra Starter** et **Zimbra Pro**, suivez directement les instructions de l'onglet **Zimbra** à l'étape 2.
 
 :::info
 **Identifier la technologie e-mail de votre offre MX Plan.**
@@ -58,7 +65,8 @@ En fonction de la date d'activation de votre offre MX Plan ou d'une migration r�
 <img className="thumbnail" alt="Identifier la technologie e-mail dans l'espace client MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
 
 - Si la technologie affichée est **RoundCube**, suivez les instructions de l'onglet **MX Plan - RoundCube**.
-- Si la technologie affichée est **OWA** ou **Zimbra**, suivez les instructions de l'onglet **MX Plan - OWA / Zimbra**.
+- Si la technologie affichée est **OWA**, suivez les instructions de l'onglet **MX Plan - OWA**.
+- Si la technologie affichée est **Zimbra**, suivez les instructions de l'onglet **Zimbra** (procédure commune à MX Plan - Zimbra, Zimbra Starter et Zimbra Pro).
 
 :::
 
@@ -92,6 +100,22 @@ Si l'activité suspecte détectée par l'anti-spam n'a pas été initiée par le
 
 - Vérifiez les réponses automatiques configurées sur l'adresse e-mail bloquée pour spam, via un logiciel de messagerie ou le webmail.
 
+:::warning
+Si le blocage concerne une adresse utilisant la technologie **Zimbra** (MX Plan - Zimbra, Zimbra Starter ou Zimbra Pro), l'adresse n'est **plus accessible** : la connexion au webmail Zimbra est suspendue en plus de l'envoi.
+
+Les filtres, redirections et réponses automatiques étant configurés directement sur le webmail, le support OVHcloud n'y a pas accès et ne peut pas les vérifier à votre place. Ces vérifications ne restent donc possibles que depuis un poste ou un logiciel de messagerie déjà configuré avec l'adresse (configuration antérieure au blocage).
+
+:::
+
+#### Mettre en place un filtre pour isoler les messages SPAM / DCE
+
+Pour réduire les risques de récidive après déblocage, il est recommandé d'ajouter un filtre côté adresse e-mail :
+
+- Le filtre doit **isoler** les e-mails dont l'objet contient les mentions **« SPAM »** ou **« DCE »** (*Dirty Commercial Email*), par exemple en les déplaçant vers un dossier dédié. **Ne les supprimez pas automatiquement** : une suppression ferait perdre d'éventuels faux positifs (messages légitimes marqués à tort).
+- **Conservez** en revanche les éventuelles **règles de redirection** déjà en place : ne les supprimez pas lors de l'ajout du filtre.
+
+Ce filtre se configure depuis le webmail ou un logiciel de messagerie.
+
 ### Étape 2 : vérifier le statut de l'adresse e-mail et accéder au ticket d'assistance associé
 
 Sélectionnez l'offre e-mail concernée dans les onglets suivants :
@@ -111,22 +135,50 @@ Passez à [l'étape 3](#step3) du guide.
     
     <img className="thumbnail" alt="Colonne statut Spam dans l'onglet Comptes e-mail Email Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan - OWA / Zimbra">
+  <Tab label="MX Plan - OWA">
     Dirigez-vous vers l'onglet <code className="action">Comptes e-mail</code> de votre plateforme. Si la colonne « statut » à droite de l'adresse e-mail concernée mentionne « Spam », cliquez sur cette mention puis sur <code className="action">Répondre au ticket</code>. L'adresse e-mail ne se débloque pas automatiquement. Contactez le support via le ticket d'assistance en répondant aux 3 questions posées.<br/>
 
 Passez à [l'étape 3](#step3) du guide.
     
     <img className="thumbnail" alt="Colonne statut Spam dans l'onglet Comptes e-mail MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
+  <Tab label="Zimbra">
+    Cet onglet s'applique à toutes les adresses utilisant la technologie **Zimbra** : **MX Plan - Zimbra**, **Zimbra Starter** et **Zimbra Pro**. Le processus de déblocage est identique pour ces trois offres.
+
+    Lors du blocage, **aucun ticket d'assistance n'est généré automatiquement** et l'adresse n'est plus accessible (webmail Zimbra et envoi désactivés).
+
+    Pour faire débloquer l'adresse :
+
+    1. Effectuez les vérifications décrites à [l'étape 1](#step1), à partir des éléments accessibles (postes utilisateurs, logiciels tiers, redirections visibles depuis un autre accès).
+    2. **Créez manuellement un ticket d'assistance** depuis votre espace client OVHcloud.
+    3. Dans le ticket, précisez :
+        - L'adresse e-mail concernée par le blocage ;
+        - Le service associé (MX Plan, Zimbra Starter ou Zimbra Pro) et son identifiant ;
+        - Les actions correctives déjà engagées (analyses antivirus, suppression des identités d'expéditeur non autorisées dans les préférences du webmail — si l'accès est encore possible depuis un poste déjà configuré, ajout du filtre SPAM/DCE, etc.).
+
+    Une fois le ticket traité par le support, l'adresse est débloquée. L'[étape 3](#step3) ne s'applique pas dans ce cas.
+  </Tab>
   <Tab label="MX Plan - RoundCube">
-    Si le blocage concerne une adresse e-mail MX Plan avec le webmail **RoundCube**, il n'y a pas de ticket d'assistance. Veillez bien à consulter [l'étape 1](#step1) de ce guide avant de suivre les instructions suivantes.
-    
-    Dirigez-vous vers l'onglet <code className="action">Emails</code> de votre plateforme. Si la colonne « Bloqué pour SPAM » mentionne « Oui », cliquez sur cette mention puis sur <code className="action">Changer le mot de passe</code>. Votre adresse e-mail est maintenant débloquée, vous n'avez pas besoin de suivre l'[étape 3](#step3).
+    Si le blocage concerne une adresse e-mail MX Plan avec le webmail **RoundCube**, aucun ticket d'assistance n'est généré.
+
+    Avant toute action, il est **indispensable d'identifier la cause du blocage** en réalisant les vérifications de [l'étape 1](#step1) (postes potentiellement infectés, logiciels tiers, redirections, filtres, réponses automatiques).
+
+    Dans l'onglet <code className="action">Emails</code> de votre plateforme, la colonne « Bloqué pour SPAM » indique « Oui » lorsque l'adresse est bloquée.
     
     <img className="thumbnail" alt="Colonne Bloqué pour SPAM dans l'onglet Emails MX Plan Roundcube" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-04.png" loading="lazy" />
     
     :::warning
-    Dans de rares cas, la colonne « Bloqué pour SPAM » peut indiquer « Non » malgré le fait que l'adresse e-mail soit bloquée. Si vous avez fait le nécessaire pour sécuriser l'adresse e-mail, la solution reste la même que ci-dessus.
+    **Ne débloquez pas l'adresse vous-même.** Même si l'interface le permet, vous devez **contacter le support OVHcloud** en créant un ticket d'assistance depuis votre espace client, afin que l'origine du blocage soit vérifiée avant tout déblocage. Un déblocage prématuré, sans traitement de la cause, expose à une récidive immédiate.
+
+    :::
+
+    :::warning
+    Le **changement de mot de passe n'est pas systématique**. Il ne doit être effectué **que si une compromission est suspectée** (poste infecté, identifiants divulgués ou partagés, accès non autorisé). Un changement de mot de passe sans cause identifiée masque le vrai problème et expose à une récidive.
+
+    :::
+
+    :::warning
+    Dans de rares cas, la colonne « Bloqué pour SPAM » peut indiquer « Non » malgré le fait que l'adresse e-mail soit bloquée. La procédure reste la même : contactez le support OVHcloud.
 
     :::
 
@@ -171,7 +223,9 @@ Dans la continuité de ce message, un échantillon d'en-têtes des e-mails envoy
 Ces en-têtes permettent de déterminer le cheminement et l'origine des e-mails envoyés.
 
 :::info
-Une fois que votre ticket a été traité par le support client et que votre adresse e-mail a été débloquée, modifiez le mot de passe de l'adresse e-mail, en veillant à ce qu'il soit suffisamment fort. Vous pouvez utiliser [l'outil de création de mot de passe solide](https://www.cnil.fr/fr/generer-un-mot-de-passe-solide) de la CNIL. Vous pouvez également consulter [Les conseils de la CNIL pour un bon mot de passe](https://www.cnil.fr/fr/les-conseils-de-la-cnil-pour-un-bon-mot-de-passe)
+Une fois votre ticket traité par le support client et votre adresse e-mail débloquée, ne procédez à un **changement de mot de passe que si une compromission est suspectée** au vu des vérifications réalisées à [l'étape 1](#step1) (poste infecté, identifiants partagés ou divulgués, accès non autorisé). Le changement de mot de passe **n'est pas systématique**.
+
+Si un nouveau mot de passe est nécessaire, veillez à ce qu'il soit suffisamment fort. Vous pouvez utiliser [l'outil de création de mot de passe solide](https://www.cnil.fr/fr/generer-un-mot-de-passe-solide) de la CNIL, ou consulter [Les conseils de la CNIL pour un bon mot de passe](https://www.cnil.fr/fr/les-conseils-de-la-cnil-pour-un-bon-mot-de-passe).
 
 :::
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
-title: Que faire en cas de compte bloqué pour spam ?
-description: Découvrez comment réagir lorsque votre adresse a été bloquée pour spam
-lastUpdated: 2026-05-18
+title: Que faire en cas d'adresse e-mail bloquée pour spam ?
+description: "Débloquez une adresse e-mail bloquée pour spam : identifiez la cause de l'activité suspecte, corrigez-la et contactez le support OVHcloud."
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -16,6 +16,7 @@ Lorsque votre adresse e-mail est bloquée pour spam, cela signifie qu'une activi
 ## Prérequis
 
 - Disposer d'une [offre e-mail OVHcloud](https://www.ovhcloud.com/fr/emails/).
+- Être connecté à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-zimbra */}
@@ -25,25 +26,25 @@ Lorsque votre adresse e-mail est bloquée pour spam, cela signifie qu'une activi
 
 ### Accès à l'espace client OVHcloud
 
-**MX Plan :**
+**MX Plan :**
 
-- **Lien direct :** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Sélectionnez votre service MX Plan
+- **Lien direct :** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
+- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Sélectionnez votre service MX Plan
 
-**Zimbra (Starter / Pro) :**
+**Zimbra (Starter / Pro) :**
 
-- **Lien direct :** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Sélectionnez votre service Zimbra
+- **Lien direct :** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
+- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Sélectionnez votre service Zimbra
 
-**Email Pro :**
+**Email Pro :**
 
-- **Lien direct :** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Sélectionnez votre plateforme
+- **Lien direct :** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
+- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Sélectionnez votre plateforme
 
-**Exchange :**
+**Exchange :**
 
-- **Lien direct :** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Sélectionnez votre plateforme
+- **Lien direct :** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
+- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Sélectionnez votre plateforme
 
 ---
 {/* CP-NAV-END:web-exchange */}
@@ -53,30 +54,30 @@ Lorsque votre adresse e-mail est bloquée pour spam, cela signifie qu'une activi
 
 ## En pratique <a name="instructions"></a>
 
-Avant de poursuivre et si le blocage concerne une adresse e-mail de type MX Plan, identifiez la technologie e-mail utilisée par votre offre pour suivre le bon processus de déblocage. Pour les offres **Zimbra Starter** et **Zimbra Pro**, suivez directement les instructions de l'onglet **Zimbra** à l'étape 2.
+Avant de poursuivre et si le blocage concerne une adresse e-mail de type MX Plan, identifiez la technologie e-mail utilisée par votre offre pour suivre le bon processus de déblocage. Pour les offres **Zimbra Starter** et **Zimbra Pro**, rendez-vous directement à l'onglet **Zimbra** de l'étape 2, sans omettre les vérifications de l'étape 1.
 
 :::info
 **Identifier la technologie e-mail de votre offre MX Plan.**
 
-En fonction de la date d'activation de votre offre MX Plan ou d'une migration récente, la technologie e-mail associée peut différer. Cette version est caractérisée par l'interface de son webmail. Pour l'identifier :
+En fonction de la date d'activation de votre offre MX Plan ou d'une migration récente, la technologie e-mail associée peut différer. Cette version est caractérisée par l'interface de son webmail. Pour l'identifier :
 
 - Depuis l'onglet <code className="action">Informations générales</code>, relevez la technologie utilisée sous la mention **Webmail** présente dans l'encadré <code className="action">Abonnement</code>.
 
 <img className="thumbnail" alt="Identifier la technologie e-mail dans l'espace client MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
 
-- Si la technologie affichée est **RoundCube**, suivez les instructions de l'onglet **MX Plan - RoundCube**.
-- Si la technologie affichée est **OWA**, suivez les instructions de l'onglet **MX Plan - OWA**.
+- Si la technologie affichée est **Roundcube**, suivez les instructions de l'onglet **MX Plan - Roundcube**.
+- Si la technologie affichée est **OWA** (Outlook Web App), suivez les instructions de l'onglet **MX Plan - OWA**.
 - Si la technologie affichée est **Zimbra**, suivez les instructions de l'onglet **Zimbra** (procédure commune à MX Plan - Zimbra, Zimbra Starter et Zimbra Pro).
 
 :::
 
 
-### Étape 1 : pourquoi votre adresse e-mail est bloquée pour spam ? <a name="step1"></a>
+### Étape 1 : comprendre et traiter la cause du blocage <a name="step1"></a>
 
 Lorsqu'une activité suspecte est détectée au niveau de l'envoi des e-mails, l'adresse concernée est automatiquement bloquée. Dans cette situation, vous ne pouvez plus envoyer d'e-mails depuis cette adresse e-mail.
 
 :::warning
-Une « activité suspecte » signifie que :
+Une « activité suspecte » signifie que :
 
 - Le serveur anti-spam, qui scanne les e-mails à l'envoi, a constaté qu'un ou plusieurs éléments de l'e-mail sont considérés comme suspects et peuvent constituer un e-mail spam.
 - La fréquence d'envoi et le nombre de destinataires sont trop importants et contribuent à considérer l'envoi comme du spamming. En effet, pour réaliser des envois massifs, il est nécessaire d'utiliser un service de mailing list et non une adresse e-mail standard.
@@ -88,11 +89,11 @@ Les raisons précises d'un blocage ne peuvent pas être divulguées pour éviter
 
 Tout d'abord, assurez-vous, auprès du (des) utilisateur(s) de l'adresse e-mail bloquée, qu'il(s) n'est (ne sont) pas directement à l'origine du blocage, suite à une utilisation inhabituelle de l'adresse e-mail (par exemple, suite à des envois massifs d'e-mails). Si c'est le cas, vous devez corriger la situation avant de débloquer l'adresse.
 
-Si l'activité suspecte détectée par l'anti-spam n'a pas été initiée par le (les) utilisateur(s) légitime(s) de l'adresse e-mail, prenez les mesures suivantes :
+Si l'activité suspecte détectée par l'anti-spam n'a pas été initiée par le (les) utilisateur(s) légitime(s) de l'adresse e-mail, prenez les mesures suivantes :
 
 - Effectuez une analyse antivirus de chacun des postes utilisant l'adresse e-mail bloquée pour spam et appliquez un correctif si ces derniers sont infectés.
 
-- Vérifiez tous les logiciels utilisant les identifiants de l'adresse e-mail bloquée pour spam (par exemple : télécopieur, logiciel métier, logiciel de messagerie).
+- Vérifiez tous les logiciels utilisant les identifiants de l'adresse e-mail bloquée pour spam (par exemple : télécopieur, logiciel métier, logiciel de messagerie).
 
 - Vérifiez les redirections appliquées sur l'adresse e-mail bloquée pour spam.
 
@@ -100,70 +101,73 @@ Si l'activité suspecte détectée par l'anti-spam n'a pas été initiée par le
 
 - Vérifiez les réponses automatiques configurées sur l'adresse e-mail bloquée pour spam, via un logiciel de messagerie ou le webmail.
 
-:::warning
-Si le blocage concerne une adresse utilisant la technologie **Zimbra** (MX Plan - Zimbra, Zimbra Starter ou Zimbra Pro), l'adresse n'est **plus accessible** : la connexion au webmail Zimbra est suspendue en plus de l'envoi.
+:::info
+Les filtres, redirections et réponses automatiques qui sont configurés directement sur le webmail (Zimbra, OWA) ou dans votre logiciel de messagerie ne sont pas accessibles au support OVHcloud : il ne peut pas les vérifier à votre place. Ces vérifications doivent être réalisées par vos soins, depuis le webmail ou un poste déjà configuré avec l'adresse.
 
-Les filtres, redirections et réponses automatiques étant configurés directement sur le webmail, le support OVHcloud n'y a pas accès et ne peut pas les vérifier à votre place. Ces vérifications ne restent donc possibles que depuis un poste ou un logiciel de messagerie déjà configuré avec l'adresse (configuration antérieure au blocage).
+:::
+
+:::warning
+Si le blocage concerne une adresse utilisant la technologie **Zimbra** (MX Plan - Zimbra, Zimbra Starter ou Zimbra Pro), l'adresse n'est **plus accessible** : la connexion au webmail Zimbra est suspendue en plus de l'envoi. Les filtres, redirections et réponses automatiques ne sont alors plus consultables depuis le webmail.
 
 :::
 
 #### Mettre en place un filtre pour isoler les messages SPAM / DCE
 
-Pour réduire les risques de récidive après déblocage, il est recommandé d'ajouter un filtre côté adresse e-mail :
+Pour réduire les risques de récidive après déblocage, nous recommandons d'ajouter un filtre côté adresse e-mail :
 
-- Le filtre doit **isoler** les e-mails dont l'objet contient les mentions **« SPAM »** ou **« DCE »** (*Dirty Commercial Email*), par exemple en les déplaçant vers un dossier dédié. **Ne les supprimez pas automatiquement** : une suppression ferait perdre d'éventuels faux positifs (messages légitimes marqués à tort).
-- **Conservez** en revanche les éventuelles **règles de redirection** déjà en place : ne les supprimez pas lors de l'ajout du filtre.
+- Le filtre doit **isoler** les e-mails dont l'objet contient les mentions **« SPAM »** ou **« DCE »** (*Dirty Commercial Email*), par exemple en les déplaçant vers un dossier dédié. **Ne les supprimez pas automatiquement** : une suppression ferait perdre d'éventuels faux positifs (messages légitimes marqués à tort).
+- **Conservez** en revanche les éventuelles **règles de redirection** déjà en place : ne les supprimez pas lors de l'ajout du filtre.
 
 Ce filtre se configure depuis le webmail ou un logiciel de messagerie.
 
-### Étape 2 : vérifier le statut de l'adresse e-mail et accéder au ticket d'assistance associé
+### Étape 2 : vérifier le statut et accéder au ticket d'assistance
 
-Sélectionnez l'offre e-mail concernée dans les onglets suivants :
+Sélectionnez l'offre e-mail concernée dans les onglets suivants :
 
 <Tabs>
   <Tab label="Exchange">
-    Dirigez-vous vers l'onglet <code className="action">Comptes e-mail</code> de votre plateforme. Si la colonne « statut » de l'adresse e-mail concernée mentionne « bloqué », cliquez sur <code className="action">...</code> à droite du compte puis sur <code className="action">Débloquer</code>. L'adresse e-mail ne se débloque pas automatiquement. Contactez le support via le ticket d'assistance en répondant aux 3 questions posées.<br/>
+    Accédez à l'onglet <code className="action">Comptes e-mail</code> de votre plateforme. Si la colonne « statut » de l'adresse e-mail concernée mentionne « bloqué », cliquez sur <code className="action">...</code> à droite du compte puis sur <code className="action">Débloquer</code>. L'adresse e-mail ne se débloque pas automatiquement. Contactez le support via le ticket d'assistance en répondant aux 3 questions posées.<br/>
 
-Passez à [l'étape 3](#step3) du guide.
+    Passez à [l'étape 3](#step3) du guide.
     
     <img className="thumbnail" alt="Colonne statut bloqué dans l'onglet Comptes e-mail Exchange" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-01.png" loading="lazy" />
   </Tab>
   <Tab label="Email Pro">
-    Dirigez-vous vers l'onglet <code className="action">Comptes e-mail</code> de votre plateforme. Si la colonne « statut » à droite de l'adresse e-mail concernée mentionne « Spam », cliquez sur cette mention puis sur <code className="action">Répondre au ticket</code>. L'adresse e-mail ne se débloque pas automatiquement. Contactez le support via le ticket d'assistance en répondant aux 3 questions posées. <br/>
+    Accédez à l'onglet <code className="action">Comptes e-mail</code> de votre plateforme. Si la colonne « statut » à droite de l'adresse e-mail concernée mentionne « Spam », cliquez sur cette mention puis sur <code className="action">Répondre au ticket</code>. L'adresse e-mail ne se débloque pas automatiquement. Contactez le support via le ticket d'assistance en répondant aux 3 questions posées. <br/>
 
-Passez à [l'étape 3](#step3) du guide.
+    Passez à [l'étape 3](#step3) du guide.
     
     <img className="thumbnail" alt="Colonne statut Spam dans l'onglet Comptes e-mail Email Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
   </Tab>
   <Tab label="MX Plan - OWA">
-    Dirigez-vous vers l'onglet <code className="action">Comptes e-mail</code> de votre plateforme. Si la colonne « statut » à droite de l'adresse e-mail concernée mentionne « Spam », cliquez sur cette mention puis sur <code className="action">Répondre au ticket</code>. L'adresse e-mail ne se débloque pas automatiquement. Contactez le support via le ticket d'assistance en répondant aux 3 questions posées.<br/>
+    Accédez à l'onglet <code className="action">Comptes e-mail</code> de votre plateforme. Si la colonne « statut » à droite de l'adresse e-mail concernée mentionne « Spam », cliquez sur cette mention puis sur <code className="action">Répondre au ticket</code>. L'adresse e-mail ne se débloque pas automatiquement. Contactez le support via le ticket d'assistance en répondant aux 3 questions posées.<br/>
 
-Passez à [l'étape 3](#step3) du guide.
+    Passez à [l'étape 3](#step3) du guide.
     
     <img className="thumbnail" alt="Colonne statut Spam dans l'onglet Comptes e-mail MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
   <Tab label="Zimbra">
-    Cet onglet s'applique à toutes les adresses utilisant la technologie **Zimbra** : **MX Plan - Zimbra**, **Zimbra Starter** et **Zimbra Pro**. Le processus de déblocage est identique pour ces trois offres.
+    Cet onglet s'applique à toutes les adresses utilisant la technologie **Zimbra** : **MX Plan - Zimbra**, **Zimbra Starter** et **Zimbra Pro**. Le processus de déblocage est identique pour ces trois offres.
 
     Lors du blocage, **aucun ticket d'assistance n'est généré automatiquement** et l'adresse n'est plus accessible (webmail Zimbra et envoi désactivés).
 
-    Pour faire débloquer l'adresse :
+    Pour faire débloquer l'adresse :
 
     1. Effectuez les vérifications décrites à [l'étape 1](#step1), à partir des éléments accessibles (postes utilisateurs, logiciels tiers, redirections visibles depuis un autre accès).
     2. **Créez manuellement un ticket d'assistance** depuis votre espace client OVHcloud.
-    3. Dans le ticket, précisez :
-        - L'adresse e-mail concernée par le blocage ;
-        - Le service associé (MX Plan, Zimbra Starter ou Zimbra Pro) et son identifiant ;
-        - Les actions correctives déjà engagées (analyses antivirus, suppression des identités d'expéditeur non autorisées dans les préférences du webmail — si l'accès est encore possible depuis un poste déjà configuré, ajout du filtre SPAM/DCE, etc.).
+    3. Dans le ticket, précisez :
+        - L'adresse e-mail concernée par le blocage ;
+        - Le service associé (MX Plan, Zimbra Starter ou Zimbra Pro) et son identifiant ;
+        - Les actions correctives déjà engagées (analyses antivirus, suppression d'expéditeurs non légitimes, ajout du filtre SPAM/DCE, etc.).
 
     Une fois le ticket traité par le support, l'adresse est débloquée. L'[étape 3](#step3) ne s'applique pas dans ce cas.
   </Tab>
-  <Tab label="MX Plan - RoundCube">
-    Si le blocage concerne une adresse e-mail MX Plan avec le webmail **RoundCube**, aucun ticket d'assistance n'est généré.
+  <Tab label="MX Plan - Roundcube">
+    Si le blocage concerne une adresse e-mail MX Plan avec le webmail **Roundcube**, aucun ticket d'assistance n'est généré.
 
     Avant toute action, il est **indispensable d'identifier la cause du blocage** en réalisant les vérifications de [l'étape 1](#step1) (postes potentiellement infectés, logiciels tiers, redirections, filtres, réponses automatiques).
 
-    Dans l'onglet <code className="action">Emails</code> de votre plateforme, la colonne « Bloqué pour SPAM » indique « Oui » lorsque l'adresse est bloquée.
+    Dans l'onglet <code className="action">Emails</code> de votre plateforme, la colonne « Bloqué pour SPAM » indique « Oui » lorsque l'adresse est bloquée.
     
     <img className="thumbnail" alt="Colonne Bloqué pour SPAM dans l'onglet Emails MX Plan Roundcube" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-04.png" loading="lazy" />
     
@@ -177,26 +181,33 @@ Passez à [l'étape 3](#step3) du guide.
 
     :::
 
-    :::warning
-    Dans de rares cas, la colonne « Bloqué pour SPAM » peut indiquer « Non » malgré le fait que l'adresse e-mail soit bloquée. La procédure reste la même : contactez le support OVHcloud.
+    :::info
+    Dans de rares cas, la colonne « Bloqué pour SPAM » peut indiquer « Non » bien que l'adresse e-mail soit bloquée. La procédure reste la même : contactez le support OVHcloud.
 
     :::
+
+    Pour faire débloquer l'adresse, **créez manuellement un ticket d'assistance** depuis votre espace client OVHcloud en précisant :
+
+    - L'adresse e-mail concernée par le blocage ;
+    - Le service MX Plan associé et son identifiant ;
+    - Les actions correctives déjà engagées (analyses antivirus, suppression d'expéditeurs non légitimes, ajout du filtre SPAM/DCE, etc.).
+
+    Une fois le ticket traité par le support, l'adresse est débloquée. L'[étape 3](#step3) ne s'applique pas dans ce cas.
 
   </Tab>
 </Tabs>
 
 
-### Étape 3 : accéder au ticket d'assistance <a name="step3"></a>
+### Étape 3 : accéder au ticket d'assistance <a name="step3"></a>
 
-Suite à l'étape 2, vous êtes alors redirigé vers la fenêtre « Mes demandes d'assistance ». Cliquez sur le bouton <code className="action">...</code> à droite du ticket mentionnant l'objet « Account locked for spam. » puis cliquez sur <code className="action">Voir le détail</code>.
+Suite à l'étape 2, vous êtes alors redirigé vers la fenêtre « Mes demandes d'assistance ». Cliquez sur le bouton <code className="action">...</code> à droite du ticket mentionnant l'objet « Account locked for spam. » puis cliquez sur <code className="action">Voir le détail</code>.
 
 <img className="thumbnail" alt="Fenêtre Mes demandes d'assistance avec le ticket de blocage spam" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-02.png" loading="lazy" />
 
 Vous retrouvez ainsi l'e-mail qui vous a été transmis, celui-ci génère un ticket d'assistance auprès du support.
 
-Le ticket d'assistance se présente comme suit :
+Le ticket d'assistance se présente comme suit :
 
->
 > Cher Client,
 >
 > Notre système a détecté que l'adresse **youraddress@example.com** hébergée sur nos systèmes sous le service **servicename** est source d'envoi de courriers indésirables (spams).
@@ -214,9 +225,6 @@ Le ticket d'assistance se présente comme suit :
 > - Avez-vous répondu à un Spam ?
 >
 > Ces réponses nous aideront à réactiver votre compte rapidement.
-> <br/>
-> <br/>
->
 
 Dans la continuité de ce message, un échantillon d'en-têtes des e-mails envoyés vous a été transmis.
 
@@ -232,7 +240,11 @@ Si un nouveau mot de passe est nécessaire, veillez à ce qu'il soit suffisammen
 
 ## Aller plus loin
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/).
+Pour gérer les alias et redirections de votre adresse e-mail, consultez le guide [Utiliser les alias et redirections e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
+
+Pour consulter vos filtres et réponses automatiques depuis le webmail, consultez les guides [Utiliser son adresse e-mail depuis le webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) et [Utiliser le webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/).
 
 Pour une assistance à l'usage et à la configuration de vos solutions OVHcloud, consultez nos [offres de support](https://www.ovhcloud.com/fr/support-levels/).
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Domande frequenti sulla soluzione Zimbra OVHcloud
 description: Ritrova le domande relative alla migrazione a Zimbra per il servizio MX Plan di OVHcloud
-lastUpdated: 2025-12-05
+lastUpdated: 2026-05-28
 ---
 
 
@@ -43,6 +43,52 @@ Esistono differenze di funzionalità tra la soluzione Zimbra utilizzata nell'off
 
 
 Una guida all’utilizzo di Zimbra è già disponibile a [questo indirizzo](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</details>
+
+
+<details>
+
+<summary>Non ho più accesso al mio account e-mail Zimbra e non capisco perché: cosa fare?</summary>
+
+
+Se riscontri una perdita totale di accesso al tuo account e-mail Zimbra (connessione alla webmail Zimbra rifiutata, invio e ricezione sospesi, credenziali apparentemente corrette), la causa più frequente è un **blocco automatico dell'indirizzo per spam**.
+
+Questa misura si applica alle tre offerte Zimbra:
+
+- **MX Plan - Zimbra**
+- **Zimbra Starter**
+- **Zimbra Pro**
+
+**Come riconoscere questo caso:**
+
+- L'accesso alla webmail Zimbra è completamente sospeso (e non solo l'invio).
+- Nessun ticket di assistenza è stato generato automaticamente nel tuo Spazio Cliente OVHcloud, a differenza delle altre tecnologie e-mail.
+- Recentemente è stata rilevata un'attività di invio insolita sull'account (invii massivi, contenuti sospetti, postazione utente potenzialmente infetta, credenziali compromesse, reindirizzamento verso un indirizzo malevolo).
+
+**Perché non ricevo una notifica chiara:**
+
+Per gli account Zimbra, il blocco antispam sospende l'intero accesso all'account e non attiva un ticket di assistenza automatico. Il cliente può quindi constatare la perdita di accesso senza ricevere una spiegazione immediata.
+
+**Cosa fare?**
+
+1. Consulta la guida ["Cosa fare se un indirizzo e-mail è bloccato per spam?"](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam) ed esegui le verifiche descritte nella fase 1 (postazione, software di terze parti, reindirizzamenti, filtri, risposte automatiche) a partire dagli elementi ancora accessibili.
+2. **Crea manualmente un ticket di assistenza** dal tuo Spazio Cliente OVHcloud. Nel ticket, indica:
+    - L'indirizzo e-mail interessato;
+    - Il servizio associato (MX Plan, Zimbra Starter o Zimbra Pro) e il suo identificativo;
+    - Le azioni correttive già intraprese.
+3. Una volta gestito il ticket dal supporto, il tuo indirizzo viene sbloccato e l'accesso alla webmail Zimbra è ripristinato.
+
+:::info
+**Altre possibili cause di perdita di accesso** (da escludere prima o dopo aver contattato il supporto):
+
+- Password modificata di recente (da te stesso o da un amministratore della piattaforma).
+- Servizio in corso di sospensione amministrativa (mancato pagamento, disdetta, fine contratto).
+- Migrazione del servizio effettuata di recente (verifica le eventuali e-mail di notifica inviate 2 settimane e poi 1 giorno prima della migrazione).
+- Incidente di infrastruttura puntuale: consulta lo [stato dei servizi OVHcloud](https://status.ovhcloud.com).
+
+:::
+
 
 </details>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
-title: Cosa fare in caso di account bloccato per spam?
-description: Scopri come procedere quando il tuo indirizzo è stato bloccato per spam
-lastUpdated: 2026-03-05
+title: Cosa fare se un indirizzo e-mail è bloccato per spam?
+description: "Sblocca un indirizzo e-mail bloccato per spam: individua la causa dell'attività sospetta, correggila e contatta il supporto OVHcloud."
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -9,15 +9,17 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Obiettivo
 
-Quando il tuo indirizzo e-mail è bloccato per spam, significa che è stata rilevata un'attività sospetta durante l'invio di e-mail da questo indirizzo. In questa situazione, non puoi più inviare e-mail da questo indirizzo e-mail. È quindi necessario capire perché è stata rilevata un'attività sospetta e agire per evitare che questa situazione si ripeta.
+Quando il tuo indirizzo e-mail viene bloccato per spam, significa che è stata rilevata un'attività sospetta durante l'invio di e-mail da questo indirizzo. In questa situazione, non puoi più inviare e-mail da tale indirizzo. Devi quindi capire perché è stata rilevata un'attività sospetta e agire per evitare che la situazione si ripeta.
 
-**Scopri come procedere quando il tuo indirizzo è bloccato per spam.**
+**Scopri come reagire quando il tuo indirizzo è bloccato per spam.**
 
 ## Prerequisiti
 
-- Disporre di una [soluzione e-mail OVHcloud](https://www.ovhcloud.com/it/emails/).
+- Disporre di un'[offerta e-mail OVHcloud](https://www.ovhcloud.com/it/emails/).
+- Aver effettuato l'accesso allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>.
 
 {/* CP-NAV-START:web-mx-plan */}
+{/* CP-NAV-START:web-zimbra */}
 {/* CP-NAV-START:web-email-pro */}
 {/* CP-NAV-START:web-exchange */}
 ---
@@ -27,159 +29,223 @@ Quando il tuo indirizzo e-mail è bloccato per spam, significa che è stata rile
 **MX Plan:**
 
 - **Link diretto:** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Seleziona il tuo servizio MX Plan
+- **Per accedere ai tuoi servizi:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Seleziona il tuo servizio MX Plan
+
+**Zimbra (Starter / Pro):**
+
+- **Link diretto:** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
+- **Per accedere ai tuoi servizi:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Seleziona il tuo servizio Zimbra
 
 **Email Pro:**
 
 - **Link diretto:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Seleziona la tua piattaforma
+- **Per accedere ai tuoi servizi:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Seleziona la tua piattaforma
 
 **Exchange:**
 
 - **Link diretto:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Seleziona la tua piattaforma
+- **Per accedere ai tuoi servizi:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Seleziona la tua piattaforma
 
 ---
 {/* CP-NAV-END:web-exchange */}
 {/* CP-NAV-END:web-email-pro */}
+{/* CP-NAV-END:web-zimbra */}
 {/* CP-NAV-END:web-mx-plan */}
 
 ## Procedura <a name="instructions"></a>
 
-Prima di proseguire, se il blocco riguarda un indirizzo e-mail di tipo MX Plan, identifica la tecnologia e-mail utilizzata dalla tua offerta per seguire il corretto processo di sblocco.
+Prima di proseguire, se il blocco riguarda un indirizzo e-mail di tipo MX Plan, individua la tecnologia e-mail utilizzata dalla tua offerta per seguire la procedura di sblocco corretta. Per le offerte **Zimbra Starter** e **Zimbra Pro**, vai direttamente alla scheda **Zimbra** della fase 2, senza tralasciare le verifiche della fase 1.
 
 :::info
-**Identificare la tecnologia e-mail della tua offerta MX Plan.**
+**Individuare la tecnologia e-mail della tua offerta MX Plan.**
 
-In base alla data di attivazione della tua offerta MX Plan o a una migrazione recente, la tecnologia e-mail associata può essere diversa. Questa versione è caratterizzata dall'interfaccia della sua webmail. Per identificarla:
+In base alla data di attivazione della tua offerta MX Plan o a una migrazione recente, la tecnologia e-mail associata può variare. Questa versione è caratterizzata dall'interfaccia del suo webmail. Per identificarla:
 
-- Dalla scheda <code className="action">Informazioni generali</code>, individua la tecnologia utilizzata sotto la voce **Webmail** presente nel riquadro <code className="action">Abbonamento</code>.
+- Dalla scheda <code className="action">Informazioni generali</code>, controlla la tecnologia utilizzata sotto la voce **Webmail** presente nel riquadro <code className="action">Abbonamento</code>.
 
-<img className="thumbnail" alt="Identificare la tecnologia e-mail nello Spazio Cliente MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
+<img className="thumbnail" alt="Individuare la tecnologia e-mail nello Spazio Cliente MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
 
-- Se la tecnologia mostrata è **RoundCube**, segui le istruzioni della scheda **MX Plan - RoundCube**.
-- Se la tecnologia mostrata è **OWA** o **Zimbra**, segui le istruzioni della scheda **MX Plan - OWA / Zimbra**.
+- Se la tecnologia visualizzata è **Roundcube**, segui le istruzioni della scheda **MX Plan - Roundcube**.
+- Se la tecnologia visualizzata è **OWA** (Outlook Web App), segui le istruzioni della scheda **MX Plan - OWA**.
+- Se la tecnologia visualizzata è **Zimbra**, segui le istruzioni della scheda **Zimbra** (procedura comune a MX Plan - Zimbra, Zimbra Starter e Zimbra Pro).
 
 :::
 
 
-### Step 1: perché il tuo indirizzo e-mail è bloccato per spam? <a name="step1"></a>
+### Fase 1: comprendere e risolvere la causa del blocco <a name="step1"></a>
 
-Quando viene rilevata un'attività sospetta a livello di invio delle e-mail, l'indirizzo interessato viene automaticamente bloccato. In questa situazione, non è possibile inviare e-mail da questo indirizzo e-mail.
+Quando viene rilevata un'attività sospetta a livello di invio delle e-mail, l'indirizzo interessato viene bloccato automaticamente. In questa situazione, non puoi più inviare e-mail da tale indirizzo.
 
 :::warning
-Un'"attività sospetta" significa che:
+Per "attività sospetta" si intende che:
 
-- Il server anti-spam, che analizza le e-mail al momento dell'invio, ha rilevato che uno o più elementi dell'e-mail sono considerati sospetti e possono costituire un'e-mail spam.
-- La frequenza di invio e il numero di destinatari sono troppo elevati e contribuiscono a far considerare l'invio come spamming. Per effettuare invii massivi, è infatti necessario utilizzare un servizio di mailing list e non un indirizzo e-mail standard.
+- Il server antispam, che esegue la scansione delle e-mail in uscita, ha rilevato che uno o più elementi dell'e-mail sono considerati sospetti e possono costituire un'e-mail di spam.
+- La frequenza di invio e il numero di destinatari sono troppo elevati e contribuiscono a far considerare l'invio come spamming. Infatti, per effettuare invii massivi, è necessario utilizzare un servizio di mailing list e non un indirizzo e-mail standard.
 
-I motivi precisi di un blocco non possono essere divulgati per evitare qualsiasi tentativo di elusione del sistema di rilevamento dello spam. Per testare il contenuto di un'e-mail, puoi utilizzare uno strumento esterno a OVHcloud come [Mailtester](https://www.mail-tester.com/).
+I motivi precisi di un blocco non possono essere divulgati per evitare qualsiasi tentativo di aggirare il sistema di rilevamento dello spam. Per verificare il contenuto di un'e-mail, puoi utilizzare uno strumento esterno a OVHcloud come [Mailtester](https://www.mail-tester.com/).
 
 :::
 
 
-Per prima cosa, assicurati presso gli utenti dell'indirizzo e-mail bloccato che non siano direttamente all'origine del blocco, a causa di un utilizzo insolito dell'indirizzo e-mail (ad esempio, in seguito a invii massivi di e-mail). In tal caso, è necessario correggere la situazione prima di sbloccare l'indirizzo.
+Innanzitutto, verifica con l'utente (o gli utenti) dell'indirizzo e-mail bloccato che non sia stato lui stesso a causare direttamente il blocco, a seguito di un utilizzo insolito dell'indirizzo e-mail (ad esempio, dopo invii massivi di e-mail). Se è questo il caso, devi correggere la situazione prima di sbloccare l'indirizzo.
 
-Se l'attività sospetta rilevata dall'anti-spam non è stata avviata dagli utenti legittimi dell'indirizzo e-mail, adotta le seguenti misure:
+Se l'attività sospetta rilevata dall'antispam non è stata avviata dall'utente (o dagli utenti) legittimo dell'indirizzo e-mail, adotta le seguenti misure:
 
-- Effettua un'analisi antivirus di ciascun dispositivo che utilizza l'indirizzo e-mail bloccato per spam e applica una correzione se risultano infetti.
+- Esegui un'analisi antivirus su ciascuna postazione che utilizza l'indirizzo e-mail bloccato per spam e applica una correzione se queste risultano infette.
 
 - Verifica tutti i software che utilizzano le credenziali dell'indirizzo e-mail bloccato per spam (ad esempio: fax, software gestionale, client di posta).
 
-- Verifica i reindirizzamenti applicati all'indirizzo e-mail bloccato per spam.
+- Verifica i reindirizzamenti applicati sull'indirizzo e-mail bloccato per spam.
 
-- Verifica i filtri applicati all'indirizzo e-mail bloccato per spam, tramite un client di posta o la webmail.
+- Verifica i filtri applicati sull'indirizzo e-mail bloccato per spam, tramite un client di posta o il webmail.
 
-- Verifica le risposte automatiche configurate sull'indirizzo e-mail bloccato per spam, tramite un client di posta o la webmail.
+- Verifica le risposte automatiche configurate sull'indirizzo e-mail bloccato per spam, tramite un client di posta o il webmail.
 
-### Step 2: verifica lo stato dell'indirizzo e-mail e accedi al ticket di assistenza associato
+:::info
+I filtri, i reindirizzamenti e le risposte automatiche configurati direttamente nel webmail (Zimbra, OWA) o nel tuo client di posta non sono accessibili al supporto OVHcloud: non può verificarli al posto tuo. Queste verifiche devono essere effettuate da te, dal webmail o da una postazione già configurata con l'indirizzo.
 
-Seleziona il servizio e-mail interessato nelle schede seguenti:
+:::
+
+:::warning
+Se il blocco riguarda un indirizzo che utilizza la tecnologia **Zimbra** (MX Plan - Zimbra, Zimbra Starter o Zimbra Pro), l'indirizzo **non è più accessibile**: la connessione al webmail Zimbra è sospesa oltre all'invio. I filtri, i reindirizzamenti e le risposte automatiche non sono quindi più consultabili dal webmail.
+
+:::
+
+#### Impostare un filtro per isolare i messaggi SPAM / DCE
+
+Per ridurre i rischi di recidiva dopo lo sblocco, ti consigliamo di aggiungere un filtro lato indirizzo e-mail:
+
+- Il filtro deve **isolare** le e-mail il cui oggetto contiene le diciture **"SPAM"** o **"DCE"** (*Dirty Commercial Email*), ad esempio spostandole in una cartella dedicata. **Non eliminarle automaticamente**: un'eliminazione farebbe perdere eventuali falsi positivi (messaggi legittimi contrassegnati erroneamente).
+- **Conserva** invece le eventuali **regole di reindirizzamento** già esistenti: non eliminarle quando aggiungi il filtro.
+
+Questo filtro si configura dal webmail o da un client di posta.
+
+### Fase 2: verificare lo stato e accedere al ticket di assistenza
+
+Seleziona l'offerta e-mail interessata nelle seguenti schede:
 
 <Tabs>
   <Tab label="Exchange">
-    Accedi alla scheda <code className="action">Account email</code> della tua piattaforma. Se la colonna "stato" dell'indirizzo e-mail interessato indica "bloccato", clicca sui <code className="action">...</code> a destra dell'account e poi su <code className="action">Sblocca</code>. Lo sblocco dell'indirizzo e-mail non avviene automaticamente. Contatta il supporto tramite il ticket di assistenza rispondendo alle 3 domande poste.<br/>
+    Accedi alla scheda <code className="action">Account email</code> della tua piattaforma. Se la colonna "stato" dell'indirizzo e-mail interessato indica "bloccato", clicca su <code className="action">...</code> a destra dell'account, poi su <code className="action">Sblocca</code>. L'indirizzo e-mail non si sblocca automaticamente. Contatta il supporto tramite il ticket di assistenza rispondendo alle 3 domande poste.<br/>
 
-Passa allo [step 3](#step3) della guida.
+    Passa alla [fase 3](#step3) della guida.
     
     <img className="thumbnail" alt="Colonna stato bloccato nella scheda Account email Exchange" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-01.png" loading="lazy" />
   </Tab>
   <Tab label="Email Pro">
-    Accedi alla scheda <code className="action">Account email</code> della tua piattaforma. Se la colonna "stato" a destra dell'indirizzo e-mail interessato indica "Spam", clicca su questa voce e poi su <code className="action">Rispondi al ticket</code>. Lo sblocco dell'indirizzo e-mail non avviene automaticamente. Contatta il supporto tramite il ticket di assistenza rispondendo alle 3 domande poste.<br/>
+    Accedi alla scheda <code className="action">Account email</code> della tua piattaforma. Se la colonna "stato" a destra dell'indirizzo e-mail interessato indica "Spam", clicca su questa dicitura, poi su <code className="action">Rispondi al ticket</code>. L'indirizzo e-mail non si sblocca automaticamente. Contatta il supporto tramite il ticket di assistenza rispondendo alle 3 domande poste. <br/>
 
-Passa allo [step 3](#step3) della guida.
+    Passa alla [fase 3](#step3) della guida.
     
     <img className="thumbnail" alt="Colonna stato Spam nella scheda Account email Email Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan - OWA / Zimbra">
-    Accedi alla scheda <code className="action">Account email</code> della tua piattaforma. Se la colonna "stato" a destra dell'indirizzo e-mail interessato indica "Spam", clicca su questa voce e poi su <code className="action">Rispondi al ticket</code>. Lo sblocco dell'indirizzo e-mail non avviene automaticamente. Contatta il supporto tramite il ticket di assistenza rispondendo alle 3 domande poste.<br/>
+  <Tab label="MX Plan - OWA">
+    Accedi alla scheda <code className="action">Account email</code> della tua piattaforma. Se la colonna "stato" a destra dell'indirizzo e-mail interessato indica "Spam", clicca su questa dicitura, poi su <code className="action">Rispondi al ticket</code>. L'indirizzo e-mail non si sblocca automaticamente. Contatta il supporto tramite il ticket di assistenza rispondendo alle 3 domande poste.<br/>
 
-Passa allo [step 3](#step3) della guida.
+    Passa alla [fase 3](#step3) della guida.
     
     <img className="thumbnail" alt="Colonna stato Spam nella scheda Account email MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan - RoundCube">
-    Se il blocco riguarda un indirizzo e-mail MX Plan con la webmail **RoundCube**, non è presente alcun ticket di assistenza. Assicurati di consultare lo [step 1](#step1) di questa guida prima di seguire le istruzioni seguenti.
-    
-    Accedi alla scheda <code className="action">Email</code> della tua piattaforma. Se la colonna "Bloccato per SPAM" indica "Sì", clicca su questa voce e poi su <code className="action">Modifica la password</code>. Il tuo indirizzo e-mail è ora sbloccato, non è necessario seguire lo [step 3](#step3).
+  <Tab label="Zimbra">
+    Questa scheda si applica a tutti gli indirizzi che utilizzano la tecnologia **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** e **Zimbra Pro**. La procedura di sblocco è identica per queste tre offerte.
+
+    Al momento del blocco, **non viene generato automaticamente alcun ticket di assistenza** e l'indirizzo non è più accessibile (webmail Zimbra e invio disattivati).
+
+    Per far sbloccare l'indirizzo:
+
+    1. Effettua le verifiche descritte nella [fase 1](#step1), a partire dagli elementi accessibili (postazioni utenti, software di terze parti, reindirizzamenti visibili da un altro accesso).
+    2. **Crea manualmente un ticket di assistenza** dal tuo Spazio Cliente OVHcloud.
+    3. Nel ticket, specifica:
+        - L'indirizzo e-mail interessato dal blocco;
+        - Il servizio associato (MX Plan, Zimbra Starter o Zimbra Pro) e il suo identificativo;
+        - Le azioni correttive già intraprese (analisi antivirus, eliminazione di mittenti non legittimi, aggiunta del filtro SPAM/DCE, ecc.).
+
+    Una volta elaborato il ticket dal supporto, l'indirizzo viene sbloccato. La [fase 3](#step3) non si applica in questo caso.
+  </Tab>
+  <Tab label="MX Plan - Roundcube">
+    Se il blocco riguarda un indirizzo e-mail MX Plan con il webmail **Roundcube**, non viene generato alcun ticket di assistenza.
+
+    Prima di qualsiasi azione, è **indispensabile individuare la causa del blocco** eseguendo le verifiche della [fase 1](#step1) (postazioni potenzialmente infette, software di terze parti, reindirizzamenti, filtri, risposte automatiche).
+
+    Nella scheda <code className="action">Email</code> della tua piattaforma, la colonna "Bloccato per SPAM" indica "Sì" quando l'indirizzo è bloccato.
     
     <img className="thumbnail" alt="Colonna Bloccato per SPAM nella scheda Email MX Plan Roundcube" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-04.png" loading="lazy" />
     
     :::warning
-    In rari casi, la colonna "Bloccato per SPAM" può indicare "No" nonostante il blocco dell'indirizzo e-mail. Se hai fatto il necessario per mettere in sicurezza l'indirizzo e-mail, la soluzione resta la stessa indicata sopra.
+    **Non sbloccare l'indirizzo autonomamente.** Anche se l'interfaccia lo consente, devi **contattare il supporto OVHcloud** creando un ticket di assistenza dal tuo Spazio Cliente, affinché l'origine del blocco venga verificata prima di qualsiasi sblocco. Uno sblocco prematuro, senza trattare la causa, espone a una recidiva immediata.
 
     :::
+
+    :::warning
+    Il **cambio di password non è sistematico**. Deve essere effettuato **solo se si sospetta una compromissione** (postazione infetta, credenziali divulgate o condivise, accesso non autorizzato). Un cambio di password senza una causa identificata maschera il vero problema ed espone a una recidiva.
+
+    :::
+
+    :::info
+    In rari casi, la colonna "Bloccato per SPAM" può indicare "No" anche se l'indirizzo e-mail è bloccato. La procedura resta la stessa: contatta il supporto OVHcloud.
+
+    :::
+
+    Per far sbloccare l'indirizzo, **crea manualmente un ticket di assistenza** dal tuo Spazio Cliente OVHcloud specificando:
+
+    - L'indirizzo e-mail interessato dal blocco;
+    - Il servizio MX Plan associato e il suo identificativo;
+    - Le azioni correttive già intraprese (analisi antivirus, eliminazione di mittenti non legittimi, aggiunta del filtro SPAM/DCE, ecc.).
+
+    Una volta elaborato il ticket dal supporto, l'indirizzo viene sbloccato. La [fase 3](#step3) non si applica in questo caso.
 
   </Tab>
 </Tabs>
 
 
-### Step 3: accedi al ticket di assistenza <a name="step3"></a>
+### Fase 3: accedere al ticket di assistenza <a name="step3"></a>
 
-In seguito allo step 2, verrai reindirizzato verso la finestra "Le mie richieste di assistenza". Clicca sul pulsante <code className="action">...</code> a destra del ticket con oggetto "Account locked for spam.", poi clicca su <code className="action">Mostra dettagli</code>.
+Dopo la fase 2, vieni reindirizzato alla finestra "Le mie richieste di assistenza". Clicca sul pulsante <code className="action">...</code> a destra del ticket con oggetto "Account locked for spam." e poi su <code className="action">Visualizza dettagli</code>.
 
 <img className="thumbnail" alt="Finestra Le mie richieste di assistenza con il ticket di blocco spam" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-02.png" loading="lazy" />
 
-Troverai così l'e-mail che ti è stata inviata, la quale genera un ticket di assistenza presso il supporto.
+In questo modo ritrovi l'e-mail che ti è stata inviata: questa genera un ticket di assistenza presso il supporto.
 
-Il ticket di assistenza si presenta nel modo seguente:
+Il ticket di assistenza si presenta come segue:
 
->
 > Gentile Cliente,
 >
-> Il nostro sistema ha rilevato che l’indirizzo **youraddress@domain.com** ospitato sui nostri sistemi sotto il servizio **servicename** è fonte di invio di messaggi indesiderati (spam).
-> Pertanto, l’invio di email è stato temporaneamente disattivato.
+> Il nostro sistema ha rilevato che l'indirizzo **youraddress@example.com** ospitato sui nostri sistemi sotto il servizio **servicename** è all'origine dell'invio di e-mail indesiderate (spam).
+> L'invio di e-mail è stato quindi temporaneamente disattivato.
 >
-> Abbiamo rilevato **X** messaggio/i sospetto/i.
+> Abbiamo attualmente rilevato **X** messaggio/i sospetto/i.
 >
-> Per consentirci di riattivare l’invio di email per l’indirizzo: **address@domain.com**,
-> rispondi a questa email fornendo le seguenti informazioni:
+> Per aiutarci a riattivare l'invio di e-mail per l'indirizzo: **address@example.com**,
+> rispondi a questa e-mail completando le seguenti domande:
 >
-> - Sei tu il mittente dell’email in questione (vedi l’intestazione qui di seguito)?
+> - Sei il mittente dell'e-mail in questione (consulta l'intestazione qui sotto)?
 >
-> - Disponi di una regola di reindirizzamento verso un altro indirizzo email?
+> - Hai una regola di reindirizzamento verso un altro indirizzo e-mail?
 >
-> - Hai risposto a un messaggio Spam?
+> - Hai risposto a uno Spam?
 >
-> Queste risposte ci consentiranno di riattivare rapidamente il tuo account.
-> <br/>
-> <br/>
->
+> Queste risposte ci aiuteranno a riattivare rapidamente il tuo account.
 
-A completamento di questo messaggio, ti è stato trasmesso un campione di intestazioni delle e-mail inviate.
+A seguito di questo messaggio, ti è stato inviato un campione di intestazioni delle e-mail inviate.
 
 Queste intestazioni permettono di determinare il percorso e l'origine delle e-mail inviate.
 
 :::info
-Una volta che il tuo ticket è stato trattato dal supporto clienti e il tuo indirizzo e-mail è stato sbloccato, modifica la password dell'indirizzo e-mail, assicurandoti che sia sufficientemente robusta. Puoi utilizzare lo [strumento di creazione di password sicure](https://www.cnil.fr/fr/generer-un-mot-de-passe-solide) della CNIL. Puoi anche consultare [I consigli della CNIL per una buona password](https://www.cnil.fr/fr/les-conseils-de-la-cnil-pour-un-bon-mot-de-passe).
+Una volta che il tuo ticket è stato elaborato dal supporto clienti e il tuo indirizzo e-mail è stato sbloccato, procedi a un **cambio di password solo se si sospetta una compromissione** alla luce delle verifiche effettuate nella [fase 1](#step1) (postazione infetta, credenziali condivise o divulgate, accesso non autorizzato). Il cambio di password **non è sistematico**.
+
+Se è necessaria una nuova password, assicurati che sia sufficientemente robusta utilizzando una combinazione di caratteri maiuscoli e minuscoli, numeri e caratteri speciali, ed evitando termini facilmente riconducibili a te (date, nomi, parole comuni).
 
 :::
 
 
 ## Per saperne di più
 
-Per prestazioni specializzate (referenziamento, sviluppo, ecc.), contatta i [partner OVHcloud](https://partner.ovhcloud.com/it/directory/).
+Per gestire gli alias e i reindirizzamenti del tuo indirizzo e-mail, consulta la guida [Utilizzare gli alias e i reindirizzamenti e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
-Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, consulta le nostre [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
+Per consultare i tuoi filtri e le tue risposte automatiche dal webmail, consulta le guide [Utilizzare il proprio indirizzo e-mail dal webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) e [Utilizzare il webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Per servizi specializzati (posizionamento sui motori di ricerca, sviluppo, ecc.), contatta i [partner OVHcloud](https://partner.ovhcloud.com/it/directory/).
+
+Per assistenza nell'utilizzo e nella configurazione delle tue soluzioni OVHcloud, consulta le nostre [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
+
+Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/it).

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ dotyczący rozwiązania Zimbra OVHcloud
 description: Poszukaj odpowiedzi na pytania dotyczące migracji do Zimbry w ofercie MX Plan OVHcloud
-lastUpdated: 2025-12-05
+lastUpdated: 2026-05-28
 ---
 
 
@@ -43,6 +43,52 @@ Występują różnice w funkcjonalności między rozwiązaniem Zimbra używanym 
 
 
 Przewodnik dotyczący korzystania z usługi Zimbra jest już dostępny pod adresem [ten adres](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</details>
+
+
+<details>
+
+<summary>Nie mogę już uzyskać dostępu do mojego konta e-mail Zimbra i nie rozumiem dlaczego: co powinienem zrobić?</summary>
+
+
+Jeśli zauważysz całkowitą utratę dostępu do swojego konta e-mail Zimbra (odmowa logowania do webmaila Zimbra, zawieszone wysyłanie i odbieranie wiadomości, dane uwierzytelniające pozornie poprawne), najczęstszą przyczyną jest **automatyczne zablokowanie adresu z powodu spamu**.
+
+Środek ten dotyczy wszystkich trzech ofert Zimbra:
+
+- **MX Plan - Zimbra**
+- **Zimbra Starter**
+- **Zimbra Pro**
+
+**Jak rozpoznać ten przypadek:**
+
+- Dostęp do webmaila Zimbra jest całkowicie zawieszony (a nie tylko wysyłanie).
+- W Panelu klienta OVHcloud nie zostało automatycznie wygenerowane żadne zgłoszenie do działu wsparcia, w przeciwieństwie do innych technologii e-mail.
+- Na koncie mogła zostać niedawno wykryta nietypowa aktywność wysyłania (masowa wysyłka, podejrzana treść, potencjalnie zainfekowana stacja robocza użytkownika, naruszone dane uwierzytelniające, przekierowanie na złośliwy adres).
+
+**Dlaczego nie otrzymujesz jasnego powiadomienia:**
+
+W przypadku kont Zimbra blokada antyspamowa zawiesza dostęp do całego konta i nie wyzwala automatycznego zgłoszenia do wsparcia. Klient może zatem zauważyć utratę dostępu, nie otrzymując natychmiastowego wyjaśnienia.
+
+**Co należy zrobić?**
+
+1. Zapoznaj się z przewodnikiem ["Co zrobić, gdy Twój adres e-mail jest zablokowany z powodu spamu"](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam) i wykonaj sprawdzenia opisane w kroku 1 (stacja robocza, oprogramowanie zewnętrzne, przekierowania, filtry, automatyczne odpowiedzi) na podstawie elementów wciąż dostępnych.
+2. **Utwórz ręcznie zgłoszenie do działu wsparcia** z poziomu Panelu klienta OVHcloud. W zgłoszeniu wskaż:
+    - Adres e-mail, którego dotyczy zgłoszenie;
+    - Powiązaną usługę (MX Plan, Zimbra Starter lub Zimbra Pro) oraz jej identyfikator;
+    - Działania naprawcze, które zostały już podjęte.
+3. Po przetworzeniu zgłoszenia przez dział wsparcia Twój adres zostanie odblokowany, a dostęp do webmaila Zimbra przywrócony.
+
+:::info
+**Inne możliwe przyczyny utraty dostępu** (do wykluczenia przed skontaktowaniem się ze wsparciem lub po nim):
+
+- Hasło niedawno zmienione (przez Ciebie lub przez administratora platformy).
+- Usługa aktualnie objęta zawieszeniem administracyjnym (niezapłacona faktura, rezygnacja, koniec umowy).
+- Niedawno przeprowadzona migracja usługi (sprawdź wszelkie e-maile z powiadomieniami wysyłane 2 tygodnie, a następnie 1 dzień przed migracją).
+- Jednorazowy incydent infrastrukturalny: sprawdź [status usług OVHcloud](https://status.ovhcloud.com).
+
+:::
+
 
 </details>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
-title: Co zrobić w przypadku konta zablokowanego z powodu spamu?
-description: Dowiedz się, jak zareagować, gdy Twój adres e-mail został zablokowany z powodu spamu
-lastUpdated: 2026-03-05
+title: Co zrobić, gdy Twój adres e-mail jest zablokowany z powodu spamu
+description: "Odblokuj adres e-mail zablokowany z powodu spamu: zidentyfikuj przyczynę podejrzanej aktywności, usuń ją i skontaktuj się z pomocą techniczną OVHcloud."
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -9,15 +9,17 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Wprowadzenie
 
-Gdy Twój adres e-mail zostaje zablokowany z powodu spamu, oznacza to, że podczas wysyłania e-maili z tego adresu wykryto podejrzaną aktywność. W takiej sytuacji nie możesz już wysyłać e-maili z tego adresu. Musisz wówczas zrozumieć, dlaczego wykryto podejrzaną aktywność, i podjąć działania, aby zapobiec powtórzeniu się tej sytuacji.
+Gdy Twój adres e-mail zostaje zablokowany z powodu spamu, oznacza to, że podczas wysyłania wiadomości z tego adresu wykryto podejrzaną aktywność. W takiej sytuacji nie możesz już wysyłać e-maili z tego adresu. Musisz zatem zrozumieć, dlaczego wykryto podejrzaną aktywność, i podjąć działania, aby zapobiec powtórzeniu się tej sytuacji.
 
-**Dowiedz się, jak zareagować, gdy Twój adres e-mail zostaje zablokowany z powodu spamu.**
+**Dowiedz się, jak postępować, gdy Twój adres zostaje zablokowany z powodu spamu.**
 
 ## Wymagania początkowe
 
 - Posiadanie [usługi e-mail OVHcloud](https://www.ovhcloud.com/pl/emails/).
+- Zalogowanie się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>.
 
 {/* CP-NAV-START:web-mx-plan */}
+{/* CP-NAV-START:web-zimbra */}
 {/* CP-NAV-START:web-email-pro */}
 {/* CP-NAV-START:web-exchange */}
 ---
@@ -27,159 +29,223 @@ Gdy Twój adres e-mail zostaje zablokowany z powodu spamu, oznacza to, że podcz
 **MX Plan:**
 
 - **Link bezpośredni:** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Wybierz usługę MX Plan
+- **Aby uzyskać dostęp do Twoich usług:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Wybierz Twoją usługę MX Plan
+
+**Zimbra (Starter / Pro):**
+
+- **Link bezpośredni:** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
+- **Aby uzyskać dostęp do Twoich usług:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Wybierz Twoją usługę Zimbra
 
 **E-mail Pro:**
 
 - **Link bezpośredni:** <ManagerLink to="/#/web/email_pro">E-mail Pro</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">E-mail Pro</code> > Wybierz platformę
+- **Aby uzyskać dostęp do Twoich usług:** <code className="action">Web Cloud</code> > <code className="action">E-mail Pro</code> > Wybierz Twoją platformę
 
 **Exchange:**
 
 - **Link bezpośredni:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Wybierz platformę
+- **Aby uzyskać dostęp do Twoich usług:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Wybierz Twoją platformę
 
 ---
 {/* CP-NAV-END:web-exchange */}
 {/* CP-NAV-END:web-email-pro */}
+{/* CP-NAV-END:web-zimbra */}
 {/* CP-NAV-END:web-mx-plan */}
 
 ## W praktyce <a name="instructions"></a>
 
-Zanim przejdziesz dalej i jeśli blokada dotyczy adresu e-mail typu MX Plan, zidentyfikuj technologię e-mail wykorzystywaną przez Twoją usługę, aby postępować zgodnie z właściwą procedurą odblokowania.
+Zanim przejdziesz dalej, jeśli blokada dotyczy adresu e-mail w usłudze MX Plan, zidentyfikuj technologię e-mail wykorzystywaną przez Twoją usługę, aby postępować zgodnie z właściwą procedurą odblokowania. W przypadku usług **Zimbra Starter** i **Zimbra Pro** przejdź bezpośrednio do zakładki **Zimbra** w kroku 2, nie pomijając kontroli wymienionych w kroku 1.
 
 :::info
-**Identyfikacja technologii e-mail usługi MX Plan.**
+**Zidentyfikuj technologię e-mail Twojej usługi MX Plan.**
 
-W zależności od daty aktywacji usługi MX Plan lub ostatniej migracji, powiązana technologia e-mail może się różnić. Wersja ta jest charakteryzowana przez interfejs poczty webmail. Aby ją zidentyfikować:
+W zależności od daty aktywacji Twojej usługi MX Plan lub po ostatniej migracji, powiązana technologia e-mail może się różnić. Wersję tę można rozpoznać po interfejsie webmail. Aby ją zidentyfikować:
 
-- W zakładce <code className="action">Informacje ogólne</code> sprawdź technologię wskazaną przy pozycji **Webmail** w sekcji <code className="action">Abonament</code>.
+- W zakładce <code className="action">Informacje ogólne</code> sprawdź wykorzystywaną technologię pod oznaczeniem **Webmail** w sekcji <code className="action">Abonament</code>.
 
-<img className="thumbnail" alt="Identyfikacja technologii e-mail w Panelu klienta MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
+<img className="thumbnail" alt="Identyfikacja technologii e-mail w Panelu klienta usługi MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
 
-- Jeśli wyświetlona technologia to **RoundCube**, postępuj zgodnie z instrukcjami z zakładki **MX Plan - RoundCube**.
-- Jeśli wyświetlona technologia to **OWA** lub **Zimbra**, postępuj zgodnie z instrukcjami z zakładki **MX Plan - OWA / Zimbra**.
+- Jeśli wyświetlana technologia to **Roundcube**, postępuj zgodnie z instrukcjami w zakładce **MX Plan - Roundcube**.
+- Jeśli wyświetlana technologia to **OWA** (Outlook Web App), postępuj zgodnie z instrukcjami w zakładce **MX Plan - OWA**.
+- Jeśli wyświetlana technologia to **Zimbra**, postępuj zgodnie z instrukcjami w zakładce **Zimbra** (procedura jest wspólna dla MX Plan - Zimbra, Zimbra Starter i Zimbra Pro).
 
 :::
 
 
-### Etap 1: dlaczego Twój adres e-mail jest zablokowany z powodu spamu? <a name="step1"></a>
+### Etap 1: Zrozum i usuń przyczynę blokady <a name="step1"></a>
 
-Gdy podczas wysyłania e-maili zostanie wykryta podejrzana aktywność, dany adres zostaje automatycznie zablokowany. W takiej sytuacji nie możesz już wysyłać e-maili z tego adresu.
+Gdy podczas wysyłania wiadomości wykryta zostanie podejrzana aktywność, dany adres zostaje automatycznie zablokowany. W takiej sytuacji nie możesz już wysyłać e-maili z tego adresu.
 
 :::warning
 "Podejrzana aktywność" oznacza, że:
 
-- Serwer antyspamowy, który skanuje e-maile przy wysyłaniu, stwierdził, że jeden lub więcej elementów e-maila jest uznawanych za podejrzane i może stanowić spam.
-- Częstotliwość wysyłki i liczba odbiorców są zbyt duże, co sprawia, że wysyłka jest traktowana jako spamming. Do masowej wysyłki e-maili konieczne jest korzystanie z usługi listy mailingowej, a nie standardowego adresu e-mail.
+- Serwer antyspamowy, który skanuje e-maile w trakcie wysyłania, stwierdził, że jeden lub kilka elementów wiadomości jest uznawanych za podejrzane i może stanowić spam.
+- Częstotliwość wysyłania oraz liczba odbiorców są zbyt wysokie i przyczyniają się do tego, że aktywność jest uznawana za spamowanie. Aby przeprowadzać masową wysyłkę wiadomości, należy korzystać z usługi listy mailingowej, a nie ze standardowego adresu e-mail.
 
-Dokładne przyczyny blokady nie mogą być ujawnione, aby uniknąć prób obejścia systemu wykrywania spamu. Aby przetestować treść e-maila, możesz skorzystać z narzędzia zewnętrznego wobec OVHcloud, takiego jak [Mailtester](https://www.mail-tester.com/).
+Dokładne przyczyny blokady nie mogą zostać ujawnione, aby zapobiec próbom obejścia systemu wykrywania spamu. Aby przetestować treść e-maila, możesz skorzystać z narzędzia zewnętrznego wobec OVHcloud, takiego jak [Mailtester](https://www.mail-tester.com/).
 
 :::
 
 
-Przede wszystkim upewnij się u użytkownika(-ów) zablokowanego adresu e-mail, że nie jest (nie są) on(i) bezpośrednio odpowiedzialny(-i) za blokadę, w wyniku nietypowego korzystania z adresu e-mail (na przykład w wyniku masowej wysyłki e-maili). Jeśli tak jest, należy poprawić sytuację przed odblokowaniem adresu.
+Przede wszystkim sprawdź wraz z użytkownikiem (lub użytkownikami) zablokowanego adresu e-mail, czy nie są oni bezpośrednio odpowiedzialni za blokadę w wyniku nietypowego korzystania z adresu e-mail (na przykład masowa wysyłka wiadomości). Jeśli tak jest, musisz naprawić sytuację przed odblokowaniem adresu.
 
-Jeśli podejrzana aktywność wykryta przez filtr antyspamowy nie została zainicjowana przez uprawnionego(-ych) użytkownika(-ów) adresu e-mail, podejmij następujące działania:
+Jeśli podejrzana aktywność wykryta przez system antyspamowy nie została zainicjowana przez prawowitego użytkownika (lub użytkowników) adresu e-mail, podejmij następujące działania:
 
-- Przeprowadź analizę antywirusową każdego urządzenia korzystającego ze zablokowanego adresu e-mail i zastosuj odpowiednie poprawki, jeśli urządzenia te są zainfekowane.
+- Wykonaj skanowanie antywirusowe na każdym urządzeniu, które korzysta z adresu e-mail zablokowanego z powodu spamu, i zastosuj poprawkę, jeśli któreś jest zainfekowane.
 
-- Sprawdź wszystkie programy wykorzystujące dane logowania zablokowanego adresu e-mail (np. faks, oprogramowanie biznesowe, program pocztowy).
+- Sprawdź całe oprogramowanie korzystające z danych logowania adresu e-mail zablokowanego z powodu spamu (na przykład: faks, oprogramowanie biznesowe, klient poczty).
 
-- Sprawdź przekierowania ustawione na zablokowanym adresie e-mail.
+- Sprawdź przekierowania zastosowane do adresu e-mail zablokowanego z powodu spamu.
 
-- Sprawdź filtry zastosowane na zablokowanym adresie e-mail, zarówno w programie pocztowym, jak i w poczcie webmail.
+- Sprawdź filtry zastosowane do adresu e-mail zablokowanego z powodu spamu, w kliencie poczty lub w webmail.
 
-- Sprawdź automatyczne odpowiedzi skonfigurowane na zablokowanym adresie e-mail, zarówno w programie pocztowym, jak i w poczcie webmail.
+- Sprawdź autorespondery skonfigurowane dla adresu e-mail zablokowanego z powodu spamu, w kliencie poczty lub w webmail.
 
-### Etap 2: sprawdzenie statusu adresu e-mail i uzyskanie dostępu do powiązanego zgłoszenia
+:::info
+Filtry, przekierowania i autorespondery skonfigurowane bezpośrednio w webmail (Zimbra, OWA) lub w Twoim kliencie poczty nie są dostępne dla pomocy technicznej OVHcloud: pomoc techniczna nie może ich sprawdzić w Twoim imieniu. Te kontrole musisz wykonać samodzielnie z poziomu webmail lub urządzenia już skonfigurowanego z danym adresem.
+
+:::
+
+:::warning
+Jeśli blokada dotyczy adresu wykorzystującego technologię **Zimbra** (MX Plan - Zimbra, Zimbra Starter lub Zimbra Pro), adres **nie jest już dostępny**: logowanie do webmail Zimbra zostaje zawieszone razem z wysyłaniem e-maili. Filtrów, przekierowań i autoresponderów nie można już zatem sprawdzić z poziomu webmail.
+
+:::
+
+#### Skonfiguruj filtr izolujący wiadomości SPAM / DCE
+
+Aby zmniejszyć ryzyko ponownego wystąpienia blokady po odblokowaniu, zalecamy dodanie filtra na adresie e-mail:
+
+- Filtr musi **izolować** e-maile, których temat zawiera oznaczenia **"SPAM"** lub **"DCE"** (*Dirty Commercial Email*), na przykład poprzez przenoszenie ich do dedykowanego folderu. **Nie usuwaj ich automatycznie**: usunięcie spowodowałoby utratę ewentualnych fałszywych alarmów (legalne wiadomości błędnie oznaczone).
+- **Zachowaj** istniejące **reguły przekierowań**: nie usuwaj ich podczas dodawania filtra.
+
+Filtr ten konfiguruje się z poziomu webmail lub klienta poczty.
+
+### Etap 2: Sprawdź status i uzyskaj dostęp do zgłoszenia
 
 Wybierz odpowiednią usługę e-mail w poniższych zakładkach:
 
 <Tabs>
   <Tab label="Exchange">
-    Przejdź do zakładki <code className="action">Konta e-mail</code> Twojej platformy. Jeśli w kolumnie "status" danego adresu e-mail widnieje "zablokowany", kliknij <code className="action">...</code> po prawej stronie konta, a następnie <code className="action">Odblokuj</code>. Odblokowanie adresu e-mail nie odbywa się automatycznie. Skontaktuj się z pomocą techniczną za pośrednictwem zgłoszenia, odpowiadając na 3 zadane pytania.<br/>
+    Przejdź do zakładki <code className="action">Konta e-mail</code> Twojej platformy. Jeśli w kolumnie "Status" danego adresu e-mail widnieje "Zablokowany", kliknij <code className="action">...</code> po prawej stronie konta, a następnie <code className="action">Odblokuj</code>. Odblokowanie adresu e-mail nie odbywa się automatycznie. Skontaktuj się z pomocą techniczną za pośrednictwem zgłoszenia, odpowiadając na 3 zadane pytania.<br/>
 
-Przejdź do [etapu 3](#step3) przewodnika.
+    Przejdź do [etapu 3](#step3) tego przewodnika.
     
-    <img className="thumbnail" alt="Kolumna status zablokowany w zakładce Konta e-mail Exchange" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Kolumna Status z wartością Zablokowany w zakładce Konta e-mail dla Exchange" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-01.png" loading="lazy" />
   </Tab>
   <Tab label="E-mail Pro">
-    Przejdź do zakładki <code className="action">Konta e-mail</code> Twojej platformy. Jeśli w kolumnie "status" po prawej stronie danego adresu e-mail widnieje "Spam", kliknij tę pozycję, a następnie <code className="action">Odpowiedz na zgłoszenie</code>. Odblokowanie adresu e-mail nie odbywa się automatycznie. Skontaktuj się z pomocą techniczną za pośrednictwem zgłoszenia, odpowiadając na 3 zadane pytania. <br/>
+    Przejdź do zakładki <code className="action">Konta e-mail</code> Twojej platformy. Jeśli w kolumnie "Status" po prawej stronie danego adresu e-mail widnieje "Spam", kliknij tę pozycję, a następnie <code className="action">Odpowiedz na zgłoszenie</code>. Odblokowanie adresu e-mail nie odbywa się automatycznie. Skontaktuj się z pomocą techniczną za pośrednictwem zgłoszenia, odpowiadając na 3 zadane pytania. <br/>
 
-Przejdź do [etapu 3](#step3) przewodnika.
+    Przejdź do [etapu 3](#step3) tego przewodnika.
     
-    <img className="thumbnail" alt="Kolumna status Spam w zakładce Konta e-mail E-mail Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
+    <img className="thumbnail" alt="Kolumna Status z wartością Spam w zakładce Konta e-mail dla E-mail Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan - OWA / Zimbra">
-    Przejdź do zakładki <code className="action">Konta e-mail</code> Twojej platformy. Jeśli w kolumnie "status" po prawej stronie danego adresu e-mail widnieje "Spam", kliknij tę pozycję, a następnie <code className="action">Odpowiedz na zgłoszenie</code>. Odblokowanie adresu e-mail nie odbywa się automatycznie. Skontaktuj się z pomocą techniczną za pośrednictwem zgłoszenia, odpowiadając na 3 zadane pytania.<br/>
+  <Tab label="MX Plan - OWA">
+    Przejdź do zakładki <code className="action">Konta e-mail</code> Twojej platformy. Jeśli w kolumnie "Status" po prawej stronie danego adresu e-mail widnieje "Spam", kliknij tę pozycję, a następnie <code className="action">Odpowiedz na zgłoszenie</code>. Odblokowanie adresu e-mail nie odbywa się automatycznie. Skontaktuj się z pomocą techniczną za pośrednictwem zgłoszenia, odpowiadając na 3 zadane pytania.<br/>
 
-Przejdź do [etapu 3](#step3) przewodnika.
+    Przejdź do [etapu 3](#step3) tego przewodnika.
     
-    <img className="thumbnail" alt="Kolumna status Spam w zakładce Konta e-mail MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
+    <img className="thumbnail" alt="Kolumna Status z wartością Spam w zakładce Konta e-mail dla MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan - RoundCube">
-    Jeśli blokada dotyczy adresu e-mail MX Plan z pocztą webmail **RoundCube**, nie ma zgłoszenia do pomocy technicznej. Przed wykonaniem poniższych instrukcji zapoznaj się z [etapem 1](#step1) tego przewodnika.
+  <Tab label="Zimbra">
+    Ta zakładka dotyczy wszystkich adresów wykorzystujących technologię **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** i **Zimbra Pro**. Procedura odblokowania jest identyczna dla tych trzech usług.
+
+    Gdy blokada zostaje zastosowana, **żadne zgłoszenie pomocy technicznej nie jest generowane automatycznie**, a adres nie jest już dostępny (zarówno webmail Zimbra, jak i wysyłanie e-maili są wyłączone).
+
+    Aby uzyskać odblokowanie adresu:
+
+    1. Wykonaj kontrole opisane w [etapie 1](#step1) w oparciu o elementy, do których masz dostęp (urządzenia użytkowników, oprogramowanie zewnętrzne, przekierowania widoczne z innego dostępu).
+    2. **Utwórz ręcznie zgłoszenie pomocy technicznej** z poziomu Twojego Panelu klienta OVHcloud.
+    3. W zgłoszeniu podaj:
+        - Adres e-mail, którego dotyczy blokada;
+        - Powiązaną usługę (MX Plan, Zimbra Starter lub Zimbra Pro) oraz jej identyfikator;
+        - Działania naprawcze już podjęte (skanowanie antywirusowe, usunięcie nielegalnych nadawców, dodanie filtra SPAM/DCE itd.).
+
+    Gdy zgłoszenie zostanie przetworzone przez pomoc techniczną, adres zostaje odblokowany. [Etap 3](#step3) nie ma w tym przypadku zastosowania.
+  </Tab>
+  <Tab label="MX Plan - Roundcube">
+    Jeśli blokada dotyczy adresu e-mail MX Plan z webmail **Roundcube**, żadne zgłoszenie pomocy technicznej nie jest generowane.
+
+    Przed podjęciem jakichkolwiek działań **konieczne jest zidentyfikowanie przyczyny blokady** poprzez wykonanie kontroli z [etapu 1](#step1) (potencjalnie zainfekowane urządzenia, oprogramowanie zewnętrzne, przekierowania, filtry, autorespondery).
+
+    W zakładce <code className="action">E-maile</code> Twojej platformy, w kolumnie "Zablokowane ze względu na SPAM" widnieje "Tak", gdy adres jest zablokowany.
     
-    Przejdź do zakładki <code className="action">E-maile</code> Twojej platformy. Jeśli w kolumnie "Zablokowane ze względu na SPAM" widnieje "Tak", kliknij tę pozycję, a następnie <code className="action">Zmień hasło</code>. Twój adres e-mail jest teraz odblokowany i nie musisz wykonywać [etapu 3](#step3).
-    
-    <img className="thumbnail" alt="Kolumna Zablokowane ze względu na SPAM w zakładce E-maile MX Plan RoundCube" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-04.png" loading="lazy" />
+    <img className="thumbnail" alt="Kolumna Zablokowane ze względu na SPAM w zakładce E-maile dla MX Plan Roundcube" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-04.png" loading="lazy" />
     
     :::warning
-    W rzadkich przypadkach kolumna "Zablokowane ze względu na SPAM" może wskazywać "Nie", mimo że adres e-mail jest zablokowany. Jeśli podjąłeś niezbędne działania w celu zabezpieczenia adresu e-mail, rozwiązanie pozostaje takie samo jak powyżej.
+    **Nie odblokowuj adresu samodzielnie.** Nawet jeśli interfejs na to pozwala, musisz **skontaktować się z pomocą techniczną OVHcloud**, tworząc zgłoszenie z poziomu Twojego Panelu klienta, aby źródło blokady mogło zostać zweryfikowane przed jakimkolwiek odblokowaniem. Przedwczesne odblokowanie, bez usunięcia przyczyny, naraża adres na natychmiastowe powtórzenie się blokady.
 
     :::
+
+    :::warning
+    Zmiana hasła **nie jest systematyczna**. Powinna zostać wykonana **tylko wtedy, gdy istnieje podejrzenie kompromitacji** (zainfekowane urządzenie, wycieknięte lub udostępnione dane logowania, nieautoryzowany dostęp). Zmiana hasła bez zidentyfikowanej przyczyny maskuje rzeczywisty problem i naraża adres na powtórzenie się sytuacji.
+
+    :::
+
+    :::info
+    W rzadkich przypadkach kolumna "Zablokowane ze względu na SPAM" może wskazywać "Nie", mimo że adres e-mail jest zablokowany. Procedura pozostaje taka sama: skontaktuj się z pomocą techniczną OVHcloud.
+
+    :::
+
+    Aby uzyskać odblokowanie adresu, **utwórz ręcznie zgłoszenie pomocy technicznej** z poziomu Twojego Panelu klienta OVHcloud, podając:
+
+    - Adres e-mail, którego dotyczy blokada;
+    - Powiązaną usługę MX Plan oraz jej identyfikator;
+    - Działania naprawcze już podjęte (skanowanie antywirusowe, usunięcie nielegalnych nadawców, dodanie filtra SPAM/DCE itd.).
+
+    Gdy zgłoszenie zostanie przetworzone przez pomoc techniczną, adres zostaje odblokowany. [Etap 3](#step3) nie ma w tym przypadku zastosowania.
 
   </Tab>
 </Tabs>
 
 
-### Etap 3: uzyskanie dostępu do zgłoszenia <a name="step3"></a>
+### Etap 3: Uzyskaj dostęp do zgłoszenia pomocy technicznej <a name="step3"></a>
 
-Po wykonaniu etapu 2 zostaniesz przekierowany do okna "Moje zgłoszenia serwisowe". Kliknij przycisk <code className="action">...</code> po prawej stronie zgłoszenia o temacie "Account locked for spam.", a następnie kliknij <code className="action">Pokaż szczegóły</code>.
+Po wykonaniu etapu 2 zostaniesz przekierowany do okna "Moje zgłoszenia". Kliknij przycisk <code className="action">...</code> po prawej stronie zgłoszenia o temacie "Account locked for spam.", a następnie kliknij <code className="action">Więcej informacji</code>.
 
-<img className="thumbnail" alt="Okno Moje zgłoszenia serwisowe ze zgłoszeniem dotyczącym blokady z powodu spamu" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-02.png" loading="lazy" />
+<img className="thumbnail" alt="Okno Moje zgłoszenia ze zgłoszeniem dotyczącym blokady za spam" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-02.png" loading="lazy" />
 
-Znajdziesz tam e-mail, który został do Ciebie wysłany. Wiadomość ta generuje zgłoszenie do pomocy technicznej.
+W tym miejscu znajdziesz wiadomość e-mail, która została do Ciebie wysłana i która generuje zgłoszenie pomocy technicznej.
 
-Zgłoszenie wygląda następująco:
+Treść zgłoszenia pomocy technicznej brzmi następująco:
 
+> Szanowny Kliencie,
 >
-> Drogi Kliencie,
+> Nasz system wykrył, że adres **twojadres@example.com**, hostowany w naszych systemach pod usługą **nazwauslugi**, jest źródłem spamu.
+> Wysyłanie e-maili zostało zatem tymczasowo wyłączone.
 >
-> Nasz system wykrył, że adres **youraddress@domain.com** hostowany w naszych systemach w ramach usługi **servicename** jest wykorzystywany do rozsyłania niechcianych wiadomości (spam).
-> Wysyłanie e-maili zostało więc tymczasowo wyłączone.
+> Obecnie wykryliśmy **X** podejrzanych wiadomości.
 >
-> Na chwilę obecną wykryliśmy następującą liczbę podejrzanych wiadomości: **X**
+> Aby pomóc nam ponownie włączyć wysyłanie dla adresu: **adres@example.com**,
+> prosimy o odpowiedź na tę wiadomość, odpowiadając na następujące pytania:
 >
-> Aby pomóc nam w reaktywowaniu wysyłki e-maili z adresu: **address@domain.com**,
-> odpowiedz na niniejszą wiadomość, załączając wyjaśnienia dotyczące następujących kwestii:
+> - Czy jesteś nadawcą danego e-maila (zobacz poniższy nagłówek)?
 >
-> - Czy jesteś nadawcą tej wiadomości e-mail (patrz nagłówek poniżej)?
->
-> - Czy masz regułę przekierowującą na inny adres e-mail?
+> - Czy masz regułę przekierowania na inny adres e-mail?
 >
 > - Czy odpowiedziałeś na spam?
 >
-> Te odpowiedzi pomogą OVHcloud szybko reaktywować Twoje konto.
-> <br/>
-> <br/>
->
+> Odpowiedzi te pomogą nam szybko ponownie włączyć Twoje konto.
 
-W dalszej części tej wiadomości przekazano próbkę nagłówków wysłanych e-maili.
+Po tej wiadomości udostępniona Ci została próbka nagłówków z wysłanych e-maili.
 
-Nagłówki te pozwalają określić trasę i pochodzenie wysłanych e-maili.
+Nagłówki te pomagają określić trasę i pochodzenie wysłanych e-maili.
 
 :::info
-Po rozpatrzeniu zgłoszenia przez dział pomocy technicznej i odblokowaniu Twojego adresu e-mail zmień hasło do tego adresu, upewniając się, że jest ono wystarczająco silne. Możesz skorzystać z [narzędzia do generowania silnych haseł](https://www.cnil.fr/fr/generer-un-mot-de-passe-solide) udostępnionego przez CNIL. Możesz również zapoznać się z [poradami CNIL dotyczącymi tworzenia dobrego hasła](https://www.cnil.fr/fr/les-conseils-de-la-cnil-pour-un-bon-mot-de-passe).
+Gdy Twoje zgłoszenie zostanie przetworzone przez pomoc techniczną, a Twój adres e-mail zostanie odblokowany, zmień hasło **tylko wtedy, gdy istnieje podejrzenie kompromitacji** na podstawie kontroli przeprowadzonych w [etapie 1](#step1) (zainfekowane urządzenie, udostępnione lub wycieknięte dane logowania, nieautoryzowany dostęp). Zmiana hasła **nie jest systematyczna**.
+
+Jeśli nowe hasło jest potrzebne, upewnij się, że jest ono wystarczająco silne. Skorzystaj z renomowanego generatora haseł i wybierz długie, złożone hasło, które jest unikalne dla tego adresu.
 
 :::
 
 
 ## Sprawdź również
 
-W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj się z [partnerami OVHcloud](https://partner.ovhcloud.com/pl/directory/).
+Aby zarządzać aliasami i przekierowaniami Twojego adresu e-mail, zapoznaj się z przewodnikiem [Korzystanie z aliasów i przekierowań e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
-Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](https://www.ovhcloud.com/pl/support-levels/).
+Aby wyświetlić filtry i autorespondery z poziomu webmail, zapoznaj się z przewodnikami [Korzystanie z adresu e-mail w webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) oraz [Korzystanie z webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+W przypadku usług specjalistycznych (SEO, programowanie itd.) skontaktuj się z [partnerami OVHcloud](https://partner.ovhcloud.com/pl/directory/).
+
+Aby uzyskać pomoc w korzystaniu i konfigurowaniu rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami wsparcia](https://www.ovhcloud.com/pl/support-levels/).
+
+Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/pl).

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ sobre a solução Zimbra OVHcloud
 description: Encontre as questões relativas à migração para Zimbra para a oferta MX Plan da OVHcloud
-lastUpdated: 2025-12-05
+lastUpdated: 2026-05-28
 ---
 
 
@@ -43,6 +43,52 @@ Existem diferenças de funcionalidade entre a solução Zimbra utilizada na ofer
 
 
 Um guia de utilização do Zimbra está desde já disponível em [este endereço](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</details>
+
+
+<details>
+
+<summary>Já não tenho acesso à minha conta de e-mail Zimbra e não compreendo porquê: que fazer?</summary>
+
+
+Se constatar uma perda total de acesso à sua conta de e-mail Zimbra (ligação ao webmail Zimbra recusada, envio e receção suspensos, identificadores aparentemente corretos), a causa mais frequente é um **bloqueio automático do endereço por spam**.
+
+Esta medida aplica-se às três ofertas Zimbra:
+
+- **MX Plan - Zimbra**
+- **Zimbra Starter**
+- **Zimbra Pro**
+
+**Como reconhecer este caso:**
+
+- O acesso ao webmail Zimbra está totalmente suspenso (e não apenas o envio).
+- Nenhum pedido de assistência foi gerado automaticamente na sua área de cliente OVHcloud, contrariamente às outras tecnologias de e-mail.
+- Pode ter sido detetada uma atividade de envio inabitual na conta recentemente (envios massivos, conteúdo suspeito, posto de utilizador potencialmente infetado, identificadores comprometidos, redirecionamento para um endereço malicioso).
+
+**Porque é que não recebo uma notificação clara:**
+
+Para as contas Zimbra, o bloqueio anti-spam suspende a totalidade do acesso à conta e não desencadeia um pedido de assistência automático. O cliente pode assim constatar a perda de acesso sem receber uma explicação imediata.
+
+**Que fazer?**
+
+1. Consulte o guia ["O que fazer no caso de um endereço de e-mail bloqueado por spam?"](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam) e realize as verificações descritas na etapa 1 (posto, software de terceiros, redirecionamentos, filtros, respostas automáticas) a partir dos elementos ainda acessíveis.
+2. **Crie manualmente um pedido de assistência** a partir da sua área de cliente OVHcloud. No pedido, indique:
+    - O endereço de e-mail em causa;
+    - O serviço associado (MX Plan, Zimbra Starter ou Zimbra Pro) e o respetivo identificador;
+    - As ações corretivas já efetuadas.
+3. Assim que o pedido for tratado pelo suporte, o seu endereço é desbloqueado e o acesso ao webmail Zimbra é restabelecido.
+
+:::info
+**Outras causas possíveis de perda de acesso** (a excluir antes ou após o contacto com o suporte):
+
+- Palavra-passe alterada recentemente (por si próprio ou por um administrador da plataforma).
+- Serviço em suspensão administrativa em curso (incumprimento, rescisão, fim de contrato).
+- Migração de serviço efetuada recentemente (verifique os eventuais e-mails de notificação enviados 2 semanas e depois 1 dia antes da migração).
+- Incidente de infraestrutura pontual: consulte o [estado dos serviços OVHcloud](https://status.ovhcloud.com).
+
+:::
+
 
 </details>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
-title: O que fazer no caso de uma conta bloqueada por spam?
-description: Descubra como proceder se o seu endereço tiver sido bloqueado por spam
-lastUpdated: 2026-03-05
+title: O que fazer no caso de um endereço de e-mail bloqueado por spam?
+description: "Desbloqueie um endereço de e-mail bloqueado por spam: identifique a causa da atividade suspeita, corrija-a e contacte o suporte da OVHcloud."
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -9,126 +9,190 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objetivo
 
-Quando o seu endereço de e-mail é bloqueado por spam, isto significa que foi detetada uma atividade suspeita ao nível do envio de e-mails a partir desse endereço. Neste caso, já não pode enviar e-mails a partir deste endereço de e-mail. Nesse caso, é necessário compreender por que razão foi detetada uma atividade suspeita e tomar medidas para evitar que esta situação se repita.
+Quando o seu endereço de e-mail é bloqueado por spam, isto significa que foi detetada uma atividade suspeita no envio de e-mails a partir desse endereço. Nesta situação, deixa de poder enviar e-mails a partir deste endereço de e-mail. Deverá então compreender por que motivo foi detetada uma atividade suspeita e agir para evitar que esta situação se repita.
 
-**Descubra como proceder se o seu endereço tiver sido bloqueado por spam.**
+**Saiba como reagir quando o seu endereço é bloqueado por spam.**
 
 ## Requisitos
 
-- Ter uma [solução de e-mail OVHcloud](https://www.ovhcloud.com/pt/emails/).
+- Dispor de uma [solução de e-mail OVHcloud](https://www.ovhcloud.com/pt/emails/).
+- Ter sessão iniciada na sua <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>.
 
 {/* CP-NAV-START:web-mx-plan */}
+{/* CP-NAV-START:web-zimbra */}
 {/* CP-NAV-START:web-email-pro */}
 {/* CP-NAV-START:web-exchange */}
 ---
 
-### Acesso à Área de Cliente OVHcloud
+### Acesso à área de cliente OVHcloud
 
 **MX Plan:**
 
 - **Ligação direta:** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Selecione o seu serviço MX Plan
+- **Para aceder aos seus serviços:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Selecione o seu serviço MX Plan
 
-**E-mail Pro:**
+**Zimbra (Starter / Pro):**
 
-- **Ligação direta:** <ManagerLink to="/#/web/email_pro">E-mail Pro</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">E-mail Pro</code> > Selecione a sua plataforma
+- **Ligação direta:** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
+- **Para aceder aos seus serviços:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Selecione o seu serviço Zimbra
+
+**Email Pro:**
+
+- **Ligação direta:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
+- **Para aceder aos seus serviços:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Selecione a sua plataforma
 
 **Exchange:**
 
 - **Ligação direta:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Selecione a sua plataforma
+- **Para aceder aos seus serviços:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Selecione a sua plataforma
 
 ---
 {/* CP-NAV-END:web-exchange */}
 {/* CP-NAV-END:web-email-pro */}
+{/* CP-NAV-END:web-zimbra */}
 {/* CP-NAV-END:web-mx-plan */}
 
 ## Instruções <a name="instructions"></a>
 
-Antes de prosseguir, e se o bloqueio afetar um endereço de e-mail do tipo MX Plan, identifique a tecnologia de e-mail utilizada pela sua oferta para seguir o processo de desbloqueio correto.
+Antes de prosseguir, e se o bloqueio disser respeito a um endereço de e-mail do tipo MX Plan, identifique a tecnologia de e-mail utilizada pela sua oferta para seguir o processo de desbloqueio correto. Para as ofertas **Zimbra Starter** e **Zimbra Pro**, dirija-se diretamente ao separador **Zimbra** da etapa 2, sem omitir as verificações da etapa 1.
 
 :::info
 **Identificar a tecnologia de e-mail da sua oferta MX Plan.**
 
-Em função da data de ativação da sua oferta MX Plan ou de uma migração recente, a tecnologia de e-mail associada pode diferir. Esta versão é caracterizada pela interface do seu webmail. Para a identificar:
+Em função da data de ativação da sua oferta MX Plan ou de uma migração recente, a tecnologia de e-mail associada pode diferir. Esta versão é caracterizada pela interface do respetivo webmail. Para a identificar:
 
 - A partir do separador <code className="action">Informações gerais</code>, consulte a tecnologia utilizada sob a menção **Webmail** presente na secção <code className="action">Subscrição</code>.
 
-<img className="thumbnail" alt="Identificar a tecnologia de e-mail na Área de Cliente MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
+<img className="thumbnail" alt="Identificar a tecnologia de e-mail na área de cliente MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
 
-- Se a tecnologia apresentada for **RoundCube**, siga as instruções do separador **MX Plan - RoundCube**.
-- Se a tecnologia apresentada for **OWA** ou **Zimbra**, siga as instruções do separador **MX Plan - OWA / Zimbra**.
+- Se a tecnologia apresentada for **Roundcube**, siga as instruções do separador **MX Plan - Roundcube**.
+- Se a tecnologia apresentada for **OWA** (Outlook Web App), siga as instruções do separador **MX Plan - OWA**.
+- Se a tecnologia apresentada for **Zimbra**, siga as instruções do separador **Zimbra** (procedimento comum a MX Plan - Zimbra, Zimbra Starter e Zimbra Pro).
 
 :::
 
 
-### Etapa 1: por que razão o seu endereço de e-mail foi bloqueado por spam? <a name="step1"></a>
+### Etapa 1: compreender e tratar a causa do bloqueio <a name="step1"></a>
 
-Quando uma atividade suspeita é detetada ao nível do envio dos e-mails, o endereço em causa é automaticamente bloqueado. Neste caso, já não pode enviar e-mails a partir deste endereço de e-mail.
+Quando é detetada uma atividade suspeita no envio dos e-mails, o endereço em causa é automaticamente bloqueado. Nesta situação, deixa de poder enviar e-mails a partir deste endereço de e-mail.
 
 :::warning
 Uma "atividade suspeita" significa que:
 
 - O servidor antispam, que analisa os e-mails no envio, constatou que um ou vários elementos do e-mail são considerados suspeitos e podem constituir um e-mail spam.
-- A frequência de envio e o número de destinatários são demasiado elevados e contribuem para que o envio seja considerado como spamming. Com efeito, para realizar envios massivos, é necessário utilizar um serviço de mailing list e não um endereço de e-mail standard.
+- A frequência de envio e o número de destinatários são demasiado elevados e contribuem para que o envio seja considerado spamming. Com efeito, para realizar envios massivos, é necessário utilizar um serviço de mailing list e não um endereço de e-mail padrão.
 
-Os motivos específicos de um bloqueio não podem ser divulgados para evitar qualquer tentativa de contornar o sistema de deteção de spam. Para testar o conteúdo de um e-mail, pode utilizar uma ferramenta externa à OVHcloud como a [Mailtester](https://www.mail-tester.com/).
+Os motivos específicos de um bloqueio não podem ser divulgados para evitar qualquer tentativa de contornar o sistema de deteção de spam. Para testar o conteúdo de um e-mail, pode utilizar uma ferramenta externa à OVHcloud, como o [Mailtester](https://www.mail-tester.com/).
 
 :::
 
 
-Em primeiro lugar, certifique-se, junto do(s) utilizador(es) do endereço de e-mail bloqueado, de que este(s) não está(ão) diretamente na origem do bloqueio, devido a uma utilização invulgar do endereço de e-mail (por exemplo, após envios massivos de e-mails). Se for o caso, deverá corrigir a situação antes de desbloquear o endereço.
+Antes de mais, certifique-se, junto do(s) utilizador(es) do endereço de e-mail bloqueado, de que este(s) não está(ão) diretamente na origem do bloqueio, na sequência de uma utilização invulgar do endereço de e-mail (por exemplo, após envios massivos de e-mails). Se for o caso, deverá corrigir a situação antes de desbloquear o endereço.
 
 Se a atividade suspeita detetada pelo antispam não tiver sido iniciada pelo(s) utilizador(es) legítimo(s) do endereço de e-mail, tome as seguintes medidas:
 
-- Efetue uma análise antivírus de cada um dos postos que utilizam o endereço de e-mail bloqueado por spam e aplique uma correção caso estes estejam infetados.
+- Efetue uma análise antivírus em cada um dos postos que utilizam o endereço de e-mail bloqueado por spam e aplique uma correção caso estes estejam infetados.
 
-- Verifique todos os softwares que utilizem as credenciais do endereço de e-mail bloqueado por spam (por exemplo: fax, software profissional, software de mensagens).
+- Verifique todos os softwares que utilizem as credenciais do endereço de e-mail bloqueado por spam (por exemplo: fax, software profissional, software de correio eletrónico).
 
 - Verifique os reencaminhamentos aplicados ao endereço de e-mail bloqueado por spam.
 
-- Verifique os filtros aplicados ao endereço de e-mail bloqueado por spam, através de um software de mensagens ou do webmail.
+- Verifique os filtros aplicados ao endereço de e-mail bloqueado por spam, através de um software de correio eletrónico ou do webmail.
 
-- Verifique as respostas automáticas configuradas no endereço de e-mail bloqueado por spam, através de um software de mensagens ou do webmail.
+- Verifique as respostas automáticas configuradas no endereço de e-mail bloqueado por spam, através de um software de correio eletrónico ou do webmail.
 
-### Etapa 2: verificar o estado do endereço de e-mail e aceder ao ticket de assistência associado
+:::info
+Os filtros, reencaminhamentos e respostas automáticas configurados diretamente no webmail (Zimbra, OWA) ou no seu software de correio eletrónico não são acessíveis ao suporte da OVHcloud: este não os pode verificar em sua substituição. Estas verificações devem ser realizadas por si, a partir do webmail ou de um posto já configurado com o endereço.
 
-Selecione a oferta de e-mail correspondente nos seguintes separadores:
+:::
+
+:::warning
+Se o bloqueio disser respeito a um endereço que utiliza a tecnologia **Zimbra** (MX Plan - Zimbra, Zimbra Starter ou Zimbra Pro), o endereço **deixa de estar acessível**: a ligação ao webmail Zimbra é suspensa, para além do envio. Os filtros, reencaminhamentos e respostas automáticas deixam então de ser consultáveis a partir do webmail.
+
+:::
+
+#### Configurar um filtro para isolar as mensagens SPAM / DCE
+
+Para reduzir os riscos de reincidência após o desbloqueio, recomendamos a adição de um filtro do lado do endereço de e-mail:
+
+- O filtro deve **isolar** os e-mails cujo assunto contenha as menções **"SPAM"** ou **"DCE"** (*Dirty Commercial Email*), por exemplo movendo-os para uma pasta dedicada. **Não os elimine automaticamente**: uma eliminação faria perder eventuais falsos positivos (mensagens legítimas marcadas indevidamente).
+- **Conserve**, em contrapartida, as eventuais **regras de reencaminhamento** já existentes: não as elimine ao adicionar o filtro.
+
+Este filtro configura-se a partir do webmail ou de um software de correio eletrónico.
+
+### Etapa 2: verificar o estado e aceder ao ticket de assistência
+
+Selecione a oferta de e-mail em causa nos seguintes separadores:
 
 <Tabs>
   <Tab label="Exchange">
-    Dirija-se ao separador <code className="action">Contas de e-mail</code> da sua plataforma. Se a coluna "Estado" do endereço de e-mail em questão mencionar "bloqueado", clique em <code className="action">...</code> à direita da conta e depois em <code className="action">Desbloquear</code>. O desbloqueio do endereço de e-mail não se faz automaticamente. Contacte o suporte através do ticket de assistência, respondendo às 3 questões colocadas.<br/>
+    Aceda ao separador <code className="action">Contas de e-mail</code> da sua plataforma. Se a coluna "estado" do endereço de e-mail em causa indicar "bloqueado", clique em <code className="action">...</code> à direita da conta e depois em <code className="action">Desbloquear</code>. O endereço de e-mail não é desbloqueado automaticamente. Contacte o suporte através do ticket de assistência, respondendo às 3 questões colocadas.<br/>
 
-Passe à [etapa 3](#step3) do guia.
+    Avance para a [etapa 3](#step3) do guia.
     
-    <img className="thumbnail" alt="Coluna Estado bloqueado no separador Contas de e-mail Exchange" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Coluna estado bloqueado no separador Contas de e-mail Exchange" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-01.png" loading="lazy" />
   </Tab>
-  <Tab label="E-mail Pro">
-    Dirija-se ao separador <code className="action">Contas de e-mail</code> da sua plataforma. Se a coluna "Estado" à direita do endereço de e-mail em questão mencionar "Spam", clique sobre esta indicação e depois em <code className="action">Responder ao ticket</code>. O desbloqueio do endereço de e-mail não se faz automaticamente. Contacte o suporte através do ticket de assistência, respondendo às 3 questões colocadas. <br/>
+  <Tab label="Email Pro">
+    Aceda ao separador <code className="action">Contas de e-mail</code> da sua plataforma. Se a coluna "estado" à direita do endereço de e-mail em causa indicar "Spam", clique nessa menção e depois em <code className="action">Responder ao ticket</code>. O endereço de e-mail não é desbloqueado automaticamente. Contacte o suporte através do ticket de assistência, respondendo às 3 questões colocadas. <br/>
 
-Passe à [etapa 3](#step3) do guia.
+    Avance para a [etapa 3](#step3) do guia.
     
-    <img className="thumbnail" alt="Coluna Estado Spam no separador Contas de e-mail E-mail Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
+    <img className="thumbnail" alt="Coluna estado Spam no separador Contas de e-mail Email Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan - OWA / Zimbra">
-    Dirija-se ao separador <code className="action">Contas de e-mail</code> da sua plataforma. Se a coluna "Estado" à direita do endereço de e-mail em questão mencionar "Spam", clique sobre esta indicação e depois em <code className="action">Responder ao ticket</code>. O desbloqueio do endereço de e-mail não se faz automaticamente. Contacte o suporte através do ticket de assistência, respondendo às 3 questões colocadas.<br/>
+  <Tab label="MX Plan - OWA">
+    Aceda ao separador <code className="action">Contas de e-mail</code> da sua plataforma. Se a coluna "estado" à direita do endereço de e-mail em causa indicar "Spam", clique nessa menção e depois em <code className="action">Responder ao ticket</code>. O endereço de e-mail não é desbloqueado automaticamente. Contacte o suporte através do ticket de assistência, respondendo às 3 questões colocadas.<br/>
 
-Passe à [etapa 3](#step3) do guia.
+    Avance para a [etapa 3](#step3) do guia.
     
-    <img className="thumbnail" alt="Coluna Estado Spam no separador Contas de e-mail MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
+    <img className="thumbnail" alt="Coluna estado Spam no separador Contas de e-mail MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan - RoundCube">
-    Se o bloqueio disser respeito a um endereço de e-mail MX Plan com o webmail **RoundCube**, não existe ticket de assistência. Certifique-se de que consultou a [etapa 1](#step1) deste guia antes de seguir as instruções abaixo.
-    
-    Dirija-se ao separador <code className="action">Emails</code> da sua plataforma. Se a coluna "Bloqueado por SPAM" mencionar "Sim", clique nesta menção e depois em <code className="action">Alterar a palavra-passe</code>. O seu endereço de e-mail está agora desbloqueado. Não precisa de seguir a [etapa 3](#step3).
+  <Tab label="Zimbra">
+    Este separador aplica-se a todos os endereços que utilizam a tecnologia **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** e **Zimbra Pro**. O processo de desbloqueio é idêntico para estas três ofertas.
+
+    No momento do bloqueio, **não é gerado automaticamente nenhum ticket de assistência** e o endereço deixa de estar acessível (webmail Zimbra e envio desativados).
+
+    Para que o endereço seja desbloqueado:
+
+    1. Efetue as verificações descritas na [etapa 1](#step1), a partir dos elementos acessíveis (postos de utilizador, softwares de terceiros, reencaminhamentos visíveis a partir de outro acesso).
+    2. **Crie manualmente um ticket de assistência** a partir da sua área de cliente OVHcloud.
+    3. No ticket, indique:
+        - O endereço de e-mail abrangido pelo bloqueio;
+        - O serviço associado (MX Plan, Zimbra Starter ou Zimbra Pro) e o respetivo identificador;
+        - As ações corretivas já realizadas (análises antivírus, eliminação de remetentes não legítimos, adição do filtro SPAM/DCE, etc.).
+
+    Assim que o ticket for tratado pelo suporte, o endereço será desbloqueado. A [etapa 3](#step3) não se aplica neste caso.
+  </Tab>
+  <Tab label="MX Plan - Roundcube">
+    Se o bloqueio disser respeito a um endereço de e-mail MX Plan com o webmail **Roundcube**, não é gerado nenhum ticket de assistência.
+
+    Antes de qualquer ação, é **indispensável identificar a causa do bloqueio**, realizando as verificações da [etapa 1](#step1) (postos potencialmente infetados, softwares de terceiros, reencaminhamentos, filtros, respostas automáticas).
+
+    No separador <code className="action">Emails</code> da sua plataforma, a coluna "Bloqueado por SPAM" indica "Sim" quando o endereço está bloqueado.
     
     <img className="thumbnail" alt="Coluna Bloqueado por SPAM no separador Emails MX Plan Roundcube" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-04.png" loading="lazy" />
     
     :::warning
-    Em casos raros, a coluna "Bloqueado por SPAM" pode indicar "Não", apesar de o endereço de e-mail estar bloqueado. Se tiver tomado as medidas necessárias para proteger o endereço de e-mail, a solução permanece a mesma que acima.
+    **Não desbloqueie o endereço por si próprio.** Mesmo que a interface o permita, deve **contactar o suporte da OVHcloud** criando um ticket de assistência a partir da sua área de cliente, para que a origem do bloqueio seja verificada antes de qualquer desbloqueio. Um desbloqueio prematuro, sem tratamento da causa, expõe a uma reincidência imediata.
 
     :::
+
+    :::warning
+    A **alteração da palavra-passe não é sistemática**. Só deve ser efetuada **se houver suspeita de compromisso** (posto infetado, credenciais divulgadas ou partilhadas, acesso não autorizado). Uma alteração da palavra-passe sem causa identificada mascara o verdadeiro problema e expõe a uma reincidência.
+
+    :::
+
+    :::info
+    Em casos raros, a coluna "Bloqueado por SPAM" pode indicar "Não" apesar de o endereço de e-mail estar bloqueado. O procedimento é o mesmo: contacte o suporte da OVHcloud.
+
+    :::
+
+    Para que o endereço seja desbloqueado, **crie manualmente um ticket de assistência** a partir da sua área de cliente OVHcloud, indicando:
+
+    - O endereço de e-mail abrangido pelo bloqueio;
+    - O serviço MX Plan associado e o respetivo identificador;
+    - As ações corretivas já realizadas (análises antivírus, eliminação de remetentes não legítimos, adição do filtro SPAM/DCE, etc.).
+
+    Assim que o ticket for tratado pelo suporte, o endereço será desbloqueado. A [etapa 3](#step3) não se aplica neste caso.
 
   </Tab>
 </Tabs>
@@ -136,50 +200,52 @@ Passe à [etapa 3](#step3) do guia.
 
 ### Etapa 3: aceder ao ticket de assistência <a name="step3"></a>
 
-Após a etapa 2, será redirecionado para a janela "Os meus pedidos de assistência". Clique no botão <code className="action">...</code> à direita do ticket que menciona o assunto "Account locked for spam." e depois clique em <code className="action">Ver em detalhe</code>.
+Na sequência da etapa 2, será então redirecionado para a janela "Os meus pedidos de assistência". Clique no botão <code className="action">...</code> à direita do ticket que menciona o assunto "Account locked for spam." e depois clique em <code className="action">Ver detalhes</code>.
 
-<img className="thumbnail" alt="Janela Os meus pedidos de assistência com o ticket de bloqueio spam" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-02.png" loading="lazy" />
+<img className="thumbnail" alt="Janela Os meus pedidos de assistência com o ticket de bloqueio por spam" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-02.png" loading="lazy" />
 
-Encontrará o e-mail que lhe foi enviado, o qual gerou um ticket de assistência junto do suporte.
+Encontrará assim o e-mail que lhe foi enviado, o qual gera um ticket de assistência junto do suporte.
 
 O ticket de assistência apresenta-se da seguinte forma:
 
->
 > Estimado/a Cliente,
 >
-> O nosso sistema detetou que o endereço **youraddress@domain.com** alojado nos nossos sistemas no serviço **servicename** é fonte de envio de mensagens indesejadas (spams).
-> O envio de e-mails deste endereço foi, por isso, temporariamente desativado.
+> O nosso sistema detetou que o endereço **youraddress@example.com** alojado nos nossos sistemas no serviço **servicename** é fonte de envio de mensagens indesejadas (spams).
+> O envio de e-mails foi, por isso, temporariamente desativado.
 >
-> Detetámos **X** mensagem(ns) suspeita(s).
+> Detetámos atualmente **X** mensagem(ns) suspeita(s).
 >
-> Para nos ajudar a reativar o envio de e-mails para o endereço: **address@domain.com**,
-> devolva-nos este e-mail respondendo às seguintes perguntas:
+> Para nos ajudar a reativar o envio de e-mails para o endereço: **address@example.com**,
+> responda a este e-mail completando as seguintes questões:
 >
-> - É o emissor do e-mail em questão (ver cabeçalho acima)?
+> - É o emissor do e-mail em questão (ver cabeçalho abaixo)?
 >
 > - Tem alguma regra de reencaminhamento para outro endereço de e-mail?
 >
 > - Respondeu a uma mensagem de spam?
 >
-> Estas respostas irão ajudar-nos a reativar a sua conta o mais rapidamente possível.
-> <br/>
-> <br/>
->
+> Estas respostas ajudar-nos-ão a reativar a sua conta rapidamente.
 
-Na continuidade desta mensagem, foi-lhe transmitida uma amostra de cabeçalhos dos e-mails enviados.
+Na continuidade desta mensagem, é-lhe transmitida uma amostra de cabeçalhos dos e-mails enviados.
 
 Estes cabeçalhos permitem determinar o percurso e a origem dos e-mails enviados.
 
 :::info
-Quando o seu ticket tiver sido tratado pelo suporte ao cliente e o seu endereço de e-mail tiver sido desbloqueado, altere a palavra-passe do endereço de e-mail, certificando-se de que é suficientemente forte. Pode utilizar a [ferramenta de criação de palavra-passe segura](https://www.cnil.fr/fr/generer-un-mot-de-passe-solide) da CNIL. Pode igualmente consultar os [conselhos da CNIL para uma boa palavra-passe](https://www.cnil.fr/fr/les-conseils-de-la-cnil-pour-un-bon-mot-de-passe).
+Assim que o seu ticket for tratado pelo suporte ao cliente e o seu endereço de e-mail for desbloqueado, só deve proceder à **alteração da palavra-passe se houver suspeita de compromisso** face às verificações realizadas na [etapa 1](#step1) (posto infetado, credenciais partilhadas ou divulgadas, acesso não autorizado). A alteração da palavra-passe **não é sistemática**.
+
+Se for necessária uma nova palavra-passe, certifique-se de que esta é suficientemente forte, combinando letras maiúsculas e minúsculas, algarismos e carateres especiais, e evitando informações pessoais facilmente identificáveis.
 
 :::
 
 
 ## Quer saber mais?
 
+Para gerir os aliases e reencaminhamentos do seu endereço de e-mail, consulte o guia [Utilizar os aliases e reencaminhamentos de e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
+
+Para consultar os seus filtros e respostas automáticas a partir do webmail, consulte os guias [Utilizar o seu endereço de e-mail a partir do webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) e [Utilizar o webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
 Para serviços especializados (referenciamento, desenvolvimento, etc.), contacte os [parceiros OVHcloud](https://partner.ovhcloud.com/pt/directory/).
 
-Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
+Para obter assistência na utilização e configuração das suas soluções OVHcloud, consulte as nossas [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/pt).


### PR DESCRIPTION
## Summary

Refresh the "locked for spam" troubleshooting flow and the Zimbra FAQ to
properly cover the **silent spam block** specific to Zimbra offers (where
no support ticket is auto-generated and the entire mailbox becomes
inaccessible). Brings in the Zimbra-aware restructuring from legacy PR
ovh/docs#9389, follows up with editorial / SEO / accessibility refinements,
and propagates everything to the six other locales.

## Scope

14 files across 7 locales:

- `web-cloud/.../troubleshooting/locked-for-spam.mdx` × 7
- `web-cloud/.../mx-plan/faq-zimbra.mdx` × 7

3 commits on the branch:

1. `48f97500` — Port spam-lock Zimbra updates from legacy PR #9389 (FR only)
2. `f6b95ece` — Refine the FR source guide and propagate translations
3. `01389461` — Add the Zimbra "lost access" FAQ entry across all locales

## `locked-for-spam` — what changed

**Structure & content**
- Add a dedicated **Zimbra** tab and split the previous combined OWA/Zimbra
  tab. The Zimbra tab documents the manual support-ticket procedure that
  applies when no auto ticket is generated (covers MX Plan - Zimbra,
  Zimbra Starter, Zimbra Pro).
- Recentre the **Roundcube** tab on root-cause investigation: require
  contacting support before any unblock, list exactly what to include in
  the ticket, and state that step 3 does not apply (no auto ticket).
- Recommend a **SPAM/DCE filter** that isolates flagged messages (does not
  delete them) so false positives can be reviewed; preserve any existing
  forwarding rules.
- Clarify that filters, redirections and auto-replies live on the **webmail**
  for Zimbra and OWA — OVHcloud support has no access and cannot verify
  them on the user's behalf.
- Make the password change **conditional** on a suspected compromise, both
  in step 1 and step 3 (avoid blanket "change your password").

**Editorial / SEO**
- Title vocabulary aligned on "adresse e-mail" instead of "compte".
- Step 1 heading covers diagnosis **and** corrective actions.
- Step 2 heading shortened to stay under TOC width.
- Description rewritten to drop the formulaic opener and fill the SERP
  snippet (≈137 chars).
- 3 internal cross-links added in "Aller plus loin" (redirections,
  Roundcube webmail, Zimbra webmail).
- OWA acronym expanded on first use; DCE expansion preserved.
- "Logged in to Control Panel" added as a prerequisite.
- FR typography pass (NBSP), blockquote tidy, `etc.)` punctuation.

## `faq-zimbra` — what changed

New Q&A entry in all 7 locales: **"I can no longer access my Zimbra email
account and I don't understand why — what should I do?"**

The entry explains:
- The Zimbra block is silent (no auto-generated ticket, full mailbox
  suspension) — unlike the other email technologies.
- How to recognise it (no auto-ticket, recent unusual sending activity).
- The manual support-ticket procedure (what to include).
- Alternative causes to rule out: recent password change, administrative
  suspension, recent migration, infrastructure incident
  (links to `https://status.ovhcloud.com`).

The FR link text to the locked-for-spam guide was updated to match its
new title — keeps the FAQ cross-reference in sync.

## Translation coverage

Standard routing applied:
- EN, ES, IT, PT translated from FR
- DE, PL translated from EN

| Locale | Notes |
|--------|-------|
| EN | CNIL password block replaced with generic guidance |
| DE | Formal "Sie", `Voraussetzungen` rewritten as full sentences, proper declination |
| ES | CNIL replaced with an AEPD reference — **to confirm with the team** |
| IT | Generic password guidance, no external authority link |
| PL | Diacritics + verb aspect verified; generic password guidance |
| PT | pt-PT throughout (no pt-BR forms), cedilla / accents correct |

The `web-zimbra` CP-NAV block was missing from several pre-existing locale
files of `locked-for-spam`; it is now restored everywhere so the
technology selector is consistent across languages.