### PR TITLE
feat(theme): display guide excerpt/description as a lead under the title

### DIFF
--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuring kubectl on an OVHcloud Managed Kubernetes cluster
-description: Find out how to retrieve the `kubectl` configuration file to interact with an OVHcloud Managed Kubernetes cluster.
+description: Find out how to retrieve the kubectl configuration file to interact with an OVHcloud Managed Kubernetes cluster.
 lastUpdated: 2022-04-27
 ---
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuring kubectl on an OVHcloud Managed Kubernetes cluster
-description: Find out how to retrieve the `kubectl` configuration file to interact with an OVHcloud Managed Kubernetes cluster.
+description: Find out how to retrieve the kubectl configuration file to interact with an OVHcloud Managed Kubernetes cluster.
 lastUpdated: 2022-04-27
 ---
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-private-registry/migrate-helm-charts.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-private-registry/migrate-helm-charts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrate Helm Charts from Chartmuseum to OCI
-description: Find out how to migrate Helm Charts From Chartmuseum (Harbor &lt; 2.8) to OCI
+description: Find out how to migrate Helm Charts from Chartmuseum (Harbor < 2.8) to OCI
 lastUpdated: 2026-02-25
 ---
 

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuring kubectl on an OVHcloud Managed Kubernetes cluster
-description: Find out how to retrieve the `kubectl` configuration file to interact with an OVHcloud Managed Kubernetes cluster.
+description: Find out how to retrieve the kubectl configuration file to interact with an OVHcloud Managed Kubernetes cluster.
 lastUpdated: 2022-04-27
 ---
 

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration du KMS avec Nutanix on OVHcloud
-description: Découvrez comment configurer le système de gestion des clés *Key Management System* (KMS) OVHcloud avec Nutanix pour sécuriser vos données au repos
+description: Découvrez comment configurer le système de gestion des clés Key Management System (KMS) OVHcloud avec Nutanix pour sécuriser vos données au repos
 lastUpdated: 2025-02-14
 ---
 

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuring kubectl on an OVHcloud Managed Kubernetes cluster
-description: Find out how to retrieve the `kubectl` configuration file to interact with an OVHcloud Managed Kubernetes cluster.
+description: Find out how to retrieve the kubectl configuration file to interact with an OVHcloud Managed Kubernetes cluster.
 lastUpdated: 2022-04-27
 ---
 

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuring kubectl on an OVHcloud Managed Kubernetes cluster
-description: Find out how to retrieve the `kubectl` configuration file to interact with an OVHcloud Managed Kubernetes cluster.
+description: Find out how to retrieve the kubectl configuration file to interact with an OVHcloud Managed Kubernetes cluster.
 lastUpdated: 2022-04-27
 ---
 

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuring kubectl on an OVHcloud Managed Kubernetes cluster
-description: Find out how to retrieve the `kubectl` configuration file to interact with an OVHcloud Managed Kubernetes cluster.
+description: Find out how to retrieve the kubectl configuration file to interact with an OVHcloud Managed Kubernetes cluster.
 lastUpdated: 2022-04-27
 ---
 

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuring kubectl on an OVHcloud Managed Kubernetes cluster
-description: Find out how to retrieve the `kubectl` configuration file to interact with an OVHcloud Managed Kubernetes cluster.
+description: Find out how to retrieve the kubectl configuration file to interact with an OVHcloud Managed Kubernetes cluster.
 lastUpdated: 2022-04-27
 ---
 

