### PR TITLE
chore(telecom): standardize guides (legacy cleanup, links, structure)

### DIFF
--- a/docs/fr/guides/web-cloud/internet/internet-access/advanced-config-router-manually.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/advanced-config-router-manually.mdx
@@ -6,7 +6,8 @@ lastUpdated: 2026-02-16
 
 ## Objectif
 
-Si vous souhaitez utiliser votre équipement personnel pour gérer la connexion PPPoE sur votre offre xDSL/FTTH OVHcloud, vous devez récupérer les identifiants PPPoE associés à cet accès.<br/>
+Si vous souhaitez utiliser votre équipement personnel pour gérer la connexion PPPoE sur votre offre xDSL/FTTH OVHcloud, vous devez récupérer les identifiants PPPoE associés à cet accès.
+
 Si vous ne les connaissez pas, vous pouvez les récupérer en suivant les étapes de notre guide « [Obtenir les identifiants PPPoE](/guides/web-cloud/internet/internet-access/obtenir-id-ppp) ».
 
 **Découvrez comment configurer votre accès Internet OVHcloud sur votre propre routeur**.
@@ -30,12 +31,14 @@ Si vous ne les connaissez pas, vous pouvez les récupérer en suivant les étape
 
 ## En pratique
 
-Les identifiants PPPoE vous sont envoyés par e-mail (à l'adresse e-mail de contact de votre compte OVHcloud) lors de la livraison de votre accès.<br/>
+Les identifiants PPPoE vous sont envoyés par e-mail (à l'adresse e-mail de contact de votre compte OVHcloud) lors de la livraison de votre accès.
+
 Ces identifiants vous permettent de configurer votre modem OVHcloud (dans le cas d’une configuration manuelle en local du modem fourni par OVHcloud) ou de votre équipement personnel pour l’usage de votre accès à Internet.
 
 Si votre offre a été fournie avec un modem OVHcloud, les identifiants PPPoE vous sont envoyés par e-mail systématiquement après chaque réinitialisation du modem.
 
-Le *login* reste identique après chaque réinitialisation.<br/>
+Le *login* reste identique après chaque réinitialisation.
+
 Pour des raisons de sécurité, le *mot de passe* est systématiquement modifié après chaque réinitialisation de votre routeur OVHcloud.
 
 **Lors de la première connexion du modem OVHcloud, celui-ci est automatiquement réinitialisé. Un nouveau mot de passe PPPoE vous est alors communiqué suite à cette réinitialisation.**
@@ -47,7 +50,6 @@ Chaque routeur a une méthode de configuration différente.
 Ce guide liste les paramètres indispensables pour faire fonctionner votre connexion mais nous vous invitons à lire le manuel utilisateur de votre modem/routeur pour vérifier comment les appliquer.
 
 :::
-
 
 ### Connaître le profil de son modem
 
@@ -98,7 +100,6 @@ La différence avec le « profil A » est l'activation du VLAN 835.
 
 :::
 
-
 Ce profil s'applique aux typologies d'accès suivantes :
 
 - Accès VDSL (Cuivre) et FTTH (Fibre) en collecte Orange
@@ -123,7 +124,6 @@ La différence avec le « profil A » est l'activation du VLAN 4001.
 
 :::
 
-
 Ce profil s'applique aux typologies d'accès suivantes :
 
 - Accès FTTH (Fibre) Bouygues
@@ -146,7 +146,6 @@ La différence avec le « profil A » est l'activation du VLAN 4070.
 
 :::
 
-
 Ce profil s'applique aux typologies d'accès suivantes :
 
 - Accès FTTE (Fibre dédiée) en collecte Celan
@@ -164,4 +163,4 @@ Les paramètres à configurer sont :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/comment-activer-bridge-zyxel.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/comment-activer-bridge-zyxel.mdx
@@ -100,4 +100,4 @@ Pour revenir en mode routeur suivez le guide « [Redémarrer ou réinitialiser u
 
 Vous pouvez retrouver plus d'informations sur la configuration du modem dans le [guide utilisateur du modem Zyxel](http://files.isp.ovhcloud.com/zyxel/VMG8825-T50K_V5.13_5.50-1.pdf).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/comment-activer-envoi-mail.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/comment-activer-envoi-mail.mdx
@@ -64,4 +64,4 @@ Le changement de statut entraînera une déconnexion/reconnexion de votre accès
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/comment-activer-mes-lignes-telephoniques-offre-adsl-vdsl.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/comment-activer-mes-lignes-telephoniques-offre-adsl-vdsl.mdx
@@ -1,5 +1,6 @@
 ---
 title: Comment activer mes lignes téléphoniques ? (Offres ADSL/VDSL/FTTH)
+description: Découvrez comment activer une ou plusieurs lignes téléphoniques sur votre pack Internet ADSL, VDSL ou FTTH OVHcloud
 lastUpdated: 2025-04-28
 ---
 
@@ -64,7 +65,8 @@ Ce type d'activation nécessite que vous possédiez un téléphone analogique pe
 Vous ne pouvez activer que deux lignes sans téléphone par accès car il n'y a que deux ports analogiques disponibles sur le modem.
 
 Pour activer une ligne sans téléphone, choisissez le nombre de lignes à activer (par défaut, « 1 » est proposé).
-<br/>Sélectionnez ensuite la case <code className="action">Ligne SIP sans téléphone</code> puis cliquez sur <code className="action">Valider la commande</code> en bas de page.
+
+Sélectionnez ensuite la case <code className="action">Ligne SIP sans téléphone</code> puis cliquez sur <code className="action">Valider la commande</code> en bas de page.
 
 <img className="thumbnail" alt="activation ligne sans téléphone " src="/images/web-cloud/internet/internet-access/comment-activer-mes-lignes-telephoniques-offre-adsl-vdsl/Activation03-edit.png" loading="lazy" />
 
@@ -74,10 +76,11 @@ Cette ligne sera alors disponible dans un délai moyen d'une heure.
 
 L'activation d'une ligne avec téléphone inclut l'envoi d'un téléphone IP sous caution qu'il suffira de brancher sur le réseau de votre modem comme un simple ordinateur.
 
-Vous pouvez consulter les détails techniques de chaque téléphone sur la [page comparatif des téléphones](https://www.ovhtelecom.fr/telephonie/comparatif-des-telephones.xml).
+Vous pouvez consulter les détails techniques de chaque téléphone sur la [page comparatif des téléphones](https://www.ovhcloud.com/fr/phone/voip/telephone/).
 
 Pour activer une ligne avec téléphone, choisissez le nombre de lignes à activer (par défaut 1 est proposé).
-<br/>Sélectionnez alors la case du téléphone de votre choix. Vous devez alors choisir le type de livraison :
+
+Sélectionnez alors la case du téléphone de votre choix. Vous devez alors choisir le type de livraison :
 
 - la livraison par transporteur à 9.99€ HT se fait via la société **DHL** sous 24h ouvrées ;
 - la livraison en point relais **Mondial Relay** gratuite et sous 48h ouvrées.
@@ -104,8 +107,10 @@ Si vous avez activé une ligne sans téléphone, vous devez posséder un simple 
 
 Pour que cette ligne soit utilisable, **les conditions suivantes doivent être remplies** :
 
-Le voyant **Voice** du modem doit être allumé sur les modems Technicolor (TG788 et TG799).<br/>
-Le voyant **Phone** du modem doit être allumé sur les modems Zyxel.<br/>
+Le voyant **Voice** du modem doit être allumé sur les modems Technicolor (TG788 et TG799).
+
+Le voyant **Phone** du modem doit être allumé sur les modems Zyxel.
+
 Si ce n'est pas le cas, vérifiez que l'activation de la ligne a bien été effectuée sur l'espace client OVHcloud et patientez une heure.
 
 <img className="thumbnail" alt="voyants technicolor" src="/images/web-cloud/internet/internet-access/comment-activer-mes-lignes-telephoniques-offre-adsl-vdsl/2015-03-18-143620_120x314_scrot.png" loading="lazy" />
@@ -119,7 +124,6 @@ Sur les modems Technicolor TG788, les ports **phone** sont inversés : le port *
 
 :::
 
-
 <img className="thumbnail" alt="schéma branchement tg788" src="/images/web-cloud/internet/internet-access/comment-activer-mes-lignes-telephoniques-offre-adsl-vdsl/untitled.jpg" loading="lazy" />
 
 ### Désactiver une ligne téléphonique associée à une offre FTTH / xDSL
@@ -132,4 +136,4 @@ Si vous souhaitez diminuer le nombre de lignes incluses dans votre offre, nous v
 
 Consultez [nos guides dédiés à la configuration de vos lignes](/guides/web-cloud/phone-and-fax/voip/faq-voip).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/comment-changer-backend-acs.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/comment-changer-backend-acs.mdx
@@ -95,4 +95,4 @@ Modifiez le champ `acsBackend` afin d'appliquer le changement de backend ACS.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/comment-changer-mon-offre-xdsl.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/comment-changer-mon-offre-xdsl.mdx
@@ -6,7 +6,6 @@ lastUpdated: 2026-01-15
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-
 ## Objectif
 
 Vous pouvez faire évoluer votre offre xDSL/Fibre afin de pouvoir accéder à de nouvelles fonctionnalités et services.
@@ -17,7 +16,6 @@ Retrouvez les offres et débits disponibles à votre adresse grâce à [notre ou
 Vous souhaitez migrer vers la Fibre ? Consultez notre guide « [Fin du cuivre - Comment migrer mon offre xDSL vers la Fibre ?](/guides/web-cloud/internet/internet-access/end-of-copper-migration-ftth) ».
 
 :::
-
 
 ## Prérequis
 
@@ -39,7 +37,6 @@ Le changement d'offre n'est pas disponible sur les offres SDSL.
 
 :::
 
-
 ## En pratique
 
 ### Conservation des options
@@ -59,7 +56,6 @@ Si un [bloc IP /29](/guides/web-cloud/internet/internet-access/comment-commander
 
 :::
 
-
 ### Changer d’offre
 
 Pour changer d'offre, depuis votre <ManagerLink to="/#/telecom/pack">espace client OVHcloud</ManagerLink>, sélectionnez le *Pack* contenant l'accès à Internet concerné, puis cliquez sur <code className="action">Changer d'offre</code> dans le cadre « Informations Générales ».
@@ -68,7 +64,8 @@ Pour changer d'offre, depuis votre <ManagerLink to="/#/telecom/pack">espace clie
 
 Sur la page suivante, retrouvez les informations nécessaires pour effectuer votre choix d'offre.
 
-La première colonne du tableau récapitule votre offre actuelle (son nom, son prix et les services actifs). Les autres colonnes concernent les offres auxquelles vous pouvez souscrire, compte tenu de votre adresse actuelle.<br/>
+La première colonne du tableau récapitule votre offre actuelle (son nom, son prix et les services actifs). Les autres colonnes concernent les offres auxquelles vous pouvez souscrire, compte tenu de votre adresse actuelle.
+
 Sélectionnez les options souhaitées (lignes téléphoniques, comptes e-mail, Garantie de Temps de Rétablissement) puis cliquez sur le bouton <code className="action">Choisir cette offre</code> sous la colonne correspondant à l'offre que vous souhaitez souscrire.
 
 :::info
@@ -76,17 +73,16 @@ Si vous souhaitez conserver les lignes téléphoniques de votre offre actuelle, 
 
 :::
 
-
 <img className="thumbnail" alt="choix de l'offre" src="/images/web-cloud/internet/internet-access/comment-changer-mon-offre-xdsl/changement-offre-details.png" loading="lazy" />
 
 Selon l'offre choisie, sélectionnez les informations requises.
 
 :::tip
-La Fibre ne vous est pas proposée ? Il peut s'agir d'une divergence d'adresses dans les bases de données.<br/>
+La Fibre ne vous est pas proposée ? Il peut s'agir d'une divergence d'adresses dans les bases de données.
+
 Vérifiez votre situation en consultant notre guide « [Fin du cuivre - Comment migrer mon offre xDSL vers la Fibre ?](/guides/web-cloud/internet/internet-access/end-of-copper-migration-ftth) ».
 
 :::
-
 
 <Tabs>
   <Tab label="xDSL Pro">
@@ -107,8 +103,8 @@ Cochez les cases des services à conserver et cliquez sur <code className="actio
   </Tab>
 </Tabs>
 
+Lors de la dernière étape, une demande de confirmation apparaît afin de valider le changement d'offre.
 
-Lors de la dernière étape, une demande de confirmation apparaît afin de valider le changement d'offre.<br/>
 Lisez les contrats, cochez la case afin de les accepter puis cliquez sur le bouton <code className="action">Valider le changement d'offre</code>.
 
 Comptez un délai d'une heure pour que le changement soit effectif, sauf pour les cas particuliers suivants :
@@ -122,7 +118,6 @@ Aucune action de modification ou de suppression de votre part n'est nécessaire.
 
 :::
 
-
 En fonction de votre offre actuelle, un remplacement du modem peut s'avérer nécessaire. Cela vous sera indiqué lors du choix de votre nouvelle offre.
 
 Les nouveaux services liés à votre nouvelle offre Pro seront accessibles une fois le changement d'offre effectif. 
@@ -131,4 +126,4 @@ Les nouveaux services liés à votre nouvelle offre Pro seront accessibles une f
 
 [VoIP / Accès Internet - Déroulement d'un RMA](/guides/web-cloud/phone-and-fax/voip/deroulement-d-un-rma)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/comment-commander-et-gerer-un-bloc-ip-29.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/comment-commander-et-gerer-un-bloc-ip-29.mdx
@@ -269,4 +269,4 @@ Si vous souhaitez résilier votre bloc IP /29, suivez le cheminement décrit dan
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/comment-configurer-le-reverse-dns-de-ma-connexion.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/comment-configurer-le-reverse-dns-de-ma-connexion.mdx
@@ -227,10 +227,10 @@ Cliquez sur les onglets ci-dessous pour afficher les détails selon le type d'IP
 </Tabs>
 
 
-Dans les deux cas, nous voyons que l'adresse IP redirige bien vers le nom de domaine [ovhtelecom.fr](https://ovhtelecom.fr).
+Dans les deux cas, nous voyons que l'adresse IP redirige bien vers le nom de domaine [ovhtelecom.fr](https://www.ovhcloud.com/fr/telecom/).
 
 Votre Reverse DNS est à présent configuré.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/comment-demenager-mon-acces-xdsl.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/comment-demenager-mon-acces-xdsl.mdx
@@ -7,7 +7,8 @@ lastUpdated: 2025-10-29
 ## Objectif
 
 Déménager un accès xDSL/Fibre vous permet de recréer votre accès Internet à une adresse différente lors d'un changement de lieu de vie ou de lieu de travail, tout en conservant les services liés à votre offre.
-<br/>Il s'agit d'un service gratuit accessible depuis votre espace client OVHcloud.
+
+Il s'agit d'un service gratuit accessible depuis votre espace client OVHcloud.
 
 **Découvrez comment demander correctement puis suivre le déménagement de votre offre xDSL/Fibre.**
 
@@ -32,7 +33,6 @@ Les accès SDSL ne peuvent être déménagés.
 
 :::
 
-
 ## En pratique
 
 ### Réaliser une demande de déménagement 
@@ -42,39 +42,43 @@ Pour réaliser une demande de déménagement, depuis votre <ManagerLink to="/#/t
 <img className="thumbnail" alt="accès déménagement" src="/images/web-cloud/internet/internet-access/comment-demenager-mon-acces-xdsl/move01-edit-2022.png" loading="lazy" />
 
 Vous pourrez ensuite définir la date à laquelle votre accès (à votre adresse actuelle) sera fermé.
-<br/>Un créneau de 30 jours vous est proposé afin de déterminer cette date.
+
+Un créneau de 30 jours vous est proposé afin de déterminer cette date.
 
 #### Choix de la nouvelle adresse
 
 ##### **Si vous disposez déjà du numéro de ligne à la nouvelle adresse**
 
 Cochez la case « Testez avec le numéro de téléphone correspondant à votre nouvelle adresse. » puis renseignez ce numéro dans le champ situé en dessous.
-<br/>Cliquez ensuite sur le bouton <code className="action">Valider</code>.
+
+Cliquez ensuite sur le bouton <code className="action">Valider</code>.
 
 <img className="thumbnail" alt="accès déménagement" src="/images/web-cloud/internet/internet-access/comment-demenager-mon-acces-xdsl/move02-edit.png" loading="lazy" />
 
 Suite à cette validation, un cadre vous indiquera l'adresse associée à ce numéro. Vérifiez que celle-ci est bien votre nouvelle adresse.
-<br/>Pour valider, cliquez sur le bouton <code className="action">Choisir cette ligne</code>.
+
+Pour valider, cliquez sur le bouton <code className="action">Choisir cette ligne</code>.
 
 :::info
 Dans de rares cas, une ligne peut apparaître active et inactive en même temps. Veillez à sélectionner la ligne correspondant bien à votre future adresse.
 
 :::
 
-
 <img className="thumbnail" alt="validation adresse demenagement" src="/images/web-cloud/internet/internet-access/comment-demenager-mon-acces-xdsl/move03-edit.png" loading="lazy" />
 
 ##### **Si vous ne disposez d'aucun numéro à la nouvelle adresse**
 
 Cochez la case « Testez avec la nouvelle adresse » puis renseignez les champs requis (code postal, ville, numéro et rue).
-<br/>Cliquez ensuite sur le bouton <code className="action">Valider</code>.
+
+Cliquez ensuite sur le bouton <code className="action">Valider</code>.
 
 <img className="thumbnail" alt="demenagement par adresse" src="/images/web-cloud/internet/internet-access/comment-demenager-mon-acces-xdsl/move04-edit.png" loading="lazy" />
 
 Dans le cas où une ou plusieurs lignes inactives existent à votre future adresse, un tableau s'affichera avec les numéros de lignes disponibles à cette adresse.
 
-<br/>À l'aide des initiales des personnes rattachées à ces lignes, sélectionnez la ligne qui correspond à votre futur logement en cliquant sur le bouton <code className="action">C'est ma ligne</code>.
-<br/>Si aucun des choix proposés ne correspond, cliquez sur le bouton <code className="action">Je n'ai pas trouvé ma ligne</code>
+À l'aide des initiales des personnes rattachées à ces lignes, sélectionnez la ligne qui correspond à votre futur logement en cliquant sur le bouton <code className="action">C'est ma ligne</code>.
+
+Si aucun des choix proposés ne correspond, cliquez sur le bouton <code className="action">Je n'ai pas trouvé ma ligne</code>
 
 <img className="thumbnail" alt="choix de ligne" src="/images/web-cloud/internet/internet-access/comment-demenager-mon-acces-xdsl/move05-edit.png" loading="lazy" />
 
@@ -105,14 +109,14 @@ Cependant, si un [bloc IP /29](/guides/web-cloud/internet/internet-access/commen
 
 :::
 
-
 <img className="thumbnail" alt="Choix de l'offre" src="/images/web-cloud/internet/internet-access/comment-demenager-mon-acces-xdsl/move07-2022.png" loading="lazy" />
 
 #### Conservation des numéros
 
 Dans certains cas, vous pourrez demander à conserver le numéro présent à votre adresse actuelle ainsi que le numéro de votre futur logement.
 Pour cela, il vous suffit de cocher la case « Je souhaite conserver le numéro : 0XXXXXXXXX ».
-<br/>Si la conservation n'est pas possible, vous obtiendrez le message « Vous ne pouvez pas porter ce numéro » en dessous de cette case.
+
+Si la conservation n'est pas possible, vous obtiendrez le message « Vous ne pouvez pas porter ce numéro » en dessous de cette case.
 
 Cliquez ensuite sur le bouton <code className="action">Confirmer la sélection</code> pour passer à l'étape suivante.
 
@@ -121,16 +125,17 @@ Cliquez ensuite sur le bouton <code className="action">Confirmer la sélection</
 #### Prise de rendez-vous pour la création de l'accès à la nouvelle adresse
 
 Cette étape n'apparaît que si la création d'une nouvelle ligne est demandée à la nouvelle adresse ou lors de l'installation d'un abonnement Fibre. 
-<br/>Cette création nécessite le déplacement d'un technicien sur place. 
+
+Cette création nécessite le déplacement d'un technicien sur place.
 
 :::warning
 Votre présence sur place lors du déplacement du technicien est indispensable, celui-ci devant accéder aux parties privatives de votre logement ou de vos locaux.
 
 :::
 
-
 Renseignez le nom de la personne qui sera présente sur site pour accueillir le technicien dans le cadre prévu à cet effet.
-<br/>Choisissez sur le planning la date et l'heure du rendez-vous en cochant la case correspondante.
+
+Choisissez sur le planning la date et l'heure du rendez-vous en cochant la case correspondante.
 
 Cliquez ensuite sur le bouton <code className="action">Confirmer la sélection</code> pour valider cette étape.
 
@@ -153,7 +158,6 @@ Aucune action de modification ou de suppression de votre part n'est nécessaire.
 
 :::
 
-
 L'accès à Internet de l'ancienne adresse est maintenu jusqu'à la livraison de l'accès à Internet à la nouvelle adresse. OVHcloud interrompt l'accès à Internet à l'ancienne adresse à la fin du mois en cours, si et uniquement si l'accès à Internet à la nouvelle adresse a été livré.
 
 C'est pourquoi, pendant une période, vous disposerez d'un accès à Internet fonctionnel aux deux adresses, ceci afin de vous assurer une continuité de service pendant la transition entre vos deux locaux ou logements.
@@ -162,4 +166,4 @@ C'est pourquoi, pendant une période, vous disposerez d'un accès à Internet fo
 
 [VoIP / Accès Internet - Déroulement d'un RMA](/guides/web-cloud/phone-and-fax/voip/deroulement-d-un-rma)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/comment-gerer-ipv6.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/comment-gerer-ipv6.mdx
@@ -102,4 +102,4 @@ Même si vous avez une IPv6, votre machine et votre routeur OVHcloud continuent 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/comment-gerer-mes-adresses-e-mails.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/comment-gerer-mes-adresses-e-mails.mdx
@@ -68,4 +68,4 @@ Si vous éprouvez des difficultés lors de la configuration de votre adresse, no
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/comment-resilier-mon-acces-xdsl.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/comment-resilier-mon-acces-xdsl.mdx
@@ -14,7 +14,6 @@ Si vous souhaitez changer d'offre, consultez notre guide « [Comment changer mon
 
 :::
 
-
 ## Prérequis
 
 - Disposer d'un [accès Internet xDSL ou FTTH OVHcloud](https://www.ovhcloud.com/fr/internet/).
@@ -30,10 +29,9 @@ Si vous souhaitez changer d'offre, consultez notre guide « [Comment changer mon
 {/* CP-NAV-END:telecom-xdsl-fttx */}
 
 :::info
-La résiliation d'un [pack SIP Trunk](https://www.ovhtelecom.fr/telephonie/sip-trunk/) doit faire l'objet d'une [demande d'assistance](https://help.ovhcloud.com/csm?id=csm_get_help) via le centre d'aide OVHcloud afin que les équipes du support la mettent en place.
+La résiliation d'un [pack SIP Trunk](https://www.ovhcloud.com/fr/phone/sip-trunk/) doit faire l'objet d'une [demande d'assistance](https://help.ovhcloud.com/csm?id=csm_get_help) via le centre d'aide OVHcloud afin que les équipes du support la mettent en place.
 
 :::
-
 
 ## En pratique
 
@@ -66,7 +64,8 @@ Vous recevrez un e-mail vous confirmant la prise en compte de la demande de rés
 
 ### Annuler la résiliation
 
-Cette action n'est possible que si la demande de résiliation a été effectuée au cours du mois.<br/>
+Cette action n'est possible que si la demande de résiliation a été effectuée au cours du mois.
+
 Cette annulation peut être réalisée jusqu'à la veille de la date de résiliation.
 
 Depuis votre <ManagerLink to="/#/telecom/pack">espace client OVHcloud</ManagerLink>, sélectionnez le *Pack* contenant l'accès à Internet concerné. Dans le cadre « Informations Générales », cliquez sur le bouton <code className="action">Annuler</code> à droite de la date de résiliation.
@@ -81,4 +80,4 @@ Vous recevrez un e-mail vous confirmant la prise en compte de l'annulation de la
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/comment-reutiliser-wifi-zyxel-otb.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/comment-reutiliser-wifi-zyxel-otb.mdx
@@ -40,7 +40,6 @@ Ce guide ne concerne que les modems de marque Zyxel. Si vous possédez un modem 
 
 :::
 
-
 ### Étape 1 : désactiver la configuration à distance <a name="desactiver-configuration-distance"></a>
 
 Depuis votre <ManagerLink to="/#/telecom/pack">espace client OVHcloud</ManagerLink>, cliquez sur votre accès à Internet FTTH ou xDSL dans le cadre `Accès Internet` à droite, puis positionnez-vous sur l'onglet <code className="action">Mon modem</code>.
@@ -70,7 +69,6 @@ L'ensemble des e-mails envoyés par OVHcloud sont accessibles depuis votre espac
 
 :::
 
-
 ### Étape 3 : accéder aux options de groupe d'interfaces
 
 Une fois connecté à l'interface locale du modem, cliquez sur l'icône de menu en haut à droite, puis sur <code className="action">Interface Grouping</code> dans le menu `Network Setting`.
@@ -88,8 +86,10 @@ Donnez un nouveau nom au groupe (`OverTheBox` dans cet exemple). Sélectionnez l
 - **ETH Type - ETHWAN** : pour une connexion de type FTTH
 
 Dans la dernière partie apparaissent deux listes, `Available LAN Interfaces` et `Selected LAN Interfaces`.
-<br/>Vous devez déplacer vers la droite les interfaces que vous souhaitez ajouter au LAN de votre OverTheBox. Dans le cadre de ce guide, il vous faut déplacer vers la droite au moins un port LAN, ainsi que les réseaux WiFi présents sur le modem.
-<br/>Si vous le souhaitez, vous pouvez également déplacer les ports LAN2 et LAN3 afin qu'ils soient également présents dans le LAN de votre OverTheBox.
+
+Vous devez déplacer vers la droite les interfaces que vous souhaitez ajouter au LAN de votre OverTheBox. Dans le cadre de ce guide, il vous faut déplacer vers la droite au moins un port LAN, ainsi que les réseaux WiFi présents sur le modem.
+
+Si vous le souhaitez, vous pouvez également déplacer les ports LAN2 et LAN3 afin qu'ils soient également présents dans le LAN de votre OverTheBox.
 
 Une fois les interfaces souhaitées déplacées dans la section `Selected LAN Interfaces`, cliquez sur <code className="action">OK</code> pour valider votre choix. Le modem va alors déplacer les interfaces dans le groupe `OverTheBox`. Un délai peut être nécessaire avant que ne s'affichent les deux groupes d'interfaces `Default` et `OverTheBox`.
 
@@ -102,8 +102,10 @@ Accédez maintenant à la page <code className="action">Home Networking</code> q
 <img className="thumbnail" alt="reutiliserWiFiOTB" src="/images/web-cloud/internet/internet-access/comment-reutiliser-wifi-zyxel-otb/reutiliserWiFiOTB-step4.png" loading="lazy" />
 
 Dans la section `Interface Group` sélectionnez le groupe `OverTheBox`.
-<br/>Dans le cadre de ce guide, nous utilisons le DHCP par défaut de l'OverTheBox (192.168.100/24). La section `LAN IP Setup` n'a donc pas besoin d'être modifiée. Elle peut nécessiter une modification si vous utilisez une autre plage pour le DHCP de votre OverTheBox, ceci pour éviter les conflits.
-<br/>Une fois connecté sur le LAN de l'OverTheBox, l'interface web du modem Zyxel sera accessible via l'IP indiquée (192.168.2.1 dans le cadre de ce guide).
+
+Dans le cadre de ce guide, nous utilisons le DHCP par défaut de l'OverTheBox (192.168.100/24). La section `LAN IP Setup` n'a donc pas besoin d'être modifiée. Elle peut nécessiter une modification si vous utilisez une autre plage pour le DHCP de votre OverTheBox, ceci pour éviter les conflits.
+
+Une fois connecté sur le LAN de l'OverTheBox, l'interface web du modem Zyxel sera accessible via l'IP indiquée (192.168.2.1 dans le cadre de ce guide).
 
 Enfin, dans la partie `DHCP Server State`, cliquez sur <code className="action">Disable</code> afin de ne pas utiliser le DHCP.
 
@@ -114,7 +116,8 @@ Une fois les modifications effectuées, cliquez sur le bouton <code className="a
 Pour que le groupe `OverTheBox` configuré sur votre modem Zyxel soit inclus dans le LAN de votre boîtier OverTheBox, il faut les relier physiquement à l'aide du câble Ethernet RJ45.
 
 Branchez la première extrémité du câble dans le port LAN4 du modem Zyxel, la seconde extrémité dans le port LAN1 de votre boîtier OverTheBox.
-<br/>Vous pouvez également vous brancher sur un switch derrière votre boîtier OverTheBox, l'important est que le port LAN4 du modem Zyxel soit bien branché dans le LAN de votre OverTheBox.
+
+Vous pouvez également vous brancher sur un switch derrière votre boîtier OverTheBox, l'important est que le port LAN4 du modem Zyxel soit bien branché dans le LAN de votre OverTheBox.
 
 ### Étape 6 : tester votre nouvelle configuration
 
@@ -132,4 +135,4 @@ Pour vérifier que votre appareil utilise bien le service OverTheBox, vous pouve
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/configuration-du-modem-a-partir-de-votre-espace-client.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/configuration-du-modem-a-partir-de-votre-espace-client.mdx
@@ -228,4 +228,4 @@ Vous pouvez dans cette partie d'activer ou de désactiver des services additionn
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/connectivity-api.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/connectivity-api.mdx
@@ -857,4 +857,4 @@ La réponse sera identique à celle de l'exemple précédent.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/cycle-de-vie-des-commandes-ftte-ftto.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/cycle-de-vie-des-commandes-ftte-ftto.mdx
@@ -6,7 +6,6 @@ lastUpdated: 2025-12-19
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-
 ## Objectif
 
 L’objectif de ce guide est de fournir une vision complète et structurée du traitement des commandes FTTE et FTTO chez OVHcloud. Il décrit chaque étape du processus pour faciliter le suivi, anticiper les actions nécessaires et assurer une gestion optimale des commandes.
@@ -17,8 +16,10 @@ L’objectif de ce guide est de fournir une vision complète et structurée du t
 
 ## En pratique
 
-Une fois votre commande FTTE ou FTTO validée et payée, elle est confirmée dans les jours qui suivent. Une visite technique a ensuite lieu afin de réaliser un état des lieux et de planifier votre raccordement ou des travaux complémentaires si nécessaire.<br/>
-Suite à cela, un technicien assure la livraison et l'installation du **RAD** (équipement d'accès au service, équivalent à l'ONT sur un accès FTTH).<br/>
+Une fois votre commande FTTE ou FTTO validée et payée, elle est confirmée dans les jours qui suivent. Une visite technique a ensuite lieu afin de réaliser un état des lieux et de planifier votre raccordement ou des travaux complémentaires si nécessaire.
+
+Suite à cela, un technicien assure la livraison et l'installation du **RAD** (équipement d'accès au service, équivalent à l'ONT sur un accès FTTH).
+
 Il est possible d'utiliser la box fournie par OVHcloud ou un [routeur personnel](/guides/web-cloud/internet/internet-access/advanced-config-router-manually).
 
 La livraison de votre accès a lieu dans les jours suivant sa mise en service.
@@ -59,7 +60,8 @@ Cliquez sur votre offre pour voir les détails du délai de livraison applicable
     :::
 
     
-    Lors de la mise en service, le technicien assure le raccordement du RAD au PTO (ou au bandeau optique) grâce à une jarretière optique, connectée à la prise « NET 1 » du RAD, via un module SFP.<br/>
+Lors de la mise en service, le technicien assure le raccordement du RAD au PTO (ou au bandeau optique) grâce à une jarretière optique, connectée à la prise « NET 1 » du RAD, via un module SFP.
+
     La prise « NET 3 » du RAD est reliée à la prise « WAN » de la box OVHcloud ou d'un routeur personnel grâce à un câble Ethernet.
   </Tab>
   <Tab label="Commande FTTO">
@@ -76,11 +78,11 @@ Cliquez sur votre offre pour voir les détails du délai de livraison applicable
     :::
 
     
-    Lors de la mise en service, le technicien assure le raccordement du RAD au PTO (ou au bandeau optique) grâce à une jarretière optique, connectée à la prise « NET 1 » du RAD, via un module SFP.<br/>
+Lors de la mise en service, le technicien assure le raccordement du RAD au PTO (ou au bandeau optique) grâce à une jarretière optique, connectée à la prise « NET 1 » du RAD, via un module SFP.
+
     La prise « NET 3 » du RAD est reliée à la prise « WAN » de la box OVHcloud ou d'un routeur personnel grâce à un câble Ethernet.
   </Tab>
 </Tabs>
-
 
 :::info
 Le délai moyen de mise en service est plus élevé sur un accès FTTE, en raison de la nécessité de coordonner une intervention avec une entité tierce au niveau du PM.
@@ -88,7 +90,6 @@ Le délai moyen de mise en service est plus élevé sur un accès FTTE, en raiso
 Le délai d'une commande FTTE ou FTTO varie également en fonction de la complexité du site à raccorder.
 :::
 
-
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/end-of-copper-migration-ftth.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/end-of-copper-migration-ftth.mdx
@@ -6,11 +6,12 @@ lastUpdated: 2026-01-15
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-
 ## Objectif
 
-Le réseau téléphonique cuivre, utilisé depuis des décennies pour fournir des services de téléphonie et des connexions à Internet via des offres xDSL (ADSL/VDSL/SDSL), est progressivement remplacé par des technologies plus modernes et performantes, notamment la fibre optique.<br/>
-Cette transition offre aux utilisateurs une connectivité plus rapide et plus fiable. D'ici 2030, le réseau cuivre sera entièrement démantelé, rendant nécessaire la migration vers la fibre optique.<br/>
+Le réseau téléphonique cuivre, utilisé depuis des décennies pour fournir des services de téléphonie et des connexions à Internet via des offres xDSL (ADSL/VDSL/SDSL), est progressivement remplacé par des technologies plus modernes et performantes, notamment la fibre optique.
+
+Cette transition offre aux utilisateurs une connectivité plus rapide et plus fiable. D'ici 2030, le réseau cuivre sera entièrement démantelé, rendant nécessaire la migration vers la fibre optique.
+
 Vous retrouverez dans ce guide les étapes clés pour assurer une transition en douceur vers la fibre optique, en tenant compte des spécificités de votre situation et des offres disponibles chez OVHcloud.
 
 ### Pourquoi cette fermeture ?
@@ -19,7 +20,8 @@ Vous retrouverez dans ce guide les étapes clés pour assurer une transition en 
 - **Amélioration des performances** : la fibre optique offre un débit plus stable et plus rapide.
 - **Objectif de transition numérique** : l'ARCEP encourage le passage progressif vers des solutions plus modernes.
 
-L'arrêt progressif du cuivre implique l'extinction des offres xDSL dans certaines zones.<br/>
+L'arrêt progressif du cuivre implique l'extinction des offres xDSL dans certaines zones.
+
 Il est possible de demander une migration vers une offre fibre, sous réserve d'éligibilité.
 
 **Découvrez comment migrer votre connexion xDSL vers la fibre optique.**
@@ -56,7 +58,6 @@ Retrouvez les offres et débits disponibles à votre adresse grâce à [notre ou
 
 :::
 
-
 ### Souscrire une offre fibre OVHcloud
 
 #### Cas n°1 : La migration est proposée directement dans l'espace client
@@ -73,7 +74,6 @@ Sélectionnez les options souhaitées (lignes téléphoniques, comptes e-mail, G
 Si vous souhaitez conserver les lignes téléphoniques de votre offre actuelle, veillez à ajouter le nombre équivalent de lignes dans votre nouvelle offre.
 
 :::
-
 
 Sélectionnez les informations requises.
 
@@ -97,8 +97,8 @@ Si un [bloc IP /29](/guides/web-cloud/internet/internet-access/comment-commander
 
 :::
 
+Un délai moyen de 10 à 30 jours est nécessaire pour la réalisation de la commande de votre nouvel accès à Internet fibre.
 
-Un délai moyen de 10 à 30 jours est nécessaire pour la réalisation de la commande de votre nouvel accès à Internet fibre.<br/>
 Dans ce cas précis, nous créons en parallèle de votre *packadsl* un nouveau *packadsl* temporaire. Cela permet de conserver votre accès cuivre opérationnel et inchangé lors de la commande fibre. Ce *packadsl* temporaire sera supprimé lors de la livraison de l’accès fibre. L'accès fibre viendra remplacer votre accès cuivre dans votre *packadsl* originel.
 
 :::warning
@@ -106,14 +106,14 @@ Aucune action de modification ou de suppression de votre part n'est nécessaire.
 
 :::
 
-
 Suivant votre offre actuelle, un remplacement du modem peut s'avérer nécessaire. Cela vous sera indiqué lors du choix de votre nouvelle offre.
 
 Les nouveaux services liés à votre nouvelle offre Fibre Pro seront accessibles une fois le changement effectif.
 
 #### Cas n°2 : Aucune migration n'est proposée
 
-L'absence de la colonne `Fibre Pro` dans le tableau `Changement d'offre` **ne signifie pas nécessairement** que vous n'êtes pas éligible à la migration vers la fibre OVHcloud.<br/>
+L'absence de la colonne `Fibre Pro` dans le tableau `Changement d'offre` **ne signifie pas nécessairement** que vous n'êtes pas éligible à la migration vers la fibre OVHcloud.
+
 Cela provient généralement d'une divergence d'adresses entre les deux bases de données suivantes :
 
 - La base de données du réseau cuivre, qui contient les informations de raccordement de votre accès xDSL actuel.
@@ -129,7 +129,7 @@ Dans ce cas de figure, nous vous recommandons de suivre les étapes ci-dessous *
     
     <img className="thumbnail" alt="ARCEP - Déploiements fibre" src="/images/web-cloud/internet/internet-access/end-of-copper-migration-ftth/arcep01.png" loading="lazy" style={{ maxWidth: '600px' }} />
 
-Identifiez votre bâtiment en recherchant votre adresse. Utilisez soit la carte (zoomez dans celle-ci), soit le champ de recherche en haut à gauche.<br/>
+Identifiez votre bâtiment en recherchant votre adresse. Utilisez soit la carte (zoomez dans celle-ci), soit le champ de recherche en haut à gauche.
 
 Cliquez ensuite sur le point vert correspondant à votre bâtiment afin d'afficher ses informations.
     Prenez note de :
@@ -179,7 +179,6 @@ Si l'identifiant ne correspond pas ou si vous avez un doute, contactez le suppor
   </Tab>
 </Tabs>
 
-
 ### Si vous ne souhaitez pas migrer vers la fibre <a name="cancel"></a>
 
 Si vous ne souhaitez pas migrer vers une offre Fibre OVHcloud, votre ligne xDSL sera automatiquement résiliée lors de la fermeture du cuivre.
@@ -189,9 +188,8 @@ Cette résiliation est uniquement **technique**. Vous devez **[résilier commerc
 
 :::
 
-
 ## Aller plus loin
 
 [VoIP / Accès Internet - Déroulement d'un RMA](/guides/web-cloud/phone-and-fax/voip/deroulement-d-un-rma)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/faq.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/faq.mdx
@@ -62,7 +62,7 @@ Enfin, vous pouvez également réaliser les vérifications que vous trouverez da
 
 #### Trucs et astuces :
 
-De nombreux conseils sont également proposés par les membres de notre communauté, vous pouvez les consulter sur le site [community.ovhcloud.com](https://community.ovhcloud.com/community/fr).
+De nombreux conseils sont également proposés par les membres de notre communauté, vous pouvez les consulter sur le site [community.ovhcloud.com](/links/community).
 
 ### Pourquoi mon débit est trop faible ?
 
@@ -88,4 +88,4 @@ Nous vous invitons à [nous contacter](https://help.ovhcloud.com/csm?id=csm_get_
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/ftth-fix-access.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/ftth-fix-access.mdx
@@ -416,4 +416,4 @@ Au sein de cette nouvelle fenêtre, assurez-vous que « Obtenir une adresse IP 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/interruption-de-service.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/interruption-de-service.mdx
@@ -92,4 +92,4 @@ Dès lors, en fonction des voyants, vous avez plusieurs possibilités :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/la-desserte-interne.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/la-desserte-interne.mdx
@@ -4,15 +4,9 @@ description: Découvrez les éléments composant la desserte interne de votre li
 lastUpdated: 2018-03-26
 ---
 
-### Préambule &#123;#préambule&#125;
+## Objectif
 
 La desserte interne correspond à la prolongation de la ligne téléphonique depuis la tête France Télécom jusqu'aux parties privatives de l'abonné. Cette partie de ligne est sous la responsabilité de l'abonné ou du propriétaire des lieux.
-
-**Sommaire :**
-
-Niveau : Débutant
-
-------------------------------------------------------------------------
 
 <img className="thumbnail" alt="Schéma de la desserte interne" src="/images/web-cloud/internet/internet-access/la-desserte-interne/desserte.png" loading="lazy" />
 
@@ -24,9 +18,11 @@ Nous allons détailler ici la partie concernant le point de concentration et la 
 1. Prise gigogne et RJ11/45
 1. Module RC
 
-------------------------------------------------------------------------
+**Découvrez les différents éléments qui composent la desserte interne de votre ligne téléphonique.**
 
-### Point de concentration &#123;#point-de-concentration&#125;
+## Les éléments de la desserte interne
+
+### Point de concentration
 
 Le point de concentration, aussi dit "**PC**", est représenté par un boîtier situé soit en façade, soit sur un poteau téléphonique ou électrique. D'un côté, le boîtier est raccordé jusqu'au sous-répartiteur par des **câbles dits de distribution** et de l'autre, il raccorde les abonnés.
 
@@ -40,9 +36,7 @@ Voici un exemple de PC :
 
 <img className="thumbnail" alt="Exemple de point de concentration" src="/images/web-cloud/internet/internet-access/la-desserte-interne/IMG_20150518_200808.jpg" loading="lazy" />
 
-------------------------------------------------------------------------
-
-### Point de terminaison &#123;#point-de-terminaison&#125;
+### Point de terminaison
 
 Le point de terminaison de ligne correspond au **premier point d'accès physique** du réseau installé par Orange. Il est généralement situé chez l'abonné. Le point de terminaison permet de séparer la ligne de la boucle locale (cf. schéma) de l'habitation ou des locaux de l'abonné.
 
@@ -56,9 +50,7 @@ Ce point est matérialisé des façons suivantes :
 
 **La responsabilité en amont du point de terminaison revient à Orange.**
 
-------------------------------------------------------------------------
-
-### DTI **: Dispositif de Terminaison Intérieur** &#123;#dti-dispositif-de-terminaison-intérieur&#125;
+### DTI : Dispositif de Terminaison Intérieur
 
 Cet appareil est installé en amont de votre réseau interne. Il a l'avantage de pouvoir tester la ligne en entrée tout en isolant votre réseau.
 
@@ -72,9 +64,7 @@ Exemple de branchement d'un DTI :
 
 En aucun cas, le DTI n'est prévu pour que l'on y branche un téléphone.
 
-------------------------------------------------------------------------
-
-### Prise gigogne et RJ45/11 &#123;#prise-gigogne-et-rj4511&#125;
+### Prise gigogne et RJ45/11
 
 La prise gigogne est une prise utilisant un type de connecteur téléphonique formant un "T". Elle permet de brancher des équipements tels que : téléphone, filtre ADSL, fax, etc.
 
@@ -92,12 +82,14 @@ Présentation et explication branchement :
 
 <img className="thumbnail" alt="Prise RJ11" src="/images/web-cloud/internet/internet-access/la-desserte-interne/RJ11.png" loading="lazy" />
 
-------------------------------------------------------------------------
-
-### Module RC &#123;#module-rc&#125;
+### Module RC
 
 Le **module RC**, également appelé "**condensateur**", est un petit boîtier de la taille d'un sucre qui était installé dans les prises téléphoniques. Ce boîtier permettait à Orange de vérifier si une ligne était opérationnelle.
 
 Il existe deux versions de modules : **deux ou trois pattes**. La version trois pattes peut perturber le signal XDSL. Il est alors recommandé de le retirer. La version deux pattes n'occasionne pas de perturbation du signal DSL sauf si celui-ci a été endommagé.
 
 Le module RC peut être présent dans un boîtier de dérivation, une prise gigogne et/ou le DTI.
+
+## Aller plus loin
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/modification-du-profil-de-synchronisation.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/modification-du-profil-de-synchronisation.mdx
@@ -56,10 +56,10 @@ Suivant le SNR défini, le débit sera plus ou moins élevé et l'accès subira 
 Plus concrètement :
 
 Plus le SNR est faible, meilleur est le débit, mais moins stable est la ligne.
-<br/>Plus le SNR est élevé, moins bon est le débit, et plus stable est la ligne.
+
+Plus le SNR est élevé, moins bon est le débit, et plus stable est la ligne.
 
 :::
-
 
 Voici la correspondance des profils avec la marge au bruit :
 
@@ -90,4 +90,4 @@ Malheureusement, la modification du profil de synchronisation n'est pas disponib
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/monitoring.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/monitoring.mdx
@@ -44,7 +44,8 @@ Pour créer une notification par e-mail, cliquez sur <code className="action">Aj
 Sélectionnez « E-mail » dans le menu déroulant correspondant au type de notification.
 
 Renseignez l'adresse e-mail à notifier dans le champ `Contact à notifier en cas d'alertes`.
-<br/>Précisez, dans le champ `Fréquence d'envoi`, la fréquence d'envoi des notifications par e-mail lors d'une coupure. Si vous sélectionnez « Une fois », vous recevrez un e-mail lors de la coupure et un e-mail lors du rétablissement de l’accès à Internet concerné.
+
+Précisez, dans le champ `Fréquence d'envoi`, la fréquence d'envoi des notifications par e-mail lors d'une coupure. Si vous sélectionnez « Une fois », vous recevrez un e-mail lors de la coupure et un e-mail lors du rétablissement de l’accès à Internet concerné.
 
 Validez l'alerte via le bouton dédié, à droite de la ligne.
 
@@ -59,8 +60,10 @@ Pour créer une notification par SMS, cliquez sur <code className="action">Ajout
 Sélectionnez « SMS » dans le menu déroulant correspondant au type de notification. 
 
 Choisissez, dans le champ `Compte SMS à débiter`, le compte SMS à utiliser pour envoyer les notifications. 
-<br/>Renseignez, dans le champ `Numéro de téléphone`, le numéro de mobile à notifier, au format international (00336xxxxxxxx).
-<br/>Précisez, dans le champ `Fréquence d'envoi`, la fréquence d'envoi des notifications SMS lors d'une coupure. Si vous sélectionnez « Une fois », vous recevrez un SMS lors de la coupure et un SMS lors du rétablissement de l’accès à Internet concerné.
+
+Renseignez, dans le champ `Numéro de téléphone`, le numéro de mobile à notifier, au format international (00336xxxxxxxx).
+
+Précisez, dans le champ `Fréquence d'envoi`, la fréquence d'envoi des notifications SMS lors d'une coupure. Si vous sélectionnez « Une fois », vous recevrez un SMS lors de la coupure et un SMS lors du rétablissement de l’accès à Internet concerné.
 
 Validez l'alerte via le bouton dédié, à droite de la ligne.
 
@@ -76,4 +79,4 @@ Pour supprimer une alerte préalablement activée, cliquez sur l'icône prévue 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/obtenir-id-ppp.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/obtenir-id-ppp.mdx
@@ -6,7 +6,6 @@ lastUpdated: 2026-02-16
 
 import Api from '@components/Api';
 
-
 ## Objectif
 
 Si vous souhaitez utiliser votre équipement personnel pour gérer la connexion PPPoE sur votre offre xDSL/FTTH OVHcloud, vous devez récupérer les identifiants PPPoE associés à cet accès.
@@ -35,7 +34,8 @@ Les identifiants *Point to Point Protocol over Ethernet* (PPPoE) sont composés 
 
 ## En pratique
 
-Les identifiants PPPoE vous sont envoyés par e-mail (à l'adresse e-mail de contact de votre compte OVHcloud) pendant la livraison de votre accès.<br/>
+Les identifiants PPPoE vous sont envoyés par e-mail (à l'adresse e-mail de contact de votre compte OVHcloud) pendant la livraison de votre accès.
+
 Ces identifiants vous permettent de configurer le modem OVHcloud, dans le cas d’une configuration manuelle en local, ou un équipement personnel pour l’usage de votre accès à Internet.
 
 Si votre offre a été fournie avec un modem OVHcloud, les identifiants PPPoE vous sont envoyés par e-mail systématiquement après chaque réinitialisation du modem.
@@ -63,7 +63,6 @@ Depuis votre <ManagerLink to="/#/telecom/pack">espace client OVHcloud</ManagerLi
 Chaque utilisation de l'appel API décrit ci-dessous générera un nouveau mot de passe PPPoE. **Cela aura pour effet de couper la session de votre modem si elle est active, occasionnant une déconnexion**. N'utilisez donc cet appel API que si vous êtes certain de pouvoir reconfigurer votre équipement personnel dans la foulée.
 
 :::
-
 
 Utilisez l'appel API :
 
@@ -95,4 +94,4 @@ Vous pouvez suivre le guide « [Configurer un routeur manuellement](/guides/web-
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/overview.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/overview.mdx
@@ -1,7 +1,7 @@
 ---
 pageType: overview
 title: "Accès Internet"
-description: "Configurez et gérez votre accès Internet OVHcloud - identifiants PPPoE, paramètres de connexion, FAQ et procédures de dépannage."
+description: "Configurez et gérez votre accès Internet OVHcloud - identifiants PPPoE, paramètres de connexion, FAQ et procédures de dépannage"
 text: "Découvrez comment gérer votre accès Internet"
 essentialsTitle: "Les guides essentiels pour commencer"
 essentials:

--- a/docs/fr/guides/web-cloud/internet/internet-access/reestablish-synchronization.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/reestablish-synchronization.mdx
@@ -134,4 +134,4 @@ Le dernier test possible consiste à réinitialiser votre modem. Si besoin, repo
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/resoudre-interruption-lenteurs-navigation.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/resoudre-interruption-lenteurs-navigation.mdx
@@ -206,4 +206,4 @@ Au sein de cette nouvelle fenêtre, assurez-vous que `Obtenir une adresse IP aut
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/restart-reboot-modem.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/restart-reboot-modem.mdx
@@ -229,4 +229,4 @@ Débranchez tous les câbles de type RJ45 (les ports jaunes sur la photo ci-dess
 La box va redémarrer plusieurs fois avant d'être pleinement opérationnelle. Ce processus devrait durer au total une quinzaine de minutes.
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/verifier-lien-xdsl-sature.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/verifier-lien-xdsl-sature.mdx
@@ -102,4 +102,4 @@ Si vous constatez un bon débit lors de vos différents tests, ceci indique que 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/internet-access/verifier-stabilite-acces.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/verifier-stabilite-acces.mdx
@@ -6,7 +6,6 @@ lastUpdated: 2025-04-28
 
 import Api from '@components/Api';
 
-
 ## Objectif
 
 Les *logs radius* disponibles via les API OVHcloud permettent de vérifier la stabilité d'un accès à Internet.
@@ -36,7 +35,8 @@ Les *logs radius* disponibles via les API OVHcloud permettent de vérifier la st
 
 Lors de chaque connexion de votre routeur sur les équipements OVHcloud, une trace est systématiquement laissée à notre niveau sur les logs de l’équipement nommé **radius**. 
 
-Lors de chaque reconnexion du lien, une nouvelle trace horodatée de la connexion est créée.<br/>
+Lors de chaque reconnexion du lien, une nouvelle trace horodatée de la connexion est créée.
+
 Une reconnexion peut avoir l'une des causes suivantes :
 
 - Un redémarrage de votre modem ;
@@ -45,11 +45,11 @@ Une reconnexion peut avoir l'une des causes suivantes :
 - L'envoi manuel de [nouveaux identifiants de connexion](/guides/web-cloud/internet/internet-access/obtenir-id-ppp).
 
 :::info
-Seules les **reconnexions** font l'objet de *logs radius*. <br/>
+Seules les **reconnexions** font l'objet de *logs radius*.
+
 Une absence de traces est donc possible sur un accès n'ayant pas connu de coupure récente ou sur un accès actuellement déconnecté.
 
 :::
-
 
 La période de récupération des logs radius est de trois mois maximum.
 
@@ -99,7 +99,6 @@ Si un accès n'est plus synchronisé, il ne pourra évidemment plus s'authentifi
 
 :::
 
-
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/advanced-creer-une-interface-modem-manuellement.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/advanced-creer-une-interface-modem-manuellement.mdx
@@ -292,4 +292,4 @@ Ce guide contient de nombreuses informations vous permettant d'établir des conf
 
 **OverTheBox** étant basé sur **OpenWRT**, vous pouvez également consulter la [documentation OpenWRT](https://openwrt.org/docs/start).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/advanced-installer-limage-overthebox-sur-votre-materiel.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/advanced-installer-limage-overthebox-sur-votre-materiel.mdx
@@ -256,4 +256,4 @@ Votre matériel est maintenant opérationnel. Vous pouvez l'installer en suivant
 
 - Consultez la [FAQ OverTheBox](/guides/web-cloud/internet/overthebox/install-faq)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/config-ipv6.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/config-ipv6.mdx
@@ -165,4 +165,4 @@ Pour des prestations spécialisées (référencement, développement, etc.), con
  
 Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr/support-levels/).
  
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/config-qos.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/config-qos.mdx
@@ -199,4 +199,4 @@ Il existe quatre classes de trafic, ce qui vous permet de classer le trafic par 
 | Normal | Pour la majorité du trafic, le trafic n'a pas de priorité particulière |
 | Low Priority | Pour un trafic jugé non prioritaire |
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/config-reset.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/config-reset.mdx
@@ -122,4 +122,4 @@ Vous pouvez restaurer la configuration de votre **OverTheBox** à l'aide d'un fi
 
 Vous pouvez suivre le guide « [Installer l’image OverTheBox sur votre matériel](/guides/web-cloud/internet/overthebox/advanced-installer-limage-overthebox-sur-votre-materiel) » pour installer manuellement la dernière image du système OverTheBox.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/config-static-route.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/config-static-route.mdx
@@ -23,7 +23,7 @@ Dans notre cas, notre OverTheBox possède trois interfaces WAN :
 - Une interface **FTTH** avec comme IP de gateway `192.168.3.1`.
 - Une interface **ADSL** avec comme IP de gateway `192.168.2.1`.
 
-Pour l'exemple de ce guide, nous souhaitons que notre service de [VoIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/) accessible sur la plage d'IP `91.121.128.0/23` ne passe pas par le tunnel de notre OverTheBox mais uniquement par l'interface FTTH.
+Pour l'exemple de ce guide, nous souhaitons que notre service de [VoIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/) accessible sur la plage d'IP `91.121.128.0/23` ne passe pas par le tunnel de notre OverTheBox mais uniquement par l'interface FTTH.
 
 Nous allons donc créer une route statique pour que la plage `91.121.128.0/23` passe uniquement par notre gateway `192.168.3.1`.
 
@@ -86,4 +86,4 @@ Pour que les changements soient correctement pris en compte, vous devez redémar
 
 **OverTheBox** étant basé sur **OpenWRT**, vous pouvez également consulter la [documentation OpenWRT](https://openwrt.org/docs/start).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/config-upgrade.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/config-upgrade.mdx
@@ -147,4 +147,4 @@ Il est toutefois possible de revenir sur une version antérieure depuis l'interf
 
 Vous pouvez suivre le guide « [Installer l’image OverTheBox sur votre matériel](/guides/web-cloud/internet/overthebox/advanced-installer-limage-overthebox-sur-votre-materiel) » pour installer manuellement la dernière image du système OverTheBox.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/install-faq.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/install-faq.mdx
@@ -5,7 +5,6 @@ lastUpdated: 2025-06-05
 ---
 
 
-
 ## Objectif
 
 Retrouvez ici les questions les plus fréquemment posées sur le service [OverTheBox](https://www.ovhcloud.com/fr/internet/overthebox/).
@@ -13,42 +12,33 @@ Retrouvez ici les questions les plus fréquemment posées sur le service [OverTh
 <details>
 <summary>Où puis-je trouver des documentations techniques à propos d'OverTheBox ?</summary>
 
-
 Vous pouvez trouver des guides sur la page de documentation OverTheBox.
 
 </details>
 
-
 <details>
 <summary>Quels sont les opérateurs compatibles avec OverTheBox ?</summary>
-
 
 Vous pouvez agréger n'importe quel type de connexion (xDSL, Fibre, Câble, 3G/4G) de n'importe quel opérateur. Il est d'ailleurs intéressant d'avoir plusieurs technologies et plusieurs opérateurs afin de garantir la redondance.
 
 </details>
 
-
 <details>
 <summary>Pourquoi, sur les OverTheBox Intel et IT, n'y a-t-il qu'un port RJ45 ?</summary>
-
 
 L'OverTheBox est un équipement réseau qui se branche sur votre réseau local comme un ordinateur. Vous pouvez constituer votre réseau local en branchant les modems entre eux, en cascade ou sur un switch.
 
 </details>
 
-
 <details>
 <summary>Dois-je avoir un réseau spécifique pour utiliser OverTheBox ?</summary>
-
 
 Tous les réseaux informatiques (même les plus basiques) sont compatibles avec le système OverTheBox. Il est donc possible d'utiliser vos propres réseaux Wi-Fi (suivant votre type d'OverTheBox) ou encore vos boîtiers CPL en fonction de la qualité du réseau électrique. Il sera cependant nécessaire de modifier certains paramètres de vos Box comme l'adresse IP ou le DHCP. Ces manipulations sont expliquées dans le guide d'installation suivant : [Comment installer OverTheBox ?](/guides/web-cloud/internet/overthebox/plus-itv2-installation)
 
 </details>
 
-
 <details>
 <summary>Quel débit maximum pourrai-je avoir ?</summary>
-
 
 Le débit total (après addition de vos connexions) dépend du type d'offre à laquelle vous avez souscrit :
 
@@ -60,19 +50,15 @@ Le débit total (après addition de vos connexions) dépend du type d'offre à l
 
 </details>
 
-
 <details>
 <summary>Est-ce que mon IP publique va changer ?</summary>
-
 
 Votre adresse IP publique va en effet changer pour une IP fournie par OVHcloud qui va agréger le trafic de vos différents liens. C'est elle aussi qui va permettre d'avoir du fail-over actif afin de ne pas avoir de coupure si vous redémarrez un modem par exemple.
 
 </details>
 
-
 <details>
 <summary>Est-ce que le Wi-Fi est intégré dans la box OverTheBox ?</summary>
-
 
 Les boîtiers OverTheBox ne supportent pas le Wi-Fi.
 Pour les OverTheBox Intel et IT v1, vous pouvez sans problème utiliser le Wi-Fi de vos modems ou un point d'accès Wi-Fi dédié.
@@ -80,46 +66,36 @@ Pour l'OverTheBox Plus ou l'OverTheBox IT v2, les modems sont isolés dans leurs
 
 </details>
 
-
 <details>
 <summary>Est-il possible de choisir le data-centre hébergeant mon service d’agrégation ?</summary>
-
 
 Actuellement il n'est pas possible de choisir le data-centre pour votre service OverTheBox. Votre agrégation sera hébergée dans le data-centre de Strasbourg ou de Gravelines.
 
 </details>
 
-
 <details>
 <summary>Est-ce qu'OverTheBox peut être utilisé à l'étranger ?</summary>
-
 
 Actuellement, nous ne fournissons pas d'IP publique ou d'hébergement hors France mais il est tout à fait possible d'utiliser OverTheBox sur un réseau étranger (sous réserve de compatibilité des routeurs sur site).
 
 </details>
 
-
 <details>
 <summary>Puis-je renvoyer le matériel fourni par OVHcloud ?</summary>
-
 
 Ce matériel est garanti 2 ans. Un échange standard est donc possible en cas de défaillance technique. Aussi, vous pouvez bénéficier de 14 jours de rétractation après la souscription si vous avez choisi cette option à la commande.
 
 </details>
 
-
 <details>
 <summary>Puis-je modifier la configuration de mon réseau via OverTheBox (IP, DHCP etc.) ?</summary>
-
 
 Le système OverTheBox est l'élément central de votre réseau, il est le véritable pilote à la place de vos Box. Vous avez cependant la main complète sur la configuration de ce réseau. Une interface web vous permet de modifier par exemple votre adresse IP, le DHCP ou encore de faire des redirections de ports.
 
 </details>
 
-
 <details>
 <summary>Est-ce que l'IPv6 est supportée ?</summary>
-
 
 Oui, l'IPv6 est actuellement supportée en bêta. L'IPv6 est incluse dans les offres OverTheBox **Starter** et **Business**.
 
@@ -129,85 +105,68 @@ Si votre offre actuelle n'inclut pas l'IPv6, il est possible de changer d'offre 
 
 </details>
 
-
 <details>
 <summary>Est-il possible d'installer OverTheBox sur son propre matériel ?</summary>
-
 
 L'image installée sur le boîtier OverTheBox est open-source et nous fournissons des images précompilées prêtes à être installées, n'hésitez pas à consulter le guide suivant : [Installer l’image OverTheBox sur votre matériel](/guides/web-cloud/internet/overthebox/advanced-installer-limage-overthebox-sur-votre-materiel).
 
 </details>
 
-
 <details>
 <summary>Quel est le délai de livraison de l'OverTheBox ?</summary>
-
 
 Si vous avez commandé le matériel OVHcloud certifié compatible, il sera expédié sous 24 à 48h ouvrées par le transporteur TNT.
 
 </details>
 
-
 <details>
 <summary>Comment fonctionne la facturation d'OverTheBox ?</summary>
-
 
 Suivant l'offre souscrite, l'abonnement sera au prix mensuel de 19,99€ HT pour l'offre Starter ou 39,99€ HT pour l'offre Business. Ce montant est prélevé automatiquement via le moyen de paiement enregistré. Ce service est sans engagement de durée. Le matériel OVHcloud certifié compatible est vendu à 349,99€ HT (OverTheBox v3).
 
 </details>
 
-
 <details>
 <summary>Est-il possible de virtualiser OverTheBox ?</summary>
-
 
 Oui, il est possible de virtualiser OverTheBox. Nous ne proposons pas de support pour cet usage. Il vous faudra pour ceci, suivre la même procédure que l'installation sur un matériel personnel, depuis une machine virtuelle compatible Linux : [Installer l’image OverTheBox sur votre matériel](/guides/web-cloud/internet/overthebox/advanced-installer-limage-overthebox-sur-votre-materiel)
 
 </details>
 
-
 <details>
 <summary>Est-il possible de réinitialiser son OverTheBox ?</summary>
-
 
 Oui, c'est possible via différentes méthodes expliquées dans ce guide : [Réinitialiser la configuration d'une OverTheBox](/guides/web-cloud/internet/overthebox/config-reset)
 
 </details>
 
-
 <details>
 <summary>Pourquoi utiliser un lien 4G avec OverTheBox ?</summary>
 
-
 Grâce à un lien 4G, votre **OverTheBox** est capable de tirer parti des réseaux mobiles afin d'améliorer les performances ou la résilience de votre accès Internet.
 Un lien 4G permet une continuité de service en cas de défaillance sur votre réseau fixe (cuivre ou fibre), en utilisant un autre support technologique pour accéder à Internet.
-<br/>De plus, les débits offerts par les connexions 4G sont souvent supérieurs aux connexions cuivre. Cela permet d'améliorer significativement votre débit, en particulier le débit montant, grâce à l'agrégation permise par votre service OverTheBox.
+
+De plus, les débits offerts par les connexions 4G sont souvent supérieurs aux connexions cuivre. Cela permet d'améliorer significativement votre débit, en particulier le débit montant, grâce à l'agrégation permise par votre service OverTheBox.
 Toutefois, les liens sur les réseaux mobiles sont sujets à de plus grandes variations de latence, ce qui peut avoir un impact négatif sur certaines applications.
 
 </details>
 
-
 <details>
 <summary>La carte SIM est-elle fournie avec un matériel OTB V3 LTE ?</summary>
-
 
 Non, la carte SIM n'est pas fournie. Le boîtier est vendu équipé d'un module 4G intégré, la carte SIM ainsi que le forfait mobile associé ne sont pas inclus.
 
 </details>
 
-
 <details>
 <summary>Quel format de carte SIM dois-je utiliser avec un matériel OTB V3 LTE ?</summary>
-
 
 La carte SIM doit être au format micro (3FF).
 
 </details>
 
-
 <details>
 <summary>Quel forfait mobile utiliser pour l'utilisation d'un lien 4G avec OverTheBox ?</summary>
-
 
 Lors de l'utilisation d'un lien 4G avec l'OverTheBox, vous devez utiliser un forfait incluant des données mobiles. L'OverTheBox agissant comme routeur principal de votre réseau local, la consommation peut être importante, il faut donc plutôt prioriser une enveloppe de données supérieure à 20 Go.
 
@@ -215,28 +174,22 @@ Les forfaits mobiles avec de plus petites enveloppes de données sont compatible
 
 </details>
 
-
 <details>
 <summary>Que se passe-t-il si je dépasse le quota de data du forfait attaché à un lien 4G ?</summary>
-
 
 Les conditions de votre opérateur mobile s'appliquent, cela peut être une facturation en hors-forfait ou une simple réduction de débit. Veuillez consulter les conditions générales de vente de votre forfait pour connaître le type de limitation appliqué en cas de dépassement.
 
 </details>
 
-
 <details>
 <summary>L'OverTheBox V3 LTE supporte-t-elle le dual SIM ?</summary>
-
 
 Non, le module 4G intégré de l'OverTheBox V3 LTE ne supporte qu'une seule SIM.
 
 </details>
 
-
 <details>
 <summary>Combien de liens 4G/5G sont supportés par OverTheBox ?</summary>
-
 
 En fonction de votre modèle, entre 2 et 3 liens 4G sont supportés en plus des interfaces ethernet.
 
@@ -246,18 +199,15 @@ En fonction de votre modèle, entre 2 et 3 liens 4G sont supportés en plus des 
 
 </details>
 
-
 <details>
 <summary>Dois-je réinstaller l'OTB V3 LTE si je remplace ma carte SIM par celle d'un autre opérateur ?</summary>
-
 
 Non, il n'est pas nécessaire de réinstaller le système. Cependant, il faudra peut-être modifier la configuration de l'interface telle que l'APN ou le PIN de la carte SIM, comme indiqué dans le guide « [Comment configurer un lien 4G sur OverTheBox ?](/guides/web-cloud/internet/overthebox/plus-itv2-lte) »
 
 </details>
 
-
 ## Aller plus loin
 
 Retrouvez plus d'informations sur les offres OverTheBox sur [notre page OverTheBox](https://www.ovhcloud.com/fr/internet/overthebox/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/intel-itv1-installation.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/intel-itv1-installation.mdx
@@ -286,4 +286,4 @@ L'OverTheBox est capable d'agréger jusqu'à 4 connexions. Il faut répéter cet
 
 Pour utiliser votre **OverTheBox** sur un **switch réseau**, la configuration ne doit pas être modifiée (hormis celle de votre switch s'il est manageable). Il vous suffit de modifier les branchements et tout connecter sur le switch.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/middle-acces-a-distance.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/middle-acces-a-distance.mdx
@@ -84,4 +84,4 @@ Vous pouvez supprimer un accès à distance en cliquant sur le symbole en forme 
 
 Pour plus de détails sur l'ouverture de port afin d'accéder à un autre équipement sur votre réseau local, consultez le guide « [Comment configurer le pare-feu (firewall) sur OverTheBox ?](/guides/web-cloud/internet/overthebox/middle-redirection-de-port) ».
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/middle-configurer-votre-lan.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/middle-configurer-votre-lan.mdx
@@ -193,4 +193,4 @@ Si vous souhaitez modifier la configuration des interfaces ou le schéma réseau
 
 **OverTheBox** étant basé sur **OpenWRT**, vous pouvez également consulter la [documentation OpenWRT](https://openwrt.org/docs/start).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/middle-redirection-de-port.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/middle-redirection-de-port.mdx
@@ -130,4 +130,4 @@ Dans cet exemple, nous souhaitons configurer un serveur VPN PPTP sans passer par
 
 **OverTheBox** étant basé sur **OpenWRT**, vous pouvez également consulter la [documentation OpenWRT](https://openwrt.org/docs/start).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/offer-migration.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/offer-migration.mdx
@@ -101,6 +101,6 @@ Pour plus d'informations sur le paiement d'un bon de commande, consultez le guid
 
 ## Aller plus loin
 
-Retrouvez plus d'informations sur les offres OverTheBox sur [notre page OverTheBox](https://www.ovhtelecom.fr/overthebox/).
+Retrouvez plus d'informations sur les offres OverTheBox sur [notre page OverTheBox](https://www.ovhcloud.com/fr/internet/overthebox/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/overview.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/overview.mdx
@@ -1,7 +1,7 @@
 ---
 pageType: overview
 title: OverTheBox
-description: "Installez, configurez et exploitez OverTheBox d'OVHcloud - agrégation d'accès Internet, premiers pas, FAQ et procédures de mise en service."
+description: "Installez, configurez et exploitez OverTheBox d'OVHcloud - agrégation d'accès Internet, premiers pas, FAQ et procédures de mise en service"
 text: "Explorez les guides OverTheBox"
 essentialsTitle: "Les guides essentiels pour commencer"
 essentials:

--- a/docs/fr/guides/web-cloud/internet/overthebox/plus-itv2-installation.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/plus-itv2-installation.mdx
@@ -177,4 +177,4 @@ Les modems sont isolés dans leur propre VLAN. Le Wi-Fi des modems est donc indi
 
 Dans les autres cas de figure, il faudra utiliser un point d'accès Wi-Fi dédié. Le Wi-Fi de vos modems reste fonctionnel mais les équipements connectés ne profiteront ni de l'agrégation, ni du tunnel chiffré.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/plus-itv2-lte.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/plus-itv2-lte.mdx
@@ -6,12 +6,12 @@ lastUpdated: 2024-10-11
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-
 ## Objectif
 
 Grâce à un lien 4G, votre **OverTheBox** est capable de tirer parti des réseaux mobiles afin d'améliorer les performances ou la résilience de votre accès internet.
 Un lien 4G permet une continuité de service en cas de défaillance sur votre réseau fixe (cuivre ou fibre), en utilisant un autre support technologique pour accéder à Internet.
-<br/>De plus, les débits offerts par les connexions 4G sont souvent supérieurs aux connexions cuivre. Cela permet d'améliorer significativement votre débit, en particulier le débit montant, grâce à l'agrégation permise par votre service OverTheBox.
+
+De plus, les débits offerts par les connexions 4G sont souvent supérieurs aux connexions cuivre. Cela permet d'améliorer significativement votre débit, en particulier le débit montant, grâce à l'agrégation permise par votre service OverTheBox.
 
 ## Prérequis
 
@@ -37,7 +37,6 @@ Avant de réaliser ces manipulations, vous devez :
 
 :::
 
-
 <iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/eSX1XWrMHPY?si=_6zsyN5hkkbnC9fN" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 <Tabs>
@@ -57,7 +56,6 @@ Avant de réaliser ces manipulations, vous devez :
     <img className="thumbnail" alt="overthebox" src="/images/web-cloud/internet/overthebox/plus-itv2-lte/v3lte-step1-3-simInsert-2024.png" loading="lazy" />
   </Tab>
 </Tabs>
-
 
 Une fois la carte SIM insérée, vous devez refermer le boîtier en répétant les mêmes étapes dans l'ordre inverse et veiller à ce que toutes les vis soient utilisées, sans trop les serrer.
 
@@ -121,7 +119,6 @@ Configurez les paramètres en fonction des informations fournies par votre opér
   </Tab>
 </Tabs>
 
-
 Validez les modifications en cliquant sur le bouton <code className="action">Save & Apply</code>.
 
 <img className="thumbnail" alt="overthebox" src="/images/web-cloud/internet/overthebox/plus-itv2-lte/v3lte-step3-4-luciltesaveitf-2024.png" loading="lazy" />
@@ -130,7 +127,6 @@ Validez les modifications en cliquant sur le bouton <code className="action">Sav
 La configuration est terminée, vérifiez le bon fonctionnement de votre lien en suivant la section « [Vérifier le fonctionnement du lien 4G](#aller-plus-loin) » de ce guide.
 :::
 
-
 ### Configurer un autre modèle de boîtier OverTheBox
 
 Si votre boîtier ne possède pas de module 4G intégré, il est tout de même possible d'ajouter un lien LTE à l'aide de l'interface USB du boîtier.
@@ -138,7 +134,6 @@ Si votre boîtier ne possède pas de module 4G intégré, il est tout de même p
 :::danger
 Attention, les clés Brovî E3372-**325** sont nativement incompatibles avec OverTheBox.
 :::
-
 
 <Tabs>
   <Tab label="Huawei E3372">
@@ -177,7 +172,6 @@ Attention, les clés Brovî E3372-**325** sont nativement incompatibles avec Ove
   </Tab>
 </Tabs>
 
-
 ## Aller plus loin
 
 ### Vérifier le fonctionnement du lien 4G
@@ -189,7 +183,6 @@ Si l'interface n'est pas entourée d'un halo vert, cela signifie que le lien n'e
 - Pour les autres modèles, vérifiez le statut de la clé USB.
 
 :::
-
 
 Que vous utilisiez une **OverTheBox V3 LTE** ou une autre méthode, l'équipement fournissant la connexion 4G attribue automatiquement une IP à l'**OverTheBox**. L'interface est donc automatiquement détectée par l'**OverTheBox** sans besoin d'intervention de votre part.
 
@@ -204,15 +197,16 @@ Pour vérifier que l'interface est correctement détectée, vérifiez qu'elle es
   </Tab>
 </Tabs>
 
-
 ### Modifier le comportement de l’agrégation
 
 Les liens mobiles sont souvent associés à des quotas de données. Si vous souhaitez limiter l'utilisation du lien pour que l’agrégation se fasse seulement en cas de souci sur le lien principal, il est possible de modifier le comportement de l’agrégation. Changer le comportement est également recommandé en cas de différence importante entre le débit de l'interface 4G et celui du lien principal (par exemple dans une configuration avec un lien fibre à 1Gbps et un lien 4G à 15Mbps).
 
 Pour limiter l'utilisation du lien, vous devez activer l'option **Backup** dans le paramètre <code className="action">Multipath TCP</code> de l'interface.
 
-Depuis le menu déroulant sélectionnez <code className="action">Network</code> > <code className="action">Interfaces</code>.<br/>
-Puis sélectionnez le bouton <code className="action">Edit</code> de l'interface en 4G.<br/>
+Depuis le menu déroulant sélectionnez <code className="action">Network</code> > <code className="action">Interfaces</code>.
+
+Puis sélectionnez le bouton <code className="action">Edit</code> de l'interface en 4G.
+
 Dans l'onglet <code className="action">Advanced Settings</code>, modifiez le paramètre <code className="action">Multipath TCP</code>.
 
 Plusieurs options sont possibles :
@@ -232,4 +226,4 @@ Les options suivantes sont également possibles, mais ne sont **pas recommandée
 
 Pour plus de détails sur la configuration des interfaces, consultez le guide « [Comment configurer une interface réseau ?](/guides/web-cloud/internet/overthebox/advanced-creer-une-interface-modem-manuellement) ».
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/internet/overthebox/start-with-overthebox.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/start-with-overthebox.mdx
@@ -61,4 +61,4 @@ De nombreuses autres configurations possibles existent, plus ou moins techniques
 
 - Consultez la [FAQ OverTheBox](/guides/web-cloud/internet/overthebox/install-faq)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/activer-la-recharge-automatique-du-credit-sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/activer-la-recharge-automatique-du-credit-sms.mdx
@@ -102,4 +102,4 @@ Cliquez sur <code className="action">Envoyer</code> pour valider le transfert. C
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/api-sms-cookbook.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/api-sms-cookbook.mdx
@@ -4,6 +4,10 @@ description: "Découvrez comment utiliser les différentes combinaisons possible
 lastUpdated: 2018-03-26
 ---
 
+## Objectif
+
+**Découvrez comment utiliser les différentes combinaisons possibles avec l'API pour la plateforme SMS OVHcloud.**
+
 ## Envoi de SMS au fil de l’eau
 
 L’envoi de SMS au fil de l’eau correspond à un appel webservice pour envoyer régulièrement un à un des SMS. Pour chaque SMS à envoyer nous allons donc réaliser un appel Webservice en POST à la méthode [/sms/&#123;serviceName&#125;/jobs](https://eu.api.ovh.com/console/#/sms/&#123;serviceName&#125;/jobs#POST)
@@ -99,4 +103,4 @@ Ce mécanisme est très intéressant pour gérer plusieurs comptes SMS de façon
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d’utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/envoi-de-sms-aux-etats-unis.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/envoi-de-sms-aux-etats-unis.mdx
@@ -112,4 +112,4 @@ Vous pouvez consulter les autres codes de retour possibles sur le guide « [Tout
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/faq-sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/faq-sms.mdx
@@ -650,4 +650,4 @@ Avant de lancer une campagne internationale, vérifiez la tarification et la dis
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/liste-de-destinataire-sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/liste-de-destinataire-sms.mdx
@@ -1,6 +1,6 @@
 ---
 title: Liste de destinataires SMS
-description: "Découvrez comment créer une liste de destinataires SMS et l'importer dans votre espace client OVHcloud."
+description: "Découvrez comment créer une liste de destinataires SMS et l'importer dans votre espace client OVHcloud"
 lastUpdated: 2022-08-05
 ---
 
@@ -100,4 +100,4 @@ Maintenant que votre liste est importée, vous pouvez suivre les instructions de
 
 [Gérer mes carnets d’adresses SMS](/guides/web-cloud/messaging/sms/sms-address-books)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/ma-premiere-campagne-sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/ma-premiere-campagne-sms.mdx
@@ -91,5 +91,5 @@ Il ne vous reste plus qu'à cliquer sur le bouton <code className="action">Envoi
 
 Consultez [notre guide dédié à la gestion de l'historique des SMS](/guides/web-cloud/messaging/sms/sms-history).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/docs/fr/guides/web-cloud/messaging/sms/overview.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/overview.mdx
@@ -1,7 +1,7 @@
 ---
 pageType: overview
 title: SMS
-description: "Envoyez des SMS et gérez vos campagnes SMS avec OVHcloud - comptes, destinataires, double authentification et intégration via l'API."
+description: "Envoyez des SMS et gérez vos campagnes SMS avec OVHcloud - comptes, destinataires, double authentification et intégration via l'API"
 text: "Découvrez les guides SMS"
 essentialsTitle: "Les guides essentiels pour commencer"
 essentials:

--- a/docs/fr/guides/web-cloud/messaging/sms/send-sms-api-java.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/send-sms-api-java.mdx
@@ -327,4 +327,4 @@ Exemple : en encodage 7bits, si votre message fait plus de 149 caractères, il s
 
 La console d'API ([https://api.ovh.com/console/#/sms](https://api.ovh.com/console/#/sms)) vous permettra de découvrir d'autres méthodes pour faciliter l'intégration de services SMS tels que : SMS permettant la réponse (uniquement pour les comptes OVHcloud en France), envoi en masse avec fichier CSV, publipostage, suivi des accusés de réception...
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/send-sms-api-nodejs.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/send-sms-api-nodejs.mdx
@@ -118,5 +118,5 @@ Exemple : en encodage 7bits, si votre message fait plus de 149 caractères, il s
 
 La console d'API ([https://api.ovh.com/console/#/sms](https://api.ovh.com/console/#/sms)) vous permettra de découvrir d'autres méthodes pour faciliter l'intégration de services SMS tels que : SMS permettant la réponse (uniquement pour les comptes OVHcloud en France), envoi en masse avec fichier CSV, publipostage, suivi des accusés de réception...
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/docs/fr/guides/web-cloud/messaging/sms/send-sms-api-php.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/send-sms-api-php.mdx
@@ -213,5 +213,5 @@ Exemple : en encodage 7bits, si votre message fait plus de 149 caractères, il s
 
 La console d'API ([https://api.ovh.com/console/#/sms](https://api.ovh.com/console/#/sms)) vous permettra de découvrir d'autres méthodes pour faciliter l'intégration de services SMS tels que : SMS permettant la réponse (uniquement pour les comptes OVHcloud en France), envoi en masse avec fichier CSV, publipostage, suivi des accusés de réception...
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/docs/fr/guides/web-cloud/messaging/sms/send-sms-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/send-sms-control-panel.mdx
@@ -117,4 +117,4 @@ Trois formats d’envoi (Standard / Flash / Sim) sont proposés (2) mais cette f
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/send-sms-email.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/send-sms-email.mdx
@@ -172,4 +172,4 @@ L’utilisation de caractères ne figurant pas dans ces tableaux provoquera le b
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/send-sms-http2sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/send-sms-http2sms.mdx
@@ -41,7 +41,8 @@ Les paramètres suivants doivent être séparés par le caractère `&`. Remplace
 |to|Numéro de téléphone du destinataire du message au **format international** (00336xxxx pour un numéro français). Il est possible d'ajouter des destinataires à la suite, séparés par une virgule ",".|
 |message|Votre message. Ajouter %0d pour insérer un saut de ligne dans le SMS envoyé|
 
-Par défaut, le message est envoyé immédiatement.<br/>
+Par défaut, le message est envoyé immédiatement.
+
 Votre navigateur vous affichera les informations suivantes :
 
 - statut de l'envoi
@@ -98,7 +99,6 @@ Remplacez les X par les informations ci-dessous :
 
 *classe 3 :* Le message est transféré sur un équipement externe connecté au mobile (PDA, PC portable…).
 :::
-
 
 :::info
 **Détail des possibilités pour le *smsCoding***
@@ -180,9 +180,12 @@ Lors d'un échec, la cause est inscrite :
 <title>HTTP2SMS</title>
 </HEAD>
 <BODY>
-OK<br/>
-1987<br/>
-10867690<br/>
+OK
+
+1987
+
+10867690
+
 </BODY>
 </HTML>
 ```
@@ -197,7 +200,10 @@ OK<br/>
 <title>HTTP2SMS</title>
 </HEAD>
 <BODY>
-KO<br/>Missing message. For more informations : https://help.ovhcloud.com/csm/fr-sms-sending-via-url-http2sms?id=kb_article_view&sysparm_article=KB0051397<br/>
+KO
+
+Missing message. For more informations : https://help.ovhcloud.com/csm/fr-sms-sending-via-url-http2sms?id=kb_article_view&sysparm_article=KB0051397
+
 </BODY>
 </HTML>
 ```
@@ -231,4 +237,4 @@ L’utilisation de caractères ne figurant pas dans ces tableaux provoquera le b
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/sending-via-api-c.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sending-via-api-c.mdx
@@ -260,4 +260,4 @@ Vous pouvez désactiver le STOP via le paramètre `noStopClause`. A noter qu'ave
 
 La console d'API vous permettra de découvrir d'autres méthodes ([https://api.ovh.com/console/#/sms](https://api.ovh.com/console/#/sms)) pour faciliter l'intégration de services tels que : SMS réponses, envoi en masse avec fichier CSV, publipostage, suivi des accusés de réception...
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/smpp-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/smpp-control-panel.mdx
@@ -71,4 +71,4 @@ Consultez [notre guide dédié à la gestion de l'historique des SMS](/guides/we
 
 [Les spécifications techniques de l'offre SMPP OVHcloud](/guides/web-cloud/messaging/sms/smpp-specification).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/smpp-specification.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/smpp-specification.mdx
@@ -46,8 +46,8 @@ Le SMPP (Short Message Peer-to-Peer) est un protocole permettant d’échanger d
 Retrouvez des informations complémentaires sur les moyens de communication au chapitre [Liste des PDUs](#pdu-list).
 :::
 
+Une fois la connexion établie entre le ESME et un SMSC OVHcloud, l'émission et/ou la réception d’un message peuvent être effectuées.
 
-Une fois la connexion établie entre le ESME et un SMSC OVHcloud, l'émission et/ou la réception d’un message peuvent être effectuées.<br/>
 L’authentification de la connexion au SMSC se fait avec le `system_id` (identifiant), le `password` et l’`adresse IP` de votre application.
 
 L’offre SMPP OVHcloud permet :
@@ -70,13 +70,16 @@ Numéro virtuel* : canal transactionnel uniquement
 
 #### Bind Request
 
-Un ESME peut se connecter dans l'un des trois modes suivants : Transmitter, Receiver, Transceiver.<br/>
+Un ESME peut se connecter dans l'un des trois modes suivants : Transmitter, Receiver, Transceiver.
+
 Ces demandes de connexion sont prises en charge conformément à la spécification du protocole SMPP v3.4.
 
 #### Bind Response
 
-Lors du processus de connexion, le ESME fait une requête de Bind en fournissant le `system_id` (identifiant) et son `mot de passe`.<br/>
-Ces informations, ainsi que l'`IP` de votre application, sont utilisées pour authentifier la demande de connexion.<br/>
+Lors du processus de connexion, le ESME fait une requête de Bind en fournissant le `system_id` (identifiant) et son `mot de passe`.
+
+Ces informations, ainsi que l'`IP` de votre application, sont utilisées pour authentifier la demande de connexion.
+
 Une réponse est ensuite envoyée par le SMSC avec un statut définissant le succès ou non de l'authentification.
 
 #### Liste des PDUs <a name="pdu-list"></a>
@@ -177,7 +180,8 @@ Le `submit_sm` est utilisé par un ESME pour soumettre un SMS au SMSC pour trans
 | its_session_info      | 5.3.2.43 | Non |
 | ussd_service_op       | 5.3.2.44 | Non |
 
-Le `submit_sm_resp` est la confirmation de la bonne réception du submit_sm par le SMSC.<br/>
+Le `submit_sm_resp` est la confirmation de la bonne réception du submit_sm par le SMSC.
+
 Il contient un `message_id` qui est l'identifiant du message du SMSC permettant de faire le lien avec l'accusé de réception (DLR) envoyé plus tard lorsque le mobile a reçu le SMS (sous réserve que la demande d'un DLR ait été spécifiée dans le `submit_sm`).
 
 ##### **deliver_sm et deliver_sm_resp**
@@ -381,4 +385,4 @@ La version du protocole est le 3.4.
 
 [Gestion d'un compte SMS SMPP](/guides/web-cloud/messaging/sms/smpp-control-panel)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/sms-address-books.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sms-address-books.mdx
@@ -110,4 +110,4 @@ Pour éditer ou supprimer un contact, cliquez, dans la colonne « Actions », su
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/sms-history.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sms-history.mdx
@@ -89,4 +89,4 @@ Vous trouverez plus de détails sur les codes ptt et les différents ID du DLR e
  
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/sms-hlr.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sms-hlr.mdx
@@ -107,4 +107,4 @@ Le fichier nettoyé remplacera l'ancien qui sera sauvegardé et accessible. Vous
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/sms-senders.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sms-senders.mdx
@@ -91,4 +91,4 @@ Si vous disposez déjà d'un compte SMS, la création d'un numéro mobile virtue
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/sms-users.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sms-users.mdx
@@ -170,4 +170,4 @@ Vous retrouverez dans le tableau ci-dessous une liste **non-exhaustive** des cod
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/sms-with-reply.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sms-with-reply.mdx
@@ -19,7 +19,6 @@ L'expéditeur du SMS réponse sera un numéro court aléatoire. Son utilisation 
 
 :::
 
-
 ## Prérequis
 
 - Disposer d'un compte SMS OVHcloud crédité.
@@ -41,7 +40,8 @@ L'expéditeur du SMS réponse sera un numéro court aléatoire. Son utilisation 
 
 ### Principe de fonctionnement et limitations
 
-Les réponses sont possibles depuis les opérateurs mobiles français (Bouygues Telecom, Free, Orange, SFR et opérateurs virtuels (MNVO) associés).<br/>
+Les réponses sont possibles depuis les opérateurs mobiles français (Bouygues Telecom, Free, Orange, SFR et opérateurs virtuels (MNVO) associés).
+
 Cela signifie que seuls les numéros géolocalisés en France métropolitaine et associés à un abonnement chez un de ces opérateurs utilisent des SMS compatibles et verront leurs réponses traitées.
 
 Les destinataires ne peuvent répondre à votre SMS que lorsque vous utilisez le [numéro virtuel](https://www.ovhcloud.com/fr/sms/virtual-numbers) ou le numéro court lors de l’envoi. Ce dernier, à 5 chiffres, est attribué aléatoirement et est spécifique à la conversation. Il ne pourra donc pas être conservé.
@@ -84,7 +84,6 @@ Si vous choisissez de répondre par SMS, le numéro court effectuant l'envoi pou
 
 :::
 
-
 #### Notification à la réception
 
 :::warning
@@ -95,7 +94,6 @@ Ce service de notification doit être réservé à votre propre usage.
 En effet, les notifications contiennent des informations relatives au destinataire de votre SMS ainsi que des données de votre compte OVHcloud (nom du compte SMS contenant votre identifiant OVHcloud).
 
 :::
-
 
 Cliquez sur <code className="action">Ajouter une notification</code> pour accéder au menu suivant.
 
@@ -133,4 +131,4 @@ Un tableau liste tous les SMS reçus en réponse de vos envois. Vous pouvez trie
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/time-2-chat.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/time-2-chat.mdx
@@ -124,4 +124,4 @@ Dès que le client répond, la **session de 24 heures** démarre. Tous les écha
 
 [Gérer l’historique des SMS](/guides/web-cloud/messaging/sms/sms-history)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/3cx-public-cloud-automatic-deployment.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/3cx-public-cloud-automatic-deployment.mdx
@@ -1,11 +1,10 @@
 ---
 title: "Déployer automatiquement l'IPBX 3CX sur l'offre Public Cloud OVHcloud"
-description: Découvrez comment vous pouvez déployer automatiquement votre IPBX 3CX sur une instance Public Cloud via un template XML.
+description: Découvrez comment vous pouvez déployer automatiquement votre IPBX 3CX sur une instance Public Cloud via un template XML
 lastUpdated: 2023-07-28
 ---
 
 import Api from '@components/Api';
-
 
 ## Objectif
 
@@ -40,10 +39,10 @@ Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur
 
 :::
 
-
 Nous allons utiliser un template au format XML afin de pouvoir configurer automatiquement l'instance 3CX. 
 
-Ce fichier XML peut être très simple, pour simplement installer 3CX et votre licence.<br/>
+Ce fichier XML peut être très simple, pour simplement installer 3CX et votre licence.
+
 Il peut aussi être très complet pour vous permettre non seulement d'installer la licence mais aussi de créer vos utilisateurs, vos trunks et les autres fonctions de 3CX.
 
 Dans ce guide, nous allons utiliser un template XML très simple. Pour un template plus complet, nous vous invitons à consulter la [documentation de 3CX](https://www.3cx.com/docs/configure-pbx-automatically/).
@@ -60,7 +59,6 @@ Le fichier XML est inclus dans le template que nous allons joindre à l'instance
 <details>
 
 <summary>Voici le fichier à utiliser pour suivre ce guide :</summary>
-
 
 ```xml
 #!/bin/bash -e
@@ -590,7 +588,6 @@ apt-get -y install 3cxpbx
 
 </details>
 
-
 Dans ce template, il y a deux éléments à modifier pour un premier test de déploiement :
 
 - Remplacez `YourLicenseKey` par votre clé de licence 3CX.
@@ -658,7 +655,6 @@ Il est également possible de déployer votre instance via API, en utilisant l'a
 
 <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/instance"} />
 
-
 - Exemple avec une flavor D2-4, Debian 10 et la facturation à l'heure :
 
 ```bash
@@ -685,4 +681,4 @@ Pour des prestations spécialisées (référencement, développement, etc.), con
 
 Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr/support-levels/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/activer-desactiver-fonctions.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/activer-desactiver-fonctions.mdx
@@ -57,5 +57,5 @@ Le code PIN par défaut pour le blocage du téléphone est 0000, il peut être m
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/adaptateur-spa112.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/adaptateur-spa112.mdx
@@ -4,9 +4,13 @@ description: "Découvrez les caractéristiques techniques, la configuration requ
 lastUpdated: 2018-03-26
 ---
 
-[<img className="thumbnail" alt="Cisco SPA112" src="/images/web-cloud/phone-and-fax/voip/adaptateur-spa112/spa112-main.jpg" loading="lazy" />](https://www.ovhtelecom.fr/telephonie/telephones/cisco_spa112/)
+## Objectif
 
-## Fiche technique : &#123;#fiche-technique&#125;
+**Découvrez les caractéristiques techniques et les points forts de l'adaptateur Cisco SPA112 pour la téléphonie sur IP.**
+
+[<img className="thumbnail" alt="Cisco SPA112" src="/images/web-cloud/phone-and-fax/voip/adaptateur-spa112/spa112-main.jpg" loading="lazy" />](https://www.ovhcloud.com/fr/phone/voip/telephone/)
+
+## Fiche technique
 
 **Description :**
 
@@ -46,4 +50,4 @@ L'adaptateur Cisco SPA 112 permet l'accès à un service de téléphonie sur IP 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/branchements-du-c530-ip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/branchements-du-c530-ip.mdx
@@ -4,14 +4,25 @@ description: Apprenez comment brancher et raccorder votre téléphone Gigaset C5
 lastUpdated: 2018-03-26
 ---
 
-## Contenu de la boîte
+## Objectif
+
+**Découvrez comment brancher et raccorder votre téléphone Gigaset C530 IP pour le rendre opérationnel sur votre réseau.**
+
+## Prérequis
+
+- Posséder [une ligne téléphonique OVHcloud](https://www.ovhcloud.com/fr/phone/).
+- Avoir réceptionné le téléphone Gigaset C530 IP fourni par OVHcloud.
+
+## En pratique
+
+### Contenu de la boîte
 
 <img className="thumbnail" alt="Contenu de la boîte du Gigaset C530 IP" src="/images/web-cloud/phone-and-fax/voip/branchements-du-c530-ip/contenu.png" loading="lazy" />
 
-## Branchement du C530 IP
+### Branchement du C530 IP
 
 <img className="thumbnail" alt="Schéma de branchement du Gigaset C530 IP" src="/images/web-cloud/phone-and-fax/voip/branchements-du-c530-ip/branchements.png" loading="lazy" />
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/branchements-ip5000.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/branchements-ip5000.mdx
@@ -4,15 +4,18 @@ description: Apprenez comment brancher votre pieuvre IP5000 avec ou sans aliment
 lastUpdated: 2018-03-26
 ---
 
-------------------------------------------------------------------------
+## Objectif
 
-**Sommaire :**
+**Découvrez comment brancher votre pieuvre IP5000 sur votre réseau, avec ou sans alimentation POE.**
 
-**Niveau : Débutant**
+## Prérequis
 
-------------------------------------------------------------------------
+- Posséder [une ligne téléphonique OVHcloud](https://www.ovhcloud.com/fr/phone/).
+- Avoir réceptionné la pieuvre de conférence IP5000 fournie par OVHcloud.
 
-### Branchement sans alimentation &#123;#branchement-sans-alimentation&#125;
+## En pratique
+
+### Branchement sans alimentation
 
 La pieuvre IP5000 peut fonctionner sans alimentation si vous possédez un switch POE. Il suffit pour cela de brancher le câble RJ45 sur le port **LAN** de la pieuvre.
 
@@ -20,9 +23,7 @@ La pieuvre IP5000 peut fonctionner sans alimentation si vous possédez un switch
 
 Une fois branchée, l'écran de la pieuvre doit s'allumer.
 
-------------------------------------------------------------------------
-
-### Branchement avec alimentation &#123;#branchement-avec-alimentation&#125;
+### Branchement avec alimentation
 
 Vous pouvez acheter l'alimentation pour la pieuvre en accessoire. Si c'est le cas, le branchement est alors différent :
 
@@ -36,4 +37,4 @@ Vous pouvez acheter l'alimentation pour la pieuvre en accessoire. Si c'est le ca
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/branchements-spa112.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/branchements-spa112.mdx
@@ -4,9 +4,18 @@ description: "Apprenez comment raccorder votre adaptateur Cisco SPA112 à votre 
 lastUpdated: 2018-03-26
 ---
 
-------------------------------------------------------------------------
+## Objectif
 
-### Branchements de l'adaptateur Cisco SPA112 &#123;#branchements-de-ladaptateur-cisco-spa112&#125;
+**Découvrez comment raccorder votre adaptateur Cisco SPA112 à votre réseau, à l'alimentation et à un téléphone analogique.**
+
+## Prérequis
+
+- Posséder [une ligne téléphonique OVHcloud](https://www.ovhcloud.com/fr/phone/).
+- Avoir réceptionné l'adaptateur Cisco SPA112 fourni par OVHcloud.
+
+## En pratique
+
+### Branchements de l'adaptateur Cisco SPA112
 
 L'équipement adaptateur doit être raccordé :
 
@@ -22,4 +31,4 @@ L'emplacement des deux prises Phone peut être trompeur. Le port N°1, qui doit 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/branchements-spa504g.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/branchements-spa504g.mdx
@@ -4,15 +4,18 @@ description: "Apprenez comment raccorder votre téléphone Cisco SPA504G à l'al
 lastUpdated: 2018-03-26
 ---
 
-------------------------------------------------------------------------
+## Objectif
 
-**Sommaire :**
+**Découvrez comment raccorder votre téléphone Cisco SPA504G à l'alimentation, au combiné et à votre réseau Ethernet.**
 
-Niveau : Débutant
+## Prérequis
 
-------------------------------------------------------------------------
+- Posséder [une ligne téléphonique OVHcloud](https://www.ovhcloud.com/fr/phone/).
+- Avoir réceptionné le téléphone Cisco SPA504G fourni par OVHcloud.
 
-### Branchements du téléphone standard de gamme Cisco SPA500g &#123;#branchements-du-téléphone-standard-de-gamme-cisco-spa500g&#125;
+## En pratique
+
+### Branchements du téléphone standard de gamme Cisco SPA500g
 
 **Le téléphone doit être raccordé :**
 
@@ -31,4 +34,4 @@ Notez que raccorder un ordinateur sur le port PC est optionnel. Ceci permet d'é
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/changer-l-offre-et-les-options-d-une-ligne-voip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/changer-l-offre-et-les-options-d-une-ligne-voip.mdx
@@ -12,7 +12,7 @@ Pour adapter votre téléphonie à votre activité professionnelle, vous pouvez 
 
 ## Prérequis
 
-- Disposer de [services VoIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/).
+- Disposer de [services VoIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -44,8 +44,10 @@ Cliquez sur l'onglet <code className="action">Services</code> puis sur la ligne 
 
 Dans l'onglet <code className="action">Gestion</code>, cliquez sur <code className="action">Changer d'offre</code>. L'offre actuelle de votre ligne VoIP vous sera alors présentée. Cliquez sur <code className="action">Modifier l'offre</code> pour accéder aux offres disponibles.
 
-Sélectionnez, dans le menu déroulant des offres disponibles, l'offre de votre choix.<br/>
-Le cas échéant, vous pouvez choisir d'appliquer cette nouvelle offre à plusieurs de vos lignes VoIP en cliquant sur <code className="action">Appliquer à plusieurs lignes</code>.<br/>
+Sélectionnez, dans le menu déroulant des offres disponibles, l'offre de votre choix.
+
+Le cas échéant, vous pouvez choisir d'appliquer cette nouvelle offre à plusieurs de vos lignes VoIP en cliquant sur <code className="action">Appliquer à plusieurs lignes</code>.
+
 Validez enfin votre choix en cliquant sur <code className="action">Valider</code>.
 
 <video className="thumbnail" autoPlay loop muted playsInline aria-label="changement-d-offre-voip" src="/images/web-cloud/phone-and-fax/voip/changer-l-offre-et-les-options-d-une-ligne-voip/changeoffer.mp4" />
@@ -58,7 +60,6 @@ Ainsi, un changement d'offre VoIP sollicité entre le 1er et le 31 janvier serai
 Une offre VoIP Entreprise ne peut pas évoluer vers une offre VoIP Découverte.
 
 :::
-
 
 <a name="cancel-change-offer"></a>
 
@@ -79,7 +80,6 @@ Une ligne VoIP découverte est limitée à 1 seul appel simultané.
 Si vous souhaitez augmenter le nombre d'appels simultanés sur une ligne VoIP Découverte, il sera nécessaire de la [convertir en ligne VoIP Entreprise](/guides/web-cloud/phone-and-fax/voip/changer-l-offre-et-les-options-d-une-ligne-voip#changer-doffre-voip).
 
 :::
-
 
 Sélectionnez votre ligne VoIP puis l'onglet <code className="action">Gestion des appels</code> (1). Cliquez alors sur <code className="action">Appels simultanés</code> (2).
 
@@ -103,7 +103,8 @@ Si vous souhaitez diminuer le nombre d'appels simultanés sur une ligne, ce chan
 
 ### Convertir une ligne SIP en numéro alias
 
-Les besoins en téléphonie d'une entreprise peuvent évoluer fréquemment. Vous pouvez donc convertir une ligne SIP en numéro alias. Cela permet notamment, une fois la conversion faite, de faire sonner plusieurs lignes lorsque le numéro est appelé.<br/>
+Les besoins en téléphonie d'une entreprise peuvent évoluer fréquemment. Vous pouvez donc convertir une ligne SIP en numéro alias. Cela permet notamment, une fois la conversion faite, de faire sonner plusieurs lignes lorsque le numéro est appelé.
+
 Pour plus d'informations sur les différences entre une ligne SIP et un numéro alias, consultez [notre FAQ](/guides/web-cloud/phone-and-fax/voip/faq-voip)
 
 :::tip
@@ -114,7 +115,6 @@ L'entreprise évoluant, le standard doit au final être assuré par plusieurs pe
 Ainsi, le numéro connu par la clientèle de l'entreprise restera le même et permettra de faire sonner plusieurs nouvelles lignes (celles-ci devant être également commandées).
 
 :::
-
 
 Pour convertir une ligne SIP en numéro alias, sélectionnez la ligne dans votre espace client OVHcloud et, depuis l'onglet <code className="action">Gestion</code>, cliquez sur <code className="action">Convertir la ligne en numéro</code>.
 
@@ -131,7 +131,6 @@ Si un téléphone Plug And Phone est attaché à cette ligne, ce dernier ne fonc
 
 :::
 
-
 <a name="alias-to-sip"></a>
 
 ### Convertir un numéro alias en ligne SIP
@@ -140,7 +139,6 @@ Si un téléphone Plug And Phone est attaché à cette ligne, ce dernier ne fonc
 Un numéro [porté depuis un autre opérateur de téléphonie](/guides/web-cloud/phone-and-fax/voip/demander-la-portabilite-de-mon-numero) ne peut pas être converti en ligne SIP.
 
 :::
-
 
 Pour répondre à tous les besoins en téléphonie, vous pouvez également convertir un numéro alias en ligne SIP.
 
@@ -173,4 +171,4 @@ Pour plus d'informations sur cette procédure, consultez le guide « [Effectuer 
 
 [Comment résilier un service VoIP ou une ligne Fax](/guides/web-cloud/phone-and-fax/voip/resilier-services-voip)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/cisco-7841-use.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/cisco-7841-use.mdx
@@ -75,4 +75,4 @@ Pour cela, repérez la mention « Permuter » dans l'écran rétroéclairé de v
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/cisco-8851-use.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/cisco-8851-use.mdx
@@ -75,4 +75,4 @@ Pour cela, repérez la mention « Permuter » dans l'écran rétroéclairé de v
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/commander-associer-ou-changer-un-telephone.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/commander-associer-ou-changer-un-telephone.mdx
@@ -12,7 +12,7 @@ Votre ligne SIP OVHcloud vous permet de recevoir et d’émettre des appels depu
 
 ## Prérequis
 
-- Disposer d'une [ligne SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/).
+- Disposer d'une [ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -28,7 +28,7 @@ Votre ligne SIP OVHcloud vous permet de recevoir et d’émettre des appels depu
 ## En pratique
 
 :::info
-Nos téléphones sont fournis en l'échange d'une caution (restituée en fin de contrat). Retrouvez l'ensemble des téléphones proposés par OVHcloud sur [cette page](https://www.ovhtelecom.fr/telephonie/comparatif-des-telephones.xml).
+Nos téléphones sont fournis en l'échange d'une caution (restituée en fin de contrat). Retrouvez l'ensemble des téléphones proposés par OVHcloud sur [cette page](https://www.ovhcloud.com/fr/phone/voip/telephone/).
 
 :::
 
@@ -156,4 +156,4 @@ Sélectionnez l'accessoire de votre choix puis suivez les étapes qui apparaisse
 
 [Déroulement d’un RMA](/guides/web-cloud/phone-and-fax/voip/deroulement-d-un-rma)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/comment-configurer-les-renvois-d-appels.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/comment-configurer-les-renvois-d-appels.mdx
@@ -12,7 +12,7 @@ Votre ligne SIP OVHcloud vous permet de recevoir et d'émettre des appels. Pour 
 
 ## Prérequis
 
-- Disposer d'une [ligne SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/).
+- Disposer d'une [ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -87,7 +87,7 @@ Pour activer une configuration, cochez la case à côté de cette dernière puis
 |Renvoyer vers un|Description|
 |---|---|  
 |Fax|Il s'agit du service fax. Cette fonctionnalité est réservée aux offres Fax.|
-|Numéro hors OVHcloud|Permet de renvoyer l'appel vers un numéro hors OVHcloud. Sachez que les communications vers un numéro non enregistré chez OVHcloud seront décomptées de votre forfait ou facturées selon le [forfait auquel vous avez souscrit](https://www.ovhtelecom.fr/telephonie/voip/) (voir la note en bas de page) et [les tarifs en vigueur](https://www.ovhtelecom.fr/telephonie/decouvrez/tarifs_telephonie.xml).|
+|Numéro hors OVHcloud|Permet de renvoyer l'appel vers un numéro hors OVHcloud. Sachez que les communications vers un numéro non enregistré chez OVHcloud seront décomptées de votre forfait ou facturées selon le [forfait auquel vous avez souscrit](https://www.ovhcloud.com/fr/phone/voip/) (voir la note en bas de page) et [les tarifs en vigueur](https://www.ovhtelecom.fr/telephonie/decouvrez/tarifs_telephonie.xml).|
 |Répondeur|Permet de renvoyer l'appel vers la boîte vocale d'une des lignes présentes dans votre parc téléphonique.|
 |Téléphone|Permet de renvoyer l'appel vers une autre ligne présente dans votre parc téléphonique.|
 
@@ -174,4 +174,4 @@ Si vous ne le faites pas, un renvoi d'appel vers le répondeur de votre ligne ne
 
 [Configurer des plages horaires et des fermetures exceptionnelles sur une ligne](/guides/web-cloud/phone-and-fax/voip/configure-time-slot-and-closing-time)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/conference.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/conference.mdx
@@ -18,7 +18,7 @@ Une interface spécifique vous propose également de suivre en temps réel les d
 
 ## Prérequis
 
-- Disposer d'un [numéro alias](https://www.ovhtelecom.fr/telephonie/numeros/).
+- Disposer d'un [numéro alias](https://www.ovhcloud.com/fr/phone/numeros/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -115,4 +115,4 @@ Les participants ont aussi la possibilité de se servir des raccourcis ci-dessou
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
@@ -26,7 +26,7 @@ Pour configurer le 3CX Phone System avec un SIP Trunk et deux DDI (**D**irect **
 
 ## Prérequis
 
-- Un [SIP Trunk OVHcloud](https://www.ovhtelecom.fr/telephonie/sip-trunk/)
+- Un [SIP Trunk OVHcloud](https://www.ovhcloud.com/fr/phone/sip-trunk/)
 - Deux [alias configurés](/guides/web-cloud/phone-and-fax/voip/redirection-avec-presentation) en DDI (Redirection avec présentation du numéro)
 - Un [softphone](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone) ou un téléphone SIP
 - [3CX](https://www.3cx.fr/) installé, activé et à jour. 
@@ -176,4 +176,4 @@ Pour des prestations spécialisées (référencement, développement, etc.), con
 
 Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr/support-levels/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-ovh-phone.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-ovh-phone.mdx
@@ -12,8 +12,8 @@ Les touches programmables (aussi appelées touches de fonction) permettent de li
 
 ## Prérequis
 
-- Posséder un téléphone fourni par OVHcloud avec des touches de fonction (cette information est disponible sur [notre site](https://www.ovhtelecom.fr/telephonie/comparatif-des-telephones.xml)).
-- Détenir une offre VoIP compatible (voir « Fonctionnalités du téléphone » sur [notre site](https://www.ovhtelecom.fr/telephonie/services_inclus/)).
+- Posséder un téléphone fourni par OVHcloud avec des touches de fonction (cette information est disponible sur [notre site](https://www.ovhcloud.com/fr/phone/voip/telephone/)).
+- Détenir une offre VoIP compatible (voir « Fonctionnalités du téléphone » sur [notre site](https://www.ovhcloud.com/fr/phone/voip/services-inclus/)).
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
 
@@ -104,7 +104,7 @@ Il s'agit des fonctions associées à un alias configuré en file d'appels.
 ### Module d'extension de touches
 
 :::info
-Pour savoir si votre poste est compatible avec un module d'extension de touches, rendez-vous sur [notre site](https://www.ovhtelecom.fr/telephonie/comparatif-des-telephones.xml).
+Pour savoir si votre poste est compatible avec un module d'extension de touches, rendez-vous sur [notre site](https://www.ovhcloud.com/fr/phone/voip/telephone/).
 
 :::
 
@@ -136,4 +136,4 @@ Si vous ne constatez pas de mise à jour des touches après quelques minutes, re
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/configure-time-slot-and-closing-time.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/configure-time-slot-and-closing-time.mdx
@@ -12,7 +12,7 @@ Votre ligne téléphonique OVHcloud vous permet de recevoir des appels. Pour div
 
 ## Prérequis
 
-- Disposer d'une [ligne OVHcloud avec un forfait compatible](https://www.ovhtelecom.fr/telephonie/voip/) ou d'une ligne Trunk.
+- Disposer d'une [ligne OVHcloud avec un forfait compatible](https://www.ovhcloud.com/fr/phone/voip/) ou d'une ligne Trunk.
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -77,7 +77,7 @@ Définissez dans un premier temps où les appels doivent être redirigés selon 
 
 Pour modifier un créneau, cliquez sur l'icône en forme de roue dentée à côté de celui-ci. Définissez où seront redirigés les appels, puis cliquez sur le bouton <code className="action">Modifier</code>. 
 
-Sachez que les communications vers un numéro non enregistré chez OVHcloud (externe) seront décomptées de votre forfait ou facturées selon le [forfait auquel vous avez souscrit](https://www.ovhtelecom.fr/telephonie/voip/) (voir la note en bas de page) et [les tarifs en vigueur](https://www.ovhtelecom.fr/telephonie/decouvrez/tarifs_telephonie.xml).
+Sachez que les communications vers un numéro non enregistré chez OVHcloud (externe) seront décomptées de votre forfait ou facturées selon le [forfait auquel vous avez souscrit](https://www.ovhcloud.com/fr/phone/voip/) (voir la note en bas de page) et [les tarifs en vigueur](https://www.ovhtelecom.fr/telephonie/decouvrez/tarifs_telephonie.xml).
 
 <img className="thumbnail" alt="gerer-plages-horaires" src="/images/web-cloud/phone-and-fax/voip/configure-time-slot-and-closing-time/manage-time-slot-step3.png" loading="lazy" />
 
@@ -133,4 +133,4 @@ Enfin, dans la partie `Paramètres` de la page, assurez-vous que le « **fuseau 
 
 [Configurer et consulter le répondeur de sa ligne](/guides/web-cloud/phone-and-fax/voip/configurer-consulter-repondeur-ligne-ovh)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/configurer-consulter-repondeur-ligne-ovh.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/configurer-consulter-repondeur-ligne-ovh.mdx
@@ -163,4 +163,4 @@ Vous avez la possibilité d’appliquer vos choix de configuration à plusieurs 
 - [Filtrer et renvoyer ses appels](/guides/web-cloud/phone-and-fax/voip/comment-configurer-les-renvois-d-appels)
 - Pour associer le déclenchement d'un répondeur à des conditions particulières (respect de certaines plages horaires, fermeture lors des jours fériés, etc.), consultez le guide « [Configurer des plages horaires et des fermetures exceptionnelles sur une ligne](/guides/web-cloud/phone-and-fax/voip/configure-time-slot-and-closing-time) ».
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/configurer-utiliser-click2call.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/configurer-utiliser-click2call.mdx
@@ -16,7 +16,7 @@ La fonctionnalité Click2Call (ou « appel en un clic ») permet de mettre en re
 
 ## Prérequis
 
-- Disposer d'une ligne SIP possédant un [forfait compatible](https://www.ovhtelecom.fr/telephonie/services_inclus/) avec la fonctionnalité Click2Call.
+- Disposer d'une ligne SIP possédant un [forfait compatible](https://www.ovhcloud.com/fr/phone/voip/services-inclus/) avec la fonctionnalité Click2Call.
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -36,9 +36,9 @@ La fonctionnalité Click2Call (ou « appel en un clic ») permet de mettre en re
 Ce guide explique comment créer et gérer un identifiant Click2Call et présente les fonctions API permettant l'intégration de cette fonctionnalité dans vos programmes.
 
 :::info
-Les communications lancées depuis la fonctionnalité Click2Call vers un numéro non enregistré chez OVHcloud (externe) seront décomptées de votre forfait ou facturées selon le [forfait auquel vous avez souscrit](https://www.ovhtelecom.fr/telephonie/voip/) (voir la note en bas de page) et [les tarifs en vigueur](https://www.ovhtelecom.fr/telephonie/decouvrez/tarifs_telephonie.xml).
+Les communications lancées depuis la fonctionnalité Click2Call vers un numéro non enregistré chez OVHcloud (externe) seront décomptées de votre forfait ou facturées selon le [forfait auquel vous avez souscrit](https://www.ovhcloud.com/fr/phone/voip/) (voir la note en bas de page) et [les tarifs en vigueur](https://www.ovhtelecom.fr/telephonie/decouvrez/tarifs_telephonie.xml).
 
-Le Click2Call peut être utilisé conjointement avec d'[autres fonctionnalités disponibles](https://www.ovhtelecom.fr/telephonie/services_inclus/) sur votre ligne SIP, telles que le [filtrage d'appel](/guides/web-cloud/phone-and-fax/voip/comment-configurer-les-renvois-d-appels) (permettant par exemple d'empêcher tout appel vers des numéros commençant par « 08 »).
+Le Click2Call peut être utilisé conjointement avec d'[autres fonctionnalités disponibles](https://www.ovhcloud.com/fr/phone/voip/services-inclus/) sur votre ligne SIP, telles que le [filtrage d'appel](/guides/web-cloud/phone-and-fax/voip/comment-configurer-les-renvois-d-appels) (permettant par exemple d'empêcher tout appel vers des numéros commençant par « 08 »).
 
 :::
 
@@ -187,4 +187,4 @@ Personnalisez si besoin [le numéro présenté depuis votre ligne SIP](/guides/w
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/contact-center-solution.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/contact-center-solution.mdx
@@ -14,7 +14,7 @@ Vous pouvez par exemple proposer à vos appelants, via la seule composition de v
 
 ## Prérequis
 
-- Disposer d'un [numéro alias](https://www.ovhtelecom.fr/telephonie/numeros/).
+- Disposer d'un [numéro alias](https://www.ovhcloud.com/fr/phone/numeros/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -58,7 +58,6 @@ Cliquez sur le bouton <code className="action">Paramétrer</code> et patientez q
 Si vous appliquez le même type de configuration à plusieurs numéros, vous devrez finaliser la configuration sur chacun des numéros concernés.
 
 :::
-
 
 ### Étape 2 : Accéder à la configuration du Contact Center Solution
 
@@ -139,7 +138,6 @@ L'ajout d'une ligne externe peut occasionner des frais car un appel reçu par ce
 
 :::
 
-
 Les agents et leurs attributs sont visibles dans la « Liste des agents ». Vous pouvez modifier ces attributs en cliquant sur le stylo à droite de chaque agent.
 
 <img className="thumbnail" alt="contact-center-solution" src="/images/web-cloud/phone-and-fax/voip/contact-center-solution/ccs-step3-1-3.png" loading="lazy" />
@@ -207,7 +205,6 @@ Pour supprimer une file, celle-ci ne doit plus faire partie d'aucun menu interac
 
 :::
 
-
 ### Étape 5 : Créer les menus interactifs (facultatif) <a name="creer-svi"></a>
 
 À la différence de la configuration d'un numéro alias en [Serveur Vocal Interactif (SVI)](/guides/web-cloud/phone-and-fax/voip/svi-serveur-vocal-interactif), le CCS permet d'associer une file d'appels entière (et non plus une simple ligne) à une touche de téléphone composée par un appelant.
@@ -251,7 +248,8 @@ Selon vos besoins, répétez ces manipulations si vous voulez créer plusieurs m
 ### Étape 6 : Configurer votre CCS <a name="configurer-CCS"></a>
 
 Une fois vos files et menus interactifs créés, il faut maintenant les articuler dans le CCS.
-<br/>Chaque appel entrant va suivre une ou plusieurs étapes successives que vous allez définir. Au sein de chaque étape, une ou plusieurs actions devront également être créées.
+
+Chaque appel entrant va suivre une ou plusieurs étapes successives que vous allez définir. Au sein de chaque étape, une ou plusieurs actions devront également être créées.
 
 Voici un exemple de configuration d'un CCS :
 
@@ -262,7 +260,8 @@ Voici un exemple de configuration d'un CCS :
 #### Ajouter des étapes et actions
 
 Pour ajouter une étape, cliquez sur le bouton <code className="action">+ Ajouter une étape</code> (1) à droite des étapes déjà créées.
-<br/>Pour ajouter une action au sein d'une étape (2), cliquez sur le bouton <code className="action">+</code> sous l'étape concernée ou sur <code className="action">+ Ajouter une action</code> dans le menu de votre étape.
+
+Pour ajouter une action au sein d'une étape (2), cliquez sur le bouton <code className="action">+</code> sous l'étape concernée ou sur <code className="action">+ Ajouter une action</code> dans le menu de votre étape.
 
 <img className="thumbnail" alt="contact-center-solution" src="/images/web-cloud/phone-and-fax/voip/contact-center-solution/gerer-etapes-actions2021.png" loading="lazy" />
 
@@ -293,7 +292,8 @@ Pour ajouter une condition à une étape, ouvrez le menu de l'étape via le bout
 Une fois vos conditions créées, vous pouvez définir une ou plusieurs action(s) correspondant aux conditions non-vérifiées. Ces actions seront alors prises en compte pour les appels ne remplissant pas les conditions.
 
 Ainsi, dans l'exemple ci-dessous, un appel pendant les plages horaires définies à l'étape 1 fera sonner les membres de la file d'appels nommée « Service commercial » (1).
-<br/>Un appel en dehors de ces plages horaires sera réceptionné sur le répondeur d'une ligne SIP OVHcloud (2).
+
+Un appel en dehors de ces plages horaires sera réceptionné sur le répondeur d'une ligne SIP OVHcloud (2).
 
 <img className="thumbnail" alt="contact-center-solution" src="/images/web-cloud/phone-and-fax/voip/contact-center-solution/exemples-plages2021.png" loading="lazy" />
 
@@ -335,7 +335,6 @@ Une fois toutes vos plages horaires définies, cliquez sur le bouton <code class
 Pour modifier une plage horaire déjà créée, il est nécessaire de la supprimer puis de créer une nouvelle plage horaire.
 
 :::
-
 
 ##### **Double condition : « Jours exceptionnels » et « Plages horaires génériques »**
 
@@ -437,7 +436,6 @@ L'activation de l'enregistrement des appels entraînera le déclenchement automa
 
 :::
 
-
 Pour activer l'enregistrement des appels, cliquez sur l'onglet <code className="action">Consultation</code> puis sur <code className="action">Enregistrements</code>.
 
 <img className="thumbnail" alt="consulter enregistrements" src="/images/web-cloud/phone-and-fax/voip/contact-center-solution/records2021.png" loading="lazy" />
@@ -455,9 +453,8 @@ Ces enregistrements sont conservés sur nos serveurs pendant une durée de 60 jo
 
 :::
 
-
 <img className="thumbnail" alt="CCS configuration" src="/images/web-cloud/phone-and-fax/voip/contact-center-solution/ccs-records3.png" loading="lazy" />
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/demander-la-portabilite-de-mon-numero.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/demander-la-portabilite-de-mon-numero.mdx
@@ -6,7 +6,6 @@ lastUpdated: 2026-02-18
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-
 ## Objectif
 
 La portabilité permet à un abonné de conserver son numéro de téléphone lorsqu'il souhaite changer d'opérateur. Toute demande doit alors suivre un processus comportant plusieurs étapes.
@@ -15,7 +14,7 @@ La portabilité permet à un abonné de conserver son numéro de téléphone lor
 
 ## Prérequis
 
-- Disposer d'au moins un numéro de téléphone chez un autre opérateur, dont le pays est compatible avec [la portabilité chez OVHcloud](https://www.ovhtelecom.fr/telephonie/services_inclus/portabilite_numero.xml).
+- Disposer d'au moins un numéro de téléphone chez un autre opérateur, dont le pays est compatible avec [la portabilité chez OVHcloud](https://www.ovhcloud.com/fr/phone/voip/services-inclus/).
 - Disposer d'une offre [VoIP OVHcloud](https://www.ovhcloud.com/fr/phone/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
@@ -37,7 +36,6 @@ La portabilité permet à un abonné de conserver son numéro de téléphone lor
 Si vous souhaitez porter un ou plusieurs numéros belges, nous vous invitons à consulter notre guide dédié « [Demander et suivre une portabilité de numéro belge](/guides/web-cloud/phone-and-fax/voip/portabilite-numero-belge) ».
 
 :::
-
 
 ### 1 - Préparer sa demande de portabilité
 
@@ -73,7 +71,6 @@ La portabilité d'un numéro spécial de Services à Valeur Ajoutée (SVA) néce
 Les numéros spéciaux (SVA) ne pouvant faire l'objet d'une demande de portabilité en numéro individuel, vous devez utiliser la demande de [portabilité d'une plage de numéros](#plage-numeros).
 
 :::
-
 
 #### Porter un numéro individuel <a name="numero-individuel"></a>
 
@@ -118,7 +115,6 @@ Cliquez sur les onglets ci-dessous pour afficher les 5 étapes.
 Dès lors, pour suivre l'avancement de votre demande, reportez-vous aux informations de la partie 3 « [Suivre une demande de portabilité](#suivre-demande) » de cette documentation.
   </Tab>
 </Tabs>
-
 
 #### Porter une plage de numéros <a name="plage-numeros"></a>
 
@@ -189,12 +185,12 @@ Pour suivre l'avancement de votre demande de portabilité, reportez-vous aux inf
   </Tab>
 </Tabs>
 
-
 #### Porter un numéro spécial de Services à Valeur Ajoutée (SVA) <a name="numero-special"></a>
 
 Les numéros spéciaux ne pouvant faire l'objet d'une demande de portabilité en numéro individuel, vous devez utiliser la demande de [portabilité d'une plage de numéros](#plage-numeros).
 
-L'exploitation de numéros de Services à Valeur Ajoutée (SVA) nécessite d'être en conformité avec le cadre réglementaire défini par l'ARCEP.<br/>
+L'exploitation de numéros de Services à Valeur Ajoutée (SVA) nécessite d'être en conformité avec le cadre réglementaire défini par l'ARCEP.
+
 Lors de la portabilité d'un numéro SVA, vous devez fournir à OVHcloud des justificatifs de l'identité de votre entreprise.
 
 Une fois le numéro spécial à porter renseigné (au format international) dans le champ prévu à cet effet, cliquez sur le bouton <code className="action">Vérifier l'identité</code>. Vous serez alors redirigé vers la procédure de vérification d'identité.
@@ -203,7 +199,6 @@ Une fois le numéro spécial à porter renseigné (au format international) dans
 Pour plus d'informations sur cette procédure, consultez notre guide « [Valider votre identité pour l'exploitation d'un numéro spécial SVA](/guides/web-cloud/phone-and-fax/voip/verification-identite-numeros-sva) ».
 
 :::
-
 
 <img className="thumbnail" alt="numberport" src="/images/web-cloud/phone-and-fax/voip/demander-la-portabilite-de-mon-numero/porting-number-sva-2026.png" loading="lazy" />
 
@@ -247,7 +242,6 @@ Vous trouverez ci-dessous un récapitulatif des différentes étapes du **proces
   </Tab>
 </Tabs>
 
-
 ### 4 - Préparer la configuration des numéros portés <a name="preparer-configuration-numero"></a>
 
 Vous avez la possibilité de préparer la configuration du ou des numéros portés 48 heures avant que celle-ci soit effective. Ceci peut vous permettre de limiter, voire d'éviter, une coupure de service lors de votre changement d'opérateur pour OVHcloud.
@@ -256,4 +250,4 @@ Pour cela, et selon la configuration que vous souhaitez mettre en place sur vos 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/depannage-c530-ip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/depannage-c530-ip.mdx
@@ -9,12 +9,14 @@ Ce guide est à présent déprécié et est uniquement conservé afin de documen
 Le processus de dépannage pour nos téléphones est à présent documenté sur [cette page](/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel).
 :::
 
-
-### Mon combiné affiche "Pas de base" &#123;#mon-combiné-affiche-pas-de-base&#125;
+### Mon combiné affiche "Pas de base"
 
 Si votre combiné affiche ce message c'est qu'il n'arrive pas à dialoguer avec la base.
 
--   Vérifiez dans un premier temps que la base est bien alimentée électriquement et que le bouton central soit allumé en bleu. <br/> <img className="thumbnail" alt="base allumée" src="/images/web-cloud/phone-and-fax/voip/depannage-c530-ip/baseallumee.png" loading="lazy" />
+-   Vérifiez dans un premier temps que la base est bien alimentée électriquement et que le bouton central soit allumé en bleu.
+
+    <img className="thumbnail" alt="base allumée" src="/images/web-cloud/phone-and-fax/voip/depannage-c530-ip/baseallumee.png" loading="lazy" />
+
 -   Si le voyant de la base est bien bleu il faut procéder à l'enregistrement du combiné.
 -   Cliquez sur le bouton central du téléphone.
 -   Déplacez vous sur "**Réglages**" puis validez en appuyant sur OK.
@@ -23,7 +25,7 @@ Si votre combiné affiche ce message c'est qu'il n'arrive pas à dialoguer avec 
 -   Il vous faut maintenant rester appuyé sur le bouton central de la base jusqu'à ce que le combiné vous indique qu'il ait trouvé une base. Un code PIN vous sera demandé, par défaut c'est "0000" (sans guillemets).
 -   Si l'opération réussit vous aurez un message vous confirmant le bon enregistrement.
 
-### Échec connexion fournis. services &#123;#echec-connexion-fournis.-services&#125;
+### Échec connexion fournis. services
 
 Lorsque votre combiné affiche ce message c'est que la base n'arrive pas à enregistrer le compte SIP inscrit en elle.
 
@@ -44,4 +46,4 @@ Pour changer ce paramètre :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/depannage-ip5000.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/depannage-ip5000.mdx
@@ -4,15 +4,18 @@ description: Découvrez comment résoudre les problèmes courants de votre pieuv
 lastUpdated: 2018-03-26
 ---
 
-------------------------------------------------------------------------
+## Objectif
 
-**Sommaire :**
+**Découvrez comment résoudre les problèmes courants de votre pieuvre IP5000, comme les pannes réseau ou la reconfiguration.**
 
-Niveau : Débutant
+## Prérequis
 
-------------------------------------------------------------------------
+- Posséder [une ligne téléphonique OVHcloud](https://www.ovhcloud.com/fr/phone/).
+- Avoir réceptionné et branché la pieuvre de conférence IP5000 fournie par OVHcloud.
 
-### Mon téléphone ne s'allume pas &#123;#mon-téléphone-ne-sallume-pas&#125;
+## En pratique
+
+### Mon téléphone ne s'allume pas
 
 Si votre téléphone ne s'allume pas malgré le bon branchement du câble Ethernet, vérifiez :
 
@@ -20,9 +23,7 @@ Si votre téléphone ne s'allume pas malgré le bon branchement du câble Ethern
 -   vérifiez le bon branchement du câble Ethernet sur votre équipement ;
 -   si vous utilisez l'alimentation proposée en accessoire, vérifiez le bon branchement et le sens.
 
-------------------------------------------------------------------------
-
-### Lorsque je branche la pieuvre sur mon réseau, celui-ci ne fonctionne plus &#123;#lorsque-je-branche-la-pieuvre-sur-mon-réseau-celui-ci-ne-fonctionne-plus&#125;
+### Lorsque je branche la pieuvre sur mon réseau, celui-ci ne fonctionne plus
 
 Sur certains routeurs, une option du client DHCP envoyé par la pieuvre n'est pas supportée et provoque une coupure du réseau. Pour pallier cette problématique, il vous suffit de définir manuellement les paramètres de votre pieuvre :
 
@@ -35,9 +36,7 @@ Sur certains routeurs, une option du client DHCP envoyé par la pieuvre n'est pa
 
 Sur ce menu du téléphone, vous allez pouvoir le passer en adressage IP manuel.
 
-------------------------------------------------------------------------
-
-### Reconfiguration téléphone &#123;#reconfiguration-téléphone&#125;
+### Reconfiguration téléphone
 
 Si la ligne configurée sur la pieuvre ne fonctionne plus, il faut la reconfigurer via ces étapes :
 
@@ -91,4 +90,4 @@ La pieuvre va redémarrer.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/depannage-spa112.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/depannage-spa112.mdx
@@ -9,8 +9,7 @@ Ce guide est à présent déprécié et est uniquement conservé afin de documen
 Le processus de dépannage pour nos téléphones est à présent documenté sur [cette page](/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel).
 :::
 
-
-## Mon adaptateur ne s'allume plus &#123;#mon-adaptateur-ne-sallume-plus&#125;
+## Mon adaptateur ne s'allume plus
 
 Si même le voyant Power n'est pas allumé : le boîtier n'est pas alimenté.
 
@@ -22,9 +21,7 @@ Soit dans le chargeur qui permet d'alimenter le SPA112. Si vous avez plusieurs �
 
 S'il s'avère que votre adaptateur est défaillant, nous vous prions de vous rapprocher du support technique par téléphone ou par mail pour procéder à un échange SAV.
 
-------------------------------------------------------------------------
-
-## Le voyant Line 1 de mon boîtier est complètement éteint &#123;#le-voyant-line-1-de-mon-boîtier-est-complètement-éteint&#125;
+## Le voyant Line 1 de mon boîtier est complètement éteint
 
 Le fait que le voyant Phone 1 soit éteint signifie que votre ligne OVHcloud n'est pas enregistrée (authentifiée) dans le SPA112. Autrement dit, le boîtier ne communique pas avec le serveur de téléphonie. Aucune chance que vous puissiez émettre ou recevoir un appel via votre ligne.
 
@@ -32,9 +29,7 @@ Nous vous invitons à vérifier que l'origine du comportement ne se situe pas su
 
 Si le phénomène persiste, reconfigurez le à l'aide du guide "[Reconfiguration de l'équipement](#DépannageSPA112-reconfiguration)"
 
-------------------------------------------------------------------------
-
-## Le voyant Line 1 de mon boîtier clignote en vert &#123;#le-voyant-line-1-de-mon-boîtier-clignote-en-vert&#125;
+## Le voyant Line 1 de mon boîtier clignote en vert
 
 Lorsque le voyant Téléphone 1 clignote en vert, de manière régulière, c'est que le combiné raccordé sur Phone 1 est en prise de ligne, décroché. Si toutefois il s'agit d'un fax, alors le télécopieur tente de prendre la ligne.
 
@@ -42,9 +37,7 @@ Pour vérifier cette hypothèse, débranchez toutes les prises raccordées au SP
 
 Si Téléphone 1 continue de clignoter après cela, nous vous prions de vous rapprocher du support technique par téléphone ou par mail pour procéder à un échange SAV.
 
-------------------------------------------------------------------------
-
-## Je ne parviens ni à émettre ni à recevoir bien que le voyant Line 1 soit allumé &#123;#je-ne-parviens-ni-à-émettre-ni-à-recevoir-malgré-que-le-voyant-line-1-soit-allumé&#125;
+## Je ne parviens ni à émettre ni à recevoir bien que le voyant Line 1 soit allumé
 
 Le fait que le voyant Phone 1 soit allumé en vert fixe signifie que votre ligne OVHcloud est bien enregistrée (authentifiée) dans le SPA112.
 
@@ -54,9 +47,7 @@ Si toutefois ce n'est pas le cas, vérifiez que le port Phone 2 n'a pas de tonal
 
 Le combiné employé peut également être source du problème rencontré. Pour écarter l'hypothèse, branchez votre téléphone sur un autre équipement (type box chez un ami, un voisin) ou employez un autre combiné.
 
-------------------------------------------------------------------------
-
-## Mon adaptateur clignote dans toutes les couleurs &#123;#mon-adaptateur-clignote-dans-toutes-les-couleurs&#125;
+## Mon adaptateur clignote dans toutes les couleurs
 
 C'est synonyme d'une mise à jour du firmware de l'équipement. Autrement dit, le SPA112 a trouvé une nouvelle version de micro-logiciel interne.
 
@@ -64,12 +55,10 @@ Pour pallier cela, laissez raccordé le boîtier directement à votre routeur/bo
 
 Si le phénomène persiste, nous vous prions de vous rapprocher du support technique par téléphone ou par mail pour procéder à un échange SAV.
 
-------------------------------------------------------------------------
-
-## Le voyant Power clignote rouge &#123;#le-voyant-power-clignote-rouge&#125;
+## Le voyant Power clignote rouge
 
 L'équipement a détecté une anomalie logicielle ou matérielle. N'hésitez pas à appliquer la même procédure que pour "[Mon adaptateur clignote dans toutes les couleurs](#DépannageSPA112-clignote)".
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/depannage-spa504g.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/depannage-spa504g.mdx
@@ -9,8 +9,7 @@ Ce guide est à présent déprécié et est uniquement conservé afin de documen
 Le processus de dépannage pour nos téléphones est à présent documenté sur [cette page](/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel).
 :::
 
-
-### Mon téléphone émet mais ne reçoit plus les appels &#123;#mon-téléphone-émet-mais-ne-reçoit-plus-les-appels&#125;
+### Mon téléphone émet mais ne reçoit plus les appels
 
 Lorsque votre téléphone présente ce symptôme, c'est que la fonction **DND** (*Do Not Disturb*) ou **NPD** (*Ne Pas Déranger*) est activée.
 
@@ -18,15 +17,14 @@ Pour désactiver cette fonction, appuyez sur le bouton sur l'écran correspondan
 
 <img className="thumbnail" alt="Bouton DND sur l'écran du Cisco SPA504G" src="/images/web-cloud/phone-and-fax/voip/depannage-spa504g/Menu.png" loading="lazy" />
 
-### Les touches de mon téléphone sont allumées en orange &#123;#les-touches-de-mon-téléphone-sont-allumées-en-orange&#125;
+### Les touches de mon téléphone sont allumées en orange
 
 Si votre téléphone affiche les touches sur le côté de l'écran orange, c'est que votre ligne n'est pas enregistrée. Vérifiez le bon fonctionnement de votre connexion Internet et le raccordement de votre téléphone à votre réseau local.
 
-
-### Mon téléphone affiche "Checking DNS" ou "Recherche DHCP" &#123;#mon-téléphone-affiche-checking-dns-ou-recherche-dhcp&#125;
+### Mon téléphone affiche "Checking DNS" ou "Recherche DHCP"
 
 Généralement cette problématique est présente lorsque le téléphone ne se voit pas attribuer d'adresse IP par votre serveur DHCP. Vérifiez le bon raccordement de votre poste à votre réseau et vérifiez la configuration de votre routeur.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/deroulement-d-un-rma.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/deroulement-d-un-rma.mdx
@@ -6,9 +6,6 @@ lastUpdated: 2025-11-14
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-
-
-
 ## Objectif
 
 Lorsque vous changez de téléphone, vous restituez votre ancien matériel. Que notre support échange votre équipement ou que vous ayez résilié votre ligne, un RMA (pour *Return Merchandise Agreement* ou « autorisation de retour d'un équipement ») est généré. Ce RMA permet de tracer et valider l'arrivée de l'équipement dans nos locaux et de restituer la caution liée au matériel.
@@ -45,7 +42,6 @@ Pour plus d'informations sur l'échange de téléphones fournis par OVHcloud, co
 
 :::
 
-
 ### Vue d'ensemble
 
 Suite à la réception de l'e-mail contenant le bon de retour, vous disposez de 15 jours pour effectuer l'envoi du matériel, avant la clôture du dossier.
@@ -64,11 +60,9 @@ Retrouvez plus d'informations sur la gestion des contacts dans notre guide « [G
 
 :::
 
-
 <details>
 
 <summary>E-mail pour un échange de matériel</summary>
-
 
 <Tabs>
   <Tab label="Échange de téléphone">
@@ -96,14 +90,11 @@ Retrouvez plus d'informations sur la gestion des contacts dans notre guide « [G
   </Tab>
 </Tabs>
 
-
 </details>
-
 
 <details>
 
 <summary>E-mail pour une résiliation</summary>
-
 
 <Tabs>
   <Tab label="Résiliation d'une ligne VoIP">
@@ -164,11 +155,10 @@ Retrouvez plus d'informations sur la gestion des contacts dans notre guide « [G
   </Tab>
 </Tabs>
 
-
 </details>
 
+Lorsque vous recevez cet e-mail, le lien vers le bon de retour au format PDF est disponible dans le corps de l'e-mail.
 
-Lorsque vous recevez cet e-mail, le lien vers le bon de retour au format PDF est disponible dans le corps de l'e-mail.<br/>
 Suivez ce lien et imprimez le bon de retour.
 
 :::info
@@ -178,11 +168,12 @@ L'ouverture du fichier PDF via le logiciel Adobe Reader peut ne pas aboutir. Dan
 
 :::
 
-
 Pour la téléphonie, vous pourrez également télécharger le bon de retour depuis votre espace client OVHcloud en suivant les étapes ci-dessous :
 
-Cliquez sur l'onglet <code className="action">Services</code> puis sur la ligne SIP concernée (vous pouvez rechercher le numéro dans le champ prévu à cet effet).<br/>
-Cliquez alors sur l'onglet <code className="action">Assistance</code> puis sur <code className="action">Suivi RMA</code>.<br/>
+Cliquez sur l'onglet <code className="action">Services</code> puis sur la ligne SIP concernée (vous pouvez rechercher le numéro dans le champ prévu à cet effet).
+
+Cliquez alors sur l'onglet <code className="action">Assistance</code> puis sur <code className="action">Suivi RMA</code>.
+
 Les informations relatives au RMA sont alors visibles, ainsi qu'un bouton pour <code className="action">Télécharger le bon de retour</code>.
 
 Cliquez sur les onglets ci-dessous pour afficher des exemples de bons RMA :
@@ -203,35 +194,35 @@ Cliquez sur les onglets ci-dessous pour afficher des exemples de bons RMA :
   </Tab>
 </Tabs>
 
-
 ### Envoi du colis
 
 <Tabs>
   <Tab label="Envoi d'un téléphone">
-    La partie basse du bon de retour est impérativement à joindre dans le colis et l'autre volet est à coller sur le colis pour l'affranchissement.<br/>
+La partie basse du bon de retour est impérativement à joindre dans le colis et l'autre volet est à coller sur le colis pour l'affranchissement.
 
-Le volet à joindre dans le colis contient la liste des éléments à renvoyer. **N'oubliez aucun élément pour récupérer la totalité de la caution**.<br/>
+Le volet à joindre dans le colis contient la liste des éléments à renvoyer. **N'oubliez aucun élément pour récupérer la totalité de la caution**.
 
-Si vous disposez de plusieurs téléphones similaires, vérifiez que l'adresse MAC (une adresse unique par téléphone) du téléphone correspond bien à celle écrite dans l'e-mail reçu ou dans la référence du bon RMA avant la mention « 3BHE » (RMAxxxx**MAC**3BHE).<br/>
+Si vous disposez de plusieurs téléphones similaires, vérifiez que l'adresse MAC (une adresse unique par téléphone) du téléphone correspond bien à celle écrite dans l'e-mail reçu ou dans la référence du bon RMA avant la mention « 3BHE » (RMAxxxx**MAC**3BHE).
+
   </Tab>
   <Tab label="Envoi d'un modem (xDSL et Fibre)">
-    La partie basse du bon de retour est impérativement à joindre dans le colis et l'autre volet est à coller sur le colis pour l'affranchissement.<br/>
+La partie basse du bon de retour est impérativement à joindre dans le colis et l'autre volet est à coller sur le colis pour l'affranchissement.
 
-Le volet à joindre dans le colis contient la liste des éléments à renvoyer. **N'oubliez aucun élément pour éviter toute pénalité**.<br/>
+Le volet à joindre dans le colis contient la liste des éléments à renvoyer. **N'oubliez aucun élément pour éviter toute pénalité**.
 
-**Modem Technicolor** : Si vous disposez de plusieurs modems similaires, vérifiez que l'adresse MAC (une adresse unique par modem) du modem correspond bien à celle écrite dans l'e-mail reçu ou dans la référence du bon RMA avant la mention « 3BHE » (RMAxxxx**MAC**3BHE).<br/>
+**Modem Technicolor** : Si vous disposez de plusieurs modems similaires, vérifiez que l'adresse MAC (une adresse unique par modem) du modem correspond bien à celle écrite dans l'e-mail reçu ou dans la référence du bon RMA avant la mention « 3BHE » (RMAxxxx**MAC**3BHE).
 
-**Modem Zyxel** : Si vous disposez de plusieurs modems similaires, vérifiez que le numéro de série (un numéro unique par modem) du modem correspond bien à celui écrit dans l'e-mail reçu ou dans la référence du bon RMA avant la mention « 3BHE » (RMAxxxx**SN**3BHE).<br/>
+**Modem Zyxel** : Si vous disposez de plusieurs modems similaires, vérifiez que le numéro de série (un numéro unique par modem) du modem correspond bien à celui écrit dans l'e-mail reçu ou dans la référence du bon RMA avant la mention « 3BHE » (RMAxxxx**SN**3BHE).
+
   </Tab>
   <Tab label="Envoi d'un modem et d'un ONT (Fibre)">
-    La partie basse du bon de retour est impérativement à joindre dans le colis et l'autre volet est à coller sur le colis pour l'affranchissement.<br/>
+La partie basse du bon de retour est impérativement à joindre dans le colis et l'autre volet est à coller sur le colis pour l'affranchissement.
 
-Le volet à joindre dans le colis contient la liste des éléments à renvoyer. **N'oubliez aucun élément pour éviter toute pénalité**.<br/>
+Le volet à joindre dans le colis contient la liste des éléments à renvoyer. **N'oubliez aucun élément pour éviter toute pénalité**.
 
 Vous pouvez effectuer l'envoi du modem et de l'ONT en un seul colis. Dans ce cas, **glissez bien les 2 bons de retour dans le colis** et collez la partie haute d'un des bons de retour sur le colis pour l'affranchissement.
   </Tab>
 </Tabs>
-
 
 #### Envoi de plusieurs équipements (téléphone(s) - modem(s) - ONT)
 
@@ -242,7 +233,6 @@ Le colis doit être envoyé depuis un bureau de Poste.
 
 :::
 
-
 Conservez le récépissé de dépôt du colis tant que vous n'avez pas eu confirmation de la bonne réception de celui-ci dans nos locaux.
 
 :::warning
@@ -252,7 +242,6 @@ Dans le cas contraire, OVHcloud tentera de prendre contact avec le client par co
 
 :::
 
-
 ### Les rappels
 
 Au bout de 10 et de 15 jours, si nous n'avons pas reçu votre colis avec le bon RMA, nous vous envoyons un rappel par e-mail sous cette forme :
@@ -260,7 +249,6 @@ Au bout de 10 et de 15 jours, si nous n'avons pas reçu votre colis avec le bon 
 <details>
 
 <summary>E-mail de rappel</summary>
-
 
 L'e-mail ci-dessous concerne un RMA pour un téléphone. Cet e-mail est similaire pour la non restitution d'un modem ou d'un ONT.
 
@@ -282,7 +270,6 @@ L'e-mail ci-dessous concerne un RMA pour un téléphone. Cet e-mail est similair
 
 </details>
 
-
 ### La clôture
 
 #### Le matériel est reçu
@@ -292,7 +279,6 @@ Lorsque nous avons reçu votre équipement, vous recevez cet e-mail :
 <details>
 
 <summary>E-mail d'accusé de réception d'un équipement</summary>
-
 
 L'e-mail ci-dessous concerne un RMA pour un téléphone. Cet e-mail est similaire pour la réception d'un modem ou d'un ONT.
 
@@ -310,8 +296,8 @@ L'e-mail ci-dessous concerne un RMA pour un téléphone. Cet e-mail est similair
 
 </details>
 
+Si une caution est restituée (uniquement valable pour un téléphone, les modems et les ONT sont fournis en prêt par OVHcloud), elle sera disponible sous forme d'avoir sur votre compte prépayé OVHcloud et servira ainsi à régler vos prochaines factures de manière automatique.
 
-Si une caution est restituée (uniquement valable pour un téléphone, les modems et les ONT sont fournis en prêt par OVHcloud), elle sera disponible sous forme d'avoir sur votre compte prépayé OVHcloud et servira ainsi à régler vos prochaines factures de manière automatique.<br/>
 Si vous le souhaitez, vous pouvez en demander le remboursement sur votre compte bancaire via les étapes suivantes, **sous réserve d'avoir [enregistré un compte bancaire SEPA dans votre compte OVHcloud et de l'avoir défini en moyen de paiement par défaut](/guides/account-and-service-management/managing-billing-payments-and-services/manage-payment-methods) au préalable** :
 
 1. Cliquez sur l'onglet <code className="action">Facturation</code> puis sur <code className="action">Virement vers un compte bancaire</code>.
@@ -325,7 +311,6 @@ Si le montant de l'avoir n'apparaît pas sur le solde du compte prépayé OVHclo
 
 :::
 
-
 #### Le matériel n'est pas reçu
 
 Vous recevez alors l'e-mail suivant :
@@ -333,7 +318,6 @@ Vous recevez alors l'e-mail suivant :
 <details>
 
 <summary>E-mail de fermeture du RMA</summary>
-
 
 L'e-mail ci-dessous concerne un RMA pour un téléphone. Cet e-mail est similaire pour la non restitution d'un modem ou d'un ONT.
 
@@ -351,7 +335,6 @@ L'e-mail ci-dessous concerne un RMA pour un téléphone. Cet e-mail est similair
 
 </details>
 
-
 **Facturation suite à la non réception du matériel**
 
 <Tabs>
@@ -363,7 +346,6 @@ L'e-mail ci-dessous concerne un RMA pour un téléphone. Cet e-mail est similair
   </Tab>
 </Tabs>
 
-
 ### Erreur d'envoi d'un téléphone, d'un modem ou d'un ONT
 
 Si vous renvoyez à OVHcloud un matériel autre que celui concerné par le RMA, il est malgré tout indispensable de nous retourner le matériel réclamé sur le bon RMA. En effet, le délai de renvoi court toujours et le matériel correspondant au RMA doit nous être restitué. 
@@ -372,4 +354,4 @@ Nous vous conseillons de contacter le support, via un [ticket d'assistance depui
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/effectuer-un-changement-de-contact-pour-les-services-voip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/effectuer-un-changement-de-contact-pour-les-services-voip.mdx
@@ -1,6 +1,6 @@
 ---
 title: Effectuer un changement de contacts pour vos groupes de téléphonie
-description: "Découvrez comment déléguer la gestion d'un groupe de téléphonie à un autre compte OVHcloud."
+description: "Découvrez comment déléguer la gestion d'un groupe de téléphonie à un autre compte OVHcloud"
 lastUpdated: 2025-04-28
 ---
 
@@ -102,4 +102,4 @@ Dès que les deux contacts ont validé la demande, le changement sera effectif s
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/faq-voip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/faq-voip.mdx
@@ -5,7 +5,6 @@ lastUpdated: 2026-03-27
 ---
 
 
-
 ## Objectif
 
 Retrouvez ici les questions les plus fréquemment posées sur les services VoIP OVHcloud.
@@ -18,16 +17,17 @@ Retrouvez ici les questions les plus fréquemment posées sur les services VoIP 
 
 <summary>Quelle est la différence entre une ligne SIP et un numéro « alias » ?</summary>
 
-
 <img className="thumbnail" alt="numéro alias et ligne sip" src="/images/web-cloud/phone-and-fax/voip/faq-voip/alias-vs-sip.png" loading="lazy" style={{ maxWidth: '600px' }} />
 
 Une ligne SIP et un numéro alias sont deux services de téléphonie distincts. Bien que complémentaires, ils n'ont pas la même fonction.
 
-Une ligne SIP est une ligne téléphonique utilisant le protocole SIP (*Session Initiation Protocol*). Elle est enregistrée sur un seul téléphone SIP, qui peut être [fourni sous caution par OVHcloud](https://www.ovhtelecom.fr/telephonie/comparatif-des-telephones.xml), ou sur un logiciel de type « *softphone* ». OVHcloud propose également un softphone, découvrez son utilisation dans le guide « [Installer et configurer Softcall](/guides/web-cloud/phone-and-fax/voip/installer-configurer-softcall) ».
-<br/>La ligne SIP est liée à un [forfait VoIP](https://www.ovhtelecom.fr/telephonie/voip/) facturé mensuellement. Il convient généralement d'avoir **une ligne SIP par personne devant disposer d'une ligne téléphonique directe** dans votre entreprise.
+Une ligne SIP est une ligne téléphonique utilisant le protocole SIP (*Session Initiation Protocol*). Elle est enregistrée sur un seul téléphone SIP, qui peut être [fourni sous caution par OVHcloud](https://www.ovhcloud.com/fr/phone/voip/telephone/), ou sur un logiciel de type « *softphone* ». OVHcloud propose également un softphone, découvrez son utilisation dans le guide « [Installer et configurer Softcall](/guides/web-cloud/phone-and-fax/voip/installer-configurer-softcall) ».
 
-Un [numéro](https://www.ovhtelecom.fr/telephonie/numeros/), souvent appelé « numéro alias », ne peut pas être enregistré sur un téléphone. Suivant votre besoin, il peut rediriger les appels vers **une ou plusieurs** lignes SIP ou peut servir à héberger une [conférence téléphonique](/guides/web-cloud/phone-and-fax/voip/conference).
-<br/>Un numéro alias peut être [acheté chez OVHcloud](https://www.ovhtelecom.fr/telephonie/numeros/) ou « porté », via la [portabilité de numéro](/guides/web-cloud/phone-and-fax/voip/demander-la-portabilite-de-mon-numero), depuis un autre opérateur téléphonique.
+La ligne SIP est liée à un [forfait VoIP](https://www.ovhcloud.com/fr/phone/voip/) facturé mensuellement. Il convient généralement d'avoir **une ligne SIP par personne devant disposer d'une ligne téléphonique directe** dans votre entreprise.
+
+Un [numéro](https://www.ovhcloud.com/fr/phone/numeros/), souvent appelé « numéro alias », ne peut pas être enregistré sur un téléphone. Suivant votre besoin, il peut rediriger les appels vers **une ou plusieurs** lignes SIP ou peut servir à héberger une [conférence téléphonique](/guides/web-cloud/phone-and-fax/voip/conference).
+
+Un numéro alias peut être [acheté chez OVHcloud](https://www.ovhcloud.com/fr/phone/numeros/) ou « porté », via la [portabilité de numéro](/guides/web-cloud/phone-and-fax/voip/demander-la-portabilite-de-mon-numero), depuis un autre opérateur téléphonique.
 
 Dans une entreprise, le schéma classique est d'avoir, au minimum, un numéro alias principal, facile à mémoriser pour la clientèle, qui redirige les appels vers les lignes SIP directes des employés.
 
@@ -40,11 +40,9 @@ Pour déterminer quelle configuration de numéro alias est la plus adaptée à v
 
 </details>
 
-
 <details>
 
 <summary>Comment suivre ma demande de portabilité ?</summary>
-
 
 <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud et choisissez le groupe de facturation dans lequel a été demandée la portabilité.
 
@@ -52,11 +50,9 @@ Vous retrouverez alors, dans l'onglet <code className="action">Tableau de bord</
 
 </details>
 
-
 <details>
 
 <summary>Pourquoi ai-je reçu un SMS m'indiquant une erreur sur ma portabilité ?</summary>
-
 
 Lorsque vous réalisez une demande de portabilité et que nous ne sommes pas capables de la traiter, nous vous informons de la situation par SMS. En complément, vous recevez également un e-mail vous précisant la raison de cette impossibilité ainsi que la procédure à suivre.
 
@@ -67,14 +63,11 @@ L'ensemble des e-mails envoyés par OVHcloud sont accessibles depuis votre espac
 
 :::
 
-
 </details>
-
 
 <details>
 
 <summary>Combien de temps prend une portabilité de numéro vers OVHcloud ?</summary>
-
 
 Le délai de portabilité dépend du type de numéro :
 
@@ -87,11 +80,9 @@ Pour plus de détails, consultez le guide « [Demander et suivre une portabilit�
 
 </details>
 
-
 <details>
 
 <summary>Puis-je porter un numéro belge vers OVHcloud ?</summary>
-
 
 Oui, OVHcloud supporte la portabilité de numéros belges (indicatif +32). La procédure est similaire à celle des numéros français, avec quelques spécificités réglementaires belges. Vous devez fournir une copie de la dernière facture de votre opérateur belge actuel, un document d'identité du titulaire de la ligne, et le numéro Easy Switch (équivalent du RIO en Belgique). La demande se fait depuis l'espace client OVHcloud, dans <code className="action">Tableau de bord</code> > <code className="action">Commander un numéro</code> > <code className="action">Porter un numéro</code>. Le délai de portabilité pour un numéro belge est d'environ 10 jours ouvrés.
 
@@ -99,11 +90,9 @@ Pour plus de détails, consultez le guide « [Demander et suivre une portabilit�
 
 </details>
 
-
 <details>
 
 <summary>Comment retrouver le RIO de mes services de téléphonie ?</summary>
-
 
 Tout numéro associé à un service VoIP est portable grâce à son **RIO** (**R**elevé d'**I**dentité **O**pérateur).
 
@@ -116,7 +105,6 @@ Pour récupérer le RIO, <ManagerLink to="/#/telecom/telephony">accédez à la s
 
 :::
 
-
 **Autres méthodes pour obtenir le RIO :**
 
 - Depuis la ligne SIP concernée : composez le **3179**.
@@ -126,11 +114,9 @@ Le RIO sera envoyé par e-mail au contact détenteur du service.
 
 </details>
 
-
 <details>
 
 <summary>Comment retrouver le relevé des consommations de mes lignes téléphoniques ?</summary>
-
 
 <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud puis cliquez sur votre groupe de facturation.
 
@@ -145,14 +131,11 @@ Vous pouvez également consulter, pour chaque ligne SIP, les appels émis et re�
 
 :::
 
-
 </details>
-
 
 <details>
 
 <summary>Comment fonctionne le dépôt de garantie pour les téléphones OVHcloud ?</summary>
-
 
 Lorsque vous commandez un téléphone Plug & Phone auprès d'OVHcloud, un dépôt de garantie est prélevé. Ce dépôt correspond à la valeur du matériel et vous est restitué lorsque vous retournez le téléphone en bon état dans le cadre d'une résiliation ou d'un échange (RMA). Le montant du dépôt varie selon le modèle du téléphone choisi. Si le téléphone n'est pas retourné ou s'il est retourné endommagé, le dépôt de garantie est conservé par OVHcloud. La gestion du dépôt de garantie et de la limite hors-forfait est consultable depuis votre espace client dans la rubrique <code className="action">Tableau de bord</code> de votre groupe de facturation.
 
@@ -160,11 +143,9 @@ Pour plus de détails, consultez le guide « [Gestion du dépôt de garantie et 
 
 </details>
 
-
 <details>
 
 <summary>Comment fonctionne la limite hors-forfait ?</summary>
-
 
 La limite hors-forfait est un seuil de dépense configurable qui protège votre compte contre les consommations excessives (appels hors forfait, appels internationaux, numéros surtaxés). Lorsque ce seuil est atteint, les appels sortants hors forfait sont automatiquement bloqués. Vous pouvez consulter et modifier cette limite depuis votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, dans <code className="action">Tableau de bord</code> du groupe de facturation. Une augmentation de la limite hors-forfait peut nécessiter un réajustement du dépôt de garantie. Il est recommandé de paramétrer cette limite en fonction de votre consommation habituelle pour éviter tout blocage imprévu, tout en vous protégeant contre une utilisation frauduleuse de vos lignes.
 
@@ -172,11 +153,9 @@ Pour plus de détails, consultez le guide « [Gestion du dépôt de garantie et 
 
 </details>
 
-
 <details>
 
 <summary>Comment gérer mes groupes de facturation téléphonie ?</summary>
-
 
 Un groupe de facturation (ou groupe de téléphonie) regroupe l'ensemble de vos services VoIP et Fax sur une même entité de facturation. Vous pouvez avoir plusieurs groupes pour séparer les coûts par département, site ou projet. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud. Les groupes sont listés dans le menu de gauche. Vous pouvez renommer un groupe pour mieux l'identifier (par exemple : « Siège Paris », « Agence Lyon »). Il est possible de déplacer un service d'un groupe à un autre via la gestion des services. Chaque groupe dispose de son propre tableau de bord avec les relevés de consommation, la gestion du dépôt de garantie et les portabilités en cours.
 
@@ -184,11 +163,9 @@ Pour plus de détails, consultez le guide « [Gérer vos groupes de téléphonie
 
 </details>
 
-
 <details>
 
 <summary>Comment changer de forfait ou d'offre sur ma ligne VoIP ?</summary>
-
 
 Vous pouvez modifier l'offre associée à votre ligne VoIP directement depuis votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink>, sélectionnez la ligne concernée dans l'onglet <code className="action">Services</code>, puis cliquez sur <code className="action">Gestion du service</code> > <code className="action">Changer d'offre</code>. Les offres disponibles sont listées avec leurs caractéristiques et tarifs. Le changement d'offre prend effet immédiatement, avec une facturation au prorata pour le mois en cours. Un changement de forfait vers une offre supérieure est immédiat ; un retour vers une offre inférieure s'applique à la prochaine période de facturation. Les options (appels simultanés, destinations internationales) peuvent être ajoutées ou retirées indépendamment du forfait.
 
@@ -196,11 +173,9 @@ Pour plus de détails, consultez le guide « [Gérer vos services VoIP](/guides/
 
 </details>
 
-
 <details>
 
 <summary>Comment valider mon identité pour utiliser les services VoIP ?</summary>
-
 
 Avant de pouvoir passer des appels sortants avec votre ligne VoIP OVHcloud, vous devez valider votre identité. Cette procédure est obligatoire et imposée par la réglementation française des télécommunications. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, puis accédez à la section <code className="action">Validation d'identité</code>. Vous devrez fournir un justificatif d'identité (carte nationale d'identité, passeport ou Kbis pour les entreprises). Le document sera vérifié par les équipes OVHcloud et la validation intervient généralement sous 48 heures ouvrées. Tant que l'identité n'est pas validée, la ligne peut recevoir des appels mais les appels sortants sont bloqués.
 
@@ -208,11 +183,9 @@ Pour plus de détails, consultez le guide « [Valider votre identité pour l'uti
 
 </details>
 
-
 <details>
 
 <summary>Comment effectuer un changement de contacts pour mon groupe de téléphonie ?</summary>
-
 
 Le changement de contacts permet de transférer la gestion technique ou la facturation d'un groupe de téléphonie à un autre identifiant client OVHcloud. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, sélectionnez le groupe de facturation, puis rendez-vous dans <code className="action">Tableau de bord</code> > <code className="action">Gestion des contacts</code>. Vous pouvez modifier trois types de contacts : le contact administrateur, le contact technique et le contact facturation. Le nouveau contact recevra un e-mail de validation qu'il devra accepter dans un délai de 72 heures. Les deux parties (ancien et nouveau contact) doivent valider le transfert. Cette procédure est utile lors d'un changement de prestataire informatique ou d'une réorganisation interne.
 
@@ -220,11 +193,9 @@ Pour plus de détails, consultez le guide « [Effectuer un changement de contact
 
 </details>
 
-
 <details>
 
 <summary>Comment résilier un service VoIP ?</summary>
-
 
 <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud. Sélectionnez le groupe de facturation contenant le service à résilier, puis cliquez sur le service dans l'onglet <code className="action">Services</code>. Depuis l'onglet <code className="action">Gestion</code>, cliquez sur <code className="action">Résiliation de la ligne</code>. La résiliation prend effet à la fin de la période de facturation en cours. Un service résilié ne peut pas être réactivé. Si un téléphone est associé au service en cours de résiliation, un bon de retour (RMA) vous sera envoyé pour le renvoyer et récupérer votre dépôt de garantie. Assurez-vous de sauvegarder vos données (enregistrements d'appels, messages du répondeur) avant la résiliation.
 
@@ -232,11 +203,9 @@ Pour plus de détails, consultez le guide « [Comment résilier un service VoIP 
 
 </details>
 
-
 <details>
 
 <summary>Comment fonctionne la procédure de RMA (retour matériel) ?</summary>
-
 
 Le RMA (Return Merchandise Authorization) est la procédure de retour du matériel téléphonique fourni sous caution par OVHcloud. Un RMA est déclenché dans les cas suivants : échange de téléphone, changement de modèle, résiliation de la ligne SIP, ou panne nécessitant un remplacement. Lorsqu'un RMA est initié, vous recevez un bon de retour par e-mail avec les instructions d'expédition. Le matériel doit être retourné dans un délai de 15 jours dans son emballage d'origine, avec tous les accessoires. À réception, OVHcloud vérifie l'état du matériel : si celui-ci est en bon état, le dépôt de garantie vous est restitué. En cas de matériel endommagé ou incomplet, le dépôt peut être conservé partiellement ou intégralement. Vous pouvez suivre l'état de votre RMA depuis l'espace client.
 
@@ -244,11 +213,9 @@ Pour plus de détails, consultez le guide « [Déroulement d'un RMA](/guides/web
 
 </details>
 
-
 <details>
 
 <summary>J'ai résilié une ligne VoIP, le bon de retour (RMA) est illisible ou absent, et je n'ai plus accès à mon compte OVHcloud. Que faire ?</summary>
-
 
 Ce cas combine deux problèmes distincts qu'il faut traiter séparément et dans l'ordre suivant :
 
@@ -278,13 +245,11 @@ Une fois l'accès au compte récupéré, si le PDF du bon de retour affiche « f
 
 </details>
 
-
 ### Lignes SIP
 
 <details>
 
 <summary>Comment utiliser mon répondeur ?</summary>
-
 
 Pour consulter le répondeur d'une ligne téléphonique OVHcloud, le plus simple est de composer le « 123 » depuis cette ligne. Pour plus de détails, consultez le guide « [Configurer et consulter le répondeur de sa ligne](/guides/web-cloud/phone-and-fax/voip/configurer-consulter-repondeur-ligne-ovh) ».
 
@@ -295,14 +260,11 @@ Le répondeur de votre ligne téléphonique est également consultable depuis vo
 
 :::
 
-
 </details>
-
 
 <details>
 
 <summary>Comment configurer un renvoi d'appel ?</summary>
-
 
 Pour effectuer le renvoi d'appels de votre ligne téléphonique, deux solutions s'offrent à vous :
 
@@ -316,14 +278,11 @@ Pour des renvois d'appels spécifiques, consultez le guide « [Activer ou désac
 
 :::
 
-
 </details>
-
 
 <details>
 
 <summary>Comment modifier le mot de passe de ma ligne SIP ?</summary>
-
 
 Le mot de passe SIP est un élément essentiel pour l'enregistrement de votre ligne sur un téléphone ou un softphone. Pour le modifier, <ManagerLink to="/#/telecom/telephony">accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud. Sélectionnez la ligne SIP concernée dans l'onglet <code className="action">Services</code>, puis rendez-vous dans <code className="action">Gestion</code> > <code className="action">Mot de passe SIP</code>. Saisissez un nouveau mot de passe respectant les critères de sécurité (minimum 8 caractères, mélange de lettres, chiffres et caractères spéciaux). Après la modification, votre téléphone se déconnectera brièvement le temps de se réenregistrer avec le nouveau mot de passe. Si vous utilisez un téléphone Plug & Phone OVHcloud, la mise à jour est automatique. Si vous utilisez un softphone ou un téléphone tiers, vous devrez mettre à jour le mot de passe manuellement dans la configuration de votre appareil.
 
@@ -331,21 +290,17 @@ Pour plus de détails, consultez le guide « [Modifier le mot de passe d'une lig
 
 </details>
 
-
 <details>
 
 <summary>Quels codecs audio sont supportés par les lignes SIP OVHcloud ?</summary>
-
 
 Les lignes SIP OVHcloud supportent les codecs audio suivants : **G.711 a-law (PCMA)**, **G.711 u-law (PCMU)** et **G.722** pour la voix HD. Le codec G.711 est le codec par défaut et offre une bonne qualité audio avec une consommation de bande passante de 64 kbps par appel. Le codec G.722 offre une qualité audio supérieure (wideband) mais nécessite un téléphone compatible HD. Le choix du codec peut être effectué dans les paramètres avancés de votre téléphone SIP ou de votre softphone. Pour une qualité optimale, il est recommandé de privilégier le G.722 si votre équipement et votre réseau le permettent, et de conserver le G.711 en codec de secours.
 
 </details>
 
-
 <details>
 
 <summary>Quelle bande passante Internet est nécessaire pour utiliser la VoIP OVHcloud ?</summary>
-
 
 Chaque appel VoIP simultané consomme environ **80 à 100 kbps** en montée et en descente avec le codec G.711 (en comptant les en-têtes réseau). Pour garantir une qualité d'appel optimale, OVHcloud recommande de disposer d'une connexion Internet avec un débit montant d'au moins **100 kbps par appel simultané** et une latence inférieure à **150 ms**. La gigue (jitter) doit idéalement rester en dessous de **30 ms**. Si vous disposez de nombreuses lignes SIP, il est conseillé d'utiliser un routeur supportant la **QoS (Quality of Service)** afin de prioriser le trafic voix. Un test de débit et de qualité réseau peut être effectué depuis l'outil de diagnostic de votre espace client.
 
@@ -353,11 +308,9 @@ Pour plus de détails, consultez le guide « [Diagnostic du réseau local](/guid
 
 </details>
 
-
 <details>
 
 <summary>Comment restreindre ma ligne SIP par adresse IP ?</summary>
-
 
 La restriction par IP empêche l'enregistrement de votre ligne SIP depuis des adresses IP non autorisées. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud. Sélectionnez la ligne SIP concernée, puis accédez à <code className="action">Gestion</code> > <code className="action">Restrictions SIP par IP</code>. Ajoutez les adresses IP publiques depuis lesquelles vous autorisez l'enregistrement de votre ligne. Vous pouvez renseigner jusqu'à 6 adresses IP. Cette fonctionnalité est particulièrement recommandée si vous utilisez un softphone ou un SIP trunk sur une infrastructure à IP fixe.
 
@@ -366,16 +319,13 @@ Si votre adresse IP publique change (cas fréquent avec les connexions grand pub
 
 :::
 
-
 Pour plus de détails, consultez le guide « [Restreindre sa ligne SIP OVHcloud par IP](/guides/web-cloud/phone-and-fax/voip/sip-ip-restriction) ».
 
 </details>
 
-
 <details>
 
 <summary>Comment configurer les touches programmables de mon téléphone OVHcloud ?</summary>
-
 
 Les téléphones fournis par OVHcloud disposent de touches programmables personnalisables. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, sélectionnez la ligne SIP associée au téléphone, puis cliquez sur <code className="action">Téléphone</code> > <code className="action">Touches programmables</code>. Vous pouvez attribuer à chaque touche une fonction parmi : appel rapide (numéro de votre choix), supervision de ligne (BLF), transfert d'appel, intercom, mise en attente, etc. Les modifications sont appliquées automatiquement au téléphone sous quelques minutes. Le nombre de touches programmables varie selon le modèle de téléphone. Des modules d'extension de touches sont également disponibles pour certains modèles.
 
@@ -383,11 +333,9 @@ Pour plus de détails, consultez le guide « [Configurer les touches programmabl
 
 </details>
 
-
 <details>
 
 <summary>Comment configurer des plages horaires et des fermetures exceptionnelles sur ma ligne ?</summary>
-
 
 <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, sélectionnez la ligne concernée dans l'onglet <code className="action">Services</code>, puis rendez-vous dans <code className="action">Gestion des appels</code> > <code className="action">Gérer les plages horaires</code>. Vous pouvez y définir les créneaux pendant lesquels la ligne est joignable et configurer un renvoi vers le répondeur ou un autre numéro en dehors de ces créneaux. Les fermetures exceptionnelles (jours fériés, congés) permettent de configurer un comportement spécifique sur des dates précises, qui prime sur les plages horaires habituelles.
 
@@ -395,11 +343,9 @@ Pour plus de détails, consultez le guide « [Configurer des plages horaires et 
 
 </details>
 
-
 <details>
 
 <summary>Comment gérer les appels simultanés sur ma ligne SIP ?</summary>
-
 
 Par défaut, une ligne SIP OVHcloud permet de gérer **2 appels simultanés** (1 appel en cours + 1 appel en attente, ou 2 appels entrants en même temps). Vous pouvez augmenter ce nombre depuis votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, en sélectionnant la ligne puis <code className="action">Gestion des appels</code> > <code className="action">Appels simultanés</code>. Des appels simultanés supplémentaires sont facturés mensuellement. Cette option est utile si vous utilisez le Click2Call ou si votre ligne reçoit un volume d'appels élevé.
 
@@ -408,16 +354,13 @@ Le nombre d'appels simultanés doit être cohérent avec la bande passante dispo
 
 :::
 
-
 Pour plus de détails, consultez le guide « [Gérer et utiliser les appels simultanés](/guides/web-cloud/phone-and-fax/voip/gerer-utiliser-appels-simultanes) ».
 
 </details>
 
-
 <details>
 
 <summary>Comment utiliser la fonctionnalité Click2Call ?</summary>
-
 
 Le Click2Call permet de déclencher un appel entre votre ligne SIP et un numéro de destination depuis votre espace client ou via l'API OVHcloud, sans avoir à composer le numéro sur le téléphone. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, sélectionnez la ligne SIP, puis cliquez sur <code className="action">Gestion des appels</code> > <code className="action">Appel en 1 clic (Click2Call)</code>. Saisissez le numéro à appeler : votre téléphone sonnera d'abord, puis le correspondant sera appelé une fois que vous aurez décroché. Le Click2Call est aussi utilisable via l'API OVHcloud (`POST /telephony/{billingAccount}/line/{serviceName}/click2CallUser`), ce qui permet de l'intégrer dans un CRM ou une application métier. Un identifiant et un mot de passe Click2Call dédiés doivent être créés au préalable.
 
@@ -425,11 +368,9 @@ Pour plus de détails, consultez le guide « [Configurer et utiliser le Click2Ca
 
 </details>
 
-
 <details>
 
 <summary>Comment configurer la présentation du numéro sur ma ligne SIP ?</summary>
-
 
 La présentation du numéro détermine quel numéro est affiché chez votre correspondant lorsque vous passez un appel sortant. Par défaut, c'est le numéro de votre ligne SIP qui est présenté. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, sélectionnez la ligne puis <code className="action">Gestion des appels</code> > <code className="action">Présentation du numéro</code>. Vous pouvez choisir de présenter : le numéro de la ligne elle-même, un numéro alias rattaché à votre compte, ou passer en mode « anonyme » (numéro masqué). La présentation d'un numéro alias est particulièrement utile en entreprise pour que tous les collaborateurs présentent le numéro principal de la société. Seuls les numéros alias associés à votre compte OVHcloud peuvent être utilisés comme numéro de présentation.
 
@@ -437,11 +378,9 @@ Pour plus de détails, consultez le guide « [Configurer la présentation de son
 
 </details>
 
-
 <details>
 
 <summary>Comment importer un carnet de contacts sur ma ligne SIP ?</summary>
-
 
 Vous pouvez importer un carnet de contacts au format CSV sur votre ligne SIP pour retrouver vos contacts directement sur l'écran de votre téléphone Plug & Phone. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, sélectionnez la ligne SIP, puis cliquez sur <code className="action">Carnets de contacts</code>. Vous pouvez y ajouter des contacts manuellement ou importer un fichier CSV. Le fichier doit respecter le format attendu : colonnes pour le nom, le prénom et le numéro de téléphone. Le carnet de contacts est synchronisé automatiquement avec le téléphone. Le nombre de contacts supporté dépend du modèle de téléphone utilisé.
 
@@ -449,11 +388,9 @@ Pour plus de détails, consultez le guide « [Gérer un carnet de contacts sur u
 
 </details>
 
-
 <details>
 
 <summary>Qu'est-ce que le mode intercom et comment l'activer ?</summary>
-
 
 Le mode intercom permet à un appelant interne de déclencher le haut-parleur du téléphone du destinataire automatiquement, sans que celui-ci n'ait besoin de décrocher. Cette fonctionnalité est utile en milieu professionnel pour les communications rapides entre bureaux. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, sélectionnez la ligne SIP concernée, puis cliquez sur <code className="action">Gestion des appels</code> > <code className="action">Double appel et Intercom</code>. Vous pouvez y définir les lignes autorisées à utiliser l'intercom vers ce poste. Le mode intercom nécessite un téléphone compatible (la plupart des téléphones Plug & Phone OVHcloud le supportent). L'appel intercom est généralement déclenché en composant un code spécifique avant le numéro abrégé du destinataire.
 
@@ -461,11 +398,9 @@ Pour plus de détails, consultez le guide « [Gérer le mode intercom de votre l
 
 </details>
 
-
 <details>
 
 <summary>Comment personnaliser la musique d'attente de ma ligne SIP ?</summary>
-
 
 La musique d'attente est diffusée à votre correspondant lorsqu'il est mis en attente pendant un appel. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, sélectionnez la ligne SIP, puis cliquez sur l'onglet <code className="action">Gestion des musiques</code>. Vous pouvez y charger un fichier audio aux formats WAV, MP3 ou OGG. Le fichier est automatiquement converti au format adapté à la téléphonie. Vous pouvez également personnaliser la sonnerie d'appel entrant de la même manière. Pour les numéros alias configurés en File d'appels ou SVI, la musique d'attente se configure directement dans la configuration du numéro alias.
 
@@ -473,11 +408,9 @@ Pour plus de détails, consultez le guide « [Modifier les musiques et sonneries
 
 </details>
 
-
 <details>
 
 <summary>Comment publier mes coordonnées dans l'annuaire avec ma ligne OVHcloud ?</summary>
-
 
 <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, sélectionnez la ligne ou le numéro concerné, puis cliquez sur l'onglet <code className="action">Coordonnées</code>. Renseignez les coordonnées à publier (nom, adresse, activité pour les professionnels). La publication est gratuite et prend effet sous 4 à 6 semaines. Vous pouvez choisir de publier en liste normale, en liste rouge (coordonnées non communiquées sauf aux services d'urgence) ou en liste orange (coordonnées publiées mais non accessibles au démarchage). La modification ou la suppression des coordonnées suit le même délai.
 
@@ -485,11 +418,9 @@ Pour plus de détails, consultez le guide « [Renseigner les coordonnées d'une 
 
 </details>
 
-
 <details>
 
 <summary>Puis-je utiliser ma ligne SIP OVHcloud sur un softphone personnel ?</summary>
-
 
 Oui, il est possible d'enregistrer votre ligne SIP OVHcloud sur un softphone (application logicielle de téléphonie) installé sur un ordinateur ou un smartphone. Les informations nécessaires sont : le nom d'utilisateur SIP (identifiant de la ligne, au format `0033xxxxxxxxx`), le mot de passe SIP (disponible ou modifiable depuis l'espace client), et le serveur SIP (`sip.ovh.fr` ou le serveur indiqué dans les paramètres de votre ligne). OVHcloud fournit des guides de configuration pour les softphones Zoiper et Linphone. Les softphones tiers compatibles SIP fonctionnent également, à condition de respecter les paramètres d'enregistrement.
 
@@ -498,16 +429,13 @@ Si vous enregistrez votre ligne sur un softphone, elle sera désenregistrée de 
 
 :::
 
-
 Pour plus de détails, consultez le guide « [Configuration sur un softphone / téléphone personnel](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone) ».
 
 </details>
 
-
 <details>
 
 <summary>Comment installer et utiliser Softcall, le softphone OVHcloud ?</summary>
-
 
 Softcall est l'application softphone développée par OVHcloud pour utiliser votre ligne SIP depuis un ordinateur (Windows ou macOS). <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, sélectionnez votre ligne SIP, puis cliquez sur l'onglet <code className="action">Softphone</code>. Téléchargez l'application correspondant à votre système d'exploitation. L'authentification se fait via un lien d'activation envoyé par e-mail, ce qui évite de manipuler les identifiants SIP. Softcall offre les fonctionnalités classiques : appels entrants/sortants, transfert d'appel, mise en attente, gestion du répondeur, et affichage du carnet de contacts.
 
@@ -516,16 +444,13 @@ L'utilisation de Softcall désenregistre tout téléphone physique préalablemen
 
 :::
 
-
 Pour plus de détails, consultez le guide « [Installer et configurer Softcall](/guides/web-cloud/phone-and-fax/voip/installer-configurer-softcall) ».
 
 </details>
 
-
 <details>
 
 <summary>Comment sécuriser ma ligne SIP contre les usages frauduleux ?</summary>
-
 
 Plusieurs mesures de sécurité sont recommandées pour protéger votre ligne SIP :
 
@@ -541,16 +466,15 @@ Pour plus de détails, consultez le guide « [Sécuriser sa ligne SIP OVHcloud](
 
 </details>
 
-
 <details>
 
 <summary>Que faire si mon téléphone ne sonne plus ?</summary>
 
-
 Si vous rencontrez un dysfonctionnement sur votre téléphone, commencez par le débrancher puis le rebrancher. Si le phénomène persiste, réalisez quelques vérifications en suivant les instructions de « Dépannage Plug & Phone », disponibles depuis votre espace client OVHcloud.
 
 <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink>, choisissez votre groupe de facturation puis votre ligne SIP depuis l'onglet <code className="action">Services</code>. Cliquez sur l'onglet <code className="action">Assistance</code> puis sur <code className="action">Dépannage Plug & Phone</code>.
-<br/>Pour plus de détails, consultez le guide « [Dépanner son téléphone OVHcloud](/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel) ».
+
+Pour plus de détails, consultez le guide « [Dépanner son téléphone OVHcloud](/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel) ».
 
 :::tip
 **Trucs et astuces**
@@ -559,14 +483,11 @@ Si vous avez récemment activé la fonctionnalité de renvoi d'appels, pensez à
 
 :::
 
-
 </details>
-
 
 <details>
 
 <summary>Un message d'erreur apparaît sur mon téléphone, que faire ?</summary>
-
 
 Pour identifier la cause de cette erreur, réalisez un diagnostic de votre téléphone. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, choisissez le groupe de facturation puis la ligne SIP concernée dans l'onglet <code className="action">Services</code>. Cliquez sur l'onglet <code className="action">Assistance</code> puis sur <code className="action">Dépannage Plug & Phone</code>.
 
@@ -577,14 +498,11 @@ Avant de lancer un diagnostic, éteignez puis rallumez votre téléphone. Cette 
 
 :::
 
-
 </details>
-
 
 <details>
 
 <summary>Pourquoi mon numéro de téléphone abrégé dysfonctionne ?</summary>
-
 
 Ce dysfonctionnement peut provenir d'une mauvaise configuration. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud et sélectionnez votre groupe de facturation. Cliquez ensuite sur <code className="action">Numéros abrégés</code> et vérifiez que la ligne concernée figure bien dans le tableau. Si ce n'est pas le cas, cliquez sur le bouton <code className="action">Actions</code> pour ajouter un numéro abrégé dédié à cette ligne.
 
@@ -595,14 +513,11 @@ Il est recommandé de mettre en place des numéros abrégés à 4 chiffres. Si l
 
 :::
 
-
 </details>
-
 
 <details>
 
 <summary>Mon téléphone affiche « No Service » ou « Pas de service », que faire ?</summary>
-
 
 Ce message signifie que le téléphone n'arrive pas à s'enregistrer auprès de l'infrastructure VoIP OVHcloud. Les causes les plus fréquentes sont :
 
@@ -617,11 +532,9 @@ Pour plus de détails, consultez le guide « [Dépanner son téléphone OVHcloud
 
 </details>
 
-
 <details>
 
 <summary>Quels sont les ports réseau à ouvrir pour le bon fonctionnement de la VoIP ?</summary>
-
 
 Pour que la téléphonie VoIP fonctionne correctement, les flux suivants doivent pouvoir transiter sans blocage à travers votre pare-feu ou routeur :
 
@@ -635,16 +548,13 @@ Il est fortement déconseillé d'activer un SIP ALG (Application Layer Gateway) 
 
 :::
 
-
 Pour plus de détails, consultez le guide « [Diagnostic du réseau local](/guides/web-cloud/phone-and-fax/voip/troubleshoot-local-network) ».
 
 </details>
 
-
 <details>
 
 <summary>Pourquoi mes appels ont-ils un son saccadé ou des coupures audio ?</summary>
-
 
 Les problèmes de qualité audio en VoIP sont généralement liés au réseau local ou à la connexion Internet. Les principales causes et solutions sont :
 
@@ -660,11 +570,9 @@ Pour plus de détails, consultez le guide « [Diagnostic du réseau local](/guid
 
 </details>
 
-
 <details>
 
 <summary>Mon correspondant n'entend pas ma voix (audio unidirectionnel), que faire ?</summary>
-
 
 L'audio unidirectionnel (vous entendez votre correspondant mais il ne vous entend pas, ou inversement) est un problème réseau fréquent en VoIP. Les causes les plus courantes sont :
 
@@ -677,13 +585,11 @@ Pour plus de détails, consultez le guide « [Diagnostic du réseau local](/guid
 
 </details>
 
-
 ### Numéros alias
 
 <details>
 
 <summary>Comment associer un autre numéro à ma ligne téléphonique ?</summary>
-
 
 Cette opération consiste à effectuer une demande de numéro alias. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, choisissez le groupe de facturation souhaité puis cliquez sur <code className="action">Commander un numéro</code> dans l'onglet <code className="action">Tableau de bord</code>.
 
@@ -694,24 +600,19 @@ Vous pouvez commander jusqu'à 100 numéros pour 1 € HT/mois/numéro.
 
 :::
 
-
 </details>
-
 
 <details>
 
 <summary>Comment configurer mes numéros alias ?</summary>
 
-
 Consultez le guide « [Choisir et appliquer une configuration pour un numéro](/guides/web-cloud/phone-and-fax/voip/quelle-configuration-est-adaptee-a-mes-besoins) » pour découvrir les différentes configurations disponibles.
 
 </details>
 
-
 <details>
 
 <summary>Comment supprimer la redirection de mon numéro alias vers ma ligne ?</summary>
-
 
 <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, choisissez le groupe de facturation puis le numéro concerné dans l'onglet <code className="action">Services</code>. Cliquez sur <code className="action">Supprimer la configuration</code>.
 
@@ -722,14 +623,11 @@ Vous pouvez également modifier la configuration du numéro en cliquant sur <cod
 
 :::
 
-
 </details>
-
 
 <details>
 
 <summary>Comment enregistrer mes appels ?</summary>
-
 
 La fonctionnalité d'enregistrement des appels nécessite une configuration « Contact Center Solution » sur le numéro de téléphone concerné. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, choisissez le groupe de facturation puis le numéro concerné dans l'onglet <code className="action">Services</code>. Cliquez sur <code className="action">Configuration du numéro</code>. Votre numéro doit être configuré en « Contact Center Solution ».
 
@@ -737,11 +635,9 @@ Pour plus de détails, consultez le guide « [Configurer un Contact Center Solut
 
 </details>
 
-
 <details>
 
 <summary>Pourquoi l'enregistrement de mes appels dysfonctionne ?</summary>
-
 
 Ce dysfonctionnement peut provenir d'une mauvaise configuration. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, choisissez le groupe de facturation puis le numéro configuré en « Contact Center Solution » depuis l'onglet <code className="action">Services</code>. Au sein de cette configuration, cliquez sur le menu « Consulter les enregistrements ». Vérifiez que la case « Enregistrement des appels » est bien cochée. Consultez le guide « [Configurer un Contact Center Solution](/guides/web-cloud/phone-and-fax/voip/contact-center-solution#consulter-les-enregistrements) » pour plus de détails.
 
@@ -752,14 +648,11 @@ Si vous rencontrez une erreur lors de la consultation d'un enregistrement, essay
 
 :::
 
-
 </details>
-
 
 <details>
 
 <summary>Quelle configuration de numéro alias choisir pour mon entreprise ?</summary>
-
 
 OVHcloud propose plusieurs configurations pour les numéros alias, chacune adaptée à un besoin spécifique :
 
@@ -773,11 +666,9 @@ Le choix dépend de la taille de votre entreprise, du volume d'appels entrants e
 
 </details>
 
-
 <details>
 
 <summary>Comment configurer un Serveur Vocal Interactif (SVI) ?</summary>
-
 
 Le SVI permet de proposer un menu vocal à vos appelants pour les orienter vers le bon service. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud. Sélectionnez le numéro alias, puis appliquez la configuration « Serveur Vocal Interactif ». Vous pouvez :
 
@@ -790,11 +681,9 @@ Le SVI peut être imbriqué sur plusieurs niveaux pour des arborescences complex
 
 </details>
 
-
 <details>
 
 <summary>Comment configurer une file d'appels sur un numéro alias ?</summary>
-
 
 La file d'appels permet de distribuer les appels entrants vers plusieurs lignes SIP. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, sélectionnez le numéro alias concerné, puis appliquez la configuration « File d'appels ». Vous pouvez :
 
@@ -808,11 +697,9 @@ Pour plus de détails, consultez le guide « [Configurer une file d'appels](/gui
 
 </details>
 
-
 <details>
 
 <summary>Comment créer et gérer une conférence téléphonique OVHcloud ?</summary>
-
 
 La conférence téléphonique permet à plusieurs participants de se réunir sur un même appel en composant un numéro dédié et un code PIN. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, sélectionnez un numéro alias, puis appliquez la configuration « Conférence ». Vous pouvez :
 
@@ -826,11 +713,9 @@ La conférence est accessible depuis n'importe quel téléphone (fixe, mobile, V
 
 </details>
 
-
 <details>
 
 <summary>Qu'est-ce que le Contact Center Solution et quelles sont ses fonctionnalités ?</summary>
-
 
 Le Contact Center Solution (CCS) est la configuration la plus avancée pour les numéros alias OVHcloud. Il combine les fonctionnalités du SVI et de la file d'appels, avec des options supplémentaires dédiées aux centres d'appels :
 
@@ -845,11 +730,9 @@ Le CCS est recommandé pour les entreprises ayant un volume d'appels entrants im
 
 </details>
 
-
 <details>
 
 <summary>Comment configurer une redirection d'appels avec présentation du numéro ?</summary>
-
 
 La redirection avec présentation permet de rediriger les appels reçus sur un numéro alias vers une ligne SIP tout en affichant le numéro de l'appelant (et non le numéro alias) sur le téléphone de destination. <ManagerLink to="/#/telecom/telephony">Accédez à la section VoIP & Fax</ManagerLink> de votre espace client OVHcloud, sélectionnez le numéro alias, appliquez la configuration « Redirection avec présentation du numéro », puis indiquez la ligne SIP de destination. Contrairement à la redirection simple (DDI), cette configuration consomme un canal d'appel simultané sur le numéro alias et présente le numéro de l'appelant d'origine. La redirection simple (DDI), quant à elle, présente le numéro alias comme appelant sur la ligne de destination.
 
@@ -857,11 +740,9 @@ Pour plus de détails, consultez le guide « [Configurer une redirection d'appel
 
 </details>
 
-
 <details>
 
 <summary>Quels types de numéros spéciaux (SVA) puis-je exploiter avec OVHcloud ?</summary>
-
 
 OVHcloud permet l'exploitation de numéros SVA (Services à Valeur Ajoutée) de différentes catégories :
 
@@ -875,23 +756,19 @@ Pour plus de détails, consultez le guide « [Gérer les reversements ou les co�
 
 </details>
 
-
 ### Lignes SIP Trunk
 
 <details>
 
 <summary>Qu'est-ce qu'un SIP Trunk OVHcloud et à quoi sert-il ?</summary>
 
-
 Un SIP Trunk est une ligne de téléphonie VoIP multi-canaux qui se connecte à votre IPBX (autocommutateur téléphonique IP). Contrairement à une ligne SIP individuelle associée à un téléphone unique, un SIP Trunk peut gérer simultanément plusieurs appels (entrants et sortants) sur un même lien. Chez OVHcloud, le SIP Trunk s'utilise principalement avec des IPBX logiciels comme 3CX, Asterisk, ou FreePBX. L'intérêt principal est de centraliser la gestion de la téléphonie d'entreprise sur votre propre infrastructure (hébergée en local ou dans le cloud) tout en bénéficiant de la connectivité et des tarifs OVHcloud pour la partie opérateur. Le nombre de canaux simultanés est configurable selon vos besoins.
 
 </details>
 
-
 <details>
 
 <summary>Comment déployer un IPBX 3CX sur OVHcloud Public Cloud ?</summary>
-
 
 OVHcloud propose un déploiement automatisé de l'IPBX 3CX sur une instance Public Cloud. La procédure s'effectue via l'espace client OVHcloud :
 
@@ -906,11 +783,9 @@ Pour plus de détails, consultez le guide « [Déployer automatiquement l'IPBX 3
 
 </details>
 
-
 <details>
 
 <summary>Comment configurer un SIP Trunk avec 3CX ?</summary>
-
 
 Pour connecter votre IPBX 3CX au SIP Trunk OVHcloud, vous devez configurer un « Fournisseur SIP » dans l'interface d'administration 3CX. Les paramètres à renseigner sont :
 
@@ -926,11 +801,9 @@ Pour plus de détails, consultez le guide « [3CX - Configuration et utilisation
 
 </details>
 
-
 <details>
 
 <summary>Quels IPBX sont compatibles avec les SIP Trunk OVHcloud ?</summary>
-
 
 Les SIP Trunk OVHcloud sont basés sur le protocole SIP standard (RFC 3261) et sont compatibles avec la grande majorité des IPBX du marché. Les IPBX les plus couramment utilisés avec OVHcloud incluent :
 
@@ -943,11 +816,9 @@ Les IPBX matériels (Avaya, Cisco, Yealink, Mitel) compatibles SIP peuvent égal
 
 </details>
 
-
 <details>
 
 <summary>Comment configurer le routage des appels entrants (DID) sur mon IPBX ?</summary>
-
 
 Le routage des appels entrants (DID — Direct Inward Dialing) consiste à diriger un appel entrant sur un numéro alias vers le bon poste interne de votre IPBX. La procédure dépend de votre IPBX mais suit le même principe :
 
@@ -959,17 +830,14 @@ En cas de difficulté, vérifiez dans les logs de votre IPBX que l'en-tête SIP 
 
 </details>
 
-
 <details>
 
 <summary>Comment gérer les appels simultanés sur un SIP Trunk ?</summary>
-
 
 Le nombre d'appels simultanés sur un SIP Trunk détermine combien de conversations téléphoniques peuvent être actives en même temps (entrantes et/ou sortantes). Ce nombre est configurable depuis votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, dans les paramètres du trunk. Chaque canal supplémentaire est facturé mensuellement. Pour dimensionner correctement votre trunk, estimez le nombre maximum d'appels simultanés pendant vos heures de pointe. Une formule courante est d'avoir un ratio de 1 canal pour 3 postes en usage bureautique, ou 1 canal pour 1,5 poste en centre d'appels. Le dépassement du nombre de canaux autorisés provoquera un signal « occupé » pour les appels excédentaires.
 
 </details>
 
-
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/fonctionalites-spa504g.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/fonctionalites-spa504g.mdx
@@ -4,22 +4,25 @@ description: "Découvrez les fonctionnalités de votre téléphone Cisco SPA504G
 lastUpdated: 2018-03-26
 ---
 
-------------------------------------------------------------------------
+## Objectif
 
-**Sommaire :**
+**Découvrez les principales fonctionnalités de votre téléphone Cisco SPA504G : transfert d'appel, conférence et carnet de contacts.**
 
-Niveau : Débutant
+## Prérequis
 
-------------------------------------------------------------------------
+- Posséder [une ligne téléphonique OVHcloud](https://www.ovhcloud.com/fr/phone/).
+- Avoir réceptionné et installé le téléphone Cisco SPA504G fourni par OVHcloud.
 
-### Effectuer un transfert d'appel &#123;#effectuer-un-transfert-dappel&#125;
+## En pratique
+
+### Effectuer un transfert d'appel
 
 Il y a deux types de transferts d'appel possible :
 
 -   **Transfert accompagné :** votre correspondant est mis en attente, vous appelez le destinataire du transfert et vous transférez l'appel selon sa disponibilité.
 -   **Transfert aveugle :** vous transférez l'appel sans vous assurer de la disponibilité de votre correspondant.
 
-#### Transfert accompagné &#123;#transfert-accompagné&#125;
+#### Transfert accompagné
 
 Si vous souhaitez effectuer un transfert d'appel accompagné :
 
@@ -27,7 +30,7 @@ Si vous souhaitez effectuer un transfert d'appel accompagné :
 -   composez le numéro du **destinataire** de l'appel ;
 -   une fois que votre correspondant a décroché, appuyez de nouveau sur la touche "**Trsf.**" ou "**Xfer**".
 
-#### Transfert aveugle &#123;#transfert-aveugle&#125;
+#### Transfert aveugle
 
 Pour le transfert à l'aveugle, une fois en communication avec votre correspondant :
 
@@ -36,15 +39,11 @@ Pour le transfert à l'aveugle, une fois en communication avec votre corresponda
 -   composez le numéro du **destinataire**de l'appel ;
 -   appuyez de nouveau sur la touche "**TrsfSi**" ou "**Bxfer**".
 
-------------------------------------------------------------------------
-
-### Réaliser une conférence &#123;#réaliser-une-conférence&#125;
+### Réaliser une conférence
 
 Vous pouvez effectuer une conférence avec le SPA. Pour ce faire, une fois en communication avec votre premier correspondant, appuyez sur la touche "**Conf.**" et composez le numéro de téléphone de votre second correspondant ou appuyez sur la touche programmable correspondant à votre correspondant. Vous serez mis immédiatement en conférence.
 
-------------------------------------------------------------------------
-
-### Carnet de contacts &#123;#carnet-de-contacts&#125;
+### Carnet de contacts
 
 Le carnet de contacts est automatiquement mis à jour sur le téléphone lors de l'ajout de contacts dans votre Manager.
 
@@ -52,4 +51,4 @@ La traduction du nom du carnet poussé par le Manager lors d'un appel entrant n'
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/gerer-la-presentation-du-numero-sur-votre-ligne-sip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/gerer-la-presentation-du-numero-sur-votre-ligne-sip.mdx
@@ -13,9 +13,9 @@ Votre ligne téléphonique OVHcloud vous permet de recevoir et d'émettre des ap
 ## Prérequis
 
 - Disposer de (au choix) :
-    - deux [lignes VoIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/);
-    - une [ligne VoIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/) et un [numéro alias OVHcloud](https://www.ovhtelecom.fr/telephonie/numeros/);
-    - une [ligne Trunk](https://www.ovhtelecom.fr/telephonie/sip-trunk/);
+    - deux [lignes VoIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/);
+    - une [ligne VoIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/) et un [numéro alias OVHcloud](https://www.ovhcloud.com/fr/phone/numeros/);
+    - une [ligne Trunk](https://www.ovhcloud.com/fr/phone/sip-trunk/);
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -166,4 +166,4 @@ Vous pouvez à présent configurer la présentation du numéro sur votre équipe
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/gerer-numeros-abreges-ligne-sip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/gerer-numeros-abreges-ligne-sip.mdx
@@ -12,7 +12,7 @@ Pour faciliter les interactions avec vos correspondants, vous pouvez créer des 
 
 ## Prérequis
 
-- Disposer d'au moins une [ligne SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/).
+- Disposer d'au moins une [ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -32,14 +32,14 @@ Il est recommandé de mettre en place des numéros abrégés à 4 chiffres. Si l
 
 :::
 
-
 ### Étape 1 : accéder à la gestion des numéros abrégés
 
 Vous pouvez créer des numéros abrégés pour une seule ligne ou partager ces numéros abrégés sur un groupe de lignes (toutes les lignes rattachées à ce groupe en bénéficient alors).
 
 - **Pour accéder à la gestion des numéros abrégés d'une seule ligne** :
 
-Cliquez sur l'onglet <code className="action">Services</code> puis sur la ligne SIP concernée.<br/>
+Cliquez sur l'onglet <code className="action">Services</code> puis sur la ligne SIP concernée.
+
 Dans l'onglet <code className="action">Gestion des appels</code>, cliquez sur <code className="action">Numéros abrégés</code>.
 
 <img className="thumbnail" alt="configuration numeros abrégés" src="/images/web-cloud/phone-and-fax/voip/gerer-numeros-abreges-ligne-sip/configurer-numeros-abreges-step1-2022.png" loading="lazy" />
@@ -92,7 +92,6 @@ Si aucun indicatif pays n'est renseigné dans les numéros cibles dans votre fic
 
 :::
 
-
 <img className="thumbnail" alt="configuration numeros abrégés" src="/images/web-cloud/phone-and-fax/voip/gerer-numeros-abreges-ligne-sip/configurer-numeros-abreges-step5-2022.png" loading="lazy" />
 
 #### Télécharger la liste des numéros abrégés actuelle
@@ -113,4 +112,4 @@ Composez alors un numéro abrégé que vous souhaitez contacter depuis l'une de 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/gerer-utiliser-appels-simultanes.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/gerer-utiliser-appels-simultanes.mdx
@@ -12,7 +12,7 @@ Votre ligne téléphonique chez OVHcloud vous permet de recevoir et d'émettre d
 
 ## Prérequis
 
-- Disposer d'une ligne téléphonique possédant un [forfait compatible](https://www.ovhtelecom.fr/telephonie/services_inclus/) avec la fonctionnalité « appels simultanés ».
+- Disposer d'une ligne téléphonique possédant un [forfait compatible](https://www.ovhcloud.com/fr/phone/voip/services-inclus/) avec la fonctionnalité « appels simultanés ».
 - Posséder et avoir installé un téléphone Plug & Phone.
 
 {/* CP-NAV-START:telecom-voip-fax */}
@@ -38,7 +38,7 @@ Dans l'onglet <code className="action">Gestion des appels</code>, cliquez sur <c
 
 La page qui s'affiche vous permet de visualiser le nombre d'appels simultanés inclus dans votre offre ou en option sur votre ligne. Selon vos besoins, vous pouvez augmenter ou diminuer ce nombre en utilisant les flèches à droite du nombre actuel d'appels simultanés. Avant d'entamer toute démarche, nous vous recommandons de vous assurer que :
 
-- le téléphone sur lequel est configurée votre ligne est apte à gérer le nombre d'appels simultanés dont vous souhaitez bénéficier. Retrouvez plus d'informations sur les téléphones depuis le lien : [https://www.ovhtelecom.fr/telephonie/comparatif-des-telephones.xml](https://www.ovhtelecom.fr/telephonie/comparatif-des-telephones.xml) ;
+- le téléphone sur lequel est configurée votre ligne est apte à gérer le nombre d'appels simultanés dont vous souhaitez bénéficier. Retrouvez plus d'informations sur les téléphones depuis le lien : [https://www.ovhcloud.com/fr/phone/voip/telephone/](https://www.ovhcloud.com/fr/phone/voip/telephone/) ;
 - la bande passante de votre connexion Internet est suffisamment dimensionnée pour gérer le nombre d'appels simultanés dont vous souhaitez bénéficier. Pour une utilisation optimale, une bande passante comprise entre 70 et 100 Kbit/s est requise par appel simultané.
 
 Dès que vous êtes prêt, modifiez le nombre d'appels simultanés grâce aux flèches, puis suivez les étapes qui s'affichent. Pour chaque ajout, n'oubliez pas de payer le bon de commande qui s'affichera.
@@ -49,7 +49,7 @@ Dès que vous êtes prêt, modifiez le nombre d'appels simultanés grâce aux fl
 
 Vous pouvez utiliser les appels simultanés selon le nombre maximum d'appels défini dans votre offre ou votre option. **Chaque appel en cours consomme un appel simultané**. La ligne utilisée doit donc disposer d'un appel simultané disponible si vous souhaitez en utiliser un nouveau. 
 
-Un signal sonore (un bip) vous avertira lorsque vous recevrez un nouvel appel, utilisant donc un appel simultané. Votre téléphone doit être compatible afin de pouvoir entendre ce signal. Reportez-vous aux documentations OVHcloud accessibles depuis le lien [https://www.ovhtelecom.fr/telephonie/telephones/cisco_CP8851/documents.xml](https://www.ovhtelecom.fr/telephonie/telephones/cisco_CP8851/documents.xml) pour le vérifier.
+Un signal sonore (un bip) vous avertira lorsque vous recevrez un nouvel appel, utilisant donc un appel simultané. Votre téléphone doit être compatible afin de pouvoir entendre ce signal. Reportez-vous aux documentations OVHcloud accessibles depuis le lien [https://www.ovhcloud.com/fr/phone/voip/telephone/](https://www.ovhcloud.com/fr/phone/voip/telephone/) pour le vérifier.
 
 Lorsque vous souhaitez utiliser les appels simultanés :
 
@@ -65,4 +65,4 @@ L'un de vos appels simultanés doit être disponible sur votre ligne quand vous 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/gestion-du-depot-de-garantie-et-de-la-limite-hors-forfait.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/gestion-du-depot-de-garantie-et-de-la-limite-hors-forfait.mdx
@@ -177,4 +177,4 @@ Une fois ces vérifications effectuées, vous pouvez débloquer le groupe en [au
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/gigaset-c530ip-use.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/gigaset-c530ip-use.mdx
@@ -78,4 +78,4 @@ Pour mettre fin à une communication, appuyez sur le bouton <code className="act
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/importer-un-carnet-de-contacts.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/importer-un-carnet-de-contacts.mdx
@@ -12,7 +12,7 @@ Votre ligne SIP OVHcloud vous permet de recevoir et d’émettre des appels. Pou
 
 ## Prérequis
 
-- Disposer au moins d'une [ligne SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/).
+- Disposer au moins d'une [ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -113,4 +113,4 @@ Afin que votre téléphone puisse utiliser le carnet de contacts ou récupérer 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/installer-configurer-softcall.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/installer-configurer-softcall.mdx
@@ -6,9 +6,6 @@ lastUpdated: 2025-04-28
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-
-
-
 ## Objectif
 
 Le Softphone est une solution qui transforme votre ordinateur, smartphone ou tablette en un téléphone virtuel, vous permettant d'utiliser votre ligne SIP (**S**ession **I**nitiation **P**rotocol) n'importe où et à tout moment. Grâce à notre application [Softcall](https://labs.ovhcloud.com/en/softphone-beta/), facilement téléchargeable sur les plateformes Android, iOS, macOS et Windows, vous pouvez accéder à toutes les fonctionnalités de votre ligne téléphonique professionnelle sans être attaché à un téléphone de bureau traditionnel. Que vous soyez en déplacement ou que vous travailliez à distance, Softcall garantit que votre ligne SIP reste aussi mobile et flexible que nécessaire.
@@ -17,7 +14,7 @@ Le Softphone est une solution qui transforme votre ordinateur, smartphone ou tab
 
 ## Prérequis
 
-- Disposer d'une [ligne SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/).
+- Disposer d'une [ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
 - Si votre ligne est rattachée à un téléphone fourni par OVHcloud, celui-ci ne pourra plus être utilisé dès lors que Softcall est activé.
 - Si votre connexion est derrière un pare-feu, vous devez y autoriser la plage d'adresses IP suivante : `5.196.180.0/27`.
 
@@ -37,14 +34,14 @@ Si Softcall est désactivé et que vous souhaitez réutiliser votre téléphone 
 
 :::
 
-
 ## En pratique
 
 ### Installer Softcall
 
 #### Activer la ligne SIP pour Softcall
 
-Cliquez sur l'onglet <code className="action">Services</code> puis sur la ligne SIP concernée.<br/>
+Cliquez sur l'onglet <code className="action">Services</code> puis sur la ligne SIP concernée.
+
 Après avoir sélectionné l'onglet <code className="action">Softphone</code>, cliquez sur l'interrupteur pour utiliser la ligne SIP sur l'ensemble de vos applications Softcall.
 
 <img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/toggle_activation_sip.png" loading="lazy" />
@@ -92,7 +89,6 @@ Cliquez sur l'icône de l'application Softcall. Au premier démarrage, vous ête
   </Tab>
 </Tabs>
 
-
 Dans l'écran <code className="action">Assistant</code> de l'application Softcall, utilisez le code de configuration ou le QR code récupérés précédemment, puis cliquez sur <code className="action">Télécharger et appliquer</code> pour valider.
 
 Votre compte Softcall est désormais configuré. Dans le menu principal de Softcall, retrouvez votre numéro de téléphone (au format international) tout en haut du menu.
@@ -111,7 +107,6 @@ Cliquez sur l'icône de l'application Softcall. Au premier démarrage, vous ête
     <img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/assistant_windows_macos.png" loading="lazy" />
   </Tab>
 </Tabs>
-
 
 Dans l'écran <code className="action">Assistant</code> de l'application Softcall, utilisez le code de configuration récupéré précédemment, puis cliquez sur <code className="action">Télécharger</code>. Un message de confirmation s'affiche.
 
@@ -137,7 +132,6 @@ Dans le menu principal en bas de l'écran, cliquez sur l'icône représentant un
     <img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/bottom_menu_ios.png" loading="lazy" />
   </Tab>
 </Tabs>
-
 
 Entrez le numéro de votre contact et cliquez sur l'icône représentant un téléphone pour passer l'appel.
 
@@ -165,7 +159,6 @@ Cette fonctionnalité permet de supprimer votre compte Softcall uniquement sur v
 
 :::
 
-
 Effectuez les actions suivantes pour supprimer votre compte Softcall de votre appareil :
 
 - Dans le menu principal, cliquez sur <code className="action">Options</code>.
@@ -181,18 +174,15 @@ Effectuez les actions suivantes pour supprimer votre compte Softcall de votre ap
 
 <summary>Appeler la messagerie vocale</summary>
 
-
 Pour appeler votre messagerie vocale, cliquez sur l'icône suivante, en haut à droite de l'interface de Softcall.
 
 <img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/voicemail_button.png" loading="lazy" />
 
 </details>
 
-
 <details>
 
 <summary>Utiliser le mode bis</summary>
-
 
 Dans le menu latéral de l'interface de Softcall, cliquez sur l'icône représentant un téléphone.
 
@@ -204,11 +194,9 @@ En haut à droite de l'écran, cliquez sur le bouton représentant un téléphon
 
 </details>
 
-
 <details>
 
 <summary>Effectuer un transfert d'appel à l'aveugle</summary>
-
 
 Lorsque vous transférez un appel téléphonique à l'aveugle, cela signifie que :
 
@@ -235,11 +223,9 @@ Pour effectuer un transfert d'appel à l'aveugle, suivez ces étapes :
 
 </details>
 
-
 <details>
 
 <summary>Effectuer un transfert d'appel accompagné</summary>
-
 
 Lorsque vous effectuez un transfert d'appel accompagné, cela signifie que :
 
@@ -270,11 +256,9 @@ Pour effectuer un transfert d'appel accompagné, suivez ces étapes :
 
 </details>
 
-
 <details>
 
 <summary>Rapporter un incident à nos équipes</summary>
-
 
 Si vous rencontrez un problème avec l'application Softcall (bug, erreur, etc.), nous vous recommandons d'envoyer un rapport d'erreurs à nos équipes en suivant ces étapes :
 
@@ -285,13 +269,11 @@ Si vous rencontrez un problème avec l'application Softcall (bug, erreur, etc.),
 
 </details>
 
-
 #### Application mobile (Android et iOS)
 
 <details>
 
 <summary>Appeler la messagerie vocale</summary>
-
 
 Pour appeler votre messagerie vocale, cliquez sur l'icône suivante, en haut à droite de l'interface de Softcall.
 
@@ -299,11 +281,9 @@ Pour appeler votre messagerie vocale, cliquez sur l'icône suivante, en haut à 
 
 </details>
 
-
 <details>
 
 <summary>Utiliser le mode bis</summary>
-
 
 Pour appeler le dernier numéro avec lequel vous avez été en contact, suivez les étapes ci-dessous :
 
@@ -319,11 +299,9 @@ Pour appeler le dernier numéro avec lequel vous avez été en contact, suivez l
 
 </details>
 
-
 <details>
 
 <summary>Effectuer un transfert d'appel à l'aveugle</summary>
-
 
 Lorsque vous transférez un appel téléphonique à l'aveugle, cela signifie que :
 
@@ -348,11 +326,9 @@ Pour effectuer un transfert d'appel à l'aveugle, suivez ces étapes :
 
 </details>
 
-
 <details>
 
 <summary>Effectuer un transfert d'appel accompagné</summary>
-
 
 Lorsque vous effectuez un transfert d'appel accompagné, cela signifie que :
 
@@ -381,21 +357,22 @@ Pour effectuer un transfert d'appel accompagné, suivez ces étapes :
 
 </details>
 
-
 <details>
 
 <summary>Rapporter un incident à nos équipes</summary>
 
-
 Si vous rencontrez un problème dans l'application Softcall (bug, erreur, etc.),nous vous recommandons d'envoyer un rapport d'erreurs à nos équipes en suivant ces étapes :
 
-Composez le numéro `#1234#`.<br/>
+Composez le numéro `#1234#`.
+
 Dans le menu qui s'affiche, cliquez sur <code className="action">Activer les traces</code>.
 
 <img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_enable_debugging.jpg" loading="lazy" />
 
-Reproduisez les actions qui provoquent l'anomalie.<br/>
-Composez à nouveau le numéro `#1234#`.<br/>
+Reproduisez les actions qui provoquent l'anomalie.
+
+Composez à nouveau le numéro `#1234#`.
+
 Dans le menu qui s'affiche, cliquez sur <code className="action">Envoyer les traces</code>.
 
 <img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_submit_logs.jpg" loading="lazy" />
@@ -404,7 +381,6 @@ Sur l'écran qui s'affiche, choisissez votre client de messagerie. Le destinatai
 Envoyez l'e-mail pour transmettre ce rapport à notre équipe en charge du produit Softcall.
 
 </details>
-
 
 ### Personnaliser Softcall
 
@@ -425,7 +401,6 @@ La modification du logo depuis l'espace client ne concerne pas l'icône de l'app
 
 :::
 
-
 Dirigez-vous dans la section <code className="action">Ajouter un logo</code>.
 
 Cliquez sur le bouton <code className="action">Drag and drop a file or select a file</code>. La photo que vous venez de charger s'affiche en-dessous de la mention `Attached file(s)` (`OVHcloud_logo.png` dans l'exemple ci-dessous).
@@ -441,9 +416,8 @@ Respectez les critères suivants pour la photo à charger :
 
 :::
 
-
 Cliquez sur le bouton <code className="action">Appliquer un logo</code>. Redémarrez votre application Softcall pour activer le changement de thème.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/la-procedure-de-validation-voip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/la-procedure-de-validation-voip.mdx
@@ -118,4 +118,4 @@ Vous pouvez le télécharger **gratuitement** via ce lien : [https://www.adobe.c
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
@@ -5,7 +5,6 @@ lastUpdated: 2026-01-22
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-
 ## Guides VoIP OVHcloud
 
 Bienvenue dans la documentation dédiée à la [téléphonie VoIP (Voice over IP) d’OVHcloud](https://www.ovhcloud.com/fr/phone/).
@@ -34,7 +33,6 @@ Avec les services VoIP d’OVHcloud, vous pouvez :
 - [Gérer vos groupes de téléphonie](/guides/web-cloud/phone-and-fax/voip/regrouper-services-telephonie)
 - [Renseigner les coordonnées d'une ligne ou d'un numéro et les faire paraître en ligne](/guides/web-cloud/phone-and-fax/voip/publication-annuaire)
 
-
 #### Administration
 
 - [Valider votre identité pour l'utilisation des services VoIP](/guides/web-cloud/phone-and-fax/voip/la-procedure-de-validation-voip)
@@ -48,10 +46,10 @@ Avec les services VoIP d’OVHcloud, vous pouvez :
 ### Configuration
 
 :::info
-**Quelle est la différence entre une ligne VoIP et un numéro alias ?**<br/>
+**Quelle est la différence entre une ligne VoIP et un numéro alias ?**
+
 Retrouvez les questions les plus fréquemment posées sur les services VoIP OVHcloud dans notre [FAQ](/guides/web-cloud/phone-and-fax/voip/faq-voip).
 :::
-
 
 <Tabs>
   <Tab label="Lignes VoIP">
@@ -92,7 +90,6 @@ Retrouvez les questions les plus fréquemment posées sur les services VoIP OVHc
   </Tab>
 </Tabs>
 
-
 ### Tutoriels
 
 - [Ligne SIP - Configuration sur un softphone / téléphone personnel](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone)
@@ -123,4 +120,4 @@ OVHcloud publie un Changelog (parfois également appelé « Release Notes ») qu
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/les-files-d-appels.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/les-files-d-appels.mdx
@@ -14,14 +14,13 @@ Vous pouvez ainsi décider, lorsqu'un appel entrant arrive sur votre numéro pri
  
 ## Prérequis
 
-- Disposer d'un [numéro alias](https://www.ovhtelecom.fr/telephonie/numeros/) dans votre compte OVHcloud.
+- Disposer d'un [numéro alias](https://www.ovhcloud.com/fr/phone/numeros/) dans votre compte OVHcloud.
 
 :::info
 Une file d'appels ne peut être configurée **que sur un numéro alias**.
 Consultez notre [FAQ](/guides/web-cloud/phone-and-fax/voip/faq-voip) pour plus d'informations sur les différences entre un numéro alias et une ligne SIP.
 
 :::
-
 
 ## En pratique
 
@@ -56,7 +55,6 @@ Cliquez sur le bouton <code className="action">Paramétrer</code> et patientez q
 Si vous appliquez le même type de configuration à plusieurs numéros, vous devrez finaliser la configuration sur chacun des numéros concernés.
 
 :::
-
 
 ### Étape 2 : Paramétrer la file d'appels
 
@@ -113,12 +111,11 @@ Comme précisé dans le menu de configuration, les conditions particulières sui
 
 - La législation interdit la redirection sur des numéros surtaxés.
 - Un appel redirigé vers une destination non-comprise dans votre forfait vous sera facturé.
-- Les redirections vers un numéro mobile ou une ligne externe à OVHcloud ne sont pas comprises dans les [forfaits VoIP](https://www.ovhtelecom.fr/telephonie/voip/#offers). Elles sont donc facturées à la seconde, sauf dans le cadre des forfaits mobile à l’heure.
+- Les redirections vers un numéro mobile ou une ligne externe à OVHcloud ne sont pas comprises dans les [forfaits VoIP](https://www.ovhcloud.com/fr/phone/voip/#offers). Elles sont donc facturées à la seconde, sauf dans le cadre des forfaits mobile à l’heure.
 
 Consultez les [tarifs de la téléphonie OVHcloud](https://www.ovhtelecom.fr/telephonie/decouvrez/tarifs_telephonie.xml) pour plus de détails.
 
 :::
-
 
 ##### 2. Configurer une stratégie d’appels
 
@@ -146,7 +143,8 @@ Une fois vos choix effectués, cliquez sur le bouton <code className="action">Va
 
 ##### 3. Organiser les lignes de la file d’appels
 
-Vous pouvez organiser les lignes dans votre file d'appels depuis le tableau où celles-ci apparaissent.<br/>
+Vous pouvez organiser les lignes dans votre file d'appels depuis le tableau où celles-ci apparaissent.
+
 Pour cela, utilisez les flèches à gauche de chacune des lignes pour les déplacer jusqu'à leurs positions adéquates. 
 
 <img className="thumbnail" alt="fileappels" src="/images/web-cloud/phone-and-fax/voip/les-files-d-appels/2022-VoIP-FA-07.png" loading="lazy" />
@@ -176,7 +174,6 @@ Vous pouvez ainsi gérer à la volée, directement depuis votre téléphone, l'a
 
 :::
 
-
 #### 2.2 Gérer les sons et l'attente <a name="manage-sounds"></a>
 
 Dans le menu « Configuration », cliquez sur <code className="action">Gestion des sons et de l'attente</code>. Plusieurs actions sont alors possibles depuis cette page. 
@@ -185,11 +182,11 @@ Dans le menu « Configuration », cliquez sur <code className="action">Gestion d
 
 :::warning
 La création des annonces sonores est de votre responsabilité. En cas de difficultés, nous vous conseillons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/) car OVHcloud ne sera pas en mesure de créer ces fichiers pour vous.
-<br/>Sachez qu'il est possible de créer des fichiers-sons via le logiciel open source et gratuit [Audacity](https://www.audacityteam.org/).
+
+Sachez qu'il est possible de créer des fichiers-sons via le logiciel open source et gratuit [Audacity](https://www.audacityteam.org/).
 Nous vous rappelons que l'utilisation d'une musique non libre d'utilisation commerciale nécessite de s'acquitter de droits de diffusion auprès des sociétés d'auteurs/compositeurs/producteurs.
 
 :::
-
 
 Vous pouvez ajouter deux sons :
 
@@ -237,8 +234,10 @@ Si votre numéro est déjà en production, nous vous conseillons de définir vos
 
 Définissez ici des scénarios de redirection que vous pourrez utiliser ensuite pour vos plages horaires. 
 
-Pour cela, dans la partie « Configuration des créneaux horaires », cliquez sur le pictogramme en forme d'engrenage à droite de chaque créneau<br/>
-Vous devrez y sélectionner ou renseigner un numéro ou un répondeur vers lequel les appels seront redirigés.<br/>
+Pour cela, dans la partie « Configuration des créneaux horaires », cliquez sur le pictogramme en forme d'engrenage à droite de chaque créneau
+
+Vous devrez y sélectionner ou renseigner un numéro ou un répondeur vers lequel les appels seront redirigés.
+
 Par défaut, la sélection est positionnée sur « Un numéro externe ». Vous pouvez bien entendu modifier ce choix en cliquant dessus.
 
 Finalisez votre choix en cliquant sur le bouton <code className="action">Modifier</code>.
@@ -250,12 +249,14 @@ Finalisez votre choix en cliquant sur le bouton <code className="action">Modifie
 Une fois les créneaux configurés à votre convenance, dans la partie « Gestion des plages horaires et des fermetures » de la page, vous pouvez définir des plages horaires et leur attribuer des créneaux.
 
 Cliquez sur un horaire et modifiez la plage associée, ou cliquez sur l’horaire de début souhaité puis glissez en maintenant le clic jusqu’à l’horaire de fin. 
-Utilisez le bouton <code className="action">Répéter</code> pour, par exemple, appliquer le même créneau sur plusieurs jours de la semaine.<br/>
+Utilisez le bouton <code className="action">Répéter</code> pour, par exemple, appliquer le même créneau sur plusieurs jours de la semaine.
+
 Définissez ensuite le créneau à appliquer grâce au bouton <code className="action">Rediriger les appels vers</code>, puis validez l’ajout de la plage horaire en cliquant sur <code className="action">Ajouter</code>.
 
 <img className="thumbnail" alt="fileappels" src="/images/web-cloud/phone-and-fax/voip/les-files-d-appels/2022-VoIP-FA-15.png" loading="lazy" />
 
-Vous pouvez également **déplacer des plages existantes**. Pour ce faire, cliquez sur ces dernières, et en maintenant le clic, glissez-les dans le tableau des horaires.<br/>
+Vous pouvez également **déplacer des plages existantes**. Pour ce faire, cliquez sur ces dernières, et en maintenant le clic, glissez-les dans le tableau des horaires.
+
 Pour **supprimer une plage**, cliquez sur celle-ci, puis sur <code className="action">Supprimer</code>.
 
 <img className="thumbnail" alt="fileappels" src="/images/web-cloud/phone-and-fax/voip/les-files-d-appels/2022-VoIP-FA-16.png" loading="lazy" />
@@ -274,7 +275,6 @@ Celles-ci vous permettront de fermer votre file d’appels sur des plages horair
 Les fermetures exceptionnelles complètent vos plages horaires paramétrées. Il est donc indispensable que ces dernières soient activées pour que les fermetures exceptionnelles soient prises en compte.
 
 :::
-
 
 Sur la page qui apparaît, positionnez vos fermetures exceptionnelles sur le calendrier en cliquant sur les jours concernés. Complétez les informations demandées :
  
@@ -353,4 +353,4 @@ Un tableau vous donnera accès aux enregistrements d'appels, vous permettant de 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/mode-intercom.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/mode-intercom.mdx
@@ -66,4 +66,4 @@ Sachez également que le mode intercom peut également être utilisé si vous so
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/modifier-mot-de-passe-ligne-sip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/modifier-mot-de-passe-ligne-sip.mdx
@@ -12,7 +12,7 @@ Votre ligne SIP OVHcloud permet d'émettre et de recevoir des appels depuis l'ap
 
 ## Prérequis
 
-- Disposer d'une [ligne SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/).
+- Disposer d'une [ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -70,4 +70,4 @@ Dans le cas contraire, nous vous invitons à vous rapprocher de l’éditeur du 
 
 [En apprendre plus sur la sécurité des mots de passe grâce à l'ANSSI](http://www.ssi.gouv.fr/guide/mot-de-passe/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/modifier-musiques-sonneries-ligne.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/modifier-musiques-sonneries-ligne.mdx
@@ -81,4 +81,4 @@ Une fois que vous êtes prêt, en dessous de la musique ou de la sonnerie que vo
 
 [Configurer des plages horaires et des fermetures exceptionnelles sur une ligne](/guides/web-cloud/phone-and-fax/voip/configure-time-slot-and-closing-time)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/popc-setting-up.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/popc-setting-up.mdx
@@ -15,8 +15,8 @@ Il remplace un téléphone physique : vous appelez, décrochez et gérez vos app
 ## Prérequis
 
 - Disposer d'un PC sous Windows (7, 8, 10).
-- Disposer de la [solution POPC OVHcloud](https://www.ovhtelecom.fr/telephonie/standard/) ainsi que de la ligne SIP associée.
-- **Uniquement pour la version d'essai de POPC** : disposer d'une [ligne SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/) sans téléphone Plug & Phone associé.
+- Disposer de la [solution POPC OVHcloud](https://www.ovhcloud.com/fr/phone/standard/) ainsi que de la ligne SIP associée.
+- **Uniquement pour la version d'essai de POPC** : disposer d'une [ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/) sans téléphone Plug & Phone associé.
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -75,7 +75,7 @@ Si vous avez commandé une offre POPC OVHcloud, le dongle USB qui vous a été f
 :::
 
 
-Vous pouvez retrouver le lien de téléchargement du logiciel POPC sur [la page de présentation du logiciel](https://www.ovhtelecom.fr/telephonie/standard/popc_standard_votre_offre.xml) ou via ce [lien direct](http://www.voiceoperatorpanel.com/priv/VoiceOperatorPanel-OVH-setup.exe).
+Vous pouvez retrouver le lien de téléchargement du logiciel POPC sur [la page de présentation du logiciel](https://www.ovhcloud.com/fr/phone/standard/) ou via ce [lien direct](http://www.voiceoperatorpanel.com/priv/VoiceOperatorPanel-OVH-setup.exe).
 
 Comme indiqué sur la page de présentation, il est possible de tester une version d'essai du logiciel POPC. Celle-ci est valable pendant 30 jours à compter de son installation. Au-delà de ce délai, l'enregistrement d'une ligne SIP sera automatiquement désactivé.
 
@@ -194,4 +194,4 @@ Une fois votre configuration terminée, vous pouvez consulter notre guide dédi�
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/popc-utilisation.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/popc-utilisation.mdx
@@ -16,7 +16,6 @@ Il se présente sous la forme d'une application, installée sur votre PC sous Wi
 Ce guide détaille les fonctionnalités basiques du logiciel et n'a pas vocation à être exhaustif quant à toutes les fonctions offertes. Vous retrouverez des modes d'emploi détaillés dans un dossier nommé « documentation » et situé dans le répertoire d'installation de votre logiciel.
 :::
 
-
 ## Prérequis
 
 - [Avoir installé le logiciel POPC](/guides/web-cloud/phone-and-fax/voip/popc-setting-up) sur votre PC sous Windows.
@@ -119,7 +118,8 @@ Des menus similaires vous permettent de supprimer, renommer, exporter un contact
 Les différents appels que vous avez reçus et émis sont tous en mémoire dans votre journal d'appels.
 
 Vous pouvez appeler directement l'un de vos correspondants depuis le journal en faisant un double clic sur l'appel ou un clic droit puis <code className="action">Appeler</code>.
-<br/>Vous pouvez également ajouter l'un des numéros à un annuaire en faisant un clic droit sur l'appel puis en cliquant sur <code className="action">Ajouter à</code> et en choisissant l'annuaire.
+
+Vous pouvez également ajouter l'un des numéros à un annuaire en faisant un clic droit sur l'appel puis en cliquant sur <code className="action">Ajouter à</code> et en choisissant l'annuaire.
 
 Les boutons situés en haut du journal vous permettent d'afficher le journal des appels des périodes précédentes.
 
@@ -135,14 +135,14 @@ En bas de cette zone, un bouton vous permet de filtrer les entrées du journal p
 #### Supervision des lignes
 
 Vous pouvez voir en temps réel, dans votre annuaire **local**, si des postes supervisés sont soit en communication soit disponibles.
-<br/>Ainsi, vous pouvez aisément savoir si vous pouvez ou non transférer un appel à l'un(e) de vos collègues.
+
+Ainsi, vous pouvez aisément savoir si vous pouvez ou non transférer un appel à l'un(e) de vos collègues.
 
 Vous pouvez aussi intercepter un appel à destination d'une ligne supervisée, par exemple si l'un(e) de vos collègues est absent(e) et que son téléphone sonne.
 
 :::warning
 Pour que la supervision soit fonctionnelle, la ligne supervisée et votre compte SIP doivent se trouver dans le même groupe de facturation OVHcloud. Retrouvez plus d'informations dans notre guide pour [gérer vos groupes de téléphonie](/guides/web-cloud/phone-and-fax/voip/regrouper-services-telephonie#regrouper-lignes).
 :::
-
 
 Pour activer la supervision, faites un clic droit sur une ligne à superviser, cliquez sur <code className="action">Contact</code> puis <code className="action">Présence</code> et enfin sur <code className="action">Activer</code>.
 
@@ -176,4 +176,4 @@ Validez les modifications en cliquant sur <code className="action">Sauvegarder</
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/portabilite-numero-belge.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/portabilite-numero-belge.mdx
@@ -158,4 +158,4 @@ Pour cela, et selon la configuration que vous souhaitez mettre en place sur vos 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/previous-phones.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/previous-phones.mdx
@@ -87,4 +87,4 @@ Les guides de **dépannage** listés ci-dessous peuvent ne plus être à jour. P
 
 [Dépanner son téléphone Plug and Phone](/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/publication-annuaire.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/publication-annuaire.mdx
@@ -24,7 +24,7 @@ Lorsque vous disposez d'une ligne ou d'un numéro chez un opérateur, il est obl
 
 ## Prérequis
 
-- Disposer d'un [numéro alias](https://www.ovhtelecom.fr/telephonie/numeros/) ou d'une [ligne VoIP OVHcloud](https://www.ovhcloud.com/fr/phone/).
+- Disposer d'un [numéro alias](https://www.ovhcloud.com/fr/phone/numeros/) ou d'une [ligne VoIP OVHcloud](https://www.ovhcloud.com/fr/phone/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -95,4 +95,4 @@ Pour vérifier la parution de vos coordonnées, vous pouvez également vous rend
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/quelle-configuration-est-adaptee-a-mes-besoins.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/quelle-configuration-est-adaptee-a-mes-besoins.mdx
@@ -18,7 +18,7 @@ Pour obtenir plus de détails sur la différence entre un **numéro alias** et u
 
 ## Prérequis
 
-- Disposer d'un [numéro alias fourni par OVHcloud](https://www.ovhtelecom.fr/telephonie/numeros/) ou d'un [numéro porté](/guides/web-cloud/phone-and-fax/voip/demander-la-portabilite-de-mon-numero) depuis un autre opérateur.
+- Disposer d'un [numéro alias fourni par OVHcloud](https://www.ovhcloud.com/fr/phone/numeros/) ou d'un [numéro porté](/guides/web-cloud/phone-and-fax/voip/demander-la-portabilite-de-mon-numero) depuis un autre opérateur.
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -117,4 +117,4 @@ Si vous appliquez le même type de configuration à plusieurs numéros, vous dev
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/redirection-avec-presentation.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/redirection-avec-presentation.mdx
@@ -16,11 +16,10 @@ Pour obtenir plus de détails sur la différence entre un **numéro alias** et u
 
 :::
 
-
 ## Prérequis
 
-- Disposer d'un [numéro alias fourni par OVHcloud](https://www.ovhtelecom.fr/telephonie/numeros/) ou d'un [numéro porté](/guides/web-cloud/phone-and-fax/voip/demander-la-portabilite-de-mon-numero) depuis un autre opérateur.
-- Disposer d'[une ligne SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/).
+- Disposer d'un [numéro alias fourni par OVHcloud](https://www.ovhcloud.com/fr/phone/numeros/) ou d'un [numéro porté](/guides/web-cloud/phone-and-fax/voip/demander-la-portabilite-de-mon-numero) depuis un autre opérateur.
+- Disposer d'[une ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
 
 ## En pratique
 
@@ -54,10 +53,10 @@ Cliquez sur le bouton <code className="action">Paramétrer</code> et patientez q
 
 :::
 
-
 ### Étape 2 : Paramétrer la redirection d'appels
 
-Dans la partie « **Vos appels entrants** », cliquez d'abord sur le bouton <code className="action">+ Sélectionner une ligne</code>.<br/>
+Dans la partie « **Vos appels entrants** », cliquez d'abord sur le bouton <code className="action">+ Sélectionner une ligne</code>.
+
 Choisissez alors, parmi les lignes affichées, celle vers laquelle vous souhaitez rediriger les appels reçus sur votre numéro. Cliquez ensuite sur le bouton <code className="action">Valider</code> pour confirmer votre sélection.
 
 <img className="thumbnail" alt="redirection d'appels" src="/images/web-cloud/phone-and-fax/voip/redirection-avec-presentation/redirection2-2022.png" loading="lazy" />
@@ -72,7 +71,8 @@ Si vous souhaitez activer cette fonctionnalité, cochez la case située à côt�
 
 <img className="thumbnail" alt="redirection d'appels - présentation" src="/images/web-cloud/phone-and-fax/voip/redirection-avec-presentation/redirection3-2022.png" loading="lazy" />
 
-Une fois vos choix effectués, cliquez sur <code className="action">Valider</code> afin d'appliquer la configuration.<br/>
+Une fois vos choix effectués, cliquez sur <code className="action">Valider</code> afin d'appliquer la configuration.
+
 Patientez quelques instants afin que celle-ci soit prise en compte.
 
 :::info
@@ -80,7 +80,6 @@ Si vous avez appliqué le même type de configuration à plusieurs numéros, vou
 
 :::
 
-
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone.mdx
@@ -6,9 +6,6 @@ lastUpdated: 2026-01-09
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-
-
-
 ## Objectif
 
 Le logiciel [Linphone](https://www.linphone.org/) est un softphone (logiciel de téléphonie) open-source et gratuit permettant d'enregistrer une ligne SIP fixe OVHcloud, afin d'émettre et recevoir des appels via cette ligne, depuis un ordinateur ou un smartphone.
@@ -22,10 +19,9 @@ Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux 
 
 :::
 
-
 ## Prérequis
 
-- Disposer d'une [ligne SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/)
+- Disposer d'une [ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/)
 - [Disposer des identifiants de votre ligne SIP OVHcloud](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone)
 - Avoir installé le logiciel [Linphone](https://www.linphone.org/) sur un smartphone ou un ordinateur
 
@@ -54,7 +50,7 @@ Cliquez sur l'onglet correspondant au système sur lequel vous utilisez Linphone
     
     <img className="thumbnail" alt="assistant linphone" src="/images/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone/linphone01.png" loading="lazy" />
 
-Renseignez alors vos identifiants SIP OVHcloud dans les champs correspondants. Vous pouvez également définir un nom d'affichage qui sera présenté lors de vos émissions d'appels.<br/>
+Renseignez alors vos identifiants SIP OVHcloud dans les champs correspondants. Vous pouvez également définir un nom d'affichage qui sera présenté lors de vos émissions d'appels.
 
 Cochez <code className="action">UDP</code> pour le transport et appuyez sur <code className="action">Connexion</code>.
     
@@ -89,7 +85,7 @@ Vous pouvez dès lors être joint et composer des appels depuis votre ligne SIP 
     
     <img className="thumbnail" alt="assistant linphone" src="/images/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone/linphone01ios.png" loading="lazy" />
 
-Renseignez alors vos identifiants SIP OVHcloud dans les champs correspondants. Vous pouvez également définir un nom d'affichage qui sera présenté lors de vos émissions d'appels.<br/>
+Renseignez alors vos identifiants SIP OVHcloud dans les champs correspondants. Vous pouvez également définir un nom d'affichage qui sera présenté lors de vos émissions d'appels.
 
 Choisissez <code className="action">UDP</code> pour le transport et appuyez sur <code className="action">Connexion</code>.
     
@@ -123,7 +119,7 @@ Vous pouvez dès lors être joint et composer des appels depuis votre ligne SIP 
     
     <img className="thumbnail" alt="assistant linphone" src="/images/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone/linphone01windows.png" loading="lazy" />
 
-Renseignez alors vos identifiants SIP OVHcloud dans les champs correspondants. Vous pouvez également définir un nom d'affichage qui sera présenté lors de vos émissions d'appels.<br/>
+Renseignez alors vos identifiants SIP OVHcloud dans les champs correspondants. Vous pouvez également définir un nom d'affichage qui sera présenté lors de vos émissions d'appels.
 
 Choisissez <code className="action">UDP</code> pour le transport et cliquez sur <code className="action">Utiliser</code>.
     
@@ -169,7 +165,6 @@ Vous pouvez dès lors être joint et composer des appels depuis votre ligne SIP 
   </Tab>
 </Tabs>
 
-
 ### Dépannage
 
 Si l'enregistrement a échoué, vérifiez que vous avez bien saisi les identifiants SIP OVHcloud, notamment le mot de passe SIP. En cas d'échecs répétés, [modifiez votre mot de passe SIP depuis l'espace client OVHcloud](/guides/web-cloud/phone-and-fax/voip/modifier-mot-de-passe-ligne-sip) et refaites un essai d'enregistrement avec un nouveau mot de passe SIP.
@@ -184,4 +179,4 @@ Vous pouvez aussi tester l'enregistrement de votre ligne [sur un autre softphone
 
 [Enregistrer une ligne SIP OVHcloud sur Zoiper](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
@@ -6,9 +6,6 @@ lastUpdated: 2025-10-06
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-
-
-
 ## Objectif
 
 Le logiciel [Zoiper](https://www.zoiper.com/) est un softphone (logiciel de téléphonie) gratuit permettant d'enregistrer une ligne SIP fixe OVHcloud afin d'émettre et recevoir des appels via cette ligne, depuis un ordinateur ou un smartphone.
@@ -22,10 +19,9 @@ Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux 
 
 :::
 
-
 ## Prérequis
 
-- Disposer d'une [ligne SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/)
+- Disposer d'une [ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/)
 - [Disposer des identifiants de votre ligne SIP OVHcloud](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone)
 - Disposer du logiciel [Zoiper](https://www.zoiper.com/en/voip-softphone/download/current) sur un smartphone ou un ordinateur
 
@@ -57,19 +53,21 @@ Une fois Zoiper ouvert, vous devez renseigner deux champs.
 
 <Tabs>
   <Tab label="Windows">
-    Une fois les deux champs complétés, cliquez sur <code className="action">Login</code>.<br/><br/>
+Une fois les deux champs complétés, cliquez sur <code className="action">Login</code>.
+
     <img className="thumbnail" alt="assistant zoiper Windows" src="/images/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper/zoiper01.png" loading="lazy" />
   </Tab>
   <Tab label="macOS">
-    Une fois les deux champs complétés, cliquez sur <code className="action">Login</code>.<br/><br/>
+Une fois les deux champs complétés, cliquez sur <code className="action">Login</code>.
+
     <img className="thumbnail" alt="assistant zoiper macOS" src="/images/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper/zoiper01-macos.png" loading="lazy" />
   </Tab>
   <Tab label="Android">
-    Une fois les deux champs complétés, cliquez sur <code className="action">Créer un compte</code>.<br/><br/>
+Une fois les deux champs complétés, cliquez sur <code className="action">Créer un compte</code>.
+
     <img className="thumbnail" alt="assistant zoiper Android" src="/images/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper/zoiper01-android.png" loading="lazy" />
   </Tab>
 </Tabs>
-
 
 Dans la fenêtre suivante, renseignez à nouveau votre **Domain** OVHcloud et cliquez sur <code className="action">Suivant</code>.
 
@@ -87,7 +85,6 @@ Un message d'avertissement apparaît si un proxy est nécessaire, poursuivez la 
     <img className="thumbnail" alt="warning domain zoiper" src="/images/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper/zoiper02-android-proxy-warning.png" loading="lazy" />
   </Tab>
 </Tabs>
-
 
 L'assistant de configuration Zoiper vous propose alors de saisir un nom d'utilisateur d'authentification et un proxy sortant.
 
@@ -111,9 +108,7 @@ Ces informations n'étant pas nécessaires pour l'enregistrement d'une ligne SIP
   </Tab>
 </Tabs>
 
-
 </details>
-
 
 <details>
 
@@ -133,9 +128,7 @@ Renseignez uniquement le proxy sortant de votre ligne SIP, puis cliquez sur le b
   </Tab>
 </Tabs>
 
-
 </details>
-
 
 Le logiciel testera ensuite les protocoles de transport possibles. Les lignes SIP OVHcloud utilisant uniquement le protocole UDP, veillez à ce qu'il soit sélectionné.
 
@@ -153,7 +146,6 @@ Sélectionnez ensuite <code className="action">Suivant</code> ou <code className
   </Tab>
 </Tabs>
 
-
 Un message de succès de l'enregistrement de la ligne est alors présenté. Si ce n'est pas le cas, consultez la section « [Dépannage](#depannage) » de ce guide.
 
 <img className="thumbnail" alt="protocole zoiper" src="/images/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper/zoiper05.png" loading="lazy" />
@@ -170,11 +162,9 @@ Les étapes ci-dessous décrivent comment configurer manuellement une ligne SIP 
 
 :::
 
-
 <details>
 
 <summary>Cliquez sur ce lien pour la procédure d'installation de Zoiper Lite sur iOS</summary>
-
 
 Une fois Zoiper Lite installé, sélectionnez <code className="action">Réglages</code> en bas à droite.
 
@@ -215,7 +205,6 @@ Appuyez ensuite sur le bouton vert <code className="action">S'enregistrer</code>
   </Tab>
 </Tabs>
 
-
 Si les informations d'identification de la ligne sont correctes, vous obtiendrez le message `État de l'enregistrement: OK`. Revenez alors au menu principal de l'application Zoiper pour utiliser votre ligne SIP.
 
 <Tabs>
@@ -227,16 +216,16 @@ Si les informations d'identification de la ligne sont correctes, vous obtiendrez
   </Tab>
 </Tabs>
 
-
 </details>
-
 
 ### Dépannage <a name="depannage"></a>
 
-Si l'enregistrement de votre ligne a échoué, vérifiez que vous avez bien saisi les identifiants SIP OVHcloud, notamment le mot de passe SIP.<br/>
+Si l'enregistrement de votre ligne a échoué, vérifiez que vous avez bien saisi les identifiants SIP OVHcloud, notamment le mot de passe SIP.
+
 En cas d'échecs répétés, [modifiez votre mot de passe SIP depuis l'espace client OVHcloud](/guides/web-cloud/phone-and-fax/voip/modifier-mot-de-passe-ligne-sip) et refaites un essai d'enregistrement avec un nouveau mot de passe SIP.
 
-Vérifiez également que l'adresse IP depuis laquelle vous utilisez Zoiper fait partie des adresses IP autorisées à utiliser votre ligne SIP.<br/>
+Vérifiez également que l'adresse IP depuis laquelle vous utilisez Zoiper fait partie des adresses IP autorisées à utiliser votre ligne SIP.
+
 Pour plus de détails, consultez le guide [Restreindre sa ligne SIP OVHcloud par IP](/guides/web-cloud/phone-and-fax/voip/sip-ip-restriction).
 
 Vous pouvez aussi tester l'enregistrement de votre ligne sur [un autre softphone](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone).
@@ -247,4 +236,4 @@ Vous pouvez aussi tester l'enregistrement de votre ligne sur [un autre softphone
 
 [Utiliser une ligne SIP OVHcloud sur Linphone](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone.mdx
@@ -5,12 +5,13 @@ lastUpdated: 2025-10-06
 ---
 
 :::tip
-Vous recherchez une solution de téléphonie fixe professionnelle flexible, que vous pouvez utiliser aussi bien en déplacement et au bureau ?<br/>
-Découvrez [Softcall](https://www.ovhcloud.com/fr/phone/softphone/) », notre service softphone !<br/>
+Vous recherchez une solution de téléphonie fixe professionnelle flexible, que vous pouvez utiliser aussi bien en déplacement et au bureau ?
+
+Découvrez [Softcall](https://www.ovhcloud.com/fr/phone/softphone/) », notre service softphone !
+
 Retrouvez plus d'informations sur notre guide « [Installer et configurer Softcall](/guides/web-cloud/phone-and-fax/voip/installer-configurer-softcall) ».
 
 :::
-
 
 ## Objectif
 
@@ -27,10 +28,9 @@ Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux 
 
 :::
 
-
 ## Prérequis
 
-- Disposer d'une [ligne SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/) sans téléphone OVHcloud associé.
+- Disposer d'une [ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/) sans téléphone OVHcloud associé.
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -44,10 +44,9 @@ Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux 
 {/* CP-NAV-END:telecom-voip-fax */}
 
 :::info
-Une ligne SIP **fournie avec un téléphone OVHcloud** ne peut pas être enregistrée sur un softphone ou sur votre propre téléphone personnel. Si c'est le cas de votre ligne et que vous souhaitez utiliser un softphone ou votre propre téléphone, nous vous invitons à [commander une ligne SIP supplémentaire](https://www.ovhtelecom.fr/telephonie/voip/), fournie sans téléphone OVHcloud.
+Une ligne SIP **fournie avec un téléphone OVHcloud** ne peut pas être enregistrée sur un softphone ou sur votre propre téléphone personnel. Si c'est le cas de votre ligne et que vous souhaitez utiliser un softphone ou votre propre téléphone, nous vous invitons à [commander une ligne SIP supplémentaire](https://www.ovhcloud.com/fr/phone/voip/), fournie sans téléphone OVHcloud.
 
 :::
-
 
 ## En pratique
 
@@ -84,7 +83,6 @@ Le **Proxy sortant** est `outbound-ovh-1.sip-proxy.io`, mais il sera différent 
 
 :::
 
-
 #### Mot de passe SIP
 
 Si vous ne connaissez pas votre mot de passe SIP ou que vous ne l'avez jamais modifié au profit d'un **mot de passe fort**, consultez notre guide pour [Modifier le mot de passe d'une ligne SIP](/guides/web-cloud/phone-and-fax/voip/modifier-mot-de-passe-ligne-sip).
@@ -94,12 +92,12 @@ Vous pouvez utiliser un coffre-fort de mots de passe, comme [KeePass](https://ke
 
 :::
 
-
 ### Étape 2 : Enregistrer la ligne SIP
 
 Une fois vos identifiants connus, vous pouvez procéder à l'enregistrement de votre ligne sur votre propre téléphone ou sur le softphone de votre choix.
 
-De nombreux logiciels de ce type sont disponibles. Nous vous proposons de suivre des méthodes pour deux d'entre eux, **Linphone** et **Zoiper**.<br/>
+De nombreux logiciels de ce type sont disponibles. Nous vous proposons de suivre des méthodes pour deux d'entre eux, **Linphone** et **Zoiper**.
+
 Cliquez sur les liens ci-dessous pour lire les tutoriels :
 
 - [Tutoriel - Enregistrer une ligne SIP OVHcloud sur Linphone](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone).
@@ -107,4 +105,4 @@ Cliquez sur les liens ci-dessous pour lire les tutoriels :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/regrouper-services-telephonie.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/regrouper-services-telephonie.mdx
@@ -16,7 +16,7 @@ Rattacher plusieurs lignes au sein d'un seul groupe permet aussi la supervision 
 
 ## Prérequis
 
-- Disposer de [lignes SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/) et/ou de [numéros alias OVHcloud](https://www.ovhtelecom.fr/telephonie/numeros/).
+- Disposer de [lignes SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/) et/ou de [numéros alias OVHcloud](https://www.ovhcloud.com/fr/phone/numeros/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -81,7 +81,8 @@ De même, il n'est pas possible d'intégrer d'autres lignes dans un groupe de t�
 #### Cas particulier des lignes liées à un accès à Internet OVHcloud
 
 Les accès à Internet OVHcloud comprennent souvent des lignes téléphoniques qu'il faut activer dans l'espace client OVHcloud, dans la partie <code className="action">Accès Internet</code>. Ces lignes, une fois activées, génèrent leur propre groupe de téléphonie (un groupe pour chaque accès à Internet).
-<br/>Ce groupe est nommé *ovhtel-XXXXXXXX-X*, contrairement à un groupe de téléphonie classique dont le nom contient votre identifiant client, par exemple *az123456-ovh-1*.
+
+Ce groupe est nommé *ovhtel-XXXXXXXX-X*, contrairement à un groupe de téléphonie classique dont le nom contient votre identifiant client, par exemple *az123456-ovh-1*.
 
 |Groupe de téléphonie classique|Groupe de téléphonie lié à un accès à Internet OVHcloud| 
 |---|---| 
@@ -92,14 +93,14 @@ Le déplacement d'une ligne liée à un accès à Internet OVHcloud, depuis un g
 
 :::
 
-
 Vous pouvez néanmoins ajouter des lignes et des numéros dans un groupe *ovhtel-XXXXXXXX-X*, leur facturation sera regroupée avec celle de l'accès à Internet lié à ce groupe.
 
 #### Cas particulier des numéros fixes SDA
 
 OVHcloud propose une offre de numéros fixes SDA (Sélection Directe à l'Arrivée) dédiés à la redirection d'appels. Ces numéros sont fournis par « blocs » de 50 ou 100 numéros consécutifs.
 
-Vous pouvez déplacer un bloc, dans son ensemble, de numéros fixes SDA commandés chez OVHcloud d'un groupe vers un autre.<br/>
+Vous pouvez déplacer un bloc, dans son ensemble, de numéros fixes SDA commandés chez OVHcloud d'un groupe vers un autre.
+
 Par contre, il n'est pas possible de déplacer un numéro unitaire appartenant à un tel bloc de numéros.
 
 ### Gérer les options d'un groupe de téléphonie
@@ -122,7 +123,6 @@ Vous pouvez déplacer ces services dans un autre groupe ou, si c'est votre souha
 
 :::
 
-
 Pour supprimer un groupe de téléphonie, sélectionnez-le dans le menu de gauche puis cliquez sur l'onglet <code className="action">Administration</code> et sur <code className="action">Supprimer le groupe</code>.
 
 <img className="thumbnail" alt="supprimer groupe" src="/images/web-cloud/phone-and-fax/voip/regrouper-services-telephonie/04-supprimer.png" loading="lazy" />
@@ -139,4 +139,4 @@ L'annulation sera prise en compte immédiatement.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/resilier-services-voip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/resilier-services-voip.mdx
@@ -12,7 +12,7 @@ Ce guide décrit comment résilier une ligne Fax ou un service VoIP OVHcloud, qu
 
 ## Prérequis
 
-- Disposer de [services VoIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/).
+- Disposer de [services VoIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -112,4 +112,4 @@ Si un équipement de type Plug & Fax est attaché à cette ligne, ce dernier ne 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/reversements-sva.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/reversements-sva.mdx
@@ -14,7 +14,7 @@ L'espace client OVHcloud vous permet de consulter et modifier votre palier tarif
 
 ## Prérequis
 
-- Posséder au moins un [numéro spécial](https://www.ovhtelecom.fr/telephonie/numeros/numeros-speciaux/numeros-francais.xml) dans votre compte OVHcloud.
+- Posséder au moins un [numéro spécial](https://www.ovhcloud.com/fr/phone/numeros/) dans votre compte OVHcloud.
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -36,18 +36,18 @@ Pour plus d'informations sur les groupes de téléphonie, consultez notre guide 
 
 :::
 
-
 ### Consulter et/ou modifier le palier tarifaire de votre numéro spécial
 
 :::info
-Vous pouvez consulter la liste complète des paliers tarifaires OVHcloud applicables aux numéros spéciaux en France sur [cette page](https://www.ovhtelecom.fr/telephonie/numeros/numeros-speciaux/numeros-francais.xml).
+Vous pouvez consulter la liste complète des paliers tarifaires OVHcloud applicables aux numéros spéciaux en France sur [cette page](https://www.ovhcloud.com/fr/phone/numeros/).
 
-La première modification du palier tarifaire est offerte.<br/>
-**Par la suite, la modification sera facturée 20 € HT**.<br/>
+La première modification du palier tarifaire est offerte.
+
+**Par la suite, la modification sera facturée 20 € HT**.
+
 Effectuée avant le 20 du mois, cette modification sera effective le 1er du mois suivant.
 
 :::
-
 
 Sélectionnez votre numéro SVA et cliquez sur <code className="action">Reversements</code> puis <code className="action">Tarification du numéro</code>.
 
@@ -63,7 +63,6 @@ Validez ensuite votre choix en cliquant sur <code className="action">Confirmer</
 Il n'est pas possible de modifier le palier tarifaire d'un numéro vert 0805 gratuit.
 
 :::
-
 
 ### Reversements des numéros surtaxés
 
@@ -99,4 +98,4 @@ Vous retrouvez sur cette page l'historique des coûts générés par les appels 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/secure-sip-line.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/secure-sip-line.mdx
@@ -12,7 +12,7 @@ Votre ligne SIP OVHcloud vous permet de recevoir et d’émettre des appels. Pou
 
 ## Prérequis
 
-- Disposer d'une [ligne SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/).
+- Disposer d'une [ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -95,4 +95,4 @@ La page qui s'affiche alors vous permet de visionner l'historique des consommati
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/sip-ip-restriction.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/sip-ip-restriction.mdx
@@ -12,7 +12,7 @@ La téléphonie sur IP utilise le web pour transmettre des communications. Elle 
 
 ## Prérequis
 
-- Disposer d'une [ligne SIP OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/) (Découverte ou Entreprise).
+- Disposer d'une [ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/) (Découverte ou Entreprise).
 - Connaître ses adresses IP publiques ou être en mesure de les récupérer.
 
 {/* CP-NAV-START:telecom-voip-fax */}
@@ -110,4 +110,4 @@ Une fois les informations complétées, cliquez sur <code className="action">Val
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/svi-serveur-vocal-interactif.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/svi-serveur-vocal-interactif.mdx
@@ -6,14 +6,15 @@ lastUpdated: 2026-01-22
 
 ## Objectif
 
-Configurer un numéro en Serveur Vocal Interactif (SVI) permet de proposer à vos correspondants un menu avec lequel ils pourront interagir, grâce aux touches de leurs téléphones.<br/>
+Configurer un numéro en Serveur Vocal Interactif (SVI) permet de proposer à vos correspondants un menu avec lequel ils pourront interagir, grâce aux touches de leurs téléphones.
+
 L'exemple le plus courant consiste à orienter un appelant entre plusieurs services d'une société : « *Appuyez sur la touche 1 pour une demande commerciale ou sur la touche 2 pour une demande technique* ».
 
 **Découvrez comment configurer un serveur vocal interactif depuis l'espace client OVHcloud.**
 
 ## Prérequis
 
-- Disposer d'un [numéro alias](https://www.ovhtelecom.fr/telephonie/numeros/).
+- Disposer d'un [numéro alias](https://www.ovhcloud.com/fr/phone/numeros/).
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -32,7 +33,6 @@ L'exemple le plus courant consiste à orienter un appelant entre plusieurs servi
 Consultez notre guide « [Choisir et appliquer une configuration pour un numéro](/guides/web-cloud/phone-and-fax/voip/quelle-configuration-est-adaptee-a-mes-besoins) » pour plus de détails sur les différentes configurations applicables à un numéro alias.
 
 :::
-
 
 ## En pratique
 
@@ -54,7 +54,6 @@ Cliquez sur le bouton <code className="action">Paramétrer</code> et patientez q
 Si vous appliquez le même type de configuration à plusieurs numéros, vous devrez finaliser la configuration sur chacun des numéros concernés.
 
 :::
-
 
 ### Étape 2 : Accéder à la configuration du serveur vocal interactif
 
@@ -84,14 +83,15 @@ Les étapes suivantes peuvent être suivies sans ordre particulier. Néanmoins, 
 **L'ajout d'un son d'accueil est la première étape indispensable pour créer votre SVI**. Ce son d'accueil sera joué dès le début de l'appel. Il précise à l'appelant les différents choix offerts par les touches.
 
 Vous pouvez ajouter plusieurs sons si vous souhaitez créer des choix de touches successifs. En effet, il vous faudra alors un son par menu interactif.
-<br/> Nous vous conseillons également de créer un son dédié aux actions invalides. Ainsi, si un appelant compose une touche que vous n'avez pas configurée, un son peut lui rappeler les choix de touches possibles.
+
+Nous vous conseillons également de créer un son dédié aux actions invalides. Ainsi, si un appelant compose une touche que vous n'avez pas configurée, un son peut lui rappeler les choix de touches possibles.
 
 :::warning
 La création des fichiers-sons est à votre charge. Nous vous conseillons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/) car OVHcloud ne sera pas en mesure de créer ces fichiers pour vous.
-<br/>Sachez qu'il est également possible de créer des fichiers-sons via le logiciel open source et gratuit [Audacity](https://www.audacityteam.org/).
+
+Sachez qu'il est également possible de créer des fichiers-sons via le logiciel open source et gratuit [Audacity](https://www.audacityteam.org/).
 
 :::
-
 
 Ouvrez le **menu du numéro** puis cliquez sur <code className="action">Gérer les sons</code>.
 
@@ -156,7 +156,6 @@ Utilisez le bouton dédié (entre chaque étape) pour modifier l'ordre de vos é
 
 :::
 
-
 #### 4.2 Ajouter une action à une étape
 
 Les actions ajoutées à une étape s'activent lorsqu'un appelant contacte votre numéro.
@@ -183,7 +182,6 @@ Selon vos besoins, répétez ces manipulations si vous souhaitez créer plusieur
 
 :::
 
-
 #### 4.3 Ajouter une condition à une étape
 
 Lorsqu'une ou plusieurs conditions sont ajoutées à une étape, celles-ci doivent être remplies pour que l'étape se déclenche. Si les conditions ne sont pas remplies, soit une action correspondant aux **conditions non-vérifiées** se déclenche, soit l'étape suivante de votre plan de configuration se déclenche.
@@ -192,7 +190,6 @@ Lorsqu'une ou plusieurs conditions sont ajoutées à une étape, celles-ci doive
 Vous pouvez ainsi faire en sorte que votre SVI se déclenche uniquement lors de vos horaires d'ouverture. En dehors de ces horaires, vous pouvez, par exemple, diffuser un son rappelant les horaires d'ouverture de votre entreprise ou déclencher le [répondeur d'une ligne SIP OVHcloud](/guides/web-cloud/phone-and-fax/voip/configurer-consulter-repondeur-ligne-ovh).
 
 :::
-
 
 Pour ajouter une condition à une étape, ouvrez le menu de l'étape via le bouton <code className="action">...</code>, puis choisissez <code className="action">Configuration avancée</code>.
 
@@ -205,7 +202,8 @@ Le menu qui apparaît vous permet de définir jusqu'à trois types de conditions
 Une fois vos conditions créées, vous pouvez définir une ou plusieurs action(s) correspondant aux conditions non-vérifiées. Ces actions seront alors prises en compte pour les appels ne remplissant pas les conditions.
 
 Ainsi, dans l'exemple ci-dessous, un appel pendant les plages horaires définies pour l'étape 1 lancera le menu interactif nommé « Menu principal ». (1).
-<br/>Un appel en dehors de ces plages horaires sera réceptionné sur le répondeur d'une ligne SIP OVHcloud (2).
+
+Un appel en dehors de ces plages horaires sera réceptionné sur le répondeur d'une ligne SIP OVHcloud (2).
 
 <img className="thumbnail" alt="SVI conditions exemple" src="/images/web-cloud/phone-and-fax/voip/svi-serveur-vocal-interactif/exemple-svi-plages2021.png" loading="lazy" />
 
@@ -254,7 +252,6 @@ Pour modifier une plage horaire déjà créée, il est nécessaire de la supprim
 
 :::
 
-
 ##### **Double condition : « Jours exceptionnels » et « Plages horaires génériques »**
 
 Pour obtenir une configuration contenant à la fois des jours exceptionnels et des plages horaires génériques, il convient de placer les jours exceptionnels sur l'étape 1 et les plages horaires génériques sur l'étape 2.
@@ -280,4 +277,4 @@ Pour enregistrer vos modifications, cliquez sur <code className="action">Modifie
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel.mdx
@@ -6,7 +6,6 @@ lastUpdated: 2025-04-28
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-
 ## Objectif
 
 À la différence des modèles de téléphones historiques fonctionnant sur la technologie cuivre analogique, les téléphones VoIP fournis par OVHcloud utilisent le réseau Internet.
@@ -23,8 +22,8 @@ Les causes d'un dysfonctionnement d'un téléphone VoIP sont donc variées :
 
 ## Prérequis
 
-- Disposer d'une [ligne téléphonique OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/).
-- Disposer d'un [téléphone fourni par OVHcloud](https://www.ovhtelecom.fr/telephonie/comparatif-des-telephones.xml) et l'avoir installé.
+- Disposer d'une [ligne téléphonique OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
+- Disposer d'un [téléphone fourni par OVHcloud](https://www.ovhcloud.com/fr/phone/voip/telephone/) et l'avoir installé.
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -41,16 +40,23 @@ Les causes d'un dysfonctionnement d'un téléphone VoIP sont donc variées :
 
 Voici la table des matières de ce guide, vous pouvez cliquer sur une des entrées pour y arriver directement :
 
-[Étape 1 - Établir un premier diagnostic](#step1)<br />
-[Étape 2 - Réinitialiser le téléphone](#step2)<br />
-[Étape 3 - Dépanner le téléphone depuis l'espace client OVHcloud](#step3)<br />
-[Étape 4 - Effectuer des tests complémentaires (facultatif)](#step4)<br />
-&emsp;&emsp;[4.1 - Réinitialiser votre routeur / modem / Box Internet](#step4-1)<br />
-&emsp;&emsp;[4.2 - Effectuer un test croisé](#step4-2)<br />
-[Étape 5 - Contacter l'assistance OVHcloud](#step5)<br />
+[Étape 1 - Établir un premier diagnostic](#step1)
+
+[Étape 2 - Réinitialiser le téléphone](#step2)
+
+[Étape 3 - Dépanner le téléphone depuis l'espace client OVHcloud](#step3)
+
+[Étape 4 - Effectuer des tests complémentaires (facultatif)](#step4)
+
+&emsp;&emsp;[4.1 - Réinitialiser votre routeur / modem / Box Internet](#step4-1)
+
+&emsp;&emsp;[4.2 - Effectuer un test croisé](#step4-2)
+
+[Étape 5 - Contacter l'assistance OVHcloud](#step5)
 
 Ce guide détaille les causes principales d'un défaut d'enregistrement de la ligne SIP associée à votre téléphone, suivant un ordre logique. 
-Nous vous conseillons donc de **suivre l'ordre des étapes de diagnostic** afin de dépanner votre téléphone.<br/>
+Nous vous conseillons donc de **suivre l'ordre des étapes de diagnostic** afin de dépanner votre téléphone.
+
 Si votre téléphone retrouve son fonctionnement normal après avoir suivi l'une des premières étapes de ce guide, il n'est pas indispensable de suivre les étapes ultérieures.
 
 Cliquez sur l'image ci-dessous pour afficher un résumé des actions à mener en fonction du défaut rencontré.
@@ -83,39 +89,75 @@ Si vous avez ajouté un carnet de contacts directement sur votre téléphone (sa
 
 :::
 
-
 Une réinitialisation permet au téléphone de récupérer une configuration saine depuis les serveurs OVHcloud et de redevenir pleinement fonctionnel.
 
 La réinitialisation d'un téléphone s'effectue généralement via son menu lorsqu'il en dispose d'un. Certains modèles de téléphones nécessitent parfois d'effectuer une combinaison de touches ou d'appuyer sur un bouton dédié.
 
-Les manipulations pour réinitialiser nos téléphones sont décrites ci-dessous.<br/>
+Les manipulations pour réinitialiser nos téléphones sont décrites ci-dessous.
+
 **Cliquez sur l'onglet correspondant au modèle de votre téléphone.**
 
 <Tabs>
   <Tab label="Cisco standard">
-    1\. Appuyez sur le bouton `Engrenage` pour accéder au menu principal.<br/>2\. Allez dans le sous-menu `Admin. Appareil`.<br/>3\. Sélectionnez l'option `Réinit. Usine`.<br/>4\.Validez la réinitialisation.
+1\. Appuyez sur le bouton `Engrenage` pour accéder au menu principal.
+
+2\. Allez dans le sous-menu `Admin. Appareil`.
+
+3\. Sélectionnez l'option `Réinit. Usine`.
+
+4\. Validez la réinitialisation.
   </Tab>
   <Tab label="Cisco sans écran (modèle ATA191)">
-    1\. Appuyez pendant 10 secondes, avec un objet pointu, dans le trou `Reset` situé à l'arrière du boîtier Cisco.<br/>2\. Le voyant **Power** va clignoter durant la procédure de réinitialisation.<br/>3\. Les voyants **Power** puis **Internet** vont ensuite rester allumés, puis le voyant **Line 1** (ou **Line 2**) s'allumera.
+1\. Appuyez pendant 10 secondes, avec un objet pointu, dans le trou `Reset` situé à l'arrière du boîtier Cisco.
+
+2\. Le voyant **Power** va clignoter durant la procédure de réinitialisation.
+
+3\. Les voyants **Power** puis **Internet** vont ensuite rester allumés, puis le voyant **Line 1** (ou **Line 2**) s'allumera.
   </Tab>
   <Tab label="Gigaset DECT (sans-fil)">
-    Les manipulations sont à effectuer sur **la base émettrice/réceptrice** et non sur le socle de rechargement du combiné.<br/>Cliquez sur [ce lien](https://raw.githubusercontent.com/ovh/docs/develop/pages/web_cloud/phone_and_fax/voip/troubleshoot-02-fix-control-panel/images/gigaset-dect.png) pour voir des modèles de bases émettrices/réceptrices Gigaset.<br/><br/>1\. Débranchez l'alimentation électrique de la base émettrice/réceptrice.<br/>2\. Rebranchez l'alimentation électrique en **maintenant enfoncé le bouton unique de la base** (en façade de celle-ci).<br/>3\. Relâchez le bouton au bout de 30 secondes après avoir rebranché l'alimentation.
+Les manipulations sont à effectuer sur **la base émettrice/réceptrice** et non sur le socle de rechargement du combiné.
+
+Consultez des [modèles de bases émettrices/réceptrices Gigaset](https://raw.githubusercontent.com/ovh/docs/develop/pages/web_cloud/phone_and_fax/voip/troubleshoot-02-fix-control-panel/images/gigaset-dect.png).
+
+1\. Débranchez l'alimentation électrique de la base émettrice/réceptrice.
+
+2\. Rebranchez l'alimentation électrique en **maintenant enfoncé le bouton unique de la base** (en façade de celle-ci).
+
+3\. Relâchez le bouton au bout de 30 secondes après avoir rebranché l'alimentation.
   </Tab>
   <Tab label="Gigaset standard">
-    1\. Dans le menu principal, sélectionnez le sous-menu `Réglages`.<br/>2\. Sélectionnez `Réinitialisation`.<br/>3\. Appuyez sur `OK` et confirmez la réinitialisation.
+1\. Dans le menu principal, sélectionnez le sous-menu `Réglages`.
+
+2\. Sélectionnez `Réinitialisation`.
+
+3\. Appuyez sur `OK` et confirmez la réinitialisation.
   </Tab>
   <Tab label="Yealink standard">
-    1\. Appuyez pendant 10 secondes sur le bouton `OK` du téléphone.<br/>2\. Confirmez la réinitialisation.
+1\. Appuyez pendant 10 secondes sur le bouton `OK` du téléphone.
+
+2\. Confirmez la réinitialisation.
   </Tab>
   <Tab label="Yealink T58 W Pro">
-    1\. Maintenez enfoncée la touche `Redial` 🔄 .<br/><br/><img className="thumbnail" alt="touche redial" src="/images/web-cloud/phone-and-fax/voip/troubleshoot-02-fix-control-panel/t58wpro-redial.png" loading="lazy" />.<br/>2\. Validez la demande de réinitialisation affichée à l'écran du téléphone.
+1\. Maintenez enfoncée la touche `Redial` 🔄 .
+
+<img className="thumbnail" alt="touche redial" src="/images/web-cloud/phone-and-fax/voip/troubleshoot-02-fix-control-panel/t58wpro-redial.png" loading="lazy" />.
+
+2\. Validez la demande de réinitialisation affichée à l'écran du téléphone.
   </Tab>
   <Tab label="Yealink DECT (sans fil)">
-    1\. Débranchez l'alimentation électrique de **la base émettrice/réceptrice** du téléphone.<br/>2\. Rebranchez l'alimentation électrique en **maintenant enfoncé le bouton au centre de la base**.<br/>3\. Relâchez le bouton quand les 3 voyants sont allumés et fixes.<br/>4\. Débranchez l'alimentation électrique de **la base** du téléphone et rebranchez-la juste après.<br/>5\. Patientez environ 5 minutes le temps que la base se mette à jour.<br/>6\. Pour associer le **combiné** à la **base**, appuyez sur le bouton `REGISTER` en bas à gauche de l'écran du **combiné**. Dans la foulée, maintenez enfoncé le bouton au centre de la **base** pendant 3 à 4 secondes.
+1\. Débranchez l'alimentation électrique de **la base émettrice/réceptrice** du téléphone.
+
+2\. Rebranchez l'alimentation électrique en **maintenant enfoncé le bouton au centre de la base**.
+
+3\. Relâchez le bouton quand les 3 voyants sont allumés et fixes.
+
+4\. Débranchez l'alimentation électrique de **la base** du téléphone et rebranchez-la juste après.
+
+5\. Patientez environ 5 minutes le temps que la base se mette à jour.
+
+6\. Pour associer le **combiné** à la **base**, appuyez sur le bouton `REGISTER` en bas à gauche de l'écran du **combiné**. Dans la foulée, maintenez enfoncé le bouton au centre de la **base** pendant 3 à 4 secondes.
   </Tab>
 </Tabs>
-
-
 
 **Une fois le téléphone réinitialisé, la date et l'heure affichées sur son écran sont-elles exactes ?**
 
@@ -131,12 +173,14 @@ Les manipulations pour réinitialiser nos téléphones sont décrites ci-dessous
 > Rendez-vous sur [http://monip.ovh](http://monip.ovh) et prenez note de l'adresse IP publique qui vous est indiquée.
 >
 
-Cliquez sur l'onglet <code className="action">Services</code> puis sur la ligne SIP concernée.<br/>
+Cliquez sur l'onglet <code className="action">Services</code> puis sur la ligne SIP concernée.
+
 Rendez-vous dans l'onglet <code className="action">Assistance</code> et cliquez sur le bouton <code className="action">Dépannage Plug & Phone</code>.
 
 <img className="thumbnail" alt="dépannage-plug-and-phone" src="/images/web-cloud/phone-and-fax/voip/troubleshoot-02-fix-control-panel/control-panel01.png" loading="lazy" />
 
-Une fois dans l'assistant, celui-ci va vous guider en vous posant plusieurs questions et en vous proposant des manipulations.<br/>
+Une fois dans l'assistant, celui-ci va vous guider en vous posant plusieurs questions et en vous proposant des manipulations.
+
 Suivez avec précision les informations qui s'affichent à chaque étape de l'assistant. Ces informations peuvent vous permettre de résoudre la panne que vous rencontrez.
 
 Assurez-vous également que votre téléphone est correctement branché électriquement et bien connecté à votre réseau local.
@@ -145,7 +189,6 @@ Assurez-vous également que votre téléphone est correctement branché électri
 L'image ci-dessous est donnée à titre d'exemple. Le modèle présenté et le nombre de questions peuvent varier selon le téléphone à dépanner. 
 
 :::
-
 
 <img className="thumbnail" alt="dépannage-plug-and-phone" src="/images/web-cloud/phone-and-fax/voip/troubleshoot-02-fix-control-panel/control-panel02.png" loading="lazy" />
 
@@ -176,7 +219,6 @@ La réinitialisation de votre routeur / modem / Box Internet peut entraîner la 
 
 :::
 
-
 Il se peut que votre routeur / modem / Box Internet ne permette plus à votre téléphone de fonctionner correctement. Afin d'écarter cette éventualité, vous pouvez effectuer une réinitialisation de celui-ci. Pour cela, deux possibilités :
 
 - **vous disposez d'une box OVHcloud** : reportez-vous aux instructions décrites dans notre documentation « [Réinitialiser votre box OVHcloud](/guides/web-cloud/internet/internet-access/restart-reboot-modem#reinitialiser-votre-box-ovhcloud) » ;
@@ -195,11 +237,12 @@ Dès lors, deux possibilités :
 
 ### Étape 5 - Contacter l'assistance OVHcloud <a name="step5"></a>
 
-Si votre téléphone OVHcloud reste inopérant malgré les manipulations décrites ci-dessus effectuées, nous vous invitons à contacter notre service support via la création d'un ticket d'assistance depuis votre espace client OVHcloud.<br/>
+Si votre téléphone OVHcloud reste inopérant malgré les manipulations décrites ci-dessus effectuées, nous vous invitons à contacter notre service support via la création d'un ticket d'assistance depuis votre espace client OVHcloud.
+
 Afin de faciliter le diagnostic du téléphone par nos équipes, veillez à bien détailler dans ce ticket l'ensemble des tests que vous avez déjà effectués.
  
 ## Aller plus loin <a name="gofurther"></a>
 
 En cas de difficultés, nous vous recommandons de faire appel à l'un de [nos partenaires](https://partner.ovhcloud.com/fr/directory/).
  
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-local-network.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-local-network.mdx
@@ -25,8 +25,8 @@ Les causes d'un dysfonctionnement d'un téléphone VoIP sont variées :
  
 ## Prérequis
 
-- Disposer d'une [ligne téléphonique OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/).
-- Disposer d'un [téléphone fourni par OVHcloud](https://www.ovhtelecom.fr/telephonie/comparatif-des-telephones.xml) et l'avoir installé.
+- Disposer d'une [ligne téléphonique OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
+- Disposer d'un [téléphone fourni par OVHcloud](https://www.ovhcloud.com/fr/phone/voip/telephone/) et l'avoir installé.
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
@@ -48,9 +48,9 @@ En cas de difficultés, nous vous recommandons de faire appel à l'un de [nos pa
 
 :::
 
-
 Ce tutoriel détaille les causes principales, liées au réseau local, d'un défaut d'enregistrement de la ligne SIP associée à votre téléphone, suivant un ordre logique. 
-Nous vous conseillons donc de **suivre l'ordre des étapes de vérification** ci-dessous afin de dépanner votre téléphone.<br/>
+Nous vous conseillons donc de **suivre l'ordre des étapes de vérification** ci-dessous afin de dépanner votre téléphone.
+
 Si votre téléphone retrouve son fonctionnement normal après avoir suivi l'une des premières étapes de ce tutoriel, il n'est pas indispensable d'en poursuivre la lecture.
  
 ### Étape 1 - Vérifier l'alimentation électrique du téléphone
@@ -89,10 +89,9 @@ Si votre réseau local est géré par un prestataire informatique ou si vous dis
 
 :::
 
-
 #### Le raccordement au réseau local
 
-Comme indiqué précédemment, chaque téléphone VoIP doit être raccordé à votre réseau local.<br/>
+Comme indiqué précédemment, chaque téléphone VoIP doit être raccordé à votre réseau local.
 
 Vérifiez donc qu'un **câble réseau Ethernet RJ45** est bien branché :
 
@@ -109,10 +108,11 @@ Sur votre routeur / modem / Box Internet, le câble doit être raccordé à l'un
 
 #### La connexion à Internet
 
-Vérifiez que les ordinateurs connectés **au même réseau** que le téléphone OVHcloud disposent bien d'une connexion à Internet fonctionnelle.<br/>
+Vérifiez que les ordinateurs connectés **au même réseau** que le téléphone OVHcloud disposent bien d'une connexion à Internet fonctionnelle.
+
 Si ce n'est pas le cas, le défaut est donc probablement lié à votre réseau local ou à votre fournisseur d'accès à Internet.
 
-Afin de le déterminer, connectez le téléphone (ou un ordinateur) **directement** sur le routeur / modem / Box Internet, sans passer par un équipement intermédiaire tel qu'un switch.<br/>
+Afin de le déterminer, connectez le téléphone (ou un ordinateur) **directement** sur le routeur / modem / Box Internet, sans passer par un équipement intermédiaire tel qu'un switch.
 
 - **Le téléphone redevient fonctionnel ou l'ordinateur se connecte à Internet ?**
 
@@ -124,8 +124,10 @@ Le défaut est alors probablement issu de la connexion à Internet. Contactez vo
 
 ##### **Si OVHcloud est votre fournisseur d'accès à Internet**
 
-Commencez par consulter la [carte des incidents](https://status.isp.ovhcloud.com/) pour vérifier si un incident générique est en cours.<br/>
-Si aucun incident générique n'est en cours dans votre zone géographique, consultez la section « Diagnostic et dépannage » de [nos guides xDSL / FTTH](/guides/web-cloud/internet/internet-access/overview) pour effectuer un premier diagnostic de votre accès à Internet.<br/>
+Commencez par consulter la [carte des incidents](https://status.isp.ovhcloud.com/) pour vérifier si un incident générique est en cours.
+
+Si aucun incident générique n'est en cours dans votre zone géographique, consultez la section « Diagnostic et dépannage » de [nos guides xDSL / FTTH](/guides/web-cloud/internet/internet-access/overview) pour effectuer un premier diagnostic de votre accès à Internet.
+
 Les guides suivants vous seront utiles :
 
 - [Dépanner son accès Internet fibre](/guides/web-cloud/internet/internet-access/ftth-fix-access)
@@ -156,4 +158,4 @@ Suivez les instructions de [ce guide](/guides/web-cloud/phone-and-fax/voip/troub
 
 ## Aller plus loin <a name="gofurther"></a>
  
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/verification-identite-numeros-sva.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/verification-identite-numeros-sva.mdx
@@ -5,7 +5,6 @@ lastUpdated: 2026-02-18
 ---
 
 
-
 ## Objectif
 
 L'exploitation de **numéros de Services à Valeur Ajoutée (SVA)** OVHcloud nécessite d'être en conformité avec le cadre réglementaire applicable, notamment les obligations définies par l'ARCEP ainsi que celles prévues par la [Directive européenne 2015/849](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32015L0849&from=FR) du Parlement européen et du Conseil du 20 mai 2015, relative à la prévention de l'utilisation du système financier à des fins de blanchiment d'argent et de financement du terrorisme.
@@ -53,7 +52,6 @@ Afin d'exploiter un numéro spécial SVA, il est obligatoire de fournir l'ensemb
 
 :::
 
-
 Que vous commandiez un nouveau numéro ou souhaitiez valider votre identité pour un numéro déjà en exploitation, cliquez sur <code className="action">Commander un numéro</code> dans le cadre « Je veux... » du <code className="action">Tableau de bord</code>.
 
 <img className="thumbnail" alt="commande de numéro" src="/images/web-cloud/phone-and-fax/voip/verification-identite-numeros-sva/sva-commande.png" loading="lazy" />
@@ -69,15 +67,14 @@ Choisissez si vous êtes un « Professionnel » ou un « Professionnel revendeur
 :::info
 **Éditeur, contact de l’éditeur et bénéficiaires : définitions.**
 
-- **Éditeur** : Personne physique ou morale exploitant le service accessible via ce numéro.<br/>
-- **Contact de l'éditeur** : Personne physique désignée pour représenter l’éditeur du numéro spécial dans le cadre du KYC, de la conformité ou de la gestion opérationnelle.<br/>
-- **Bénéficiaires** : Personnes physiques ou morales tirant un avantage financier, économique ou opérationnel de l’exploitation du numéro spécial, notamment :<br/>
-    - Les personnes physiques détenant directement ou indirectement une participation significative dans l’entreprise (≥ 25 %).<br/>
-    - Les personnes exerçant un contrôle effectif sur la société.<br/>
+- **Éditeur** : Personne physique ou morale exploitant le service accessible via ce numéro.
+- **Contact de l'éditeur** : Personne physique désignée pour représenter l’éditeur du numéro spécial dans le cadre du KYC, de la conformité ou de la gestion opérationnelle.
+- **Bénéficiaires** : Personnes physiques ou morales tirant un avantage financier, économique ou opérationnel de l’exploitation du numéro spécial, notamment :
+- Les personnes physiques détenant directement ou indirectement une participation significative dans l’entreprise (≥ 25 %).
+- Les personnes exerçant un contrôle effectif sur la société.
     - Les personnes pour lesquelles le service est mis en place (par exemple : service externalisé géré par un prestataire pour le compte d’une autre entreprise).
 
 :::
-
 
 <img className="thumbnail" alt="renseigner coordonnées" src="/images/web-cloud/phone-and-fax/voip/verification-identite-numeros-sva/sva-coordonnees01.png" loading="lazy" />
 
@@ -99,7 +96,6 @@ Dans le cas contraire, cliquez sur <code className="action">+ Ajouter un bénéf
 Vous pouvez ajouter jusqu'à 4 bénéficiaires.
 
 :::
-
 
 <img className="thumbnail" alt="ajout bénéficiaires" src="/images/web-cloud/phone-and-fax/voip/verification-identite-numeros-sva/sva-beneficiaire03.png" loading="lazy" />
 
@@ -133,7 +129,6 @@ Pour accéder par la suite à la plateforme Lemonway : depuis le <code className
 
 :::
 
-
 #### Liste des documents requis
 
 :::info
@@ -144,7 +139,6 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 :::
 
-
 **Cliquez sur le type d'entité concerné pour accéder à la liste des documents requis.**
 
 ##### Entité juridique
@@ -152,7 +146,6 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 <details>
 
 <summary>Société non cotée</summary>
-
 
 - Une **pièce d'identité** en cours de validité du représentant légal de la société titulaire du compte OVHcloud : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
 - Une **pièce d'identité** en cours de validité de chacun des bénéficiaires effectifs de la société titulaire du compte OVHcloud : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
@@ -165,11 +158,9 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 <details>
 
 <summary>Société cotée dans un pays de l'UE ou un pays tiers équivalent</summary>
-
 
 - Une **pièce d'identité** en cours de validité du représentant légal de la société titulaire du compte OVHcloud : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
 - Un **KBIS de moins de trois mois** de la société titulaire du compte OVHcloud. Si non précisé sur le KBIS, le poste de la personne physique habilitée à représenter la société doit être publiquement vérifiable (par exemple sur LinkedIn) ou une délégation de pouvoir doit être fournie.
@@ -181,11 +172,9 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 <details>
 
 <summary>Association/Organisme juridique</summary>
-
 
 - Une **pièce d'identité** en cours de validité de la personne physique représentant l'association titulaire du compte OVHcloud : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso). La personne physique représentant l'association doit occuper le poste de président, trésorier ou secrétaire de l'association.
 - Une **copie de moins d'un an du procès-verbal** de la dernière assemblée générale de l'association titulaire du compte OVHcloud.
@@ -197,11 +186,9 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 <details>
 
 <summary>Administration/Autorité ou Agences publiques et autorités régionales</summary>
-
 
 - Une **pièce d'identité** en cours de validité de la personne physique habilitée par l'administration titulaire du compte OVHcloud : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
 - Un **mandat accordé par l'administration titulaire du compte OVHcloud** à la personne physique agissant en son nom.
@@ -211,11 +198,9 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 <details>
 
 <summary>Fondation</summary>
-
 
 - Une **pièce d'identité** en cours de validité de la personne physique représentant la fondation titulaire du compte OVHcloud : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
 - Un **document officiel certifiant** que la personne physique identifiée est bien autorisée à **représenter la fondation** et à gérer le compte OVHcloud.
@@ -227,11 +212,9 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 <details>
 
 <summary>Fonds de dotation</summary>
-
 
 - Une **pièce d'identité** en cours de validité de la personne physique responsable de gérer le compte OVHcloud du fonds de dotation : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
 - Un **document officiel** certifiant que la personne physique identifiée est bien autorisée à représenter le fonds de dotation et à gérer le compte OVHcloud.
@@ -243,11 +226,9 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 <details>
 
 <summary>Artisan</summary>
-
 
 - Une **pièce d'identité** en cours de validité de l'artisan qualifié titulaire du compte OVHcloud : carte d'identité (recto et verso), passeport, titre de résidence (recto et verso), permis de conduire biométrique (recto et verso).
 - Un **certificat d'immatriculation au Registre des Métiers** de moins de 3 mois au nom de l'artisan titulaire du compte OVHcloud.
@@ -257,11 +238,9 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 <details>
 
 <summary>Exploitation agricole à responsabilité limitée</summary>
-
 
 - Une **pièce d'identité** en cours de validité du président ou trésorier de l'EARL titulaire du compte OVHcloud : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
 - Une **pièce d'identité** en cours de validité de chacun des **bénéficiaires effectifs** de l'EARL : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
@@ -274,11 +253,9 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 <details>
 
 <summary>Auto-entrepreneur</summary>
-
 
 - Une **première pièce d'identité** en cours de validité du titulaire du compte : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
 - Un **second justificatif d’identité en cours de validité ou document officiel complémentaire** du titulaire du compte : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire (recto et verso), dernier avis d'imposition daté de moins d'un an, livret de famille, récépissé d'enregistrement du pacte civil de solidarité ou carte vitale.
@@ -289,11 +266,9 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 <details>
 
 <summary>Comité social et économique (CSE)</summary>
-
 
 - Une **pièce d'identité** en cours de validité de la personne physique responsable de gérer le compte OVHcloud au nom du CSE : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
 - Une **copie de moins d'un an du procès-verbal de la dernière assemblée générale** ou la liste des membres du conseil d'administration du CSE titulaire du compte OVHcloud.
@@ -303,11 +278,9 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 <details>
 
 <summary>Groupement d'intérêt public, Centre hospitalier universitaire, Établissement public d'intérêt général, Société d'investissement immobilier, Établissements de santé privés d'intérêt collectif</summary>
-
 
 - Une **pièce d'identité** en cours de validité de la personne physique responsable de gérer le compte OVHcloud au nom de l'agence publique : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
 - Un **document officiel** certifiant que la personne physique identifiée est bien autorisée à **représenter l'agence publique** et à gérer le compte OVHcloud.
@@ -317,11 +290,9 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 <details>
 
 <summary>Compagnie d'assurance</summary>
-
 
 - Une **pièce d'identité** en cours de validité de la personne physique responsable de gérer le compte OVHcloud au nom de la compagnie d'assurance : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
 - Une **décision** (extrait de la délibération ou mandat) désignant la ou **les mandataire(s)** (non exécutifs) autorisés à gérer le compte OVHcloud au nom de la compagnie d'assurance.
@@ -334,11 +305,9 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 <details>
 
 <summary>Paroisse ou église</summary>
-
 
 - Une **pièce d'identité** en cours de validité de la personne physique responsable de gérer le compte OVHcloud au nom de la paroisse ou de l'église : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
 - Une copie de moins d'un an du **procès-verbal de la dernière assemblée générale** de l'association diocésaine autorisant l'ouverture du compte et désignant les personnes autorisées à le gérer.
@@ -350,13 +319,11 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 ##### Fonds d'investissement
 
 <details>
 
 <summary>Fonds avec personnalité morale</summary>
-
 
 - Une **pièce d'identité** en cours de validité du mandataire du fonds titulaire du compte OVHcloud : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
 - Un **KBIS** (extrait attestant de la création de l'entreprise) de moins de trois mois du fonds titulaire du compte OVHcloud.
@@ -367,11 +334,9 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 <details>
 
 <summary>Fonds commun de placement (FCP)</summary>
-
 
 - Une **pièce d'identité** en cours de validité du mandataire de la société de gestion titulaire du compte OVHcloud : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
 - Un **KBIS** (extrait attestant de la création de l'entreprise) de moins de trois mois de la société de gestion titulaire du compte OVHcloud.
@@ -382,18 +347,18 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-
 **La vérification d’identité par vidéo** consiste à confirmer l’identité du représentant légal ou de la personne habilitée à gérer le compte en comparant son visage à sa pièce d’identité via un processus sécurisé de reconnaissance biométrique.
 
 :::info
-Le **Relevé d'Identité Bancaire** doit être déposé sur votre espace client OVHcloud afin de permettre les futurs reversements. Les autres documents doivent être fournis sur l’interface Lemonway.<br/>
-Pour téléverser votre RIB, rendez-vous dans la rubrique <code className="action">Télécom</code> > <code className="action">VoIP & Fax</code>.<br/>
+Le **Relevé d'Identité Bancaire** doit être déposé sur votre espace client OVHcloud afin de permettre les futurs reversements. Les autres documents doivent être fournis sur l’interface Lemonway.
+
+Pour téléverser votre RIB, rendez-vous dans la rubrique <code className="action">Télécom</code> > <code className="action">VoIP & Fax</code>.
+
 Cliquez sur <code className="action">Gérer mes reversements</code> puis sur <code className="action">Modifier mes coordonnées bancaires</code>.
 
 <img className="thumbnail" alt="sva iban" src="/images/web-cloud/phone-and-fax/voip/verification-identite-numeros-sva/sva-iban.png" loading="lazy" />
 
 :::
-
 
 ### Vérifier le statut de mes documents <a name="statut-docs"></a>
 
@@ -427,4 +392,4 @@ En cas de document refusé, vous devrez téléverser un nouveau justificatif qui
 
 [Lemonway : notice d’information relative à la protection des données à caractère personnel](https://www.lemonway.com/protection-des-donnees)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/yealink-cp860-use.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/yealink-cp860-use.mdx
@@ -93,4 +93,4 @@ Il existe deux façons de mettre fin à un appel :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/yealink-t4x-use.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/yealink-t4x-use.mdx
@@ -10,7 +10,7 @@ lastUpdated: 2018-05-30
 
 ## Prérequis
 
-- Posséder [une ligne téléphonique OVHcloud](https://www.ovhtelecom.fr/telephonie/voip/).
+- Posséder [une ligne téléphonique OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
 - Avoir réceptionné et installé le téléphone Yealink T4X fourni par OVHcloud.
 
 {/* CP-NAV-START:telecom-voip-fax */}
@@ -106,4 +106,4 @@ Il existe trois modes de transfert :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/yealink-w56p-use.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/yealink-w56p-use.mdx
@@ -87,4 +87,4 @@ Pour mettre fin à un appel via le socle de rechargement, placez le combiné sur
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).


### PR DESCRIPTION
Standardize the telecom guides (internet, overthebox, sms, voip) to the new-docs conventions. 133 files, no dates changed.

Remove inline <br/> from prose (paragraph breaks / steps; tables and blockquotes preserved) — 39 files
Canonicalize the community link: community.ovhcloud.com/community/fr -> /links/community — 129 files
Rewrite the obsolete ovhtelecom.fr domain -> ovhcloud.com (targets verified via 301 redirects) — 40 files
Clean up legacy markup (Sommaire, Niveau, horizontal rules, manual anchors {#...}) — 11 guides
Restructure 9 guides: Objectif/Prérequis/En pratique template on 6 VoIP hardware guides; tailored Objectif/structure added to 3 others (la-desserte-interne, adaptateur-spa112, api-sms-cookbook)
Fix descriptions (trailing punctuation, missing description) plus a vague anchor text and a typo
Note: 5 tarifs_telephonie.xml links left as-is (no confirmed canonical target); flag:hidden files left untouched.