### PR TITLE
docs(port): restore missing OVHcloud CLI tabs on additional-disk guide

### DIFF
--- a/docs/de/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zusätzliches Volume auf einer Instanz erstellen und konfigurieren
 description: Erfahren Sie hier, wie Sie eine neue Disk erstellen und zu Ihrer Public Cloud Instanz hinzufügen
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -328,6 +328,38 @@ Wählen Sie die Instanz aus, an die Sie Ihr Volume anhängen möchten, und klick
     | Device | /dev/sdb |
     | Tag | None |
     +-----------+-------------------------------------+
+    ```
+  </Tab>
+  <Tab label="Über die OVHcloud CLI">
+    :::warning
+    Wenn der Volume-Typ `high-speed-gen2` oder `luks` nicht in der Liste erscheint, ist er in dieser Region nicht verfügbar.
+
+    :::
+
+    
+    | Option | Beschreibung |
+    |--------|--------------|
+    | `<region>` | Region, in der das Volume erstellt wird (z. B. `GRA11`) |
+    | `--name` | Name des Volumes |
+    | `--size` | Größe des Volumes in GB |
+    | `--type` | Volume-Typ: `classic`, `high-speed`, `high-speed-gen2` oder entsprechende `-luks`-Variante |
+    | `--wait` | Warten, bis die Erstellung abgeschlossen ist, bevor das Programm beendet wird |
+    
+    Erstellen Sie ein Volume, indem Sie die Region, einen Namen, die Größe in GB und einen Typ angeben:
+    
+    ```bash
+    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ```
+    
+    Sobald das Volume erstellt ist, hängen Sie es an eine Instanz an:
+    
+    | Parameter | Beschreibung |
+    |-----------|--------------|
+    | `<volume_id>` | ID des anzuhängenden Volumes |
+    | `<instance_id>` | ID der Instanz, an die das Volume angehängt werden soll |
+    
+    ```bash
+    ovhcloud cloud storage-block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -775,6 +807,16 @@ Klicken Sie im neuen Fenster auf <code className="action">Bestätigen</code>, um
     openstack_compute_volume_attach_v2.va_1: Destruction complete after 17s
     
     Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
+    ```
+  </Tab>
+  <Tab label="Über die OVHcloud CLI">
+    | Parameter | Beschreibung |
+    |-----------|--------------|
+    | `<volume_id>` | ID des abzutrennenden Volumes |
+    | `<instance_id>` | ID der Instanz, von der das Volume abgetrennt werden soll |
+    
+    ```bash
+    ovhcloud cloud storage-block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>

--- a/docs/de/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -348,7 +348,7 @@ Wählen Sie die Instanz aus, an die Sie Ihr Volume anhängen möchten, und klick
     Erstellen Sie ein Volume, indem Sie die Region, einen Namen, die Größe in GB und einen Typ angeben:
     
     ```bash
-    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ovhcloud cloud storage block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
     ```
     
     Sobald das Volume erstellt ist, hängen Sie es an eine Instanz an:
@@ -359,7 +359,7 @@ Wählen Sie die Instanz aus, an die Sie Ihr Volume anhängen möchten, und klick
     | `<instance_id>` | ID der Instanz, an die das Volume angehängt werden soll |
     
     ```bash
-    ovhcloud cloud storage-block attach <volume_id> <instance_id>
+    ovhcloud cloud storage block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -816,7 +816,7 @@ Klicken Sie im neuen Fenster auf <code className="action">Bestätigen</code>, um
     | `<instance_id>` | ID der Instanz, von der das Volume abgetrennt werden soll |
     
     ```bash
-    ovhcloud cloud storage-block detach <volume_id> <instance_id>
+    ovhcloud cloud storage block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>

--- a/docs/en/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -350,7 +350,7 @@ Select the instance to which you wish to attach your volume, then click on <code
     Create a volume by specifying the region, a name, the size in GB, and a type:
     
     ```bash
-    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ovhcloud cloud storage block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
     ```
     
     Once the volume is created, attach it to an instance:
@@ -361,7 +361,7 @@ Select the instance to which you wish to attach your volume, then click on <code
     | `<instance_id>` | ID of the instance to attach the volume to |
     
     ```bash
-    ovhcloud cloud storage-block attach <volume_id> <instance_id>
+    ovhcloud cloud storage block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -822,7 +822,7 @@ Click on <code className="action">Confirm</code> in the pop up window to start t
     | `<instance_id>` | ID of the instance to detach the volume from |
     
     ```bash
-    ovhcloud cloud storage-block detach <volume_id> <instance_id>
+    ovhcloud cloud storage block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>

