### PR TITLE
fix(web-hosting,file-storage): blank line before ::: closer after list

### DIFF
--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
@@ -111,6 +111,7 @@ Je nach Bedarf existieren weitere Endpunkte:
 
 - `ovh-eu` für die OVHcloud Europe API
 - `ovh-ca` für die OVHcloud America/Asia API
+
 :::
 
 

--- a/docs/de/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -109,6 +109,7 @@ Ihr neues Passwort muss folgenden **Richtlinien** entsprechen:
 - Mindestens ein Kleinbuchstabe
 - Mindestens eine Ziffer
 - Nur Ziffern und Buchstaben
+
 :::
 
 Gehen Sie dann zum Tab <code className="action">Aktuelle Tasks</code> und laden Sie die Seite ggf. neu, um den Fortschritt zu überprüfen. Die Änderung benötigt einige Minuten, bis sie wirksam ist.

--- a/docs/de/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
@@ -48,6 +48,7 @@ Im <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> können Sie die Kapaz
 - [Wie erhalte ich eine temporäre Leistungssteigerung bei meinem Performance Hosting Angebot?](#boost)
 - [Verschwende ich die verbleibende Zeit meines aktuellen Webhosting-Angebots, wenn ich das Angebot wechsle?](#billing)
 - [Kann ich mein aktuelles Angebot auf ein kleineres Angebot umstellen?](#checks)
+
 :::
 
 ### Webhosting-Angebot wechseln <a name="modify"></a>

--- a/docs/de/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -133,6 +133,7 @@ Bevor Sie den Status ändern, sollten Sie die Faktoren kennen, die die Reputatio
 - Reputation der IP-Adresse, von der der Versand stammt ([die Ihres Webhostings](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip)), mit einem Tool wie [MXtoolbox](https://mxtoolbox.com/) oder [Spamhaus](https://check.spamhaus.org/) testen.
 - Die E-Mail enthält keine Elemente, die als spam interpretiert werden könnten. Eine nicht erschöpfende Liste dieser Elemente finden Sie im Abschnitt "[Fall 3: Versand legitimer E-Mails, die als spam eingestuft werden](#elements-list-spam)" dieser Anleitung.
 - Wenn OVHcloud die E-Mail nicht blockiert und diese vom Empfänger nicht empfangen oder abgelehnt wurde, wenden Sie sich an den Empfänger, um zu überprüfen, ob die E-Mail auf dem empfangenden Server blockiert wurde.
+
 :::
 
 #### Der Zustand "Inaktiv"

--- a/docs/de/guides/web-cloud/web-hosting/sql-create-database.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/sql-create-database.mdx
@@ -120,6 +120,7 @@ Wir empfehlen außerdem diese Maßnahmen:
 - Erneuern Passwörter regelmäßig.
 - Bewahren Sie Passwörter nicht schriftlich auf und geben Sie sie nicht an andere Personen weiter (auch nicht per E-Mail).
 - Speichern Sie Passwörter nicht im Webbrowser, auch wenn dies automatisch angeboten wird.
+
 :::
 
 :::warning

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
@@ -111,6 +111,7 @@ Other endpoints exist, depending on your needs:
 
 - `ovh-eu` for OVHcloud Europe API
 - `ovh-ca` for OVHcloud America/Asia API
+
 :::
 
 

--- a/docs/en/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -113,6 +113,7 @@ Your new password must respect the following **password policy**:
 - At least one lower-case letter
 - At least one number
 - Be composed only of numbers and letters
+
 :::
 
 Then go to the <code className="action">Ongoing tasks</code> tab and refresh the page regularly. Your change will be effective within a few minutes.

--- a/docs/en/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
@@ -47,6 +47,7 @@ In your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, you can increa
 - [How do I get a temporary performance boost on my Performance hosting plan?](#boost)
 - [Will I lose the time remaining on my current hosting plan when I change plans?](#billing)
 - [Can I downgrade my current plan?](#checks)
+
 :::
 
 ### Modifying your web hosting plan <a name="modify"></a>

--- a/docs/en/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -135,6 +135,7 @@ Verify the following upstream:
 - Check the reputation of the IP address that sent the email ([here the IP of your web hosting plan](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip), using tools such as [MXtoolbox](https://mxtoolbox.com/) or [Spamhaus](https://check.spamhaus.org/).
 - The email does not contain any elements that could be interpreted as spam. You can find a non-exhaustive list of these elements in the "[Case 3: Sending legitimate emails classified as spam](#elements-list-spam)" section of this guide.
 - If there is no blockage on the OVHcloud side, and if the email has not been received or rejected by the recipient, contact the recipient to have them check if the email has been blocked on the receiving server.
+
 :::
 
 #### The "Disabled" status

--- a/docs/en/guides/web-cloud/web-hosting/sql-create-database.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/sql-create-database.mdx
@@ -124,6 +124,7 @@ We also recommend the following policies:
 - Renew your password regularly.
 - Do not keep written records of your password or send it to other people (including via email).
 - Do not save your password in your web browser, even if your browser offers to do so.
+
 :::
 
 :::warning

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
@@ -111,6 +111,7 @@ Existen otros endpoints, en función de sus necesidades:
 
 - `ovh-eu` para las API de OVHcloud Europa
 - `ovh-ca` para las API de OVHcloud América / Asia
+
 :::
 
 

--- a/docs/es/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -109,6 +109,7 @@ La nueva contraseña debe respetar la siguiente **política de contraseñas**:
 - Al menos una letra minúscula
 - Al menos una cifra
 - Estar compuesta únicamente por números y letras
+
 :::
 
 Por último, abra la pestaña <code className="action">Tareas en curso</code> y vuelva a actualizar la página periódicamente. El cambio de contraseña tarda unos minutos en aplicarse.

--- a/docs/es/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
@@ -48,6 +48,7 @@ Su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink> permite aument
 - [¿Cómo disfrutar de un aumento de rendimiento temporal en mi plan de hosting Performance?](#boost)
 - [¿Perderé el tiempo restante de mi plan de hosting actual al cambiar de plan?](#billing)
 - [¿Es posible cambiar mi plan actual a un plan inferior?](#checks)
+
 :::
 
 ### Cambiar su plan de hosting <a name="modify"></a>

--- a/docs/es/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -133,6 +133,7 @@ Compruebe lo siguiente:
 - Compruebe la reputación de la dirección IP que origina el envío ([la de su alojamiento web](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip) en su caso), utilizando una herramienta como [MXtoolbox](https://mxtoolbox.com/) o [Spamhaus](https://check.spamhaus.org/).
 - El mensaje de correo electrónico no contiene elementos que puedan ser interpretados como spam. Para más información, consulte la sección «[Caso n°3: Envío de correos electrónicos legítimos considerados spam](#elements-list-spam)» de esta guía.
 - En caso de que OVHcloud no haya bloqueado el correo electrónico y el destinatario no lo haya recibido o rechazado, póngase en contacto con el destinatario para comprobar si el mensaje se ha bloqueado en el servidor de recepción.
+
 :::
 
 #### El estado «Inactivo»

--- a/docs/es/guides/web-cloud/web-hosting/sql-create-database.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/sql-create-database.mdx
@@ -120,6 +120,7 @@ También se recomienda:
 - renovar su contraseña regularmente;
 - no conservar ningún registro escrito de su contraseña y no enviarla a otras personas (incluso a través de su dirección de correo electrónico);
 - no guardar su contraseña en su navegador de Internet, incluso si su navegador lo permite.
+
 :::
 
 :::warning

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
@@ -111,6 +111,7 @@ D'autres points de terminaison existent, en fonction de vos besoins :
 
 - `ovh-eu` pour les API OVHcloud Europe
 - `ovh-ca` pour les API OVHcloud Amérique / Asie
+
 :::
 
 

--- a/docs/fr/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -109,6 +109,7 @@ Votre nouveau mot de passe doit respecter la **politique des mots de passe** sui
 - Au moins une lettre minuscule ;
 - Au moins un chiffre ;
 - Être composé uniquement de chiffres et de lettres.
+
 :::
 
 Consultez l'onglet <code className="action">Tâches en cours</code> et rafraîchissez la page régulièrement. Le changement ne nécessite que quelques minutes pour être effectif.

--- a/docs/fr/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
@@ -48,6 +48,7 @@ Votre <ManagerLink to="/">espace client OVHcloud</ManagerLink> permet d'augmente
 - [Comment bénéficier d'un gain de performance temporaire sur mon offre d'hébergement performance ?](#boost)
 - [Vais-je perdre le temps restant sur mon offre d'hébergement actuelle lors de mon changement d'offre ?](#billing)
 - [Est-il possible de changer mon offre actuelle vers une offre inférieure ?](#checks)
+
 :::
 
 ### Modifier votre offre d'hébergement web <a name="modify"></a>

--- a/docs/fr/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -133,6 +133,7 @@ Vérifiez les points suivants en amont :
 - Vérifiez la réputation de l'adresse IP à l'origine de l'envoi ([celle de votre hébergement web](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip) dans votre cas), à l'aide d'un outil tel que [MXtoolbox](https://mxtoolbox.com/) ou [Spamhaus](https://check.spamhaus.org/).
 - L'e-mail ne contient pas d'éléments susceptibles d'être interprétés comme du spam. Retrouvez une liste non exhaustive de ces éléments dans la partie « [Cas n°3 : Envoi d'e-mails légitimes considérés comme du spam](#elements-list-spam) » de ce guide.
 - En cas d'absence de blocage du côté d'OVHcloud et si l'e-mail n'a pas été reçu ou rejeté par le destinataire, contactez le destinataire afin qu'il vérifie si l'e-mail n'a pas été bloqué au niveau du serveur de réception.
+
 :::
 
 #### L'état « Désactivé »

--- a/docs/fr/guides/web-cloud/web-hosting/sql-create-database.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/sql-create-database.mdx
@@ -120,6 +120,7 @@ Nous vous recommandons également de :
 - renouveler votre mot de passe régulièrement;
 - ne pas conserver de traces écrites de votre mot de passe et de ne pas l'envoyer à d'autres personnes (y compris par le biais de votre adresse e-mail);
 - ne pas sauvegarder votre mot de passe sur votre navigateur internet, même si votre navigateur vous le propose.
+
 :::
 
 :::warning

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
@@ -111,6 +111,7 @@ Esistono altri endpoint, in base alle tue esigenze:
 
 - `ovh-eu` per le API OVHcloud Europa
 - `ovh-ca` per le API OVHcloud America / Asia
+
 :::
 
 

--- a/docs/it/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -109,6 +109,7 @@ La nuova password dovrà rispettare la seguente **politica delle password**:
 - Almeno una lettera minuscola
 - Almeno una cifra
 - Essere composta esclusivamente da cifre e lettere
+
 :::
 
 Consulta la scheda <code className="action">Operazioni in corso</code> e aggiorna regolarmente la pagina. La modifica richiede solo pochi minuti per essere effettiva.

--- a/docs/it/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
@@ -48,6 +48,7 @@ Il tuo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> permette di aum
 - [Come usufruire di un miglioramento temporaneo delle performance sul tuo piano di hosting performance?](#boost)
 - [Perderò il tempo residuo sul mio piano di hosting attuale quando cambierò offerta?](#billing)
 - [Posso cambiare la mia offerta attuale verso un'offerta inferiore?](#checks)
+
 :::
 
 ### Modificare il piano di hosting Web <a name="modify"></a>

--- a/docs/it/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -133,6 +133,7 @@ Verifica preventivamente i seguenti punti:
 - Verifica la reputazione dell'indirizzo IP all'origine dell'invio ([quello del tuo hosting web](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip) nel tuo caso), tramite uno strumento come [MXtoolbox](https://mxtoolbox.com/) o [Spamhaus](https://check.spamhaus.org/).
 - L'email non contiene elementi suscettibili di essere interpretati come spam. Trovi un elenco non esaustivo di questi elementi nella sezione «[Caso n°3: Invio di email legittime considerate come spam](#elements-list-spam)» di questa guida.
 - In assenza di blocco da parte di OVHcloud e se l'email non è stata ricevuta o rifiutata dal destinatario, contatta il destinatario affinché verifichi se l'email non è stata bloccata a livello del server di ricezione.
+
 :::
 
 #### Lo stato «Disattivato»

--- a/docs/it/guides/web-cloud/web-hosting/sql-create-database.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/sql-create-database.mdx
@@ -120,6 +120,7 @@ Ti consigliamo inoltre di:
 - modificare regolarmente la password;
 - non conservare una traccia scritta della password e non inviarla ad altri (anche tramite il tuo indirizzo email);
 - non salvare la password sul vostro browser internet, anche se il vostro browser vi propone di farlo.
+
 :::
 
 :::warning

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
@@ -111,6 +111,7 @@ W zależności od potrzeb dostępne są inne punkty końcowe:
 
 - `ovh-eu` dla OVHcloud Europe API
 - `ovh-ca` dla OVHcloud America/Asia API
+
 :::
 
 

--- a/docs/pl/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -109,6 +109,7 @@ Nowe hasło powinno być zgodne z następującą **polityką haseł**:
 - Przynajmniej jedna mała litera
 - Przynajmniej jedna cyfra
 - Składać się wyłącznie z cyfr i liter
+
 :::
 
 Następnie przejdź do zakładki <code className="action">Zadania w toku</code> i odśwież stronę regularnie. Zmiana wymaga zaledwie kilku minut, aby stała się skuteczna.

--- a/docs/pl/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
@@ -48,6 +48,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 - [Jak skorzystać z tymczasowej wydajności hostingu Performance?](#boost)
 - [Czy tracę pozostały czas na aktualny hosting w momencie zmiany oferty?](#billing)
 - [Czy mogę zmienić moją aktualną ofertę na niższą?](#checks)
+
 :::
 
 ### Zmień ofertę hostingu <a name="modify"></a>

--- a/docs/pl/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -133,6 +133,7 @@ Wcześniej sprawdź następujące punkty:
 - Sprawdź reputację adresu IP, z którego pochodzi wysyłka ([adres IP Twojego hostingu](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip)), za pomocą narzędzia takiego jak [MXtoolbox](https://mxtoolbox.com/) lub [Spamhaus](https://check.spamhaus.org/).
 - Wiadomość e-mail nie zawiera elementów, które mogłyby być interpretowane jako spam. Niewyczerpującą listę takich elementów znajdziesz w sekcji «[Przypadek nr 3: Wysyłka legalnych wiadomości e-mail uznanych za spam](#elements-list-spam)» niniejszego przewodnika.
 - W przypadku braku blokady po stronie OVHcloud i jeśli wiadomość e-mail nie została odebrana lub odrzucona przez odbiorcę, skontaktuj się z odbiorcą, aby sprawdzić, czy wiadomość nie została zablokowana na poziomie serwera odbiorczego.
+
 :::
 
 #### Stan «Dezaktywowany»

--- a/docs/pl/guides/web-cloud/web-hosting/sql-create-database.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/sql-create-database.mdx
@@ -120,6 +120,7 @@ Zalecamy również:
 - regularnie odnawiaj hasło;
 - nie zachowuj zapisanych logów hasła i nie wysyłaj ich do innych osób (w tym za pośrednictwem Twojego konta e-mail);
 - nie zachowywać haseł w przeglądarce internetowej, nawet jeśli zostanie wyświetlona taka propozycja.
+
 :::
 
 :::warning

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-terraform.mdx
@@ -111,6 +111,7 @@ Existem outros endpoints, em função das suas necessidades:
 
 - `ovh-eu` para a API OVHcloud Europa
 - `ovh-ca` para a API OVHcloud América / Ásia
+
 :::
 
 

--- a/docs/pt/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -109,6 +109,7 @@ A sua nova palavra-passe deverá respeitar a seguinte **política das palavras-p
 - Pelo menos uma letra minúscula
 - Pelo menos um número
 - Ser composta unicamente por números e letras
+
 :::
 
 Por fim, consulte o separador <code className="action">Operações em curso</code> e atualize a página regularmente. A alteração demorará alguns minutos até ficar efetiva.

--- a/docs/pt/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
@@ -48,6 +48,7 @@ A sua <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> permite aument
 - [Como beneficiar de um ganho temporário de desempenho na minha oferta de alojamento Performance?](#boost)
 - [Vou perder o tempo restante na minha oferta de alojamento atual quando mudar para outro serviço?](#billing)
 - [É possível alterar a minha oferta atual para uma oferta inferior?](#checks)
+
 :::
 
 ### Alterar a oferta de alojamento web <a name="modify"></a>

--- a/docs/pt/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -133,6 +133,7 @@ Verifique os seguintes pontos previamente:
 - Verifique a reputação do endereço IP na origem do envio ([o do seu alojamento web](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip) no seu caso), com a ajuda de uma ferramenta como [MXtoolbox](https://mxtoolbox.com/) ou [Spamhaus](https://check.spamhaus.org/).
 - O e-mail não contém elementos suscetíveis de ser interpretados como spam. Encontre uma lista não exaustiva destes elementos na secção «[Caso n°3: Envio de e-mails legítimos considerados como spam](#elements-list-spam)» deste guia.
 - Na ausência de bloqueio do lado da OVHcloud e se o e-mail não foi recebido ou rejeitado pelo destinatário, contacte o destinatário para que este verifique se o e-mail não foi bloqueado ao nível do servidor de receção.
+
 :::
 
 #### O estado «Desativado»

--- a/docs/pt/guides/web-cloud/web-hosting/sql-create-database.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/sql-create-database.mdx
@@ -120,6 +120,7 @@ Também recomendamos que:
 - renovar a sua palavra-passe regularmente;
 - não manter registos escritos da sua palavra-passe nem enviá-la a outras pessoas (incluindo através do seu endereço de e-mail);
 - não guarde a sua palavra-passe no seu browser, mesmo que o seu browser lhe proponha fazê-lo.
+
 :::
 
 :::warning


### PR DESCRIPTION
A directive closer (:::) immediately following a list item gets absorbed into the list, so the callout never closes and expands until the next directive. Insert a blank line before the closer on all affected guides.

Fixes 5 guides across 7 locales (35 files).