### PR TITLE
Dev/bbellion/update databases network limitations

### DIFF
--- a/docs/de/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,8 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- *Discovery*
 - *Essential*
 - *Business/Production*
 - *Enterprise/Advanced*
@@ -51,6 +52,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
+| *Discovery*           | 1               | No               |
 | *Essential*           | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
@@ -59,6 +61,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
+- **Discovery**: the cluster consists of one node.
 - **Essential**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.

--- a/docs/de/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,10 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- *Discovery*
-- *Essential*
+- *Essential/Discovery*
 - *Business/Production*
 - *Enterprise/Advanced*
 
@@ -52,8 +51,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
-| *Discovery*           | 1               | No               |
-| *Essential*           | 1               | No               |
+| *Essential/Discovery* | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
 
@@ -61,8 +59,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
-- **Discovery**: the cluster consists of one node.
-- **Essential**: the cluster consists of one node.
+- **Essential/Discovery**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.
 

--- a/docs/de/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka Connect
 description: Discover the capabilities and limitations of Analytics for Kafka Connect
-lastUpdated: 2026-02-17
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/de/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,10 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/de/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,8 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/de/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka MirrorMaker
 description: Discover the capabilities and limitations of Analytics for Kafka MirrorMaker
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/de/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -84,7 +84,6 @@ The database service's IP address is subject to change periodically. Thus, it is
 Here are some considerations to take into account when using private network:
 
 - Network ports are created in the private network of your choice. Thus, further operations on that network might be restricted - e.g. you won’t be able to delete the network if you didn’t stop the Public Cloud Databases services first.
-- **DHCP must be enabled** in your private network in order to launch MongoDB clusters in the said private network.
 - When connecting from an outside subnet, the Openstack IP gateway must be enabled in the subnet used for the Database service. The customer is responsible for any other custom network setup.
 - Subnet sizing should include considerations for service nodes, other co-located services within the same subnet, and an allocation of additional available IP addresses for maintenance purposes. Failure to adequately size subnets could result in operational challenges and the malfunctioning of services.
 - You can only create private network services if you are the original owner of the network. You can not create private network services on a shared network.

--- a/docs/de/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for MongoDB
 description: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/de/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for MySQL
 description: Discover the capabilities and limitations of Public Cloud Databases for MySQL
-lastUpdated: 2026-05-05
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/de/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,6 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/de/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,8 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/de/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,10 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/de/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,8 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/de/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch - Capabilities and Limitations
 description: Discover the capabilities and limitations of Public Cloud Databases for OpenSearch
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/de/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for PostgreSQL
 description: Discover the capabilities and limitations of Public Cloud Databases for PostgreSQL
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/de/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,6 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/de/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,8 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/de/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,8 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Two plans are available:
+Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 

--- a/docs/de/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,10 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Three plans are available:
+Two plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as backup retention.

--- a/docs/de/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/redis-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for Valkey
 description: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/en/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,8 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- *Discovery*
 - *Essential*
 - *Business/Production*
 - *Enterprise/Advanced*
@@ -51,6 +52,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
+| *Discovery*           | 1               | No               |
 | *Essential*           | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
@@ -59,6 +61,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
+- **Discovery**: the cluster consists of one node.
 - **Essential**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.

--- a/docs/en/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,10 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- *Discovery*
-- *Essential*
+- *Essential/Discovery*
 - *Business/Production*
 - *Enterprise/Advanced*
 
@@ -52,8 +51,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
-| *Discovery*           | 1               | No               |
-| *Essential*           | 1               | No               |
+| *Essential/Discovery* | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
 
@@ -61,8 +59,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
-- **Discovery**: the cluster consists of one node.
-- **Essential**: the cluster consists of one node.
+- **Essential/Discovery**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.
 

--- a/docs/en/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka Connect
 description: Discover the capabilities and limitations of Analytics for Kafka Connect
-lastUpdated: 2026-02-17
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/en/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,10 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/en/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,8 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/en/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka MirrorMaker
 description: Discover the capabilities and limitations of Analytics for Kafka MirrorMaker
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/en/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -84,7 +84,6 @@ The database service's IP address is subject to change periodically. Thus, it is
 Here are some considerations to take into account when using private network:
 
 - Network ports are created in the private network of your choice. Thus, further operations on that network might be restricted - e.g. you won’t be able to delete the network if you didn’t stop the Public Cloud Databases services first.