--- a/docs/en/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to create and configure an additional disk on an instance
 description: Find out how to attach a new volume to your Public Cloud instance
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -330,6 +330,38 @@ Select the instance to which you wish to attach your volume, then click on <code
     | Device | /dev/sdb |
     | Tag | None |
     +-----------+-------------------------------------+
+    ```
+  </Tab>
+  <Tab label="Via the OVHcloud CLI">
+    :::warning
+    If the volume type "high-speed-gen2" or "luks" does not appear in the list, it is not available in this region.
+
+    :::
+
+    
+    | Option | Description |
+    |--------|-------------|
+    | `<region>` | Region where the volume will be created (e.g. `GRA11`) |
+    | `--name` | Volume name |
+    | `--size` | Volume size in GB |
+    | `--type` | Volume type: `classic`, `high-speed`, `high-speed-gen2`, or equivalent `-luks` variant |
+    | `--wait` | Wait for creation to complete before exiting |
+    
+    Create a volume by specifying the region, a name, the size in GB, and a type:
+    
+    ```bash
+    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ```
+    
+    Once the volume is created, attach it to an instance:
+    
+    | Parameter | Description |
+    |-----------|-------------|
+    | `<volume_id>` | ID of the volume to attach |
+    | `<instance_id>` | ID of the instance to attach the volume to |
+    
+    ```bash
+    ovhcloud cloud storage-block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -781,6 +813,16 @@ Click on <code className="action">Confirm</code> in the pop up window to start t
     openstack_compute_volume_attach_v2.va_1: Destruction complete after 17s
     
     Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
+    ```
+  </Tab>
+  <Tab label="Via the OVHcloud CLI">
+    | Parameter | Description |
+    |-----------|-------------|
+    | `<volume_id>` | ID of the volume to detach |
+    | `<instance_id>` | ID of the instance to detach the volume from |
+    
+    ```bash
+    ovhcloud cloud storage-block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>

--- a/docs/es/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -357,7 +357,7 @@ Seleccione la instancia a la que quiere asociar el volumen y haga clic en <code 
     Cree un volumen especificando la región, un nombre, el tamaño en GB y un tipo:
     
     ```bash
-    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ovhcloud cloud storage block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
     ```
     
     Una vez creado el volumen, asócielo a una instancia:
@@ -368,7 +368,7 @@ Seleccione la instancia a la que quiere asociar el volumen y haga clic en <code 
     | `<instance_id>` | ID de la instancia a la que se asociará el volumen |
     
     ```bash
-    ovhcloud cloud storage-block attach <volume_id> <instance_id>
+    ovhcloud cloud storage block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -831,7 +831,7 @@ Haga clic en <code className="action">Confirmar</code> en la nueva ventana para 
     | `<instance_id>` | ID de la instancia de la que desvincular el volumen |
     
     ```bash
-    ovhcloud cloud storage-block detach <volume_id> <instance_id>
+    ovhcloud cloud storage block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>

--- a/docs/es/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Crear y configurar un disco adicional en una instancia
 description: Cómo asociar un nuevo volumen a una instancia de Public Cloud
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -337,6 +337,38 @@ Seleccione la instancia a la que quiere asociar el volumen y haga clic en <code 
     | Device | /dev/sdb |
     | Tag | None |
     +-----------+-------------------------------------+
+    ```
+  </Tab>
+  <Tab label="A través de la CLI OVHcloud">
+    :::warning
+    Si el tipo de volumen `high-speed-gen2` o `luks` no aparece en la lista, no está disponible en esta región.
+
+    :::
+
+    
+    | Opción | Descripción |
+    |--------|-------------|
+    | `<region>` | Región en la que se creará el volumen (ej.: `GRA11`) |
+    | `--name` | Nombre del volumen |
+    | `--size` | Tamaño del volumen en GB |
+    | `--type` | Tipo de volumen: `classic`, `high-speed`, `high-speed-gen2`, o la variante `-luks` correspondiente |
+    | `--wait` | Espera a que termine la creación antes de salir |
+    
+    Cree un volumen especificando la región, un nombre, el tamaño en GB y un tipo:
+    
+    ```bash
+    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ```
+    
+    Una vez creado el volumen, asócielo a una instancia:
+    
+    | Parámetro | Descripción |
+    |-----------|-------------|
+    | `<volume_id>` | ID del volumen que se va a asociar |
+    | `<instance_id>` | ID de la instancia a la que se asociará el volumen |
+    
+    ```bash
+    ovhcloud cloud storage-block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -790,6 +822,16 @@ Haga clic en <code className="action">Confirmar</code> en la nueva ventana para 
     openstack_compute_volume_attach_v2.va_1: Destruction complete after 17s
     
     Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
