### PR TITLE
Network Security Dashboard : Ticket opening Step 1 no longer required

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitoring von DDoS-Angriffen mit dem Network Security Dashboard
 description: Erfahren Sie hier, wie Sie das Network Security Dashboard im OVHcloud Kundencenter verwenden
-lastUpdated: 2025-10-31
+lastUpdated: 2026-05-27
 ---
 
 ## Ziel
@@ -137,29 +137,9 @@ DDoS-Schutz-Infrastrukturen sind eine Lösung, die auf höchste Effizienz und ei
 
 Um Ihren Fall zu verstehen und Ihnen besser helfen zu können, senden Sie uns einige Details mit:
 
-#### Schritt 1 - Traffic erfassen
+#### Informationen für OVHcloud
 
-Um die beste Lösung für Sie zu liefern, müssen wir zunächst eine Traffic-Probe analysieren.
-
-Um uns eine solche Aufzeichnung zu erhalten, führen Sie diesen Befehl unter Linux aus:
-
-```bash
-tcpdump -w capture-ovh -c 100000 port not ssh
-```
-
-:::info
-Von Windows aus verwenden Sie [Wireshark](https://www.wireshark.org/) und erfassen damit 100000 Pakete.
-
-:::
-
-
-Sobald der Befehl ausgeführt wurde, wird die Capture-Datei erstellt. Sie können die erstellte Datei entweder an Ihr Support-Ticket anhängen oder anhand [dieser Anleitung](/guides/account-and-service-management/account-information/use-plik) unser Tool zum Dateiversand nutzen.
-
-Stellen Sie sicher, dass Sie den Link der hochgeladenen Datei dem Support-Team in Ihrem Ticket mitteilen.
-
-#### Schritt 2 - Informationen für OVHcloud
-
-In allen Fällen, für die Anpassungen unseres DDoS-Schutzes erforderlich sein werden, müssen wir die folgenden spezifischen Angaben erhalten:
+In allen Fällen, für die Anpassungen unseres DDoS-Schutzes erforderlich sind, müssen wir die folgenden spezifischen Angaben erhalten:
 
 - Auf dem betroffenen Server gehosteter Dienst
 - Datum und Uhrzeit des Angriffsbeginns
@@ -174,6 +154,23 @@ In allen Fällen, für die Anpassungen unseres DDoS-Schutzes erforderlich sein w
 - Wird legitimer Traffic verworfen: JA/NEIN
 - Verbindung zum Server verloren: JA/NEIN
 - Welche Art legitimer Traffic geblockt wird
+
+:::info
+In einigen Fällen bitten wir Sie möglicherweise, einen zusätzlichen Traffic-Mitschnitt durchzuführen.
+
+Um uns eine solche Aufzeichnung zu erhalten, führen Sie diesen Befehl unter Linux aus:
+
+```bash
+tcpdump -w capture-ovh -c 100000 port not ssh
+```
+
+Von Windows aus verwenden Sie [Wireshark](https://www.wireshark.org/) und erfassen damit 100000 Pakete.
+
+Sie können die erstellte Datei entweder an Ihr Support-Ticket anhängen oder anhand [dieser Anleitung](/guides/account-and-service-management/account-information/use-plik) unser Tool zum Dateiversand nutzen.
+
+Teilen Sie den Link der hochgeladenen Datei in Ihrem Support-Ticket mit.
+
+:::
 
 ## Weiterführende Informationen
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitoring von DDoS-Angriffen mit dem Network Security Dashboard
 description: Erfahren Sie hier, wie Sie das Network Security Dashboard im OVHcloud Kundencenter verwenden
-lastUpdated: 2026-05-27
+lastUpdated: 2026-05-28
 ---
 
 ## Ziel

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitoring DDoS attacks with the Network Security Dashboard
 description: Learn how to navigate through the Network Security Dashboard
-lastUpdated: 2026-05-27
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -137,29 +137,9 @@ Anti-DDoS infrastructure is a solution designed for best efficiency and wide ran
 
 To let us better understand your case and to be able to help you, please provide us with some more details:
 
-#### Step 1 - Capture traffic
+#### Provide OVHcloud with information
 
-In order to deliver the best solution for you, first we will need to analyse a traffic sample.
-
-To provide us with such a capture, run this command on Linux:
-
-```bash
-tcpdump -w capture-ovh -c 100000 port not ssh
-```
-
-:::info
-If you are using Windows, use [Wireshark](https://www.wireshark.org/) and capture 100000 packets.
-
-:::
-
-
-Once the command finishes running, the capture file is created. You can either attach the created file to your support ticket or upload it to our file sharing solution using [this guide](/guides/account-and-service-management/account-information/use-plik).
-
-Make sure to share the uploaded file's link with the support team in your ticket.
-
-#### Step 2 - Provide OVHcloud with information
-
-In any case where adjustments to our Anti-DDoS system will be necessary, it is mandatory to provide us the following specific details:
+In any case where adjustments to our Anti-DDoS system are necessary, it is mandatory to provide us the following specific details:
 
 - Service hosted on the server that is affected
 - Date and time of when the attack started
@@ -174,6 +154,23 @@ In any case where adjustments to our Anti-DDoS system will be necessary, it is m
 - Is legitimate traffic being dropped: YES/NO
 - Was connection to the server lost: YES/NO
 - Which type of legitimate traffic is being dropped
+
+:::info
+In some cases, we may request additional traffic capture from your side.
+
+To provide us with such a capture, run this command on Linux: 
+
+```bash
+tcpdump -w capture-ovh -c 100000 port not ssh
+```
+
+If you are using Windows, use [Wireshark](https://www.wireshark.org/) and capture 100000 packets.
+
+You can either attach the created file to your support ticket or upload it to our file sharing solution using [this guide](/guides/account-and-service-management/account-information/use-plik).
+
+Make sure to share the uploaded file's link with the support team in your ticket.
+
+:::
 
 ## Go further
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitoring DDoS attacks with the Network Security Dashboard
 description: Learn how to navigate through the Network Security Dashboard
-lastUpdated: 2025-10-31
+lastUpdated: 2026-05-27
 ---
 
 ## Objective
@@ -139,7 +139,7 @@ To let us better understand your case and to be able to help you, please provide
 
 #### Provide OVHcloud with information
 
-In any case where adjustments to our Anti-DDoS system are necessary, it is mandatory to provide us the following specific details:
+In any case where adjustments to our Anti-DDoS system are necessary, it is mandatory to provide us with the following specific details:
 
 - Service hosted on the server that is affected
 - Date and time of when the attack started
@@ -156,9 +156,9 @@ In any case where adjustments to our Anti-DDoS system are necessary, it is manda
 - Which type of legitimate traffic is being dropped
 
 :::info
-In some cases, we may request additional traffic capture from your side.
+In some cases, we may request an additional traffic capture from you.
 
-To provide us with such a capture, run this command on Linux: 
+To provide us with such a capture, run this command on Linux:
 
 ```bash
 tcpdump -w capture-ovh -c 100000 port not ssh
@@ -168,7 +168,7 @@ If you are using Windows, use [Wireshark](https://www.wireshark.org/) and captur
 
 You can either attach the created file to your support ticket or upload it to our file sharing solution using [this guide](/guides/account-and-service-management/account-information/use-plik).
 
-Make sure to share the uploaded file's link with the support team in your ticket.
+Share the uploaded file's link in your support ticket.
 
 :::
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitorización de los ataques DDoS con el Network Security Dashboard
 description: Aprenda a navegar por el panel de control de seguridad de red
-lastUpdated: 2026-05-27
+lastUpdated: 2026-05-28
 ---
 
 ## Objetivo

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitorización de los ataques DDoS con el Network Security Dashboard
 description: Aprenda a navegar por el panel de control de seguridad de red
-lastUpdated: 2025-10-31
+lastUpdated: 2026-05-27
 ---
 
 ## Objetivo
@@ -138,27 +138,7 @@ La infraestructura anti-DDoS es una solución diseñada para ofrecer la mejor ef
 
 Para permitirnos comprender mejor su caso y poder ayudarle, indíquenos algunos detalles más:
 
-#### Paso 1 - Capturar tráfico
-
-Para poder ofrecerle la mejor solución, primero tendremos que analizar una muestra de tráfico.
-
-Para proporcionarnos una captura de este tipo, ejecute este comando en Linux:
-
-```bash
-tcpdump -w capture-ovh -c 100000 port not ssh
-```
-
-:::info
-Si utiliza Windows, utilice [Wireshark](https://www.wireshark.org/) y capture 100.000 paquetes.
-
-:::
-
-
-Una vez que el comando termina de ejecutarse, se crea el archivo de captura. Puede adjuntar el archivo creado a su tíquet de soporte o subirlo a nuestra solución de uso compartido de archivos utilizando [esta guía](/guides/account-and-service-management/account-information/use-plik).
-
-Asegúrese de compartir el enlace del archivo cargado con el equipo de soporte de su tíquet.
-
-#### Paso 2 - Proporcionar información a OVHcloud
+#### Proporcionar información a OVHcloud
 
 En cualquier caso en el que sea necesario realizar ajustes en nuestro sistema anti-DDoS, es obligatorio proporcionarnos los siguientes datos específicos:
 
@@ -175,6 +155,23 @@ En cualquier caso en el que sea necesario realizar ajustes en nuestro sistema an
 - ¿Se está eliminando el tráfico legítimo?: SÍ/NO
 - Se ha perdido la conexión con el servidor: SÍ/NO
 - Qué tipo de tráfico legítimo se va a eliminar
+
+:::info
+En algunos casos, es posible que le solicitemos una captura de tráfico adicional.
+
+Para proporcionarnos una captura de este tipo, ejecute este comando en Linux:
+
+```bash
+tcpdump -w capture-ovh -c 100000 port not ssh
+```
+
+Si utiliza Windows, utilice [Wireshark](https://www.wireshark.org/) y capture 100.000 paquetes.
+
+Puede adjuntar el archivo creado a su tíquet de soporte o subirlo a nuestra solución de uso compartido de archivos utilizando [esta guía](/guides/account-and-service-management/account-information/use-plik).
+
+Comparta el enlace del archivo cargado en su tíquet de soporte.
+
+:::
 
 ## Más información <a name="go-further"></a>
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -137,29 +137,9 @@ L’infrastructure anti-DDoS est une solution conçue pour une efficacité optim
 
 Afin de nous permettre de mieux comprendre votre cas d'usage et de pouvoir vous aider, nous vous invitons à nous fournir plus de détails :
 
-#### Étape 1 - Capturer le trafic
+#### Fournir des informations à OVHcloud
 
-Afin de vous offrir la meilleure solution, nous aurons besoin d'analyser un échantillon de trafic.
-
-Pour nous fournir une telle capture, veuillez exécuter cette commande sur Linux :
-
-```bash
-tcpdump -w capture-ovh -c 100000 port not ssh
-```
-
-:::info
-Si vous utilisez Windows, utilisez [Wireshark](https://www.wireshark.org/) et capturez 100000 paquets.
-
-:::
-
-
-Une fois l'exécution de la commande terminée, le fichier de capture est créé. Vous pouvez soit joindre le fichier créé à votre ticket d'assistance, soit le téléverser sur notre solution de partage de fichiers à l'aide de [ce guide](/guides/account-and-service-management/account-information/use-plik).
-
-Veillez à partager, dans le ticket d'assistance, le lien du fichier téléversé.
-
-#### Étape 2 - Fournir des informations à OVHcloud
-
-Dans tous les cas de figure où des ajustements de notre système Anti-DDoS seront nécessaires, il sera indispensable de nous fournir les détails spécifiques suivants :
+Dans tous les cas de figure où des ajustements de notre système Anti-DDoS sont nécessaires, il est indispensable de nous fournir les détails spécifiques suivants :
 
 - Service hébergé sur le serveur concerné :
 - Date et heure de début de l'attaque :
@@ -174,6 +154,23 @@ Dans tous les cas de figure où des ajustements de notre système Anti-DDoS sero
 - Le trafic légitime est-il supprimé : OUI/NON
 - La connexion au serveur a-t-elle été perdue : OUI/NON
 - Quel type de trafic légitime est supprimé :
+
+:::info
+Dans certains cas, nous pouvons également vous demander de faire une capture du trafic réseau.
+
+Pour nous fournir une telle capture, veuillez exécuter cette commande sur Linux :
+
+```bash
+tcpdump -w capture-ovh -c 100000 port not ssh
+```
+
+Si vous utilisez Windows, utilisez [Wireshark](https://www.wireshark.org/) et capturez 100000 paquets.
+
+Vous pouvez soit joindre le fichier créé à votre ticket d'assistance, soit le téléverser sur notre solution de partage de fichiers à l'aide de [ce guide](/guides/account-and-service-management/account-information/use-plik).
+
+Veillez à partager, dans le ticket d'assistance, le lien du fichier téléversé.
+
+:::
 
 ## Aller plus loin
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitoring des attaques DDoS avec le Network Security Dashboard
 description: Apprenez à naviguer dans le Network Security Dashboard
-lastUpdated: 2026-05-27
+lastUpdated: 2026-05-28
 ---
 
 ## Objectif

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitoring des attaques DDoS avec le Network Security Dashboard
 description: Apprenez à naviguer dans le Network Security Dashboard
-lastUpdated: 2025-10-31
+lastUpdated: 2026-05-27
 ---
 
 ## Objectif
@@ -156,7 +156,7 @@ Dans tous les cas de figure où des ajustements de notre système Anti-DDoS sont
 - Quel type de trafic légitime est supprimé :
 
 :::info
-Dans certains cas, nous pouvons également vous demander de faire une capture du trafic réseau.
+Dans certains cas, nous pouvons vous demander d'effectuer une capture du trafic réseau.
 
 Pour nous fournir une telle capture, veuillez exécuter cette commande sur Linux :
 
@@ -168,7 +168,7 @@ Si vous utilisez Windows, utilisez [Wireshark](https://www.wireshark.org/) et ca
 
 Vous pouvez soit joindre le fichier créé à votre ticket d'assistance, soit le téléverser sur notre solution de partage de fichiers à l'aide de [ce guide](/guides/account-and-service-management/account-information/use-plik).
 
-Veillez à partager, dans le ticket d'assistance, le lien du fichier téléversé.
+Partagez le lien du fichier téléversé dans votre ticket d'assistance.
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitoraggio degli attacchi DDoS con il Network Security Dashboard
 description: Scopri come navigare attraverso il dashboard di sicurezza di rete
-lastUpdated: 2026-05-27
+lastUpdated: 2026-05-28
 ---
 
 ## Obiettivo

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitoraggio degli attacchi DDoS con il Network Security Dashboard
 description: Scopri come navigare attraverso il dashboard di sicurezza di rete
-lastUpdated: 2025-10-31
+lastUpdated: 2026-05-27
 ---
 
 ## Obiettivo
@@ -137,29 +137,9 @@ L’infrastruttura anti-DDoS è progettata per offrire la massima efficienza e u
 
 Per permetterci di comprendere meglio il suo caso e di aiutarla, può fornirci ulteriori dettagli:
 
-#### Step 1 - Acquisisci traffico
+#### Fornisci informazioni a OVHcloud
 
-Per offrirti la soluzione più adatta alle tue esigenze, è necessario analizzare un campione di traffico.
-
-Per fornirci questa possibilità, esegui questo comando su Linux:
-
-```bash
-tcpdump -w capture-ovh -c 100000 port not ssh
-```
-
-:::info
-Se si utilizza Windows, utilizzare [Wireshark](https://www.wireshark.org/) e acquisire 1000000 pacchetti.
-
-:::
-
-
-Al termine dell'esecuzione del comando, viene creato il file di acquisizione. È possibile allegare il file creato al ticket di supporto oppure caricarlo nella nostra soluzione di condivisione file utilizzando [questa guida](/guides/account-and-service-management/account-information/use-plik).
-
-Assicurati di condividere il collegamento del file caricato con il team di supporto nel ticket.
-
-#### Step 2 - Fornisci informazioni a OVHcloud
-
-In tutti i casi in cui sarà necessario apportare modifiche al nostro sistema anti-DDoS, è obbligatorio fornire i seguenti dettagli specifici:
+In tutti i casi in cui sia necessario apportare modifiche al nostro sistema anti-DDoS, è obbligatorio fornire i seguenti dettagli specifici:
 
 - Servizio ospitato sul server interessato
 - Data e ora di inizio dell'attacco
@@ -174,6 +154,23 @@ In tutti i casi in cui sarà necessario apportare modifiche al nostro sistema an
 - Il traffico legittimo è stato eliminato: SÌ/NO
 - Connessione al server interrotta: SÌ/NO
 - Quale tipo di traffico legittimo viene eliminato
+
+:::info
+In alcuni casi, potremmo richiedere un'acquisizione aggiuntiva del traffico.
+
+Per fornirci questa possibilità, esegui questo comando su Linux:
+
+```bash
+tcpdump -w capture-ovh -c 100000 port not ssh
+```
+
+Se si utilizza Windows, utilizzare [Wireshark](https://www.wireshark.org/) e acquisire 100000 pacchetti.
+
+È possibile allegare il file creato al ticket di supporto oppure caricarlo nella nostra soluzione di condivisione file utilizzando [questa guida](/guides/account-and-service-management/account-information/use-plik).
+
+Condividi il link del file caricato nel tuo ticket di supporto.
+
+:::
 
 ## Per saperne di più
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitoring ataków DDoS za pomocą Network Security Dashboard
 description: Dowiedz się, jak nawigować za pomocą pulpitu nawigacyjnego zabezpieczeń sieciowych
-lastUpdated: 2026-05-27
+lastUpdated: 2026-05-28
 ---
 
 ## Wprowadzenie

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitoring ataków DDoS za pomocą Network Security Dashboard
 description: Dowiedz się, jak nawigować za pomocą pulpitu nawigacyjnego zabezpieczeń sieciowych
-lastUpdated: 2025-10-31
+lastUpdated: 2026-05-27
 ---
 
 ## Wprowadzenie
@@ -137,29 +137,9 @@ Infrastruktura anty-DDoS została zaprojektowana w celu uzyskania najlepszej wyd
 
 Abyśmy mogli lepiej zrozumieć Twoją sprawę i udzielić Ci pomocy, prosimy o podanie kilku informacji:
 
-#### Etap 1 - Przechwytywanie ruchu
+#### Dostarczenie informacji OVHcloud
 
-Aby dostarczyć najlepsze rozwiązanie, najpierw musimy przeanalizować próbkę ruchu.
-
-Aby udostępnić nam takie ujęcie, uruchom następujące polecenie w systemie Linux:
-
-```bash
-tcpdump -w capture-ovh -c 100000 port not ssh
-```
-
-:::info
-Jeśli używasz systemu Windows, użyj [Wireshark](https://www.wireshark.org/) i przechwyć 100000 pakietów.
-
-:::
-
-
-Po zakończeniu działania polecenia zostanie utworzony plik przechwytywania. Możesz dołączyć utworzony plik do zgłoszenia serwisowego lub przesłać go do naszego rozwiązania udostępniania plików za pomocą [this guide](/guides/account-and-service-management/account-information/use-plik).
-
-Udostępnij link do przekazanego pliku zespołowi pomocy technicznej w zgłoszeniu.
-
-#### Etap 2 - dostarczenie informacji OVHcloud
-
-W każdym przypadku, kiedy konieczne będą zmiany w naszym systemie Anty-DDoS, należy obowiązkowo podać nam następujące informacje:
+W każdym przypadku, kiedy konieczne są zmiany w naszym systemie Anty-DDoS, należy obowiązkowo podać nam następujące informacje:
 
 - Usługa instalowana na serwerze, którego dotyczy operacja
 - Data i godzina rozpoczęcia ataku
@@ -174,6 +154,23 @@ W każdym przypadku, kiedy konieczne będą zmiany w naszym systemie Anty-DDoS, 
 - Czy ruch zgodny z prawem jest odrzucany: TAK/NIE
 - Czy połączenie z serwerem zostało utracone: TAK/NIE
 - Jaki rodzaj dozwolonego ruchu jest odrzucany.
+
+:::info
+W niektórych przypadkach możemy poprosić o dodatkowe przechwycenie ruchu.
+
+Aby udostępnić nam takie ujęcie, uruchom następujące polecenie w systemie Linux:
+
+```bash
+tcpdump -w capture-ovh -c 100000 port not ssh
+```
+
+Jeśli używasz systemu Windows, użyj [Wireshark](https://www.wireshark.org/) i przechwyć 100000 pakietów.
+
+Możesz dołączyć utworzony plik do zgłoszenia serwisowego lub przesłać go do naszego rozwiązania udostępniania plików za pomocą [tego przewodnika](/guides/account-and-service-management/account-information/use-plik).
+
+Udostępnij link do przesłanego pliku w zgłoszeniu serwisowym.
+
+:::
 
 ## Sprawdź również
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitorização dos ataques DDoS com o Network Security Dashboard
 description: Saiba como navegar no Dashboard de Segurança da Rede
-lastUpdated: 2026-05-27
+lastUpdated: 2026-05-28
 ---
 
 ## Objetivo

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-security-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitorização dos ataques DDoS com o Network Security Dashboard
 description: Saiba como navegar no Dashboard de Segurança da Rede
-lastUpdated: 2025-10-31
+lastUpdated: 2026-05-27
 ---
 
 ## Objetivo
@@ -137,27 +137,7 @@ A infraestrutura anti-DDoS é uma solução concebida para assegurar a melhor ef
 
 Para podermos compreender melhor o seu caso e podermos ajudá-lo, forneça-nos alguns detalhes adicionais:
 
-### Passo 1 - Capturar tráfego
-
-Para lhe oferecer a melhor solução, em primeiro lugar, teremos de analisar uma amostra de tráfego.
-
-Para nos fornecer essa captura, execute este comando em Linux:
-
-```bash
-tcpdump -w capture-ovh -c 100000 port not ssh
-```
-
-:::info
-Se estiver a utilizar o Windows, utilize o [Wireshark](https://www.wireshark.org/) e capture 100.000 pacotes.
-
-:::
-
-
-Quando o comando terminar de ser executado, o arquivo de captura é criado. Pode anexar o ficheiro criado ao ticket de suporte ou carregá-lo na nossa solução de partilha de ficheiros utilizando [este guia](/guides/account-and-service-management/account-information/use-plik).
-
-Certifique-se de que partilha a ligação do ficheiro carregado com o suporte do seu ticket.
-
-### Etapa 2 - Fornecer informações à OVHcloud
+#### Fornecer informações à OVHcloud
 
 Em todos os casos em que seja necessário um ajuste do nosso sistema Anti-DDoS, deverá fornecer-nos as seguintes informações específicas:
 
@@ -174,6 +154,23 @@ Em todos os casos em que seja necessário um ajuste do nosso sistema Anti-DDoS, 
 - Está a ser eliminado tráfego legítimo: SIM/NÃO
 - A ligação ao servidor foi perdida: SIM/NÃO
 - Que tipo de tráfego legítimo está a ser eliminado
+
+:::info
+Em alguns casos, poderemos solicitar uma captura de tráfego adicional.
+
+Para nos fornecer essa captura, execute este comando em Linux:
+
+```bash
+tcpdump -w capture-ovh -c 100000 port not ssh
+```
+
+Se estiver a utilizar o Windows, utilize o [Wireshark](https://www.wireshark.org/) e capture 100.000 pacotes.
+
+Pode anexar o ficheiro criado ao ticket de suporte ou carregá-lo na nossa solução de partilha de ficheiros utilizando [este guia](/guides/account-and-service-management/account-information/use-plik).
+
+Partilhe a ligação do ficheiro carregado no seu ticket de suporte.
+
+:::
 
 ## Quer saber mais?
 


### PR DESCRIPTION
Capturing traffic is no longer required to open a ticket. 
Step 1 removed, its contents moved to a disclaimer for cases where we ask for a capture.

- Update of existing guide(s)
- No translation required
- Can be merged immediately