### PR TITLE
docs: update FTP user offer names in ftp-change-password (SK-2672)

### DIFF
--- a/docs/de/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -115,4 +115,4 @@ Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.
 
 Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](https://community.ovhcloud.com/) bei.

--- a/docs/de/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Passwort eines FTP-Benutzers ändern
 description: Erfahren Sie hier, wie Sie das Passwort eines auf Ihrem OVHcloud Webhosting erstellten FTP-Benutzers ändern
-lastUpdated: 2025-10-14
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -55,7 +55,7 @@ Klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
   <Tab label="Schritt 2">
     Klicken Sie auf den Tab <code className="action">FTP - SSH</code>.
     
-    <img className="thumbnail" alt="FTP 6 SSH" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh.png" loading="lazy" />
+    <img className="thumbnail" alt="FTP - SSH" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 3">
     Eine Tabelle zeigt die *FTP-Benutzer*, die auf Ihrem Webhosting erstellt wurden. Mit diesen Benutzern können Sie auf Ihren FTP-Speicherplatz zugreifen, um dort die Dateien Ihrer Website online zu stellen. Bei der Installation Ihres Webhostings wird automatisch ein Benutzer erstellt.
@@ -73,13 +73,13 @@ Für weitere Informationen zu bewährten Praktiken bei der Passwortverwaltung fo
 
 Je nach Ihrem [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) erfolgt die Änderung des Passworts Ihres FTP-Benutzers im Tab <code className="action">FTP - SSH</code> über zwei verschiedene Wege:
 
-- **Für Hosting-Pakete, die keinen zweiten FTP-Benutzer erstellen können** (*Kostenloses Hosting 100M* und *Basic Hosting*):
+- **Für Hosting-Pakete, die keinen zweiten FTP-Benutzer erstellen können** (*Kostenloses Hosting*, *Starter*, *Basic* und *Startup*):
 
 Klicken Sie in der Spalte <code className="action">Passwort</code> der angezeigten Tabelle auf das *Stift-Symbol*, geben Sie das neue Passwort **unter Beachtung der Passwortrichtlinie** ein und bestätigen Sie die Änderung, indem Sie auf den *grünen Button* klicken.
 
 <img className="thumbnail" alt="change-ftp-password-step1-perso" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png" loading="lazy" />
 
-- **Für Hosting-Pakete, die es erlauben, mehrere FTP-Benutzer zu erstellen** (*Pro* und *Performance*): 
+- **Für Hosting-Pakete, die es erlauben, mehrere FTP-Benutzer zu erstellen** (*Pro*, *Performance*, *Agency*, *Agency Plus* und *Agency Max*): 
 
 Klicken Sie auf den Button <code className="action">...</code> rechts neben dem betreffenden FTP-Benutzer und anschließend auf <code className="action">Passwort ändern</code>. Geben Sie im angezeigten Fenster das neue Passwort **unter Beachtung der Passwortrichtlinie** ein, bestätigen Sie, indem Sie es ein zweites Mal eingeben und klicken Sie dann auf den Button <code className="action">Bestätigen</code>.
 
@@ -101,13 +101,13 @@ Gehen Sie dann zum Tab <code className="action">Aktuelle Tasks</code> und laden 
 
 ### 3 - Auf Ihren Speicherplatz zugreifen
 
-Um auf Ihren FTP-Speicherplatz zuzugreifen, lesen Sie unsere Anleitung ["Mit dem Speicherplatz Ihres Webhostings verbinden"](/guides/web-cloud/web-hosting/ftp-connection).
+Um auf Ihren FTP-Speicherplatz zuzugreifen, lesen Sie unsere Anleitung ["Mit dem FTP-Speicherplatz Ihres Webhostings verbinden"](/guides/web-cloud/web-hosting/ftp-connection).
 
 ## Weiterführende Informationen <a name="go-further"></a>
 
 [Das Passwort Ihres Kunden-Accounts anlegen und verwalten](/guides/account-and-service-management/account-information/manage-ovh-password)
 
-[Mit dem Speicherplatz eines Webhostings verbinden](/guides/web-cloud/web-hosting/ftp-connection)
+[Mit dem FTP-Speicherplatz eines Webhostings verbinden](/guides/web-cloud/web-hosting/ftp-connection)
 
 [Ihre Website online stellen](/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online)
 

--- a/docs/en/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Changing an FTP user password
 description: Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan
-lastUpdated: 2025-10-14
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -73,11 +73,11 @@ For more information on password management best practices, follow the instructi
 
 Depending on which OVHcloud [Web Hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/) you have, there are two different paths for changing your FTP user password user via the <code className="action">FTP - SSH</code> tab:
 
-- **For Web Hosting plans that do not allow you to create a second FTP user** (*100M free hosting* and *Personal hosting*): Click on the *pencil icon* in the <code className="action">Password</code> column of the table that appears, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+- **For Web Hosting plans that do not allow you to create a second FTP user** (*Free hosting*, *Starter*, *Personal* and *Startup*): Click on the *pencil icon* in the <code className="action">Password</code> column of the table that appears, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
 
 <img className="thumbnail" alt="change-ftp-password-step1-perso" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png" loading="lazy" />
 
-- **For plans that allow you to create multiple FTP users** (*Pro* and *Performance*): Click on the <code className="action">...</code> button to the right of the FTP user concerned, then <code className="action">Change password</code>. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the <code className="action">Confirm</code> button.
+- **For plans that allow you to create multiple FTP users** (*Professional*, *Performance*, *Agency*, *Agency Plus* and *Agency Max*): Click on the <code className="action">...</code> button to the right of the FTP user concerned, then <code className="action">Change password</code>. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the <code className="action">Confirm</code> button.
 
 <img className="thumbnail" alt="change-ftp-password-pro" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png" loading="lazy" />
 
@@ -97,13 +97,13 @@ Then go to the <code className="action">Ongoing tasks</code> tab and refresh the
 
 ### 3 - Access your storage space
 
-To access your FTP storage space, please refer to our guide ["Logging in to your Web Hosting plan’s storage space"](/guides/web-cloud/web-hosting/ftp-connection).
+To access your FTP storage space, please refer to our guide ["Logging in to your Web Hosting plan’s FTP storage space"](/guides/web-cloud/web-hosting/ftp-connection).
 
 ## Go further <a name="go-further"></a>
 
 [Setting and managing an account password](/guides/account-and-service-management/account-information/manage-ovh-password)
 
-[Logging in to your Web Hosting plan’s storage space](/guides/web-cloud/web-hosting/ftp-connection)
+[Logging in to your Web Hosting plan’s FTP storage space](/guides/web-cloud/web-hosting/ftp-connection)
 
 [Put your website online](/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online)
 

--- a/docs/en/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -111,4 +111,4 @@ For specialised services (SEO, development, etc.), contact [OVHcloud partners](h
 
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-gb/support-levels/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/es/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cambiar la contraseña de un usuario FTP
 description: Descubra cómo cambiar la contraseña de un usuario FTP en un alojamiento de OVHcloud
-lastUpdated: 2025-10-14
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -70,11 +70,11 @@ Para más información sobre las buenas prácticas de gestión de contraseñas, 
 
 Según el plan de [hosting de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/), la modificación de la contraseña del usuario FTP a través de la pestaña <code className="action">FTP - SSH</code> se realizará por dos caminos diferentes:
 
-- **productos que no permiten crear un segundo usuario FTP** (*Alojamiento gratuito 100M* y *Personal*): haga clic en el *pictograma con forma de lápiz* en la columna <code className="action">Contraseña</code> de la tabla que aparece, introduzca la nueva contraseña **respetando la política de contraseñas** y luego confirme el cambio haciendo clic en *botón verde* de validación.
+- **productos que no permiten crear un segundo usuario FTP** (*Hosting gratuito*, *Starter*, *Personal* y *Startup*): haga clic en el *pictograma con forma de lápiz* en la columna <code className="action">Contraseña</code> de la tabla que aparece, introduzca la nueva contraseña **respetando la política de contraseñas** y luego confirme el cambio haciendo clic en *botón verde* de validación.
 
 <img className="thumbnail" alt="change-ftp-password-step1-perso" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png" loading="lazy" />
 
-- **Planes que permiten crear varios usuarios FTP** (planes *Pro* y *Performance*): pulse el botón <code className="action">...</code> a la derecha del usuario FTP correspondiente y luego <code className="action">Cambiar la contraseña</code>. Se abrirá una ventana en la que deberá introducir la nueva contraseña **respetando la política de contraseñas**, confirmarla introduciéndola por segunda vez y haciendo clic en el botón <code className="action">Aceptar</code>.
+- **Planes que permiten crear varios usuarios FTP** (planes *Pro*, *Performance*, *Agency*, *Agency Plus* y *Agency Max*): pulse el botón <code className="action">...</code> a la derecha del usuario FTP correspondiente y luego <code className="action">Cambiar la contraseña</code>. Se abrirá una ventana en la que deberá introducir la nueva contraseña **respetando la política de contraseñas**, confirmarla introduciéndola por segunda vez y haciendo clic en el botón <code className="action">Aceptar</code>.
 
 <img className="thumbnail" alt="change-ftp-password-pro" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png" loading="lazy" />
 
@@ -94,13 +94,13 @@ Por último, abra la pestaña <code className="action">Tareas en curso</code> y 
 
 ### 3 - Acceder al espacio de almacenamiento
 
-Para acceder a su espacio de almacenamiento FTP, consulte nuestra guía ["Conectarse al espacio de almacenamiento de un alojamiento web"](/guides/web-cloud/web-hosting/ftp-connection).
+Para acceder a su espacio de almacenamiento FTP, consulte nuestra guía ["Conectarse al espacio de almacenamiento FTP de un alojamiento web"](/guides/web-cloud/web-hosting/ftp-connection).
 
 ## Más información <a name="go-further"></a>
 
 [Establecer y gestionar la contraseña de su cuenta](/guides/account-and-service-management/account-information/manage-ovh-password)
 
-[Conectarse al espacio de almacenamiento de un alojamiento web](/guides/web-cloud/web-hosting/ftp-connection)
+[Conectarse al espacio de almacenamiento FTP de un alojamiento web](/guides/web-cloud/web-hosting/ftp-connection)
 
 [Publicar el sitio web](/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online)
 

--- a/docs/es/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -108,4 +108,4 @@ Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con 
 
 Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/).

--- a/docs/fr/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Modifier le mot de passe d'un utilisateur FTP"
 description: "Découvrez comment changer le mot de passe d'un utilisateur FTP créé sur votre hébergement web OVHcloud"
-lastUpdated: 2025-10-14
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -55,7 +55,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
   <Tab label="Étape 2">
     Sur la page qui s'affiche, cliquez sur l'onglet <code className="action">FTP - SSH</code>. 
     
-    <img className="thumbnail" alt="FTP- SSH" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh.png" loading="lazy" />
+    <img className="thumbnail" alt="FTP - SSH" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 3">
     Un tableau affiche les *utilisateurs FTP* créés sur votre hébergement web. Ces utilisateurs vous permettent d'accéder à votre espace de stockage FTP afin d'y mettre en ligne les fichiers de votre site web. Un utilisateur est créé automatiquement lors de l'installation de votre hébergement web.
@@ -73,11 +73,11 @@ Pour plus d'informations sur les bonnes pratiques en matière de gestion de mots
 
 Selon votre offre d'[hébergement web OVHcloud](https://www.ovhcloud.com/fr/web-hosting/), la modification du mot de passe de votre utilisateur FTP via l'onglet <code className="action">FTP - SSH</code> se fera par deux chemins différents :
 
-- **pour les offres ne permettant pas de créer un second utilisateur FTP** (offres *Perso* et *Hébergement gratuit 100M*) : cliquez sur le *pictogramme en forme de crayon* dans la colonne <code className="action">Mot de passe</code> du tableau qui s'affiche, renseignez le nouveau mot de passe **en respectant la politique des mots de passe** puis confirmez le changement en cliquant sur le *bouton vert* de validation.
+- **pour les offres ne permettant pas de créer un second utilisateur FTP** (offres *Hébergement gratuit*, *Starter*, *Perso* et *Startup*) : cliquez sur le *pictogramme en forme de crayon* dans la colonne <code className="action">Mot de passe</code> du tableau qui s'affiche, renseignez le nouveau mot de passe **en respectant la politique des mots de passe** puis confirmez le changement en cliquant sur le *bouton vert* de validation.
 
 <img className="thumbnail" alt="change-ftp-password-step1-perso" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png" loading="lazy" />
 
-- **pour les offres permettant de créer plusieurs utilisateurs FTP** (offres *Pro* et *Performance*) : cliquez sur le boutton <code className="action">...</code> à droite de l'utilisateur FTP concerné puis sur <code className="action">Changer le mot de passe</code>. Dans la fenêtre qui s'affiche, renseignez le nouveau mot de passe souhaité **en respectant la politique des mots de passe**, confirmez en le saisissant une seconde fois puis cliquez sur le bouton <code className="action">Valider</code>.
+- **pour les offres permettant de créer plusieurs utilisateurs FTP** (offres *Pro*, *Performance*, *Agency*, *Agency Plus* et *Agency Max*) : cliquez sur le bouton <code className="action">...</code> à droite de l'utilisateur FTP concerné puis sur <code className="action">Changer le mot de passe</code>. Dans la fenêtre qui s'affiche, renseignez le nouveau mot de passe souhaité **en respectant la politique des mots de passe**, confirmez en le saisissant une seconde fois puis cliquez sur le bouton <code className="action">Valider</code>.
 
 <img className="thumbnail" alt="change-ftp-password-pro" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png" loading="lazy" />
 
@@ -97,13 +97,13 @@ Consultez enfin l'onglet <code className="action">Tâches en cours</code> et raf
 
 ### 3 - Accéder à votre espace de stockage
 
-Pour accéder à votre espace de stockage FTP, consultez notre guide [« Se connecter à l’espace de stockage de son hébergement web »](/guides/web-cloud/web-hosting/ftp-connection).
+Pour accéder à votre espace de stockage FTP, consultez notre guide [« Se connecter à l’espace de stockage FTP de son hébergement web »](/guides/web-cloud/web-hosting/ftp-connection).
 
 ## Aller plus loin <a name="go-further"></a>
 
 [Modifier le mot de passe de votre compte](/guides/account-and-service-management/account-information/manage-ovh-password)
 
-[Se connecter à l’espace de stockage de son hébergement web](/guides/web-cloud/web-hosting/ftp-connection)
+[Se connecter à l’espace de stockage FTP de son hébergement web](/guides/web-cloud/web-hosting/ftp-connection)
 
 [Mettre en ligne votre site](/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online)
 

--- a/docs/fr/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -111,4 +111,4 @@ Pour des prestations spécialisées (référencement, développement, etc), cont
 
 Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr/support-levels/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/).