-- **DHCP must be enabled** in your private network in order to launch MongoDB clusters in the said private network.
 - When connecting from an outside subnet, the Openstack IP gateway must be enabled in the subnet used for the Database service. The customer is responsible for any other custom network setup.
 - Subnet sizing should include considerations for service nodes, other co-located services within the same subnet, and an allocation of additional available IP addresses for maintenance purposes. Failure to adequately size subnets could result in operational challenges and the malfunctioning of services.
 - You can only create private network services if you are the original owner of the network. You can not create private network services on a shared network.

--- a/docs/en/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for MongoDB
 description: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/en/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for MySQL
 description: Discover the capabilities and limitations of Public Cloud Databases for MySQL
-lastUpdated: 2026-05-05
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/en/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,6 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/en/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,8 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/en/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,10 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/en/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,8 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/en/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch - Capabilities and Limitations
 description: Discover the capabilities and limitations of Public Cloud Databases for OpenSearch
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/en/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for PostgreSQL
 description: Discover the capabilities and limitations of Public Cloud Databases for PostgreSQL
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/en/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,6 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/en/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,8 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/en/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,8 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Two plans are available:
+Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 

--- a/docs/en/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,10 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Three plans are available:
+Two plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as backup retention.

--- a/docs/en/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for Valkey
 description: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/es/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,8 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- *Discovery*
 - *Essential*
 - *Business/Production*
 - *Enterprise/Advanced*
@@ -51,6 +52,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
+| *Discovery*           | 1               | No               |
 | *Essential*           | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
@@ -59,6 +61,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
+- **Discovery**: the cluster consists of one node.
 - **Essential**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.

--- a/docs/es/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,10 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- *Discovery*
-- *Essential*
+- *Essential/Discovery*
 - *Business/Production*
 - *Enterprise/Advanced*
 
@@ -52,8 +51,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
-| *Discovery*           | 1               | No               |
-| *Essential*           | 1               | No               |
+| *Essential/Discovery* | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
 
@@ -61,8 +59,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
-- **Discovery**: the cluster consists of one node.
-- **Essential**: the cluster consists of one node.
+- **Essential/Discovery**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.
 

--- a/docs/es/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka Connect
 description: Discover the capabilities and limitations of Analytics for Kafka Connect
-lastUpdated: 2026-02-17
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/es/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,10 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/es/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,8 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/es/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka MirrorMaker
 description: Discover the capabilities and limitations of Analytics for Kafka MirrorMaker
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/es/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -84,7 +84,6 @@ The database service's IP address is subject to change periodically. Thus, it is
 Here are some considerations to take into account when using private network:
 
 - Network ports are created in the private network of your choice. Thus, further operations on that network might be restricted - e.g. you won’t be able to delete the network if you didn’t stop the Public Cloud Databases services first.
-- **DHCP must be enabled** in your private network in order to launch MongoDB clusters in the said private network.
 - When connecting from an outside subnet, the Openstack IP gateway must be enabled in the subnet used for the Database service. The customer is responsible for any other custom network setup.
 - Subnet sizing should include considerations for service nodes, other co-located services within the same subnet, and an allocation of additional available IP addresses for maintenance purposes. Failure to adequately size subnets could result in operational challenges and the malfunctioning of services.
 - You can only create private network services if you are the original owner of the network. You can not create private network services on a shared network.

--- a/docs/es/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for MongoDB
 description: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/es/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for MySQL
 description: Discover the capabilities and limitations of Public Cloud Databases for MySQL
-lastUpdated: 2026-05-05
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/es/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,6 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/es/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,8 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/es/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,10 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/es/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,8 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/es/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch - Capabilities and Limitations
 description: Discover the capabilities and limitations of Public Cloud Databases for OpenSearch
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/es/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for PostgreSQL
 description: Discover the capabilities and limitations of Public Cloud Databases for PostgreSQL
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/es/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,6 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/es/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,8 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/es/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,8 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Two plans are available:
+Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 

--- a/docs/es/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,10 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Three plans are available:
+Two plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as backup retention.

--- a/docs/es/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/redis-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for Valkey
 description: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/fr/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,8 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- *Discovery*
 - *Essential*
 - *Business/Production*
 - *Enterprise/Advanced*
@@ -51,6 +52,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
+| *Discovery*           | 1               | No               |
 | *Essential*           | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
@@ -59,6 +61,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
+- **Discovery**: the cluster consists of one node.
 - **Essential**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.

--- a/docs/fr/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capacités et limitations pour Analytics avec Kafka Connect (EN)
 description: Discover the capabilities and limitations of Analytics for Kafka Connect
-lastUpdated: 2026-02-17
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/fr/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,10 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- *Discovery*
-- *Essential*
+- *Essential/Discovery*
 - *Business/Production*
 - *Enterprise/Advanced*
 
