### PR TITLE
docs(web-cloud/domains): clarify DynHost myip parameter for IPv4/IPv6

### DIFF
--- a/docs/de/guides/web-cloud/domains/dns-dynhost.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-dynhost.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguration von dynamischen DNS-Aktualisierungen (DynHost/DynDNS) für Ihren Domainnamen
 description: Erfahren Sie hier, wie Sie einen dynamischen DNS-Eintrag (DynHost) für Ihren Domainnamen einrichten
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -210,6 +210,15 @@ https://dns.eu.ovhapis.com/nic/update?system=dyndns&hostname=$HOSTNAME&myip=$IP
 |---|---|
 |$HOSTNAME|Subdomain, die von der Aktualisierung betroffen ist|
 |$IP|Die neue IPv4- oder IPv6-Zieladresse.|
+
+:::warning
+
+Das Verhalten des Parameters `myip` hängt von der verwendeten IP-Protokollversion ab:
+
+- **IPv4**: Der Parameter `myip` ist optional. Wird er weggelassen, wird automatisch die IP-Adresse verwendet, von der der API-Aufruf ausgeht.
+- **IPv6**: Da `dns.eu.ovhapis.com` über IPv6 nicht erreichbar ist, ist der Parameter `myip` zwingend erforderlich, um die Zieladresse zu übermitteln.
+
+:::
 
 Sie können überprüfen, ob die Ziel-IP aktualisiert wurde. Klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
 

--- a/docs/en/guides/web-cloud/domains/dns-dynhost.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-dynhost.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure dynamic DNS (DynHost/DynDNS) for your domain name
 description: Find out how to configure a dynamic DNS record for your OVHcloud domain name
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -210,6 +210,15 @@ https://dns.eu.ovhapis.com/nic/update?system=dyndns&hostname=$HOSTNAME&myip=$IP
 |---|---|
 |$HOSTNAME|The subdomain you are modifying the DNS configuration for|
 |$IP|The new target IPv4 or IPv6 address|
+
+:::warning
+
+The behaviour of the `myip` parameter depends on the IP protocol version used:
+
+- **IPv4**: the `myip` parameter is optional. If it is omitted, the IP address from which the API call originates is used automatically.
+- **IPv6**: since `dns.eu.ovhapis.com` is not reachable over IPv6, the `myip` parameter is mandatory in order to pass the target address.
+
+:::
 
 You can check if the destination IP address has been updated. To do this, click on the tabs below to view each of the **3** steps.
 

--- a/docs/es/guides/web-cloud/domains/dns-dynhost.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-dynhost.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar un DNS dinámico (DynHost/DynDNS) para un dominio
 description: Descubra cómo configurar un registro DNS dinámico para un dominio de OVHcloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -210,6 +210,15 @@ https://dns.eu.ovhapis.com/nic/update?system=dyndns&hostname=$HOSTNAME&myip=$IP
 |---|---|
 |$HOSTNAME|El subdominio afectado por la actualización.|
 |$IP|La nueva dirección IPv4 o IPv6 de destino.|
+
+:::warning
+
+El comportamiento del parámetro `myip` depende de la versión del protocolo IP utilizada:
+
+- **IPv4**: el parámetro `myip` es opcional. Si se omite, se utiliza automáticamente la dirección IP desde la que se origina la llamada a la API.
+- **IPv6**: dado que no se puede acceder a `dns.eu.ovhapis.com` mediante IPv6, el parámetro `myip` es obligatorio para transmitir la dirección de destino.
+
+:::
 
 Puede comprobar si la dirección IP de destino se ha actualizado correctamente. Para ello, haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 

--- a/docs/fr/guides/web-cloud/domains/dns-dynhost.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-dynhost.mdx
@@ -1,7 +1,7 @@
 ---
 title: Paramétrer un DNS dynamique (DynHost/DynDNS) pour votre nom de domaine
 description: Découvrez comment paramétrer un enregistrement DNS dynamique pour votre nom de domaine OVHcloud
-lastUpdated: 2026-05-26
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 

--- a/docs/fr/guides/web-cloud/domains/dns-dynhost.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-dynhost.mdx
@@ -1,7 +1,7 @@
 ---
 title: Paramétrer un DNS dynamique (DynHost/DynDNS) pour votre nom de domaine
 description: Découvrez comment paramétrer un enregistrement DNS dynamique pour votre nom de domaine OVHcloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-05-26
 availableIn: [eu]
 ---
 
@@ -210,6 +210,16 @@ https://dns.eu.ovhapis.com/nic/update?system=dyndns&hostname=$HOSTNAME&myip=$IP
 |---|---|
 |$HOSTNAME|Le sous-domaine concerné par la modification.|
 |$IP|La nouvelle adresse IPv4 ou IPv6 de destination.|
+
+:::tip
+`myip` est un paramètre optionnel en IPv4, auquel cas l'IP réalisant l'appel API sera utilisé.
+
+:::
+
+:::warning
+`dns.eu.ovhapis.com` n'est pas joignable en IPv6. `myip` est donc un paramètre obligatoire.
+
+:::
 
 Vous pouvez vérifier si l'adresse IP de destination a bien été mise à jour. Pour cela, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 