+    ```
+  </Tab>
+  <Tab label="A través de la CLI OVHcloud">
+    | Parámetro | Descripción |
+    |-----------|-------------|
+    | `<volume_id>` | ID del volumen que se va a desvincular |
+    | `<instance_id>` | ID de la instancia de la que desvincular el volumen |
+    
+    ```bash
+    ovhcloud cloud storage-block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>

--- a/docs/fr/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Créer et configurer un disque supplementaire sur une instance
 description: Découvrez comment attacher un nouveau volume à votre instance Public Cloud
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -331,6 +331,38 @@ Selectionnez l'instance à laquelle vous souhaitez attacher votre volume, puis c
     | Device    | /dev/sdb                            |
     | Tag       | None                                |
     +-----------+-------------------------------------+
+    ```
+  </Tab>
+  <Tab label="Via la CLI OVHcloud">
+    :::warning
+    Si le type de volume `high-speed-gen2` ou `luks` n'apparaît pas dans la liste, il n'est pas disponible dans cette région.
+
+    :::
+
+    
+    | Option | Description |
+    |--------|-------------|
+    | `<region>` | Région dans laquelle le volume sera créé (ex. : `GRA11`) |
+    | `--name` | Nom du volume |
+    | `--size` | Taille du volume en GB |
+    | `--type` | Type de volume : `classic`, `high-speed`, `high-speed-gen2`, ou la variante `-luks` correspondante |
+    | `--wait` | Attend la fin de la création avant de quitter |
+    
+    Créez un volume en spécifiant la région, un nom, la taille en GB et un type :
+    
+    ```bash
+    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ```
+    
+    Une fois le volume créé, attachez-le à une instance :
+    
+    | Paramètre | Description |
+    |-----------|-------------|
+    | `<volume_id>` | ID du volume à attacher |
+    | `<instance_id>` | ID de l'instance à laquelle attacher le volume |
+    
+    ```bash
+    ovhcloud cloud storage-block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -780,6 +812,16 @@ Cliquez sur <code className="action">Confirmer</code> dans la fenêtre qui s'aff
     openstack_compute_volume_attach_v2.va_1: Destruction complete after 17s
     
     Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
+    ```
+  </Tab>
+  <Tab label="Via la CLI OVHcloud">
+    | Paramètre | Description |
+    |-----------|-------------|
+    | `<volume_id>` | ID du volume à détacher |
+    | `<instance_id>` | ID de l'instance de laquelle détacher le volume |
+    
+    ```bash
+    ovhcloud cloud storage-block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>

--- a/docs/fr/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -351,7 +351,7 @@ Selectionnez l'instance à laquelle vous souhaitez attacher votre volume, puis c
     Créez un volume en spécifiant la région, un nom, la taille en GB et un type :
     
     ```bash
-    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ovhcloud cloud storage block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
     ```
     
     Une fois le volume créé, attachez-le à une instance :
@@ -362,7 +362,7 @@ Selectionnez l'instance à laquelle vous souhaitez attacher votre volume, puis c
     | `<instance_id>` | ID de l'instance à laquelle attacher le volume |
     
     ```bash
-    ovhcloud cloud storage-block attach <volume_id> <instance_id>
+    ovhcloud cloud storage block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -821,7 +821,7 @@ Cliquez sur <code className="action">Confirmer</code> dans la fenêtre qui s'aff
     | `<instance_id>` | ID de l'instance de laquelle détacher le volume |
     
     ```bash
-    ovhcloud cloud storage-block detach <volume_id> <instance_id>
+    ovhcloud cloud storage block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>

--- a/docs/it/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Crea e configura un disco aggiuntivo sulla tua istanza
 description: Come associare un nuovo volume alla tua istanza Public Cloud
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -328,6 +328,38 @@ Seleziona l’istanza a cui vuoi associare il tuo volume e clicca su <code class
     | Device | /dev/sdb |
     | Tag | None |
     +-----------+-------------------------------------+
