### PR TITLE
docs(port): restore missing bare-metal legacy content (surgical)

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-05-25
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -23,6 +23,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](https://www.ovhcloud.com/de/bare-metal/) in your OVHcloud account
 - Access to the [OVHcloud API](/guides/manage-and-operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+:::info
+To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -82,8 +87,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnImage Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-image/byoi-controlpanel04.png" loading="lazy" />
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -119,13 +122,13 @@ In the `customizations` section, only `imageURL`, `imageType` and `efiBootloader
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -155,17 +158,17 @@ Once you have filled in the fields, start the deployment by clicking <code class
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process). Examples:
 
@@ -185,8 +188,10 @@ The paths below use JSON escaping: `\\` represents a single backslash. For examp
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 :::info
-The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 
 :::
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Linux (BYOLinux) (EN)
 description: Find out how to easily deploy your own Linux images on dedicated servers
-lastUpdated: 2026-03-16
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -24,6 +24,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/guides/manage-and-operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process).
+
+:::info
+To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -72,8 +77,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnLinux Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-linux/byolinux-controlpanel04.png" loading="lazy" />
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ In the example above, the `imageCheckSum` value has been masked because it chang
 :::
 
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -153,16 +156,16 @@ Once you have filled in the fields, start the deployment by clicking <code class
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process). Examples:
 
@@ -182,8 +185,10 @@ The paths below use JSON escaping: `\\` represents a single backslash. For examp
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 :::info
-The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 
 :::
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
@@ -1,7 +1,7 @@
 ---
 title: Optimierung des E-Mail-Versands, damit Ihre E-Mails nicht als Spam markiert werden
 description: Erfahren Sie hier, wie Sie mit vorbeugenden Maßnahmen das Risiko minimieren, dass Ihre legitimen E-Mails durch Spam-Schutz blockiert werden
-lastUpdated: 2024-01-24
+lastUpdated: 2026-05-28
 ---
 
 :::info
@@ -123,6 +123,13 @@ Es kann sein, dass Microsoft die Entsperrung Ihrer IP-Adresse verweigert. In die
 #### Gmail Server
 
 Das Hinzufügen spezifischer Einträge wie DMARC (Domain-based Message Authentication, Reporting, and Conformance) oder DKIM (DomainKeys Identified Mail) kann den Empfang von E-Mails vereinfachen, wenn der Empfänger bei Gmail ist. Hilfe dazu finden Sie in den [unten auf dieser Seite aufgeführten Anleitungen](#go-further).
+
+### Blockierter SMTP-Port (Port 25)
+
+Wenn keine E-Mails gesendet werden oder der SMTP-Server nicht antwortet, ist ein blockierter Port eine häufige Ursache. Standardmäßig ist der ausgehende **Port 25** in der OVHcloud Infrastruktur (Dedicated Servers, VPS, Public Cloud Instanzen) blockiert, um Spam-Missbrauch zu verhindern. Zur Lösung dieses Problems:
+
+- Verwenden Sie **Port 587** (STARTTLS) für den ausgehenden E-Mail-Versand.
+- Wenn Ihr Anwendungsfall Port 25 erfordert, beantragen Sie dessen Entsperrung, indem Sie [unser Support-Team kontaktieren](/links/support-contact).
 
 ### Ihre Konfiguration überprüfen
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-05-25
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -23,6 +23,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](https://www.ovhcloud.com/en-gb/bare-metal/) in your OVHcloud account
 - Access to the [OVHcloud API](/guides/manage-and-operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+:::info
+To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -82,8 +87,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnImage Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-image/byoi-controlpanel04.png" loading="lazy" />
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -119,13 +122,13 @@ In the `customizations` section, only `imageURL`, `imageType` and `efiBootloader
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -155,17 +158,17 @@ Once you have filled in the fields, start the deployment by clicking <code class
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process). Examples:
 
@@ -185,8 +188,10 @@ The paths below use JSON escaping: `\\` represents a single backslash. For examp
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 :::info
-The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Linux (BYOLinux)
 description: Find out how to easily deploy your own Linux images on dedicated servers
-lastUpdated: 2026-03-16
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -24,6 +24,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/guides/manage-and-operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process).
+
+:::info
+To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -72,8 +77,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnLinux Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-linux/byolinux-controlpanel04.png" loading="lazy" />
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ In the example above, the `imageCheckSum` value has been masked because it chang
 :::
 
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -153,16 +156,16 @@ Once you have filled in the fields, start the deployment by clicking <code class
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process). Examples:
 
