### PR TITLE
Fix: Restore EN frontmatter on 4 Public Cloud guides

### DIFF
--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-coding-assistant.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-coding-assistant.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI Notebooks - Using a code assistant (EN)
+title: AI Notebooks - Using a code assistant with AI Endpoints
 description: Learn how to use AI Endpoints in AI Notebooks to get a personalized coding assistant and boost your development productivity
 lastUpdated: 2025-10-21
 ---

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-definition.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-definition.mdx
@@ -1,6 +1,6 @@
 ---
-title: AI Notebooks - Premiers pas (EN)
-description: Découvrez comment lancer un AI Notebooks
+title: AI Notebooks - Getting started with Public Cloud AI
+description: Create, configure, and manage Jupyter and VSCode Notebooks on OVHcloud AI Notebooks via the Control Panel, CLI, API, and Python SDK
 lastUpdated: 2026-01-28
 ---
 

--- a/docs/en/guides/public-cloud/databases/configure-vrack.mdx
+++ b/docs/en/guides/public-cloud/databases/configure-vrack.mdx
@@ -1,5 +1,5 @@
 ---
-title: Configurer le réseau privé des bases de données Public Cloud (EN)
+title: Configure the private network for Public Cloud Databases
 description: Connect a Public Cloud Database to vRack
 lastUpdated: 2023-08-17
 ---

--- a/docs/en/guides/public-cloud/databases/logs-to-customers.mdx
+++ b/docs/en/guides/public-cloud/databases/logs-to-customers.mdx
@@ -1,6 +1,6 @@
 ---
-title: Mettre en place le transfert de logs des bases de données Public Cloud (EN)
-description: Find out how to forward logs of your database service to your Logs Data Platform data stream
+title: Set up logs forwarding for Public Cloud Databases
+description: Forward logs of your Public Cloud database service to your Logs Data Platform data stream
 lastUpdated: 2024-10-28
 ---
 


### PR DESCRIPTION
- Frontmatter flagged as untranslated, migrator copied titles verbatim
- Rewrite to EN + SEO
- Titles realigned with config/sidebar/index.md link text

- public-cloud/databases/configure-vrack
- public-cloud/databases/logs-to-customers
- public-cloud/ai-machine-learning/ai-notebooks-definition
- public-cloud/ai-machine-learning/ai-notebooks-coding-assistant

