### PR TITLE
Fix: Restore images, API links, cp-nav in PCI getting-started

### DIFF
--- a/docs/de/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/de/guides/public-cloud/compute/getting-started.mdx
@@ -108,11 +108,7 @@ Die in Ihrem OVHcloud Kundencenter hinzugefügten öffentlichen SSH-Schlüssel s
   <Tab label="Über das Kundencenter">
     Öffnen Sie <code className="action">SSH-Schlüssel</code> im linken Menü unter **Einstellungen**. Klicken Sie auf den Button <code className="action">SSH-Schlüssel hinzufügen</code>.
 
-    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
-
     Geben Sie im neuen Fenster einen Namen für den Schlüssel ein. Füllen Sie das Feld `Schlüssel` mit der Zeichenfolge Ihres öffentlichen Schlüssels aus, beispielsweise dem in [Schritt 1](#schritt-1-ssh-schlusselpaar-erstellen) erstellten. Bestätigen Sie, indem Sie auf <code className="action">Hinzufügen</code> klicken.
-
-    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     Sie können diesen Schlüssel nun in [Schritt 4](#schritt-4-instanz-erstellen) auswählen, um ihn einer neuen Instanz hinzuzufügen.
   </Tab>
@@ -421,13 +417,9 @@ Wenn Sie ein **Betriebssystem mit Anwendung** installiert haben, beachten Sie un
 
 Wählen Sie <code className="action">Instanzen</code> in der linken Navigationsleiste unter **Compute** aus. Ihre Instanz ist bereit, wenn der Status in der Tabelle `Aktiviert` anzeigt. Wenn die Instanz kürzlich erstellt wurde und einen anderen Status hat, klicken Sie auf den Button „Aktualisieren" neben dem Suchfilter.
 
-<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
-
 Klicken Sie auf den Instanznamen in dieser Tabelle, um das <code className="action">Dashboard</code> zu öffnen, auf dem Sie alle Informationen zur Instanz finden. Weitere Informationen zu den auf dieser Seite verfügbaren Funktionen finden Sie in unserer Anleitung zur [Verwaltung von Instanzen im Kundencenter](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Ein **Benutzer mit erhöhten Rechten (*sudo*) wird automatisch auf der Instanz erstellt**. Der Benutzername entspricht dem installierten Image, z.B. „ubuntu", „debian", „fedora", etc. Sie können dies auf der rechten Seite des <code className="action">Dashboard</code> im Abschnitt **Netzwerke** überprüfen.
-
-<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 
 :::info
 Über die OVHcloud CLI können Sie den Status der Instanz überprüfen und ihre IP-Adresse abrufen mit:
@@ -552,8 +544,6 @@ Die freie Open-Source-Software `Remmina Remote Desktop Client` ist für viele GN
 Mit der VNC-Konsole können Sie sich mit Ihren Instanzen verbinden, auch wenn keine anderen Zugriffsmöglichkeiten verfügbar sind.
 
 Wählen Sie <code className="action">Instanzen</code> in der linken Navigationsleiste unter **Compute** aus. Klicken Sie auf den Instanznamen und öffnen Sie den Tab <code className="action">VNC-Konsole</code>.
-
-<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instanz mit GNU/Linux Betriebssystem">

--- a/docs/de/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/de/guides/public-cloud/compute/getting-started.mdx
@@ -5,6 +5,7 @@ lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
+import Api from '@components/Api';
 
 ## Ziel
 
@@ -107,7 +108,11 @@ Die in Ihrem OVHcloud Kundencenter hinzugefügten öffentlichen SSH-Schlüssel s
   <Tab label="Über das Kundencenter">
     Loggen Sie sich in das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> ein, navigieren Sie zum Bereich <code className="action">Public Cloud</code> und wählen Sie Ihr Public Cloud Projekt aus.
 
+    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+
     Öffnen Sie <code className="action">SSH-Schlüssel</code> im linken Menü unter **Einstellungen**. Klicken Sie auf den Button <code className="action">SSH-Schlüssel hinzufügen</code>.
+
+    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     Geben Sie im neuen Fenster einen Namen für den Schlüssel ein. Füllen Sie das Feld `Schlüssel` mit der Zeichenfolge Ihres öffentlichen Schlüssels aus, beispielsweise dem in [Schritt 1](#schritt-1-ssh-schlusselpaar-erstellen) erstellten. Bestätigen Sie, indem Sie auf <code className="action">Hinzufügen</code> klicken.
 
@@ -116,7 +121,7 @@ Die in Ihrem OVHcloud Kundencenter hinzugefügten öffentlichen SSH-Schlüssel s
   <Tab label="Über die OVHcloud API">
     Verwenden Sie den folgenden Aufruf, um Ihren öffentlichen SSH-Schlüssel zu importieren:
 
-    > **POST** `/cloud/project/{serviceName}/sshkey`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/sshkey"} />
 
     Parameter:
 
@@ -287,7 +292,7 @@ Weitere Informationen finden Sie auf der [Webseite zu Local Zones](https://www.o
 
     Erstellen Sie die Instanz:
 
-    > **POST** `/cloud/project/{serviceName}/instance`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/instance"} />
 
     Hauptparameter:
 
@@ -418,9 +423,13 @@ Wenn Sie ein **Betriebssystem mit Anwendung** installiert haben, beachten Sie un
 
 Wählen Sie <code className="action">Instanzen</code> in der linken Navigationsleiste unter **Compute** aus. Ihre Instanz ist bereit, wenn der Status in der Tabelle `Aktiviert` anzeigt. Wenn die Instanz kürzlich erstellt wurde und einen anderen Status hat, klicken Sie auf den Button „Aktualisieren" neben dem Suchfilter.
 
+<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
+
 Klicken Sie auf den Instanznamen in dieser Tabelle, um das <code className="action">Dashboard</code> zu öffnen, auf dem Sie alle Informationen zur Instanz finden. Weitere Informationen zu den auf dieser Seite verfügbaren Funktionen finden Sie in unserer Anleitung zur [Verwaltung von Instanzen im Kundencenter](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Ein **Benutzer mit erhöhten Rechten (*sudo*) wird automatisch auf der Instanz erstellt**. Der Benutzername entspricht dem installierten Image, z.B. „ubuntu", „debian", „fedora", etc. Sie können dies auf der rechten Seite des <code className="action">Dashboard</code> im Abschnitt **Netzwerke** überprüfen.
+
+<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 
 :::info
 Über die OVHcloud CLI können Sie den Status der Instanz überprüfen und ihre IP-Adresse abrufen mit:
@@ -479,21 +488,31 @@ Anschließend müssen Sie die Erstkonfiguration Ihres Windows-Betriebssystems ab
 <Tabs>
   <Tab label="1. Lokale Einstellungen">
     Konfigurieren Sie **Land/Region**, die bevorzugte **Windows-Sprache** und Ihr **Tastaturlayout**. Klicken Sie dann unten rechts auf <code className="action">Next</code>.
+
+    <img className="thumbnail" alt="Windows locale settings" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" />
   </Tab>
   <Tab label="2. Administratorpasswort">
     Geben Sie ein Passwort für den Windows-Account `Administrator` ein und bestätigen Sie. Klicken Sie dann auf <code className="action">Finish</code>.
+
+    <img className="thumbnail" alt="Set the Windows Administrator password" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" />
   </Tab>
   <Tab label="3. Anmeldebildschirm">
     Windows wendet Ihre Einstellungen an und zeigt dann den Anmeldebildschirm an. Klicken Sie oben rechts auf <code className="action">Send CtrlAltDel</code>, um sich anzumelden.
+
+    <img className="thumbnail" alt="Windows login screen in the VNC console" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" />
   </Tab>
   <Tab label="4. Administrator-Login">
     Geben Sie das im vorherigen Schritt erstellte Passwort des Accounts `Administrator` ein und klicken Sie auf den `Pfeil`.
+
+    <img className="thumbnail" alt="Windows Administrator login" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
   </Tab>
 </Tabs>
 
 ##### 5.3.2: Remoteverbindung von Windows aus
 
 Auf Ihrem lokalen Windows-Gerät können Sie sich über die Client-Anwendung `Remote Desktop Connection` mit Ihrer Instanz verbinden.
+
+<img className="thumbnail" alt="Remote Desktop Connection to the instance" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Geben Sie die IPv4-Adresse Ihrer Instanz sowie Ihren Benutzernamen und Ihr Passwort ein. In der Regel wird eine Warnmeldung angezeigt, die Sie auffordert, die Verbindung aufgrund eines unbekannten Zertifikats zu bestätigen. Klicken Sie auf <code className="action">Ja</code>, um sich anzumelden.
 
@@ -515,12 +534,18 @@ Die freie Open-Source-Software `Remmina Remote Desktop Client` ist für viele GN
 <Tabs>
   <Tab label="1. Verbindung">
     Öffnen Sie Remmina und stellen Sie sicher, dass das Verbindungsprotokoll auf „RDP" eingestellt ist. Geben Sie die IPv4-Adresse Ihrer Public Cloud Instanz ein und drücken Sie `Enter`.
+
+    <img className="thumbnail" alt="Remmina connection to the instance" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" />
   </Tab>
   <Tab label="2. Authentifizierung">
     Wenn eine Zertifikatwarnung angezeigt wird, klicken Sie auf <code className="action">Yes</code>. Geben Sie den Benutzernamen und Ihr Passwort für Windows ein und klicken Sie auf <code className="action">OK</code>, um die Verbindung herzustellen.
+
+    <img className="thumbnail" alt="Remmina authentication" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" />
   </Tab>
   <Tab label="3. Einstellungen">
     Sie finden einige nützliche Einstellungsoptionen in der linken Symbolleiste. Klicken Sie beispielsweise auf das Symbol <code className="action">Toggle Dynamic Resolution Update</code>, um die Auflösung des Remote-Fensters zu verbessern.
+
+    <img className="thumbnail" alt="Remmina session settings" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -529,6 +554,8 @@ Die freie Open-Source-Software `Remmina Remote Desktop Client` ist für viele GN
 Mit der VNC-Konsole können Sie sich mit Ihren Instanzen verbinden, auch wenn keine anderen Zugriffsmöglichkeiten verfügbar sind.
 
 Wählen Sie <code className="action">Instanzen</code> in der linken Navigationsleiste unter **Compute** aus. Klicken Sie auf den Instanznamen und öffnen Sie den Tab <code className="action">VNC-Konsole</code>.
+
+<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instanz mit GNU/Linux Betriebssystem">

--- a/docs/de/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/de/guides/public-cloud/compute/getting-started.mdx
@@ -106,15 +106,13 @@ Die in Ihrem OVHcloud Kundencenter hinzugefügten öffentlichen SSH-Schlüssel s
 
 <Tabs>
   <Tab label="Über das Kundencenter">
-    Loggen Sie sich in das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> ein, navigieren Sie zum Bereich <code className="action">Public Cloud</code> und wählen Sie Ihr Public Cloud Projekt aus.
+    Öffnen Sie <code className="action">SSH-Schlüssel</code> im linken Menü unter **Einstellungen**. Klicken Sie auf den Button <code className="action">SSH-Schlüssel hinzufügen</code>.
 
     <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
 
-    Öffnen Sie <code className="action">SSH-Schlüssel</code> im linken Menü unter **Einstellungen**. Klicken Sie auf den Button <code className="action">SSH-Schlüssel hinzufügen</code>.
+    Geben Sie im neuen Fenster einen Namen für den Schlüssel ein. Füllen Sie das Feld `Schlüssel` mit der Zeichenfolge Ihres öffentlichen Schlüssels aus, beispielsweise dem in [Schritt 1](#schritt-1-ssh-schlusselpaar-erstellen) erstellten. Bestätigen Sie, indem Sie auf <code className="action">Hinzufügen</code> klicken.
 
     <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
-
-    Geben Sie im neuen Fenster einen Namen für den Schlüssel ein. Füllen Sie das Feld `Schlüssel` mit der Zeichenfolge Ihres öffentlichen Schlüssels aus, beispielsweise dem in [Schritt 1](#schritt-1-ssh-schlusselpaar-erstellen) erstellten. Bestätigen Sie, indem Sie auf <code className="action">Hinzufügen</code> klicken.
 
     Sie können diesen Schlüssel nun in [Schritt 4](#schritt-4-instanz-erstellen) auswählen, um ihn einer neuen Instanz hinzuzufügen.
   </Tab>
@@ -214,7 +212,7 @@ Weitere Informationen finden Sie auf der [Webseite zu Local Zones](https://www.o
 
     :::
 
-    Loggen Sie sich in das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> ein, navigieren Sie zum Bereich <code className="action">Public Cloud</code> und wählen Sie Ihr Public Cloud Projekt aus. Klicken Sie auf der **Startseite** auf <code className="action">Instanz erstellen</code>.
+    Klicken Sie auf der **Startseite** auf <code className="action">Instanz erstellen</code>.
 
     **4.1 Name**
 

--- a/docs/en/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/en/guides/public-cloud/compute/getting-started.mdx
@@ -5,6 +5,7 @@ lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
+import Api from '@components/Api';
 
 ## Objective
 
@@ -107,7 +108,11 @@ Public SSH keys added to your OVHcloud Control Panel will be available for Publi
   <Tab label="via the Control Panel">
     Log in to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, navigate to the <code className="action">Public Cloud</code> section and select your Public Cloud project.
 
+    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+
     Open <code className="action">SSH Keys</code> in the left-hand menu under **Settings**. Click on the button <code className="action">Add an SSH key</code>.
+
+    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     In the new window, enter a name for the key. Fill in the `Key` field with your public key string, for example the one created in [Step 1](#step-1-create-an-ssh-key-set). Confirm by clicking <code className="action">Add</code>.
 
@@ -116,7 +121,7 @@ Public SSH keys added to your OVHcloud Control Panel will be available for Publi
   <Tab label="via the OVHcloud API">
     Use the following call to import your public SSH key:
 
-    > **POST** `/cloud/project/{serviceName}/sshkey`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/sshkey"} />
 
     Parameters:
 
@@ -287,7 +292,7 @@ Find out more on the [Local Zones web page](https://www.ovhcloud.com/en-gb/publi
 
     Create the instance:
 
-    > **POST** `/cloud/project/{serviceName}/instance`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/instance"} />
 
     Main parameters:
 
@@ -418,9 +423,13 @@ If you have installed an **OS with application**, refer to our [guide on first s
 
 Select <code className="action">Instances</code> in the left-hand navigation bar under **Compute**. Your instance is ready when the status is set to `Enabled` in the table. If the instance was recently created and has a different status, click on the "Refresh" button located next to the search filter.
 
+<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
+
 Click on the instance's name in this table to open the <code className="action">Dashboard</code> on which you can find all information about the instance. To learn more about the functions available on this page, consult our guide on [managing instances in the Control Panel](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 A **user with elevated permissions (*sudo*) is automatically created** on the instance. The username reflects the image installed, e.g "ubuntu", "debian", "fedora", etc. You can verify this on the right-hand side of the <code className="action">Dashboard</code> in the section **Networks**.
+
+<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 
 :::info
 Via the OVHcloud CLI, check the instance status and retrieve its IP address with:
@@ -479,21 +488,31 @@ You will then need to complete the initial setup of your Windows OS. Follow the 
 <Tabs>
   <Tab label="1. Locale settings">
     Configure your **country/region**, the preferred **Windows language**, and your **keyboard layout**. Then click on the button <code className="action">Next</code> at the bottom right.
+
+    <img className="thumbnail" alt="Windows locale settings" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" />
   </Tab>
   <Tab label="2. Administrator password">
     Set a password for your Windows `Administrator` account and confirm it, then click on <code className="action">Finish</code>.
+
+    <img className="thumbnail" alt="Set the Windows Administrator password" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" />
   </Tab>
   <Tab label="3. Login screen">
     Windows will apply your settings and then display the login screen. Click on the <code className="action">Send CtrlAltDel</code> button in the top right corner to sign in.
+
+    <img className="thumbnail" alt="Windows login screen in the VNC console" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" />
   </Tab>
   <Tab label="4. Administrator login">
     Enter the `Administrator` password you have created in the previous step and click on the `Arrow` button.
+
+    <img className="thumbnail" alt="Windows Administrator login" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
   </Tab>
 </Tabs>
 
 ##### 5.3.2: Log in remotely from Windows
 
 On your local Windows device, you can use the `Remote Desktop Connection` client application to connect to your instance.
+
+<img className="thumbnail" alt="Remote Desktop Connection to the instance" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Enter the IPv4 address of your instance, then your username and passphrase. Usually a warning message will appear, asking to confirm the connection because of an unknown certificate. Click on <code className="action">Yes</code> to log in.
 
@@ -515,12 +534,18 @@ The free and open-source software `Remmina Remote Desktop Client` is available f
 <Tabs>
   <Tab label="1. Connection">
     Open Remmina and make sure the connection protocol is set to "RDP". Enter the IPv4 address of your Public Cloud instance and press `Enter`.
+
+    <img className="thumbnail" alt="Remmina connection to the instance" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" />
   </Tab>
   <Tab label="2. Authentication">
     If a certificate warning message appears, click on <code className="action">Yes</code>. Enter the username and your password for Windows and click on <code className="action">OK</code> to establish the connection.
+
+    <img className="thumbnail" alt="Remmina authentication" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" />
   </Tab>
   <Tab label="3. Settings">
     You can find some useful items in the left-hand toolbar. For example, click on the icon <code className="action">Toggle dynamic resolution update</code> to improve the window resolution.
+
+    <img className="thumbnail" alt="Remmina session settings" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -529,6 +554,8 @@ The free and open-source software `Remmina Remote Desktop Client` is available f
 The VNC console allows you to connect to your instances even when other means of access are not available.
 
 Select <code className="action">Instances</code> in the left-hand navigation bar under **Compute**. Click on the instance name and open the tab <code className="action">VNC console</code>.
+
+<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instance with a GNU/Linux OS installed">

--- a/docs/en/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/en/guides/public-cloud/compute/getting-started.mdx
@@ -106,15 +106,13 @@ Public SSH keys added to your OVHcloud Control Panel will be available for Publi
 
 <Tabs>
   <Tab label="via the Control Panel">
-    Log in to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, navigate to the <code className="action">Public Cloud</code> section and select your Public Cloud project.
+    Open <code className="action">SSH Keys</code> in the left-hand menu under **Settings**. Click on the button <code className="action">Add an SSH key</code>.
 
     <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
 
-    Open <code className="action">SSH Keys</code> in the left-hand menu under **Settings**. Click on the button <code className="action">Add an SSH key</code>.
+    In the new window, enter a name for the key. Fill in the `Key` field with your public key string, for example the one created in [Step 1](#step-1-create-an-ssh-key-set). Confirm by clicking <code className="action">Add</code>.
 
     <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
-
-    In the new window, enter a name for the key. Fill in the `Key` field with your public key string, for example the one created in [Step 1](#step-1-create-an-ssh-key-set). Confirm by clicking <code className="action">Add</code>.
 
     You can now select this key in [Step 4](#step-4-create-the-instance) to add it to a new instance.
   </Tab>
@@ -214,7 +212,7 @@ Find out more on the [Local Zones web page](https://www.ovhcloud.com/en-gb/publi
 
     :::
 
-    Log in to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, navigate to the <code className="action">Public Cloud</code> section and select your Public Cloud project. On the **Home** page, click <code className="action">Create an instance</code>.
+    On the **Home** page, click <code className="action">Create an instance</code>.
 
     **4.1 Name**
 

--- a/docs/en/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/en/guides/public-cloud/compute/getting-started.mdx
@@ -109,11 +109,7 @@ Public SSH keys added to your OVHcloud Control Panel will be available for Publi
   <Tab label="via the Control Panel">
     Open <code className="action">SSH Keys</code> in the left-hand menu under **Settings**. Click on the button <code className="action">Add an SSH key</code>.
 
-    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
-
     In the new window, enter a name for the key. Fill in the `Key` field with your public key string, for example the one created in [Step 1](#step-1-create-an-ssh-key-set). Confirm by clicking <code className="action">Add</code>.
-
-    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     You can now select this key in [Step 4](#step-4-create-the-instance) to add it to a new instance.
   </Tab>
@@ -426,13 +422,10 @@ If you have installed an **OS with application**, refer to our [guide on first s
 {/* CP-STEPS-START:verify-instance-status */}
 Select <code className="action">Instances</code> in the left-hand navigation bar under **Compute**. Your instance is ready when the status is set to `Enabled` in the table. If the instance was recently created and has a different status, click on the "Refresh" button located next to the search filter.
 
-<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
-
 Click on the instance's name in this table to open the <code className="action">Dashboard</code> on which you can find all information about the instance. To learn more about the functions available on this page, consult our guide on [managing instances in the Control Panel](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 A **user with elevated permissions (*sudo*) is automatically created** on the instance. The username reflects the image installed, e.g "ubuntu", "debian", "fedora", etc. You can verify this on the right-hand side of the <code className="action">Dashboard</code> in the section **Networks**.
 
-<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 {/* CP-STEPS-END:verify-instance-status */}
 
 :::info
@@ -560,7 +553,6 @@ The VNC console allows you to connect to your instances even when other means of
 {/* CP-STEPS-START:vnc-console-access */}
 Select <code className="action">Instances</code> in the left-hand navigation bar under **Compute**. Click on the instance name and open the tab <code className="action">VNC console</code>.
 
-<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 {/* CP-STEPS-END:vnc-console-access */}
 
 <Tabs>

--- a/docs/en/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/en/guides/public-cloud/compute/getting-started.mdx
@@ -104,6 +104,7 @@ Public SSH keys added to your OVHcloud Control Panel will be available for Publi
 
 :::
 
+{/* CP-STEPS-START:import-ssh-key */}
 <Tabs>
   <Tab label="via the Control Panel">
     Open <code className="action">SSH Keys</code> in the left-hand menu under **Settings**. Click on the button <code className="action">Add an SSH key</code>.
@@ -171,6 +172,7 @@ Public SSH keys added to your OVHcloud Control Panel will be available for Publi
     Refer to the [Terraform guide for OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform) for the initial provider setup.
   </Tab>
 </Tabs>
+{/* CP-STEPS-END:import-ssh-key */}
 
 ### Step 3: Prepare the network configuration
 
@@ -205,6 +207,7 @@ Find out more on the [Local Zones web page](https://www.ovhcloud.com/en-gb/publi
 
 ### Step 4: Create the instance
 
+{/* CP-STEPS-START:create-instance */}
 <Tabs>
   <Tab label="via the Control Panel">
     :::info
@@ -402,6 +405,7 @@ Find out more on the [Local Zones web page](https://www.ovhcloud.com/en-gb/publi
     Refer to the [Terraform guide for OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform) for the initial provider setup and authentication.
   </Tab>
 </Tabs>
+{/* CP-STEPS-END:create-instance */}
 
 ### Step 5: Connect to the instance
 
@@ -419,6 +423,7 @@ If you have installed an **OS with application**, refer to our [guide on first s
 
 #### 5.1: Verify the instance status in the OVHcloud Control Panel
 
+{/* CP-STEPS-START:verify-instance-status */}
 Select <code className="action">Instances</code> in the left-hand navigation bar under **Compute**. Your instance is ready when the status is set to `Enabled` in the table. If the instance was recently created and has a different status, click on the "Refresh" button located next to the search filter.
 
 <img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
@@ -428,6 +433,7 @@ Click on the instance's name in this table to open the <code className="action">
 A **user with elevated permissions (*sudo*) is automatically created** on the instance. The username reflects the image installed, e.g "ubuntu", "debian", "fedora", etc. You can verify this on the right-hand side of the <code className="action">Dashboard</code> in the section **Networks**.
 
 <img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
+{/* CP-STEPS-END:verify-instance-status */}
 
 :::info
 Via the OVHcloud CLI, check the instance status and retrieve its IP address with:
@@ -551,9 +557,11 @@ The free and open-source software `Remmina Remote Desktop Client` is available f
 
 The VNC console allows you to connect to your instances even when other means of access are not available.
 
+{/* CP-STEPS-START:vnc-console-access */}
 Select <code className="action">Instances</code> in the left-hand navigation bar under **Compute**. Click on the instance name and open the tab <code className="action">VNC console</code>.
 
 <img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
+{/* CP-STEPS-END:vnc-console-access */}
 
 <Tabs>
   <Tab label="Instance with a GNU/Linux OS installed">

--- a/docs/es/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/es/guides/public-cloud/compute/getting-started.mdx
@@ -5,6 +5,7 @@ lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
+import Api from '@components/Api';
 
 ## Objetivo
 
@@ -107,7 +108,11 @@ Las claves SSH públicas añadidas al área de cliente de OVHcloud estarán disp
   <Tab label="Desde el área de cliente">
     Conéctese al <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, acceda a la sección <code className="action">Public Cloud</code> y seleccione el proyecto Public Cloud correspondiente.
 
+    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+
     Abra <code className="action">Claves SSH</code> en el menú de la izquierda en **Parámetros**. Haga clic en el botón <code className="action">Añadir una clave SSH</code>.
+
+    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     En la nueva ventana, introduzca un nombre para la clave. Rellene el campo `Clave` con su cadena de clave pública, por ejemplo, la creada en el [paso 1](#paso-1-crear-un-juego-de-claves-ssh). Confirme haciendo clic en <code className="action">Añadir</code>.
 
@@ -116,7 +121,7 @@ Las claves SSH públicas añadidas al área de cliente de OVHcloud estarán disp
   <Tab label="Desde la API de OVHcloud">
     Utilice la siguiente llamada para importar su clave SSH pública:
 
-    > **POST** `/cloud/project/{serviceName}/sshkey`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/sshkey"} />
 
     Parámetros:
 
@@ -287,7 +292,7 @@ Para más información, consulte la [página web de Local Zones](https://www.ovh
 
     Cree la instancia:
 
-    > **POST** `/cloud/project/{serviceName}/instance`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/instance"} />
 
     Parámetros principales:
 
@@ -420,9 +425,13 @@ Conéctese al <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, ac
 
 Seleccione <code className="action">Instancias</code> en la barra de navegación de la izquierda en **Compute**. La instancia está lista cuando el estado se establece en `Activado` en la tabla. Si la instancia se ha creado recientemente y tiene un estado diferente, haga clic en el botón "Actualizar" situado junto al filtro de búsqueda.
 
+<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
+
 Haga clic en el nombre de la instancia en esta tabla para abrir el <code className="action">Panel de control</code>, donde puede encontrar toda la información relativa a la instancia. Para más información sobre las funciones disponibles en esta página, consulte nuestra guía sobre [la gestión de las instancias en el área de cliente](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Se creará automáticamente un **usuario con derechos elevados (*sudo*)** en la instancia. El nombre de usuario refleja la imagen instalada, por ejemplo "ubuntu", "debian", "fedora", etc. Puede comprobarlo en el <code className="action">Panel de control</code> en la sección **Redes**.
+
+<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 
 :::info
 A través de la CLI de OVHcloud, compruebe el estado y obtenga la dirección IP de su instancia con:
@@ -481,21 +490,31 @@ A continuación, complete la configuración inicial del sistema operativo Window
 <Tabs>
   <Tab label="1. Configuración regional">
     Configure su **país/región**, el **idioma preferido de Windows** y su **distribución de teclado**. Haga clic en el botón <code className="action">Siguiente</code> en la esquina inferior derecha.
+
+    <img className="thumbnail" alt="Windows locale settings" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" />
   </Tab>
   <Tab label="2. Contraseña de administrador">
     Establezca una contraseña para su cuenta Windows `Administrator` y confírmela, y haga clic en <code className="action">Finalizar</code>.
+
+    <img className="thumbnail" alt="Set the Windows Administrator password" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" />
   </Tab>
   <Tab label="3. Pantalla de conexión">
     Windows aplicará la configuración y mostrará la pantalla de inicio de sesión. Haga clic en el botón <code className="action">Send CtrlAltDel</code> en la esquina superior derecha para conectarse.
+
+    <img className="thumbnail" alt="Windows login screen in the VNC console" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" />
   </Tab>
   <Tab label="4. Inicio de sesión de administrador">
     Introduzca la contraseña `Administrator` que creó en el paso anterior y haga clic en el botón "Arrow".
+
+    <img className="thumbnail" alt="Windows Administrator login" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
   </Tab>
 </Tabs>
 
 ##### 5.3.2: Conéctese de forma remota desde Windows
 
 En su equipo Windows local, puede utilizar la aplicación cliente `Remote Desktop Connection` para conectarse a su instancia.
+
+<img className="thumbnail" alt="Remote Desktop Connection to the instance" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Introduzca la dirección IPv4 de su instancia, su identificador y su contraseña. Normalmente, aparece un mensaje de advertencia solicitándole que confirme la conexión debido a un certificado desconocido. Haga clic en <code className="action">Sí</code> para conectarse.
 
@@ -517,12 +536,18 @@ El software libre y open source `Remmina Remote Desktop Client` está disponible
 <Tabs>
   <Tab label="1. Conexión">
     Abra Remmina y asegúrese de que el protocolo de conexión está establecido en "RDP". Introduzca la dirección IPv4 de su instancia Public Cloud y pulse "Enter".
+
+    <img className="thumbnail" alt="Remmina connection to the instance" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" />
   </Tab>
   <Tab label="2. Autenticación">
     Si aparece un mensaje de advertencia de certificado, haga clic en <code className="action">Yes</code>. Introduzca el nombre de usuario y la contraseña de Windows y haga clic en <code className="action">OK</code> para establecer la conexión.
+
+    <img className="thumbnail" alt="Remmina authentication" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" />
   </Tab>
   <Tab label="3. Parámetros">
     Puede encontrar elementos útiles en la barra de herramientas de la izquierda. Por ejemplo, haga clic en el icono <code className="action">Toggle dynamic resolution update</code> para mejorar la resolución de la ventana.
+
+    <img className="thumbnail" alt="Remmina session settings" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -531,6 +556,8 @@ El software libre y open source `Remmina Remote Desktop Client` está disponible
 La consola VNC le permite conectarse a sus instancias incluso cuando otros medios de acceso no están disponibles.
 
 Seleccione <code className="action">Instancias</code> en la barra de navegación de la izquierda en **Compute**. Haga clic en el nombre de la instancia y abra la pestaña <code className="action">Consola VNC</code>.
+
+<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instancia con un SO GNU/Linux instalado">

--- a/docs/es/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/es/guides/public-cloud/compute/getting-started.mdx
@@ -108,11 +108,7 @@ Las claves SSH públicas añadidas al área de cliente de OVHcloud estarán disp
   <Tab label="Desde el área de cliente">
     Abra <code className="action">Claves SSH</code> en el menú de la izquierda en **Parámetros**. Haga clic en el botón <code className="action">Añadir una clave SSH</code>.
 
-    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
-
     En la nueva ventana, introduzca un nombre para la clave. Rellene el campo `Clave` con su cadena de clave pública, por ejemplo, la creada en el [paso 1](#paso-1-crear-un-juego-de-claves-ssh). Confirme haciendo clic en <code className="action">Añadir</code>.
-
-    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     Ahora puede seleccionar esta clave en el [Paso 4](#paso-4-crear-la-instancia) para añadirla a una nueva instancia.
   </Tab>
@@ -421,13 +417,9 @@ Si ha instalado un **SO con aplicación**, consulte nuestra [guía sobre los pri
 
 Seleccione <code className="action">Instancias</code> en la barra de navegación de la izquierda en **Compute**. La instancia está lista cuando el estado se establece en `Activado` en la tabla. Si la instancia se ha creado recientemente y tiene un estado diferente, haga clic en el botón "Actualizar" situado junto al filtro de búsqueda.
 
-<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
-
 Haga clic en el nombre de la instancia en esta tabla para abrir el <code className="action">Panel de control</code>, donde puede encontrar toda la información relativa a la instancia. Para más información sobre las funciones disponibles en esta página, consulte nuestra guía sobre [la gestión de las instancias en el área de cliente](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Se creará automáticamente un **usuario con derechos elevados (*sudo*)** en la instancia. El nombre de usuario refleja la imagen instalada, por ejemplo "ubuntu", "debian", "fedora", etc. Puede comprobarlo en el <code className="action">Panel de control</code> en la sección **Redes**.
-
-<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 
 :::info
 A través de la CLI de OVHcloud, compruebe el estado y obtenga la dirección IP de su instancia con:
@@ -552,8 +544,6 @@ El software libre y open source `Remmina Remote Desktop Client` está disponible
 La consola VNC le permite conectarse a sus instancias incluso cuando otros medios de acceso no están disponibles.
 
 Seleccione <code className="action">Instancias</code> en la barra de navegación de la izquierda en **Compute**. Haga clic en el nombre de la instancia y abra la pestaña <code className="action">Consola VNC</code>.
-
-<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instancia con un SO GNU/Linux instalado">

--- a/docs/es/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/es/guides/public-cloud/compute/getting-started.mdx
@@ -106,15 +106,13 @@ Las claves SSH públicas añadidas al área de cliente de OVHcloud estarán disp
 
 <Tabs>
   <Tab label="Desde el área de cliente">
-    Conéctese al <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, acceda a la sección <code className="action">Public Cloud</code> y seleccione el proyecto Public Cloud correspondiente.
+    Abra <code className="action">Claves SSH</code> en el menú de la izquierda en **Parámetros**. Haga clic en el botón <code className="action">Añadir una clave SSH</code>.
 
     <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
 
-    Abra <code className="action">Claves SSH</code> en el menú de la izquierda en **Parámetros**. Haga clic en el botón <code className="action">Añadir una clave SSH</code>.
+    En la nueva ventana, introduzca un nombre para la clave. Rellene el campo `Clave` con su cadena de clave pública, por ejemplo, la creada en el [paso 1](#paso-1-crear-un-juego-de-claves-ssh). Confirme haciendo clic en <code className="action">Añadir</code>.
 
     <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
-
-    En la nueva ventana, introduzca un nombre para la clave. Rellene el campo `Clave` con su cadena de clave pública, por ejemplo, la creada en el [paso 1](#paso-1-crear-un-juego-de-claves-ssh). Confirme haciendo clic en <code className="action">Añadir</code>.
 
     Ahora puede seleccionar esta clave en el [Paso 4](#paso-4-crear-la-instancia) para añadirla a una nueva instancia.
   </Tab>
@@ -214,7 +212,7 @@ Para más información, consulte la [página web de Local Zones](https://www.ovh
 
     :::
 
-    Conéctese al <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, acceda a la sección <code className="action">Public Cloud</code> y seleccione el proyecto Public Cloud correspondiente. En la página **Inicio**, haga clic en <code className="action">Crear una instancia</code>.
+    En la página **Inicio**, haga clic en <code className="action">Crear una instancia</code>.
 
     **4.1 Nombre**
 
@@ -420,8 +418,6 @@ Si ha instalado un **SO con aplicación**, consulte nuestra [guía sobre los pri
 :::
 
 #### 5.1: Verificar el estado de la instancia en el área de cliente
-
-Conéctese al <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, acceda a la sección <code className="action">Public Cloud</code> y seleccione el proyecto Public Cloud correspondiente.
 
 Seleccione <code className="action">Instancias</code> en la barra de navegación de la izquierda en **Compute**. La instancia está lista cuando el estado se establece en `Activado` en la tabla. Si la instancia se ha creado recientemente y tiene un estado diferente, haga clic en el botón "Actualizar" situado junto al filtro de búsqueda.
 

--- a/docs/fr/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/fr/guides/public-cloud/compute/getting-started.mdx
@@ -5,6 +5,7 @@ lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
+import Api from '@components/Api';
 
 ## Objectif
 
@@ -97,7 +98,11 @@ Les clés SSH publiques ajoutées à votre espace client OVHcloud seront disponi
   <Tab label="Via l’espace client">
     Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section <code className="action">Public Cloud</code> et sélectionnez le projet Public Cloud concerné.
 
+    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+
     Ouvrez <code className="action">Clés SSH</code> dans le menu de gauche sous **Paramètres**. Cliquez sur le bouton <code className="action">Ajouter une clé SSH</code>.
+
+    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     Dans la nouvelle fenêtre, entrez un nom pour la clé. Remplissez le champ `Clé` avec votre chaîne de clé publique, par exemple celle créée à l'[étape 1](#etape-1-creer-un-jeu-de-cles-ssh). Confirmez en cliquant sur <code className="action">Ajouter</code>.
 
@@ -106,7 +111,7 @@ Les clés SSH publiques ajoutées à votre espace client OVHcloud seront disponi
   <Tab label="Via l’API OVHcloud">
     Utilisez l'appel suivant pour importer votre clé SSH publique :
 
-    > **POST** `/cloud/project/{serviceName}/sshkey`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/sshkey"} />
 
     Paramètres :
 
@@ -277,7 +282,7 @@ Pour en savoir plus, consultez la [page web des Local Zones](https://www.ovhclou
 
     Créez l'instance :
 
-    > **POST** `/cloud/project/{serviceName}/instance`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/instance"} />
 
     Paramètres principaux :
 
@@ -410,9 +415,13 @@ Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, re
 
 Sélectionnez <code className="action">Instances</code> dans la barre de navigation de gauche sous **Compute**. Votre instance est prête lorsque l'état est défini sur `Activé` dans le tableau. Si l'instance a été créée récemment et a un statut différent, cliquez sur le bouton « Actualiser » situé à côté du filtre de recherche.
 
+<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
+
 Cliquez sur le nom de l'instance dans ce tableau pour ouvrir le <code className="action">Tableau de bord</code> sur lequel vous pouvez trouver toutes les informations concernant l'instance. Pour en savoir plus sur les fonctions disponibles sur cette page, consultez notre guide sur [la gestion des instances dans l'espace client](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Un **utilisateur avec des droits élevés (*sudo*) est automatiquement créé** sur l'instance. Le nom d'utilisateur reflète l'image installée, par exemple « ubuntu », « debian », « fedora », etc. Vous pouvez le vérifier dans le <code className="action">Tableau de bord</code> dans la section **Réseaux**.
+
+<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 
 :::info
 Via l'OVHcloud CLI, vérifiez l'état et récupérez l'adresse IP de votre instance avec :
@@ -471,21 +480,31 @@ Il vous faudra ensuite finaliser la configuration initiale de votre système d�
 <Tabs>
   <Tab label="1. Paramètres régionaux">
     Configurez votre **pays/région**, la **langue Windows** préférée et votre **disposition du clavier**. Cliquez ensuite sur le bouton <code className="action">Suivant</code> en bas à droite.
+
+    <img className="thumbnail" alt="Windows locale settings" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" />
   </Tab>
   <Tab label="2. Mot de passe administrateur">
     Définissez un mot de passe pour votre compte Windows `Administrator` et confirmez-le, puis cliquez sur <code className="action">Terminer</code>.
+
+    <img className="thumbnail" alt="Set the Windows Administrator password" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" />
   </Tab>
   <Tab label="3. Écran de connexion">
     Windows appliquera vos paramètres, puis affichera l'écran de connexion. Cliquez sur le bouton <code className="action">Send CtrlAltDel</code> en haut à droite pour vous connecter.
+
+    <img className="thumbnail" alt="Windows login screen in the VNC console" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" />
   </Tab>
   <Tab label="4. Login administrateur">
     Entrez le mot de passe `Administrator` que vous avez créé à l'étape précédente et cliquez sur le bouton « Arrow ».
+
+    <img className="thumbnail" alt="Windows Administrator login" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
   </Tab>
 </Tabs>
 
 ##### 5.3.2 : Connectez-vous à distance depuis Windows
 
 Sur votre poste Windows local, vous pouvez utiliser l'application cliente `Remote Desktop Connection` pour vous connecter à votre instance.
+
+<img className="thumbnail" alt="Remote Desktop Connection to the instance" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Renseignez l'adresse IPv4 de votre instance, puis votre identifiant et votre passphrase. Généralement, un message d'avertissement apparaît, vous demandant de confirmer la connexion en raison d'un certificat inconnu. Cliquez sur <code className="action">Oui</code> pour vous connecter.
 
@@ -507,12 +526,18 @@ Le logiciel libre et open source `Remmina Remote Desktop Client` est disponible 
 <Tabs>
   <Tab label="1. Connexion">
     Ouvrez Remmina et assurez-vous que le protocole de connexion est défini sur « RDP ». Entrez l'adresse IPv4 de votre instance Public Cloud et appuyez sur « Entrée ».
+
+    <img className="thumbnail" alt="Remmina connection to the instance" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" />
   </Tab>
   <Tab label="2. Authentification">
     Si un message d'avertissement de certificat apparaît, cliquez sur <code className="action">Yes</code>. Entrez le nom d'utilisateur et votre mot de passe pour Windows et cliquez sur <code className="action">OK</code> pour établir la connexion.
+
+    <img className="thumbnail" alt="Remmina authentication" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" />
   </Tab>
   <Tab label="3. Paramètres">
     Vous pouvez trouver des éléments utiles dans la barre d'outils de gauche. Par exemple, cliquez sur l'icône <code className="action">Toggle dynamic resolution update</code> pour améliorer la résolution de la fenêtre.
+
+    <img className="thumbnail" alt="Remmina session settings" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -523,6 +548,8 @@ La console VNC vous permet de vous connecter à vos instances même lorsque d'au
 Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section <code className="action">Public Cloud</code> et sélectionnez le projet Public Cloud concerné.
 
 Sélectionnez <code className="action">Instances</code> dans la barre de navigation de gauche sous **Compute**. Cliquez sur le nom de l'instance et ouvrez l'onglet <code className="action">Console VNC</code>.
+
+<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instance avec un OS GNU/Linux installé">

--- a/docs/fr/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/fr/guides/public-cloud/compute/getting-started.mdx
@@ -17,7 +17,17 @@ Vous pourrez ensuite aller plus loin avec votre projet Public Cloud en fonction 
 ## Prérequis
 
 - Un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
-- Être connecté à l’<ManagerLink to="/">espace client OVHcloud</ManagerLink>
+
+{/* CP-NAV-START:publiccloud-projects */}
+---
+
+### Accès à l'espace client OVHcloud
+
+- **Lien direct :** <ManagerLink to="/#/pci/projects">Projets Public Cloud</ManagerLink>
+- **Pour accéder à vos services :** <code className="action">Public Cloud</code> > Sélectionnez votre projet
+
+---
+{/* CP-NAV-END:publiccloud-projects */}
 
 :::tip
 Bénéficiez de prix réduits en vous engageant sur une période de 1 à 36 mois sur vos ressources Public Cloud. Plus d’informations sur notre page [Savings Plans](https://www.ovhcloud.com/fr/public-cloud/savings-plan/).
@@ -96,15 +106,13 @@ Les clés SSH publiques ajoutées à votre espace client OVHcloud seront disponi
 
 <Tabs>
   <Tab label="Via l’espace client">
-    Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section <code className="action">Public Cloud</code> et sélectionnez le projet Public Cloud concerné.
+    Ouvrez <code className="action">Clés SSH</code> dans le menu de gauche sous **Paramètres**. Cliquez sur le bouton <code className="action">Ajouter une clé SSH</code>.
 
     <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
 
-    Ouvrez <code className="action">Clés SSH</code> dans le menu de gauche sous **Paramètres**. Cliquez sur le bouton <code className="action">Ajouter une clé SSH</code>.
+    Dans la nouvelle fenêtre, entrez un nom pour la clé. Remplissez le champ `Clé` avec votre chaîne de clé publique, par exemple celle créée à l'[étape 1](#etape-1-creer-un-jeu-de-cles-ssh). Confirmez en cliquant sur <code className="action">Ajouter</code>.
 
     <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
-
-    Dans la nouvelle fenêtre, entrez un nom pour la clé. Remplissez le champ `Clé` avec votre chaîne de clé publique, par exemple celle créée à l'[étape 1](#etape-1-creer-un-jeu-de-cles-ssh). Confirmez en cliquant sur <code className="action">Ajouter</code>.
 
     Vous pouvez dorénavant sélectionner cette clé à l'[Étape 4](#etape-4-creer-linstance) pour l'ajouter à une nouvelle instance.
   </Tab>
@@ -204,7 +212,7 @@ Pour en savoir plus, consultez la [page web des Local Zones](https://www.ovhclou
 
     :::
 
-    Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section <code className="action">Public Cloud</code> et sélectionnez le projet Public Cloud concerné. Sur la page **Accueil**, cliquez sur <code className="action">Créer une instance</code>.
+    Sur la page **Accueil**, cliquez sur <code className="action">Créer une instance</code>.
 
     **4.1 Nom**
 
@@ -411,8 +419,6 @@ Si vous avez installé un **OS avec application**, reportez-vous à notre [guide
 
 #### 5.1 : Vérifier l'état de l'instance dans l'espace client
 
-Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section <code className="action">Public Cloud</code> et sélectionnez le projet Public Cloud concerné.
-
 Sélectionnez <code className="action">Instances</code> dans la barre de navigation de gauche sous **Compute**. Votre instance est prête lorsque l'état est défini sur `Activé` dans le tableau. Si l'instance a été créée récemment et a un statut différent, cliquez sur le bouton « Actualiser » situé à côté du filtre de recherche.
 
 <img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
@@ -544,8 +550,6 @@ Le logiciel libre et open source `Remmina Remote Desktop Client` est disponible 
 #### 5.4 : accès console VNC
 
 La console VNC vous permet de vous connecter à vos instances même lorsque d'autres moyens d'accès ne sont pas disponibles.
-
-Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section <code className="action">Public Cloud</code> et sélectionnez le projet Public Cloud concerné.
 
 Sélectionnez <code className="action">Instances</code> dans la barre de navigation de gauche sous **Compute**. Cliquez sur le nom de l'instance et ouvrez l'onglet <code className="action">Console VNC</code>.
 

--- a/docs/fr/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/fr/guides/public-cloud/compute/getting-started.mdx
@@ -108,11 +108,7 @@ Les clés SSH publiques ajoutées à votre espace client OVHcloud seront disponi
   <Tab label="Via l’espace client">
     Ouvrez <code className="action">Clés SSH</code> dans le menu de gauche sous **Paramètres**. Cliquez sur le bouton <code className="action">Ajouter une clé SSH</code>.
 
-    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
-
     Dans la nouvelle fenêtre, entrez un nom pour la clé. Remplissez le champ `Clé` avec votre chaîne de clé publique, par exemple celle créée à l'[étape 1](#etape-1-creer-un-jeu-de-cles-ssh). Confirmez en cliquant sur <code className="action">Ajouter</code>.
-
-    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     Vous pouvez dorénavant sélectionner cette clé à l'[Étape 4](#etape-4-creer-linstance) pour l'ajouter à une nouvelle instance.
   </Tab>
@@ -421,13 +417,9 @@ Si vous avez installé un **OS avec application**, reportez-vous à notre [guide
 
 Sélectionnez <code className="action">Instances</code> dans la barre de navigation de gauche sous **Compute**. Votre instance est prête lorsque l'état est défini sur `Activé` dans le tableau. Si l'instance a été créée récemment et a un statut différent, cliquez sur le bouton « Actualiser » situé à côté du filtre de recherche.
 
-<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
-
 Cliquez sur le nom de l'instance dans ce tableau pour ouvrir le <code className="action">Tableau de bord</code> sur lequel vous pouvez trouver toutes les informations concernant l'instance. Pour en savoir plus sur les fonctions disponibles sur cette page, consultez notre guide sur [la gestion des instances dans l'espace client](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Un **utilisateur avec des droits élevés (*sudo*) est automatiquement créé** sur l'instance. Le nom d'utilisateur reflète l'image installée, par exemple « ubuntu », « debian », « fedora », etc. Vous pouvez le vérifier dans le <code className="action">Tableau de bord</code> dans la section **Réseaux**.
-
-<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 
 :::info
 Via l'OVHcloud CLI, vérifiez l'état et récupérez l'adresse IP de votre instance avec :
@@ -552,8 +544,6 @@ Le logiciel libre et open source `Remmina Remote Desktop Client` est disponible 
 La console VNC vous permet de vous connecter à vos instances même lorsque d'autres moyens d'accès ne sont pas disponibles.
 
 Sélectionnez <code className="action">Instances</code> dans la barre de navigation de gauche sous **Compute**. Cliquez sur le nom de l'instance et ouvrez l'onglet <code className="action">Console VNC</code>.
-
-<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instance avec un OS GNU/Linux installé">

--- a/docs/it/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/it/guides/public-cloud/compute/getting-started.mdx
@@ -108,11 +108,7 @@ Le chiavi SSH pubbliche aggiunte al tuo Spazio Cliente OVHcloud saranno disponib
   <Tab label="Tramite lo Spazio Cliente">
     Apri <code className="action">Chiavi SSH</code> nel menu a sinistra sotto **Impostazioni**. Clicca sul pulsante <code className="action">Aggiungi una chiave SSH</code>.
 
-    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
-
     Nella nuova finestra, inserisci un nome per la chiave. Compila il campo `Chiave` con la tua stringa di chiave pubblica, ad esempio quella creata allo [step 1](#step-1-creare-un-set-di-chiavi-ssh). Conferma cliccando su <code className="action">Aggiungi</code>.
-
-    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     Da questo momento puoi selezionare questa chiave allo [Step 4](#step-4-creare-listanza) per aggiungerla a una nuova istanza.
   </Tab>
@@ -421,13 +417,9 @@ Se hai installato un **OS con applicazione**, consulta la nostra [guida sui prim
 
 Seleziona <code className="action">Istanze</code> nella barra di navigazione a sinistra sotto **Compute**. La tua istanza è pronta quando lo stato è impostato su `Attivato` nella tabella. Se l'istanza è stata creata di recente e ha uno stato diverso, clicca sul pulsante "Aggiorna" accanto al filtro di ricerca.
 
-<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
-
 Clicca sul nome dell'istanza in questa tabella per aprire il <code className="action">Dashboard</code>, dove puoi trovare tutte le informazioni relative all'istanza. Per maggiori informazioni sulle funzioni disponibili in questa pagina, consulta la nostra guida sulla [gestione delle istanze nello Spazio Cliente](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Un **utente con diritti elevati (*sudo*) viene creato automaticamente** sull'istanza. Il nome utente riflette l'immagine installata, ad esempio "ubuntu", "debian", "fedora", ecc. Puoi verificarlo nel <code className="action">Dashboard</code> nella sezione **Reti**.
-
-<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 
 :::info
 Tramite l'OVHcloud CLI, verifica lo stato e recupera l'indirizzo IP della tua istanza con:
@@ -552,8 +544,6 @@ Il software libero e open source `Remmina Remote Desktop Client` è disponibile 
 La console VNC ti permette di connetterti alle tue istanze anche quando altri mezzi di accesso non sono disponibili.
 
 Seleziona <code className="action">Istanze</code> nella barra di navigazione a sinistra sotto **Compute**. Clicca sul nome dell'istanza e apri la scheda <code className="action">Console VNC</code>.
-
-<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Istanza con OS GNU/Linux installato">

--- a/docs/it/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/it/guides/public-cloud/compute/getting-started.mdx
@@ -5,6 +5,7 @@ lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
+import Api from '@components/Api';
 
 ## Obiettivo
 
@@ -107,7 +108,11 @@ Le chiavi SSH pubbliche aggiunte al tuo Spazio Cliente OVHcloud saranno disponib
   <Tab label="Tramite lo Spazio Cliente">
     Accedi allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, vai alla sezione <code className="action">Public Cloud</code> e seleziona il progetto Public Cloud interessato.
 
+    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+
     Apri <code className="action">Chiavi SSH</code> nel menu a sinistra sotto **Impostazioni**. Clicca sul pulsante <code className="action">Aggiungi una chiave SSH</code>.
+
+    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     Nella nuova finestra, inserisci un nome per la chiave. Compila il campo `Chiave` con la tua stringa di chiave pubblica, ad esempio quella creata allo [step 1](#step-1-creare-un-set-di-chiavi-ssh). Conferma cliccando su <code className="action">Aggiungi</code>.
 
@@ -116,7 +121,7 @@ Le chiavi SSH pubbliche aggiunte al tuo Spazio Cliente OVHcloud saranno disponib
   <Tab label="Tramite l'API OVHcloud">
     Utilizza la seguente chiamata per importare la tua chiave SSH pubblica:
 
-    > **POST** `/cloud/project/{serviceName}/sshkey`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/sshkey"} />
 
     Parametri:
 
@@ -287,7 +292,7 @@ Per saperne di più, consulta la [pagina web delle Local Zone](https://www.ovhcl
 
     Crea l'istanza:
 
-    > **POST** `/cloud/project/{serviceName}/instance`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/instance"} />
 
     Parametri principali:
 
@@ -420,9 +425,13 @@ Accedi allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, vai alla 
 
 Seleziona <code className="action">Istanze</code> nella barra di navigazione a sinistra sotto **Compute**. La tua istanza è pronta quando lo stato è impostato su `Attivato` nella tabella. Se l'istanza è stata creata di recente e ha uno stato diverso, clicca sul pulsante "Aggiorna" accanto al filtro di ricerca.
 
+<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
+
 Clicca sul nome dell'istanza in questa tabella per aprire il <code className="action">Dashboard</code>, dove puoi trovare tutte le informazioni relative all'istanza. Per maggiori informazioni sulle funzioni disponibili in questa pagina, consulta la nostra guida sulla [gestione delle istanze nello Spazio Cliente](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Un **utente con diritti elevati (*sudo*) viene creato automaticamente** sull'istanza. Il nome utente riflette l'immagine installata, ad esempio "ubuntu", "debian", "fedora", ecc. Puoi verificarlo nel <code className="action">Dashboard</code> nella sezione **Reti**.
+
+<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 
 :::info
 Tramite l'OVHcloud CLI, verifica lo stato e recupera l'indirizzo IP della tua istanza con:
@@ -481,21 +490,31 @@ A questo punto dovrai completare la configurazione iniziale del sistema operativ
 <Tabs>
   <Tab label="1. Impostazioni regionali">
     Configura il tuo **paese/area geografica**, la **lingua Windows** preferita e la **disposizione della tastiera**. Clicca poi sul pulsante <code className="action">Avanti</code> in basso a destra.
+
+    <img className="thumbnail" alt="Windows locale settings" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" />
   </Tab>
   <Tab label="2. Password amministratore">
     Definisci una password per il tuo account Windows `Administrator` e confermala, poi clicca su <code className="action">Fine</code>.
+
+    <img className="thumbnail" alt="Set the Windows Administrator password" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" />
   </Tab>
   <Tab label="3. Schermata di accesso">
     Windows applicherà le impostazioni, poi visualizzerà la schermata di accesso. Clicca sul pulsante <code className="action">Send CtrlAltDel</code> in alto a destra per accedere.
+
+    <img className="thumbnail" alt="Windows login screen in the VNC console" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" />
   </Tab>
   <Tab label="4. Login amministratore">
     Inserisci la password `Administrator` creata nel passaggio precedente e clicca sul pulsante "Freccia".
+
+    <img className="thumbnail" alt="Windows Administrator login" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
   </Tab>
 </Tabs>
 
 ##### 5.3.2: Connettersi da remoto da Windows
 
 Sul tuo computer Windows locale, puoi utilizzare l'applicazione client `Remote Desktop Connection` per connetterti alla tua istanza.
+
+<img className="thumbnail" alt="Remote Desktop Connection to the instance" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Inserisci l'indirizzo IPv4 della tua istanza, il tuo identificativo e la tua password. In genere viene visualizzato un messaggio di avviso che richiede di confermare la connessione a causa di un certificato sconosciuto. Clicca su <code className="action">Sì</code> per connetterti.
 
@@ -517,12 +536,18 @@ Il software libero e open source `Remmina Remote Desktop Client` è disponibile 
 <Tabs>
   <Tab label="1. Connessione">
     Apri Remmina e assicurati che il protocollo di connessione sia impostato su "RDP". Inserisci l'indirizzo IPv4 della tua istanza Public Cloud e premi "Invio".
+
+    <img className="thumbnail" alt="Remmina connection to the instance" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" />
   </Tab>
   <Tab label="2. Autenticazione">
     Se appare un messaggio di avviso relativo al certificato, clicca su <code className="action">Yes</code>. Inserisci il nome utente e la password per Windows e clicca su <code className="action">OK</code> per stabilire la connessione.
+
+    <img className="thumbnail" alt="Remmina authentication" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" />
   </Tab>
   <Tab label="3. Impostazioni">
     Puoi trovare elementi utili nella barra degli strumenti a sinistra. Ad esempio, clicca sull'icona <code className="action">Toggle dynamic resolution update</code> per migliorare la risoluzione della finestra.
+
+    <img className="thumbnail" alt="Remmina session settings" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -533,6 +558,8 @@ La console VNC ti permette di connetterti alle tue istanze anche quando altri me
 Accedi allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, vai alla sezione <code className="action">Public Cloud</code> e seleziona il progetto Public Cloud interessato.
 
 Seleziona <code className="action">Istanze</code> nella barra di navigazione a sinistra sotto **Compute**. Clicca sul nome dell'istanza e apri la scheda <code className="action">Console VNC</code>.
+
+<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Istanza con OS GNU/Linux installato">

--- a/docs/it/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/it/guides/public-cloud/compute/getting-started.mdx
@@ -106,15 +106,13 @@ Le chiavi SSH pubbliche aggiunte al tuo Spazio Cliente OVHcloud saranno disponib
 
 <Tabs>
   <Tab label="Tramite lo Spazio Cliente">
-    Accedi allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, vai alla sezione <code className="action">Public Cloud</code> e seleziona il progetto Public Cloud interessato.
+    Apri <code className="action">Chiavi SSH</code> nel menu a sinistra sotto **Impostazioni**. Clicca sul pulsante <code className="action">Aggiungi una chiave SSH</code>.
 
     <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
 
-    Apri <code className="action">Chiavi SSH</code> nel menu a sinistra sotto **Impostazioni**. Clicca sul pulsante <code className="action">Aggiungi una chiave SSH</code>.
+    Nella nuova finestra, inserisci un nome per la chiave. Compila il campo `Chiave` con la tua stringa di chiave pubblica, ad esempio quella creata allo [step 1](#step-1-creare-un-set-di-chiavi-ssh). Conferma cliccando su <code className="action">Aggiungi</code>.
 
     <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
-
-    Nella nuova finestra, inserisci un nome per la chiave. Compila il campo `Chiave` con la tua stringa di chiave pubblica, ad esempio quella creata allo [step 1](#step-1-creare-un-set-di-chiavi-ssh). Conferma cliccando su <code className="action">Aggiungi</code>.
 
     Da questo momento puoi selezionare questa chiave allo [Step 4](#step-4-creare-listanza) per aggiungerla a una nuova istanza.
   </Tab>
@@ -214,7 +212,7 @@ Per saperne di più, consulta la [pagina web delle Local Zone](https://www.ovhcl
 
     :::
 
-    Accedi allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, vai alla sezione <code className="action">Public Cloud</code> e seleziona il progetto Public Cloud interessato. Nella pagina **Home**, clicca su <code className="action">Crea un'istanza</code>.
+    Nella pagina **Home**, clicca su <code className="action">Crea un'istanza</code>.
 
     **4.1 Nome**
 
@@ -421,8 +419,6 @@ Se hai installato un **OS con applicazione**, consulta la nostra [guida sui prim
 
 #### 5.1: Verificare lo stato dell'istanza nello Spazio Cliente
 
-Accedi allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, vai alla sezione <code className="action">Public Cloud</code> e seleziona il progetto Public Cloud interessato.
-
 Seleziona <code className="action">Istanze</code> nella barra di navigazione a sinistra sotto **Compute**. La tua istanza è pronta quando lo stato è impostato su `Attivato` nella tabella. Se l'istanza è stata creata di recente e ha uno stato diverso, clicca sul pulsante "Aggiorna" accanto al filtro di ricerca.
 
 <img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
@@ -554,8 +550,6 @@ Il software libero e open source `Remmina Remote Desktop Client` è disponibile 
 #### 5.4: Accesso console VNC
 
 La console VNC ti permette di connetterti alle tue istanze anche quando altri mezzi di accesso non sono disponibili.
-
-Accedi allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, vai alla sezione <code className="action">Public Cloud</code> e seleziona il progetto Public Cloud interessato.
 
 Seleziona <code className="action">Istanze</code> nella barra di navigazione a sinistra sotto **Compute**. Clicca sul nome dell'istanza e apri la scheda <code className="action">Console VNC</code>.
 

--- a/docs/pl/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/pl/guides/public-cloud/compute/getting-started.mdx
@@ -108,11 +108,7 @@ Publiczne klucze SSH dodane do Panelu klienta OVHcloud będą dostępne dla usł
   <Tab label="W Panelu klienta">
     Otwórz <code className="action">Klucze SSH</code> w menu po lewej stronie, w sekcji **Ustawienia**. Kliknij przycisk <code className="action">Dodaj klucz SSH</code>.
 
-    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
-
     W nowym oknie wpisz nazwę klucza. Wypełnij pole `Klucz` ciągiem klucza publicznego, na przykład kluczem utworzonym w [Kroku 1](#krok-1-tworzenie-zestawu-kluczy-ssh). Potwierdź, klikając <code className="action">Dodaj</code>.
-
-    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     Możesz teraz wybrać ten klucz w [Kroku 4](#krok-4-tworzenie-instancji), aby dodać go do nowej instancji.
   </Tab>
@@ -421,13 +417,9 @@ Jeśli zainstalowałeś **system OS z aplikacją**, zapoznaj się z naszym [prze
 
 Wybierz <code className="action">Instancje</code> na pasku nawigacyjnym po lewej stronie, w sekcji **Compute**. Twoja instancja jest gotowa, gdy w tabeli stan jest ustawiony na `Włączony`. Jeśli instancja została niedawno utworzona i ma inny stan, kliknij przycisk "Odśwież" znajdujący się obok filtru wyszukiwania.
 
-<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
-
 Kliknij nazwę instancji w tej tabeli, aby otworzyć <code className="action">Dashboard</code>, na którym znajdziesz wszystkie informacje dotyczące instancji. Aby dowiedzieć się więcej o funkcjach dostępnych na tej stronie, zapoznaj się z naszym przewodnikiem dotyczącym [zarządzania instancjami w Panelu klienta](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Na instancji **automatycznie tworzony jest użytkownik z podwyższonymi uprawnieniami (*sudo*)**. Nazwa użytkownika odzwierciedla zainstalowany obraz, np. "ubuntu", "debian", "fedora", itp. Możesz to sprawdzić po prawej stronie <code className="action">Dashboard</code> w sekcji **Sieci**.
-
-<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 
 :::info
 Za pomocą OVHcloud CLI sprawdź stan instancji i pobierz jej adres IP:
@@ -552,8 +544,6 @@ Wolne oprogramowanie open source `Remmina Remote Desktop Client` jest dostępne 
 Konsola VNC pozwala na łączenie się z instancjami, nawet jeśli inne metody dostępu nie są dostępne.
 
 Wybierz <code className="action">Instancje</code> na pasku nawigacyjnym po lewej stronie, w sekcji **Compute**. Kliknij nazwę instancji i otwórz kartę <code className="action">Konsola VNC</code>.
-
-<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instancja z zainstalowanym systemem GNU/Linux">

--- a/docs/pl/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/pl/guides/public-cloud/compute/getting-started.mdx
@@ -5,6 +5,7 @@ lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
+import Api from '@components/Api';
 
 ## Wprowadzenie
 
@@ -107,7 +108,11 @@ Publiczne klucze SSH dodane do Panelu klienta OVHcloud będą dostępne dla usł
   <Tab label="W Panelu klienta">
     Zaloguj się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, przejdź do sekcji <code className="action">Public Cloud</code> i wybierz swój projekt Public Cloud.
 
+    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+
     Otwórz <code className="action">Klucze SSH</code> w menu po lewej stronie, w sekcji **Ustawienia**. Kliknij przycisk <code className="action">Dodaj klucz SSH</code>.
+
+    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     W nowym oknie wpisz nazwę klucza. Wypełnij pole `Klucz` ciągiem klucza publicznego, na przykład kluczem utworzonym w [Kroku 1](#krok-1-tworzenie-zestawu-kluczy-ssh). Potwierdź, klikając <code className="action">Dodaj</code>.
 
@@ -116,7 +121,7 @@ Publiczne klucze SSH dodane do Panelu klienta OVHcloud będą dostępne dla usł
   <Tab label="Za pomocą API OVHcloud">
     Użyj następującego wywołania, aby zaimportować swój publiczny klucz SSH:
 
-    > **POST** `/cloud/project/{serviceName}/sshkey`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/sshkey"} />
 
     Parametry:
 
@@ -287,7 +292,7 @@ Więcej informacji znajdziesz na [stronie internetowej Local Zones](https://www.
 
     Utwórz instancję:
 
-    > **POST** `/cloud/project/{serviceName}/instance`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/instance"} />
 
     Główne parametry:
 
@@ -418,9 +423,13 @@ Jeśli zainstalowałeś **system OS z aplikacją**, zapoznaj się z naszym [prze
 
 Wybierz <code className="action">Instancje</code> na pasku nawigacyjnym po lewej stronie, w sekcji **Compute**. Twoja instancja jest gotowa, gdy w tabeli stan jest ustawiony na `Włączony`. Jeśli instancja została niedawno utworzona i ma inny stan, kliknij przycisk "Odśwież" znajdujący się obok filtru wyszukiwania.
 
+<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
+
 Kliknij nazwę instancji w tej tabeli, aby otworzyć <code className="action">Dashboard</code>, na którym znajdziesz wszystkie informacje dotyczące instancji. Aby dowiedzieć się więcej o funkcjach dostępnych na tej stronie, zapoznaj się z naszym przewodnikiem dotyczącym [zarządzania instancjami w Panelu klienta](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Na instancji **automatycznie tworzony jest użytkownik z podwyższonymi uprawnieniami (*sudo*)**. Nazwa użytkownika odzwierciedla zainstalowany obraz, np. "ubuntu", "debian", "fedora", itp. Możesz to sprawdzić po prawej stronie <code className="action">Dashboard</code> w sekcji **Sieci**.
+
+<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 
 :::info
 Za pomocą OVHcloud CLI sprawdź stan instancji i pobierz jej adres IP:
@@ -479,21 +488,31 @@ Następnie należy dokończyć wstępną konfigurację systemu operacyjnego Wind
 <Tabs>
   <Tab label="1. Ustawienia regionalne">
     Skonfiguruj swój **kraj/region**, **preferowany język Windows** i **układ klawiatury**. Następnie kliknij przycisk <code className="action">Next</code> w prawym dolnym rogu.
+
+    <img className="thumbnail" alt="Windows locale settings" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" />
   </Tab>
   <Tab label="2. Hasło administratora">
     Ustaw hasło dla konta Windows `Administrator` i potwierdź je, następnie kliknij <code className="action">Finish</code>.
+
+    <img className="thumbnail" alt="Set the Windows Administrator password" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" />
   </Tab>
   <Tab label="3. Ekran logowania">
     System Windows zastosuje ustawienia, a następnie wyświetli ekran logowania. Kliknij przycisk <code className="action">Send CtrlAltDel</code> w prawym górnym rogu, aby się zalogować.
+
+    <img className="thumbnail" alt="Windows login screen in the VNC console" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" />
   </Tab>
   <Tab label="4. Logowanie administratora">
     Wprowadź hasło `Administrator` utworzone na poprzednim etapie i kliknij przycisk `Strzałka`.
+
+    <img className="thumbnail" alt="Windows Administrator login" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
   </Tab>
 </Tabs>
 
 ##### 5.3.2: Zdalne logowanie z systemu Windows
 
 Na lokalnym komputerze z systemem Windows możesz zalogować się do instancji za pomocą aplikacji klienckiej `Remote Desktop Connection`.
+
+<img className="thumbnail" alt="Remote Desktop Connection to the instance" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Wprowadź adres IPv4 Twojej instancji, następnie swoją nazwę użytkownika i hasło. Zazwyczaj pojawia się komunikat ostrzegawczy z prośbą o potwierdzenie połączenia z powodu nieznanego certyfikatu. Kliknij <code className="action">Tak</code>, aby się zalogować.
 
@@ -515,12 +534,18 @@ Wolne oprogramowanie open source `Remmina Remote Desktop Client` jest dostępne 
 <Tabs>
   <Tab label="1. Połączenie">
     Otwórz Remmina i upewnij się, że protokół połączenia jest ustawiony na "RDP". Wprowadź adres IPv4 Twojej instancji Public Cloud i naciśnij `Enter`.
+
+    <img className="thumbnail" alt="Remmina connection to the instance" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" />
   </Tab>
   <Tab label="2. Uwierzytelnianie">
     Jeśli pojawi się komunikat ostrzegawczy dotyczący certyfikatu, kliknij <code className="action">Yes</code>. Wprowadź nazwę użytkownika i hasło dla systemu Windows, a następnie kliknij <code className="action">OK</code>, aby nawiązać połączenie.
+
+    <img className="thumbnail" alt="Remmina authentication" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" />
   </Tab>
   <Tab label="3. Ustawienia">
     Przydatne elementy znajdziesz na pasku narzędzi po lewej stronie. Na przykład kliknij ikonę <code className="action">Toggle dynamic resolution update</code>, aby poprawić rozdzielczość okna.
+
+    <img className="thumbnail" alt="Remmina session settings" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -529,6 +554,8 @@ Wolne oprogramowanie open source `Remmina Remote Desktop Client` jest dostępne 
 Konsola VNC pozwala na łączenie się z instancjami, nawet jeśli inne metody dostępu nie są dostępne.
 
 Wybierz <code className="action">Instancje</code> na pasku nawigacyjnym po lewej stronie, w sekcji **Compute**. Kliknij nazwę instancji i otwórz kartę <code className="action">Konsola VNC</code>.
+
+<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instancja z zainstalowanym systemem GNU/Linux">

--- a/docs/pl/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/pl/guides/public-cloud/compute/getting-started.mdx
@@ -106,15 +106,13 @@ Publiczne klucze SSH dodane do Panelu klienta OVHcloud będą dostępne dla usł
 
 <Tabs>
   <Tab label="W Panelu klienta">
-    Zaloguj się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, przejdź do sekcji <code className="action">Public Cloud</code> i wybierz swój projekt Public Cloud.
+    Otwórz <code className="action">Klucze SSH</code> w menu po lewej stronie, w sekcji **Ustawienia**. Kliknij przycisk <code className="action">Dodaj klucz SSH</code>.
 
     <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
 
-    Otwórz <code className="action">Klucze SSH</code> w menu po lewej stronie, w sekcji **Ustawienia**. Kliknij przycisk <code className="action">Dodaj klucz SSH</code>.
+    W nowym oknie wpisz nazwę klucza. Wypełnij pole `Klucz` ciągiem klucza publicznego, na przykład kluczem utworzonym w [Kroku 1](#krok-1-tworzenie-zestawu-kluczy-ssh). Potwierdź, klikając <code className="action">Dodaj</code>.
 
     <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
-
-    W nowym oknie wpisz nazwę klucza. Wypełnij pole `Klucz` ciągiem klucza publicznego, na przykład kluczem utworzonym w [Kroku 1](#krok-1-tworzenie-zestawu-kluczy-ssh). Potwierdź, klikając <code className="action">Dodaj</code>.
 
     Możesz teraz wybrać ten klucz w [Kroku 4](#krok-4-tworzenie-instancji), aby dodać go do nowej instancji.
   </Tab>
@@ -214,7 +212,7 @@ Więcej informacji znajdziesz na [stronie internetowej Local Zones](https://www.
 
     :::
 
-    Zaloguj się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, przejdź do sekcji <code className="action">Public Cloud</code> i wybierz swój projekt Public Cloud. Na stronie **Strona główna** kliknij <code className="action">Utwórz instancję</code>.
+    Na stronie **Strona główna** kliknij <code className="action">Utwórz instancję</code>.
 
     **4.1 Nazwa**
 

--- a/docs/pt/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/pt/guides/public-cloud/compute/getting-started.mdx
@@ -108,11 +108,7 @@ As chaves SSH públicas adicionadas à sua área de cliente OVHcloud estarão di
   <Tab label="Através da área de cliente">
     Abra <code className="action">Chaves SSH</code> no menu à esquerda em **Parâmetros**. Clique no botão <code className="action">Adicionar chave SSH</code>.
 
-    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
-
     Na nova janela, introduza um nome para a chave. Preencha o campo `Chave` com a sua cadeia de chave pública, por exemplo, a criada na [etapa 1](#etapa-1-criar-um-conjunto-de-chaves-ssh). Confirme clicando em <code className="action">Adicionar</code>.
-
-    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     Agora pode selecionar esta chave na [Etapa 4](#etapa-4-criar-a-instancia) para a adicionar a uma nova instância.
   </Tab>
@@ -421,13 +417,9 @@ Se instalou um **SO com aplicação**, consulte o nosso [guia de primeiros passo
 
 Selecione <code className="action">Instâncias</code> na barra de navegação à esquerda em **Compute**. A sua instância está pronta quando o estado está definido em `Ativado` na tabela. Se a instância tiver sido criada recentemente e tiver um estado diferente, clique no botão "Atualizar" junto do filtro de pesquisa.
 
-<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
-
 Clique no nome da instância nesta tabela para abrir o <code className="action">Dashboard</code> no qual pode encontrar todas as informações relativas à instância. Para saber mais sobre as funções disponíveis nesta página, consulte o guia [Gestão das instâncias na área de cliente](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Um **utilizador com permissões elevadas (*sudo*) é automaticamente criado** na instância. O nome de utilizador reflete a imagem instalada, por exemplo "ubuntu", "debian", "fedora", etc. Pode verificá-lo no <code className="action">Dashboard</code> na secção **Redes**.
-
-<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 
 :::info
 Através do OVHcloud CLI, verifique o estado e recupere o endereço IP da sua instância com:
@@ -552,8 +544,6 @@ O software livre e open source `Remmina Remote Desktop Client` está disponível
 A consola VNC permite-lhe ligar-se às suas instâncias mesmo quando não estão disponíveis outros meios de acesso.
 
 Selecione <code className="action">Instâncias</code> na barra de navegação à esquerda em **Compute**. Clique no nome da instância e abra o separador <code className="action">Consola VNC</code>.
-
-<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instância com um SO GNU/Linux instalado">

--- a/docs/pt/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/pt/guides/public-cloud/compute/getting-started.mdx
@@ -106,15 +106,13 @@ As chaves SSH públicas adicionadas à sua área de cliente OVHcloud estarão di
 
 <Tabs>
   <Tab label="Através da área de cliente">
-    Ligue-se à <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>, aceda à secção <code className="action">Public Cloud</code> e selecione o projeto Public Cloud em questão.
+    Abra <code className="action">Chaves SSH</code> no menu à esquerda em **Parâmetros**. Clique no botão <code className="action">Adicionar chave SSH</code>.
 
     <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
 
-    Abra <code className="action">Chaves SSH</code> no menu à esquerda em **Parâmetros**. Clique no botão <code className="action">Adicionar chave SSH</code>.
+    Na nova janela, introduza um nome para a chave. Preencha o campo `Chave` com a sua cadeia de chave pública, por exemplo, a criada na [etapa 1](#etapa-1-criar-um-conjunto-de-chaves-ssh). Confirme clicando em <code className="action">Adicionar</code>.
 
     <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
-
-    Na nova janela, introduza um nome para a chave. Preencha o campo `Chave` com a sua cadeia de chave pública, por exemplo, a criada na [etapa 1](#etapa-1-criar-um-conjunto-de-chaves-ssh). Confirme clicando em <code className="action">Adicionar</code>.
 
     Agora pode selecionar esta chave na [Etapa 4](#etapa-4-criar-a-instancia) para a adicionar a uma nova instância.
   </Tab>
@@ -214,7 +212,7 @@ Para saber mais, consulte a [página Web das Local Zones](https://www.ovhcloud.c
 
     :::
 
-    Ligue-se à <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>, aceda à secção <code className="action">Public Cloud</code> e selecione o projeto Public Cloud em questão. Na página **Página Inicial**, clique em <code className="action">Criar uma instância</code>.
+    Na página **Página Inicial**, clique em <code className="action">Criar uma instância</code>.
 
     **4.1 Nome**
 
@@ -421,8 +419,6 @@ Se instalou um **SO com aplicação**, consulte o nosso [guia de primeiros passo
 
 #### 5.1: Verificar o estado da instância na área de cliente
 
-Ligue-se à <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>, aceda à secção <code className="action">Public Cloud</code> e selecione o projeto Public Cloud em questão.
-
 Selecione <code className="action">Instâncias</code> na barra de navegação à esquerda em **Compute**. A sua instância está pronta quando o estado está definido em `Ativado` na tabela. Se a instância tiver sido criada recentemente e tiver um estado diferente, clique no botão "Atualizar" junto do filtro de pesquisa.
 
 <img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
@@ -554,8 +550,6 @@ O software livre e open source `Remmina Remote Desktop Client` está disponível
 #### 5.4: Acesso consola VNC
 
 A consola VNC permite-lhe ligar-se às suas instâncias mesmo quando não estão disponíveis outros meios de acesso.
-
-Ligue-se à <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>, aceda à secção <code className="action">Public Cloud</code> e selecione o projeto Public Cloud em questão.
 
 Selecione <code className="action">Instâncias</code> na barra de navegação à esquerda em **Compute**. Clique no nome da instância e abra o separador <code className="action">Consola VNC</code>.
 

--- a/docs/pt/guides/public-cloud/compute/getting-started.mdx
+++ b/docs/pt/guides/public-cloud/compute/getting-started.mdx
@@ -5,6 +5,7 @@ lastUpdated: 2026-05-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
+import Api from '@components/Api';
 
 ## Objetivo
 
@@ -107,7 +108,11 @@ As chaves SSH públicas adicionadas à sua área de cliente OVHcloud estarão di
   <Tab label="Através da área de cliente">
     Ligue-se à <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>, aceda à secção <code className="action">Public Cloud</code> e selecione o projeto Public Cloud em questão.
 
+    <img className="thumbnail" alt="SSH Keys section in the OVHcloud Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-sshkeys.png" loading="lazy" />
+
     Abra <code className="action">Chaves SSH</code> no menu à esquerda em **Parâmetros**. Clique no botão <code className="action">Adicionar chave SSH</code>.
+
+    <img className="thumbnail" alt="Add an SSH key" src="/images/public-cloud/compute/public-cloud-first-steps/24-addkey.png" loading="lazy" />
 
     Na nova janela, introduza um nome para a chave. Preencha o campo `Chave` com a sua cadeia de chave pública, por exemplo, a criada na [etapa 1](#etapa-1-criar-um-conjunto-de-chaves-ssh). Confirme clicando em <code className="action">Adicionar</code>.
 
@@ -116,7 +121,7 @@ As chaves SSH públicas adicionadas à sua área de cliente OVHcloud estarão di
   <Tab label="Através da API OVHcloud">
     Utilize a chamada seguinte para importar a sua chave SSH pública:
 
-    > **POST** `/cloud/project/{serviceName}/sshkey`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/sshkey"} />
 
     Parâmetros:
 
@@ -287,7 +292,7 @@ Para saber mais, consulte a [página Web das Local Zones](https://www.ovhcloud.c
 
     Crie a instância:
 
-    > **POST** `/cloud/project/{serviceName}/instance`
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/instance"} />
 
     Parâmetros principais:
 
@@ -420,9 +425,13 @@ Ligue-se à <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>, aceda �
 
 Selecione <code className="action">Instâncias</code> na barra de navegação à esquerda em **Compute**. A sua instância está pronta quando o estado está definido em `Ativado` na tabela. Se a instância tiver sido criada recentemente e tiver um estado diferente, clique no botão "Atualizar" junto do filtro de pesquisa.
 
+<img className="thumbnail" alt="Instances list in the Control Panel" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect01.png" loading="lazy" />
+
 Clique no nome da instância nesta tabela para abrir o <code className="action">Dashboard</code> no qual pode encontrar todas as informações relativas à instância. Para saber mais sobre as funções disponíveis nesta página, consulte o guia [Gestão das instâncias na área de cliente](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
 
 Um **utilizador com permissões elevadas (*sudo*) é automaticamente criado** na instância. O nome de utilizador reflete a imagem instalada, por exemplo "ubuntu", "debian", "fedora", etc. Pode verificá-lo no <code className="action">Dashboard</code> na secção **Redes**.
+
+<img className="thumbnail" alt="Instance dashboard" src="/images/public-cloud/compute/public-cloud-first-steps/24-instance-connect02.png" loading="lazy" />
 
 :::info
 Através do OVHcloud CLI, verifique o estado e recupere o endereço IP da sua instância com:
@@ -481,21 +490,31 @@ De seguida, terá de finalizar a configuração inicial do seu sistema operativo
 <Tabs>
   <Tab label="1. Parâmetros regionais">
     Configure o seu **país/região**, o **idioma preferido do Windows** e a sua **configuração do teclado**. A seguir, clique no botão <code className="action">Seguinte</code> no canto inferior direito.
+
+    <img className="thumbnail" alt="Windows locale settings" src="/images/assets/screens/other/windows/windows-locale.png" loading="lazy" />
   </Tab>
   <Tab label="2. Palavra-passe de administrador">
     Defina uma palavra-passe para a sua conta Windows `Administrator` e confirme-a e clique em <code className="action">Terminar</code>.
+
+    <img className="thumbnail" alt="Set the Windows Administrator password" src="/images/assets/screens/other/windows/windows-admin.png" loading="lazy" />
   </Tab>
   <Tab label="3. Ecrã de ligação">
     O Windows aplicará as suas definições e, em seguida, apresentará o ecrã de ligação. Clique no botão <code className="action">Send CtrlAltDel</code> no canto superior direito para iniciar sessão.
+
+    <img className="thumbnail" alt="Windows login screen in the VNC console" src="/images/assets/screens/other/windows/windows-vnc.png" loading="lazy" />
   </Tab>
   <Tab label="4. Login de administrador">
     Introduza a palavra-passe `Administrator` que criou na etapa anterior e clique no botão "Seta".
+
+    <img className="thumbnail" alt="Windows Administrator login" src="/images/assets/screens/other/windows/windows-login.png" loading="lazy" />
   </Tab>
 </Tabs>
 
 ##### 5.3.2: Ligue-se remotamente a partir do Windows
 
 No seu computador Windows local, pode utilizar a aplicação cliente `Remote Desktop Connection` para se ligar à sua instância.
+
+<img className="thumbnail" alt="Remote Desktop Connection to the instance" src="/images/assets/screens/other/windows/windows-rdp.png" loading="lazy" />
 
 Introduza o endereço IPv4 da sua instância, depois o seu identificador e a sua passphrase. Normalmente, é apresentada uma mensagem de aviso a pedir-lhe para confirmar a ligação devido a um certificado desconhecido. Clique em <code className="action">Sim</code> para se ligar.
 
@@ -517,12 +536,18 @@ O software livre e open source `Remmina Remote Desktop Client` está disponível
 <Tabs>
   <Tab label="1. Ligação">
     Abra o Remmina e certifique-se de que o protocolo de ligação está definido como "RDP". Introduza o endereço IPv4 da sua instância Public Cloud e prima "Enter".
+
+    <img className="thumbnail" alt="Remmina connection to the instance" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect02.png" loading="lazy" />
   </Tab>
   <Tab label="2. Autenticação">
     Se aparecer uma mensagem de aviso de certificado, clique em <code className="action">Yes</code>. Introduza o nome de utilizador e a palavra-passe para o Windows e clique em <code className="action">OK</code> para estabelecer a ligação.
+
+    <img className="thumbnail" alt="Remmina authentication" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect03.png" loading="lazy" />
   </Tab>
   <Tab label="3. Parâmetros">
     Pode encontrar elementos úteis na barra de ferramentas à esquerda. Por exemplo, clique no ícone <code className="action">Toggle dynamic resolution update</code> para melhorar a resolução da janela.
+
+    <img className="thumbnail" alt="Remmina session settings" src="/images/public-cloud/compute/public-cloud-first-steps/24-rem-connect04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -533,6 +558,8 @@ A consola VNC permite-lhe ligar-se às suas instâncias mesmo quando não estão
 Ligue-se à <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>, aceda à secção <code className="action">Public Cloud</code> e selecione o projeto Public Cloud em questão.
 
 Selecione <code className="action">Instâncias</code> na barra de navegação à esquerda em **Compute**. Clique no nome da instância e abra o separador <code className="action">Consola VNC</code>.
+
+<img className="thumbnail" alt="VNC console access in the Control Panel" src="/images/assets/screens/control-panel/product-selection/public-cloud/cp-pci-vnc-login.png" loading="lazy" />
 
 <Tabs>
   <Tab label="Instância com um SO GNU/Linux instalado">


### PR DESCRIPTION
Fix multiple issues in How to create a Public Cloud instance and connect:

- Restore 8 screenshots into their matching tabs/sections (deleted by PR #30)
- Fix API format / links

- Add CP-nav sections (& extract)