@@ -182,8 +185,10 @@ The paths below use JSON escaping: `\\` represents a single backslash. For examp
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 :::info
-The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to prevent your emails from being marked as spam
 description: Find out how to apply best practices for email sending in order to limit the risk of legitimate emails being blocked by spam protection
-lastUpdated: 2024-09-24
+lastUpdated: 2026-05-28
 ---
 
 ## Objective
@@ -119,6 +119,13 @@ It may happen that Microsoft refuses to delist your IP(s), in which case OVHclou
 #### To a Gmail server
 
 Adding specific records, such as a Domain-based Message Authentication, Reporting, and Compliance (DMARC) or DomainKeys Identified Mail (DKIM) record, can make it easier to receive emails if your recipient is at Gmail. Please refer to our guides listed [at the bottom of this page](#go-further) to configure them.
+
+### Blocked SMTP port (port 25)
+
+If emails are not sending or SMTP is not responding, a blocked port is a common cause. By default, outgoing **port 25** is blocked on OVHcloud infrastructure (dedicated servers, VPS, Public Cloud instances) to prevent spam abuse. To resolve this:
+
+- Use **port 587** (STARTTLS) for outbound mail submission.
+- If your use case requires port 25, request it to be unblocked by [contacting our support team](/links/support-contact).
 
 ### Check your information
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-05-25
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -23,6 +23,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](https://www.ovhcloud.com/es-es/bare-metal/) in your OVHcloud account
 - Access to the [OVHcloud API](/guides/manage-and-operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+:::info
+To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -82,8 +87,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnImage Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-image/byoi-controlpanel04.png" loading="lazy" />
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -119,13 +122,13 @@ In the `customizations` section, only `imageURL`, `imageType` and `efiBootloader
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -155,17 +158,17 @@ Once you have filled in the fields, start the deployment by clicking <code class
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process). Examples:
 
@@ -185,8 +188,10 @@ The paths below use JSON escaping: `\\` represents a single backslash. For examp
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 :::info
-The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 
 :::
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Linux (BYOLinux) (EN)
 description: Find out how to easily deploy your own Linux images on dedicated servers
-lastUpdated: 2026-03-16
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -24,6 +24,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/guides/manage-and-operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process).
+
+:::info
+To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -72,8 +77,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnLinux Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-linux/byolinux-controlpanel04.png" loading="lazy" />
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ In the example above, the `imageCheckSum` value has been masked because it chang
 :::
 
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -153,16 +156,16 @@ Once you have filled in the fields, start the deployment by clicking <code class
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process). Examples:
 
@@ -182,8 +185,10 @@ The paths below use JSON escaping: `\\` represents a single backslash. For examp
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 :::info
-The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 
 :::
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cómo evitar que sus correos electrónicos sean marcados como spam
 description: Aprenda a aplicar las buenas prácticas de envío de correo electrónico para limitar el riesgo de bloqueo de los mensajes legítimos mediante la protección contra el spam
-lastUpdated: 2024-01-24
+lastUpdated: 2026-05-28
 ---
 
 :::info
@@ -118,6 +118,13 @@ Es posible que Microsoft se niegue a desbloquear su dirección o direcciones IP,
 #### Desde el servidor de Gmail
 
 La adición de registros específicos, como un registro de Domain-based Message Authentication, Reporting, and Conformance (DMARC) o DKIM (DomainKeys Identified Mail), puede facilitar la recepción de mensajes de correo electrónico si el destinatario está en Gmail. Consulte nuestras guías [en la parte inferior de esta página](#go-further) para configurarlas.
+
+### Puerto SMTP bloqueado (puerto 25)
+
+Si sus e-mails no se envían o el servidor SMTP no responde, un puerto bloqueado es una causa frecuente. Por defecto, el **puerto 25** saliente está bloqueado en la infraestructura de OVHcloud (servidores dedicados, VPS, instancias Public Cloud) para prevenir el abuso de spam. Para resolver este problema:
+
+- Utilice el **puerto 587** (STARTTLS) para el envío de e-mails salientes.
+- Si su caso de uso requiere el puerto 25, solicite su desbloqueo [contactando con nuestro soporte](/links/support-contact).
 
 ### Revisa su información
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI)
 description: Découvrez comment déployer facilement vos propres images sur des serveurs dédiés
-lastUpdated: 2026-05-25
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -23,6 +23,11 @@ En plus des prérequis et limitations mentionnés ci-dessous, vous devez vous as
 - Un [serveur dédié](https://www.ovhcloud.com/fr/bare-metal/) dans votre compte OVHcloud
 - Avoir accès à l'[API OVHcloud](/guides/manage-and-operate/api/first-steps) (pour la méthode de [déploiement via l'API](#viaapi) de ce guide)
 - Votre image doit être inférieure à la RAM du serveur moins 3 Gio
+
+:::info
+Pour appliquer les personnalisations OVHcloud au premier démarrage, votre image doit inclure [cloud-init](https://cloud-init.io/) ou une alternative compatible (par exemple [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/) sur FreeBSD).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -82,8 +87,6 @@ Vous allez être redirigé vers la page de configuration. Assurez-vous que l'URL
 
 Vous trouverez plus de détails sur les options dans la section « [options de déploiement](#options) » ci-dessous.
 
-Pour plus d'informations et des exemples sur ConfigDrive de Cloud-Init, consultez la documentation officielle sur [cette page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnImage Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-image/byoi-controlpanel04.png" loading="lazy" />
 
 ### Déploiement de votre image via l'API <a name="viaapi"></a>
@@ -119,13 +122,13 @@ Dans la section `customizations`, seuls les champs `imageURL`, `imageType` et `e
 }
 ```
 
-Même si le configDrive user data peut être envoyé à l'API en clair directement en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
+Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Voici le configDrive user data en clair avec l'exemple ci-dessus :
+Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
 
 ```yaml
 #cloud-config
@@ -155,17 +158,17 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur <code
 |-|-|-|
 | customizations/hostname | Le hostname | ❌ |
 | customizations/sshKey | La clé publique SSH | ❌ |
-| customizations/imageURL | L'URL de votre image | ✅ |
-| customizations/imageType | Le type/format de votre image (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Checksum de votre image | ❌ |
-| customizations/imageCheckSumType | Type de checksum de votre image. (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
-| customizations/configDriveUserData | Contenu de votre fichier configDrive¹ | ❌ |
-| customizations/configDriveMetadata | Métadonnées Cloud-Init personnalisées | ❌ |
+| customizations/imageURL | L'URL de l'image | ✅ |
+| customizations/imageType | Le type/format de l'image (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Checksum de l'image | ❌ |
+| customizations/imageCheckSumType | Type de checksum de l'image (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
+| customizations/configDriveUserData | Données utilisateur (user-data) cloud-init¹ | ❌ |
+| customizations/configDriveMetadata | Métadonnées cloud-init personnalisées, exposées sous la clé `meta` de `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | Clé des en-têtes HTTP | ❌² |
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |
 | userMetadata/efiBootloaderPath | Le chemin du bootloader EFI | ✅³ |
 
-¹ Il peut s'agir d'un `#cloud-config` ou d'un script. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
+¹ [Données utilisateur](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) cloud-init standard — généralement un document `#cloud-config` ou un script (voir les [exemples officiels de cloud-init](https://docs.cloud-init.io/en/latest/reference/examples.html)). Équivalent à `server create --user-data <fichier>` chez OpenStack. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
 ² À utiliser uniquement si vous avez besoin d'en-têtes HTTP, tels que `Basic Auth`<br />
 ³ Le chemin du bootloader EFI est utilisé par iPXE pour démarrer votre système d'exploitation. Pour plus d'informations, consultez notre guide « [Comprendre le processus de démarrage des serveurs dédiés](/guides/bare-metal-cloud/dedicated-servers/boot-process) ». Exemples :
 
@@ -185,8 +188,10 @@ Les chemins ci-dessous utilisent l'échappement JSON : `\\` représente un seul 
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property clé=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
+
 :::info
-La partition ConfigDrive est utilisée par cloud-init lors du premier démarrage du serveur afin d'appliquer vos configurations. Vous pouvez choisir d'utiliser la partition par défaut ou une partition personnalisée (en utilisant `configDriveUserData`).
+Lorsque vous renseignez l'une des personnalisations de cette page, OVHcloud ajoute une petite partition de [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) lors de l'installation ; sinon, aucun config drive n'est créé. Cloud-init la lit au premier démarrage. Renseignez `configDriveUserData` pour ajouter vos propres données utilisateur (user-data) cloud-init.
 
 :::
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -122,13 +122,13 @@ Dans la section `customizations`, seuls les champs `imageURL`, `imageType` et `e
 }
 ```
 
-Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
+Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
+Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
 
 ```yaml
 #cloud-config
@@ -156,17 +156,17 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur <code
 
 | Champ | Description | Obligatoire |
 |-|-|-|
-| customizations/hostname | Le hostname | ❌ |
-| customizations/sshKey | La clé publique SSH | ❌ |
-| customizations/imageURL | L'URL de l'image | ✅ |
-| customizations/imageType | Le type/format de l'image (qcow2, raw) | ✅ |
+| customizations/hostname | Hostname | ❌ |
+| customizations/sshKey | Clé publique SSH | ❌ |
+| customizations/imageURL | URL de l'image | ✅ |
+| customizations/imageType | Type/format de l'image (qcow2, raw) | ✅ |
 | customizations/imageCheckSum | Checksum de l'image | ❌ |
 | customizations/imageCheckSumType | Type de checksum de l'image (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
 | customizations/configDriveUserData | Données utilisateur (user-data) cloud-init¹ | ❌ |
 | customizations/configDriveMetadata | Métadonnées cloud-init personnalisées, exposées sous la clé `meta` de `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | Clé des en-têtes HTTP | ❌² |
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |
-| userMetadata/efiBootloaderPath | Le chemin du bootloader EFI | ✅³ |
+| userMetadata/efiBootloaderPath | Chemin du bootloader EFI | ✅³ |
 
 ¹ [Données utilisateur](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) cloud-init standard — généralement un document `#cloud-config` ou un script (voir les [exemples officiels de cloud-init](https://docs.cloud-init.io/en/latest/reference/examples.html)). Équivalent à `server create --user-data <fichier>` chez OpenStack. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
 ² À utiliser uniquement si vous avez besoin d'en-têtes HTTP, tels que `Basic Auth`<br />
@@ -188,10 +188,10 @@ Les chemins ci-dessous utilisent l'échappement JSON : `\\` représente un seul 
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
-⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property clé=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
+⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property clé=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
 
 :::info
-Lorsque vous renseignez l'une des personnalisations de cette page, OVHcloud ajoute une petite partition de [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) lors de l'installation ; sinon, aucun config drive n'est créé. Cloud-init la lit au premier démarrage. Renseignez `configDriveUserData` pour ajouter vos propres données utilisateur (user-data) cloud-init.
+Lorsque vous renseignez l'une des personnalisations de cette page, OVHcloud ajoute une petite partition de [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) lors de l'installation ; sinon, aucun config drive n'est créé. Cloud-init la lit au premier démarrage. Renseignez `configDriveUserData` pour ajouter vos propres données utilisateur (user-data) cloud-init.
 
 :::
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Linux (BYOLinux)
 description: Découvrez comment déployer facilement vos propres images Linux sur des serveurs dédiés
-lastUpdated: 2026-03-16
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -24,6 +24,11 @@ En plus des prérequis et limitations mentionnés ci-dessous, vous devez vous as
 - Avoir accès à l'[API OVHcloud](/guides/manage-and-operate/api/first-steps) (pour la méthode de [déploiement via l'API](#viaapi) de ce guide)
 - Votre image doit être inférieure à la RAM du serveur moins 3 Gio
 - Un script `/root/.ovh/make_image_bootable.sh` exécutable, qui installera ou configurera le bootloader, [par exemple GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). Ce script ne doit pas modifier l'ordre de boot NVRAM (par exemple, utilisez `grub-install --no-nvram`). Pour plus d'informations, consultez notre guide « [Comprendre le processus de démarrage des serveurs dédiés](/guides/bare-metal-cloud/dedicated-servers/boot-process) ».
+
+:::info
+Pour appliquer les personnalisations OVHcloud au premier démarrage, votre image doit inclure [cloud-init](https://cloud-init.io/) ou une alternative compatible (par exemple [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/) sur FreeBSD).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -72,8 +77,6 @@ Vous allez être redirigé vers la page de configuration. Assurez-vous que l'URL
 
 Vous trouverez plus de détails sur les options dans la section « [options de déploiement](#options) » ci-dessous.
 
-Pour plus d'informations et des exemples sur ConfigDrive de Cloud-Init, consultez la documentation officielle sur [cette page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnLinux Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-linux/byolinux-controlpanel04.png" loading="lazy" />
 
 ### Déploiement de votre image via l'API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ Dans l'exemple ci-dessus, la valeur de `imageCheckSum` a été masquée, car ell
 :::
 
 
-Même si le configDrive user data peut être envoyé à l'API en clair directement en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
+Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Voici le configDrive user data en clair avec l'exemple ci-dessus :
+Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
 
 ```yaml
 #cloud-config
@@ -153,16 +156,16 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur <code
 |-|-|-|
 | customizations/hostname | Le hostname | ❌ |
 | customizations/sshKey | La clé publique SSH | ❌ |
-| customizations/imageURL | L'URL de votre image Linux | ✅ |
-| customizations/imageCheckSum | Checksum de votre image | ❌ |
-| customizations/imageCheckSumType | Type de checksum de votre image (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
-| customizations/configDriveUserData | Contenu de votre fichier configDrive¹ | ❌ |
-| customizations/configDriveMetadata | Métadonnées Cloud-Init personnalisées | ❌ |
+| customizations/imageURL | L'URL de l'image Linux | ✅ |
+| customizations/imageCheckSum | Checksum de l'image | ❌ |
+| customizations/imageCheckSumType | Type de checksum de l'image (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
+| customizations/configDriveUserData | Données utilisateur (user-data) cloud-init¹ | ❌ |
+| customizations/configDriveMetadata | Métadonnées cloud-init personnalisées, exposées sous la clé `meta` de `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | Clé des en-têtes HTTP | ❌² |
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |
 | userMetadata/efiBootloaderPath | Le chemin du bootloader EFI | ✅³ |
 
-¹ Il peut s'agir d'un `#cloud-config` ou d'un script. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
+¹ [Données utilisateur](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) cloud-init standard — généralement un document `#cloud-config` ou un script (voir les [exemples officiels de cloud-init](https://docs.cloud-init.io/en/latest/reference/examples.html)). Équivalent à `server create --user-data <fichier>` chez OpenStack. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
 ² À utiliser uniquement si vous avez besoin d'en-têtes HTTP, tels que `Basic Auth`<br />
 ³ Le chemin du bootloader EFI est utilisé par iPXE pour démarrer votre système d'exploitation. Pour plus d'informations, consultez notre guide « [Comprendre le processus de démarrage des serveurs dédiés](/guides/bare-metal-cloud/dedicated-servers/boot-process) ». Exemples :
 
@@ -182,8 +185,10 @@ Les chemins ci-dessous utilisent l'échappement JSON : `\\` représente un seul 
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property clé=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
+
 :::info
-La partition ConfigDrive est utilisée par cloud-init lors du premier démarrage du serveur afin d'appliquer vos configurations. Vous pouvez choisir d'utiliser la partition par défaut ou une partition personnalisée (en utilisant `configDriveUserData`).
+Lors de l'installation, OVHcloud ajoute une petite partition de [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) sur votre serveur. Cloud-init la lit au premier démarrage pour appliquer la configuration de base d'OVHcloud. Renseignez `configDriveUserData` pour ajouter vos propres données utilisateur (user-data) cloud-init.
 
 :::
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
@@ -116,13 +116,13 @@ Dans l'exemple ci-dessus, la valeur de `imageCheckSum` a été masquée, car ell
 :::
 
 
-Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
+Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
+Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
 
 ```yaml
 #cloud-config
@@ -154,16 +154,16 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur <code
 
 | Champ | Description | Obligatoire |
 |-|-|-|
-| customizations/hostname | Le hostname | ❌ |
-| customizations/sshKey | La clé publique SSH | ❌ |
-| customizations/imageURL | L'URL de l'image Linux | ✅ |
+| customizations/hostname | Hostname | ❌ |
+| customizations/sshKey | Clé publique SSH | ❌ |
+| customizations/imageURL | URL de l'image Linux | ✅ |
 | customizations/imageCheckSum | Checksum de l'image | ❌ |
 | customizations/imageCheckSumType | Type de checksum de l'image (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
 | customizations/configDriveUserData | Données utilisateur (user-data) cloud-init¹ | ❌ |
 | customizations/configDriveMetadata | Métadonnées cloud-init personnalisées, exposées sous la clé `meta` de `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | Clé des en-têtes HTTP | ❌² |
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |
-| userMetadata/efiBootloaderPath | Le chemin du bootloader EFI | ✅³ |
+| userMetadata/efiBootloaderPath | Chemin du bootloader EFI | ✅³ |
 
 ¹ [Données utilisateur](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) cloud-init standard — généralement un document `#cloud-config` ou un script (voir les [exemples officiels de cloud-init](https://docs.cloud-init.io/en/latest/reference/examples.html)). Équivalent à `server create --user-data <fichier>` chez OpenStack. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
 ² À utiliser uniquement si vous avez besoin d'en-têtes HTTP, tels que `Basic Auth`<br />
@@ -185,7 +185,7 @@ Les chemins ci-dessous utilisent l'échappement JSON : `\\` représente un seul 
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
-⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property clé=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
+⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property clé=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
 
 :::info
 Lors de l'installation, OVHcloud ajoute une petite partition de [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) sur votre serveur. Cloud-init la lit au premier démarrage pour appliquer la configuration de base d'OVHcloud. Renseignez `configDriveUserData` pour ajouter vos propres données utilisateur (user-data) cloud-init.

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
@@ -125,7 +125,7 @@ L'ajout d'enregistrements spécifiques, tel qu'un enregistrement DMARC (Domain-b
 
 ### Port SMTP bloqué (port 25)
 
-Si vos e-mails ne s'envoient pas ou que le serveur SMTP ne répond pas, un port bloqué est une cause fréquente. Par défaut, le **port 25** sortant est bloqué sur l'infrastructure OVHcloud (serveurs dédiés, VPS, instances Public Cloud) afin de prévenir les abus de spam. Pour résoudre ce problème :
+Si vos e-mails ne s'envoient pas ou que le serveur SMTP ne répond pas, un port bloqué est une cause fréquente. Par défaut, le **port 25** sortant est bloqué sur l'infrastructure OVHcloud (serveurs dédiés, VPS, instances Public Cloud) afin de prévenir les abus de spam. Pour résoudre ce problème :
 
 - Utilisez le **port 587** (STARTTLS) pour la soumission des e-mails sortants.
 - Si votre cas d'usage nécessite le port 25, demandez son déblocage en [contactant notre support](/links/support-contact).

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comment éviter que vos e-mails ne soient marqués comme spam
 description: "Découvrez comment appliquer les bonnes pratiques d'envoi d'e-mails afin de limiter les risques de blocage des e-mails légitimes par la protection contre les spams"
-lastUpdated: 2024-09-24
+lastUpdated: 2026-05-28
 ---
 
 ## Objectif
@@ -122,6 +122,13 @@ Il est possible que Microsoft refuse de débloquer votre adresse IP, auquel cas 
 #### Vers un serveur Gmail
 
 L'ajout d'enregistrements spécifiques, tel qu'un enregistrement DMARC (Domain-based Message Authentication, Reporting, and Conformance) ou DKIM (DomainKeys Identified Mail) peut faciliter la réception des e-mails si votre destinataire est chez Gmail. Consultez nos guides mentionnés [en bas de cette page](#go-further) pour les configurer.
+
+### Port SMTP bloqué (port 25)
+
+Si vos e-mails ne s'envoient pas ou que le serveur SMTP ne répond pas, un port bloqué est une cause fréquente. Par défaut, le **port 25** sortant est bloqué sur l'infrastructure OVHcloud (serveurs dédiés, VPS, instances Public Cloud) afin de prévenir les abus de spam. Pour résoudre ce problème :
+
+- Utilisez le **port 587** (STARTTLS) pour la soumission des e-mails sortants.
+- Si votre cas d'usage nécessite le port 25, demandez son déblocage en [contactant notre support](/links/support-contact).
 
 ### Vérifier vos informations
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-05-25
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -23,6 +23,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](https://www.ovhcloud.com/it/bare-metal/) in your OVHcloud account
 - Access to the [OVHcloud API](/guides/manage-and-operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+:::info
+To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -82,8 +87,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnImage Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-image/byoi-controlpanel04.png" loading="lazy" />
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -119,13 +122,13 @@ In the `customizations` section, only `imageURL`, `imageType` and `efiBootloader
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -155,17 +158,17 @@ Once you have filled in the fields, start the deployment by clicking <code class
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process). Examples:
 
@@ -185,8 +188,10 @@ The paths below use JSON escaping: `\\` represents a single backslash. For examp
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 :::info
-The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Linux (BYOLinux) (EN)
 description: Find out how to easily deploy your own Linux images on dedicated servers
-lastUpdated: 2026-03-16
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -24,6 +24,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/guides/manage-and-operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process).
+
+:::info
+To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -72,8 +77,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnLinux Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-linux/byolinux-controlpanel04.png" loading="lazy" />
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ In the example above, the `imageCheckSum` value has been masked because it chang
 :::
 
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -153,16 +156,16 @@ Once you have filled in the fields, start the deployment by clicking <code class
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process). Examples:
 
@@ -182,8 +185,10 @@ The paths below use JSON escaping: `\\` represents a single backslash. For examp
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 :::info
-The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
@@ -1,7 +1,7 @@
 ---
 title: Come evitare che le tue email siano contrassegnate come Spam
 description: Scopri come applicare le best practice per l’invio di email al fine di limitare i rischi di blocco delle email legittime da parte della protezione contro gli spam
-lastUpdated: 2024-01-24
+lastUpdated: 2026-05-28
 ---
 
 :::info
@@ -122,6 +122,13 @@ Per maggiori informazioni, invia una [richiesta di assistenza](https://support.m
 #### Verso un server Gmail
 
 L'aggiunta di record specifici, ad esempio un record DMARC (Domain-based Message Authentication, Reporting, and Conformance) o DKIM (DomainKeys Identified Mail), può facilitare la ricezione delle email se il destinatario è in Gmail. Consulta le nostre guide riportate [in fondo a questa pagina](#go-further) per configurarle.
+
+### Porta SMTP bloccata (porta 25)
+
+Se le tue e-mail non vengono inviate o il server SMTP non risponde, una porta bloccata è una causa frequente. Per impostazione predefinita, la **porta 25** in uscita è bloccata sull'infrastruttura OVHcloud (server dedicati, VPS, istanze Public Cloud) per prevenire gli abusi di spam. Per risolvere questo problema:
+
+- Utilizza la **porta 587** (STARTTLS) per l'invio di e-mail in uscita.
+- Se il tuo caso d'uso richiede la porta 25, richiedi lo sblocco [contattando il nostro supporto](/links/support-contact).
 
 ### Verifica le tue informazioni
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-05-25
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -23,6 +23,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](https://www.ovhcloud.com/pl/bare-metal/) in your OVHcloud account
 - Access to the [OVHcloud API](/guides/manage-and-operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+:::info
+To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -82,8 +87,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnImage Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-image/byoi-controlpanel04.png" loading="lazy" />
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -119,13 +122,13 @@ In the `customizations` section, only `imageURL`, `imageType` and `efiBootloader
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -155,17 +158,17 @@ Once you have filled in the fields, start the deployment by clicking <code class
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process). Examples:
 
@@ -185,8 +188,10 @@ The paths below use JSON escaping: `\\` represents a single backslash. For examp
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 :::info
-The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 
 :::
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Linux (BYOLinux) (EN)
 description: Find out how to easily deploy your own Linux images on dedicated servers
-lastUpdated: 2026-03-16
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -24,6 +24,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/guides/manage-and-operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process).
+
+:::info
+To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -72,8 +77,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnLinux Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-linux/byolinux-controlpanel04.png" loading="lazy" />
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ In the example above, the `imageCheckSum` value has been masked because it chang
 :::
 
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -153,16 +156,16 @@ Once you have filled in the fields, start the deployment by clicking <code class
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process). Examples:
 
@@ -182,8 +185,10 @@ The paths below use JSON escaping: `\\` represents a single backslash. For examp
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 :::info
-The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 
 :::
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
@@ -1,7 +1,7 @@
 ---
 title: Jak zapobiec sytuacjom, w których Twoje e-maile są oznaczone jako spam
 description: Dowiedz się, jak zastosować dobre praktyki wysyłania wiadomości e-mail, aby ograniczyć ryzyko blokowania wiadomości uzasadnionych ochroną przed spamem
-lastUpdated: 2024-01-24
+lastUpdated: 2026-05-28
 ---
 
 :::info
@@ -124,6 +124,13 @@ Możliwe, że Microsoft odmówi odblokowania adresu lub adresów IP. W takim prz
 #### Na serwer Gmail
 
 Dodanie określonych rekordów, takich jak DMARC (Domain-based Message Authentication, Reporting and Conformance) lub DKIM (DomainKeys Identified Mail) może ułatwić odbieranie wiadomości e-mail, jeśli Twój odbiorca jest w Gmailu. Zapoznaj się z naszymi przewodnikami [na dole tej strony](#go-further), aby je skonfigurować.
+
+### Zablokowany port SMTP (port 25)
+
+Jeśli e-maile nie są wysyłane lub serwer SMTP nie odpowiada, częstą przyczyną jest zablokowany port. Domyślnie wychodzący **port 25** jest zablokowany w infrastrukturze OVHcloud (serwery dedykowane, VPS, instancje Public Cloud), aby zapobiec nadużyciom spamu. Aby rozwiązać ten problem:
+
+- Użyj **portu 587** (STARTTLS) do wysyłki e-maili wychodzących.
+- Jeśli Twój przypadek użycia wymaga portu 25, poproś o jego odblokowanie, [kontaktując się z naszym zespołem wsparcia](/links/support-contact).
 
 ### Sprawdź Twoje dane
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Image (BYOI) (EN)
 description: Find out how to easily deploy your own images on dedicated servers
-lastUpdated: 2026-05-25
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -23,6 +23,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](https://www.ovhcloud.com/pt/bare-metal/) in your OVHcloud account
 - Access to the [OVHcloud API](/guides/manage-and-operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+:::info
+To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -82,8 +87,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnImage Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-image/byoi-controlpanel04.png" loading="lazy" />
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -119,13 +122,13 @@ In the `customizations` section, only `imageURL`, `imageType` and `efiBootloader
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -155,17 +158,17 @@ Once you have filled in the fields, start the deployment by clicking <code class
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process). Examples:
 
@@ -185,8 +188,10 @@ The paths below use JSON escaping: `\\` represents a single backslash. For examp
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 :::info
-The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 
 :::
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Linux (BYOLinux) (EN)
 description: Find out how to easily deploy your own Linux images on dedicated servers
-lastUpdated: 2026-03-16
+lastUpdated: 2026-05-28
 ---
 
 import Api from '@components/Api';
@@ -24,6 +24,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/guides/manage-and-operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process).
+
+:::info
+To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+
+:::
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -72,8 +77,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 <img className="thumbnail" alt="BringYourOwnLinux Control Panel 04" src="/images/bare-metal-cloud/dedicated-servers/bring-your-own-linux/byolinux-controlpanel04.png" loading="lazy" />
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ In the example above, the `imageCheckSum` value has been masked because it chang
 :::
 
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -153,16 +156,16 @@ Once you have filled in the fields, start the deployment by clicking <code class
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/guides/bare-metal-cloud/dedicated-servers/boot-process). Examples:
 
@@ -182,8 +185,10 @@ The paths below use JSON escaping: `\\` represents a single backslash. For examp
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 :::info
-The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 
 :::
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
@@ -1,7 +1,7 @@
 ---
 title: Como evitar que os seus e-mails sejam marcados como spam
 description: Descubra como aplicar as boas práticas de envio de e-mails para reduzir os riscos de bloqueio de e-mails legítimos pela proteção contra spams
-lastUpdated: 2024-01-24
+lastUpdated: 2026-05-28
 ---
 
 :::info
@@ -124,6 +124,13 @@ Para mais informações queira abrir um [pedido de assistência](https://support
 #### Para um servidor Gmail
 
 A adição de registos específicos, como por exemplo um registo DMARC (Domain-based Message Authentication, Reporting, and Conformance) ou DKIM (DomainKeys Identified Mail), pode facilitar a receção de e-mails se o seu destinatário estiver no Gmail. Consulte os nossos guias mencionados [na parte inferior desta página](#go-further) para os configurar.
+
+### Porta SMTP bloqueada (porta 25)
+
+Se os seus e-mails não estão a ser enviados ou o servidor SMTP não responde, uma porta bloqueada é uma causa frequente. Por predefinição, a **porta 25** de saída está bloqueada na infraestrutura OVHcloud (servidores dedicados, VPS, instâncias Public Cloud) para prevenir o abuso de spam. Para resolver este problema:
+
+- Utilize a **porta 587** (STARTTLS) para o envio de e-mails de saída.
+- Se o seu caso de uso exigir a porta 25, peça o seu desbloqueio [contactando a nossa equipa de suporte](/links/support-contact).
 
 ### Verificar as suas informações
 


### PR DESCRIPTION
bring-your-own-{linux,image} config drive & cloud-init (legacy #9375) and mail-sending-optimization blocked-SMTP-port section (legacy #9330), across all 7 locales. Content missed by the 2026-05-12 migration refresh.

Original-URL: https://github.com/ovh/docs/pull/9375
Original-URL: https://github.com/ovh/docs/pull/9330
Original-author: @sbraz (#9375)
Original-author: @OvhValentin (#9330)