--- a/theme/components/FallbackHeading/index.scss
+++ b/theme/components/FallbackHeading/index.scss
@@ -1,0 +1,36 @@
+.rp-guide-title-block {
+  display: flex;
+  flex-direction: column;
+
+  // Keep the title flush with the top like a bare H1 would be, and remove the
+  // gap below it so the lead sits directly under the title (no blank line).
+  > h1 {
+    order: 1;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  // Lead sits flush under the title, with one blank line before the buttons.
+  .rp-guide-lead {
+    order: 2;
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    font-size: 1.125rem;
+    line-height: 1.6;
+    color: var(--rp-c-text-2);
+  }
+
+  // The LLMs action row ("Copy Markdown" / "Ask AI") moves below the lead.
+  // Drop its default bottom margin so the gap before the first content heading
+  // is driven solely by the sibling rule below (one blank line).
+  > .rp-llms-container {
+    order: 3;
+    margin-bottom: 0;
+  }
+}
+
+// First content heading right after the title block: collapse the theme's
+// large default heading top-margin down to a single blank line.
+.rp-guide-title-block + :is(h1, h2, h3, h4, h5, h6) {
+  margin-top: 1.5rem;
+}

--- a/theme/components/FallbackHeading/index.tsx
+++ b/theme/components/FallbackHeading/index.tsx
@@ -1,0 +1,42 @@
+import { useFrontmatter } from '@rspress/core/runtime';
+import { FallbackHeading as OriginalFallbackHeading } from '@rspress/core/theme-original';
+import './index.scss';
+
+interface FallbackHeadingProps {
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  title: string;
+}
+
+/**
+ * Custom FallbackHeading that renders the page title (from frontmatter, when
+ * the body has no H1) and, right below the H1, a "lead" paragraph built from
+ * the `excerpt` (or legacy `description`) frontmatter field.
+ *
+ * Rspress only uses these fields for the `<head>` meta description, never in
+ * the visible page. This override surfaces the summary on the page itself.
+ *
+ * The original H1 bundles the LLMs action row ("Copy Markdown" / "Ask AI") as
+ * a sibling `.rp-llms-container` right after the heading. We want the lead to
+ * sit between the title and that button row, so we wrap both in a flex column
+ * and reorder them with CSS (see index.scss).
+ */
+export function FallbackHeading(props: FallbackHeadingProps) {
+  const { frontmatter } = useFrontmatter();
+  const fm = frontmatter as Record<string, unknown>;
+  const lead = (fm?.excerpt ?? fm?.description) as string | undefined;
+
+  const heading = <OriginalFallbackHeading {...props} />;
+
+  // SSG markdown export (llms.txt etc.) expects a plain heading string.
+  // Also skip the wrapper for non-title headings or when there is no summary.
+  if (process.env.__SSR_MD__ || props.level !== 1 || !lead) {
+    return heading;
+  }
+
+  return (
+    <div className="rp-guide-title-block">
+      {heading}
+      <p className="rp-guide-lead">{lead}</p>
+    </div>
+  );
+}

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -10,6 +10,7 @@ import { AnalyticsBootstrap } from '@components/Analytics';
 import { AIChatbotDrawerProvider } from 'theme/components/AIChatbotDrawer/context';
 import Breadcrumbs from 'theme/components/Breadcrumbs/Breadcrumbs.tsx';
 import { EditLink } from 'theme/components/EditLink';
+import { FallbackHeading } from 'theme/components/FallbackHeading';
 import { LlmsViewOptions } from 'theme/components/LlmsViewOptions';
 import { Nav } from 'theme/components/Nav';
 import { PageFeedback } from 'theme/components/PageFeedback';
@@ -117,6 +118,7 @@ export {
   DocLayout,
   EditLink,
   ELearningLayout,
+  FallbackHeading,
   HomeLayout,
   Layout,
   LlmsViewOptions,


### PR DESCRIPTION
What
Surfaces a guide's summary on the page itself: the excerpt (or legacy description) frontmatter field is now rendered as a lead paragraph directly under the H1 title.

Why
Rspress only uses excerpt/description to populate the <meta name="description"> tag in the page <head> (SEO). Until now the summary was never visible on the rendered page — readers only saw the title, then the first section. This makes the guide's purpose visible at a glance.

How
Overrides Rspress's FallbackHeading component (theme/components/FallbackHeading/) and wires it in theme/index.tsx, following the existing override pattern (LastUpdated, Sidebar, …):

Source field: excerpt ?? description (works for both the project convention and Rspress-native frontmatter).
Layout order: title → lead → LLM action row ("Copy Markdown" / "Ask AI"), using a flex column with CSS order (the action row is otherwise bundled with the H1).
Spacing: title→lead 0 (flush), lead→buttons and buttons→first heading ≈ one blank line each.
SSG markdown export (llms.txt, etc.) is short-circuited to a plain heading.
Scope
Site-wide: applies to every guide that has an excerpt/description (the vast majority). No content changes — purely presentational.

Notes
Covers guides whose title comes from frontmatter (the standard case). Guides with an in-body # H1 use a different render path and are not affected by this change.