+    ```
+  </Tab>
+  <Tab label="Tramite la CLI OVHcloud">
+    :::warning
+    Se il tipo di volume `high-speed-gen2` o `luks` non è presente nell'elenco, significa che non è disponibile in questa area.
+
+    :::
+
+    
+    | Opzione | Descrizione |
+    |---------|-------------|
+    | `<region>` | Region in cui sarà creato il volume (es.: `GRA11`) |
+    | `--name` | Nome del volume |
+    | `--size` | Dimensione del volume in GB |
+    | `--type` | Tipo di volume: `classic`, `high-speed`, `high-speed-gen2`, o la variante `-luks` corrispondente |
+    | `--wait` | Attende il termine della creazione prima di uscire |
+    
+    Crea un volume specificando la Region, un nome, la dimensione in GB e un tipo:
+    
+    ```bash
+    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ```
+    
+    Una volta creato il volume, associalo a un'istanza:
+    
+    | Parametro | Descrizione |
+    |-----------|-------------|
+    | `<volume_id>` | ID del volume da associare |
+    | `<instance_id>` | ID dell'istanza a cui associare il volume |
+    
+    ```bash
+    ovhcloud cloud storage-block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -781,6 +813,16 @@ Clicca su <code className="action">Conferma</code> nella finestra che appare per
     openstack_compute_volume_attach_v2.va_1: Destruction complete after 17s
     
     Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
+    ```
+  </Tab>
+  <Tab label="Tramite la CLI OVHcloud">
+    | Parametro | Descrizione |
+    |-----------|-------------|
+    | `<volume_id>` | ID del volume da scollegare |
+    | `<instance_id>` | ID dell'istanza da cui scollegare il volume |
+    
+    ```bash
+    ovhcloud cloud storage-block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>

--- a/docs/it/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -348,7 +348,7 @@ Seleziona l’istanza a cui vuoi associare il tuo volume e clicca su <code class
     Crea un volume specificando la Region, un nome, la dimensione in GB e un tipo:
     
     ```bash
-    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ovhcloud cloud storage block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
     ```
     
     Una volta creato il volume, associalo a un'istanza:
@@ -359,7 +359,7 @@ Seleziona l’istanza a cui vuoi associare il tuo volume e clicca su <code class
     | `<instance_id>` | ID dell'istanza a cui associare il volume |
     
     ```bash
-    ovhcloud cloud storage-block attach <volume_id> <instance_id>
+    ovhcloud cloud storage block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -822,7 +822,7 @@ Clicca su <code className="action">Conferma</code> nella finestra che appare per
     | `<instance_id>` | ID dell'istanza da cui scollegare il volume |
     
     ```bash
-    ovhcloud cloud storage-block detach <volume_id> <instance_id>
+    ovhcloud cloud storage block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>

--- a/docs/pl/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zarządzanie wolumenem instancji Public Cloud
 description: Dowiedz się, jak przypisać nowy wolumen do instancji Public Cloud
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -328,6 +328,38 @@ Wybierz instancję, do której chcesz przypisać wolumen, następnie kliknij <co
     | Device | /dev/sdb |
     | Tag | None |
     +-----------+-------------------------------------+
+    ```
+  </Tab>
+  <Tab label="Przez OVHcloud CLI">
+    :::warning
+    Jeśli typ woluminu `high-speed-gen2` lub `luks` nie pojawia się na liście, oznacza to, że nie jest dostępny w tym regionie.
+
+    :::
+
+    
+    | Opcja | Opis |
+    |--------|-------------|
+    | `<region>` | Region, w którym wolumen zostanie utworzony (np. `GRA11`) |
+    | `--name` | Nazwa wolumenu |
+    | `--size` | Rozmiar wolumenu w GB |
+    | `--type` | Typ wolumenu: `classic`, `high-speed`, `high-speed-gen2` lub równoważny wariant `-luks` |
+    | `--wait` | Poczekaj na zakończenie tworzenia przed wyjściem |
+    
+    Utwórz wolumen, podając region, nazwę, rozmiar w GB oraz typ:
+    
+    ```bash
+    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ```
+    
+    Po utworzeniu wolumenu przypisz go do instancji:
+    
+    | Parametr | Opis |
+    |-----------|-------------|
+    | `<volume_id>` | ID wolumenu, który ma zostać przypisany |
+    | `<instance_id>` | ID instancji, do której wolumen ma zostać przypisany |
+    
+    ```bash
+    ovhcloud cloud storage-block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -784,6 +816,16 @@ Kliknij <code className="action">Potwierdź</code> w oknie, które się wyświet
     openstack_compute_volume_attach_v2.va_1: Destruction complete after 17s
     
     Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
+    ```
+  </Tab>
+  <Tab label="Przez OVHcloud CLI">
+    | Parametr | Opis |
+    |-----------|-------------|
+    | `<volume_id>` | ID wolumenu, który ma zostać odłączony |
+    | `<instance_id>` | ID instancji, od której wolumen ma zostać odłączony |
+    
+    ```bash
+    ovhcloud cloud storage-block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>

