### PR TITLE
docs(port): Legacy PR #9387 - Network Services known-limits

### DIFF
--- a/docs/de/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/de/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Known limits (EN)
 description: Requirements and limits to respect
-lastUpdated: 2024-11-12
+lastUpdated: 2026-05-29
 ---
 
 import Api from '@components/Api';
@@ -69,6 +69,15 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 | 738e3c59-439d-4eed-bded-c7c301717a8c |      | fa:16:3e:62:32:5e | ip_address='10.0.0.128', subnet_id='578deb7c-211f-4f0f-8e45-c8ed07b3e16b' | ACTIVE |
 +--------------------------------------+------+-------------------+---------------------------------------------------------------------------+--------+
 ```
+
+## OpenStack Router and Floating IP routing conflict
+
+The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur and prevent Floating IP traffic from working correctly.
+
+:::warning
+Avoid using any CIDR within the `172.31.0.0/17` range for your private subnets when Floating IPs are in use. Use a different private address range (e.g. `10.0.0.0/8` or `192.168.0.0/16`) to prevent routing conflicts.
+
+:::
 
 ## We want your feedback!
 

--- a/docs/de/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/de/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Known limits (EN)
 description: Requirements and limits to respect
-lastUpdated: 2026-05-29
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
@@ -70,9 +70,9 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 +--------------------------------------+------+-------------------+---------------------------------------------------------------------------+--------+
 ```
 
-## OpenStack Router and Floating IP routing conflict
+## OpenStack router and Floating IP routing conflict
 
-The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur and prevent Floating IP traffic from working correctly.
+The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur, preventing Floating IP traffic from working correctly.
 
 :::warning
 Avoid using any CIDR within the `172.31.0.0/17` range for your private subnets when Floating IPs are in use. Use a different private address range (e.g. `10.0.0.0/8` or `192.168.0.0/16`) to prevent routing conflicts.

--- a/docs/en/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/en/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Known limits
 description: Requirements and limits to respect
-lastUpdated: 2024-11-12
+lastUpdated: 2026-05-29
 ---
 
 import Api from '@components/Api';
@@ -69,6 +69,15 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 | 738e3c59-439d-4eed-bded-c7c301717a8c |      | fa:16:3e:62:32:5e | ip_address='10.0.0.128', subnet_id='578deb7c-211f-4f0f-8e45-c8ed07b3e16b' | ACTIVE |
 +--------------------------------------+------+-------------------+---------------------------------------------------------------------------+--------+
 ```
+
+## OpenStack Router and Floating IP routing conflict
+
+The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur and prevent Floating IP traffic from working correctly.
+
+:::warning
+Avoid using any CIDR within the `172.31.0.0/17` range for your private subnets when Floating IPs are in use. Use a different private address range (e.g. `10.0.0.0/8` or `192.168.0.0/16`) to prevent routing conflicts.
+
+:::
 
 ## We want your feedback!
 

--- a/docs/en/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/en/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Known limits
 description: Requirements and limits to respect
-lastUpdated: 2026-05-29
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
@@ -70,9 +70,9 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 +--------------------------------------+------+-------------------+---------------------------------------------------------------------------+--------+
 ```
 
-## OpenStack Router and Floating IP routing conflict
+## OpenStack router and Floating IP routing conflict
 
-The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur and prevent Floating IP traffic from working correctly.
+The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur, preventing Floating IP traffic from working correctly.
 
 :::warning
 Avoid using any CIDR within the `172.31.0.0/17` range for your private subnets when Floating IPs are in use. Use a different private address range (e.g. `10.0.0.0/8` or `192.168.0.0/16`) to prevent routing conflicts.

--- a/docs/es/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/es/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Known limits (EN)
 description: Requirements and limits to respect
-lastUpdated: 2024-11-12
+lastUpdated: 2026-05-29
 ---
 
 import Api from '@components/Api';
@@ -69,6 +69,15 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 | 738e3c59-439d-4eed-bded-c7c301717a8c |      | fa:16:3e:62:32:5e | ip_address='10.0.0.128', subnet_id='578deb7c-211f-4f0f-8e45-c8ed07b3e16b' | ACTIVE |
 +--------------------------------------+------+-------------------+---------------------------------------------------------------------------+--------+
 ```
+
+## OpenStack Router and Floating IP routing conflict
+
+The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur and prevent Floating IP traffic from working correctly.
+
+:::warning
+Avoid using any CIDR within the `172.31.0.0/17` range for your private subnets when Floating IPs are in use. Use a different private address range (e.g. `10.0.0.0/8` or `192.168.0.0/16`) to prevent routing conflicts.
+
+:::
 
 ## We want your feedback!
 

--- a/docs/es/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/es/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Known limits (EN)
 description: Requirements and limits to respect
-lastUpdated: 2026-05-29
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
@@ -70,9 +70,9 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 +--------------------------------------+------+-------------------+---------------------------------------------------------------------------+--------+
 ```
 
