### PR TITLE
docs(bare-metal): extend hardware-upgrade guide to Advance servers [SK-2673]

### DIFF
--- a/config/links.ts
+++ b/config/links.ts
@@ -13,6 +13,15 @@ export const externalLinks: LinkMap = {
     'pl': 'https://eu.api.ovh.com/',
     'pt': 'https://eu.api.ovh.com/',
   },
+  'bare-metal/advance': {
+    'fr': 'https://www.ovhcloud.com/fr/bare-metal/advance/',
+    'en': 'https://www.ovhcloud.com/en-gb/bare-metal/advance/',
+    'de': 'https://www.ovhcloud.com/de/bare-metal/advance/',
+    'es': 'https://www.ovhcloud.com/es-es/bare-metal/advance/',
+    'it': 'https://www.ovhcloud.com/it/bare-metal/advance/',
+    'pl': 'https://www.ovhcloud.com/pl/bare-metal/advance/',
+    'pt': 'https://www.ovhcloud.com/pt/bare-metal/advance/',
+  },
   'bare-metal/backup-storage': {
     'fr': 'https://www.ovhcloud.com/fr/bare-metal/backup-storage/',
     'en': 'https://www.ovhcloud.com/en-gb/bare-metal/backup-storage/',

--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -163,7 +163,7 @@
                 + [Changing the admin password on a Windows dedicated server](bare-metal-cloud/dedicated-servers/changing-admin-password-on-windows)
                 + [How to reset the Windows Administrator password with the Windows customer rescue system](bare-metal-cloud/dedicated-servers/rcw-changing-admin-password-on-windows)
                 + [How to manage Intel SGX on a dedicated server](bare-metal-cloud/dedicated-servers/sgx-enable-and-use)
-                + [Hardware upgrade on a High Grade or Scale dedicated server](bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale)
+                + [Hardware upgrade on an Advance, High Grade or Scale dedicated server](bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale)
                 + [How to assign a tag to a Bare Metal server](bare-metal-cloud/dedicated-servers/resource-tag-assign)
                 + [How to install VMware ESXi 8 on a dedicated server](bare-metal-cloud/dedicated-servers/esxi-partitioning)
             + [Storage](bare-metal-cloud-dedicated-servers-configuration-storage)

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
-title: Hardware-Upgrade auf einem Dedicated Server der Reihen High Grade oder SCALE
-description: Erfahren Sie hier, wie Sie über das OVHcloud Kundencenter ein Hardware-Upgrade für High Grade und SCALE beantragen können
-lastUpdated: 2024-01-04
+title: Hardware-Upgrade auf einem Dedicated Server der Reihen Advance, High Grade oder SCALE
+description: Erfahren Sie hier, wie Sie über das OVHcloud Kundencenter ein Hardware-Upgrade für Advance, High Grade und SCALE beantragen können
+lastUpdated: 2026-06-04
 ---
 
 :::info
@@ -17,14 +17,14 @@ Dedicated Server der Reihen High Grade und SCALE bieten Ihnen eine Skalierungsop
 **Diese Anleitung erklärt die Vorgehensweise zum Hardware-Upgrade für OVHcloud Dedicated Server der Reihen High Grade und SCALE.**
 
 :::info
-Die in dieser Anleitung beschriebenen Schritte gelten nur für unsere aktuellen Produktreihen High Grade und SCALE. Bei älteren Diensten ist die Anfrage über ein Ticket an den Kundensupport zu richten.
+Die in dieser Anleitung beschriebenen Schritte gelten nur für unsere aktuellen Produktreihen Advance, High Grade und SCALE. Bei älteren Diensten ist die Anfrage über ein Ticket an den Kundensupport zu richten.
 
 :::
 
 
 ## Voraussetzungen
 
-- Sie haben einen [High Grade Dedicated Server](https://www.ovhcloud.com/de/bare-metal/high-grade/) oder [SCALE Dedicated Server](https://www.ovhcloud.com/de/bare-metal/scale/).
+- Sie haben einen [Advance Dedicated Server](/links/bare-metal/advance), [High Grade Dedicated Server](/links/bare-metal/hg) oder [SCALE Dedicated Server](/links/bare-metal/scale).
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -95,4 +95,4 @@ Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.
  
 Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
  
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Für den Austausch mit unserer [User Community](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
-title: Hardware upgrade on a High Grade or Scale dedicated server
-description: Find out how to request a hardware upgrade on High Grade & SCALE ranges via the OVHcloud Control Panel
-lastUpdated: 2023-12-18
+title: Hardware upgrade on an Advance, High Grade or Scale dedicated server
+description: Find out how to request a hardware upgrade on Advance, High Grade & SCALE ranges via the OVHcloud Control Panel
+lastUpdated: 2026-06-04
 ---
 
 ## Objective
@@ -11,14 +11,14 @@ Our High Grade and Scale servers offer a scalable option that allows you increas
 **The purpose of this guide is to walk you through the process of requesting a hardware upgrade on OVHcloud High Grade and SCALE dedicated servers.**
 
 :::info
-The steps in this guide only apply to our new ranges (High Grade and Scale). For older ranges, the request must be made via a support ticket.
+The steps in this guide only apply to our new ranges (Advance, High Grade and Scale). For older ranges, the request must be made via a support ticket.
 
 :::
 
 
 ## Requirements
 
-- A [High Grade](https://www.ovhcloud.com/en-gb/bare-metal/high-grade/) or [SCALE](https://www.ovhcloud.com/en-gb/bare-metal/scale/) server
+- An [Advance](/links/bare-metal/advance), [High Grade](/links/bare-metal/hg) or [SCALE](/links/bare-metal/scale) server
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -85,4 +85,4 @@ If you would like to schedule an upgrade in RAM and storage during the same inte
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
-title: Actualización del hardware en un servidor dedicado High Grade o Scale
-description: Cómo solicitar la actualización del hardware para las gamas High Grade y SCALE desde el área de cliente
-lastUpdated: 2024-01-04
+title: Actualización del hardware en un servidor dedicado Advance, High Grade o Scale
+description: Cómo solicitar la actualización del hardware para las gamas Advance, High Grade y SCALE desde el área de cliente
+lastUpdated: 2026-06-04
 ---
 
 :::info
@@ -17,14 +17,14 @@ Nuestros servidores High Grade y Scale le ofrecen una opción escalable que le p
 **El objetivo de esta guía es guiarle en el proceso de solicitud de mejora del hardware en los servidores dedicados High Grade y SCALE de OVHcloud.**
 
 :::info
-Los pasos de esta guía solo se aplican a nuestras nuevas gamas (High Grade y Scale). En el caso de las gamas anteriores, la solicitud debe enviarse a través de un tíquet al servicio de atención al cliente.
+Los pasos de esta guía solo se aplican a nuestras nuevas gamas (Advance, High Grade y Scale). En el caso de las gamas anteriores, la solicitud debe enviarse a través de un tíquet al servicio de atención al cliente.
 
 :::
 
 
 ## Requisitos
 
-- Un servidor [High Grade](https://www.ovhcloud.com/es-es/bare-metal/high-grade/) o [SCALE](https://www.ovhcloud.com/es-es/bare-metal/scale/)
+- Un servidor [Advance](/links/bare-metal/advance), [High Grade](/links/bare-metal/hg) o [SCALE](/links/bare-metal/scale)
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -95,4 +95,4 @@ Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con 
  
 Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
  
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
-title: Mise à niveau du matériel sur un serveur dédié High Grade ou Scale
-description: Découvrez comment demander une mise à niveau du matériel pour les gammes High Grade et SCALE via votre espace client
-lastUpdated: 2023-12-18
+title: Mise à niveau du matériel sur un serveur dédié Advance, High Grade ou Scale
+description: Découvrez comment demander une mise à niveau du matériel pour les gammes Advance, High Grade et SCALE via votre espace client
+lastUpdated: 2026-06-04
 ---
 
 ## Objectif
@@ -11,14 +11,14 @@ Nos serveurs High Grade et Scale vous proposent une option évolutive qui vous p
 **L'objectif de ce guide est de vous guider dans le processus de demande d'upgrade du matériel sur les serveurs dédiés High Grade et SCALE OVHcloud.**
 
 :::info
-Les étapes de ce guide ne s'appliquent qu'à nos nouvelles gammes (High Grade et Scale). Pour les gammes plus anciennes, la demande doit être effectuée via un ticket auprès du support client.
+Les étapes de ce guide ne s'appliquent qu'à nos nouvelles gammes (Advance, High Grade et Scale). Pour les gammes plus anciennes, la demande doit être effectuée via un ticket auprès du support client.
 
 :::
 
 
 ## Prérequis
 
-- Un serveur [High Grade](https://www.ovhcloud.com/fr/bare-metal/high-grade/) ou [SCALE](https://www.ovhcloud.com/fr/bare-metal/scale/)
+- Un serveur [Advance](/links/bare-metal/advance), [High Grade](/links/bare-metal/hg) ou [SCALE](/links/bare-metal/scale)
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -85,4 +85,4 @@ Si vous souhaitez planifier une évolution de mémoire et de stockage lors de la
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Aggiornamento dell'hardware su un server dedicato High Grade o Scale"
-description: "Scopri come richiedere un aggiornamento dell'hardware per le gamme High Grade e SCALE dal tuo Spazio Cliente"
-lastUpdated: 2024-01-04
+title: "Aggiornamento dell'hardware su un server dedicato Advance, High Grade o Scale"
+description: "Scopri come richiedere un aggiornamento dell'hardware per le gamme Advance, High Grade e SCALE dal tuo Spazio Cliente"
+lastUpdated: 2026-06-04
 ---
 
 :::info
@@ -17,14 +17,14 @@ I nostri server High Grade e Scale offrono un'opzione di scalabilità che permet
 **Lo scopo di questa guida è di guidarti nel processo di richiesta dell'upgrade dell'hardware sui server dedicati High Grade e SCALE OVHcloud.**
 
 :::info
-Gli step di questa guida riguardano solo le nostre nuove gamme (High Grade e Scale). Per le gamme meno recenti, la richiesta deve essere effettuata tramite ticket all'assistenza clienti.
+Gli step di questa guida riguardano solo le nostre nuove gamme (Advance, High Grade e Scale). Per le gamme meno recenti, la richiesta deve essere effettuata tramite ticket all'assistenza clienti.
 
 :::
 
 
 ## Prerequisiti
 
-- Un server [High Grade](https://www.ovhcloud.com/it/bare-metal/high-grade/) o [SCALE](https://www.ovhcloud.com/it/bare-metal/scale/)
+- Un server [Advance](/links/bare-metal/advance), [High Grade](/links/bare-metal/hg) o [SCALE](/links/bare-metal/scale)
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -95,4 +95,4 @@ Per prestazioni specializzate (referenziamento, sviluppo, ecc...), contatta i [p
  
 Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre soluzioni [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
  
-Contatta la nostra Community di utenti all'indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
-title: Modernizacja sprzętu na serwerze dedykowanym High Grade lub Scale
-description: Dowiedz się, jak przeprowadzić modernizację sprzętu zarówno dla gam High Grade, jak i Scale, z poziomu Panelu klienta
-lastUpdated: 2024-01-04
+title: Modernizacja sprzętu na serwerze dedykowanym Advance, High Grade lub Scale
+description: Dowiedz się, jak przeprowadzić modernizację sprzętu dla gam Advance, High Grade i Scale, z poziomu Panelu klienta
+lastUpdated: 2026-06-04
 ---
 
 :::info
@@ -17,14 +17,14 @@ Nasze serwery High Grade i Scale oferują opcję skalowalną, która pozwala na 
 **Niniejszy przewodnik ma na celu pomóc Ci w procesie zmiany oferty sprzętu na serwerach dedykowanych High Grade i SCALE OVHcloud.**
 
 :::info
-Etapy niniejszego przewodnika dotyczą tylko naszych nowych gam (High Grade i Scale). W przypadku starszych gam zgłoszenie należy przesłać za pośrednictwem zgłoszenia do działu obsługi klienta.
+Etapy niniejszego przewodnika dotyczą tylko naszych nowych gam (Advance, High Grade i Scale). W przypadku starszych gam zgłoszenie należy przesłać za pośrednictwem zgłoszenia do działu obsługi klienta.
 
 :::
 
 
 ## Wymagania początkowe
 
-- Serwer [High Grade](https://www.ovhcloud.com/pl/bare-metal/high-grade/) lub [SCALE](https://www.ovhcloud.com/pl/bare-metal/scale/)
+- Serwer [Advance](/links/bare-metal/advance), [High Grade](/links/bare-metal/hg) lub [SCALE](/links/bare-metal/scale)
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -95,4 +95,4 @@ W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj
  
 Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](https://www.ovhcloud.com/pl/support-levels/).
  
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [społeczności naszych użytkowników](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/hardware-upgrade-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
-title: Atualização do hardware num servidor dedicado High Grade ou Scale
-description: Saiba como solicitar uma atualização de hardware para as gamas High Grade e SCALE através da Área de Cliente
-lastUpdated: 2024-01-04
+title: Atualização do hardware num servidor dedicado Advance, High Grade ou Scale
+description: Saiba como solicitar uma atualização de hardware para as gamas Advance, High Grade e SCALE através da Área de Cliente
+lastUpdated: 2026-06-04
 ---
 
 :::info
@@ -17,14 +17,14 @@ Os nossos servidores High Grade e Scale propõem-lhe uma opção escalável que 
 **O objetivo deste guia é de o orientar no processo de pedido de upgrade do hardware nos servidores dedicados High Grade e SCALE OVHcloud.**
 
 :::info
-As etapas deste guia aplicam-se apenas às nossas novas gamas (High Grade e Scale). Para as gamas mais antigas, o pedido deve ser efetuado através de um ticket junto do suporte ao cliente.
+As etapas deste guia aplicam-se apenas às nossas novas gamas (Advance, High Grade e Scale). Para as gamas mais antigas, o pedido deve ser efetuado através de um ticket junto do suporte ao cliente.
 
 :::
 
 
 ## Requisitos
 
-- Um servidor [High Grade](https://www.ovhcloud.com/pt/bare-metal/high-grade/) ou [SCALE](https://www.ovhcloud.com/pt/bare-metal/scale/)
+- Um servidor [Advance](/links/bare-metal/advance), [High Grade](/links/bare-metal/hg) ou [SCALE](/links/bare-metal/scale)
 
 {/* CP-NAV-START:baremetal-dedicated-servers */}
 ---
@@ -95,4 +95,4 @@ Para serviços especializados (referenciamento, desenvolvimento, etc), contacte 
  
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
  
-Fale com nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com a nossa [comunidade de utilizadores](/links/community).


### PR DESCRIPTION
The hardware-upgrade procedure now also applies to the Advance range, not only High Grade and Scale. Updated title, description, info callout and requirements across all 7 locales, plus the sidebar index title.

Switched the range and community links to the /links redirect method and added the bare-metal/advance slug to config/links.ts.