--- a/docs/it/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -110,4 +110,4 @@ Per prestazioni specializzate (referenziamento, sviluppo, ecc...), contatta i [p
 
 Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre soluzioni [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](https://community.ovhcloud.com/).

--- a/docs/it/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Modificare la password di un utente FTP
 description: Questa guida ti mostra come cambiare la password di un utente FTP creata sul tuo hosting Web OVHcloud
-lastUpdated: 2025-10-14
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -54,7 +54,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** pa
   <Tab label="Passaggio 2">
     Nella nuova pagina clicca sulla scheda <code className="action">FTP - SSH</code>.
     
-    <img className="thumbnail" alt="FTP -SSH" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh.png" loading="lazy" />
+    <img className="thumbnail" alt="FTP - SSH" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh.png" loading="lazy" />
   </Tab>
   <Tab label="Passaggio 3">
     Una tabella mostra gli *utenti FTP* creati sul tuo hosting Web. Questi utenti ti permettono di accedere al tuo spazio di archiviazione FTP per mettere online i file del tuo sito web. Un utente viene creato automaticamente durante l'installazione del tuo hosting Web.
@@ -72,11 +72,11 @@ Per maggiori informazioni sulle best practice di gestione delle password, segui 
 
 In base al piano di [hosting Web OVHcloud](https://www.ovhcloud.com/it/web-hosting/), la modifica della password dell'utente FTP tramite la scheda <code className="action">FTP - SSH</code> sarà effettuata su due sentieri diversi:
 
-- **per le offerte che non permettono di creare un secondo utente FTP** (offerte *Personale* e *Hosting gratuito 100M*): clicca sul *pittogramma a forma di matita* nella colonna <code className="action">Password</code> della tabella che appare, inserisci la nuova password **seguendo la politica delle password** e confermala cliccando sul *pulsante verde* di conferma.
+- **per le offerte che non permettono di creare un secondo utente FTP** (offerte *Hosting gratuito*, *Starter*, *Personale* e *Startup*): clicca sul *pittogramma a forma di matita* nella colonna <code className="action">Password</code> della tabella che appare, inserisci la nuova password **seguendo la politica delle password** e confermala cliccando sul *pulsante verde* di conferma.
 
 <img className="thumbnail" alt="change-ftp-password-step1-perso" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png" loading="lazy" />
 
-- **per le offerte che permettono di creare diversi utenti FTP** (offerte *Pro* e *Performance*): clicca sul pulsante <code className="action">...</code> a destra dell'utente FTP interessato e poi su <code className="action">Modifica la password</code>. Nella nuova finestra, inserisci la nuova password**seguendo la politica delle password**, confermala inserendola una seconda volta e clicca su <code className="action">Conferma</code>.
+- **per le offerte che permettono di creare diversi utenti FTP** (offerte *Pro*, *Performance*, *Agency*, *Agency Plus* e *Agency Max*): clicca sul pulsante <code className="action">...</code> a destra dell'utente FTP interessato e poi su <code className="action">Modifica la password</code>. Nella nuova finestra, inserisci la nuova password **seguendo la politica delle password**, confermala inserendola una seconda volta e clicca su <code className="action">Conferma</code>.
 
 <img className="thumbnail" alt="change-ftp-password-pro" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png" loading="lazy" />
 
@@ -96,13 +96,13 @@ Consulta la scheda <code className="action">Operazioni in corso</code> e aggiorn
 
 ### 3 - Accedere al tuo spazio di archiviazione
 
-Per accedere al tuo spazio di storage FTP, consulta la nostra guida ["Connettersi allo spazio di storage di un hosting Web"](/guides/web-cloud/web-hosting/ftp-connection)".
+Per accedere al tuo spazio di storage FTP, consulta la nostra guida ["Connettersi allo spazio di storage FTP di un hosting Web"](/guides/web-cloud/web-hosting/ftp-connection)".
 
 ## Per saperne di più <a name="go-further"></a>
 
 [Impostare e gestire la password di un account OVHcloud](/guides/account-and-service-management/account-information/manage-ovh-password)
 
-[Accedere allo spazio di storage di un hosting Web](/guides/web-cloud/web-hosting/ftp-connection)
+[Accedere allo spazio di storage FTP di un hosting Web](/guides/web-cloud/web-hosting/ftp-connection)
 
 [Mettere online il tuo sito](/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online)
 

--- a/docs/pl/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zmiana hasła do konta FTP
 description: Dowiedz się, jak zmienić hasło dla użytkownika FTP utworzonego na Twoim hostingu
-lastUpdated: 2025-10-14
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -73,11 +73,11 @@ Aby uzyskać więcej informacji na temat dobrych praktyk w zakresie zarządzania
 
 W zależności od pakietu [hostingowego OVHcloud](https://www.ovhcloud.com/pl/web-hosting/) zmiana hasła do konta FTP w zakładce <code className="action">FTP - SSH</code> zostanie wykonana na dwie różne sposoby:
 
-- **w przypadku pakietów, które nie pozwalają na utworzenie drugiego użytkownika FTP** (oferty *Darmowy hosting 100M* i *Perso*): kliknij *piktogram w formie ołówka* w kolumnie <code className="action">Hasło</code> tabeli, która się wyświetla, wprowadź nowe hasło **zgodnie z polityką haseł**, a następnie potwierdź zmianę, klikając *zielony przycisk* do zatwierdzenia.
+- **w przypadku pakietów, które nie pozwalają na utworzenie drugiego użytkownika FTP** (oferty *Hosting darmowy*, *Starter*, *Perso* i *Startup*): kliknij *piktogram w formie ołówka* w kolumnie <code className="action">Hasło</code> tabeli, która się wyświetla, wprowadź nowe hasło **zgodnie z polityką haseł**, a następnie potwierdź zmianę, klikając *zielony przycisk* do zatwierdzenia.
 
 <img className="thumbnail" alt="change-ftp-password-step1-perso" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png" loading="lazy" />
 
-- **w przypadku pakietów umożliwiających utworzenie kilku użytkowników FTP** (oferty *Pro* i *Performance*): kliknij przycisk <code className="action">...</code> po prawej stronie odpowiedniego użytkownika FTP a następnie kliknij <code className="action">Zmień hasło</code>. W oknie, które się wyświetla wprowadź nowe hasło **zgodnie z polityką haseł**, potwierdź, wprowadzając je ponownie i klikając przycisk <code className="action">Zatwierdź</code>.
+- **w przypadku pakietów umożliwiających utworzenie kilku użytkowników FTP** (oferty *Pro*, *Performance*, *Agency*, *Agency Plus* i *Agency Max*): kliknij przycisk <code className="action">...</code> po prawej stronie odpowiedniego użytkownika FTP a następnie kliknij <code className="action">Zmień hasło</code>. W oknie, które się wyświetla wprowadź nowe hasło **zgodnie z polityką haseł**, potwierdź, wprowadzając je ponownie i klikając przycisk <code className="action">Zatwierdź</code>.
 
 <img className="thumbnail" alt="change-ftp-password-pro" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png" loading="lazy" />
 
@@ -97,13 +97,13 @@ Następnie przejdź do zakładki <code className="action">Zadania w realizacji</
 
 ### 3 - Dostęp do Twojej przestrzeni dyskowej
 
-Aby uzyskać dostęp do przestrzeni FTP, zapoznaj się z naszym przewodnikiem "[Logowanie do przestrzeni dyskowej Twojego hostingu](/guides/web-cloud/web-hosting/ftp-connection)".
+Aby uzyskać dostęp do przestrzeni FTP, zapoznaj się z naszym przewodnikiem "[Logowanie do przestrzeni dyskowej FTP Twojego hostingu](/guides/web-cloud/web-hosting/ftp-connection)".
 
 ## Sprawdź również <a name="go-further"></a>
 
 [Tworzenie i zarządzanie hasłem do konta](/guides/account-and-service-management/account-information/manage-ovh-password)
 
-[Logowanie do przestrzeni dyskowej hostingu](/guides/web-cloud/web-hosting/ftp-connection)
+[Logowanie do przestrzeni dyskowej FTP hostingu](/guides/web-cloud/web-hosting/ftp-connection)
 
 [Umieszczenie strony WWW w Internecie](/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online)
 

--- a/docs/pl/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -111,4 +111,4 @@ W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj
 
 Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](https://www.ovhcloud.com/pl/support-levels/).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/).

--- a/docs/pt/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -110,4 +110,4 @@ Para serviços especializados (referenciamento, desenvolvimento, etc), contacte 
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en). 
+Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/). 

--- a/docs/pt/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alterar a palavra-passe de um utilizador FTP
 description: Descubra como alterar a palavra-passe de um utilizador FTP criado num alojamento web da OVHcloud
-lastUpdated: 2025-10-14
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -72,13 +72,11 @@ Para mais informações sobre as boas práticas de gestão de palavras-passe, si
 
 Dependendo do seu plano de [alojamento web da OVHcloud](https://www.ovhcloud.com/pt/web-hosting/), a alteração da palavra-passe do utilizador FTP através do separador <code className="action">FTP - SSH</code> poderá ser efetuada de duas formas:
 
-- **para as ofertas que não permitem criar um segundo utilizador FTP** (ofertas *Alojamento gratuito 100M* e *Perso*): clique no *pictograma em forma de lápis* na coluna <code className="action">Palavra-passe</code> do quadro que aparece, introduza a nova palavra-passe **seguindo a política das palavras-passe** e confirme a alteração clicando no *botão verde* de validação.
+- **para as ofertas que não permitem criar um segundo utilizador FTP** (ofertas *Alojamento gratuito*, *Starter*, *Perso* e *Startup*): clique no *pictograma em forma de lápis* na coluna <code className="action">Palavra-passe</code> do quadro que aparece, introduza a nova palavra-passe **seguindo a política das palavras-passe** e confirme a alteração clicando no *botão verde* de validação.
 
 <img className="thumbnail" alt="change-ftp-password-step1-perso" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png" loading="lazy" />
 
-- **para as ofertas que permitem criar vários utilizadores FTP** (ofertas *Pro* e *Performance*): clique nos três pontos à direita do utilizador FTP em causa e, a seguir, em <code className="action">Alterar palavra-passe</code>. Na nova janela, introduza a nova palavra-passe pretendida, confirme introduzindo-a uma segunda vez e clique no botão <code className="action">Validar</code>.
-
-clique no botão <code className="action">...</code> à direita do utilizador FTP em questão, depois por <code className="action">Alterar a palavra-passe</code>. Na nova janela, introduza a nova palavra-passe desejada *** seguindo a política de palavras-passe**, confirme introduzindo-a novamente e clique no botão <code className="action">Validar</code>.
+- **para as ofertas que permitem criar vários utilizadores FTP** (ofertas *Pro*, *Performance*, *Agency*, *Agency Plus* e *Agency Max*): clique no botão <code className="action">...</code> à direita do utilizador FTP em causa e, a seguir, em <code className="action">Alterar palavra-passe</code>. Na nova janela, introduza a nova palavra-passe pretendida **seguindo a política das palavras-passe**, confirme introduzindo-a uma segunda vez e clique no botão <code className="action">Validar</code>.
 
 <img className="thumbnail" alt="change-ftp-password-pro" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png" loading="lazy" />
 
@@ -98,13 +96,13 @@ Por fim, consulte o separador <code className="action">Operações em curso</cod
 
 ### 3 - Aceder ao espaço de armazenamento
 
-Para aceder ao seu espaço de armazenamento FTP, consulte o nosso guia "[Aceder ao espaço de armazenamento do alojamento web](/guides/web-cloud/web-hosting/ftp-connection)".
+Para aceder ao seu espaço de armazenamento FTP, consulte o nosso guia "[Aceder ao espaço de armazenamento FTP do alojamento web](/guides/web-cloud/web-hosting/ftp-connection)".
 
 ## Quer saber mais? <a name="go-further"></a>
 
 [Definir e gerir a palavra-passe da sua conta](/guides/account-and-service-management/account-information/manage-ovh-password)
 
-[Aceder ao espaço de armazenamento do alojamento web](/guides/web-cloud/web-hosting/ftp-connection)
+[Aceder ao espaço de armazenamento FTP do alojamento web](/guides/web-cloud/web-hosting/ftp-connection)
 
 [Publicar o seu site](/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online)
 


### PR DESCRIPTION
- Refresh the single-/multi-FTP-user plan lists with current commercial names: drop the "100M" suffix, add Starter and Startup (single), and the Agency / Agency Plus / Agency Max range (multi)
- Use the names shown on each localized ovhcloud.com page (EN: "Professional" and "Free hosting"; localized free-plan and "Perso"-tier names per locale)
- Align "Go further" / step-3 link text with the ftp-connection guide titles (add "FTP")
- Fix broken image alt text (DE "FTP 6 SSH", IT "FTP -SSH") and FR typo "boutton" -> "bouton"
- PT: remove a duplicated/broken paragraph in the multi-user bullet; IT: fix bold markup spacing
- Bump lastUpdated to 2026-06-02

Applied across 7 locales: fr, en, de, es, it, pl, pt.