-## OpenStack Router and Floating IP routing conflict
+## OpenStack router and Floating IP routing conflict
 
-The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur and prevent Floating IP traffic from working correctly.
+The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur, preventing Floating IP traffic from working correctly.
 
 :::warning
 Avoid using any CIDR within the `172.31.0.0/17` range for your private subnets when Floating IPs are in use. Use a different private address range (e.g. `10.0.0.0/8` or `192.168.0.0/16`) to prevent routing conflicts.

--- a/docs/fr/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/fr/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Limites connues
 description: Prérequis et limites à respecter
-lastUpdated: 2026-05-29
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
@@ -72,7 +72,7 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 
 ## Conflit de routage entre le routeur OpenStack et les Floating IPs
 
-Le réseau Ext-Net utilise le sous-réseau réservé `172.31.0.0/17` en interne pour les ports de passerelle sur les nœuds de calcul qui gèrent les Floating IPs localement. Si un sous-réseau privé client chevauche cette plage, des conflits de routage peuvent survenir et empêcher le bon fonctionnement du trafic via les Floating IPs.
+Le réseau Ext-Net utilise le sous-réseau réservé `172.31.0.0/17` en interne pour les ports de passerelle sur les nœuds de calcul qui gèrent les Floating IPs localement. Si un sous-réseau privé client chevauche cette plage, des conflits de routage peuvent survenir et perturber le trafic via les Floating IPs.
 
 :::warning
 Évitez d'utiliser un CIDR dans la plage `172.31.0.0/17` pour vos sous-réseaux privés lorsque des Floating IPs sont en service. Privilégiez une autre plage d'adresses privées (par exemple `10.0.0.0/8` ou `192.168.0.0/16`) afin d'éviter tout conflit de routage.

--- a/docs/fr/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/fr/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Limites connues
 description: Prérequis et limites à respecter
-lastUpdated: 2024-11-12
+lastUpdated: 2026-05-29
 ---
 
 import Api from '@components/Api';
@@ -69,6 +69,15 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 | 738e3c59-439d-4eed-bded-c7c301717a8c |      | fa:16:3e:62:32:5e | ip_address='10.0.0.128', subnet_id='578deb7c-211f-4f0f-8e45-c8ed07b3e16b' | ACTIVE |
 +--------------------------------------+------+-------------------+---------------------------------------------------------------------------+--------+
 ```
+
+## Conflit de routage entre le routeur OpenStack et les Floating IPs
+
+Le réseau Ext-Net utilise le sous-réseau réservé `172.31.0.0/17` en interne pour les ports de passerelle sur les nœuds de calcul qui gèrent les Floating IPs localement. Si un sous-réseau privé client chevauche cette plage, des conflits de routage peuvent survenir et empêcher le bon fonctionnement du trafic via les Floating IPs.
+
+:::warning
+Évitez d'utiliser un CIDR dans la plage `172.31.0.0/17` pour vos sous-réseaux privés lorsque des Floating IPs sont en service. Privilégiez une autre plage d'adresses privées (par exemple `10.0.0.0/8` ou `192.168.0.0/16`) afin d'éviter tout conflit de routage.
+
+:::
 
 ## Nous voulons vos retours !
 

--- a/docs/it/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/it/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Known limits (EN)
 description: Requirements and limits to respect
-lastUpdated: 2024-11-12
+lastUpdated: 2026-05-29
 ---
 
 import Api from '@components/Api';
@@ -69,6 +69,15 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 | 738e3c59-439d-4eed-bded-c7c301717a8c |      | fa:16:3e:62:32:5e | ip_address='10.0.0.128', subnet_id='578deb7c-211f-4f0f-8e45-c8ed07b3e16b' | ACTIVE |
 +--------------------------------------+------+-------------------+---------------------------------------------------------------------------+--------+
 ```
+
+## OpenStack Router and Floating IP routing conflict
+
+The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur and prevent Floating IP traffic from working correctly.
+
+:::warning
+Avoid using any CIDR within the `172.31.0.0/17` range for your private subnets when Floating IPs are in use. Use a different private address range (e.g. `10.0.0.0/8` or `192.168.0.0/16`) to prevent routing conflicts.
+
+:::
 
 ## We want your feedback!
 

--- a/docs/it/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/it/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Known limits (EN)
 description: Requirements and limits to respect
