### PR TITLE
docs(port): restore BYOIP range-slicing Control Panel instructions (#9296

### DIFF
--- a/docs/de/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/de/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -1,10 +1,11 @@
 ---
 title: How to use the Bring Your Own IP feature (EN)
 description: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
+import { Tab, Tabs } from '@rspress/core/theme';
 
 
 ## Objective
@@ -172,55 +173,73 @@ To be able to slice/merge an existing IP block, it must be unused (i.e. in the p
 :::
 
 
-To slice a block, use the following API call:
+To segment your BYOIP block, follow these steps:
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+<Tabs>
+  <Tab label="Via the OVHcloud Control Panel">
+    1. Navigate to the <code className="action">Public IP Addresses</code> page and locate your BYOIP block.
+    2. Click the <code className="action">⋮</code> button on the right side of the table.
+    3. Select <code className="action">Segment</code>.
+    4. Choose your desired **CIDR subnet mask** to define the size of the child blocks.
+    5. Review the preview of the generated blocks, then click <code className="action">Confirm</code> to finalize the segmentation.
+  </Tab>
+  <Tab label="Via the OVHcloud API">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-Use the following parameters:
+    Use the following parameters:
 
-- ip: the IP block you want to slice, in CIDR notation.
-- slicingSize: the resulting size of the sliced blocks, expressed as a network prefix size, in bits. For example if you want to slice a /24 block into 2 smaller blocks of size /25, you should enter the value "25".
+    - ip: the IP block you want to slice, in CIDR notation.
+    - slicingSize: the resulting size of the sliced blocks, expressed as a network prefix size, in bits. For example if you want to slice a /24 block into 2 smaller blocks of size /25, you should enter the value "25".
 
-:::info
-This API call is asynchronous, the newly created blocks are made available shortly after the call. They will be usable as any other Additional IP block or individual address.
+    :::info
+    This API call is asynchronous, the newly created blocks are made available shortly after the call. They will be usable as any other Additional IP block or individual address.
+    :::
 
-:::
+    You can preview the resulting blocks that would be created for each block size, by using the following API call:
 
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-You can preview the resulting blocks that would be created for each block size, by using the following API call:
+    Use the following parameters:
 
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+    - ip: the IP block you want to slice, in CIDR notation.
+  </Tab>
+</Tabs>
 
-Use the following parameters:
+To combine several child blocks into a parent block, follow these steps:
 
-- ip: the IP block you want to slice, in CIDR notation.
+<Tabs>
+  <Tab label="Via the OVHcloud Control Panel">
+    1. Navigate to the <code className="action">Public IP Addresses</code> page and locate one of the BYOIP block segments you want to combine.
+    2. Click the <code className="action">⋮</code> button on the right side of the table.
+    3. Select <code className="action">Combine</code>.
+    4. Choose the desired parent block.
+    5. Review the preview of the generated blocks, then click <code className="action">Confirm</code> to finalize the aggregation.
+  </Tab>
+  <Tab label="Via the OVHcloud API">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-To merge back a block into a parent block, use this API call:
+    Use the following parameters:
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
+    - ip: the IP block you want to merge, in CIDR notation.
+    - aggregationIp: the resulting block, in CIDR notation.
 
-Use the following parameters:
+    The resulting block will be an aggregate of all its children blocks.
 
-- ip: the IP block you want to merge, in CIDR notation.
-- aggregationIp: the resulting block, in CIDR notation.
+    :::info
+    This API call is asynchronous, the re-aggregated blocks are made available shortly after the call.
+    :::
 
-The resulting block will be an aggregate of all its children blocks.
+    You can preview all the possible configurations of aggregated blocks for a given IP block, by using the following API call:
 
-:::info
-This API call is asynchronous, the re-aggregated blocks are made available shortly after the call.
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-:::
+    Use the following parameters:
 
+    - ip: the IP block you want to merge into a parent block, in CIDR notation.
 
-You can preview all the possible configurations of aggregated blocks for a given IP block, by using the following API call:
-
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
-
-Use the following parameters:
-
-- ip: the IP block you want to merge into a parent block, in CIDR notation.
-
-This call returns a list of possible aggregated blocks and, for each one of them, gives the list of children blocks to be merged back.
+    This call returns a list of possible aggregated blocks and, for each one of them, gives the list of children blocks to be merged back.
+  </Tab>
+</Tabs>
 
 **Limitations**:
 

--- a/docs/en/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/en/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -1,10 +1,11 @@
 ---
 title: How to use the Bring Your Own IP feature
 description: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
+import { Tab, Tabs } from '@rspress/core/theme';
 
 
 ## Objective
@@ -108,7 +109,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 - APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 :::warning
-If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
+If your imported IP block is already advertised on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
 
 :::
 
@@ -172,55 +173,73 @@ To be able to slice/merge an existing IP block, it must be unused (i.e. in the p
 :::
 
 
-To slice a block, use the following API call:
+To segment your BYOIP block, follow these steps:
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+<Tabs>
+  <Tab label="Via the OVHcloud Control Panel">
+    1. Navigate to the <code className="action">Public IP Addresses</code> page and locate your BYOIP block.
+    2. Click the <code className="action">⋮</code> button on the right side of the table.
+    3. Select <code className="action">Segment</code>.
+    4. Choose your desired **CIDR subnet mask** to define the size of the child blocks.
+    5. Review the preview of the generated blocks, then click <code className="action">Confirm</code> to finalize the segmentation.
+  </Tab>
+  <Tab label="Via the OVHcloud API">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-Use the following parameters:
+    Use the following parameters:
 
-- ip: the IP block you want to slice, in CIDR notation.
-- slicingSize: the resulting size of the sliced blocks, expressed as a network prefix size, in bits. For example if you want to slice a /24 block into 2 smaller blocks of size /25, you should enter the value "25".
+    - ip: the IP block you want to slice, in CIDR notation.
+    - slicingSize: the resulting size of the sliced blocks, expressed as a network prefix size, in bits. For example if you want to slice a /24 block into 2 smaller blocks of size /25, you should enter the value "25".
 
-:::info
-This API call is asynchronous, the newly created blocks are made available shortly after the call. They will be usable as any other Additional IP block or individual address.
+    :::info
+    This API call is asynchronous, the newly created blocks are made available shortly after the call. They will be usable as any other Additional IP block or individual address.
+    :::
 
-:::
+    You can preview the resulting blocks that would be created for each block size, by using the following API call:
 
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-You can preview the resulting blocks that would be created for each block size, by using the following API call:
+    Use the following parameters:
 
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+    - ip: the IP block you want to slice, in CIDR notation.
+  </Tab>
+</Tabs>
 
-Use the following parameters:
+To combine several child blocks into a parent block, follow these steps:
 
-- ip: the IP block you want to slice, in CIDR notation.
+<Tabs>
+  <Tab label="Via the OVHcloud Control Panel">
+    1. Navigate to the <code className="action">Public IP Addresses</code> page and locate one of the BYOIP block segments you want to combine.
+    2. Click the <code className="action">⋮</code> button on the right side of the table.
+    3. Select <code className="action">Combine</code>.
+    4. Choose the desired parent block.
+    5. Review the preview of the generated blocks, then click <code className="action">Confirm</code> to finalize the aggregation.
+  </Tab>
+  <Tab label="Via the OVHcloud API">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-To merge back a block into a parent block, use this API call:
+    Use the following parameters:
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
+    - ip: the IP block you want to merge, in CIDR notation.
+    - aggregationIp: the resulting block, in CIDR notation.
 
-Use the following parameters:
+    The resulting block will be an aggregate of all its children blocks.
 
-- ip: the IP block you want to merge, in CIDR notation.-
-- aggregationIp: the resulting block, in CIDR notation.
+    :::info
+    This API call is asynchronous, the re-aggregated blocks are made available shortly after the call.
+    :::
 
-The resulting block will be an aggregate of all its children blocks.
+    You can preview all the possible configurations of aggregated blocks for a given IP block, by using the following API call:
 
-:::info
-This API call is asynchronous, the re-aggregated blocks are made available shortly after the call.
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-:::
+    Use the following parameters:
 
+    - ip: the IP block you want to merge into a parent block, in CIDR notation.
 
-You can preview all the possible configurations of aggregated blocks for a given IP block, by using the following API call:
-
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
-
-Use the following parameters:
-
-- ip: the IP block you want to merge into a parent block, in CIDR notation.
-
-This call returns a list of possible aggregated blocks and, for each one of them, gives the list of children blocks to be merged back.
+    This call returns a list of possible aggregated blocks and, for each one of them, gives the list of children blocks to be merged back.
+  </Tab>
+</Tabs>
 
 **Limitations**:
 

--- a/docs/es/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/es/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -1,10 +1,11 @@
 ---
 title: How to use the Bring Your Own IP feature (EN)
 description: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
+import { Tab, Tabs } from '@rspress/core/theme';
 
 
 ## Objective
@@ -172,55 +173,73 @@ To be able to slice/merge an existing IP block, it must be unused (i.e. in the p
 :::
 
 
-To slice a block, use the following API call:
+To segment your BYOIP block, follow these steps:
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+<Tabs>
+  <Tab label="Via the OVHcloud Control Panel">
+    1. Navigate to the <code className="action">Public IP Addresses</code> page and locate your BYOIP block.
+    2. Click the <code className="action">⋮</code> button on the right side of the table.
+    3. Select <code className="action">Segment</code>.
+    4. Choose your desired **CIDR subnet mask** to define the size of the child blocks.
+    5. Review the preview of the generated blocks, then click <code className="action">Confirm</code> to finalize the segmentation.
+  </Tab>
+  <Tab label="Via the OVHcloud API">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-Use the following parameters:
+    Use the following parameters:
 
-- ip: the IP block you want to slice, in CIDR notation.
-- slicingSize: the resulting size of the sliced blocks, expressed as a network prefix size, in bits. For example if you want to slice a /24 block into 2 smaller blocks of size /25, you should enter the value "25".
+    - ip: the IP block you want to slice, in CIDR notation.
+    - slicingSize: the resulting size of the sliced blocks, expressed as a network prefix size, in bits. For example if you want to slice a /24 block into 2 smaller blocks of size /25, you should enter the value "25".
 
-:::info
-This API call is asynchronous, the newly created blocks are made available shortly after the call. They will be usable as any other Additional IP block or individual address.
+    :::info
+    This API call is asynchronous, the newly created blocks are made available shortly after the call. They will be usable as any other Additional IP block or individual address.
+    :::
 
-:::
+    You can preview the resulting blocks that would be created for each block size, by using the following API call:
 
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-You can preview the resulting blocks that would be created for each block size, by using the following API call:
+    Use the following parameters:
 
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+    - ip: the IP block you want to slice, in CIDR notation.
+  </Tab>
+</Tabs>
 
-Use the following parameters:
+To combine several child blocks into a parent block, follow these steps:
 
-- ip: the IP block you want to slice, in CIDR notation.
+<Tabs>
+  <Tab label="Via the OVHcloud Control Panel">
+    1. Navigate to the <code className="action">Public IP Addresses</code> page and locate one of the BYOIP block segments you want to combine.
+    2. Click the <code className="action">⋮</code> button on the right side of the table.
+    3. Select <code className="action">Combine</code>.
+    4. Choose the desired parent block.
+    5. Review the preview of the generated blocks, then click <code className="action">Confirm</code> to finalize the aggregation.
+  </Tab>
+  <Tab label="Via the OVHcloud API">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-To merge back a block into a parent block, use this API call:
+    Use the following parameters:
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
+    - ip: the IP block you want to merge, in CIDR notation.
+    - aggregationIp: the resulting block, in CIDR notation.
 
-Use the following parameters:
+    The resulting block will be an aggregate of all its children blocks.
 
-- ip: the IP block you want to merge, in CIDR notation.
-- aggregationIp: the resulting block, in CIDR notation.
+    :::info
+    This API call is asynchronous, the re-aggregated blocks are made available shortly after the call.
+    :::
 
-The resulting block will be an aggregate of all its children blocks.
+    You can preview all the possible configurations of aggregated blocks for a given IP block, by using the following API call:
 
-:::info
-This API call is asynchronous, the re-aggregated blocks are made available shortly after the call.
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-:::
+    Use the following parameters:
 
+    - ip: the IP block you want to merge into a parent block, in CIDR notation.
 
-You can preview all the possible configurations of aggregated blocks for a given IP block, by using the following API call:
-
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
-
-Use the following parameters:
-
-- ip: the IP block you want to merge into a parent block, in CIDR notation.
-
-This call returns a list of possible aggregated blocks and, for each one of them, gives the list of children blocks to be merged back.
+    This call returns a list of possible aggregated blocks and, for each one of them, gives the list of children blocks to be merged back.
+  </Tab>
+</Tabs>
 
 **Limitations**:
 

--- a/docs/fr/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/fr/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -1,10 +1,11 @@
 ---
 title: Utiliser la fonctionnalité Bring Your Own IP
 description: Découvrez comment importer facilement votre propre adresse IP comme Additional IP dans votre compte OVHcloud
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
+import { Tab, Tabs } from '@rspress/core/theme';
 
 
 ## Objectif
@@ -173,55 +174,73 @@ Pour pouvoir découper/fusionner un bloc IP existant, il doit être inutilisé (
 :::
 
 
-Pour découper un bloc, utilisez l'appel API suivant :
+Pour segmenter votre bloc BYOIP, suivez les étapes ci-dessous :
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+<Tabs>
+  <Tab label="Via l'espace client OVHcloud">
+    1. Rendez-vous sur la page <code className="action">Adresses IP Publiques</code> et repérez votre bloc BYOIP.
+    2. Cliquez sur le bouton <code className="action">⋮</code> à droite du tableau.
+    3. Sélectionnez <code className="action">Segmenter</code>.
+    4. Choisissez le **masque de sous-réseau CIDR** souhaité pour définir la taille des blocs enfants.
+    5. Vérifiez l'aperçu des blocs générés, puis cliquez sur <code className="action">Confirmer</code> pour finaliser la segmentation.
+  </Tab>
+  <Tab label="Via l'API OVHcloud">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-Avec les paramètres suivants :
+    Avec les paramètres suivants :
 
-- ip : le bloc IP que vous souhaitez découper, en notation CIDR.
-- slicingSize : la taille résultante des blocs découpés, exprimée en taille de préfixe réseau, en bits. Par exemple, si vous souhaitez découper un bloc /24 en 2 blocs plus petits de taille /25, vous devez saisir la valeur "25".
+    - ip : le bloc IP que vous souhaitez découper, en notation CIDR.
+    - slicingSize : la taille résultante des blocs découpés, exprimée en taille de préfixe réseau, en bits. Par exemple, si vous souhaitez découper un bloc /24 en 2 blocs plus petits de taille /25, vous devez saisir la valeur "25".
 
-:::info
-Cet appel API est asynchrone, les blocs nouvellement créés sont rendus disponibles peu de temps après l'appel. Ils seront utilisables comme tout autre bloc IP supplémentaire ou adresse individuelle.
+    :::info
+    Cet appel API est asynchrone, les blocs nouvellement créés sont rendus disponibles peu de temps après l'appel. Ils seront utilisables comme tout autre bloc IP supplémentaire ou adresse individuelle.
+    :::
 
-:::
+    Vous pouvez prévisualiser les blocs résultants qui seraient créés pour chaque taille de bloc, à l'aide de l'appel API suivant :
 
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-Vous pouvez prévisualiser les blocs résultants qui seraient créés pour chaque taille de bloc, à l'aide de l'appel API suivant :
+    Avec les paramètres suivants :
 
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+    - ip : le bloc IP que vous souhaitez découper, en notation CIDR.
+  </Tab>
+</Tabs>
 
-Avec les paramètres suivants :
+Pour agréger plusieurs blocs enfants en un bloc parent, suivez les étapes ci-dessous :
 
-- ip : le bloc IP que vous souhaitez découper, en notation CIDR.
+<Tabs>
+  <Tab label="Via l'espace client OVHcloud">
+    1. Rendez-vous sur la page <code className="action">Adresses IP Publiques</code> et repérez l'un des segments de bloc BYOIP que vous souhaitez agréger.
+    2. Cliquez sur le bouton <code className="action">⋮</code> à droite du tableau.
+    3. Sélectionnez <code className="action">Agréger</code>.
+    4. Choisissez le bloc parent souhaité.
+    5. Vérifiez l'aperçu des blocs générés, puis cliquez sur <code className="action">Confirmer</code> pour finaliser l'agrégation.
+  </Tab>
+  <Tab label="Via l'API OVHcloud">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-Pour fusionner un bloc dans un bloc parent, utilisez cet appel API :
+    Avec les paramètres suivants :
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
+    - ip : le bloc IP que vous souhaitez agréger, en notation CIDR.
+    - aggregationIp : le bloc résultant, en notation CIDR.
 
-Avec les paramètres suivants :
+    Le bloc résultant sera un agrégat de tous ses blocs enfants.
 
-- ip : le bloc IP que vous souhaitez agréger, en notation CIDR.
-- aggregationIp : le bloc résultant, en notation CIDR.
+    :::info
+    Cet appel API est asynchrone, les blocs nouvellement fusionnés sont rendus disponibles peu de temps après l'appel.
+    :::
 
-Le bloc résultant sera un agrégat de tous ses blocs enfants.
+    Vous pouvez prévisualiser toutes les configurations possibles des blocs agrégés pour un bloc IP donné, en utilisant l'appel API suivant :
 
-:::info
-Cet appel API est asynchrone, les blocs nouvellement fusionnés sont rendus disponibles peu de temps après l'appel.
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-:::
+    Avec les paramètres suivants :
 
+    - ip : le bloc IP que vous souhaitez fusionner dans un bloc parent, en notation CIDR.
 
-Vous pouvez prévisualiser toutes les configurations possibles des blocs agrégés pour un bloc IP donné, en utilisant l'appel API suivant :
-
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
-
-Avec les paramètres suivants :
-
-- ip : le bloc IP que vous souhaitez fusionner dans un bloc parent, en notation CIDR.
-
-Cet appel renvoie une liste de blocs agrégés possibles et, pour chacun d'eux, donne la liste des blocs enfants à fusionner.
+    Cet appel renvoie une liste de blocs agrégés possibles et, pour chacun d'eux, donne la liste des blocs enfants à fusionner.
+  </Tab>
+</Tabs>
 
 **Limites** :
 

--- a/docs/it/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/it/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -1,10 +1,11 @@
 ---
 title: How to use the Bring Your Own IP feature (EN)
 description: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
+import { Tab, Tabs } from '@rspress/core/theme';
 
 
 ## Objective
@@ -172,55 +173,73 @@ To be able to slice/merge an existing IP block, it must be unused (i.e. in the p
 :::
 
 
-To slice a block, use the following API call:
+To segment your BYOIP block, follow these steps:
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+<Tabs>
+  <Tab label="Via the OVHcloud Control Panel">
+    1. Navigate to the <code className="action">Public IP Addresses</code> page and locate your BYOIP block.
+    2. Click the <code className="action">⋮</code> button on the right side of the table.
+    3. Select <code className="action">Segment</code>.
+    4. Choose your desired **CIDR subnet mask** to define the size of the child blocks.
+    5. Review the preview of the generated blocks, then click <code className="action">Confirm</code> to finalize the segmentation.
+  </Tab>
+  <Tab label="Via the OVHcloud API">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-Use the following parameters:
+    Use the following parameters:
 
-- ip: the IP block you want to slice, in CIDR notation.
-- slicingSize: the resulting size of the sliced blocks, expressed as a network prefix size, in bits. For example if you want to slice a /24 block into 2 smaller blocks of size /25, you should enter the value "25".
+    - ip: the IP block you want to slice, in CIDR notation.
+    - slicingSize: the resulting size of the sliced blocks, expressed as a network prefix size, in bits. For example if you want to slice a /24 block into 2 smaller blocks of size /25, you should enter the value "25".
 
-:::info
-This API call is asynchronous, the newly created blocks are made available shortly after the call. They will be usable as any other Additional IP block or individual address.
+    :::info
+    This API call is asynchronous, the newly created blocks are made available shortly after the call. They will be usable as any other Additional IP block or individual address.
+    :::
 
-:::
+    You can preview the resulting blocks that would be created for each block size, by using the following API call:
 
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-You can preview the resulting blocks that would be created for each block size, by using the following API call:
+    Use the following parameters:
 
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+    - ip: the IP block you want to slice, in CIDR notation.
+  </Tab>
+</Tabs>
 
-Use the following parameters:
+To combine several child blocks into a parent block, follow these steps:
 
-- ip: the IP block you want to slice, in CIDR notation.
+<Tabs>
+  <Tab label="Via the OVHcloud Control Panel">
+    1. Navigate to the <code className="action">Public IP Addresses</code> page and locate one of the BYOIP block segments you want to combine.
+    2. Click the <code className="action">⋮</code> button on the right side of the table.
+    3. Select <code className="action">Combine</code>.
+    4. Choose the desired parent block.
+    5. Review the preview of the generated blocks, then click <code className="action">Confirm</code> to finalize the aggregation.
+  </Tab>
+  <Tab label="Via the OVHcloud API">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-To merge back a block into a parent block, use this API call:
+    Use the following parameters:
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
+    - ip: the IP block you want to merge, in CIDR notation.
+    - aggregationIp: the resulting block, in CIDR notation.
 
-Use the following parameters:
+    The resulting block will be an aggregate of all its children blocks.
 
-- ip: the IP block you want to merge, in CIDR notation.
-- aggregationIp: the resulting block, in CIDR notation.
+    :::info
+    This API call is asynchronous, the re-aggregated blocks are made available shortly after the call.
+    :::
 
-The resulting block will be an aggregate of all its children blocks.
+    You can preview all the possible configurations of aggregated blocks for a given IP block, by using the following API call:
 
-:::info
-This API call is asynchronous, the re-aggregated blocks are made available shortly after the call.
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-:::
+    Use the following parameters:
 
+    - ip: the IP block you want to merge into a parent block, in CIDR notation.
 
-You can preview all the possible configurations of aggregated blocks for a given IP block, by using the following API call:
-
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
-
-Use the following parameters:
-
-- ip: the IP block you want to merge into a parent block, in CIDR notation.
-
-This call returns a list of possible aggregated blocks and, for each one of them, gives the list of children blocks to be merged back.
+    This call returns a list of possible aggregated blocks and, for each one of them, gives the list of children blocks to be merged back.
+  </Tab>
+</Tabs>
 
 **Limitations**:
 

--- a/docs/pl/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/pl/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -1,10 +1,11 @@
 ---
 title: How to use the Bring Your Own IP feature (EN)
 description: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
+import { Tab, Tabs } from '@rspress/core/theme';
 
 
 ## Objective
@@ -172,55 +173,73 @@ To be able to slice/merge an existing IP block, it must be unused (i.e. in the p
 :::
 
 
-To slice a block, use the following API call:
+To segment your BYOIP block, follow these steps:
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+<Tabs>
+  <Tab label="Via the OVHcloud Control Panel">
+    1. Navigate to the <code className="action">Public IP Addresses</code> page and locate your BYOIP block.
+    2. Click the <code className="action">⋮</code> button on the right side of the table.
+    3. Select <code className="action">Segment</code>.
+    4. Choose your desired **CIDR subnet mask** to define the size of the child blocks.
+    5. Review the preview of the generated blocks, then click <code className="action">Confirm</code> to finalize the segmentation.
+  </Tab>
+  <Tab label="Via the OVHcloud API">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-Use the following parameters:
+    Use the following parameters:
 
-- ip: the IP block you want to slice, in CIDR notation.
-- slicingSize: the resulting size of the sliced blocks, expressed as a network prefix size, in bits. For example if you want to slice a /24 block into 2 smaller blocks of size /25, you should enter the value "25".
+    - ip: the IP block you want to slice, in CIDR notation.
+    - slicingSize: the resulting size of the sliced blocks, expressed as a network prefix size, in bits. For example if you want to slice a /24 block into 2 smaller blocks of size /25, you should enter the value "25".
 
-:::info
-This API call is asynchronous, the newly created blocks are made available shortly after the call. They will be usable as any other Additional IP block or individual address.
+    :::info
+    This API call is asynchronous, the newly created blocks are made available shortly after the call. They will be usable as any other Additional IP block or individual address.
+    :::
 
-:::
+    You can preview the resulting blocks that would be created for each block size, by using the following API call:
 
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-You can preview the resulting blocks that would be created for each block size, by using the following API call:
+    Use the following parameters:
 
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+    - ip: the IP block you want to slice, in CIDR notation.
+  </Tab>
+</Tabs>
 
-Use the following parameters:
+To combine several child blocks into a parent block, follow these steps:
 
-- ip: the IP block you want to slice, in CIDR notation.
+<Tabs>
+  <Tab label="Via the OVHcloud Control Panel">
+    1. Navigate to the <code className="action">Public IP Addresses</code> page and locate one of the BYOIP block segments you want to combine.
+    2. Click the <code className="action">⋮</code> button on the right side of the table.
+    3. Select <code className="action">Combine</code>.
+    4. Choose the desired parent block.
+    5. Review the preview of the generated blocks, then click <code className="action">Confirm</code> to finalize the aggregation.
+  </Tab>
+  <Tab label="Via the OVHcloud API">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-To merge back a block into a parent block, use this API call:
+    Use the following parameters:
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
+    - ip: the IP block you want to merge, in CIDR notation.
+    - aggregationIp: the resulting block, in CIDR notation.
 
-Use the following parameters:
+    The resulting block will be an aggregate of all its children blocks.
 
-- ip: the IP block you want to merge, in CIDR notation.
-- aggregationIp: the resulting block, in CIDR notation.
+    :::info
+    This API call is asynchronous, the re-aggregated blocks are made available shortly after the call.
+    :::
 
-The resulting block will be an aggregate of all its children blocks.
+    You can preview all the possible configurations of aggregated blocks for a given IP block, by using the following API call:
 
-:::info
-This API call is asynchronous, the re-aggregated blocks are made available shortly after the call.
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-:::
+    Use the following parameters:
 
+    - ip: the IP block you want to merge into a parent block, in CIDR notation.
 
-You can preview all the possible configurations of aggregated blocks for a given IP block, by using the following API call:
-
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
-
-Use the following parameters:
-
-- ip: the IP block you want to merge into a parent block, in CIDR notation.
-
-This call returns a list of possible aggregated blocks and, for each one of them, gives the list of children blocks to be merged back.
+    This call returns a list of possible aggregated blocks and, for each one of them, gives the list of children blocks to be merged back.
+  </Tab>
+</Tabs>
 
 **Limitations**:
 

--- a/docs/pt/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/pt/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -1,10 +1,11 @@
 ---
 title: How to use the Bring Your Own IP feature (EN)
 description: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-01
 ---
 
 import Api from '@components/Api';
+import { Tab, Tabs } from '@rspress/core/theme';
 
 
 ## Objective
@@ -172,55 +173,73 @@ To be able to slice/merge an existing IP block, it must be unused (i.e. in the p
 :::
 
 
-To slice a block, use the following API call:
+To segment your BYOIP block, follow these steps:
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+<Tabs>
+  <Tab label="Via the OVHcloud Control Panel">
+    1. Navigate to the <code className="action">Public IP Addresses</code> page and locate your BYOIP block.
+    2. Click the <code className="action">⋮</code> button on the right side of the table.
+    3. Select <code className="action">Segment</code>.
+    4. Choose your desired **CIDR subnet mask** to define the size of the child blocks.
+    5. Review the preview of the generated blocks, then click <code className="action">Confirm</code> to finalize the segmentation.
+  </Tab>
+  <Tab label="Via the OVHcloud API">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-Use the following parameters:
+    Use the following parameters:
 
-- ip: the IP block you want to slice, in CIDR notation.
-- slicingSize: the resulting size of the sliced blocks, expressed as a network prefix size, in bits. For example if you want to slice a /24 block into 2 smaller blocks of size /25, you should enter the value "25".
+    - ip: the IP block you want to slice, in CIDR notation.
+    - slicingSize: the resulting size of the sliced blocks, expressed as a network prefix size, in bits. For example if you want to slice a /24 block into 2 smaller blocks of size /25, you should enter the value "25".
 
-:::info
-This API call is asynchronous, the newly created blocks are made available shortly after the call. They will be usable as any other Additional IP block or individual address.
+    :::info
+    This API call is asynchronous, the newly created blocks are made available shortly after the call. They will be usable as any other Additional IP block or individual address.
+    :::
 
-:::
+    You can preview the resulting blocks that would be created for each block size, by using the following API call:
 
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
 
-You can preview the resulting blocks that would be created for each block size, by using the following API call:
+    Use the following parameters:
 
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/slice"} />
+    - ip: the IP block you want to slice, in CIDR notation.
+  </Tab>
+</Tabs>
 
-Use the following parameters:
+To combine several child blocks into a parent block, follow these steps:
 
-- ip: the IP block you want to slice, in CIDR notation.
+<Tabs>
+  <Tab label="Via the OVHcloud Control Panel">
+    1. Navigate to the <code className="action">Public IP Addresses</code> page and locate one of the BYOIP block segments you want to combine.
+    2. Click the <code className="action">⋮</code> button on the right side of the table.
+    3. Select <code className="action">Combine</code>.
+    4. Choose the desired parent block.
+    5. Review the preview of the generated blocks, then click <code className="action">Confirm</code> to finalize the aggregation.
+  </Tab>
+  <Tab label="Via the OVHcloud API">
+    <Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-To merge back a block into a parent block, use this API call:
+    Use the following parameters:
 
-<Api version="v1" section="/ip" method="POST" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
+    - ip: the IP block you want to merge, in CIDR notation.
+    - aggregationIp: the resulting block, in CIDR notation.
 
-Use the following parameters:
+    The resulting block will be an aggregate of all its children blocks.
 
-- ip: the IP block you want to merge, in CIDR notation.
-- aggregationIp: the resulting block, in CIDR notation.
+    :::info
+    This API call is asynchronous, the re-aggregated blocks are made available shortly after the call.
+    :::
 
-The resulting block will be an aggregate of all its children blocks.
+    You can preview all the possible configurations of aggregated blocks for a given IP block, by using the following API call:
 
-:::info
-This API call is asynchronous, the re-aggregated blocks are made available shortly after the call.
+    <Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
 
-:::
+    Use the following parameters:
 
+    - ip: the IP block you want to merge into a parent block, in CIDR notation.
 
-You can preview all the possible configurations of aggregated blocks for a given IP block, by using the following API call:
-
-<Api version="v1" section="/ip" method="GET" route={"/ip/\{ip\}/bringYourOwnIp/aggregate"} />
-
-Use the following parameters:
-
-- ip: the IP block you want to merge into a parent block, in CIDR notation.
-
-This call returns a list of possible aggregated blocks and, for each one of them, gives the list of children blocks to be merged back.
+    This call returns a list of possible aggregated blocks and, for each one of them, gives the list of children blocks to be merged back.
+  </Tab>
+</Tabs>
 
 **Limitations**:
 


### PR DESCRIPTION
Ports ovh/docs #9296 (BYOIP range slicing - Manager instructions), missed by the bulk migration (this guide was frozen at the 2026-02-19 baseline).

Restructures the flat API-only "Range slicing" content into two `<Tabs>` blocks (segment and combine), each with a "Via the OVHcloud Control Panel" tab (the new Manager steps) and a "Via the OVHcloud API" tab (the existing `<Api>` calls, reused as-is). Also fixes the "advertized" -> "advertised" typo (EN only; other locales already had it correct).

All 7 locales: EN body in en/de/es/it/pl/pt, translated in fr.

## Validation

- Structural guard vs develop: `<Tabs>`/`<Tab>` balanced 2/2 and 4/4, `:::` balanced, 4 `<Api>` preserved per locale, `Tabs` import added.
- /proofread-pr: clean (0 NBSP-before-colon in FR, no untranslated residue, buttons in `<code className="action">` format).

Source PR: ovh/docs #9296