@@ -52,8 +51,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
-| *Discovery*           | 1               | No               |
-| *Essential*           | 1               | No               |
+| *Essential/Discovery* | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
 
@@ -61,8 +59,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
-- **Discovery**: the cluster consists of one node.
-- **Essential**: the cluster consists of one node.
+- **Essential/Discovery**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.
 

--- a/docs/fr/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capacités et limitations pour Analytics avec Kafka MirrorMaker (EN)
 description: Discover the capabilities and limitations of Analytics for Kafka MirrorMaker
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/fr/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,10 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/fr/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,8 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/fr/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -84,7 +84,6 @@ The database service's IP address is subject to change periodically. Thus, it is
 Here are some considerations to take into account when using private network:
 
 - Network ports are created in the private network of your choice. Thus, further operations on that network might be restricted - e.g. you won’t be able to delete the network if you didn’t stop the Public Cloud Databases services first.
-- **DHCP must be enabled** in your private network in order to launch MongoDB clusters in the said private network.
 - When connecting from an outside subnet, the Openstack IP gateway must be enabled in the subnet used for the Database service. The customer is responsible for any other custom network setup.
 - Subnet sizing should include considerations for service nodes, other co-located services within the same subnet, and an allocation of additional available IP addresses for maintenance purposes. Failure to adequately size subnets could result in operational challenges and the malfunctioning of services.
 - You can only create private network services if you are the original owner of the network. You can not create private network services on a shared network.

--- a/docs/fr/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capacités et limitations de Public Cloud pour MongoDB (EN)
 description: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/fr/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capacités et limitations de Public Cloud Databases pour MySQL (EN)
 description: Discover the capabilities and limitations of Public Cloud Databases for MySQL
-lastUpdated: 2026-05-05
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/fr/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,6 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/fr/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,8 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/fr/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,10 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/fr/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,8 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/fr/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch – Capacités et limitations (EN)
 description: Discover the capabilities and limitations of Public Cloud Databases for OpenSearch
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/fr/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,6 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/fr/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,8 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/fr/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capacités et limitations de Public Cloud Databases pour PostgreSQL (EN)
 description: Discover the capabilities and limitations of Public Cloud Databases for PostgreSQL
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/fr/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/redis-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capacités et limitations de Public Cloud Databases pour Valkey (EN)
 description: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/fr/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,8 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Two plans are available:
+Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 

--- a/docs/fr/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,10 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Three plans are available:
+Two plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as backup retention.

--- a/docs/it/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,8 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- *Discovery*
 - *Essential*
 - *Business/Production*
 - *Enterprise/Advanced*
@@ -51,6 +52,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
+| *Discovery*           | 1               | No               |
 | *Essential*           | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
@@ -59,6 +61,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
+- **Discovery**: the cluster consists of one node.
 - **Essential**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.

--- a/docs/it/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,10 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- *Discovery*
-- *Essential*
+- *Essential/Discovery*
 - *Business/Production*
 - *Enterprise/Advanced*
 
@@ -52,8 +51,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
-| *Discovery*           | 1               | No               |
-| *Essential*           | 1               | No               |
+| *Essential/Discovery* | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
 
@@ -61,8 +59,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
-- **Discovery**: the cluster consists of one node.
-- **Essential**: the cluster consists of one node.
+- **Essential/Discovery**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.
 

--- a/docs/it/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka Connect
 description: Discover the capabilities and limitations of Analytics for Kafka Connect
-lastUpdated: 2026-02-17
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/it/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,10 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/it/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,8 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/it/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka MirrorMaker
 description: Discover the capabilities and limitations of Analytics for Kafka MirrorMaker
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/it/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -84,7 +84,6 @@ The database service's IP address is subject to change periodically. Thus, it is
 Here are some considerations to take into account when using private network:
 
 - Network ports are created in the private network of your choice. Thus, further operations on that network might be restricted - e.g. you won’t be able to delete the network if you didn’t stop the Public Cloud Databases services first.
-- **DHCP must be enabled** in your private network in order to launch MongoDB clusters in the said private network.
 - When connecting from an outside subnet, the Openstack IP gateway must be enabled in the subnet used for the Database service. The customer is responsible for any other custom network setup.
 - Subnet sizing should include considerations for service nodes, other co-located services within the same subnet, and an allocation of additional available IP addresses for maintenance purposes. Failure to adequately size subnets could result in operational challenges and the malfunctioning of services.
 - You can only create private network services if you are the original owner of the network. You can not create private network services on a shared network.

