### PR TITLE
fix(i18n): add missing OPCP Landing Zone Manager sidebar label

### DIFF
--- a/i18n.json
+++ b/i18n.json
@@ -7091,6 +7091,15 @@
     "pl": "Pierwsze kroki",
     "pt": "Primeiros passos"
   },
+  "sidebar.gen.hostedPrivateCloudHostedPrivateCloudOpcpLandingZoneManager": {
+    "fr": "Landing Zone Manager",
+    "en": "Landing Zone Manager",
+    "de": "Landing Zone Manager",
+    "es": "Landing Zone Manager",
+    "it": "Landing Zone Manager",
+    "pl": "Landing Zone Manager",
+    "pt": "Landing Zone Manager"
+  },
   "sidebar.gen.hostedPrivateCloudHostedPrivateCloudOpcpSecurity": {
     "fr": "Sécurité",
     "en": "Security",


### PR DESCRIPTION
The "Landing Zone Manager" section node added to config/sidebar/index.md in PR #99 had no sidebar.gen.* entry in i18n.json, so non-EN sidebars fell back to the raw key. Seeded via `pnpm sidebar:sync-i18n` — kept as the untranslated product name across all 7 locales, like CloudStore.