--- a/docs/pl/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -348,7 +348,7 @@ Wybierz instancję, do której chcesz przypisać wolumen, następnie kliknij <co
     Utwórz wolumen, podając region, nazwę, rozmiar w GB oraz typ:
     
     ```bash
-    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ovhcloud cloud storage block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
     ```
     
     Po utworzeniu wolumenu przypisz go do instancji:
@@ -359,7 +359,7 @@ Wybierz instancję, do której chcesz przypisać wolumen, następnie kliknij <co
     | `<instance_id>` | ID instancji, do której wolumen ma zostać przypisany |
     
     ```bash
-    ovhcloud cloud storage-block attach <volume_id> <instance_id>
+    ovhcloud cloud storage block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -825,7 +825,7 @@ Kliknij <code className="action">Potwierdź</code> w oknie, które się wyświet
     | `<instance_id>` | ID instancji, od której wolumen ma zostać odłączony |
     
     ```bash
-    ovhcloud cloud storage-block detach <volume_id> <instance_id>
+    ovhcloud cloud storage block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>

--- a/docs/pt/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Criar e configurar um disco suplementar numa instância
 description: Saiba como associar um novo volume à sua instância Public Cloud
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-02
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -328,6 +328,38 @@ Selecione a instância à qual deseja associar o seu volume e, a seguir, clique 
     | Device | /dev/sdb |
     | Tag | None |
     +-----------+-------------------------------------+
+    ```
+  </Tab>
+  <Tab label="Através da CLI OVHcloud">
+    :::warning
+    Se o tipo de volume `high-speed-gen2` ou `luks` não aparecer na lista, não está disponível nesta região.
+
+    :::
+
+    
+    | Opção | Descrição |
+    |-------|-----------|
+    | `<region>` | Região na qual o volume será criado (ex.: `GRA11`) |
+    | `--name` | Nome do volume |
+    | `--size` | Tamanho do volume em GB |
+    | `--type` | Tipo de volume: `classic`, `high-speed`, `high-speed-gen2`, ou a variante `-luks` correspondente |
+    | `--wait` | Aguarda o fim da criação antes de sair |
+    
+    Crie um volume especificando a região, um nome, o tamanho em GB e um tipo:
+    
+    ```bash
+    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ```
+    
+    Após a criação do volume, associe-o a uma instância:
+    
+    | Parâmetro | Descrição |
+    |-----------|-----------|
+    | `<volume_id>` | ID do volume a associar |
+    | `<instance_id>` | ID da instância à qual associar o volume |
+    
+    ```bash
+    ovhcloud cloud storage-block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -778,6 +810,16 @@ Clique em <code className="action">Confirmar</code> na nova janela para lançar 
     openstack_compute_volume_attach_v2.va_1: Destruction complete after 17s
     
     Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
+    ```
+  </Tab>
+  <Tab label="Através da CLI OVHcloud">
+    | Parâmetro | Descrição |
+    |-----------|-----------|
+    | `<volume_id>` | ID do volume a desassociar |
+    | `<instance_id>` | ID da instância da qual desassociar o volume |
+    
+    ```bash
+    ovhcloud cloud storage-block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>

--- a/docs/pt/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance.mdx
@@ -348,7 +348,7 @@ Selecione a instância à qual deseja associar o seu volume e, a seguir, clique 
     Crie um volume especificando a região, um nome, o tamanho em GB e um tipo:
     
     ```bash
-    ovhcloud cloud storage-block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
+    ovhcloud cloud storage block create <region> --name <volume-name> --size <size-in-GB> --type <volume-type> --wait
     ```
     
     Após a criação do volume, associe-o a uma instância:
@@ -359,7 +359,7 @@ Selecione a instância à qual deseja associar o seu volume e, a seguir, clique 
     | `<instance_id>` | ID da instância à qual associar o volume |
     
     ```bash
-    ovhcloud cloud storage-block attach <volume_id> <instance_id>
+    ovhcloud cloud storage block attach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>
@@ -819,7 +819,7 @@ Clique em <code className="action">Confirmar</code> na nova janela para lançar 
     | `<instance_id>` | ID da instância da qual desassociar o volume |
     
     ```bash
-    ovhcloud cloud storage-block detach <volume_id> <instance_id>
+    ovhcloud cloud storage block detach <volume_id> <instance_id>
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
The "Via the OVHcloud CLI" tab was missing from both the attach and detach tab groups across all 7 locales. Legacy PR #9333 (2026-05-04) added it, but the 2026-05-28 port only reconciled PR #9356, so the CLI tabs were never carried over.

Restores the storage-block create/attach/detach commands and their option/parameter tables, using the existing legacy translations per locale. lastUpdated bumped to 2026-06-02.

Original-URL: https://github.com/ovh/docs/pull/9333