--- a/docs/it/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for MongoDB
 description: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/it/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for MySQL
 description: Discover the capabilities and limitations of Public Cloud Databases for MySQL
-lastUpdated: 2026-05-05
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/it/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,6 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/it/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,8 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/it/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,10 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/it/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,8 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/it/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch - Capabilities and Limitations
 description: Discover the capabilities and limitations of Public Cloud Databases for OpenSearch
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/it/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for PostgreSQL
 description: Discover the capabilities and limitations of Public Cloud Databases for PostgreSQL
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/it/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,6 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/it/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,8 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/it/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,8 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Two plans are available:
+Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 

--- a/docs/it/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,10 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Three plans are available:
+Two plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as backup retention.

--- a/docs/it/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/redis-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for Valkey
 description: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pl/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,8 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- *Discovery*
 - *Essential*
 - *Business/Production*
 - *Enterprise/Advanced*
@@ -51,6 +52,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
+| *Discovery*           | 1               | No               |
 | *Essential*           | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
@@ -59,6 +61,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
+- **Discovery**: the cluster consists of one node.
 - **Essential**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.

--- a/docs/pl/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,10 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- *Discovery*
-- *Essential*
+- *Essential/Discovery*
 - *Business/Production*
 - *Enterprise/Advanced*
 
@@ -52,8 +51,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
-| *Discovery*           | 1               | No               |
-| *Essential*           | 1               | No               |
+| *Essential/Discovery* | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
 
@@ -61,8 +59,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
-- **Discovery**: the cluster consists of one node.
-- **Essential**: the cluster consists of one node.
+- **Essential/Discovery**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.
 

--- a/docs/pl/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka Connect
 description: Discover the capabilities and limitations of Analytics for Kafka Connect
-lastUpdated: 2026-02-17
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pl/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,10 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/pl/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,8 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/pl/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka MirrorMaker
 description: Discover the capabilities and limitations of Analytics for Kafka MirrorMaker
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pl/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -84,7 +84,6 @@ The database service's IP address is subject to change periodically. Thus, it is
 Here are some considerations to take into account when using private network:
 
 - Network ports are created in the private network of your choice. Thus, further operations on that network might be restricted - e.g. you won’t be able to delete the network if you didn’t stop the Public Cloud Databases services first.
-- **DHCP must be enabled** in your private network in order to launch MongoDB clusters in the said private network.
 - When connecting from an outside subnet, the Openstack IP gateway must be enabled in the subnet used for the Database service. The customer is responsible for any other custom network setup.
 - Subnet sizing should include considerations for service nodes, other co-located services within the same subnet, and an allocation of additional available IP addresses for maintenance purposes. Failure to adequately size subnets could result in operational challenges and the malfunctioning of services.
 - You can only create private network services if you are the original owner of the network. You can not create private network services on a shared network.

--- a/docs/pl/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for MongoDB
 description: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pl/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for MySQL
 description: Discover the capabilities and limitations of Public Cloud Databases for MySQL
-lastUpdated: 2026-05-05
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pl/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,6 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/pl/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,8 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/pl/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,10 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/pl/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,8 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/pl/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch - Capabilities and Limitations
 description: Discover the capabilities and limitations of Public Cloud Databases for OpenSearch
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pl/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for PostgreSQL
 description: Discover the capabilities and limitations of Public Cloud Databases for PostgreSQL
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pl/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,6 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/pl/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,8 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/pl/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,8 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Two plans are available:
+Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 

--- a/docs/pl/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,10 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Three plans are available:
+Two plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as backup retention.

--- a/docs/pl/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/redis-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for Valkey
 description: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pt/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,8 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- *Discovery*
 - *Essential*
 - *Business/Production*
 - *Enterprise/Advanced*
@@ -51,6 +52,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
+| *Discovery*           | 1               | No               |
 | *Essential*           | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
@@ -59,6 +61,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
+- **Discovery**: the cluster consists of one node.
 - **Essential**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.

