### PR TITLE
docs(port): Legacy PR #9386 - BMC firmware fix

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: BMC-Firmware-Version auf einem Linux Dedicated Server überprüfen
 description: Überprüfen Sie die BMC-Firmware-Version auf Ihrem OVHcloud Dedicated Server, um die Kompatibilität der Hardware-Verwaltung sicherzustellen.
-lastUpdated: 2026-06-03
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: BMC-Firmware-Version auf einem Linux Dedicated Server überprüfen
 description: Überprüfen Sie die BMC-Firmware-Version auf Ihrem OVHcloud Dedicated Server, um die Kompatibilität der Hardware-Verwaltung sicherzustellen.
-lastUpdated: 2026-02-25
+lastUpdated: 2026-06-03
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -54,8 +54,14 @@ sudo ipmitool mc info
 
 <img className="thumbnail" alt="BMC-Firmware-Version in der ipmitool-Ausgabe unter Linux" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool.png" loading="lazy" /> 
 
-- Wenn die Firmware-Version kleiner oder gleich 1.14 ist, kontaktieren Sie unser Support-Team, indem Sie ein [Support-Ticket im OVHcloud Help Center](https://help.ovhcloud.com/csm?id=csm_get_help) erstellen, um ein Firmware-Update anzufordern. 
+:::warning
+
+**Hauptplatine TYAN S8056**
+
+- Wenn Ihr Server eine **TYAN S8056**-Hauptplatine verwendet und die Firmware-Version kleiner oder gleich 1.14 ist, kontaktieren Sie unser Support-Team, indem Sie ein [Support-Ticket im OVHcloud Help Center](https://help.ovhcloud.com/csm?id=csm_get_help) erstellen, um ein Firmware-Update anzufordern.
 - Wenn die Version höher als 1.14 ist, sind keine Maßnahmen erforderlich.
+
+:::
 
 ### Auf einem Windows-Server
 
@@ -77,8 +83,14 @@ ipmitool mc info
 
 <img className="thumbnail" alt="BMC-Firmware-Version in der ipmitool-Ausgabe im Rescue-Modus" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool_rescue.png" loading="lazy" />
 
-- Wenn die Firmware-Version kleiner oder gleich 1.14 ist, kontaktieren Sie unser Support-Team, indem Sie ein [Support-Ticket im OVHcloud Help Center](https://help.ovhcloud.com/csm?id=csm_get_help) erstellen, um ein Firmware-Update anzufordern. 
+:::warning
+
+**Hauptplatine TYAN S8056**
+
+- Wenn Ihr Server eine **TYAN S8056**-Hauptplatine verwendet und die Firmware-Version kleiner oder gleich 1.14 ist, kontaktieren Sie unser Support-Team, indem Sie ein [Support-Ticket im OVHcloud Help Center](https://help.ovhcloud.com/csm?id=csm_get_help) erstellen, um ein Firmware-Update anzufordern.
 - Wenn die Version höher als 1.14 ist, sind keine Maßnahmen erforderlich.
+
+:::
 
 ## Weiterführende Informationen
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: Verify the BMC Firmware Version on a Linux Dedicated Server
 description: Check and verify the BMC firmware version on your OVHcloud dedicated server to ensure hardware management compatibility.
-lastUpdated: 2026-02-25
+lastUpdated: 2026-06-03
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -54,6 +54,15 @@ sudo ipmitool mc info
 
 <img className="thumbnail" alt="BMC firmware version output from ipmitool on Linux" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool.png" loading="lazy" />
 
+:::warning
+
+**TYAN S8056 motherboard**
+
+- If your server uses a **TYAN S8056** motherboard and the firmware version is equal to or lower than 1.14, please contact our support team by creating a [support ticket via the OVHcloud Help Center](https://help.ovhcloud.com/csm?id=csm_get_help) to request a firmware update.
+- If the version is higher than 1.14, no action is required.
+
+:::
+
 ### On a Windows Server
 
 Currently, we are only able to provide the procedure for servers running Linux operating systems. We recommend that you restart your Windows server in our [rescue mode](/guides/bare-metal-cloud/dedicated-servers/rescue-mode) environment to check the version by following the instructions below.
@@ -73,6 +82,15 @@ ipmitool mc info
 ```
 
 <img className="thumbnail" alt="BMC firmware version output from ipmitool in rescue mode" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool_rescue.png" loading="lazy" />
+
+:::warning
+
+**TYAN S8056 motherboard**
+
+- If your server uses a **TYAN S8056** motherboard and the firmware version is equal to or lower than 1.14, please contact our support team by creating a [support ticket via the OVHcloud Help Center](https://help.ovhcloud.com/csm?id=csm_get_help) to request a firmware update.
+- If the version is higher than 1.14, no action is required.
+
+:::
 
 ## Go further
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -54,9 +54,6 @@ sudo ipmitool mc info
 
 <img className="thumbnail" alt="BMC firmware version output from ipmitool on Linux" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool.png" loading="lazy" />
 
-- If the firmware version is equal to or lower than 1.14, please contact our support team by creating a [support ticket via the OVHcloud Help Center](https://help.ovhcloud.com/csm?id=csm_get_help) to request a firmware update. 
-- If the version is higher than 1.14, no action is required.
-
 ### On a Windows Server
 
 Currently, we are only able to provide the procedure for servers running Linux operating systems. We recommend that you restart your Windows server in our [rescue mode](/guides/bare-metal-cloud/dedicated-servers/rescue-mode) environment to check the version by following the instructions below.
@@ -76,9 +73,6 @@ ipmitool mc info
 ```
 
 <img className="thumbnail" alt="BMC firmware version output from ipmitool in rescue mode" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool_rescue.png" loading="lazy" />
-
-- If the firmware version is equal to or lower than 1.14, please contact our support team by creating a [support ticket via the OVHcloud Help Center](https://help.ovhcloud.com/csm?id=csm_get_help) to request a firmware update. 
-- If the version is higher than 1.14, no action is required.
 
 ## Go further
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: Verify the BMC Firmware Version on a Linux Dedicated Server
 description: Check and verify the BMC firmware version on your OVHcloud dedicated server to ensure hardware management compatibility.
-lastUpdated: 2026-06-03
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: Verificar la versión del firmware BMC en un servidor dedicado Linux
 description: Verifique la versión del firmware BMC en su servidor dedicado OVHcloud para garantizar la compatibilidad de la gestión de hardware.
-lastUpdated: 2026-02-25
+lastUpdated: 2026-06-03
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -54,8 +54,14 @@ sudo ipmitool mc info
 
 <img className="thumbnail" alt="bmc" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool.png" loading="lazy" /> 
 
-- Si la versión del firmware es inferior o igual a 1.14, póngase en contacto con nuestro soporte creando un [ticket de asistencia desde el centro de ayuda de OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) para solicitar una actualización del firmware.
+:::warning
+
+**Placa base TYAN S8056**
+
+- Si su servidor utiliza una placa base **TYAN S8056** y la versión del firmware es inferior o igual a 1.14, póngase en contacto con nuestro soporte creando un [ticket de asistencia desde el centro de ayuda de OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) para solicitar una actualización del firmware.
 - Si la versión es superior a 1.14, no es necesario realizar ninguna acción.
+
+:::
 
 
 ### En un Servidor Windows
@@ -78,8 +84,14 @@ ipmitool mc info
 
 <img className="thumbnail" alt="bmc" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool_rescue.png" loading="lazy" />
 
-- Si la versión del firmware es inferior o igual a 1.14, póngase en contacto con nuestro soporte creando un [ticket de asistencia desde el centro de ayuda de OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) para solicitar una actualización del firmware.
+:::warning
+
+**Placa base TYAN S8056**
+
+- Si su servidor utiliza una placa base **TYAN S8056** y la versión del firmware es inferior o igual a 1.14, póngase en contacto con nuestro soporte creando un [ticket de asistencia desde el centro de ayuda de OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) para solicitar una actualización del firmware.
 - Si la versión es superior a 1.14, no es necesario realizar ninguna acción.
+
+:::
 
 ## Más información
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: Verificar la versión del firmware BMC en un servidor dedicado Linux
 description: Verifique la versión del firmware BMC en su servidor dedicado OVHcloud para garantizar la compatibilidad de la gestión de hardware.
-lastUpdated: 2026-06-03
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: Vérifier la version du firmware BMC sur un serveur dédié Linux
 description: Vérifiez la version du firmware BMC sur votre serveur dédié OVHcloud pour garantir la compatibilité de gestion matérielle
-lastUpdated: 2026-06-03
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: Vérifier la version du firmware BMC sur un serveur dédié Linux
 description: Vérifiez la version du firmware BMC sur votre serveur dédié OVHcloud pour garantir la compatibilité de gestion matérielle
-lastUpdated: 2026-02-25
+lastUpdated: 2026-06-03
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -54,8 +54,14 @@ sudo ipmitool mc info
 
 <img className="thumbnail" alt="Version du firmware BMC obtenue via ipmitool sous Linux" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool.png" loading="lazy" /> 
 
-- Si la version du firmware est inférieure ou égale à 1.14, veuillez contacter notre support en créant un [ticket d'assistance depuis le centre d'aide OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) pour demander une mise à jour du firmware. 
+:::warning
+
+**Carte mère TYAN S8056**
+
+- Si votre serveur utilise une carte mère **TYAN S8056** et que la version du firmware est inférieure ou égale à 1.14, veuillez contacter notre support en créant un [ticket d'assistance depuis le centre d'aide OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) pour demander une mise à jour du firmware.
 - Si la version est supérieure à 1.14, aucune action n'est requise.
+
+:::
 
 ### Sur un Serveur Windows
 
@@ -77,8 +83,14 @@ ipmitool mc info
 
 <img className="thumbnail" alt="Version du firmware BMC obtenue via ipmitool en mode rescue" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool_rescue.png" loading="lazy" />
 
-- Si la version du firmware est inférieure ou égale à 1.14, veuillez contacter notre support en créant un [ticket d'assistance depuis le centre d'aide OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) pour demander une mise à jour du firmware. 
-- Si la version est supérieure à 1.14, aucune action n'est nécessaire.
+:::warning
+
+**Carte mère TYAN S8056**
+
+- Si votre serveur utilise une carte mère **TYAN S8056** et que la version du firmware est inférieure ou égale à 1.14, veuillez contacter notre support en créant un [ticket d'assistance depuis le centre d'aide OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) pour demander une mise à jour du firmware.
+- Si la version est supérieure à 1.14, aucune action n'est requise.
+
+:::
 
 ## Aller plus loin
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: Verificare la versione del firmware BMC su un server dedicato Linux
 description: Verifica la versione del firmware BMC sul tuo server dedicato OVHcloud per garantire la compatibilità della gestione hardware.
-lastUpdated: 2026-06-03
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: Verificare la versione del firmware BMC su un server dedicato Linux
 description: Verifica la versione del firmware BMC sul tuo server dedicato OVHcloud per garantire la compatibilità della gestione hardware.
-lastUpdated: 2026-02-25
+lastUpdated: 2026-06-03
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -54,8 +54,14 @@ sudo ipmitool mc info
 
 <img className="thumbnail" alt="bmc" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool.png" loading="lazy" /> 
 
-- Se la versione del firmware è inferiore o uguale a 1.14, contattate il nostro supporto creando un [ticket di assistenza dal centro di aiuto OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) per richiedere un aggiornamento del firmware. 
+:::warning
+
+**Scheda madre TYAN S8056**
+
+- Se il vostro server utilizza una scheda madre **TYAN S8056** e la versione del firmware è inferiore o uguale a 1.14, contattate il nostro supporto creando un [ticket di assistenza dal centro di aiuto OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) per richiedere un aggiornamento del firmware.
 - Se la versione è superiore alla 1.14, non è richiesta alcuna azione.
+
+:::
 
 ### Su un Server Windows
 
@@ -77,8 +83,14 @@ ipmitool mc info
 
 <img className="thumbnail" alt="bmc" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool_rescue.png" loading="lazy" />
 
-- Se la versione del firmware è inferiore o uguale a 1.14, contattate il nostro supporto creando un [ticket di assistenza dal centro di aiuto OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) per richiedere un aggiornamento del firmware. 
+:::warning
+
+**Scheda madre TYAN S8056**
+
+- Se il vostro server utilizza una scheda madre **TYAN S8056** e la versione del firmware è inferiore o uguale a 1.14, contattate il nostro supporto creando un [ticket di assistenza dal centro di aiuto OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) per richiedere un aggiornamento del firmware.
 - Se la versione è superiore alla 1.14, non è richiesta alcuna azione.
+
+:::
 
 ## Per saperne di più
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: Sprawdzenie wersji firmware BMC na serwerze dedykowanym Linux
 description: Sprawdź wersję firmware BMC na serwerze dedykowanym OVHcloud, aby zapewnić kompatybilność zarządzania sprzętowego.
-lastUpdated: 2026-02-25
+lastUpdated: 2026-06-03
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -54,7 +54,14 @@ sudo ipmitool mc info
 
 <img className="thumbnail" alt="Wersja firmware BMC z narzędzia ipmitool w systemie Linux" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool.png" loading="lazy" /> 
 
-Jeśli wersja oprogramowania sprzętowego jest równa lub mniejsza niż 1.14, skontaktuj się z naszym zespołem wsparcia, tworząc [żądanie wsparcia za pośrednictwem OVHcloud Help Center](https://help.ovhcloud.com/csm?id=csm_get_help), aby zażądać aktualizacji oprogramowania. Jeśli wersja jest wyższa niż 1.14, nie jest wymagana żadna akcja.
+:::warning
+
+**Płyta główna TYAN S8056**
+
+- Jeśli Twój serwer korzysta z płyty głównej **TYAN S8056** i wersja oprogramowania sprzętowego jest równa lub mniejsza niż 1.14, skontaktuj się z naszym zespołem wsparcia, tworząc [żądanie wsparcia za pośrednictwem OVHcloud Help Center](https://help.ovhcloud.com/csm?id=csm_get_help), aby zażądać aktualizacji oprogramowania.
+- Jeśli wersja jest wyższa niż 1.14, nie jest wymagana żadna akcja.
+
+:::
 
 ### Na serwerze z systemem Windows
 
@@ -76,7 +83,14 @@ ipmitool mc info
 
 <img className="thumbnail" alt="Wersja firmware BMC z narzędzia ipmitool w trybie rescue" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool_rescue.png" loading="lazy" />
 
-Jeśli wersja oprogramowania sprzętowego jest równa lub mniejsza niż 1.14, skontaktuj się z naszym zespołem wsparcia, tworząc [żądanie wsparcia za pośrednictwem OVHcloud Help Center](https://help.ovhcloud.com/csm?id=csm_get_help), aby zażądać aktualizacji oprogramowania. Jeśli wersja jest wyższa niż 1.14, nie jest wymagana żadna akcja.
+:::warning
+
+**Płyta główna TYAN S8056**
+
+- Jeśli Twój serwer korzysta z płyty głównej **TYAN S8056** i wersja oprogramowania sprzętowego jest równa lub mniejsza niż 1.14, skontaktuj się z naszym zespołem wsparcia, tworząc [żądanie wsparcia za pośrednictwem OVHcloud Help Center](https://help.ovhcloud.com/csm?id=csm_get_help), aby zażądać aktualizacji oprogramowania.
+- Jeśli wersja jest wyższa niż 1.14, nie jest wymagana żadna akcja.
+
+:::
 
 ## Sprawdź również
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: Sprawdzenie wersji firmware BMC na serwerze dedykowanym Linux
 description: Sprawdź wersję firmware BMC na serwerze dedykowanym OVHcloud, aby zapewnić kompatybilność zarządzania sprzętowego.
-lastUpdated: 2026-06-03
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: Verificar a versão do firmware BMC num servidor dedicado Linux
 description: Verifique a versão do firmware BMC no seu servidor dedicado OVHcloud para garantir a compatibilidade da gestão de hardware.
-lastUpdated: 2026-02-25
+lastUpdated: 2026-06-03
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -55,8 +55,14 @@ sudo ipmitool mc info
 
 <img className="thumbnail" alt="bmc" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool.png" loading="lazy" /> 
 
-- Se a versão do firmware for inferior ou igual a 1.14, contacte o nosso apoio técnico criando um [ticket de assistência a partir do centro de ajuda OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) para solicitar uma atualização do firmware. 
+:::warning
+
+**Placa-mãe TYAN S8056**
+
+- Se o seu servidor utilizar uma placa-mãe **TYAN S8056** e a versão do firmware for inferior ou igual a 1.14, contacte o nosso apoio técnico criando um [ticket de assistência a partir do centro de ajuda OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) para solicitar uma atualização do firmware.
 - Se a versão for superior a 1.14, não é necessária nenhuma ação.
+
+:::
 
 ### Num Servidor Windows
 
@@ -78,8 +84,14 @@ ipmitool mc info
 
 <img className="thumbnail" alt="bmc" src="/images/bare-metal-cloud/dedicated-servers/bmc-fw-update/ipmi_tool_rescue.png" loading="lazy" />
 
-- Se a versão do firmware for inferior ou igual a 1.14, contacte o nosso apoio técnico criando um [ticket de assistência a partir do centro de ajuda OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) para solicitar uma atualização do firmware. 
+:::warning
+
+**Placa-mãe TYAN S8056**
+
+- Se o seu servidor utilizar uma placa-mãe **TYAN S8056** e a versão do firmware for inferior ou igual a 1.14, contacte o nosso apoio técnico criando um [ticket de assistência a partir do centro de ajuda OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) para solicitar uma atualização do firmware.
 - Se a versão for superior a 1.14, não é necessária nenhuma ação.
+
+:::
 
 ## Quer saber mais?
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/bmc-fw-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: Verificar a versão do firmware BMC num servidor dedicado Linux
 description: Verifique a versão do firmware BMC no seu servidor dedicado OVHcloud para garantir a compatibilidade da gestão de hardware.
-lastUpdated: 2026-06-03
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';


### PR DESCRIPTION
- Removes two identical blocks referencing firmware version 1.14 from the Bare Metal BMC firmware update guide
- Original-URL: https://github.com/ovh/docs/pull/9386

---

#### Original comments:

> Replicating an update made on the US documentation at the behest of the US Bare Metal team: "There should be no reference to versions being lower than '1.14' or anything else. Each motherboard will have its own version, so there is no unified version to compare with."

> Removing references to version 1.14, as requested by the US Bare Metal Team. "There should be no reference to versions being lower than '1.14' or anything else. Each motherboard will have its own versions, so there is no unified version to compare with."

Forwarding feedback from @sbraz:

> Hello @SR-OVH-US, we discussed this change with the Bare Metal Hardware team. The scope of this documentation is **only the TYAN S8056 board**. The change should be to clarify that in the summary/prerequisites. Maybe the path should be updated to match this too, @Y0Coss?
>
> The references to a specific firmware version must remain.
> This documentation complements the email which we sent to customers (PUBM-50687), in which we clearly stated:
> > * **Affected motherboard :** TYAN S8056
> > * **New BMC firmware version :** 2.00.0
>
> If this documentation were to become more generic, we would probably need to update wording and screenshots with additional examples.

Follow-up from @sbraz:

> > If this documentation were to become more generic
>
> For the record, I'm in favor of keeping separate pages for separate boards/BMCs, like we do for disk firmware upgrade guides.