-lastUpdated: 2026-05-29
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
@@ -70,9 +70,9 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 +--------------------------------------+------+-------------------+---------------------------------------------------------------------------+--------+
 ```
 
-## OpenStack Router and Floating IP routing conflict
+## OpenStack router and Floating IP routing conflict
 
-The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur and prevent Floating IP traffic from working correctly.
+The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur, preventing Floating IP traffic from working correctly.
 
 :::warning
 Avoid using any CIDR within the `172.31.0.0/17` range for your private subnets when Floating IPs are in use. Use a different private address range (e.g. `10.0.0.0/8` or `192.168.0.0/16`) to prevent routing conflicts.

--- a/docs/pl/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/pl/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Known limits (EN)
 description: Requirements and limits to respect
-lastUpdated: 2024-11-12
+lastUpdated: 2026-05-29
 ---
 
 import Api from '@components/Api';
@@ -69,6 +69,15 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 | 738e3c59-439d-4eed-bded-c7c301717a8c |      | fa:16:3e:62:32:5e | ip_address='10.0.0.128', subnet_id='578deb7c-211f-4f0f-8e45-c8ed07b3e16b' | ACTIVE |
 +--------------------------------------+------+-------------------+---------------------------------------------------------------------------+--------+
 ```
+
+## OpenStack Router and Floating IP routing conflict
+
+The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur and prevent Floating IP traffic from working correctly.
+
+:::warning
+Avoid using any CIDR within the `172.31.0.0/17` range for your private subnets when Floating IPs are in use. Use a different private address range (e.g. `10.0.0.0/8` or `192.168.0.0/16`) to prevent routing conflicts.
+
+:::
 
 ## We want your feedback!
 

--- a/docs/pl/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/pl/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Known limits (EN)
 description: Requirements and limits to respect
-lastUpdated: 2026-05-29
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
@@ -70,9 +70,9 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 +--------------------------------------+------+-------------------+---------------------------------------------------------------------------+--------+
 ```
 
-## OpenStack Router and Floating IP routing conflict
+## OpenStack router and Floating IP routing conflict
 
-The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur and prevent Floating IP traffic from working correctly.
+The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur, preventing Floating IP traffic from working correctly.
 
 :::warning
 Avoid using any CIDR within the `172.31.0.0/17` range for your private subnets when Floating IPs are in use. Use a different private address range (e.g. `10.0.0.0/8` or `192.168.0.0/16`) to prevent routing conflicts.

--- a/docs/pt/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/pt/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Known limits (EN)
 description: Requirements and limits to respect
-lastUpdated: 2024-11-12
+lastUpdated: 2026-05-29
 ---
 
 import Api from '@components/Api';
@@ -69,6 +69,15 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 | 738e3c59-439d-4eed-bded-c7c301717a8c |      | fa:16:3e:62:32:5e | ip_address='10.0.0.128', subnet_id='578deb7c-211f-4f0f-8e45-c8ed07b3e16b' | ACTIVE |
 +--------------------------------------+------+-------------------+---------------------------------------------------------------------------+--------+
 ```
+
+## OpenStack Router and Floating IP routing conflict
+
+The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur and prevent Floating IP traffic from working correctly.
+
+:::warning
+Avoid using any CIDR within the `172.31.0.0/17` range for your private subnets when Floating IPs are in use. Use a different private address range (e.g. `10.0.0.0/8` or `192.168.0.0/16`) to prevent routing conflicts.
+
+:::
 
 ## We want your feedback!
 

--- a/docs/pt/guides/public-cloud/network-services/known-limits.mdx
+++ b/docs/pt/guides/public-cloud/network-services/known-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud Network Services - Known limits (EN)
 description: Requirements and limits to respect
-lastUpdated: 2026-05-29
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
@@ -70,9 +70,9 @@ openstack port list --network <PRIVATE_NETWORK_UID> --device-owner network:dhcp
 +--------------------------------------+------+-------------------+---------------------------------------------------------------------------+--------+
 ```
 
-## OpenStack Router and Floating IP routing conflict
+## OpenStack router and Floating IP routing conflict
 
-The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur and prevent Floating IP traffic from working correctly.
+The Ext-Net network uses the reserved subnet `172.31.0.0/17` internally for gateway ports on compute nodes that handle Floating IPs locally. If a private customer subnet overlaps with this range, routing conflicts may occur, preventing Floating IP traffic from working correctly.
 
 :::warning
 Avoid using any CIDR within the `172.31.0.0/17` range for your private subnets when Floating IPs are in use. Use a different private address range (e.g. `10.0.0.0/8` or `192.168.0.0/16`) to prevent routing conflicts.


### PR DESCRIPTION
- Network Services known-limits: CIDR/Floating IP conflict
- Adds a new "OpenStack Router and Floating IP routing conflict" section to the Public Cloud Network Services known-limits guide
- SK-2645
- Original-URL: https://github.com/ovh/docs/pull/9387