### PR TITLE
docs(port): restore missing public-cloud content (7 guides, hand-port)

### DIFF
--- a/docs/de/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/de/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cloud Guthaben aufladen
 description: Erfahren Sie hier, wie Sie Ihrem Public Cloud Projekt Guthaben oder Gutscheine hinzufügen
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Ziel
@@ -72,4 +72,8 @@ Da die Gültigkeitsdauer der Gutscheine in der Regel kürzer ist, wird der Gutha
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+:::info
+Neukunden erhalten automatisch ein Gratis-Testguthaben von 200 €, sobald sie ihr erstes Public Cloud Projekt aktivieren. Lesen Sie hierzu unsere Anleitung "[Erstellung Ihres ersten OVHcloud Public Cloud Projekts](/guides/public-cloud/cross-functional/create-a-public-cloud-project)".
+:::
+
+Treten Sie unserer [User Community](https://community.ovhcloud.com/) bei.

--- a/docs/de/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zusätzliches Volume auf einer Instanz erstellen und konfigurieren
 description: Erfahren Sie hier, wie Sie eine neue Disk erstellen und zu Ihrer Public Cloud Instanz hinzufügen
-lastUpdated: 2025-09-19
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -65,24 +65,16 @@ In den 3AZ-Regionen sind Classic Volumes regionale Dienste, die *Distributed Era
 
 <details>
 
-<summary>**High-Speed - Bis zu 3000 IOPS**</summary>
+<summary>**High Speed Gen2 – 30 IOPS/GB und bis zu 20.000 IOPS**</summary>
 
 
-Das High Speed-Volume wurde für Anwendungen entwickelt, die einen schnelleren Datenzugriff erfordern. Mit einer Leistung von bis zu 3000 IOPS ist es ideal für folgende Anwendungsfälle:
+High Speed Volumes der zweiten Generation sind für die anspruchsvollsten Workloads optimiert. Die Leistung skaliert mit der Volume-Größe:
 
-- Transaktionsdatenbanken (MySQL, PostgreSQL, etc.)
-- Virtualisierungs- und Containerumgebungen
-- Anwendungen, die eine geringe Latenz und einen hohen Durchsatz erfordern
+- **IOPS**: 30 IOPS/GB (Basis 3.000 IOPS für 10–100 GB, bis zu 20.000 IOPS)
+- **Durchsatz**: 0,5 MB/s/GB (Basis 50 MB/s für 10–100 GB, bis zu 512 MB/s)
+- **Maximale Größe**: 12 TB
 
-</details>
-
-
-<details>
-
-<summary>**High-Speed Gen2 - 30 IOPS/GB und bis zu 20.000 IOPS**</summary>
-
-
-High Speed Volumes der zweiten Generation sind für die anspruchsvollsten Workloads optimiert. Mit einer Performance von 30 IOPS/GB bis zu 20.000 IOPS wird dieser Volume-Typ für folgende Anwendungen empfohlen:
+Dieser Volume-Typ wird für folgende Anwendungen empfohlen:
 
 - Big Data und Analysen in Echtzeit
 - Künstliche Intelligenz und Machine Learning
@@ -90,6 +82,12 @@ High Speed Volumes der zweiten Generation sind für die anspruchsvollsten Worklo
 
 </details>
 
+
+:::info
+**Sie können High Speed (Gen1) Volumes nicht mehr über das OVHcloud Kundencenter bestellen.** Sie wurden durch High Speed Gen2 Volumes zum gleichen Preis ersetzt, mit besserer Leistung für Volumes über 100 GB. High Speed Volumes bleiben über die API, Terraform und OpenStack verfügbar.
+
+Bestehende High Speed Volumes werden weiterhin unterstützt. Sie können auch [den Typ Ihres Block Storage Volumes ändern](/guides/public-cloud/compute/switch-volume-type), um diese auf Gen2 zu migrieren.
+:::
 
 <img className="thumbnail" alt="standardvolumes" src="/images/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance/volume-types.png" loading="lazy" />
 
@@ -786,4 +784,4 @@ Klicken Sie im neuen Fenster auf <code className="action">Bestätigen</code>, um
 
 [Die Größe einer zusätzlichen Disk erweitern](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](https://community.ovhcloud.com/) bei.

--- a/docs/de/guides/public-cloud/compute/switch-volume-type.mdx
+++ b/docs/de/guides/public-cloud/compute/switch-volume-type.mdx
@@ -1,7 +1,7 @@
 ---
 title: Block Storage Volume bearbeiten
 description: Erfahren Sie hier, wie Sie den Typ eines Block Storage Volumes mit OpenStack ändern
-lastUpdated: 2026-01-13
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -38,9 +38,7 @@ Diese Änderung kann über Horizon oder OpenStack CLI vorgenommen werden.
 :::warning
 Wenn das Block Storage-Volumen an eine Instanz angeschlossen ist, müssen Sie es abtrennen. Weitere Informationen finden Sie im Abschnitt **Volume abtrennen** in "[Zusätzliches Volume auf einer Instanz erstellen und konfigurieren](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#detach-a-volume)".
 
-Das Ändern des Volumetyps (Retyping) über das OVHcloud Kundencenter oder die OVHcloud API ist nur für nicht verschlüsselte Volumes verfügbar. Volumes des Typs **-LUKS** können über diese Schnittstellen nicht retypisiert werden.
-
-Retyping wird über OpenStack / Horizon nur für **-LUKS** zu **-LUKS** Volumen unterstützt. In diesem Fall ist die Wiederherstellung des Volumens nach dem Retyping nicht möglich.
+Das Ändern des Volumetyps (Retyping) über das OVHcloud Kundencenter oder die OVHcloud API ist nur für nicht verschlüsselte Volumes verfügbar. Verschlüsselte Volumes vom Typ **-LUKS** können nicht retypisiert werden.
 
 Konvertierungen von **-LUKS** zu **nicht -LUKS** (oder umgekehrt) werden nicht unterstützt, auch nicht über OpenStack / Horizon.
 
@@ -119,6 +117,6 @@ Im Pop-up-Fenster klicken Sie auf das Dropdown-Menü unter `Type` und wählen Si
 
 Weitere Informationen zur Migration eines Block Storage Volumes auf ein LUKS-verschlüsseltes Volume finden Sie in unserer dedizierten Anleitung [Block Storage Volume auf ein LUKS-verschlüsseltes Volume migrieren](/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume).(EN).
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](https://community.ovhcloud.com/) bei.

--- a/docs/de/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Erstellung Ihres ersten OVHcloud Public Cloud Projekts
 description: Erfahren Sie hier, wie Sie Ihr erstes Public Cloud Projekt über das OVHcloud Kundencenter erstellen
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 :::info
@@ -30,6 +30,8 @@ Das Erstellen eines Projekts ist die Voraussetzung, um [Public Cloud Instanzen](
 {/* CP-NAV-END:publiccloud-projects */}
 
 ## In der praktischen Anwendung
+
+### Erstellung des Projekts
 
 Nachdem Sie die Vertragsbedingungen gelesen haben, bestätigen Sie diese, indem Sie das entsprechende Kästchen ankreuzen und auf <code className="action">Das Public-Cloud-Universum entdecken</code> klicken.
 
@@ -60,6 +62,20 @@ Um das volle Potenzial der Public Cloud auszuschöpfen und Ihre ersten Ressource
 
 <iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/N7r_VCB7nmI?si=fcyToz1wK8Tw7skw" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen={true}></iframe>
 
+### Projektaktivierung und Gratis-Testphase
+
+Wenn Sie im `Discovery-Modus` auf <code className="action">Projekt aktivieren</code> klicken und ein Zahlungsmittel hinterlegen, wird Ihnen ein **Gratis-Testguthaben von 200 €** gutgeschrieben, sofern Sie dafür berechtigt sind.
+
+:::info
+**Bedingungen für das Gratis-Testguthaben**
+
+- Das Guthaben wird zum Zeitpunkt der Projektaktivierung freigeschaltet und ist **einen Monat** lang gültig.
+- **Berechtigt:** Alle OVHcloud Kunden, die ihr erstes Public Cloud Projekt erstellen, auch wenn sie bereits einen OVHcloud Account besitzen.
+- **Nicht berechtigt:** Kunden mit einem aktuellen oder früheren Public Cloud Projekt sowie Kunden, die bereits ein Gratis-Testguthaben in Anspruch genommen haben.
+
+Weitere Informationen finden Sie auf der Seite [OVHcloud Public Cloud Gratis-Testphase](/links/public-cloud/free-trial).
+:::
+
 ## Weiterführende Informationen
 
 - [Erste Public Cloud Instanz erstellen und auf dieser einloggen](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
@@ -68,6 +84,6 @@ Um das volle Potenzial der Public Cloud auszuschöpfen und Ihre ersten Ressource
 - [Ein Public Cloud Projekt löschen](/guides/public-cloud/cross-functional/delete-a-project)
 - [Informationen zu den Abrechnungsoptionen der Public Cloud](/guides/public-cloud/cross-functional/analyze-billing)
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovhcloud.com/](https://community.ovhcloud.com/en/).

--- a/docs/de/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Quota erhöhen
 description: Erfahren Sie hier, wie Sie eine Erhöhung Ihrer Kontingente für Public Cloud beantragen
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-28
 ---
 
 ## Ziel
@@ -32,6 +32,10 @@ Um zusätzliche Ressourcen und Instanzen nutzen zu können, müssen deren Quotas
 ### Erhöhung der Ressourcenquote
 
 Gemäß interner Kriterien (Dienstalter, bezahlte Rechnungen usw.) können Sie direkt vom OVHcloud Kundencenter aus Quotenerhöhungen für Ihre Public Cloud Projekte beantragen.
+
+:::info
+Erstmalige Public Cloud Nutzer erhalten bei der Projekterstellung automatisch ein [Gratis-Guthaben von 200 €](/links/public-cloud/free-trial), das einen Monat lang gültig ist. Da die Berechtigung für eine Quotenerhöhung von Kriterien wie der Account-Dauer und bezahlten Rechnungen abhängt, stehen Nutzern des Gratis-Testguthabens möglicherweise nur eingeschränkte Optionen zur Quotenerhöhung zur Verfügung, bis ihre erste Rechnung beglichen wurde.
+:::
 
 Sie können Ihre Ressourcenquote manuell oder automatisch erhöhen.
 
@@ -135,6 +139,6 @@ Für bestimmte Ressourcen oder Dienste können spezifische Quoten gelten. Weiter
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](https://community.ovhcloud.com/) bei.
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -1,7 +1,7 @@
 ---
 title: Einführung in das Public Cloud Interface
 description: Erfahren Sie hier, wie Sie das Public Cloud Interface verwenden
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Ziel
@@ -61,6 +61,9 @@ Sie können den Projektnamen im Tab <code className="action">Einstellungen</code
 |**Container & Orchestrierung**|Diese Rubrik bietet Ihnen verschiedene Tools zur Automatisierung Ihrer Architekturen und zur Erhöhung der Flexibilität.|
 |**Datenbanken und Analysen**|Diese Dienste unterstützen Sie bei der Lösung von Big Data und Data Analytics Problemen.|
 |**AI & Machine Learning**|In diesem Abschnitt finden Sie OVHcloud Tools für künstliche Intelligenz.|
+|**Quantum**|Dieser Bereich umfasst Dienste rund um Quantencomputing.|
+|**Management Interfaces**|Ein direkter Link zum Horizon-Interface.|
+|**Einstellungen**|In diesem Bereich können Sie Aspekte des Projekts konfigurieren und verwalten.|
 
 
 ### Shortcuts
@@ -78,7 +81,7 @@ Für jede Ressource, die Sie im Kundencenter erstellen, wird Ihnen ein Konfigura
 
 ### Die Verwaltungswerkzeuge
 
-In Ihrem Public Cloud Projekt sind mehrere Management-Tools verfügbar, die sich im unteren Bereich der linken Menüleiste befinden.
+In Ihrem Public Cloud Projekt stehen mehrere Management-Tools zur Konfiguration Ihrer Ressourcen, Benutzer und Einstellungen zur Verfügung. Sie können über das Menü unten links darauf zugreifen. Die Tools sind in zwei Hauptbereiche unterteilt: **Management Interfaces**, das den Link zum Horizon-Interface enthält, und **Einstellungen**, die alle Projektkonfigurationsoptionen zusammenfasst (Benutzer, Quotas, SSH, Abrechnung, Kontakte usw.).
 
 <img className="thumbnail" alt="Public Cloud Interface - Verwaltungswerkzeuge" src="/images/public-cloud/cross-functional/03-public-cloud-interface-walk-me/management-tools-2025.png" loading="lazy" />
 
@@ -121,6 +124,6 @@ Die folgende Tabelle vergleicht die wichtigsten Merkmale jedes Tools, um Ihnen d
 
 [Public Cloud Instanz erstellen und verwenden](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](https://community.ovhcloud.com/) bei.

--- a/docs/de/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
+++ b/docs/de/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring a public IP block in a vRack on a Public Cloud instance
 description: Find out how to link a block of public IP addresses to the vRack for configuration on a Public Cloud Instance
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -393,7 +393,7 @@ Click the tab that corresponds to your distribution:
     **Configuration example:**
     
     ```bash
-      ens7:
+      eno2:
         dhcp4: false
         addresses:
         - 203.0.113.1/29
@@ -538,7 +538,7 @@ Click the tab that corresponds to your distribution:
     sudo nmcli con mod 'Wired connection 1' connection.autoconnect true
     ```
     
-    Reboot your network with the following command:
+    Restart your network with the following command:
     
     ```bash
     sudo systemctl restart NetworkManager
@@ -549,4 +549,4 @@ Click the tab that corresponds to your distribution:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/en/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/en/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Adding cloud credit
 description: Find out how to add credit or vouchers to your Public Cloud project
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Objective
@@ -71,4 +71,8 @@ Since the validity periods of vouchers are usually more limited, the voucher bal
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+:::info
+New customers automatically receive £175 of free trial credit when they activate their first Public Cloud project. See our guide on [Creating your first OVHcloud Public Cloud project](/guides/public-cloud/cross-functional/create-a-public-cloud-project).
+:::
+
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/en/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to create and configure an additional disk on an instance
 description: Find out how to attach a new volume to your Public Cloud instance
-lastUpdated: 2025-09-19
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -67,24 +67,16 @@ In 3AZ regions, Classic Volumes are regional services that use distributed erasu
 
 <details>
 
-<summary>**High-Speed – Up to 3000 IOPS**</summary>
+<summary>**High Speed Gen2 – 30 IOPS/GB and up to 20,000 IOPS**</summary>
 
 
-The High-Speed volume is designed for applications requiring faster data access. With performance of up to 3000 IOPS, it is ideally suited to the following use cases:
+Generation 2 High Speed volumes are optimized for the most demanding workloads. Performance scales with volume size:
 
-- Transactional databases (MySQL, PostgreSQL, etc.)
-- Virtualization and container environments
-- Applications requiring low latency and high throughput
+- **IOPS**: 30 IOPS/GB (base 3,000 IOPS for 10–100 GB, up to 20,000 IOPS)
+- **Throughput**: 0.5 MB/s/GB (base 50 MB/s for 10–100 GB, up to 512 MB/s)
+- **Maximum size**: 12 TB
 
-</details>
-
-
-<details>
-
-<summary>**High-Speed Gen2 – 30 IOPS/GB and up to 20,000 IOPS**</summary>
-
-
-Generation 2 High-Speed volumes are optimized for the most demanding workloads. With a performance of 30 IOPS/GB, up to 20,000 IOPS, this type of volume is recommended for:
+This type of volume is recommended for:
 
 - Big Data and real-time analysis
 - Artificial intelligence and machine learning
@@ -92,6 +84,12 @@ Generation 2 High-Speed volumes are optimized for the most demanding workloads. 
 
 </details>
 
+
+:::info
+**You can no longer order High Speed (Gen1) volumes via the OVHcloud Control Panel.** They have been replaced by High Speed Gen2 volumes at the same price, with better performance for volumes above 100 GB. High Speed volumes remain available via the API, Terraform, and OpenStack.
+
+Existing High Speed volumes remain supported. You can also [change your Block Storage volume type](/guides/public-cloud/compute/switch-volume-type) to migrate them to Gen2.
+:::
 
 <img className="thumbnail" alt="volume_types" src="/images/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance/volume-types.png" loading="lazy" />
 
@@ -792,4 +790,4 @@ Click on <code className="action">Confirm</code> in the pop up window to start t
 
 [Increasing the size of an additional disk](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/en/guides/public-cloud/compute/switch-volume-type.mdx
+++ b/docs/en/guides/public-cloud/compute/switch-volume-type.mdx
@@ -1,7 +1,7 @@
 ---
 title: Change your block storage volume type
 description: Find out how to change your volume type using OpenStack
-lastUpdated: 2026-01-13
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -38,9 +38,7 @@ This modification can be made via Horizon or the OpenStack CLI.
 :::warning
 If the block storage volume is attached to an instance, you must first detach it before proceeding. For more information, see the **Detach a volume** section of the guide "[How to create and configure an additional disk on an instance](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#detach-a-volume)".
 
-Changing the volume type (retyping) via the OVHcloud Control Panel or the OVHcloud API is available only for unencrypted volumes. Encrypted volumes of type **-LUKS** cannot be retyped using these interfaces.
-
-Retyping is supported via OpenStack / Horizon only for **-LUKS** to **-LUKS** volumes. In this case, volume restoration after retyping is not possible.
+Changing the volume type (retyping) via the OVHcloud Control Panel or the OVHcloud API is available only for unencrypted volumes. Encrypted volumes of type **-LUKS** cannot be retyped.
 
 Conversions from **-LUKS** to **non -LUKS** (or vice versa) are not supported, including via OpenStack / Horizon.
 
@@ -49,7 +47,7 @@ Conversions from **-LUKS** to **non -LUKS** (or vice versa) are not supported, i
 
 <Tabs>
   <Tab label="Via the OVHcloud Control Panel">
-    Click on <code className="action">Block Storage</code> in the left-hand menu under **Storage & backup**.
+    Click on <code className="action">Block Storage</code> in the left-hand menu under **Storage & Backup**.
     
     Locate the relevant volume in the list, then click the <code className="action">...</code> button on the right. Select <code className="action">Change the volume type</code>.
     
@@ -119,6 +117,6 @@ In the pop-up window, click on the drop-down menu under `Type` and select <code 
 
 To learn how to migrate a Block Storage volume to an encrypted LUKS volume, check out our dedicated guide: [Migrating a Block Storage volume to an encrypted LUKS volume](/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/en/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creating your first OVHcloud Public Cloud project
 description: Find out how to create your first Public Cloud project via the OVHcloud Control Panel
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Objective
@@ -24,6 +24,8 @@ Creating a project is the first step in deploying [Public Cloud instances](https
 {/* CP-NAV-END:publiccloud-projects */}
 
 ## Instructions
+
+### Project creation
 
 Once you have read and understood the terms of the contracts, tick the corresponding box, then click <code className="action">Discover the Public Cloud universe</code>.
 
@@ -54,6 +56,20 @@ To harness the full potential of the Public Cloud and start your first resources
 
 <iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/N7r_VCB7nmI?si=fcyToz1wK8Tw7skw" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen={true}></iframe>
 
+### Project activation and free trial
+
+When you click <code className="action">Activate project</code> from `discovery mode` and register a payment method, a **£175 free trial credit** is applied if you are eligible.
+
+:::info
+**Free trial conditions**
+
+- The credit is activated at the time of project activation and is valid for **one month**.
+- **Eligible:** Any OVHcloud customer creating their first Public Cloud project, even if they already have an OVHcloud account.
+- **Not eligible:** Customers with a current or past Public Cloud project, or who have already used a free trial credit.
+
+Learn more on the [OVHcloud Public Cloud free trial](/links/public-cloud/free-trial) page.
+:::
+
 ## Go further
 
 - [Creating and connecting to your first Public Cloud instance](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
@@ -62,6 +78,6 @@ To harness the full potential of the Public Cloud and start your first resources
 - [Deleting a Public Cloud project](/guides/public-cloud/cross-functional/delete-a-project)
 - [Information regarding Public Cloud billing options](/guides/public-cloud/cross-functional/analyze-billing)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/en/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to increase Public Cloud quotas
 description: Find out how to apply for a Public Cloud quota extension
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-28
 ---
 
 ## Objective
@@ -32,6 +32,10 @@ To be able to use additional resources and projects, the quotas need to be incre
 ### Increasing your resources quota
 
 In compliance with internal criteria (seniority, existence of paid invoices, etc.), you are now free to request quota increases for your Public Cloud projects resources directly from your OVHcloud Control Panel.
+
+:::info
+First-time Public Cloud users get [£175 of free credit](/links/public-cloud/free-trial) automatically activated upon project creation, valid for one month. Because quota increase eligibility depends on criteria such as account seniority and paid invoices, free trial users may have limited quota increase options until their first invoice has been settled.
+:::
 
 You can increase your resources quota manually or automatically.
 
@@ -135,6 +139,6 @@ For certain resources or services, specific quotas may apply. For more informati
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to use the Public Cloud interface
 description: Guided tour of the Public Cloud interface to explore the different sections
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Objective
@@ -61,6 +61,9 @@ You can change the project name via the <code className="action">Settings</code>
 |**Containers & Orchestration**|This section offers you various tools to automate your architectures and gain flexibility.|
 |**Databases & Analytics**|These services will help you solve your Big Data and Data Analytics problems.|
 |**AI & Machine Learning**|In this section, you will find the OVHcloud artificial intelligence tools.|
+|**Quantum**|This section includes services related to quantum computing.|
+|**Management Interfaces**|A single link to the Horizon interface.|
+|**Settings**|This section allows you to configure and manage aspects of the project.|
 
 ### Shortcuts
 
@@ -77,7 +80,7 @@ For each resource you want to create, you will be accompanied by a configuration
 
 ### Management tools
 
-There are several management tools available in your Public Cloud project, they are located at the bottom of the left-side menu bar.
+In your Public Cloud project, several management tools are available to configure your resources, users, and settings. You can access them from the bottom-left menu. The tools are grouped into two main sections: **Management Interfaces**, which contains the link to the Horizon interface, and **Settings**, which includes all the project configuration options (users, quotas, SSH, billing, contacts, etc.).
 
 <img className="thumbnail" alt="Public Cloud interface - management tools" src="/images/public-cloud/cross-functional/03-public-cloud-interface-walk-me/management-tools-2025.png" loading="lazy" />
 
@@ -120,6 +123,6 @@ The matrix below compares the key features of each tool to help you choose the s
 
 [Creating and connecting to your first Public Cloud instance](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/en/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
+++ b/docs/en/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring a public IP block in a vRack on a Public Cloud instance
 description: Find out how to link a block of public IP addresses to the vRack for configuration on a Public Cloud Instance
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -393,7 +393,7 @@ Click the tab that corresponds to your distribution:
     **Configuration example:**
     
     ```bash
-      ens7:
+      eno2:
         dhcp4: false
         addresses:
         - 203.0.113.1/29
@@ -538,7 +538,7 @@ Click the tab that corresponds to your distribution:
     sudo nmcli con mod 'Wired connection 1' connection.autoconnect true
     ```
     
-    Reboot your network with the following command:
+    Restart your network with the following command:
     
     ```bash
     sudo systemctl restart NetworkManager
@@ -549,4 +549,4 @@ Click the tab that corresponds to your distribution:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/es/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/es/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Añadir crédito Cloud
 description: Cómo añadir créditos o códigos promocionales a su proyecto de Public Cloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Objetivo
@@ -72,4 +72,8 @@ Los períodos de validez de los códigos promocionales suelen ser más limitados
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+:::info
+Los nuevos clientes reciben automáticamente 200 € de crédito de prueba al activar su primer proyecto Public Cloud. Consulte nuestra guía "[Creando tu primer proyecto de Public Cloud de OVHcloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project)".
+:::
+
+Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/).

--- a/docs/es/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Crear y configurar un disco adicional en una instancia
 description: Cómo asociar un nuevo volumen a una instancia de Public Cloud
-lastUpdated: 2025-09-19
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -65,24 +65,16 @@ En las regiones 3AZ, los volúmenes Classic son servicios regionales que utiliza
 
 <details>
 
-<summary>**High-Speed - Hasta 3000 IOPS**</summary>
+<summary>**High Speed Gen2 – 30 IOPS/GB y hasta 20.000 IOPS**</summary>
 
 
-El volumen High-Speed está diseñado para aplicaciones que requieren un acceso más rápido a los datos. Con un rendimiento de hasta 3000 IOPS, es ideal para los siguientes casos de uso:
+La generación 2 de los volúmenes High Speed está optimizada para las cargas de trabajo más exigentes. Las prestaciones se adaptan al tamaño del volumen:
 
-- Bases de datos transaccionales (MySQL, PostgreSQL, etc.)
-- Entornos de virtualización y contenedores
-- Aplicaciones que requieren una latencia reducida y un rendimiento elevado
+- **IOPS**: 30 IOPS/GB (base 3.000 IOPS para 10–100 GB, hasta 20.000 IOPS)
+- **Rendimiento**: 0,5 MB/s/GB (base 50 MB/s para 10–100 GB, hasta 512 MB/s)
+- **Tamaño máximo**: 12 TB
 
-</details>
-
-
-<details>
-
-<summary>**High-Speed Gen2 - 30 IOPS/GB y hasta 20.000 IOPS**</summary>
-
-
-La generación 2 de los volúmenes High-Speed está optimizada para las cargas de trabajo más exigentes. Con un rendimiento de 30 IOPS/GB, hasta 20.000 IOPS, este tipo de volumen se recomienda para los siguientes usos:
+Este tipo de volumen se recomienda para los siguientes usos:
 
 - Big Data y análisis en tiempo real
 - Inteligencia artificial y Machine Learning
@@ -90,6 +82,12 @@ La generación 2 de los volúmenes High-Speed está optimizada para las cargas d
 
 </details>
 
+
+:::info
+**Ya no puede pedir volúmenes High Speed (Gen1) desde el área de cliente de OVHcloud.** Han sido sustituidos por los volúmenes High Speed Gen2 a la misma tarifa, con mejores prestaciones para los volúmenes de más de 100 GB. Los volúmenes High Speed siguen estando disponibles a través de la API, Terraform y OpenStack.
+
+Los volúmenes High Speed existentes siguen siendo compatibles. También puede [modificar el tipo de su volumen Block Storage](/guides/public-cloud/compute/switch-volume-type) para migrarlos al tipo High Speed Gen2.
+:::
 
 <img className="thumbnail" alt="volumes_types" src="/images/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance/volume-types.png" loading="lazy" />
 
@@ -801,4 +799,4 @@ Haga clic en <code className="action">Confirmar</code> en la nueva ventana para 
 
 [Aumentar el tamaño de un disco adicional](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/).

--- a/docs/es/guides/public-cloud/compute/switch-volume-type.mdx
+++ b/docs/es/guides/public-cloud/compute/switch-volume-type.mdx
@@ -1,7 +1,7 @@
 ---
 title: Modificar un Volume Block Storage
 description: Descubra cómo cambiar el tipo de un volume block storage utilizando OpenStack
-lastUpdated: 2026-01-13
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -38,9 +38,7 @@ Esta modificación puede realizarse a través de Horizon o a través de la inter
 :::warning
 Si el volumen Block Storage está conectado a una instancia, debe desconectarlo antes de continuar. Para más información, consulte la sección **Desvincular un volumen** de la guía "[Crear y configurar un disco adicional en una instancia](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#detach-a-volume)".
 
-El cambio de tipo de volumen (retyping) a través del área de cliente de OVHcloud o la API OVHcloud solo está disponible para volúmenes no cifrados. No es posible modificar el tipo de volúmenes cifrados de tipo **-LUKS** a través de estas interfaces.
-
-El retyping es posible a través de OpenStack / Horizon solo para volúmenes **-LUKS** a **-LUKS**. En este caso, la restauración del volumen después del retyping no es posible.
+El cambio de tipo de volumen (retyping) a través del área de cliente de OVHcloud o la API OVHcloud solo está disponible para volúmenes no cifrados. Los volúmenes cifrados de tipo **-LUKS** no pueden ser modificados.
 
 Las conversiones **-LUKS** a **no -LUKS** no están soportadas, incluso a través de OpenStack / Horizon.
 
@@ -120,6 +118,6 @@ En la ventana que aparece, haga clic en el menú desplegable bajo `Type` y selec
 
 Para saber cómo migrar un volumen Block Storage hacia un volumen cifrado LUKS, consulte nuestra guía dedicada [Migrating a Block Storage volume to an encrypted LUKS volume](/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume) (EN).
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/).

--- a/docs/es/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creando tu primer proyecto de Public Cloud de OVHcloud
 description: Cómo crear su primer proyecto de Public Cloud a través del área de cliente de OVHcloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 :::info
@@ -30,6 +30,8 @@ Crear un proyecto es el primer paso para implementar [instancias Public Cloud](h
 {/* CP-NAV-END:publiccloud-projects */}
 
 ## Procedimiento
+
+### Creación del proyecto
 
 Una vez que haya consultado la documentación disponible, acepte los términos del contrato marcando la casilla correspondiente y haga clic en <code className="action">Descubrir el universo Public Cloud</code>.
 
@@ -60,6 +62,20 @@ Para aprovechar al máximo el potencial del Public Cloud y empezar a utilizar su
 
 <iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/N7r_VCB7nmI?si=fcyToz1wK8Tw7skw" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen={true}></iframe>
 
+### Activación del proyecto y prueba gratuita
+
+Cuando haga clic en <code className="action">Activar el proyecto</code> desde el `Modo Discovery` y registre un método de pago, se aplicará un **crédito de prueba de 200 €** si cumple los requisitos.
+
+:::info
+**Condiciones de la prueba gratuita**
+
+- El crédito se activa en el momento de la activación del proyecto y es válido durante **un mes**.
+- **Elegible:** cualquier cliente de OVHcloud que cree su primer proyecto Public Cloud, aunque ya disponga de una cuenta OVHcloud.
+- **No elegible:** los clientes que ya disponen o han dispuesto de un proyecto Public Cloud, o que ya se han beneficiado de un crédito de prueba gratuito.
+
+Más información en la página [Prueba gratuita Public Cloud OVHcloud](/links/public-cloud/free-trial).
+:::
+
 ## Más información
 
 - [Crear y conectarse a una instancia de Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
@@ -68,6 +84,6 @@ Para aprovechar al máximo el potencial del Public Cloud y empezar a utilizar su
 - [Eliminar un proyecto de Public Cloud](/guides/public-cloud/cross-functional/delete-a-project)
 - [Información sobre el tipo de facturación cloud](/guides/public-cloud/cross-functional/analyze-billing)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra comunidad de usuarios en [https://community.ovhcloud.com/](https://community.ovhcloud.com/en/).

--- a/docs/es/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aumentar las cuotas de Public Cloud
 description: Descubra cómo solicitar el aumento de sus cuotas de Public Cloud
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-28
 ---
 
 ## Objetivo
@@ -32,6 +32,10 @@ Si desea crear más, será necesario aumentar la cuota.
 ### Aumentar la cuota de recursos
 
 De acuerdo con criterios internos (antigüedad, existencia de facturas pagadas, etc.), ahora es libre de solicitar aumentos de cuota para los recursos de sus proyectos de Public Cloud directamente desde el área de cliente de OVHcloud.
+
+:::info
+Los nuevos usuarios de Public Cloud disfrutan de [200 € de crédito gratuito](/links/public-cloud/free-trial) que se activa automáticamente al crear el proyecto, válido durante un mes. La elegibilidad para el aumento de cuota depende de criterios como la antigüedad de la cuenta y la existencia de facturas pagadas. Por lo tanto, los usuarios en período de prueba pueden tener opciones de aumento de cuota limitadas mientras no se haya pagado su primera factura.
+:::
 
 Puede aumentar la cuota de recursos de forma manual o automática.
 
@@ -135,6 +139,6 @@ Para ciertos recursos o servicios, pueden aplicarse cuotas específicas. Para ob
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -1,7 +1,7 @@
 ---
 title: Conocer la interfaz de Public Cloud
 description: Visita guiada de la interfaz de Public Cloud para descubrir las diferentes secciones
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Objetivo
@@ -61,6 +61,9 @@ Puede cambiar el nombre del proyecto en la pestaña <code className="action">Aju
 |**Containers and Orchestration**|Esta sección ofrece diversas herramientas para automatizar sus arquitecturas y aumentar la flexibilidad.|
 |**Databases & Analytics**|Estos servicios le ayudarán a resolver sus problemas de Big Data y de Data Analytics.|
 |**AI and Machine Learning**|En esta sección encontrará las herramientas de OVHcloud para la inteligencia artificial.|
+|**Quantum**|Esta sección agrupa los servicios relacionados con la computación cuántica.|
+|**Management Interfaces**|Un único enlace a la interfaz Horizon.|
+|**Ajustes**|Esta sección permite configurar y gestionar los aspectos del proyecto.|
 
 ### Atajos rápidos
 
@@ -77,7 +80,7 @@ Para cada recurso que quiera crear, le guiará un asistente de configuración qu
 
 ### Herramientas de gestión
 
-El proyecto de Public Cloud incluye diversas herramientas de gestión, que se encuentran en la parte inferior de la barra de menú, a la izquierda.
+En su proyecto de Public Cloud, hay varias herramientas de gestión disponibles para configurar sus recursos, usuarios y parámetros. Puede acceder a ellas desde el menú de la izquierda, en la parte inferior. Las herramientas se agrupan en dos secciones principales: **Management Interfaces**, que contiene el enlace a la interfaz Horizon, y **Ajustes**, que agrupa todas las opciones de configuración del proyecto (usuarios, cuotas, SSH, facturación, contactos, etc.).
 
 <img className="thumbnail" alt="Public Cloud interface - Herramientas de gestión" src="/images/public-cloud/cross-functional/03-public-cloud-interface-walk-me/management-tools-2025.png" loading="lazy" />
 
@@ -120,6 +123,6 @@ La siguiente matriz compara las características clave de cada herramienta para 
 
 [Crear y conectarse a una instancia de Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/).

--- a/docs/es/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
+++ b/docs/es/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring a public IP block in a vRack on a Public Cloud instance
 description: Find out how to link a block of public IP addresses to the vRack for configuration on a Public Cloud Instance
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -393,7 +393,7 @@ Click the tab that corresponds to your distribution:
     **Configuration example:**
     
     ```bash
-      ens7:
+      eno2:
         dhcp4: false
         addresses:
         - 203.0.113.1/29
@@ -538,7 +538,7 @@ Click the tab that corresponds to your distribution:
     sudo nmcli con mod 'Wired connection 1' connection.autoconnect true
     ```
     
-    Reboot your network with the following command:
+    Restart your network with the following command:
     
     ```bash
     sudo systemctl restart NetworkManager
@@ -549,4 +549,4 @@ Click the tab that corresponds to your distribution:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ajouter du crédit cloud
 description: Découvrez comment ajouter du crédit ou des vouchers à votre projet Public Cloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Objectif
@@ -72,4 +72,8 @@ Les périodes de validité des vouchers étant généralement plus limitées, le
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+:::info
+Les nouveaux clients reçoivent automatiquement 200 € de crédit d'essai lors de l'activation de leur premier projet Public Cloud. Consultez notre guide « [Créer votre premier projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) ».
+:::
+
+Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/).

--- a/docs/fr/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Créer et configurer un disque supplementaire sur une instance
 description: Découvrez comment attacher un nouveau volume à votre instance Public Cloud
-lastUpdated: 2025-09-19
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -68,24 +68,16 @@ Dans les régions 3AZ, les volumes Classic sont des services régionaux qui util
 
 <details>
 
-<summary>**High-Speed – Jusqu’à 3000 IOPS**</summary>
+<summary>**High Speed Gen2 – 30 IOPS/Go et jusqu’à 20 000 IOPS**</summary>
 
 
-Le volume High-Speed est conçu pour des applications nécessitant un accès plus rapide aux données. Avec une performance pouvant atteindre 3000 IOPS, il convient parfaitement aux cas d’usage suivants :
+La génération 2 des volumes High Speed est optimisée pour les workloads les plus exigeants. Les performances s’adaptent à la taille du volume :
 
-- Bases de données transactionnelles (MySQL, PostgreSQL, etc.)
-- Environnements de virtualisation et de conteneurs
-- Applications nécessitant une latence réduite et un débit élevé
+- **IOPS** : 30 IOPS/Go (base 3 000 IOPS pour 10–100 Go, jusqu’à 20 000 IOPS)
+- **Débit** : 0,5 Mo/s/Go (base 50 Mo/s pour 10–100 Go, jusqu’à 512 Mo/s)
+- **Taille maximale** : 12 To
 
-</details>
-
-
-<details>
-
-<summary>**High-Speed Gen2 – 30 IOPS/GB et jusqu’à 20 000 IOPS**</summary>
-
-
-La génération 2 des volumes High-Speed est optimisée pour les workloads les plus exigeants. Avec une performance de 30 IOPS/GB, pouvant atteindre 20 000 IOPS, ce type de volume est recommandé pour les usages suivants :
+Ce type de volume est recommandé pour les usages suivants :
 
 - Big Data et analyses en temps réel
 - Intelligence artificielle et Machine Learning
@@ -93,6 +85,12 @@ La génération 2 des volumes High-Speed est optimisée pour les workloads les p
 
 </details>
 
+
+:::info
+**Vous ne pouvez plus commander de volumes High Speed (Gen1) depuis l’espace client OVHcloud.** Ils ont été remplacés par les volumes High Speed Gen2 au même tarif, avec de meilleures performances pour les volumes de plus de 100 Go. Les volumes High Speed restent disponibles via l’API, Terraform et OpenStack.
+
+Les volumes High Speed existants restent pris en charge. Vous pouvez également [modifier le type de votre volume Block Storage](/guides/public-cloud/compute/switch-volume-type) pour les migrer vers le type High Speed Gen2.
+:::
 
 <img className="thumbnail" alt="volumes_types" src="/images/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance/volume-types.png" loading="lazy" />
 
@@ -791,4 +789,4 @@ Cliquez sur <code className="action">Confirmer</code> dans la fenêtre qui s'aff
 
 [Augmenter la taille d’un disque supplémentaire](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/).

--- a/docs/fr/guides/public-cloud/compute/switch-volume-type.mdx
+++ b/docs/fr/guides/public-cloud/compute/switch-volume-type.mdx
@@ -1,7 +1,7 @@
 ---
 title: Modifier un Volume Block Storage
 description: "Découvrez comment changer le type d'un volume block storage en utilisant OpenStack"
-lastUpdated: 2026-01-13
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -38,9 +38,7 @@ Cette modification peut être réalisée via Horizon ou via l’interface de lig
 :::warning
 Si le volume Block Storage est attaché à une instance, vous devez d'abord le détacher avant de continuer. Pour plus d'informations, consultez la section **Détacher un volume** du guide « [Créer et configurer un disque supplémentaire sur une instance](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#detach-a-volume) ».
 
-Le changement de type de volume (retyping) via l'espace client OVHcloud ou l’API OVHcloud est disponible uniquement pour les volumes non chiffrés. Il n'est pas possible de modifier le type des volumes chiffrés de type **-LUKS** via ces interfaces.
-
-Le retyping est possible via OpenStack / Horizon uniquement pour des volumes **-LUKS** vers **-LUKS**. Dans ce cas, la restauration du volume après retyping n’est pas possible.
+Le changement de type de volume (retyping) via l'espace client OVHcloud ou l’API OVHcloud est disponible uniquement pour les volumes non chiffrés. Il n'est pas possible de modifier le type des volumes chiffrés de type **-LUKS**.
 
 Les conversions **-LUKS** vers **non -LUKS** ne sont pas prises en charge, y compris via OpenStack / Horizon.
 
@@ -120,6 +118,6 @@ Dans la fenêtre qui s'affiche, cliquez sur le menu déroulant sous `Type` et s�
 
 Pour découvrir comment migrer un volume Block Storage vers un volume chiffré LUKS, consultez notre guide dédié : [Migrer un volume Block Storage vers un volume chiffré LUKS](/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume).
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/).

--- a/docs/fr/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Créer votre premier projet Public Cloud
 description: Découvrez comment créer votre premier projet Public Cloud depuis l’espace client OVHcloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Objectif
@@ -24,6 +24,8 @@ La création d’un projet est la première étape indispensable pour déployer 
 {/* CP-NAV-END:publiccloud-projects */}
 
 ## En pratique
+
+### Création du projet
 
 Après en avoir pris connaissance, validez les termes des contrats en cochant la case correspondante puis cliquez sur <code className="action">Découvrir l'univers Public Cloud</code>.
 
@@ -56,6 +58,20 @@ Pour exploiter pleinement le potentiel du Public Cloud et démarrer vos premièr
 
 <iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/xTG4mAaGqN4?si=RtSEte_rV3Babwm6" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen={true}></iframe>
 
+### Activation du projet et essai gratuit
+
+Lorsque vous cliquez sur <code className="action">Activer le projet</code> depuis le `Mode découverte` et enregistrez un moyen de paiement, un **crédit d'essai de 200 €** est appliqué si vous êtes éligible.
+
+:::info
+**Conditions de l'essai gratuit**
+
+- Le crédit est activé au moment de l'activation du projet et est valable **un mois**.
+- **Éligible :** tout client OVHcloud créant son premier projet Public Cloud, même s'il dispose déjà d'un compte OVHcloud.
+- **Non éligible :** les clients disposant déjà ou ayant déjà disposé d'un projet Public Cloud, ou ayant déjà bénéficié d'un crédit d'essai gratuit.
+
+En savoir plus sur la page [Essai gratuit Public Cloud OVHcloud](/links/public-cloud/free-trial).
+:::
+
 ## Aller plus loin
 
 - [Créer une première instance Public Cloud et s'y connecter](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
@@ -64,6 +80,6 @@ Pour exploiter pleinement le potentiel du Public Cloud et démarrer vos premièr
 - [Supprimer un projet Public Cloud](/guides/public-cloud/cross-functional/delete-a-project)
 - [Informations concernant le mode de facturation cloud](/guides/public-cloud/cross-functional/analyze-billing)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/).

--- a/docs/fr/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: Augmenter les quotas Public Cloud
 description: Découvrez comment demander l’augmentation de vos quotas Public Cloud
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-28
 ---
 
 ## Objectif
@@ -32,6 +32,10 @@ Si vous souhaitez en créer davantage, une augmentation de quota est alors néce
 ### Augmenter votre quota de ressources
 
 En accord avec des critères internes (ancienneté, existence de factures acquitées, etc.), vous êtes désormais autonome sur les demandes d’augmentation de quotas en lien avec vos projets Public Cloud.
+
+:::info
+Les nouveaux utilisateurs Public Cloud bénéficient de [200 € de crédit offert](/links/public-cloud/free-trial) activé automatiquement à la création du projet, valable un mois. L'éligibilité à l'augmentation de quota dépend de critères tels que l'ancienneté du compte et l'existence de factures acquittées. Les utilisateurs en période d'essai peuvent donc avoir des options d'augmentation de quota limitées tant que leur première facture n'a pas été réglée.
+:::
 
 Vous avez la possibilté d'augmenter votre quota de ressources manuellement ou automatiquement.
 
@@ -135,6 +139,6 @@ Pour certaines ressources ou services, des quotas spécifiques peuvent s’appli
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Se familiariser avec l'interface Public Cloud"
 description: "Visite guidée de l'interface Public Cloud"
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Objectif
@@ -61,6 +61,9 @@ Vous pouvez modifier le nom du projet via l'onglet <code className="action">Para
 |**Containers & Orchestration**|Cette section vous propose différents outils pour automatiser vos architectures et gagner en flexibilité.|
 |**Databases & Analytics**|Ces services vous aideront à résoudre vos problématiques de Big Data et de Data Analytics.|
 |**AI & Machine Learning**|Vous trouverez dans cette section les outils OVHcloud pour l'intelligence artificielle.|
+|**Quantum**|Cette section regroupe les services liés au calcul quantique.|
+|**Management Interfaces**|Un seul lien vers l'interface Horizon.|
+|**Paramètres**|Cette section permet de configurer et gérer les aspects du projet.|
 
 ### Les raccourcis
 
@@ -77,7 +80,7 @@ Pour chaque ressource que vous souhaitez créer, vous serez accompagné par un a
 
 ### Les outils de gestion
 
-Plusieurs outils de gestion sont disponibles dans votre projet Public Cloud, ils se trouvent en bas de la barre de menu de gauche.
+Dans votre projet Public Cloud, plusieurs outils de gestion sont disponibles pour configurer vos ressources, vos utilisateurs et vos paramètres. Vous pouvez y accéder depuis la partie inférieure du menu de gauche. Les outils sont regroupés sous deux sections principales : **Management Interfaces**, qui contient le lien vers l'interface Horizon, et **Paramètres**, qui regroupe toutes les options de configuration du projet (utilisateurs, quotas, SSH, facturation, contacts, etc.).
 
 <img className="thumbnail" alt="Public Cloud interface - outils de gestion" src="/images/public-cloud/cross-functional/03-public-cloud-interface-walk-me/management-tools-2025.png" loading="lazy" />
 
@@ -120,6 +123,6 @@ La matrice ci-dessous compare les caractéristiques clés de chaque outil afin d
 
 [Créer une première instance Public Cloud et s’y connecter](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/).

--- a/docs/fr/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
+++ b/docs/fr/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer un bloc IP dans un vRack sur une instance Public Cloud
 description: Découvrez comment associer un bloc d’adresses IP publiques au vRack pour une configuration sur une instance Public Cloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -395,7 +395,7 @@ Cliquez sur l'onglet correspondant à votre distribution :
     **Exemple de configuration :**
     
     ```bash
-      ens7:
+      eno2:
         dhcp4: false
         addresses:
         - 203.0.113.1/29
@@ -551,4 +551,4 @@ Cliquez sur l'onglet correspondant à votre distribution :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/).

--- a/docs/it/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/it/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aggiungi credito Cloud al tuo progetto
 description: Come aggiungere credito o voucher al tuo progetto Public Cloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Obiettivo
@@ -72,4 +72,8 @@ Poiché i periodi di validità dei voucher sono generalmente più limitati, prim
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+:::info
+I nuovi clienti ricevono automaticamente 200 € di credito di prova al momento dell'attivazione del loro primo progetto Public Cloud. Consulta la nostra guida "[Creazione del tuo primo progetto Public Cloud OVHcloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project)".
+:::
+
+Contatta la nostra [Community di utenti](https://community.ovhcloud.com/).

--- a/docs/it/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Crea e configura un disco aggiuntivo sulla tua istanza
 description: Come associare un nuovo volume alla tua istanza Public Cloud
-lastUpdated: 2025-09-19
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -65,24 +65,16 @@ Nelle aree 3AZ, i volumi Classic sono servizi locali che utilizzano un Erasure C
 
 <details>
 
-<summary>**High Speed - Fino a 3000 IOPS**</summary>
+<summary>**High Speed Gen2 – 30 IOPS/GB e fino a 20.000 IOPS**</summary>
 
 
-Il volume High-Speed è progettato per applicazioni che richiedono un accesso più rapido ai dati. Con prestazioni fino a 3000 IOPS, l'ideale per i seguenti utilizzi:
+La generazione 2 dei volumi High Speed è ottimizzata per i workload più esigenti. Le prestazioni si adattano alla dimensione del volume:
 
-- Database transazionali (MySQL, PostgreSQL, ecc.)
-- Ambienti di virtualizzazione e container
-- Applicazioni che richiedono latenza ridotta e throughput elevato
+- **IOPS**: 30 IOPS/GB (base 3.000 IOPS per 10–100 GB, fino a 20.000 IOPS)
+- **Throughput**: 0,5 MB/s/GB (base 50 MB/s per 10–100 GB, fino a 512 MB/s)
+- **Dimensione massima**: 12 TB
 
-</details>
-
-
-<details>
-
-<summary>**High-Speed Gen2 - 30 IOPS/GB e fino a 20.000 IOPS**</summary>
-
-
-La generazione 2 dei volumi High Speed è ottimizzata per i workload più esigenti. Con una performance di 30 IOPS/GB, fino a 20.000 IOPS, questo tipo di volume è consigliato per i seguenti utilizzi:
+Questo tipo di volume è consigliato per i seguenti utilizzi:
 
 - Big Data e analisi in tempo reale
 - Intelligenza artificiale e Machine Learning
@@ -90,6 +82,12 @@ La generazione 2 dei volumi High Speed è ottimizzata per i workload più esigen
 
 </details>
 
+
+:::info
+**Non è più possibile ordinare volumi High Speed (Gen1) dallo Spazio Cliente OVHcloud.** Sono stati sostituiti dai volumi High Speed Gen2 allo stesso prezzo, con prestazioni migliori per i volumi superiori a 100 GB. I volumi High Speed restano disponibili tramite API, Terraform e OpenStack.
+
+I volumi High Speed esistenti continuano a essere supportati. È inoltre possibile [modificare il tipo del volume Block Storage](/guides/public-cloud/compute/switch-volume-type) per migrarli al tipo High Speed Gen2.
+:::
 
 <img className="thumbnail" alt="volume_types" src="/images/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance/volume-types.png" loading="lazy" />
 
@@ -792,4 +790,4 @@ Clicca su <code className="action">Conferma</code> nella finestra che appare per
 
 [Aumenta la dimensione di un disco aggiuntivo](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](https://community.ovhcloud.com/).

--- a/docs/it/guides/public-cloud/compute/switch-volume-type.mdx
+++ b/docs/it/guides/public-cloud/compute/switch-volume-type.mdx
@@ -1,7 +1,7 @@
 ---
 title: Modificare un Volume Block Storage
 description: Scopri come modificare il tipo di un volume block storage utilizzando Openstack
-lastUpdated: 2026-01-13
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -38,9 +38,7 @@ La modifica può essere effettuata via Horizon o tramite l’interfaccia da riga
 :::warning
 Se il volume Block Storage è collegato a un'istanza, devi prima scollegarlo prima di procedere. Per ulteriori informazioni, consulta la sezione **Scollega un volume** della guida "[Crea e configura un disco aggiuntivo sulla tua istanza](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#detach-a-volume)".
 
-Il cambio di tipo di volume (retyping) tramite l'Spazio Cliente OVHcloud o l'API OVHcloud è disponibile solo per i volumi non crittografati. Non è possibile modificare il tipo dei volumi crittografati di tipo **-LUKS** tramite queste interfacce.
-
-Il retyping è possibile tramite OpenStack / Horizon solo per volumi **-LUKS** verso **-LUKS**. In questo caso, la ripristinazione del volume dopo il retyping non è possibile.
+Il cambio di tipo di volume (retyping) tramite lo Spazio Cliente OVHcloud o l'API OVHcloud è disponibile solo per i volumi non cifrati. I volumi cifrati di tipo **-LUKS** non possono essere modificati.
 
 Le conversioni **-LUKS** verso **non -LUKS** non sono supportate, nemmeno tramite OpenStack / Horizon.
 
@@ -120,6 +118,6 @@ Nella finestra che appare, clicca sul menu a discesa sotto `Type` e seleziona <c
 
 Per scoprire come migrare un volume Block Storage verso un volume crittografato LUKS, consulta la nostra guida dedicata [Migrating a Block Storage volume to an encrypted LUKS volume](/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume) (EN).
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](https://community.ovhcloud.com/).

--- a/docs/it/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creazione del tuo primo progetto Public Cloud OVHcloud
 description: Come creare il tuo primo progetto Public Cloud tramite lo Spazio Cliente OVHcloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 :::info
@@ -30,6 +30,8 @@ La creazione di un progetto è il primo passo nella distribuzione delle [istanze
 {/* CP-NAV-END:publiccloud-projects */}
 
 ## Procedura
+
+### Creazione del progetto
 
 Leggi le condizioni contrattuali selezionando la casella corrispondente e clicca su <code className="action">Scopri l’universo Public Cloud</code>.
 
@@ -60,6 +62,20 @@ Per sfruttare appieno il potenziale del Public Cloud e avviare le prime risorse,
 
 <iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/N7r_VCB7nmI?si=fcyToz1wK8Tw7skw" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen={true}></iframe>
 
+### Attivazione del progetto e prova gratuita
+
+Quando clicchi su <code className="action">Attivare il progetto</code> dalla `Modalità Discovery` e registri un metodo di pagamento, viene applicato un **credito di prova di 200 €** se sei idoneo.
+
+:::info
+**Condizioni della prova gratuita**
+
+- Il credito viene attivato al momento dell'attivazione del progetto ed è valido **un mese**.
+- **Idoneo:** qualsiasi cliente OVHcloud che crea il suo primo progetto Public Cloud, anche se dispone già di un account OVHcloud.
+- **Non idoneo:** i clienti che dispongono già o hanno già disposto di un progetto Public Cloud, oppure che hanno già beneficiato di un credito di prova gratuita.
+
+Per saperne di più, consulta la pagina [Prova gratuita Public Cloud OVHcloud](/links/public-cloud/free-trial).
+:::
+
 ## Per saperne di più
 
 - [Creare e connettersi a un’istanza Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
@@ -68,6 +84,6 @@ Per sfruttare appieno il potenziale del Public Cloud e avviare le prime risorse,
 - [Eliminare un progetto Public Cloud](/guides/public-cloud/cross-functional/delete-a-project)
 - [Sistema di fatturazione dei servizi Cloud](/guides/public-cloud/cross-functional/analyze-billing)
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra Community di utenti all’indirizzo [https://community.ovhcloud.com/](https://community.ovhcloud.com/en/).

--- a/docs/it/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aumentare le quote Public Cloud
 description: Come aumentare la quota Public Cloud
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-28
 ---
 
 ## Obiettivo
@@ -32,6 +32,10 @@ Per creare di più, è necessario aumentare la quota disponibile.
 ### Aumentare la quota di risorse 
 
 In base a criteri interni (anzianità, esistenza di fatture pagate, ecc.), ora siete autonomi nelle richieste di aumento delle quote relative ai vostri progetti Public Cloud.
+
+:::info
+I nuovi utenti Public Cloud beneficiano di [200 € di credito offerto](/links/public-cloud/free-trial) attivato automaticamente alla creazione del progetto, valido per un mese. L'idoneità all'aumento della quota dipende da criteri quali l'anzianità dell'account e l'esistenza di fatture pagate. Gli utenti in periodo di prova possono quindi avere opzioni di aumento della quota limitate finché la loro prima fattura non è stata saldata.
+:::
 
 È possibile aumentare la quota delle risorse manualmente o automaticamente.
 
@@ -135,6 +139,6 @@ Per alcune risorse o servizi potrebbero essere applicate quote specifiche. Per u
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](https://community.ovhcloud.com/).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -1,7 +1,7 @@
 ---
 title: Scopri l’interfaccia Public Cloud
 description: "Visita guidata dell'interfaccia Public Cloud per scoprire le diverse sezioni"
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Obiettivo
@@ -61,6 +61,9 @@ Per modificare il nome del progetto, accedi alla scheda <code className="action"
 |**Containers and Orchestration**|Questa sezione propone diversi strumenti per automatizzare le architetture e ottenere una maggiore flessibilità.|
 |**Databases & Analytics**|Questi servizi ti aiuteranno a risolvere le tue problematiche relative ai Big Data e Data Analytics.|
 |**AI & Machine Learning**|In questa sezione trovi gli strumenti OVHcloud per l'intelligenza artificiale.|
+|**Quantum**|Questa sezione raggruppa i servizi legati al calcolo quantistico.|
+|**Management Interfaces**|Un unico link all'interfaccia Horizon.|
+|**Impostazioni**|Questa sezione consente di configurare e gestire gli aspetti del progetto.|
 
 ### Le scorciatoie
 
@@ -77,7 +80,7 @@ Per ogni risorsa che vuoi creare, sarai accompagnato da un assistente di configu
 
 ### Strumenti di gestione
 
-Nel tuo progetto Public Cloud sono disponibili diversi tool di gestione, in fondo alla barra dei menu di sinistra.
+Nel tuo progetto Public Cloud sono disponibili diversi strumenti di gestione per configurare risorse, utenti e impostazioni. Puoi accedervi dal menu di sinistra, in basso. Gli strumenti sono raggruppati in due sezioni principali: **Management Interfaces**, che contiene il link all'interfaccia Horizon, e **Impostazioni**, che raggruppa tutte le opzioni di configurazione del progetto (utenti, quote, SSH, fatturazione, contatti, ecc.).
 
 <img className="thumbnail" alt="Public Cloud Interfaccia - strumenti di gestione" src="/images/public-cloud/cross-functional/03-public-cloud-interface-walk-me/management-tools-2025.png" loading="lazy" />
 
@@ -120,6 +123,6 @@ La matrice seguente confronta le caratteristiche principali di ogni strumento pe
 
 [Creare e connettersi a un’istanza Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](https://community.ovhcloud.com/).

--- a/docs/it/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
+++ b/docs/it/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring a public IP block in a vRack on a Public Cloud instance
 description: Find out how to link a block of public IP addresses to the vRack for configuration on a Public Cloud Instance
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -393,7 +393,7 @@ Click the tab that corresponds to your distribution:
     **Configuration example:**
     
     ```bash
-      ens7:
+      eno2:
         dhcp4: false
         addresses:
         - 203.0.113.1/29
@@ -538,7 +538,7 @@ Click the tab that corresponds to your distribution:
     sudo nmcli con mod 'Wired connection 1' connection.autoconnect true
     ```
     
-    Reboot your network with the following command:
+    Restart your network with the following command:
     
     ```bash
     sudo systemctl restart NetworkManager
@@ -549,4 +549,4 @@ Click the tab that corresponds to your distribution:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/pl/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/pl/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Korzystanie z vouchera
 description: Dowiedz się, jak dodać zasilenie lub vouchery do Twojego projektu Public Cloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Wprowadzenie
@@ -72,4 +72,8 @@ Ze względu na to, że kody promocyjne są ważne przez dłuższy czas, pozosta�
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+:::info
+Nowi klienci automatycznie otrzymują 1 000 PLN bezpłatnego kredytu próbnego, gdy aktywują swój pierwszy projekt Public Cloud. Sprawdź nasz przewodnik "[Utworzenie pierwszego projektu Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project)".
+:::
+
+Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/).

--- a/docs/pl/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zarządzanie wolumenem instancji Public Cloud
 description: Dowiedz się, jak przypisać nowy wolumen do instancji Public Cloud
-lastUpdated: 2025-09-19
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -65,24 +65,16 @@ W regionach 3AZ woluminy Classic są usługami regionalnymi, które korzystają 
 
 <details>
 
-<summary>**High-Speed - Do 3000 IOPS**</summary>
+<summary>**High Speed Gen2 – 30 IOPS/GB i do 20 000 IOPS**</summary>
 
 
-Wolumen High-Speed jest przeznaczony dla aplikacji wymagających szybszego dostępu do danych. Dzięki wydajności do 3000 IOPS rozwiązanie to jest idealne do następujących zastosowań:
+Wolumeny High Speed drugiej generacji są zoptymalizowane pod kątem najbardziej wymagających obciążeń. Wydajność skaluje się wraz z rozmiarem wolumenu:
 
-- Transakcyjne bazy danych (MySQL, PostgreSQL, etc.)
-- Środowiska wirtualizacji i kontenerów
-- Aplikacje wymagające krótkiego czasu odpowiedzi i dużej przepustowości
+- **IOPS**: 30 IOPS/GB (bazowo 3 000 IOPS dla 10–100 GB, do 20 000 IOPS)
+- **Przepustowość**: 0,5 MB/s/GB (bazowo 50 MB/s dla 10–100 GB, do 512 MB/s)
+- **Maksymalny rozmiar**: 12 TB
 
-</details>
-
-
-<details>
-
-<summary>**High-Speed Gen2 - 30 IOPS/GB i do 20 000 IOPS**</summary>
-
-
-Generowanie 2 wolumenów High-Speed jest zoptymalizowane pod kątem najbardziej wymagających obciążeń. Przy wydajności 30 IOPS/GB i wydajności do 20 000 IOPS ten typ wolumenu jest zalecany do następujących zastosowań:
+Ten typ wolumenu jest zalecany do następujących zastosowań:
 
 - Big Data i analizy w czasie rzeczywistym
 - Sztuczna inteligencja i Machine Learning
@@ -90,6 +82,12 @@ Generowanie 2 wolumenów High-Speed jest zoptymalizowane pod kątem najbardziej 
 
 </details>
 
+
+:::info
+**Nie można już zamawiać wolumenów High Speed (Gen1) za pośrednictwem Panelu klienta OVHcloud.** Zostały one zastąpione przez wolumeny High Speed Gen2 w tej samej cenie, oferujące lepszą wydajność dla wolumenów powyżej 100 GB. Wolumeny High Speed pozostają dostępne za pośrednictwem API, Terraform oraz OpenStack.
+
+Istniejące wolumeny High Speed są nadal obsługiwane. Możesz również [zmienić typ wolumenu Block Storage](/guides/public-cloud/compute/switch-volume-type), aby przeprowadzić ich migrację do Gen2.
+:::
 
 <img className="thumbnail" alt="volume_types" src="/images/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance/volume-types.png" loading="lazy" />
 
@@ -795,4 +793,4 @@ Kliknij <code className="action">Potwierdź</code> w oknie, które się wyświet
 
 [Zwiększ rozmiar dodatkowego dysku](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/).

--- a/docs/pl/guides/public-cloud/compute/switch-volume-type.mdx
+++ b/docs/pl/guides/public-cloud/compute/switch-volume-type.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zmień wolumen Block Storage
 description: Dowiedz się, jak zmienić typ wolumenu block storage przy użyciu technologii Openstack
-lastUpdated: 2026-01-13
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -38,9 +38,7 @@ Modyfikacja ta może zostać przeprowadzona za pośrednictwem interfejsu Horizon
 :::warning
 Jeśli wolumin Block Storage jest dołączone do instancji, musisz go najpierw odłączyć, zanim przejdziesz dalej. Aby uzyskać więcej informacji, zobacz sekcję **Odłącz wolumen** przewodnika "[Zarządzanie wolumenem instancji Public Cloud](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#detach-a-volume)".
 
-Zmiana typu woluminu (retypowanie) za pomocą Panelu klienta OVHcloud lub OVHcloud API jest możliwa tylko dla niezaszyfrowanych woluminów. Zaszyfrowane woluminy typu **-LUKS** nie mogą być retypowane za pomocą tych interfejsów.
-
-Retypowanie jest obsługiwane za pomocą OpenStack / Horizon tylko dla woluminów **-LUKS** do **-LUKS**. W takim przypadku, przywracanie woluminu po retypowaniu nie jest możliwe.
+Zmiana typu woluminu (retypowanie) za pomocą Panelu klienta OVHcloud lub OVHcloud API jest możliwa tylko dla niezaszyfrowanych woluminów. Zaszyfrowane woluminy typu **-LUKS** nie mogą być retypowane.
 
 Konwersje z **-LUKS** do **nie-LUKS** (lub odwrotnie) nie są obsługiwane, w tym za pomocą OpenStack / Horizon.
 
@@ -119,6 +117,6 @@ W oknie dialogowym kliknij rozwijane menu pod `Type` i wybierz <code className="
 
 Aby dowiedzieć się, jak migrować wolumen Block Storage do zaszyfrowanego wolumenu LUKS, zapoznaj się z naszym przewodnikiem [Migrating a Block Storage volume to an encrypted LUKS volume](/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume) (EN).
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/).

--- a/docs/pl/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utworzenie pierwszego projekt Public Cloud
 description: Dowiedz się, jak utworzyć pierwszy projekt Public Cloud w Panelu klienta OVHcloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 :::info
@@ -30,6 +30,8 @@ Utworzenie projekt jest pierwszym krokiem we wdrażaniu [instancji Public Cloud]
 {/* CP-NAV-END:publiccloud-projects */}
 
 ## Wskazówki
+
+### Tworzenie projektu
 
 Zapoznaj się z nimi i zaakceptuj warunki umów, zaznaczając odpowiednie pole, następnie kliknij <code className="action">Poznaj naszą ofertę Public Cloud</code>.
 
@@ -62,6 +64,20 @@ Aby w pełni wykorzystać potencjał Public Cloud i uruchomić pierwsze zasoby, 
 
 <iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/N7r_VCB7nmI?si=fcyToz1wK8Tw7skw" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen={true}></iframe>
 
+### Aktywacja projektu i bezpłatny okres próbny
+
+Gdy klikniesz <code className="action">Aktywuj projekt</code> z poziomu `Trybu Discovery` i zarejestrujesz metodę płatności, otrzymasz **bezpłatny kredyt próbny w wysokości 1 000 PLN**, jeśli spełniasz warunki kwalifikacji.
+
+:::info
+**Warunki bezpłatnego okresu próbnego**
+
+- Kredyt jest aktywowany w momencie aktywacji projektu i jest ważny przez **jeden miesiąc**.
+- **Kwalifikujący się:** każdy klient OVHcloud tworzący swój pierwszy projekt Public Cloud, nawet jeśli posiada już konto OVHcloud.
+- **Niekwalifikujący się:** klienci, którzy mają obecny lub miniony projekt Public Cloud lub którzy już skorzystali z bezpłatnego kredytu próbnego.
+
+Więcej informacji znajdziesz na stronie [Bezpłatny okres próbny OVHcloud Public Cloud](/links/public-cloud/free-trial).
+:::
+
 ## Sprawdź również
 
 - [Tworzenie pierwszej instancji Public Cloud i łączenie się z nią](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
@@ -70,6 +86,6 @@ Aby w pełni wykorzystać potencjał Public Cloud i uruchomić pierwsze zasoby, 
 - [Usuwanie projektu Public Cloud](/guides/public-cloud/cross-functional/delete-a-project)
 - [Rozliczanie należności za usługę Public Cloud](/guides/public-cloud/cross-functional/analyze-billing)
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do społeczności naszych użytkowników na stronie [https://community.ovhcloud.com/](https://community.ovhcloud.com/en/).

--- a/docs/pl/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zwiększenie limitów Public Cloud
 description: Dowiedz się, jak zwiększyć limity Public Cloud
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-28
 ---
 
 ## Wprowadzenie
@@ -32,6 +32,10 @@ Jeśli chcesz utworzyć więcej zasobów, musisz zwiększyć limit.
 ### Zwiększenie limitu zasobów
 
 Zgodnie z wewnętrznymi kryteriami (staż pracy, istnienie faktur zapłaconych...) możesz teraz dowolnie wnioskować o zwiększenie limitu zasobów projektu Public Cloud bezpośrednio w Panelu klienta OVHcloud.
+
+:::info
+Nowi użytkownicy Public Cloud otrzymują [1 000 PLN bezpłatnego kredytu](/links/public-cloud/free-trial) automatycznie aktywowanego przy tworzeniu projektu, ważnego przez jeden miesiąc. Ponieważ kwalifikacja do zwiększenia limitu zależy od kryteriów takich jak staż konta i opłacone faktury, użytkownicy korzystający z bezpłatnego okresu próbnego mogą mieć ograniczone możliwości zwiększenia limitu do czasu uregulowania pierwszej faktury.
+:::
 
 Możesz zwiększyć limit zasobów ręcznie lub automatycznie.
 
@@ -135,6 +139,6 @@ Dla niektórych zasobów lub usług mogą obowiązywać specjalne limity. Aby uz
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -1,7 +1,7 @@
 ---
 title: Poznaj interfejs Public Cloud
 description: Przewodnik po interfejsie Public Cloud do znajdowania poszczególnych sekcji
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Wprowadzenie
@@ -61,6 +61,9 @@ Możesz zmienić nazwę projektu w zakładce <code className="action">Ustawienia
 |**Konteneryzacja i Orkiestracja**|W tej sekcji możesz korzystać z różnych narzędzi do automatyzacji architektury.|
 |**Databases & Analytics**|Usługi te pomogą Ci rozwiązać problem Big Data i Data Analytics.|
 |**AI & Machine Learning**|W tej sekcji znajdziesz narzędzia OVHcloud do sztucznej inteligencji.|
+|**Quantum**|Ta sekcja zawiera usługi związane z obliczeniami kwantowymi.|
+|**Management Interfaces**|Bezpośredni link do interfejsu Horizon.|
+|**Ustawienia**|Ta sekcja pozwala konfigurować i zarządzać aspektami projektu.|
 
 ### Skróty
 
@@ -77,7 +80,7 @@ Dla każdego zasobu, który chcesz utworzyć, towarzyszą Ci asystent konfigurac
 
 ### Narzędzia do zarządzania
 
-W projekcie Public Cloud dostępnych jest kilka narzędzi do zarządzania. Są one na dole paska menu po lewej stronie.
+W Twoim projekcie Public Cloud dostępnych jest kilka narzędzi do zarządzania, umożliwiających konfigurację zasobów, użytkowników i ustawień. Możesz uzyskać do nich dostęp z lewego menu na dole. Narzędzia są podzielone na dwie główne sekcje: **Management Interfaces**, który zawiera link do interfejsu Horizon, oraz **Ustawienia**, który grupuje wszystkie opcje konfiguracji projektu (użytkownicy, limity, SSH, rozliczenia, kontakty itp.).
 
 <img className="thumbnail" alt="Public Cloud interface - narzędzia do zarządzania" src="/images/public-cloud/cross-functional/03-public-cloud-interface-walk-me/management-tools-2025.png" loading="lazy" />
 
@@ -120,6 +123,6 @@ Poniższa macierz porównuje kluczowe cechy każdego narzędzia, aby pomóc Ci w
 
 [Tworzenie pierwszej instancji Public Cloud i łączenie się z nią](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/).

--- a/docs/pl/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
+++ b/docs/pl/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring a public IP block in a vRack on a Public Cloud instance
 description: Find out how to link a block of public IP addresses to the vRack for configuration on a Public Cloud Instance
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -393,7 +393,7 @@ Click the tab that corresponds to your distribution:
     **Configuration example:**
     
     ```bash
-      ens7:
+      eno2:
         dhcp4: false
         addresses:
         - 203.0.113.1/29
@@ -538,7 +538,7 @@ Click the tab that corresponds to your distribution:
     sudo nmcli con mod 'Wired connection 1' connection.autoconnect true
     ```
     
-    Reboot your network with the following command:
+    Restart your network with the following command:
     
     ```bash
     sudo systemctl restart NetworkManager
@@ -549,4 +549,4 @@ Click the tab that corresponds to your distribution:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/pt/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/pt/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Adicionar um crédito cloud
 description: Saiba como adicionar crédito ou vouchers ao seu projeto Public Cloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Objetivo
@@ -72,4 +72,8 @@ Uma vez que os prazos de validade dos vouchers são geralmente mais limitados, o
 
 ## Quer saber mais?
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+:::info
+Os novos clientes recebem automaticamente 200 € de crédito de teste aquando da ativação do seu primeiro projeto Public Cloud. Consulte o nosso guia "[Criar o seu primeiro projeto Public Cloud da OVHcloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project)".
+:::
+
+Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/).

--- a/docs/pt/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Criar e configurar um disco suplementar numa instância
 description: Saiba como associar um novo volume à sua instância Public Cloud
-lastUpdated: 2025-09-19
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -65,24 +65,16 @@ Nas regiões 3AZ, os volumes Classic são serviços regionais que utilizam um Er
 
 <details>
 
-<summary>**High-Speed - Até 3000 IOPS**</summary>
+<summary>**High Speed Gen2 – 30 IOPS/GB e até 20 000 IOPS**</summary>
 
 
-O volume High-Speed foi concebido para aplicações que requerem um acesso mais rápido aos dados. Com um rendimento de até 3000 IOPS, é ideal para os seguintes casos de utilização:
+A geração 2 dos volumes High Speed é otimizada para as cargas de trabalho mais exigentes. Os desempenhos adaptam-se à dimensão do volume:
 
-- Bases de dados transacionais (MySQL, PostgreSQL, etc.)
-- Ambientes de virtualização e de containers
-- Aplicações que requerem uma latência reduzida e uma velocidade elevada
+- **IOPS**: 30 IOPS/GB (base de 3 000 IOPS para 10–100 GB, até 20 000 IOPS)
+- **Débito**: 0,5 MB/s/GB (base de 50 MB/s para 10–100 GB, até 512 MB/s)
+- **Tamanho máximo**: 12 TB
 
-</details>
-
-
-<details>
-
-<summary>**High-Speed Gen2 - 30 IOPS/GB e até 20 000 IOPS**</summary>
-
-
-A geração 2 dos volumes High-Speed é otimizada para as cargas de trabalho mais exigentes. Com um desempenho de 30 IOPS/GB, até 20 000 IOPS, este tipo de volume é recomendado para as seguintes utilizações:
+Este tipo de volume é recomendado para as seguintes utilizações:
 
 - Big Data e análises em tempo real
 - Inteligência artificial e Machine Learning
@@ -90,6 +82,12 @@ A geração 2 dos volumes High-Speed é otimizada para as cargas de trabalho mai
 
 </details>
 
+
+:::info
+**Já não é possível encomendar volumes High Speed (Gen1) a partir da área de cliente OVHcloud.** Foram substituídos pelos volumes High Speed Gen2 ao mesmo preço, com melhores desempenhos para os volumes com mais de 100 GB. Os volumes High Speed permanecem disponíveis através da API, do Terraform e do OpenStack.
+
+Os volumes High Speed existentes continuam a ser suportados. Pode também [modificar o tipo do seu volume Block Storage](/guides/public-cloud/compute/switch-volume-type) para os migrar para o tipo High Speed Gen2.
+:::
 
 <img className="thumbnail" alt="volume_types" src="/images/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance/volume-types.png" loading="lazy" />
 
@@ -789,4 +787,4 @@ Clique em <code className="action">Confirmar</code> na nova janela para lançar 
 
 [Aumentar o tamanho de um disco adicional](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/).

--- a/docs/pt/guides/public-cloud/compute/switch-volume-type.mdx
+++ b/docs/pt/guides/public-cloud/compute/switch-volume-type.mdx
@@ -1,7 +1,7 @@
 ---
 title: Modificar um Volume Block Storage
 description: Saiba como alterar o tipo de um volume block storage utilizando Openstack
-lastUpdated: 2026-01-13
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -38,9 +38,7 @@ Esta alteração pode ser realizada através da interface Horizon ou através da
 :::warning
 Se o volume Block Storage estiver ligado a uma instância, deverá desligá-lo antes de continuar. Para mais informações, consulte a secção **Desassociar um volume** do guia "[Criar e configurar um disco suplementar numa instância](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance#detach-a-volume)".
 
-A alteração do tipo de volume (retyping) através da área de cliente OVHcloud ou da API OVHcloud só está disponível para volumes não encriptados. Não é possível alterar o tipo de volumes encriptados do tipo **-LUKS** através destas interfaces.
-
-O retyping é possível através do OpenStack / Horizon apenas para volumes **-LUKS** para **-LUKS**. Neste caso, a restauração do volume após o retyping não é possível.
+A alteração do tipo de volume (retyping) através da área de cliente OVHcloud ou da API OVHcloud só está disponível para volumes não encriptados. Os volumes encriptados do tipo **-LUKS** não podem ser modificados.
 
 As conversões **-LUKS** para **não -LUKS** não são suportadas, incluindo através do OpenStack / Horizon.
 
@@ -120,6 +118,6 @@ Na janela que aparece, clique no menu pendente em `Type` e selecione <code class
 
 Para saber como migrar um volume Block Storage para um volume encriptado LUKS, consulte o nosso guia dedicado [Migrating a Block Storage volume to an encrypted LUKS volume](/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume) (EN).
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/).

--- a/docs/pt/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Criando seu primeiro projeto Public Cloud da OVHcloud
 description: Saiba como criar seu primeiro projeto Public Cloud através da Área de Cliente OVHcloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 :::info
@@ -30,6 +30,8 @@ A criação de um projeto é a primeira etapa na implantação de [instâncias P
 {/* CP-NAV-END:publiccloud-projects */}
 
 ## Instruções
+
+### Criação do projeto
 
 Após ter tomado conhecimento, valide os termos dos contratos selecionando a caixa correspondente e clique em <code className="action">Descobrir o universo Public Cloud</code>.
 
@@ -60,6 +62,20 @@ Para explorar plenamente o potencial do Public Cloud e iniciar os seus primeiros
 
 <iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/N7r_VCB7nmI?si=fcyToz1wK8Tw7skw" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen={true}></iframe>
 
+### Ativação do projeto e teste gratuito
+
+Quando clica em <code className="action">Ativar o projeto</code> a partir do `Modo Descoberta` e regista um método de pagamento, é aplicado um **crédito de teste de 200 €** se for elegível.
+
+:::info
+**Condições do teste gratuito**
+
+- O crédito é ativado no momento da ativação do projeto e é válido durante **um mês**.
+- **Elegível:** qualquer cliente OVHcloud que crie o seu primeiro projeto Public Cloud, mesmo que já disponha de uma conta OVHcloud.
+- **Não elegível:** os clientes que disponham ou tenham disposto de um projeto Public Cloud, ou que já tenham beneficiado de um crédito de teste gratuito.
+
+Saiba mais na página [Teste gratuito Public Cloud OVHcloud](/links/public-cloud/free-trial).
+:::
+
 ## Quer saber mais?
 
 - [Criação e conexão a uma primeira instância Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
@@ -68,6 +84,6 @@ Para explorar plenamente o potencial do Public Cloud e iniciar os seus primeiros
 - [Eliminar um projeto Public Cloud](/guides/public-cloud/cross-functional/delete-a-project)
 - [Informações sobre o método de faturação cloud](/guides/public-cloud/cross-functional/analyze-billing)
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com a nossa comunidade de utilizadores: [https://community.ovhcloud.com/](https://community.ovhcloud.com/en/).

--- a/docs/pt/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/increasing-public-cloud-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aumentar as quotas Public Cloud
 description: Saiba como solicitar o aumento das suas quotas Public Cloud
-lastUpdated: 2026-02-04
+lastUpdated: 2026-05-28
 ---
 
 ## Objetivo
@@ -32,6 +32,10 @@ Se desejar criar mais, será necessário aumentar a quota.
 ### Aumentando sua cota de recursos
 
 De acordo com critérios internos (antiguidade, existência de faturas pagas, etc.), agora você tem autonomia para solicitar aumentos de cotas relacionadas aos seus projetos de nuvem pública.
+
+:::info
+Os novos utilizadores Public Cloud beneficiam de [200 € de crédito oferecido](/links/public-cloud/free-trial) ativado automaticamente aquando da criação do projeto, válido durante um mês. A elegibilidade ao aumento de quota depende de critérios como a antiguidade da conta e a existência de faturas pagadas. Os utilizadores em período de teste podem, por isso, ter opções de aumento de quota limitadas enquanto a sua primeira fatura não for liquidada.
+:::
 
 Tem a possibilidade de aumentar a sua quota de recursos manualmente ou automaticamente.
 
@@ -135,6 +139,6 @@ Para certos recursos ou serviços, podem aplicar-se quotas específicos. Para ma
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -1,7 +1,7 @@
 ---
 title: Familiarizar-se com a interface Public Cloud
 description: Visita guiada da interface Public Cloud para descobrir as diferentes secções
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 ## Objetivo
@@ -61,6 +61,9 @@ Pode alterar o nome do projeto através do separador <code className="action">Pa
 |**Containers & orquestração**|Esta secção propõe-lhe diferentes ferramentas para automatizar as suas arquiteturas e ganhar em flexibilidade.|
 |**Databases & Analytics**|Estes serviços irão ajudá-lo a resolver os seus problemas de Big Data e Data Analytics.|
 |**IA & Machine Learning**|Nesta secção, encontrará as ferramentas da OVHcloud para a inteligência artificial.|
+|**Quantum**|Esta secção agrupa os serviços relacionados com a computação quântica.|
+|**Management Interfaces**|Uma única ligação à interface Horizon.|
+|**Parâmetros**|Esta secção permite configurar e gerir os aspetos do projeto.|
 
 ### Atalhos
 
@@ -77,7 +80,7 @@ Para cada recurso que deseja criar, será acompanhado por um assistente de confi
 
 ### Ferramentas de gestão
 
-Encontram-se disponíveis várias ferramentas de gestão no seu projeto Public Cloud, na parte inferior da barra de menu à esquerda.
+No seu projeto Public Cloud, estão disponíveis várias ferramentas de gestão para configurar os seus recursos, utilizadores e parâmetros. Pode aceder-lhes a partir do menu da esquerda, na parte inferior. As ferramentas estão agrupadas em duas secções principais: **Management Interfaces**, que contém a ligação à interface Horizon, e **Parâmetros**, que agrupa todas as opções de configuração do projeto (utilizadores, quotas, SSH, faturação, contactos, etc.).
 
 <img className="thumbnail" alt="Public Cloud interface - ferramentas de gestão" src="/images/public-cloud/cross-functional/03-public-cloud-interface-walk-me/management-tools-2025.png" loading="lazy" />
 
@@ -120,6 +123,6 @@ A matriz abaixo compara as principais características de cada ferramenta para o
 
 [Criação e conexão a uma primeira instância Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/).

--- a/docs/pt/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
+++ b/docs/pt/guides/public-cloud/network-services/configure-ip-block-vrack-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring a public IP block in a vRack on a Public Cloud instance
 description: Find out how to link a block of public IP addresses to the vRack for configuration on a Public Cloud Instance
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -393,7 +393,7 @@ Click the tab that corresponds to your distribution:
     **Configuration example:**
     
     ```bash
-      ens7:
+      eno2:
         dhcp4: false
         addresses:
         - 203.0.113.1/29
@@ -538,7 +538,7 @@ Click the tab that corresponds to your distribution:
     sudo nmcli con mod 'Wired connection 1' connection.autoconnect true
     ```
     
-    Reboot your network with the following command:
+    Restart your network with the following command:
     
     ```bash
     sudo systemctl restart NetworkManager
@@ -549,4 +549,4 @@ Click the tab that corresponds to your distribution:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).


### PR DESCRIPTION
Seven public-cloud guides where source-PR content was missing from new-docs since the bulk migration. Hand-ported per /legacy-pr-port conventions after the /legacy-batch-port skill produced false positives on this universe's larger source-PR set.

Guides:
- public-cloud/compute/switch-volume-type (PR #9265): drop the LUKS-retyping sentence; trim the unencrypted-volume wording.
- public-cloud/network-services/configure-ip-block-vrack-instance (PR #9256): update interface name ens7 → eno2; tighten Reboot → Restart.
- account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project (PR #9329): add free-trial credit :::info callout in Go further.
- public-cloud/cross-functional/increasing-public-cloud-quota (PR #9329): add free-trial quota-eligibility :::info callout.
- public-cloud/cross-functional/create-a-public-cloud-project (PR #9329): add Project creation heading + new Project activation and free trial section.
- public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance (PR #9356): drop the High-Speed Gen1 details block, update Gen2 details with the new bullet-format performance spec (30 IOPS/GB, 0.5 MB/s/GB, max 12 TB), add the :::info callout announcing that Gen1 volumes can no longer be ordered from the Control Panel.
- public-cloud/cross-functional/public-cloud-interface-walk-me (PR #9258): add 3 new main-menu rows (Quantum, Management Interfaces, Settings), expand the Management Tools paragraph to describe the two-section grouping (Management Interfaces / Settings).

While in the area: normalize 54 community URLs (bare https://community.ovhcloud.com/) and 21 hardcoded professional-services URLs (→ /links/professional-services) across the touched files.

All 7 locales touched per guide. No regression vs develop. deploy-a-gpu-instance (PR #9259) deferred: new-docs has a partial-port state already (Windows sysprep content present, but old section structure remains) and full reconciliation needs more care than a batch port. databases/getting-started (PR #9313) and data-analytics/analytics/getting-started (PR #9313) also deferred as whole-guide rewrites.

Original-URL: https://github.com/ovh/docs/pull/9265
Original-URL: https://github.com/ovh/docs/pull/9256
Original-URL: https://github.com/ovh/docs/pull/9329
Original-URL: https://github.com/ovh/docs/pull/9356
Original-URL: https://github.com/ovh/docs/pull/9258