### PR TITLE
fix(data-platform): restore clickable image links on Data Platform landing guide

### DIFF
--- a/docs/en/guides/public-cloud/data-platform/general-what-is-the-data-platform.mdx
+++ b/docs/en/guides/public-cloud/data-platform/general-what-is-the-data-platform.mdx
@@ -41,38 +41,34 @@ A Project contains **all the components you need to manage your data's life cycl
 
 We’re excited to have you on board ! There are four sections in this documentation that you can browse to discover the Data Platform, from the most basic to the more advanced. Anyone can use the Data Platform, from non-technical professionals to technical developers.
 
-<div class="block-step">
-   <img src="/images/public-cloud/data-platform/general-what-is-the-data-platform/pict1.png" />
+<a href="https://docs.dataplatform.ovh.net/#/en/getting-started/index" target="_blank" rel="noopener noreferrer" style={{display:"flex", alignItems:"center", textDecoration:"none", color:"var(--rp-c-text-1)", backgroundColor:"var(--rp-c-bg-soft)", borderRadius:"8px", boxShadow:"0 3px 13px 0 rgba(151, 167, 183, 0.3)", margin:"10px 4px 25px", padding:"0 20px 0 0"}}>
+   <img className="no-zoom" src="/images/public-cloud/data-platform/general-what-is-the-data-platform/pict1.png" alt="Getting started" style={{width:"175px", margin:"0 10px 0 0"}} />
    <div>
-      <h3 style={{color:"#2199e8 !important", paddingTop:"5px !important"}}>GETTING STARTED</h3>
+      <h3 style={{color:"#2199e8", paddingTop:"5px"}}>GETTING STARTED</h3>
       <p>You’d like to get up and running as quickly as possible? No problem, we’ve got you covered! Check out this awesome Getting Started tutorial, which will help you build a Project using sample datasets.</p>
    </div>
-   <a href="https://docs.dataplatform.ovh.net/#/en/getting-started/index"></a>
-</div>
+</a>
 
-<div class="block-step">
-   <img src="/images/public-cloud/data-platform/general-what-is-the-data-platform/pict2.png" />
+<a href="https://docs.dataplatform.ovh.net/#/en/getting-further/index" target="_blank" rel="noopener noreferrer" style={{display:"flex", alignItems:"center", textDecoration:"none", color:"var(--rp-c-text-1)", backgroundColor:"var(--rp-c-bg-soft)", borderRadius:"8px", boxShadow:"0 3px 13px 0 rgba(151, 167, 183, 0.3)", margin:"10px 4px 25px", padding:"0 20px 0 0"}}>
+   <img className="no-zoom" src="/images/public-cloud/data-platform/general-what-is-the-data-platform/pict2.png" alt="Tutorials" style={{width:"175px", margin:"0 10px 0 0"}} />
    <div>
-      <h3 style={{color:"#2199e8 !important", paddingTop:"5px !important"}}>TUTORIALS</h3>
+      <h3 style={{color:"#2199e8", paddingTop:"5px"}}>TUTORIALS</h3>
       <p>You can't get enough of the Getting Started guides and want to see hands-on tutorials for more advanced use cases? Check out our Getting Further guide series!</p>
    </div>
-   <a href="https://docs.dataplatform.ovh.net/#/en/getting-further/index"></a>
-</div>
+</a>
 
-<div class="block-step">
-   <img src="/images/public-cloud/data-platform/general-what-is-the-data-platform/pict3.png" />
+<a href="https://docs.dataplatform.ovh.net/#/en/product/index" target="_blank" rel="noopener noreferrer" style={{display:"flex", alignItems:"center", textDecoration:"none", color:"var(--rp-c-text-1)", backgroundColor:"var(--rp-c-bg-soft)", borderRadius:"8px", boxShadow:"0 3px 13px 0 rgba(151, 167, 183, 0.3)", margin:"10px 4px 25px", padding:"0 20px 0 0"}}>
+   <img className="no-zoom" src="/images/public-cloud/data-platform/general-what-is-the-data-platform/pict3.png" alt="Platform documentation" style={{width:"175px", margin:"0 10px 0 0"}} />
    <div>
-      <h3 style={{color:"#2199e8 !important", paddingTop:"5px !important"}}>PLATFORM DOCUMENTATION</h3>
+      <h3 style={{color:"#2199e8", paddingTop:"5px"}}>PLATFORM DOCUMENTATION</h3>
       <p>Starting out with the Platform? Still unsure of what's called what and figuring out how every feature works? This if for you.</p>
    </div>
-   <a href="https://docs.dataplatform.ovh.net/#/en/product/index"></a>
-</div>
+</a>
 
-<div class="block-step">
-   <img src="/images/public-cloud/data-platform/general-what-is-the-data-platform/pict4.png" />
+<a href="https://docs.dataplatform.ovh.net/#/en/technical/index" target="_blank" rel="noopener noreferrer" style={{display:"flex", alignItems:"center", textDecoration:"none", color:"var(--rp-c-text-1)", backgroundColor:"var(--rp-c-bg-soft)", borderRadius:"8px", boxShadow:"0 3px 13px 0 rgba(151, 167, 183, 0.3)", margin:"10px 4px 25px", padding:"0 20px 0 0"}}>
+   <img className="no-zoom" src="/images/public-cloud/data-platform/general-what-is-the-data-platform/pict4.png" alt="Developer documentation" style={{width:"175px", margin:"0 10px 0 0"}} />
    <div>
-      <h3 style={{color:"#2199e8 !important", paddingTop:"5px !important"}}>DEVELOPER DOCUMENTATION</h3>
+      <h3 style={{color:"#2199e8", paddingTop:"5px"}}>DEVELOPER DOCUMENTATION</h3>
       <p>You're an advanced user and are exploring what's under the hood, check out our component's API Reference and SDK functions.</p>
    </div>
-   <a href="https://docs.dataplatform.ovh.net/#/en/technical/index"></a>
-</div>
+</a>

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -111,6 +111,10 @@ export default defineConfig({
     },
   },
   globalStyles: path.join(__dirname, 'styles/index.css'),
+  // Default zoom applies to every `.rspress-doc img`. Let images opt out with
+  // `className="no-zoom"` so clickable image-links (e.g. card icons wrapped in
+  // an <a>) follow the link on click instead of opening the zoom overlay.
+  mediumZoom: { selector: '.rspress-doc img:not(.no-zoom)' },
   title: 'OVHcloud Documentation',
   icon: '/images/favicon.png',
   logo: {


### PR DESCRIPTION
The legacy guide made each landing card a link via an absolutely-positioned overlay anchor defined in an inline <style> block. That block was dropped during migration, so the cards rendered as empty zero-size anchors and the bare images only triggered medium-zoom.

Rewrite the four cards as real <a> anchors (whole card is the link) with inline styles and theme-aware colors. Add a `mediumZoom` selector option so images tagged `className="no-zoom"` opt out of zoom and follow the link on click instead. The option is additive and affects no existing images.