--- a/docs/pt/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -41,10 +41,9 @@ Please refer to the [Analytics lifecycle policy guide](/guides/public-cloud/data
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- *Discovery*
-- *Essential*
+- *Essential/Discovery*
 - *Business/Production*
 - *Enterprise/Advanced*
 
@@ -52,8 +51,7 @@ Here is an overview of the various plans' capabilities:
 
 | Plan                  | Number of nodes | Additional nodes |
 | --------------------- | --------------- | ---------------- |
-| *Discovery*           | 1               | No               |
-| *Essential*           | 1               | No               |
+| *Essential/Discovery* | 1               | No               |
 | *Business/Production* | 3               | No               |
 | *Enterprise/Advanced* | 6               | No               |
 
@@ -61,8 +59,7 @@ Your choice of plan affects the number of nodes your cluster run or the SLA.
 
 #### Nodes
 
-- **Discovery**: the cluster consists of one node.
-- **Essential**: the cluster consists of one node.
+- **Essential/Discovery**: the cluster consists of one node.
 - **Business/Production**: the cluster is delivered with 3 nodes.
 - **Enterprise/Advanced**: the cluster is delivered with 6 nodes.
 

--- a/docs/pt/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka Connect
 description: Discover the capabilities and limitations of Analytics for Kafka Connect
-lastUpdated: 2026-02-17
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pt/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,10 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/pt/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -47,8 +47,9 @@ Additionally, Kafka Connect is available at OVHcloud.
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/pt/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Analytics with Kafka MirrorMaker
 description: Discover the capabilities and limitations of Analytics for Kafka MirrorMaker
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pt/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -84,7 +84,6 @@ The database service's IP address is subject to change periodically. Thus, it is
 Here are some considerations to take into account when using private network:
 
 - Network ports are created in the private network of your choice. Thus, further operations on that network might be restricted - e.g. you won’t be able to delete the network if you didn’t stop the Public Cloud Databases services first.
-- **DHCP must be enabled** in your private network in order to launch MongoDB clusters in the said private network.
 - When connecting from an outside subnet, the Openstack IP gateway must be enabled in the subnet used for the Database service. The customer is responsible for any other custom network setup.
 - Subnet sizing should include considerations for service nodes, other co-located services within the same subnet, and an allocation of additional available IP addresses for maintenance purposes. Failure to adequately size subnets could result in operational challenges and the malfunctioning of services.
 - You can only create private network services if you are the original owner of the network. You can not create private network services on a shared network.

--- a/docs/pt/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for MongoDB
 description: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pt/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for MySQL
 description: Discover the capabilities and limitations of Public Cloud Databases for MySQL
-lastUpdated: 2026-05-05
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pt/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,6 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/pt/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -47,8 +47,7 @@ You can use any of the [MySQL-recommended connectors and API](https://dev.mysql.
 
 Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/pt/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,10 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Four plans are available:
+Three plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes
 

--- a/docs/pt/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -44,8 +44,9 @@ You can use any of the [OpenSearch-recommended clients and plugins](https://open
 
 ### Plans
 
-Three plans are available:
+Four plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 3 nodes
 - **Enterprise/Advanced**: 6 nodes

--- a/docs/pt/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch - Capabilities and Limitations
 description: Discover the capabilities and limitations of Public Cloud Databases for OpenSearch
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pt/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for PostgreSQL
 description: Discover the capabilities and limitations of Public Cloud Databases for PostgreSQL
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective

--- a/docs/pt/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,6 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes

--- a/docs/pt/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -50,8 +50,7 @@ You can use any of the [PostgreSQL-recommended drivers and extensions](https://w
 
 Different plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 - **Enterprise/Advanced**: 3 nodes
 

--- a/docs/pt/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,8 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Two plans are available:
+Three plans are available:
 
+- **Discovery**: 1 node
 - **Essential**: 1 node
 - **Business/Production**: 2 nodes
 

--- a/docs/pt/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/redis-capabilities.mdx
@@ -46,10 +46,9 @@ You can use any of the [clients recommended by Redis®](https://redis.io/clients
 
 ### Plans
 
-Three plans are available:
+Two plans are available:
 
-- **Discovery**: 1 node
-- **Essential**: 1 node
+- **Essential/Discovery**: 1 node
 - **Business/Production**: 2 nodes
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as backup retention.

--- a/docs/pt/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/redis-capabilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capabilities and Limitations of Public Cloud Databases for Valkey
 description: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-lastUpdated: 2026-04-15
+lastUpdated: 2026-05-28
 ---
 
 ## Objective


### PR DESCRIPTION
  - MongoDB capabilities: drop the "DHCP must be enabled on the private network" requirement — no longer needed to launch clusters in a vRack subnet.
  - Plan tiers: surface the new Discovery name as part of the 1-node tier across PostgreSQL, MySQL, Redis/Valkey, MirrorMaker, OpenSearch, and Kafka Connect — renamed to Essential/Discovery, matching the
  existing Business/Production and Enterprise/Advanced double-naming convention. Plan counts are unchanged.

  Applied across all 7 language variants. MongoDB already lists Discovery; Kafka has no 1-node tier; Grafana has no Discovery plan; ClickHouse already documents Discovery — intentionally untouched.