--- a/docs/fr/guides/web-cloud/domains/dns-dynhost.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-dynhost.mdx
@@ -211,13 +211,12 @@ https://dns.eu.ovhapis.com/nic/update?system=dyndns&hostname=$HOSTNAME&myip=$IP
 |$HOSTNAME|Le sous-domaine concerné par la modification.|
 |$IP|La nouvelle adresse IPv4 ou IPv6 de destination.|
 
-:::tip
-`myip` est un paramètre optionnel en IPv4, auquel cas l'IP réalisant l'appel API sera utilisé.
-
-:::
-
 :::warning
-`dns.eu.ovhapis.com` n'est pas joignable en IPv6. `myip` est donc un paramètre obligatoire.
+
+Le comportement du paramètre `myip` dépend de la version du protocole IP utilisée :
+
+- **IPv4** : le paramètre `myip` est optionnel. S'il est omis, l'adresse IP à l'origine de l'appel API est automatiquement utilisée.
+- **IPv6** : l'adresse `dns.eu.ovhapis.com` n'étant pas joignable en IPv6, le paramètre `myip` est obligatoire pour transmettre l'adresse de destination.
 
 :::
 

--- a/docs/it/guides/web-cloud/domains/dns-dynhost.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-dynhost.mdx
@@ -1,7 +1,7 @@
 ---
 title: Impostare un DNS dinamico (DynHost/DynDNS) per il tuo dominio
 description: Questa guida ti mostra come configurare un record DNS dinamico per il tuo dominio OVHcloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -210,6 +210,15 @@ https://dns.eu.ovhapis.com/nic/update?system=dyndns&hostname=$HOSTNAME&myip=$IP
 |---|---|
 |$HOSTNAME|Il sottodominio interessato dalla modifica|
 |$IP|Il nuovo indirizzo IPv4 o IPv6 di destinazione|
+
+:::warning
+
+Il comportamento del parametro `myip` dipende dalla versione del protocollo IP utilizzata:
+
+- **IPv4**: il parametro `myip` è facoltativo. Se viene omesso, viene utilizzato automaticamente l'indirizzo IP da cui ha origine la chiamata API.
+- **IPv6**: poiché `dns.eu.ovhapis.com` non è raggiungibile tramite IPv6, il parametro `myip` è obbligatorio per trasmettere l'indirizzo di destinazione.
+
+:::
 
 Verifica che l'indirizzo IP di destinazione sia stato aggiornato correttamente. Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passi.
 

--- a/docs/pl/guides/web-cloud/domains/dns-dynhost.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-dynhost.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja dynamicznego DNS (DynHost/DynDNS) dla Twojej domeny
 description: Dowiedz się, jak skonfigurować dynamiczny rekord DNS dla Twojej domeny OVHcloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -210,6 +210,15 @@ https://dns.eu.ovhapis.com/nic/update?system=dyndns&hostname=$HOSTNAME&myip=$IP
 |---|---|
 |$HOSTNAME|Subdomena, której dotyczy modyfikacja.|
 |$IP|Nowy docelowy adres IPv4 lub IPv6.|
+
+:::warning
+
+Zachowanie parametru `myip` zależy od używanej wersji protokołu IP:
+
+- **IPv4**: parametr `myip` jest opcjonalny. W przypadku jego pominięcia automatycznie używany jest adres IP, z którego pochodzi wywołanie API.
+- **IPv6**: ponieważ adres `dns.eu.ovhapis.com` nie jest osiągalny przez IPv6, parametr `myip` jest obowiązkowy, aby przekazać adres docelowy.
+
+:::
 
 Możesz sprawdzić, czy docelowy adres IP został zaktualizowany. W tym celu kliknij poniższe zakładki, aby wyświetlić kolejne **3** kroki.
 

--- a/docs/pt/guides/web-cloud/domains/dns-dynhost.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-dynhost.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar um DNS dinâmico (DynHost/DynDNS) para o seu nome de domínio
 description: Saiba como configurar um registo DNS dinâmico para o seu nome de domínio OVHcloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -210,6 +210,15 @@ https://dns.eu.ovhapis.com/nic/update?system=dyndns&hostname=$HOSTNAME&myip=$IP
 |---|---|
 |$HOSTNAME|O subdomínio abrangido pela alteração.|
 |$IP|O novo endereço IPv4 ou IPv6 de destino.|
+
+:::warning
+
+O comportamento do parâmetro `myip` depende da versão do protocolo IP utilizada:
+
+- **IPv4**: o parâmetro `myip` é opcional. Se for omitido, é utilizado automaticamente o endereço IP a partir do qual a chamada à API tem origem.
+- **IPv6**: uma vez que `dns.eu.ovhapis.com` não está acessível através de IPv6, o parâmetro `myip` é obrigatório para transmitir o endereço de destino.
+
+:::
 
 Pode verificar se o endereço IP de destino foi atualizado. Para isso, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 


### PR DESCRIPTION
Supersedes #52 (rebased onto current develop to resolve the conflict). Original FR change by @moviuro, whose commits are preserved here.

FR (@moviuro, #52): :::warning callout on dns-dynhost.mdx — myip is optional for IPv4, mandatory for IPv6 (no AAAA on dns.eu.ovhapis.com).
Kept availableIn: [eu] from develop.
Translated the callout into en, de, es, it, pl, pt.
Bumped lastUpdated to 2026-06-08 on all 7 locales.