### PR TITLE
docs: integrate new web-hosting offer range across multisite & WCDB guides

### DIFF
--- a/docs/de/guides/web-cloud/databases/db-backup-export-database-server.mdx
+++ b/docs/de/guides/web-cloud/databases/db-backup-export-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Eine Datenbank Ihres Datenbankservers sichern und exportieren
 description: Erfahren Sie, wie Sie eine Datenbank auf Ihrem Web Cloud Databases Server über das OVHcloud Kundencenter oder phpMyAdmin sichern und exportieren
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Ihre Datenbank kann eine Vielzahl von Informationen enthalten, die für Ihre Web
 
 ## Voraussetzungen
 
-- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (in einem [Performance Webhosting](https://www.ovhcloud.com/de/web-hosting/) Angebot enthalten).
+- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) Performance, Agency, Agency Plus oder Agency Max Angebot enthalten).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/de/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/de/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfigurieren Ihres Datenbankservers
 description: Erfahren Sie, wie Sie Ihren Datenbankserver konfigurieren und optimieren
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Web Cloud Databases Datenbankserver ermöglichen es Ihnen, die globalen Einstell
 
 ## Voraussetzungen
 
-- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (auch in einem [Performance Webhosting](https://www.ovhcloud.com/de/web-hosting/) Angebot enthalten).
+- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (auch in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) Performance, Agency, Agency Plus oder Agency Max Angebot enthalten).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---
@@ -130,11 +130,11 @@ Klicken Sie auf die unten stehenden Tabs, um die **3** Schritte nacheinander anz
 ### Ihren Web Cloud Databases Dienst ändern <a name="modify-ram-web-cloud-db"></a>
 
 :::warning
-Wenn Ihr Web Cloud Databases Dienst an ein **Performance** Webhosting gebunden ist, müssen Sie ihn zuerst von Ihrem **Performance** Hosting trennen, um den Dienst hochzustufen.
+Wenn Ihr Web Cloud Databases Dienst an ein **Performance**, **Agency**, **Agency Plus** oder **Agency Max** Webhosting gebunden ist, müssen Sie ihn zuerst von Ihrem Webhosting trennen, um den Dienst hochzustufen.
 
-Um einen Web Cloud Databases Dienst vom Webhosting **Performance** abzutrennen, lesen Sie unsere Anleitung "[Web Cloud Databases von einem Webhosting abtrennen](/guides/web-cloud/databases/db-detach-from-web-hosting)".
+Um einen Web Cloud Databases Dienst von einem **Performance**, **Agency**, **Agency Plus** oder **Agency Max** Webhosting abzutrennen, lesen Sie unsere Anleitung "[Web Cloud Databases von einem Webhosting abtrennen](/guides/web-cloud/databases/db-detach-from-web-hosting)".
 
-**Diese Aktion ist unwiderruflich. Der Web Cloud Databases Dienst wird anschließend unabhängig von Ihrem Performance Webhosting abgerechnet.**
+**Diese Aktion ist unwiderruflich. Der Web Cloud Databases Dienst wird anschließend unabhängig von Ihrem Performance, Agency, Agency Plus oder Agency Max Webhosting abgerechnet.**
 
 :::
 
@@ -164,7 +164,7 @@ Klicken Sie auf die unten stehenden Tabs, um die **3** Schritte nacheinander anz
     Nach Bestätigung der Verträge werden Sie auf den Bestellschein umgeleitet, um die Änderung zu bezahlen. Diese wird dann innerhalb weniger Stunden wirksam.
     
     :::warning
-    Wenn Sie derzeit über eine kostenfreie, in einem Performance Hosting inkludierte Web Cloud Databases Instanz verfügen, wird diese mit dem Wechsel des Dienstes kostenpflichtig.
+    Wenn Sie derzeit über eine kostenfreie, in einem Performance, Agency, Agency Plus oder Agency Max Hosting inkludierte Web Cloud Databases Instanz verfügen, wird diese mit dem Wechsel des Dienstes kostenpflichtig.
 
     :::
 

--- a/docs/de/guides/web-cloud/databases/db-connecting-database-server.mdx
+++ b/docs/de/guides/web-cloud/databases/db-connecting-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Cloud Databases - Verbindung mit einer Datenbank herstellen
 description: Erfahren Sie hier, wie Sie sich mit einer Datenbank auf Ihrer Web Cloud Databases Lösung verbinden
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Sie können den Inhalt Ihrer Datenbank über ein Interface einsehen. Es gibt ver
 
 ## Voraussetzungen
 
-- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (in einem [Performance Webhosting](https://www.ovhcloud.com/de/web-hosting/) Angebot enthalten).
+- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) Performance, Agency, Agency Plus oder Agency Max Angebot enthalten).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/de/guides/web-cloud/databases/db-create-databases-users.mdx
+++ b/docs/de/guides/web-cloud/databases/db-create-databases-users.mdx
@@ -1,7 +1,7 @@
 ---
 title: Datenbanken und Benutzer auf Ihrem Datenbankserver erstellen
 description: Erfahren Sie hier, wie Sie eine Datenbank auf Ihrem Datenbankserver erstellen
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -15,7 +15,7 @@ In einer Datenbank (DB) können sogenannte dynamische Elemente, wie zum Beispiel
 
 ## Voraussetzungen
 
-- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (auch in einem [Performance Web Hosting](https://www.ovhcloud.com/de/web-hosting/) Angebot enthalten).
+- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (auch in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) Performance, Agency, Agency Plus oder Agency Max Angebot enthalten).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/de/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
+++ b/docs/de/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Cloud Databases von einem Webhosting abtrennen
 description: Erfahren Sie hier, wie Sie den Dienst Web Cloud Databases von einem Webhosting separieren können
-lastUpdated: 2025-01-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -9,13 +9,13 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Ziel
 
-Die Lösung [Web Cloud Databases](https://www.ovhcloud.com/de/web-cloud/databases/) ist in unseren [Performance Webhostings](https://www.ovhcloud.com/de/web-hosting/) inklusive und können ohne Zusatzkosten aktiviert werden. In diesem Fall werden sie dem Webhosting zugewiesen, von dem aus sie aktiviert wurden. Wenn sich im Laufe der Nutzung Ihrer Dienste etwas verändert, müssen Sie möglicherweise Ihre Web Cloud Databases vom zugehörigen Performance Webhosting abtrennen.
+Die Lösung [Web Cloud Databases](https://www.ovhcloud.com/de/web-cloud/databases/) ist in unseren [Webhostings](https://www.ovhcloud.com/de/web-hosting/) Performance, Agency, Agency Plus und Agency Max inklusive und kann ohne Zusatzkosten aktiviert werden. In diesem Fall wird sie dem Webhosting zugewiesen, von dem aus sie aktiviert wurde. Wenn sich im Laufe der Nutzung Ihrer Dienste etwas verändert, müssen Sie möglicherweise Ihre Web Cloud Databases von dem Webhosting, an das sie gebunden ist, abtrennen.
 
 **Diese Anleitung erklärt, wie Sien Sie Ihre Web Cloud Databases von einem Webhosting abtrennen.**
 
 ## Voraussetzungen
 
-- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/), die mit einem [Performance Webhosting](https://www.ovhcloud.com/de/web-hosting/) verbunden ist.
+- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/), die mit einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) Performance, Agency, Agency Plus oder Agency Max verbunden ist.
 - Sie sind der [Administrator-Kontakt](/guides/account-and-service-management/account-information/managing-contacts) der betroffenen Dienste.
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/de/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
+++ b/docs/de/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Erste Schritte mit MySQL und MariaDB
 description: Verwendung Ihrer Datenbanken
-lastUpdated: 2023-07-26
+lastUpdated: 2026-06-08
 ---
 
 ## Ziel
@@ -24,7 +24,7 @@ Das System ist 100% kompatibel und gilt insgesamt als „freier“ als das origi
 
 ## Voraussetzungen
 
-- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (auch enthalten in einem [Performance Webhosting](https://www.ovhcloud.com/de/web-hosting/)).
+- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (auch enthalten in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) Performance, Agency, Agency Plus oder Agency Max).
 - Sie haben Zugriff auf Ihr <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink>.
 - Sie haben die [Anleitung zum Start mit Web Cloud Databases](/guides/web-cloud/databases/db-getting-started) befolgt.
 

--- a/docs/de/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/de/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Erste Schritte mit Web Cloud Databases
 description: Erfahren Sie, wie Sie mit der Lösung Web Cloud Databases starten
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -16,7 +16,7 @@ Standardmäßig ist Ihre Web Cloud Databases Lösung mit dem OVHcloud Webhosting
 
 ## Voraussetzungen
 
-- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (in einem [Performance Webhosting](https://www.ovhcloud.com/de/web-hosting/) enthalten).
+- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) Performance, Agency, Agency Plus oder Agency Max enthalten).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/de/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
+++ b/docs/de/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: EOL Policy für Managed Databases
-lastUpdated: 2023-03-07
+lastUpdated: 2026-06-08
 ---
 
 ## Ziel
@@ -14,7 +14,7 @@ Von OVHcloud verwaltete Datenbanken (*Managed Databases*) verwenden verschiedene
 Sie verfügen über einen der folgenden Dienste:
 
 - Eine in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) enthaltene Datenbank.
-- Eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (auch in einem [Performance Webhosting](https://www.ovhcloud.com/de/web-hosting/) enthalten).
+- Eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (auch in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) Performance, Agency, Agency Plus oder Agency Max enthalten).
 - Ein [Start SQL Datenbank-Paket](https://www.ovhcloud.com/de/web-hosting/options/start-sql/).
 
 ## In der praktischen Anwendung

--- a/docs/de/guides/web-cloud/databases/db-restore-import-database.mdx
+++ b/docs/de/guides/web-cloud/databases/db-restore-import-database.mdx
@@ -1,7 +1,7 @@
 ---
 title: Datenbank auf Ihrem Datenbankserver wiederherstellen und importieren
 description: Erfahren Sie, wie Sie eine Datenbank auf Ihrem Web Cloud Databases Server über das OVHcloud Kundencenter oder phpMyAdmin wiederherstellen und importieren
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Nach einem Fehler auf Ihrer Datenbank müssen Sie in der Lage sein, ein Backup w
 
 ## Voraussetzungen
 
-- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (auch in einem [Performance Webhosting](https://www.ovhcloud.com/de/web-hosting/) Angebot enthalten).
+- Sie verfügen über eine [Web Cloud Databases Instanz](https://www.ovhcloud.com/de/web-cloud/databases/) (auch in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) Performance, Agency, Agency Plus oder Agency Max Angebot enthalten).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/de/guides/web-cloud/web-hosting/access-websites-view.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/access-websites-view.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alle Ihre Websites im OVHcloud Kundencenter anzeigen und verwalten
 description: Erfahren Sie hier, wie Sie alle Ihre Websites über das OVHcloud Kundencenter anzeigen und verwalten
-lastUpdated: 2025-05-27
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -72,7 +72,7 @@ Wenn Sie hier klicken, werden Sie auf den Tab <code className="action">Allgemein
 
 #### Angebot
 
-Zeigt die Webhosting-Reihe an: Starter, Personal, Professional oder Performance.
+Zeigt die Webhosting-Reihe an: Kostenloses Hosting, Starter, Basic, Startup, Pro, Performance, Agency, Agency Plus oder Agency Max.
 
 Wenn Sie hier klicken, werden Sie auf den Tab <code className="action">Allgemeine Informationen</code> für das betreffende Webhosting weitergeleitet.
 

--- a/docs/de/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ihre Webseiten mit CDN beschleunigen
 description: Diese Anleitung erklärt, wie Sie die Ladezeiten Ihres Webhostings mit der CDN-Option verbessern
-lastUpdated: 2025-10-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,7 +39,7 @@ Jeder Server speichert einen Teil Ihrer Webseite im Cache, um die Funktion zu ge
 ###  Die CDN-Option aktivieren
 
 :::info
-Die CDN-Option ist bereits in den Webhosting-Angeboten der Reihe "Performance" enthalten.
+Die CDN-Option ist bereits in den Webhosting-Angeboten "Performance", "Agency", "Agency Plus" und "Agency Max" enthalten.
 
 :::
 
@@ -94,7 +94,7 @@ Gehen Sie zum Tab <code className="action">Multisite</code> Ihres Hostings, klic
 Gehen Sie auf den Tab <code className="action">Multisite</code> Ihres Hostings, klicken Sie auf <code className="action">...</code> rechts neben dem betreffenden Domain- oder Subdomain-Namen und dann auf <code className="action">CDN bearbeiten</code>.
 
 :::warning
-Einige Optionen sind für das Hosting-Angebot "Basic" nicht verfügbar und erfordern die Aktivierung von [CDN Security](https://www.ovhcloud.com/de/web-hosting/options/cdn/) oder [CDN Advanced](https://www.ovhcloud.com/de/web-hosting/options/cdn/).
+Einige Optionen sind für CDN Basic nicht verfügbar und erfordern die Aktivierung von [CDN Security](https://www.ovhcloud.com/de/web-hosting/options/cdn/) oder [CDN Advanced](https://www.ovhcloud.com/de/web-hosting/options/cdn/).
 
 :::
 

--- a/docs/de/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: 1-Klick-Module verwalten
 description: Erfahren Sie hier, wie Sie Ihr 1-Klick-Modul über Ihr OVHcloud Kundencenter verwalten
-lastUpdated: 2024-11-15
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. De
 ## Voraussetzungen
 
 <Region zones={['eu']}>
-- Sie verfügen über ein [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/), auf dem Sie 1-Klick-Module installieren können (ausgenommen  [Kostenloses Hosting 100M](/guides/web-cloud/web-hosting/activate-start10m)).
+- Sie verfügen über ein [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/), auf dem Sie 1-Klick-Module installieren können (ausgenommen [Kostenloses Hosting](/guides/web-cloud/web-hosting/activate-start10m)).
 </Region>
 <Region zones={['ca', 'apac']}>
 - Sie verfügen über ein [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/), auf dem Sie 1-Klick-Module installieren können.
@@ -139,7 +139,7 @@ Unsere Anleitungen:
 :::warning
 Die Löschung Ihres 1-Klick-Moduls **beinhaltet nicht die Löschung der Datenbank**. Wenn Sie die Installation eines neuen CMS starten, ohne zuvor die bestehende Datenbank gelöscht zu haben (und Ihr Hosting erlaubt nicht die automatische Erstellung einer neuen Datenbank), erscheint die Nachricht “[Beim Laden der Informationen ist ein Fehler aufgetreten (You need at least one free database)](/guides/web-cloud/web-hosting/diagnostic-errors-module1clic#beim-laden-der-informationen-ist-ein-fehler-aufgetreten-sie-benotigen-mindestens-eine-freie-datenbank)“ in Ihrem Kundencenter.
 
-Wenn Sie über ein [Basic Hosting](https://www.ovhcloud.com/de/web-hosting/personal-offer/) verfügen oder bereits vier Datenbanken auf Ihrem [Pro Hosting](https://www.ovhcloud.com/de/web-hosting/professional-offer/) oder [Performance Hosting](https://www.ovhcloud.com/de/web-hosting/performance-offer/) erstellt haben, müssen Sie **ZUERST** die im [ersten Schritt](#step1) identifizierte Datenbank löschen, um ein neues 1-Klick-Modul erstellen zu können.
+Wenn Sie die maximale Anzahl an Datenbanken Ihres [Webhosting-Angebots](https://www.ovhcloud.com/de/web-hosting/) erreicht haben, müssen Sie **ZUERST** die im [ersten Schritt](#step1) identifizierte Datenbank löschen, um ein neues 1-Klick-Modul erstellen zu können.
 
 :::
 

--- a/docs/de/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -1,7 +1,7 @@
 ---
 title: Die häufigsten Fehler bei 1-Klick-Modulen beheben
 description: Erfahren Sie hier, wie Sie die häufigsten Fehler bei der Erstellung von 1-Klick-Modulen beheben können
-lastUpdated: 2024-03-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -89,7 +89,7 @@ Klicken Sie in Ihrem <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> auf
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-Die Angebote [Pro](https://www.ovhcloud.com/de/web-hosting/professional-offer/) und [Performance](https://www.ovhcloud.com/de/web-hosting/performance-offer/) ermöglichen Ihnen die Erstellung von bis zu drei zusätzlichen 1-Klick-Modulen mit einer unabhängigen Datenbank für jedes Modul. Mit den **Performance** Angeboten können Sie auch kostenlos einen [Web Cloud Databases](https://www.ovhcloud.com/de/web-cloud/databases/) Server aktivieren.
+Die Angebote **Pro**, **Performance**, **Agency**, **Agency Plus** und **Agency Max** ermöglichen Ihnen die Erstellung weiterer 1-Klick-Module mit jeweils einer unabhängigen Datenbank. Mit den Angeboten **Performance**, **Agency**, **Agency Plus** und **Agency Max** können Sie auch kostenlos einen [Web Cloud Databases](https://www.ovhcloud.com/de/web-cloud/databases/) Server aktivieren.
 
 Anschließend können Sie ein neues 1-Klick-Modul installieren.
 
@@ -187,7 +187,7 @@ Gehen Sie in Ihrem <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> in de
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-Die Angebote [Pro](https://www.ovhcloud.com/de/web-hosting/professional-offer/) und [Performance](https://www.ovhcloud.com/de/web-hosting/performance-offer/) ermöglichen Ihnen die Erstellung von bis zu drei zusätzlichen 1-Klick-Modulen mit einer unabhängigen Datenbank für jedes Modul. Mit den **Performance** Angeboten können Sie auch kostenlos einen [Web Cloud Databases](https://www.ovhcloud.com/de/web-cloud/databases/) Server aktivieren.
+Die Angebote **Pro**, **Performance**, **Agency**, **Agency Plus** und **Agency Max** ermöglichen Ihnen die Erstellung weiterer 1-Klick-Module mit jeweils einer unabhängigen Datenbank. Mit den Angeboten **Performance**, **Agency**, **Agency Plus** und **Agency Max** können Sie auch kostenlos einen [Web Cloud Databases](https://www.ovhcloud.com/de/web-cloud/databases/) Server aktivieren.
 
 ### „Verbindung zur Datenbank kann nicht hergestellt werden“ <a name="delete-the-module"></a>
 

--- a/docs/de/guides/web-cloud/web-hosting/faq.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ Webhosting
 description: Hier finden Sie Antworten zu den am häufigsten gestellten Fragen zu den OVHcloud Webhostings
-lastUpdated: 2025-11-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,7 +27,7 @@ Führen Sie die folgenden Schritte aus:
 Dort können Sie Ihre SSL Zertifikate, die auf Ihrem Webhosting angewendete PHP Version, die CDN Option, Multisites, Datenbanken, etc. verwalten.
 
 :::tip
-Um Ihnen bei der Konfiguration Ihres Webhostings zu helfen, lesen Sie bitte die Abschnitte „*Erste Schritte*“ und „*Konfiguration von Basic, Pro und Performance Webhostings*“ auf [dieser Seite](/guides/web-cloud/web-hosting/overview).
+Um Ihnen bei der Konfiguration Ihres Webhostings zu helfen, lesen Sie bitte die Abschnitte „*Erste Schritte*“ und „*Konfiguration eines Webhostings*“ auf [dieser Seite](/guides/web-cloud/web-hosting/overview).
 
 :::
 
@@ -299,11 +299,11 @@ Führen Sie die folgenden Schritte aus:
 
 <details>
 
-<summary>Wie kann ich bei einer Kündigung eines „Performance“ Webhostings das dazugehörige Angebot „Web Cloud Databases“ beibehalten?</summary>
+<summary>Wie kann ich bei einer Kündigung eines Webhostings das dazugehörige kostenlose Angebot „Web Cloud Databases“ beibehalten?</summary>
 
 
-Die Webhosting-Pakete **Performance** enthalten kostenlos aktivierbare Web Cloud Databases.  
-Wenn Sie Ihr Webhosting kündigen oder löschen **Performance**, wird auch das eventuell damit verbundene Angebot Web Cloud Databases gekündigt. Um Ihre Web Cloud Databases Lösung zu behalten, müssen Sie diese **vor** Kündigung des Hostings abtrennen.
+Die Webhosting-Pakete **Performance**, **Agency**, **Agency Plus** und **Agency Max** enthalten kostenlos aktivierbare Web Cloud Databases.  
+Wenn Sie Ihr Webhosting kündigen oder löschen, wird auch das eventuell damit verbundene Angebot Web Cloud Databases gekündigt. Um Ihre Web Cloud Databases Lösung zu behalten, müssen Sie diese **vor** Kündigung des Hostings abtrennen.
 
 Führen Sie die folgenden Schritte aus:
 
@@ -312,14 +312,14 @@ Führen Sie die folgenden Schritte aus:
 3. Klicken Sie auf der angezeigten Seite und in der Randleiste **Konfiguration** auf die Schaltfläche <code className="action">...</code> rechts neben `Web Cloud Databases` und dann auf <code className="action">Abrennen</code>.
 4. Befolgen Sie die Anweisungen, um einen unabhängigen Web Cloud Databases Dienst zu bestellen, damit Ihre bereits erstellte Lösung für Web Cloud Databases erhalten bleibt.
 
-**Diese Aktion kann nicht rückgängig gemacht werden. Das Angebot Web Cloud Databases wird dann unabhängig von Ihrem Performance Webhosting abgerechnet.**
+**Diese Aktion kann nicht rückgängig gemacht werden. Das Angebot Web Cloud Databases wird dann unabhängig von Ihrem Webhosting abgerechnet.**
 
 </details>
 
 
 <details>
 
-<summary>Wie kann ich den RAM eines Web Cloud Databases Angebots im Zusammenhang mit einem Performance Webhosting erhöhen?</summary>
+<summary>Wie kann ich den RAM eines Web Cloud Databases Angebots im Zusammenhang mit einem Performance, Agency, Agency Plus oder Agency Max Webhosting erhöhen?</summary>
 
 
 Führen Sie die folgenden Schritte aus:

--- a/docs/de/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Den Speicherplatz Ihres Webhostings wiederherstellen
 description: Erfahren Sie hier, wie Sie eine Datei oder den gesamten Speicherplatz Ihres Webhostings wiederherstellen
-lastUpdated: 2025-12-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,10 +27,10 @@ Wenn Sie ein Sicherheitsbackup für Ihre Website erstellen und eine Datenbank ve
 ## Voraussetzungen
 
 <Region zones={['eu']}>
-- Sie verfügen über ein [OVHcloud Webhosting](https://www.ovh.com/de/hosting/) Angebot (mit Ausnahme von [Cloud Web](https://www.ovhcloud.com/de/web-hosting/cloud-web-offer/)).
+- Sie verfügen über ein [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) Angebot (mit Ausnahme von [Cloud Web](https://www.ovhcloud.com/de/web-hosting/)).
 </Region>
 <Region zones={['ca', 'apac']}>
-- Sie verfügen über ein [OVHcloud Webhosting](https://www.ovh.com/de/hosting/) Angebot.
+- Sie verfügen über ein [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) Angebot.
 </Region>
 - Je nach der verwendeten Methode benötigen Sie Zugriff auf die Verwaltung des Webhostings über das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> oder das Passwort des FTP-Benutzers, um sich mit Ihrem Speicherplatz zu verbinden. 
 

--- a/docs/de/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Webhosting - Ändern von mit einem Webhosting verbundenen Domainnamen
 description: Erfahren Sie hier, wie Sie die Zuordnungseinstellungen von Domainnamen oder Subdomains ändern, die bereits auf Ihrem Webhosting deklariert sind
-lastUpdated: 2025-11-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -103,7 +103,7 @@ Wenn Sie einen nicht existierenden Ordnernamen im FTP-Speicherbereich Ihres Webh
 
 ##### Die Option "CDN aktivieren"
 
-Um diese Option nutzen zu können, müssen Sie zuerst ein CDN von OVHcloud abonniert haben oder über ein Performance Webhosting verfügen.
+Um diese Option nutzen zu können, müssen Sie zuerst ein CDN von OVHcloud abonniert haben oder über ein Performance, Agency, Agency Plus oder Agency Max Webhosting verfügen.
 
 Aktivieren/deaktivieren Sie diese Option, um die CDN-Option für Ihren Domainnamen oder Ihre Subdomain zu aktivieren/deaktivieren.
 

--- a/docs/de/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Webhosting - Schnellstart-Anleitung
 description: Erfahren Sie hier, wie Sie auf einem Webhosting eine neue Website mithilfe eines 1-Klick-Moduls online stellen und personalisierte E-Mail-Adressen mit Ihrem Domainnamen verwenden
-lastUpdated: 2025-04-07
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -16,7 +16,7 @@ Sie möchten eine Website für Ihr Unternehmen oder einen persönlichen Blog ers
 :::info
 - Sie möchten eine bestehende Website zu einem anderen Hosting-Anbieter migrieren? Ziehen Sie unsere spezielle Anleitung zu Rate: [Migration Ihrer Website und zugehörigen Dienste zu OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh).
 <Region zones={['eu']}>
-- Sie möchten nur eine einfache Homepage für Ihr Business? Lesen Sie unsere Anleitung: [Webhosting - Kostenloses Hosting 100M aktivieren](/guides/web-cloud/web-hosting/activate-start10m).
+- Sie möchten nur eine einfache Homepage für Ihr Business? Lesen Sie unsere Anleitung: [Webhosting - Kostenloses Hosting aktivieren](/guides/web-cloud/web-hosting/activate-start10m).
 </Region>
 
 :::
@@ -25,7 +25,7 @@ Sie möchten eine Website für Ihr Unternehmen oder einen persönlichen Blog ers
 ## Voraussetzungen
 
 <Region zones={['eu']}>
-- Sie verfügen über ein [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) mit mindestens einer verfügbaren Datenbank (mit Ausnahme des Kostenloses Hosting 100M Angebots).
+- Sie verfügen über ein [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) mit mindestens einer verfügbaren Datenbank (mit Ausnahme des kostenlosen Hosting-Angebots).
 </Region>
 <Region zones={['ca','apac']}>
 - Sie verfügen über ein [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) mit mindestens einer verfügbaren Datenbank.

--- a/docs/de/guides/web-cloud/web-hosting/website-project.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/website-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Erstellen Ihrer Website - So setzen Sie Ihr Projekt in 5 Schritten um
 description: Erfahren Sie hier, wie Sie Ihr Projekt definieren, Ihre Website veröffentlichen und E-Mail-Adressen mit Ihrer Webhosting-Lösung erstellen
-lastUpdated: 2025-04-25
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -213,7 +213,7 @@ Für Webhostings bietet OVHcloud 3 CDN-Varianten:
 Weitere Informationen zum CDN finden Sie in unserer Anleitung „[Ihre Webseiten mit CDN beschleunigen](/guides/web-cloud/web-hosting/cdn-how-to-use-cdn)“.
 
 :::info
-Das Angebot **CDN Basic** ist nur bei **Performance** Webhostings kostenlos inklusive.
+Das Angebot **CDN Basic** ist bei **Performance**, **Agency**, **Agency Plus** und **Agency Max** Webhostings kostenlos inklusive.
 
 Sie können nicht mehrere CDN-Varianten auf demselben Webhosting zusammenfassen.
 
@@ -225,7 +225,7 @@ Sie können nicht mehrere CDN-Varianten auf demselben Webhosting zusammenfassen.
 
 <summary>Die Web Cloud Databases Datenbankserver</summary>
 
-Wenn Sie über ein Webhosting **Performance** verfügen, können Sie kostenlos einen [Web Cloud Databases](https://www.ovhcloud.com/de/web-cloud/databases/) Datenbankserver aktivieren.
+Wenn Sie über ein Webhosting **Performance**, **Agency**, **Agency Plus** oder **Agency Max** verfügen, können Sie kostenlos einen [Web Cloud Databases](https://www.ovhcloud.com/de/web-cloud/databases/) Datenbankserver aktivieren.
 
 Weitere Informationen zur Verwendung finden Sie in unserer Dokumentation „[Erste Schritte mit Web Cloud Databases](/guides/web-cloud/databases/db-getting-started)“.
 

--- a/docs/en/guides/web-cloud/databases/db-backup-export-database-server.mdx
+++ b/docs/en/guides/web-cloud/databases/db-backup-export-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Backing up and exporting a database on your database server
 description: Find out how to back up and export a database from your Web Cloud Databases server using the OVHcloud Control Panel or phpMyAdmin
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Your database can contain a large amount of essential information for your websi
 
 ## Requirements
 
-- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Performance web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/)).
+- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) Performance, Agency, Agency Plus or Agency Max plan).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/en/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/en/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring your database server
 description: Find out how to configure and optimise your database server
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Web Cloud Databases database servers allow you to modify the global settings of 
 
 ## Requirements
 
-- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Performance web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/)).
+- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) Performance, Agency, Agency Plus or Agency Max plan).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---
@@ -130,11 +130,11 @@ Click on the tabs below to view each of the **3** steps.
 ### Modify your Web Cloud Databases plan <a name="modify-ram-web-cloud-db"></a>
 
 :::warning
-If your Web Cloud Databases plan is linked to a **Performance** web hosting plan, you must first detach the Web Cloud Databases plan from your **Performance** hosting plan before upgrading to a higher plan.
+If your Web Cloud Databases plan is linked to a **Performance**, **Agency**, **Agency Plus** or **Agency Max** web hosting plan, you must first detach the Web Cloud Databases plan from your hosting plan before upgrading to a higher plan.
 
-To detach a Web Cloud Databases plan from a **Performance** web hosting plan, please refer to our guide "[Detach my Web Cloud Databases solution from a web hosting plan](/guides/web-cloud/databases/db-detach-from-web-hosting)".
+To detach a Web Cloud Databases plan from a **Performance**, **Agency**, **Agency Plus** or **Agency Max** web hosting plan, please refer to our guide "[Detach my Web Cloud Databases solution from a web hosting plan](/guides/web-cloud/databases/db-detach-from-web-hosting)".
 
-**This action is irreversible, and the Web Cloud Databases plan will then be billed separately from your Performance web hosting plan.**
+**This action is irreversible, and the Web Cloud Databases plan will then be billed separately from your Performance, Agency, Agency Plus or Agency Max web hosting plan.**
 
 :::
 
@@ -164,7 +164,7 @@ Click on the tabs below to view each of the **3** steps.
     Once you have confirmed your contracts, you will be redirected to the purchase order to pay for this change. It will then be effective within a few hours.
     
     :::warning
-    If you currently have a free Web Cloud Databases with your Performance hosting plan, modifying the plan will mean it is no longer free.
+    If you currently have a free Web Cloud Databases with your Performance, Agency, Agency Plus or Agency Max hosting plan, modifying the plan will mean it is no longer free.
 
     :::
 

--- a/docs/en/guides/web-cloud/databases/db-connecting-database-server.mdx
+++ b/docs/en/guides/web-cloud/databases/db-connecting-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Cloud Databases - Connecting to a database
 description: Find out how to connect to a database on your Web Cloud Databases solution
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ You can view the content of your database via an interface. There are several wa
 
 ## Requirements
 
-- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Performance web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/)).
+- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) Performance, Agency, Agency Plus or Agency Max plan).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/en/guides/web-cloud/databases/db-create-databases-users.mdx
+++ b/docs/en/guides/web-cloud/databases/db-create-databases-users.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creating databases and users on your database server
 description: Find out how to create a database on your database server.
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -15,7 +15,7 @@ A database (DB) is used to store what are known as dynamic elements, such as com
 
 ## Requirements
 
-- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Performance web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/)).
+- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) Performance, Agency, Agency Plus or Agency Max plan).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/en/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
+++ b/docs/en/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to detach the Web Cloud Databases solution from a web hosting plan
 description: Find out how to unlink your Web Cloud Databases solution from a web hosting plan
-lastUpdated: 2025-01-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -9,13 +9,13 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objective
 
-[Web Cloud Databases](https://www.ovhcloud.com/en-gb/web-cloud/databases/) can be activated free of charge from our [Performance web hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/). In this case, they are associated with the web hosting plan from which they have been activated. As you use your services, you may find that you need to unlink your Web Cloud Databases solution from the Performance web hosting plan it is linked to.
+[Web Cloud Databases](https://www.ovhcloud.com/en-gb/web-cloud/databases/) can be activated free of charge from our [web hosting](https://www.ovhcloud.com/en-gb/web-hosting/) Performance, Agency, Agency Plus and Agency Max plans. In this case, they are associated with the web hosting plan from which they have been activated. As you use your services, you may find that you need to unlink your Web Cloud Databases solution from the web hosting plan it is linked to.
 
 **This guide explains how to unlink your Web Cloud Databases solution from a web hosting plan.**
 
 ## Requirements
 
-- You have a [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) associated with a [Performance web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/).
+- You have a [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) associated with a [Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) Performance, Agency, Agency Plus or Agency Max plan.
 - You are the [Administrator](/guides/account-and-service-management/account-information/managing-contacts) contact of the OVHcloud services concerned.
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/en/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
+++ b/docs/en/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting started with MySQL and MariaDB
 description: Using Your Databases
-lastUpdated: 2023-07-26
+lastUpdated: 2026-06-08
 ---
 
 ## Objective
@@ -24,7 +24,7 @@ This engine is 100% compatible, and is "freer" than its sibling MySQL. All the b
 
 ## Requirements
 
-- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [performance web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/)).
+- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) Performance, Agency, Agency Plus or Agency Max plan).
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
 - You need to have read the [Web Cloud Databases startup guide](/guides/web-cloud/databases/db-getting-started).
 

--- a/docs/en/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/en/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting started with the Web Cloud Databases service
 description: Find out how to get started with the Web Cloud Databases service
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -16,7 +16,7 @@ By default, your Web Cloud Databases solution is linked to the OVHcloud web host
 
 ## Requirements
 
-- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Performance web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/)).
+- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) Performance, Agency, Agency Plus or Agency Max plan).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/en/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
+++ b/docs/en/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Managed databases EOL policy
-lastUpdated: 2023-03-07
+lastUpdated: 2026-06-08
 ---
 
 ## Objective
@@ -14,7 +14,7 @@ OVHcloud managed databases offer several Database Management Systems (DBMS), suc
 At least one of the following 3 solutions:
 
 - One of the included databases with a [Web Hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/).
-- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Performance Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) offer).
+- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) Performance, Agency, Agency Plus or Agency Max plan).
 - A [Start SQL](https://www.ovhcloud.com/en-gb/web-hosting/options/start-sql/) database pack.
 
 ## Instructions

--- a/docs/en/guides/web-cloud/databases/db-restore-import-database.mdx
+++ b/docs/en/guides/web-cloud/databases/db-restore-import-database.mdx
@@ -1,7 +1,7 @@
 ---
 title: Restoring and importing a database to your database server
 description: Find out how to restore and import a database on your Web Cloud Databases server from the OVHcloud Control Panel or via phpMyAdmin
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Following an error on your database, you must be able to restore a backup or imp
 
 ## Requirements
 
-- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Performance web hosting](https://www.ovhcloud.com/en-gb/web-hosting/) plan)
+- A [Web Cloud Databases instance](https://www.ovhcloud.com/en-gb/web-cloud/databases/) (included in a [Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) Performance, Agency, Agency Plus or Agency Max plan)
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/en/guides/web-cloud/web-hosting/access-websites-view.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/access-websites-view.mdx
@@ -1,7 +1,7 @@
 ---
 title: View and manage all your websites from the OVHcloud Control Panel
 description: Find out how to view and manage all of your websites via the OVHcloud Control Panel
-lastUpdated: 2025-05-27
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -72,7 +72,7 @@ Clicking this will redirect you to the <code className="action">General informat
 
 #### Service plan
 
-Shows the type of solution associated with the hosting plan: Starter, Personal, Professional or Performance.
+Shows the type of solution associated with the hosting plan: Free hosting, Starter, Personal, Startup, Professional, Performance, Agency, Agency Plus or Agency Max.
 
 Clicking this will redirect you to the <code className="action">General information</code> tab for the web hosting plan concerned.
 

--- a/docs/en/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
@@ -1,7 +1,7 @@
 ---
 title: Speeding up your website with CDN
 description: Find out how to improve your website by reducing loading times on a Web Hosting plan using the CDN
-lastUpdated: 2025-10-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,7 +39,7 @@ In order for this to work, each server stores a part of your website in its cach
 ### Enabling the CDN option
 
 :::info
-The CDN option is already included in the "Performance" Web Hosting plans.
+The CDN option is already included in the "Performance", "Agency", "Agency Plus" and "Agency Max" Web Hosting plans.
 
 :::
 
@@ -94,7 +94,7 @@ Go to the <code className="action">Multisite</code> tab for your Web Hosting pla
 Go to the <code className="action">Multisite</code> tab for your Web Hosting plan, click on <code className="action">...</code> to the right of the domain name or subdomain concerned, then click <code className="action">Modify the CDN</code>.
 
 :::warning
-Some options are locked on the Basic solution and require you to sign up to [CDN Security](https://www.ovhcloud.com/en-gb/web-hosting/options/cdn/) or [CDN Advanced](https://www.ovhcloud.com/en-gb/web-hosting/options/cdn/).
+Some options are locked on CDN Basic and require you to sign up to [CDN Security](https://www.ovhcloud.com/en-gb/web-hosting/options/cdn/) or [CDN Advanced](https://www.ovhcloud.com/en-gb/web-hosting/options/cdn/).
 
 :::
 

--- a/docs/en/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to manage your 1-click module
 description: Find out how to manage your 1-click module in the OVHcloud Control Panel
-lastUpdated: 2024-11-15
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ This guide is designed to assist you in common tasks as much as possible. Nevert
 ## Requirements
 
 <Region zones={['eu']}>
-- An [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/) that allows you to install a 1-click module (only the free [100M free hosting](/guides/web-cloud/web-hosting/activate-start10m) does not provide this feature)
+- An [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/) that allows you to install a 1-click module (only [free hosting](/guides/web-cloud/web-hosting/activate-start10m) does not provide this feature)
 </Region>
 <Region zones={['ca', 'apac']}>
 - An [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/) that allows you to install a 1-click module.
@@ -139,7 +139,7 @@ See our guides:
 :::warning
 Deleting your 1-click module **will not automatically delete its database**. If you launch the installation of a new CMS without having previously deleted the database from the previous one and if your hosting plan does not allow the automatic creation of another database, the message "[An error has occurred loading the information (You need at least one free database)](/guides/web-cloud/web-hosting/diagnostic-errors-module1clic#an-error-has-occurred-loading-the-information-you-need-at-least-one-free-database)" will appear in your Control Panel.
 
-If you have a [Personal Hosting](https://www.ovhcloud.com/en-gb/web-hosting/personal-offer/) subscription or if you have already created all four databases of your [Pro Hosting](https://www.ovhcloud.com/en-gb/web-hosting/professional-offer/) or [Performance Hosting](https://www.ovhcloud.com/en-gb/web-hosting/performance-offer/), you will need to delete the database identified in [step 1](#step1) **BEFORE** creating a new 1-click module.
+If you have reached the maximum number of databases allowed by your [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), you will need to delete the database identified in [step 1](#step1) **BEFORE** creating a new 1-click module.
 
 :::
 

--- a/docs/en/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting common 1-click module errors
 description: Find out how to diagnose the most common cases of 1-click module creation errors
-lastUpdated: 2024-03-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -89,7 +89,7 @@ In your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, click <code cl
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-The offers [Pro](https://www.ovhcloud.com/en-gb/web-hosting/professional-offer/) and [Performance](https://www.ovhcloud.com/en-gb/web-hosting/performance-offer/) will allow you to create up to three additional 1-click modules with an independent database for each of them. With the **Performance** plans, you can also activate a [Web Cloud Databases](https://www.ovhcloud.com/en-gb/web-cloud/databases/) server for free.
+The **Pro**, **Performance**, **Agency**, **Agency Plus** and **Agency Max** plans will allow you to create more 1-click modules, each with its own independent database. With the **Performance**, **Agency**, **Agency Plus** and **Agency Max** plans, you can also activate a [Web Cloud Databases](https://www.ovhcloud.com/en-gb/web-cloud/databases/) server for free.
 
 Once complete, you will be able to install a new 1-click module.
 
@@ -187,7 +187,7 @@ In your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, go to the <cod
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-The [Pro](https://www.ovhcloud.com/en-gb/web-hosting/professional-offer/) and [Performance](https://www.ovhcloud.com/en-gb/web-hosting/performance-offer/) offers will allow you to create up to three additional 1-click modules with an independent database for each of them. With the **Performance** plans, you can also activate a [Web Cloud Databases](https://www.ovhcloud.com/en-gb/web-cloud/databases/) server for free.
+The **Pro**, **Performance**, **Agency**, **Agency Plus** and **Agency Max** plans will allow you to create more 1-click modules, each with its own independent database. With the **Performance**, **Agency**, **Agency Plus** and **Agency Max** plans, you can also activate a [Web Cloud Databases](https://www.ovhcloud.com/en-gb/web-cloud/databases/) server for free.
 
 ### "Unable to connect to database" <a name="delete-the-module"></a>
 

--- a/docs/en/guides/web-cloud/web-hosting/faq.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Hosting FAQ
 description: Find the answers to the most frequently asked questions about OVHcloud web hosting plans
-lastUpdated: 2025-11-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,7 +27,7 @@ Follow these steps:
 You can manage your SSL certificates, the PHP version applied to your web hosting plan, the CDN option, multisites, databases, etc.
 
 :::tip
-To help you configure your web hosting plan, please refer to the sections *Getting started* and *Configuring a Personal, Professional or Performance web hosting plan* of [this page](/guides/web-cloud/web-hosting/overview).
+To help you configure your web hosting plan, please refer to the sections *Getting started* and *Configuring a web hosting plan* of [this page](/guides/web-cloud/web-hosting/overview).
 
 :::
 
@@ -301,11 +301,11 @@ Follow these steps:
 
 <details>
 
-<summary>When I cancel a Performance web hosting plan, how do I keep the attached Web Cloud Databases solution?</summary>
+<summary>When I cancel a web hosting plan that includes a free Web Cloud Databases solution, how do I keep it?</summary>
 
 
-**Performance** web hosting plans include a Web Cloud Databases solution that can be activated for free.<br/>
-When you cancel or delete your **Performance** web hosting plan, any attached Web Cloud Databases solution will also be cancelled. To keep your Web Cloud Databases solution, you will need to detach it **before** the hosting plan is cancelled.
+**Performance**, **Agency**, **Agency Plus** and **Agency Max** web hosting plans include a Web Cloud Databases solution that can be activated for free.<br/>
+When you cancel or delete this web hosting plan, any attached Web Cloud Databases solution will also be cancelled. To keep your Web Cloud Databases solution, you will need to detach it **before** the hosting plan is cancelled.
 
 Follow these steps:
 
@@ -314,14 +314,14 @@ Follow these steps:
 3. On the page that pops up, in the **Configuration** box, click the <code className="action">...</code> button to the right of the `Web Cloud Databases` comment, then <code className="action">Detach</code>.
 4. Follow the instructions to order an independent Web Cloud Databases solution in order to keep your Web Cloud Databases solution already created.
 
-**This action cannot be undone, and the Web Cloud Databases solution will then be billed separately from your Performance web hosting plan.**
+**This action cannot be undone, and the Web Cloud Databases solution will then be billed separately from your web hosting plan.**
 
 </details>
 
 
 <details>
 
-<summary>How do I increase the RAM of a "Web Cloud Databases" solution linked to a "Performance" web hosting plan?</summary>
+<summary>How do I increase the RAM of a "Web Cloud Databases" solution linked to a Performance, Agency, Agency Plus or Agency Max web hosting plan?</summary>
 
 
 Follow these steps:

--- a/docs/en/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Restoring your Web Hosting plan’s storage space
 description: Find out how to restore a file or an entire storage space from your Web Hosting plan
-lastUpdated: 2025-12-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,7 +27,7 @@ When you do a security backup for your site and you are using a database, also c
 ## Requirements
 
 <Region zones={['eu']}>
-- A [Web Hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/) (please note that this does not work with [Cloud Web](https://www.ovhcloud.com/en-gb/web-hosting/cloud-web-offer/)).
+- A [Web Hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/) (please note that this does not work with [Cloud Web](https://www.ovhcloud.com/en-gb/web-hosting/)).
 </Region>
 <Region zones={['ca', 'apac']}>
 - A [Web Hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/).

--- a/docs/en/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Hosting - How to modify a domain name already associated to a hosting plan
 description: Find out how to change the association settings for a domainname or subdomain already declared on your web hosting plan
-lastUpdated: 2025-11-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -103,7 +103,7 @@ If you enter a non-existent folder name in your web hosting plan’s FTP storage
 
 ##### The "Activate the CDN" option
 
-To use this option, you must have already subscribed to an OVHcloud CDN solution, or have a Performance web hosting plan.
+To use this option, you must have already subscribed to an OVHcloud CDN solution, or have a Performance, Agency, Agency Plus or Agency Max web hosting plan.
 
 Tick/untick this box to enable/disable the CDN option for your domain name or subdomain.
 

--- a/docs/en/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to get started with your web hosting plan
 description: Find out how to put a new website online with our 1-click modules, how to create a new custom email address with your domain name, all using our web hosting solution
-lastUpdated: 2025-04-07
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -16,7 +16,7 @@ Want to create a website for your business or a personal blog? Need an e-commerc
 :::info
 - Want to migrate an existing website from another hosting provider? Read directly our dedicated guide: [Migrating your website and associated services to OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh).
 <Region zones={['eu']}>
-- You only want a simple homepage for your professional activity? Read our dedicated guide: [Web Hosting - Activate free 100M hosting](/guides/web-cloud/web-hosting/activate-start10m).
+- You only want a simple homepage for your professional activity? Read our dedicated guide: [Web Hosting - Activate free hosting](/guides/web-cloud/web-hosting/activate-start10m).
 </Region>
 
 :::
@@ -25,7 +25,7 @@ Want to create a website for your business or a personal blog? Need an e-commerc
 ## Requirements
 
 <Region zones={['eu']}>
-- A [OVHcloud Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) plan with at least one database available (apart from the free 100M hosting offer).
+- A [OVHcloud Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) plan with at least one database available (apart from the free hosting offer).
 </Region>
 <Region zones={['ca','apac']}>
 - A [OVHcloud Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) plan with at least one database available.

--- a/docs/en/guides/web-cloud/web-hosting/website-project.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/website-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to create a website - Carrying out your project in 5 steps
 description: Find out how to define your project, publish your website and create email addresses with your web hosting solution
-lastUpdated: 2025-04-25
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -213,7 +213,7 @@ With web hosting plans, OVHcloud offers 3 CDN solutions:
 You can find more information on our CDN solutions in our guide on "[Speeding up your website with CDN](/guides/web-cloud/web-hosting/cdn-how-to-use-cdn)".
 
 :::info
-The **CDN Basic** solution is included free with **Performance** web hosting plans only.
+The **CDN Basic** solution is included free with **Performance**, **Agency**, **Agency Plus** and **Agency Max** web hosting plans.
 
 You cannot combine several CDN offers on the same web hosting plan.
 
@@ -225,7 +225,7 @@ You cannot combine several CDN offers on the same web hosting plan.
 
 <summary>Web Cloud Database Servers</summary>
 
-If you have a **Performance** web hosting plan, you can activate a [Web Cloud Databases](https://www.ovhcloud.com/en-gb/web-cloud/databases/) database server for free.
+If you have a **Performance**, **Agency**, **Agency Plus** or **Agency Max** web hosting plan, you can activate a [Web Cloud Databases](https://www.ovhcloud.com/en-gb/web-cloud/databases/) database server for free.
 
 You can find more details on how to use it in our documentation “[Getting started with the Web Cloud Databases service](/guides/web-cloud/databases/db-getting-started)”.
 

--- a/docs/es/guides/web-cloud/databases/db-backup-export-database-server.mdx
+++ b/docs/es/guides/web-cloud/databases/db-backup-export-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Guardar y exportar una base de datos en un servidor de bases de datos
 description: Cómo realizar el backup y la exportación de una base de datos en su servidor Web Cloud Databases desde el área de cliente de OVHcloud o a través de phpMyAdmin
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Su base de datos puede contener una gran cantidad de información esencial para 
 
 ## Requisitos
 
-- Tener una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un plan de [hosting Performance](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Tener una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un plan de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/) Performance, Agency, Agency Plus o Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/es/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/es/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar el servidor de bases de datos
 description: Cómo configurar y optimizar el servidor de bases de datos
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Los servidores de bases de datos Web Cloud Databases le permiten modificar los p
 
 ## Requisitos
 
-- Disponer de una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un [plan de hosting Performance](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Disponer de una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un plan de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/) Performance, Agency, Agency Plus o Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---
@@ -130,11 +130,11 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
 ### Modificar su solución Web Cloud Databases <a name="modify-ram-web-cloud-db"></a>
 
 :::warning
-Si su solución Web Cloud Databases está asociada a un plan de hosting **Performance**, deberá desvincular previamente la solución Web Cloud Databases de su alojamiento **Performance** antes de migrar a un plan superior.
+Si su solución Web Cloud Databases está asociada a un plan de hosting **Performance**, **Agency**, **Agency Plus** o **Agency Max**, deberá desvincular previamente la solución Web Cloud Databases de su alojamiento antes de migrar a un plan superior.
 
-Para desvincular una solución Web Cloud Databases de un alojamiento web **Performance**, consulte nuestra guía "[Desvincular mi solución Web Cloud Databases de un alojamiento web](/guides/web-cloud/databases/db-detach-from-web-hosting)".
+Para desvincular una solución Web Cloud Databases de un alojamiento web **Performance**, **Agency**, **Agency Plus** o **Agency Max**, consulte nuestra guía "[Desvincular mi solución Web Cloud Databases de un alojamiento web](/guides/web-cloud/databases/db-detach-from-web-hosting)".
 
-**Esta acción es irreversible y la solución Web Cloud Databases se facturará de forma independiente de su plan de hosting Performance.**
+**Esta acción es irreversible y la solución Web Cloud Databases se facturará de forma independiente de su alojamiento web Performance, Agency, Agency Plus o Agency Max.**
 
 :::
 
@@ -164,7 +164,7 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
     Una vez aceptados los contratos, será redirigido a la orden de pedido para abonar la modificación. El cambio será efectivo en unas horas.
     
     :::warning
-    Si actualmente dispone de un Web Cloud Databases gratuito gracias a su hosting Performance, la modificación del plan hará que deje de ser gratuito.
+    Si actualmente dispone de un Web Cloud Databases gratuito gracias a su alojamiento Performance, Agency, Agency Plus o Agency Max, la modificación del plan hará que deje de ser gratuito.
 
     :::
 

--- a/docs/es/guides/web-cloud/databases/db-connecting-database-server.mdx
+++ b/docs/es/guides/web-cloud/databases/db-connecting-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Cloud Databases - Conectarse a una base de datos
 description: Descubra cómo conectarse a una base de datos de su solución Web Cloud Databases
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Es posible consultar el contenido de la base de datos a través de una interfaz.
 
 ## Requisitos
 
-- Una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un [plan de hosting Performance](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un plan de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/) Performance, Agency, Agency Plus o Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/es/guides/web-cloud/databases/db-create-databases-users.mdx
+++ b/docs/es/guides/web-cloud/databases/db-create-databases-users.mdx
@@ -1,7 +1,7 @@
 ---
 title: Crear bases de datos y usuarios en un servidor de bases de datos
 description: Cómo crear una base de datos en un servidor de bases de datos
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -15,7 +15,7 @@ Una base de datos (DB) permite almacenar elementos denominados dinámicos, como 
 
 ## Requisitos
 
-- Disponer de una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un [plan de hosting Performance](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Disponer de una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un plan de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/) Performance, Agency, Agency Plus o Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/es/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
+++ b/docs/es/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Desvincular mi solución Web Cloud Databases de un alojamiento web
 description: Descubra cómo desvincular una solución Web Cloud Databases de un alojamiento web
-lastUpdated: 2025-01-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -9,13 +9,13 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objetivo
 
-Las soluciones [Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) pueden activarse gratuitamente desde nuestros [planes de hosting Performance](https://www.ovhcloud.com/es-es/web-hosting/). En ese caso, estarán asociadas al alojamiento web desde el que se hayan activado. Durante el uso de sus servicios, es posible que tenga que desvincular su solución Web Cloud Databases del alojamiento web Performance al que está asociada.
+Las soluciones [Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) pueden activarse gratuitamente desde nuestros [planes de alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/) Performance, Agency, Agency Plus y Agency Max. En ese caso, estarán asociadas al alojamiento web desde el que se hayan activado. Durante el uso de sus servicios, es posible que tenga que desvincular su solución Web Cloud Databases del alojamiento web al que está asociada.
 
 **Descubra cómo desvincular su solución Web Cloud Databases de un alojamiento web.**
 
 ## Requisitos
 
-- Disponer de una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) asociada a un plan de hosting [web Performance](https://www.ovhcloud.com/es-es/web-hosting/).
+- Disponer de una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) asociada a un plan de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/) Performance, Agency, Agency Plus o Agency Max.
 - Ser, como mínimo, el contacto "[Administrador](/guides/account-and-service-management/account-information/managing-contacts)" de los servicios sobre los que quiera actuar.
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/es/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
+++ b/docs/es/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Empezar con MySQL y MariaDB
 description: Como utilizar las bases de datos
-lastUpdated: 2023-07-26
+lastUpdated: 2026-06-08
 ---
 
 ## Objetivo
@@ -26,7 +26,7 @@ Este motor es 100% compatible y más «libre» que su hermano mayor MySQL. Al co
 
 Para seguir los pasos de esta guía, es necesario:
 
-- Tener una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un plan de [hosting Performance](https://www.ovhcloud.com/es-es/web-hosting/))
+- Tener una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un plan de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/) Performance, Agency, Agency Plus o Agency Max)
 - Estar conectado a su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>
 - Haber consultado la [guía de inicio de Web Cloud Databases](/guides/web-cloud/databases/db-getting-started).
 

--- a/docs/es/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/es/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Primeros pasos con Web Cloud Databases
 description: Descubra cómo empezar a utilizar la solución Web Cloud Databases
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -16,7 +16,7 @@ Por defecto, su solución Web Cloud Databases está asociada a la red de alojami
 
 ## Requisitos
 
-- Una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un plan de [alojamiento web Performance](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un plan de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/) Performance, Agency, Agency Plus o Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/es/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
+++ b/docs/es/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Política de fin de vida de las bases de datos administradas
-lastUpdated: 2023-03-07
+lastUpdated: 2026-06-08
 ---
 
 ## Objetivo
@@ -14,7 +14,7 @@ Las bases de datos administradas de OVHcloud ofrecen varios sistemas de gestión
 Tener al menos una de las 3 ofertas siguientes:
 
 - Una de las bases de datos incluidas con un [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/).
-- Una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/)  (incluida en un [plan de hosting Performance](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un plan de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/) Performance, Agency, Agency Plus o Agency Max).
 - Un pack de bases de datos [Start SQL](https://www.ovhcloud.com/es-es/web-hosting/options/start-sql/).
 
 ## Procedimiento

--- a/docs/es/guides/web-cloud/databases/db-restore-import-database.mdx
+++ b/docs/es/guides/web-cloud/databases/db-restore-import-database.mdx
@@ -1,7 +1,7 @@
 ---
 title: Restaurar e importar una base de datos en su servidor de bases de datos
 description: Cómo restaurar e importar una base de datos en su servidor Web Cloud Databases desde el área de cliente de OVHcloud o a través de phpMyAdmin
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Si se produce un error en la base de datos, es necesario poder restaurar una cop
 
 ## Requisitos
 
-- Tener una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un plan de [hosting Performance](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Tener una [instancia Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/) (incluida en un plan de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/) Performance, Agency, Agency Plus o Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/es/guides/web-cloud/web-hosting/access-websites-view.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/access-websites-view.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ver y gestionar todos sus sitios web desde el área de cliente de OVHcloud
 description: Cómo consultar y gestionar todos sus sitios web desde el área de cliente de OVHcloud
-lastUpdated: 2025-05-27
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -72,7 +72,7 @@ Al hacer clic, se abrirá la pestaña <code className="action">Información gene
 
 #### Plan
 
-Muestra el tipo de producto asociado al alojamiento: Starter, Personal, Profesional o Performance.
+Muestra el tipo de producto asociado al alojamiento: Hosting gratuito, Starter, Personal, Startup, Pro, Performance, Agency, Agency Plus o Agency Max.
 
 Al hacer clic, se abrirá la pestaña <code className="action">Información general</code> del alojamiento correspondiente.
 

--- a/docs/es/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
@@ -1,7 +1,7 @@
 ---
 title: Acelerar un sitio web utilizando la CDN
 description: Descubra cómo acelerar la carga de un sitio web en el alojamiento utilizando el servicio CDN
-lastUpdated: 2025-10-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,7 +39,7 @@ Para funcionar, cada servidor guarda en memoria caché una parte de su sitio web
 ### Activar la opción CDN
 
 :::info
-La opción CDN ya está incluida en los planes de alojamiento web Performance.
+La opción CDN ya está incluida en los planes de alojamiento web Performance, Agency, Agency Plus y Agency Max.
 
 :::
 
@@ -94,7 +94,7 @@ Acceda a la pestaña <code className="action">Multisitio</code> de su alojamient
 Acceda a la pestaña <code className="action">Multisitio</code> de su alojamiento, haga clic en <code className="action">...</code> a la derecha del dominio o subdominio correspondiente y luego en en <code className="action">Modificar la CDN</code>. 
 
 :::warning
-Algunas opciones están bloqueadas en la solución Basic y requieren la suscripción a la [CDN Security](https://www.ovhcloud.com/es-es/web-hosting/options/cdn/) o a la [CDN Advanced](https://www.ovhcloud.com/es-es/web-hosting/options/cdn/)
+Algunas opciones están bloqueadas en CDN Basic y requieren la suscripción a la [CDN Security](https://www.ovhcloud.com/es-es/web-hosting/options/cdn/) o a la [CDN Advanced](https://www.ovhcloud.com/es-es/web-hosting/options/cdn/)
 
 :::
 

--- a/docs/es/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: ¿Cómo gestionar su módulo en 1 clic?
 description: Descubra cómo gestionar su módulo en 1 clic desde el área de cliente de OVHcloud
-lastUpdated: 2024-11-15
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -131,7 +131,7 @@ Consulte nuestras guías:
 :::warning
 Si elimina el módulo 1 clic **no se eliminará automáticamente la base de datos**. Si inicia la instalación de un nuevo CMS sin haber eliminado previamente la base de datos del anterior (y su alojamiento no permite la creación automática de una nueva base de datos), el mensaje "[Se ha producido un error al cargar la información. (You need at least one free database)](/guides/web-cloud/web-hosting/diagnostic-errors-module1clic#se-ha-producido-un-error-al-cargar-la-informacion-you-need-at-least-one-free-database)" se mostrará en su área de cliente.
 
-Si tiene contratado [Hosting Personal](https://www.ovhcloud.com/es-es/web-hosting/personal-offer/), o si ya ha creado cuatro bases de datos en su alojamiento [Hosting Pro](https://www.ovhcloud.com/es-es/web-hosting/professional-offer/) o [Hosting Performance](https://www.ovhcloud.com/es-es/web-hosting/performance-offer/), deberá eliminar la base de datos indicada en [el paso 1](#step1) **ANTES** de poder crear un nuevo módulo en 1 clic.
+Si ha alcanzado el número máximo de bases de datos permitido por su [plan de hosting](https://www.ovhcloud.com/es-es/web-hosting/), deberá eliminar la base de datos indicada en [el paso 1](#step1) **ANTES** de poder crear un nuevo módulo en 1 clic.
 
 :::
 

--- a/docs/es/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -1,7 +1,7 @@
 ---
 title: Resolver los errores más frecuentes relacionados con los módulos en un clic
 description: Descubra cómo diagnóstico de los errores más comunes relacionados con la creación de módulos en 1 clic
-lastUpdated: 2024-03-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -89,7 +89,7 @@ En su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, haga clic 
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-Los planes [Pro](https://www.ovhcloud.com/es-es/web-hosting/professional-offer/) y [Performance](https://www.ovhcloud.com/es-es/web-hosting/performance-offer/) le permitirán crear hasta tres "módulos en un clic" adicionales con una base de datos independiente para cada uno de ellos. Los planes de hosting **Performance** también le permitirán activar gratuitamente un servidor [Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/).
+Los planes **Pro**, **Performance**, **Agency**, **Agency Plus** y **Agency Max** le permitirán crear más "módulos en un clic", cada uno con una base de datos independiente. Los planes **Performance**, **Agency**, **Agency Plus** y **Agency Max** también le permitirán activar gratuitamente un servidor [Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/).
 
 Una vez finalizado, podrá instalar un nuevo "módulo en un clic".
 
@@ -187,7 +187,7 @@ En su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, acceda a l
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-Los planes [Pro](https://www.ovhcloud.com/es-es/web-hosting/professional-offer/) y [Performance](https://www.ovhcloud.com/es-es/web-hosting/performance-offer/) le permitirán crear hasta tres "módulos en un clic" adicionales con una base de datos independiente para cada uno de ellos. Los planes de hosting **Performance** también le permitirán activar gratuitamente un servidor [Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/).
+Los planes **Pro**, **Performance**, **Agency**, **Agency Plus** y **Agency Max** le permitirán crear más "módulos en un clic", cada uno con una base de datos independiente. Los planes **Performance**, **Agency**, **Agency Plus** y **Agency Max** también le permitirán activar gratuitamente un servidor [Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/).
 
 ### "No se puede conectar a la base de datos" <a name="delete-the-module"></a>
 

--- a/docs/es/guides/web-cloud/web-hosting/faq.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ Web Hosting
 description: Principales preguntas sobre los planes de hosting de OVHcloud
-lastUpdated: 2025-11-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,7 +27,7 @@ Siga estos pasos:
 Desde ahí podrá gestionar sus certificados SSL, la versión PHP aplicada a su alojamiento web, la opción CDN, los posibles multisitios, las bases de datos, etc.
 
 :::tip
-Para ayudarle a configurar su alojamiento web, no dude en consultar las secciones "*Primeros pasos*" y "*Configurar un web hosting Personal, Profesional o Performance*" de [esta página](/guides/web-cloud/web-hosting/overview).
+Para ayudarle a configurar su alojamiento web, no dude en consultar las secciones "*Primeros pasos*" y "*Configurar un web hosting*" de [esta página](/guides/web-cloud/web-hosting/overview).
 
 :::
 
@@ -287,7 +287,7 @@ Para más información, consulte nuestra guía "[Web hosting - Cómo mejorar su 
 <summary>Al dar de baja el servicio, ¿cómo puedo conservar la solución de correo asociada a mi alojamiento web?</summary>
 
 
-Al dar de baja o eliminar el alojamiento web, también se dará de baja la solución de correo asociada. Para conservar sus direcciones de correo, deberá desvincular la solución de correo **antes* de la baja del alojamiento web correspondiente.
+Al dar de baja o eliminar el alojamiento web, también se dará de baja la solución de correo asociada. Para conservar sus direcciones de correo, deberá desvincular la solución de correo **antes** de la baja del alojamiento web correspondiente.
 
 Siga estos pasos:
 
@@ -301,11 +301,11 @@ Siga estos pasos:
 
 <details>
 
-<summary>Tras la baja de un alojamiento web Performance, ¿cómo puedo conservar la solución Web Cloud Databases asociada?</summary>
+<summary>Tras la baja de un alojamiento web que incluye una solución Web Cloud Databases gratuita, ¿cómo puedo conservarla?</summary>
 
 
-Los planes de hosting **Performance** incluyen una solución Web Cloud Databases que puede activar gratuitamente.<br/>
-Al dar de baja o eliminar el alojamiento web **Performance**, también se dará de baja la solución Web Cloud Databases asociada. Para conservar su solución Web Cloud Databases, deberá desvincularla **antes* de la baja del alojamiento.
+Los planes de hosting **Performance**, **Agency**, **Agency Plus** y **Agency Max** incluyen una solución Web Cloud Databases que puede activar gratuitamente.<br/>
+Al dar de baja o eliminar el alojamiento web, también se dará de baja la solución Web Cloud Databases asociada. Para conservar su solución Web Cloud Databases, deberá desvincularla **antes** de la baja del alojamiento.
 
 Siga estos pasos:
 
@@ -314,14 +314,14 @@ Siga estos pasos:
 3. En la página que se abre, en el recuadro **Configuración**, haga clic en el botón <code className="action">...</code> a la derecha de la mención `Web Cloud Databases` y seleccione <code className="action">Desvincular</code>.
 4. Siga las instrucciones para contratar una solución Web Cloud Databases independiente con el fin de conservar su solución Web Cloud Databases ya creada.
 
-**Esta acción es irreversible y la solución Web Cloud Databases se facturará independientemente de su alojamiento web Performance.**
+**Esta acción es irreversible y la solución Web Cloud Databases se facturará independientemente de su alojamiento web.**
 
 </details>
 
 
 <details>
 
-<summary>¿Cómo aumentar la RAM de una solución Web Cloud Databases asociada a un alojamiento web Performance?</summary>
+<summary>¿Cómo aumentar la RAM de una solución Web Cloud Databases asociada a un alojamiento web Performance, Agency, Agency Plus o Agency Max?</summary>
 
 
 Siga estos pasos:

--- a/docs/es/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Restaurar el espacio de almacenamiento de un alojamiento web
 description: Descubra cómo restaurar un archivo o el espacio de almacenamiento completo de un alojamiento web
-lastUpdated: 2025-12-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,7 +27,7 @@ Si realiza una copia de seguridad para su sitio web y utiliza una base de datos,
 ## Requisitos
 
 <Region zones={['eu']}>
-- Tener contratado un [plan de hosting de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/) (salvo el hosting [Cloud Web](https://www.ovhcloud.com/es-es/web-hosting/cloud-web-offer/)).
+- Tener contratado un [plan de hosting de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/) (salvo el hosting [Cloud Web](https://www.ovhcloud.com/es-es/web-hosting/)).
 </Region>
 <Region zones={['ca', 'apac']}>
 - Tener contratado un [plan de hosting de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/).

--- a/docs/es/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web hosting - Modificar un dominio ya asociado a un alojamiento
 description: Descubra cómo modificar la configuración de asociación de un dominio o subdominio ya declarado en su plan de hosting
-lastUpdated: 2025-11-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -103,7 +103,7 @@ Si introduce un nombre de carpeta que no existe en el espacio de almacenamiento 
 
 ##### La opción "Activar la CDN"
 
-Para poder utilizar esta opción, es necesario haber contratado previamente un plan CDN de OVHcloud o disponer de un plan de hosting Performance.
+Para poder utilizar esta opción, es necesario haber contratado previamente un plan CDN de OVHcloud o disponer de un plan de hosting Performance, Agency, Agency Plus o Agency Max.
 
 Marque o desmarque esta casilla para activar o desactivar la opción CDN para su dominio o subdominio.
 

--- a/docs/es/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cómo empezar correctamente con su alojamiento web
 description: "Descubra cómo publicar un nuevo sitio web a través de nuestras opciones de \"Módulos en un clic\" y cómo crear una nueva dirección de correo personalizada con su nombre de dominio gracias a nuestra solución de alojamiento web"
-lastUpdated: 2025-04-07
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -16,7 +16,7 @@ import { Region } from '@components/Zone';
 :::info
 - ¿Quiere migrar un sitio web existente en otro proveedor de hosting? Consulte directamente nuestra guía dedicada: [Migrar un sitio web y los servicios asociados a OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh).
 <Region zones={['eu']}>
-- ¿Desea solo una página de inicio sencilla para su actividad profesional? Consulte nuestra guía dedicada: [Web hosting - Activar el alojamiento gratuito 100M](/guides/web-cloud/web-hosting/activate-start10m).
+- ¿Desea solo una página de inicio sencilla para su actividad profesional? Consulte nuestra guía dedicada: [Web hosting - Activar el alojamiento gratuito](/guides/web-cloud/web-hosting/activate-start10m).
 </Region>
 
 :::
@@ -25,7 +25,7 @@ import { Region } from '@components/Zone';
 ## Requisitos
 
 <Region zones={['eu']}>
-- Tener contratado un [plan de hosting de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/) con al menos una base de datos disponible (fuera del plan de hosting gratuito 100M).
+- Tener contratado un [plan de hosting de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/) con al menos una base de datos disponible (fuera del plan de hosting gratuito).
 </Region>
 <Region zones={['ca','apac']}>
 - Tener contratado un [plan de hosting de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/) con al menos una base de datos disponible.

--- a/docs/es/guides/web-cloud/web-hosting/website-project.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/website-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cómo crear un sitio web - Realizar un proyecto en 5 pasos
 description: Esta guía explica cómo configurar un proyecto, publicar un sitio web y crear direcciones de correo electrónico con un plan de hosting
-lastUpdated: 2025-04-25
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -213,7 +213,7 @@ Con los planes de hosting, OVHcloud ofrece 3 productos CDN:
 Para más información, consulte nuestra guía "[Acelerar un sitio web utilizando la CDN](/guides/web-cloud/web-hosting/cdn-how-to-use-cdn)".
 
 :::info
-La oferta **CDN Basic** solo está incluida de forma gratuita en los alojamientos web **Performance**.
+La oferta **CDN Basic** está incluida de forma gratuita en los alojamientos web **Performance**, **Agency**, **Agency Plus** y **Agency Max**.
 
 No es posible combinar varios productos CDN en un mismo alojamiento web.
 
@@ -225,7 +225,7 @@ No es posible combinar varios productos CDN en un mismo alojamiento web.
 
 <summary>Los servidores de bases de datos Web Cloud Databases</summary>
 
-Si tiene un alojamiento web **Performance**, puede activar gratuitamente un servidor de bases de datos [Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/).
+Si tiene un alojamiento web **Performance**, **Agency**, **Agency Plus** o **Agency Max**, puede activar gratuitamente un servidor de bases de datos [Web Cloud Databases](https://www.ovhcloud.com/es-es/web-cloud/databases/).
 
 Para más información, consulte nuestra guía "[Primeros pasos con el servicio Web Cloud Databases](/guides/web-cloud/databases/db-getting-started)".
 

--- a/docs/fr/guides/web-cloud/databases/db-backup-export-database-server.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-backup-export-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Sauvegarder et exporter une base de données sur votre serveur de bases de données
 description: "Découvrez comment sauvegarder et exporter une base de données sur votre serveur Web Cloud Databases depuis l'espace client OVHcloud ou via phpMyAdmin"
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Votre base de données peut contenir un grand nombre d'informations essentielles
 
 ## Prérequis
 
-- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web Performance](https://www.ovhcloud.com/fr/web-hosting/)).
+- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web](https://www.ovhcloud.com/fr/web-hosting/) Performance, Agency, Agency Plus ou Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/fr/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer votre serveur de bases de données
 description: Découvrez comment configurer et optimiser votre serveur de base de données
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Les serveurs de bases de données Web Cloud Databases vous permettent de modifie
 
 ## Prérequis
 
-- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web performance](https://www.ovhcloud.com/fr/web-hosting/)).
+- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web](https://www.ovhcloud.com/fr/web-hosting/) Performance, Agency, Agency Plus ou Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---
@@ -130,11 +130,11 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 ### Modifier votre offre Web Cloud Databases <a name="modify-ram-web-cloud-db"></a>
 
 :::warning
-Si votre offre Web Cloud Databases est liée à une offre d'hébergement web **Performance**, vous devrez obligatoirement et préalablement délier l'offre Web Cloud Databases de votre hébergement **Performance** pour basculer sur une offre supérieure.
+Si votre offre Web Cloud Databases est liée à une offre d'hébergement web **Performance**, **Agency**, **Agency Plus** ou **Agency Max**, vous devrez obligatoirement et préalablement délier l'offre Web Cloud Databases de votre hébergement pour basculer sur une offre supérieure.
 
-Pour délier une offre Web Cloud Databases associée à un hébergement web **Performance**, consultez notre guide « [Délier ma solution Web Cloud Databases d'un hébergement web](/guides/web-cloud/databases/db-detach-from-web-hosting) ».
+Pour délier une offre Web Cloud Databases associée à un hébergement web **Performance**, **Agency**, **Agency Plus** ou **Agency Max**, consultez notre guide « [Délier ma solution Web Cloud Databases d'un hébergement web](/guides/web-cloud/databases/db-detach-from-web-hosting) ».
 
-**Cette action est irréversible et l'offre Web Cloud Databases sera ensuite facturée indépendamment de votre hébergement web Performance.**
+**Cette action est irréversible et l'offre Web Cloud Databases sera ensuite facturée indépendamment de votre hébergement web Performance, Agency, Agency Plus ou Agency Max.**
 
 :::
 
@@ -164,7 +164,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
     Après validation des contrats, vous serez redirigé vers le bon de commande afin de régler cette modification. Celle-ci sera effective sous quelques heures.
     
     :::warning
-    Si vous disposez actuellement d'un Web Cloud Databases gratuit grâce à votre hébergement Performance, la modification de l'offre vous fera perdre sa gratuité.
+    Si vous disposez actuellement d'un Web Cloud Databases gratuit grâce à votre hébergement Performance, Agency, Agency Plus ou Agency Max, la modification de l'offre vous fera perdre sa gratuité.
 
     :::
 

--- a/docs/fr/guides/web-cloud/databases/db-connecting-database-server.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-connecting-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Cloud Databases - Se connecter à une base de données
 description: Découvrez comment se connecter à une base de données présente sur votre solution Web Cloud Databases
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Il est possible de consulter le contenu de votre base de données via une interf
 
 ## Prérequis
 
-- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web Performance](https://www.ovhcloud.com/fr/web-hosting/)).
+- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web](https://www.ovhcloud.com/fr/web-hosting/) Performance, Agency, Agency Plus ou Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/fr/guides/web-cloud/databases/db-create-databases-users.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-create-databases-users.mdx
@@ -1,7 +1,7 @@
 ---
 title: Créer vos bases de données et vos utilisateurs sur votre serveur de bases de données
 description: Découvrez comment créer une base de données sur votre serveur de bases de données.
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -15,7 +15,7 @@ Une base de données (*database*, « DB » ou « BDD ») permet de stocker des �
 
 ## Prérequis
 
-- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web Performance](https://www.ovhcloud.com/fr/web-hosting/)).
+- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web](https://www.ovhcloud.com/fr/web-hosting/) Performance, Agency, Agency Plus ou Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/fr/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Délier ma solution Web Cloud Databases d'un hébergement web"
 description: "Découvrez comment délier votre solution Web Cloud Databases d'un hébergement web"
-lastUpdated: 2025-01-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -9,13 +9,13 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objectif
 
-Les solutions [Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) peuvent être activées gratuitement à partir de nos [offres d'hébergement web Performance](https://www.ovhcloud.com/fr/web-hosting/). Dans ce cas de figure, elles sont alors associées à l'hébergement web depuis lesquelles elles ont été activées. Au cours de l'utilisation de vos services, vous pouvez être amenés à devoir délier votre solution Web Cloud Databases de l'hébergement web Performance auquel elle est associée.
+Les solutions [Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) peuvent être activées gratuitement à partir de nos [offres d'hébergement web](https://www.ovhcloud.com/fr/web-hosting/) Performance, Agency, Agency Plus et Agency Max. Dans ce cas de figure, elles sont alors associées à l'hébergement web depuis lequel elles ont été activées. Au cours de l'utilisation de vos services, vous pouvez être amenés à devoir délier votre solution Web Cloud Databases de l'hébergement web auquel elle est associée.
 
 **Découvrez comment délier votre solution Web Cloud Databases d'un hébergement web.**
 
 ## Prérequis
 
-- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) associée à une offre d'[hébergement web Performance](https://www.ovhcloud.com/fr/web-hosting/).
+- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) associée à une offre d'[hébergement web](https://www.ovhcloud.com/fr/web-hosting/) Performance, Agency, Agency Plus ou Agency Max.
 - Être, a minima, contact « [Administrateur](/guides/account-and-service-management/account-information/managing-contacts) » des services sur lesquels vous souhaitez agir.
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/fr/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Démarrez avec MySQL et MariaDB
 description: Utilisez vos bases de données
-lastUpdated: 2023-07-26
+lastUpdated: 2026-06-08
 ---
 
 ## Objectif
@@ -24,7 +24,7 @@ Ce moteur est 100% compatible, et se veut plus "libre" que sa grande sœur MySQL
 
 ## Prérequis
 
-- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web performance](https://www.ovhcloud.com/fr/web-hosting/))
+- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web](https://www.ovhcloud.com/fr/web-hosting/) Performance, Agency, Agency Plus ou Agency Max)
 - Être connecté à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>
 - Avoir consulté le [guide de démarrage de Web Cloud Databases](/guides/web-cloud/databases/db-getting-started)
 

--- a/docs/fr/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Premiers pas avec le service Web Cloud Databases
 description: Découvrez comment bien débuter avec la solution Web Cloud Databases
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -16,7 +16,7 @@ Par défaut, votre solution Web Cloud Databases est liée au réseau d'hébergem
 
 ## Prérequis
 
-- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web performance](https://www.ovhcloud.com/fr/web-hosting/)).
+- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web](https://www.ovhcloud.com/fr/web-hosting/) Performance, Agency, Agency Plus ou Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/fr/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Politique de fin de vie des bases de données managées
-lastUpdated: 2023-03-07
+lastUpdated: 2026-06-08
 ---
 
 ## Objectif
@@ -14,7 +14,7 @@ Les bases de données managées OVHcloud proposent plusieurs Systèmes de Gestio
 Posséder au moins l'une des 3 offres suivantes:
 
 - Une des bases de données incluses avec un [hébergement web](https://www.ovhcloud.com/fr/web-hosting/).
-- Une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web Performance](https://www.ovhcloud.com/fr/web-hosting/)).
+- Une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web](https://www.ovhcloud.com/fr/web-hosting/) Performance, Agency, Agency Plus ou Agency Max).
 - Un pack de base de données [Start SQL](https://www.ovhcloud.com/fr/web-hosting/options/start-sql/).
 
 ## En pratique

--- a/docs/fr/guides/web-cloud/databases/db-restore-import-database.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-restore-import-database.mdx
@@ -1,7 +1,7 @@
 ---
 title: Restaurer et importer une base de données sur votre serveur de bases de données
 description: "Découvrez comment restaurer et importer une base de données sur votre serveur Web Cloud Databases depuis l'espace client OVHcloud ou via phpMyAdmin"
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ En cas d'erreur sur votre base de données, vous devez pouvoir restaurer une sau
 
 ## Prérequis
 
-- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web Performance](https://www.ovhcloud.com/fr/web-hosting/)).
+- Disposer d'une [instance Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/) (incluse dans une offre d'[hébergement web](https://www.ovhcloud.com/fr/web-hosting/) Performance, Agency, Agency Plus ou Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/fr/guides/web-cloud/web-hosting/access-websites-view.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/access-websites-view.mdx
@@ -1,7 +1,7 @@
 ---
 title: Visualiser et gérer tous ses sites web depuis son espace client OVHcloud
 description: "Découvrez comment consulter et gérer l'ensemble de vos sites web depuis votre espace client OVHcloud"
-lastUpdated: 2025-05-27
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -72,7 +72,7 @@ Au clic, vous êtes redirigé vers l'onglet <code className="action">Information
 
 #### Offre
 
-Affiche le type d’offre associée à l’hébergement : Starter, Perso, Pro ou Performance.
+Affiche le type d’offre associé à l’hébergement : Hébergement gratuit, Starter, Perso, Startup, Pro, Performance, Agency, Agency Plus ou Agency Max.
 
 Au clic, vous êtes redirigé vers l'onglet <code className="action">Informations générales</code> de l'hébergement concerné.
 

--- a/docs/fr/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
@@ -1,7 +1,7 @@
 ---
 title: Accélérer mon site web en utilisant le CDN
 description: Découvrez comment améliorer votre site web en accélérant son chargement sur votre hébergement web grâce au CDN
-lastUpdated: 2025-10-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,7 +39,7 @@ Pour fonctionner, chaque serveur garde en mémoire cache une partie de votre sit
 ###  Mettre en place l'option CDN
 
 :::info
-L'option CDN est déjà incluse dans les offres d'hébergement web Performance.
+L'option CDN est déjà incluse dans les offres d'hébergement web Performance, Agency, Agency Plus et Agency Max.
 
 :::
 
@@ -94,7 +94,7 @@ Dirigez-vous sur l'onglet <code className="action">Multisite</code> de votre hé
 Dirigez-vous sur l'onglet <code className="action">Multisite</code> de votre hébergement, cliquez sur <code className="action">...</code> à droite du nom de domaine ou sous-domaine concerné puis sur <code className="action">Modifier le CDN</code>.
 
 :::warning
-Certaines options sont verrouillées sur l'offre Basic et nécessitent la souscription au [CDN security](https://www.ovhcloud.com/fr/web-hosting/options/cdn/) ou au [CDN Advanced](https://www.ovhcloud.com/fr/web-hosting/options/cdn/)
+Certaines options sont verrouillées sur le CDN Basic et nécessitent la souscription au [CDN security](https://www.ovhcloud.com/fr/web-hosting/options/cdn/) ou au [CDN Advanced](https://www.ovhcloud.com/fr/web-hosting/options/cdn/)
 
 :::
 

--- a/docs/fr/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comment gérer votre module en 1 clic ?
 description: Découvrez comment gérer votre module en 1 clic depuis votre espace client OVHcloud
-lastUpdated: 2024-11-15
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur
 ## Prérequis
 
 <Region zones={['eu']}>
-- Disposer d'une [offre d'hébergement Web Cloud](https://www.ovhcloud.com/fr/web-hosting/) permettant l'installation d'un module en 1 clic (seule l'[offre d'hébergement gratuit 100M](/guides/web-cloud/web-hosting/activate-start10m) n'est pas concernée).
+- Disposer d'une [offre d'hébergement Web Cloud](https://www.ovhcloud.com/fr/web-hosting/) permettant l'installation d'un module en 1 clic (seule l'[offre d'hébergement gratuit](/guides/web-cloud/web-hosting/activate-start10m) n'est pas concernée).
 </Region>
 <Region zones={['ca', 'apac']}>
 - Disposer d'une [offre d'hébergement Web Cloud](https://www.ovhcloud.com/fr/web-hosting/) permettant l'installation d'un module en 1 clic.
@@ -139,7 +139,7 @@ Consultez nos guides :
 :::warning
 La suppression de votre module 1 clic **n'entraînera pas automatiquement celle de sa base de données**. Si vous lancez l'installation d'un nouveau CMS sans avoir supprimé préalablement la base de données du précédent (et que votre hébergement ne permet pas la création automatique d'une nouvelle base), le message « [Une erreur s’est produite lors du chargement des informations (You need at least one free database)](/guides/web-cloud/web-hosting/diagnostic-errors-module1clic#une-erreur-sest-produite-lors-du-chargement-des-informations-you-need-at-least-one-free-database) » s'affichera sur votre espace client.
 
-Si vous disposez d'un abonnement [Perso](https://www.ovhcloud.com/fr/web-hosting/personal-offer/) ou si vous avez déjà créé quatre bases de données sur votre hébergement [Pro](https://www.ovhcloud.com/fr/web-hosting/professional-offer/) ou [Performance](https://www.ovhcloud.com/fr/web-hosting/performance-offer/), vous devrez donc supprimer la base de données identifiée à [l'étape 1](#step1) **AVANT** de pouvoir créer un nouveau module en 1 clic.
+Si vous avez atteint le nombre maximal de bases de données autorisé par votre [offre d'hébergement web](https://www.ovhcloud.com/fr/web-hosting/), vous devrez supprimer la base de données identifiée à [l'étape 1](#step1) **AVANT** de pouvoir créer un nouveau module en 1 clic.
 
 :::
 

--- a/docs/fr/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -1,7 +1,7 @@
 ---
 title: Résoudre les erreurs les plus fréquentes liées aux modules en 1 clic
 description: "Découvrez comment diagnostiquer les cas les plus courants d'erreurs liées aux créations de modules en 1 clic"
-lastUpdated: 2024-03-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -89,7 +89,7 @@ Dans votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, cliquez sur
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-Les offres [Pro](https://www.ovhcloud.com/fr/web-hosting/professional-offer/) et [Performance](https://www.ovhcloud.com/fr/web-hosting/performance-offer/) vous permettront de créer jusqu'à trois « modules en 1 clic » supplémentaires avec une base de données indépendante pour chacun d'eux. Les offres **Performance** vous permettront aussi d'activer gratuitement un serveur [Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/).
+Les offres **Pro**, **Performance**, **Agency**, **Agency Plus** et **Agency Max** vous permettront de créer davantage de « modules en 1 clic », chacun associé à une base de données indépendante. Les offres **Performance**, **Agency**, **Agency Plus** et **Agency Max** vous permettront aussi d'activer gratuitement un serveur [Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/).
 
 Une fois terminé, vous serez en mesure d'installer un nouveau « module en 1 clic ».
 
@@ -187,7 +187,7 @@ Dans votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-Les offres [Pro](https://www.ovhcloud.com/fr/web-hosting/professional-offer/) et [Performance](https://www.ovhcloud.com/fr/web-hosting/performance-offer/) vous permettront de créer jusqu'à trois « modules en 1 clic » supplémentaires avec une base de données indépendante pour chacun d'eux. Les offres **Performance** vous permettront aussi d'activer gratuitement un serveur [Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/).
+Les offres **Pro**, **Performance**, **Agency**, **Agency Plus** et **Agency Max** vous permettront de créer davantage de « modules en 1 clic », chacun associé à une base de données indépendante. Les offres **Performance**, **Agency**, **Agency Plus** et **Agency Max** vous permettront aussi d'activer gratuitement un serveur [Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/).
 
 ### « Impossible de se connecter à la base de données » <a name="delete-the-module"></a>
 

--- a/docs/fr/guides/web-cloud/web-hosting/faq.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hébergement Web - FAQ
 description: Retrouvez les principales questions posées sur les hébergements web OVHcloud
-lastUpdated: 2025-11-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,7 +27,7 @@ Suivez ces étapes :
 Vous pourrez y gérer vos certificats SSL, la version PHP appliquée à votre hébergement web, l'option CDN, les éventuels multisites, les bases de données, etc.
 
 :::tip
-Pour vous aider à configurer votre hébergement web, n'hésitez pas à consulter les rubriques « *Premiers pas* » et « *Configurer son hébergement web Perso, Pro ou Performance* » de [cette page](/guides/web-cloud/web-hosting/overview).
+Pour vous aider à configurer votre hébergement web, n'hésitez pas à consulter les rubriques « *Premiers pas* » et « *Configurer son hébergement web* » de [cette page](/guides/web-cloud/web-hosting/overview).
 
 :::
 
@@ -301,11 +301,11 @@ Suivez ces étapes :
 
 <details>
 
-<summary>Lors d'une résiliation d'un hébergement web « Performance », comment conserver l'offre « Web Cloud Databases » liée ?</summary>
+<summary>Lors d'une résiliation d'un hébergement web comprenant une offre « Web Cloud Databases » gratuite, comment la conserver ?</summary>
 
 
-Les hébergements web **Performance** comprennent une offre Web Cloud Databases activable gratuitement.<br/>
-Lorsque vous résiliez ou supprimez votre hébergement web **Performance**, l'offre Web Cloud Databases éventuellement attachée est également résiliée. Pour conserver votre solution Web Cloud Databases, vous devrez la détacher **avant** la résiliation de l'hébergement.
+Les hébergements web **Performance**, **Agency**, **Agency Plus** et **Agency Max** comprennent une offre Web Cloud Databases activable gratuitement.<br/>
+Lorsque vous résiliez ou supprimez cet hébergement web, l'offre Web Cloud Databases éventuellement attachée est également résiliée. Pour conserver votre solution Web Cloud Databases, vous devrez la détacher **avant** la résiliation de l'hébergement.
 
 Suivez ces étapes :
 
@@ -314,14 +314,14 @@ Suivez ces étapes :
 3. Sur la page qui s'affiche et dans l'encadré **Configuration**, cliquez sur le bouton <code className="action">...</code> à droite de la mention `Web Cloud Databases`, puis sur <code className="action">Délier</code>.
 4. Suivez les instructions pour commander une offre Web Cloud Databases indépendante afin de conserver votre solution Web Cloud Databases déjà créée.
 
-**Cette action est irréversible et l'offre Web Cloud Databases sera ensuite facturée indépendamment de votre hébergement web Performance.**
+**Cette action est irréversible et l'offre Web Cloud Databases sera ensuite facturée indépendamment de votre hébergement web.**
 
 </details>
 
 
 <details>
 
-<summary>Comment augmenter la RAM d'une offre « Web Cloud Databases » liée à un hébergement web « Performance » ?</summary>
+<summary>Comment augmenter la RAM d'une offre « Web Cloud Databases » liée à un hébergement web Performance, Agency, Agency Plus ou Agency Max ?</summary>
 
 
 Suivez ces étapes :

--- a/docs/fr/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Restaurer l'espace de stockage de son hébergement web"
 description: "Apprenez à restaurer un fichier ou l'intégralité de l'espace de stockage de votre hébergement web"
-lastUpdated: 2025-12-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,7 +27,7 @@ Lorsque vous effectuez une sauvegarde de sécurité pour votre site et que vous 
 ## Prérequis
 
 <Region zones={['eu']}>
-- Disposer d'une offre d'[hébergement web](https://www.ovhcloud.com/fr/web-hosting/) (ne fonctionne pas avec un [hébergement Cloud Web](https://www.ovhcloud.com/fr/web-hosting/cloud-web-offer/)).
+- Disposer d'une offre d'[hébergement web](https://www.ovhcloud.com/fr/web-hosting/) (ne fonctionne pas avec un [hébergement Cloud Web](https://www.ovhcloud.com/fr/web-hosting/)).
 </Region>
 <Region zones={['ca', 'apac']}>
 - Disposer d'une offre d'[hébergement web](https://www.ovhcloud.com/fr/web-hosting/).

--- a/docs/fr/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hébergement web - Modifier un nom de domaine déjà associé à un hébergement
 description: "Découvrez comment modifier les paramètres d'association d'un nom de domaine/sous-domaine déjà déclaré sur votre offre d'hébergement web"
-lastUpdated: 2025-11-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -103,7 +103,7 @@ Si vous renseignez un nom de dossier inexistant dans l'espace de stockage FTP de
 
 ##### L'option « Activer CDN »
 
-Pour pouvoir utiliser cette option, vous devez avoir au préalable souscrit à une offre CDN OVHcloud ou disposer d'une offre d'hébergement web Performance.
+Pour pouvoir utiliser cette option, vous devez avoir au préalable souscrit à une offre CDN OVHcloud ou disposer d'une offre d'hébergement web Performance, Agency, Agency Plus ou Agency Max.
 
 Cochez/décochez cette case afin d'activer/désactiver l'option CDN pour votre nom de domaine ou votre sous-domaine.
 

--- a/docs/fr/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comment bien débuter avec votre hébergement web
 description: "Découvrez comment mettre en ligne un nouveau site Internet via nos options de « Modules en 1 clic », comment créer une nouvelle adresse e-mail personnalisée avec votre nom de domaine, le tout grâce à notre solution d'hébergement web"
-lastUpdated: 2025-04-07
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -16,7 +16,7 @@ Vous souhaitez créer un site Internet pour votre entreprise ou un blog personne
 :::info
 - Vous souhaitez migrer un site web existant déjà chez un autre hébergeur ? Consultez directement notre guide dédié : [Migrer son site web et ses services associés vers OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh).
 <Region zones={['eu']}>
-- Vous souhaitez uniquement une page d'accueil simple pour votre activité professionnelle ? Consultez notre guide dédié : [Hébergement web - Activer l’hébergement gratuit 100M](/guides/web-cloud/web-hosting/activate-start10m).
+- Vous souhaitez uniquement une page d'accueil simple pour votre activité professionnelle ? Consultez notre guide dédié : [Hébergement web - Activer l’hébergement gratuit](/guides/web-cloud/web-hosting/activate-start10m).
 </Region>
 
 :::
@@ -25,7 +25,7 @@ Vous souhaitez créer un site Internet pour votre entreprise ou un blog personne
 ## Prérequis
 
 <Region zones={['eu']}>
-- Disposer d'une offre d'[hébergement web OVHcloud](https://www.ovhcloud.com/fr/web-hosting/) avec au moins une base de données disponible (hors offre d'hébergement gratuite 100M).
+- Disposer d'une offre d'[hébergement web OVHcloud](https://www.ovhcloud.com/fr/web-hosting/) avec au moins une base de données disponible (hors offre d'hébergement gratuite).
 </Region>
 <Region zones={['ca','apac']}>
 - Disposer d'une offre d'[hébergement web OVHcloud](https://www.ovhcloud.com/fr/web-hosting/) avec au moins une base de données disponible.

--- a/docs/fr/guides/web-cloud/web-hosting/website-project.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/website-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comment créer un site web - Réaliser votre projet en 5 étapes
 description: "Découvrez comment définir votre projet, publier votre site internet et créer des adresses e-mail avec votre solution d'hébergement web"
-lastUpdated: 2025-04-25
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -214,7 +214,7 @@ Avec les hébergements web, OVHcloud propose 3 offres CDN :
 Retrouvez plus d'informations sur nos différentes offres CDN dans notre guide « [Accélérer mon site web en utilisant le CDN](/guides/web-cloud/web-hosting/cdn-how-to-use-cdn) ».
 
 :::info
-L'offre **CDN Basic** est incluse gratuitement sur les hébergements web **Performance** uniquement.
+L'offre **CDN Basic** est incluse gratuitement sur les hébergements web **Performance**, **Agency**, **Agency Plus** et **Agency Max**.
 
 Vous ne pouvez pas cumuler plusieurs offres CDN sur un même hébergement web.
 
@@ -226,7 +226,7 @@ Vous ne pouvez pas cumuler plusieurs offres CDN sur un même hébergement web.
 
 <summary>Les serveurs de base de données Web Cloud Databases</summary>
 
-Si vous disposez d'un hébergement web **Performance**, vous pouvez activer gratuitement un serveur de base de données [Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/).
+Si vous disposez d'un hébergement web **Performance**, **Agency**, **Agency Plus** ou **Agency Max**, vous pouvez activer gratuitement un serveur de base de données [Web Cloud Databases](https://www.ovhcloud.com/fr/web-cloud/databases/).
 
 Retrouvez plus de détails sur son utilisation dans notre documentation « [Premiers pas avec le service Web Cloud Databases](/guides/web-cloud/databases/db-getting-started) ».
 

--- a/docs/it/guides/web-cloud/databases/db-backup-export-database-server.mdx
+++ b/docs/it/guides/web-cloud/databases/db-backup-export-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Salvare ed esportare un database sul server di database
 description: Scopri come salvare ed esportare un database dal tuo server Web Cloud Databases dallo Spazio Cliente OVHcloud o tramite phpMyAdmin
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Il tuo database può contenere numerose informazioni essenziali per il tuo sito 
 
 ## Prerequisiti
 
-- Disporre di un'[istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un'offerta di [hosting web Performance](https://www.ovhcloud.com/it/web-hosting/)).
+- Disporre di un'[istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un'offerta di [hosting Web](https://www.ovhcloud.com/it/web-hosting/) Performance, Agency, Agency Plus o Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/it/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/it/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configura il tuo database server
 description: Come configurare e ottimizzare il tuo database server
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ I database server Web Cloud Databases permettono di modificare le impostazioni g
 
 ## Prerequisiti
 
-- Disporre di un'[istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un piano di [hosting web Performance](https://www.ovhcloud.com/it/web-hosting/)).
+- Disporre di un'[istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un piano di [hosting Web](https://www.ovhcloud.com/it/web-hosting/) Performance, Agency, Agency Plus o Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---
@@ -130,11 +130,11 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
 ### Modifica la tua offerta Web Cloud Databases <a name="modify-ram-web-cloud-db"></a>
 
 :::warning
-Se la tua offerta Web Cloud Databases è associata a un hosting Web **Performance**, è necessario svincolare preventivamente l'offerta Web Cloud Databases dal tuo hosting **Performance** prima di passare a un'offerta superiore.
+Se la tua offerta Web Cloud Databases è associata a un hosting Web **Performance**, **Agency**, **Agency Plus** o **Agency Max**, è necessario svincolare preventivamente l'offerta Web Cloud Databases dal tuo hosting prima di passare a un'offerta superiore.
 
-Per scollegare un'offerta Web Cloud Databases da un hosting Web **Performance**, consulta la nostra guida "[Scollegare la mia soluzione Web Cloud Databases da un hosting Web](/guides/web-cloud/databases/db-detach-from-web-hosting)".
+Per scollegare un'offerta Web Cloud Databases da un hosting Web **Performance**, **Agency**, **Agency Plus** o **Agency Max**, consulta la nostra guida "[Scollegare la mia soluzione Web Cloud Databases da un hosting Web](/guides/web-cloud/databases/db-detach-from-web-hosting)".
 
-**Questa azione è irreversibile e l'offerta Web Cloud Databases sarà fatturata separatamente dal tuo hosting Web Performance.**
+**Questa azione è irreversibile e l'offerta Web Cloud Databases sarà fatturata separatamente dal tuo hosting Web Performance, Agency, Agency Plus o Agency Max.**
 
 :::
 
@@ -164,7 +164,7 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
     Dopo la conferma dei contratti, verrai reindirizzato al buono d'ordine per pagare questa modifica. L'operazione sarà effettiva entro qualche ora.
     
     :::warning
-    Se disponi attualmente di un Web Cloud Databases gratuito con il tuo hosting Performance, la modifica dell'offerta comporterà la perdita della gratuità.
+    Se disponi attualmente di un Web Cloud Databases gratuito con il tuo hosting Performance, Agency, Agency Plus o Agency Max, la modifica dell'offerta comporterà la perdita della gratuità.
 
     :::
 

--- a/docs/it/guides/web-cloud/databases/db-connecting-database-server.mdx
+++ b/docs/it/guides/web-cloud/databases/db-connecting-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Cloud Databases - Connettersi a un database
 description: Scopri come connetterti a un database sulla tua soluzione Web Cloud Databases
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Prerequisiti
 
-- Una [istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un piano di [hosting web Performance](https://www.ovhcloud.com/it/web-hosting/)).
+- Una [istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un piano di [hosting Web](https://www.ovhcloud.com/it/web-hosting/) Performance, Agency, Agency Plus o Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/it/guides/web-cloud/databases/db-create-databases-users.mdx
+++ b/docs/it/guides/web-cloud/databases/db-create-databases-users.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creare database e utenti sul tuo database server
 description: Scopri come creare un database sul tuo database server
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -15,7 +15,7 @@ Un database (DB) permette di archiviare elementi detti dinamici, come commenti o
 
 ## Prerequisiti
 
-- Disporre di un'[istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un piano di [hosting web Performance](https://www.ovhcloud.com/it/web-hosting/)).
+- Disporre di un'[istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un piano di [hosting Web](https://www.ovhcloud.com/it/web-hosting/) Performance, Agency, Agency Plus o Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/it/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
+++ b/docs/it/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Scollegare la mia soluzione Web Cloud Databases da un hosting Web
 description: Questa guida ti mostra come scollegare la tua soluzione Web Cloud Databases da un hosting Web
-lastUpdated: 2025-01-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -9,13 +9,13 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Obiettivo
 
-Le soluzioni [Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) possono essere attivate gratuitamente a partire dalle nostre [offerte di hosting Web Performance](https://www.ovhcloud.com/it/web-hosting/). in questo caso, vengono associate all’hosting Web da cui sono state attivate. Durante l’utilizzo dei servizi, potrebbe essere necessario scollegare la soluzione Web Cloud Databases dall’hosting Web Performance al quale è associata.
+Le soluzioni [Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) possono essere attivate gratuitamente a partire dalle nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/) Performance, Agency, Agency Plus e Agency Max. In questo caso, vengono associate all’hosting Web da cui sono state attivate. Durante l’utilizzo dei servizi, potrebbe essere necessario scollegare la soluzione Web Cloud Databases dall’hosting Web al quale è associata.
 
 **Questa guida ti mostra come scollegare la soluzione Web Cloud Databases da un hosting Web.**
 
 ## Prerequisiti
 
-- Disporre di un’ [istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) associata a una soluzione di [hosting Web Performance](https://www.ovhcloud.com/it/web-hosting/).
+- Disporre di un’[istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) associata a una soluzione di [hosting Web](https://www.ovhcloud.com/it/web-hosting/) Performance, Agency, Agency Plus o Agency Max.
 - essere almeno contatto "[Amministratore](/guides/account-and-service-management/account-information/managing-contacts)" dei servizi sui quali si desidera agire.
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/it/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
+++ b/docs/it/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Come utilizzare MySQL e MariaDB
 description: "Guida all'utilizzo dei tuoi database"
-lastUpdated: 2023-07-26
+lastUpdated: 2026-06-08
 ---
 
 ## Obiettivo
@@ -24,7 +24,7 @@ Questo motore è compatibile al 100% ed è stato progettato per essere più "lib
 
 ## Prerequisiti
 
-- Disporre di una [istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un'offerta di[hosting web performance](https://www.ovhcloud.com/it/web-hosting/)
+- Disporre di una [istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un'offerta di [hosting Web](https://www.ovhcloud.com/it/web-hosting/) Performance, Agency, Agency Plus o Agency Max)
 - Avere accesso allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>
 - Consulta la guida [all'avvio di Web Cloud Databases](/guides/web-cloud/databases/db-getting-started)
 

--- a/docs/it/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/it/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Iniziare a utilizzare Web Cloud Databases
 description: Scopri come iniziare a utilizzare la soluzione Web Cloud Databases
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -16,7 +16,7 @@ Di default, la soluzione Web Cloud Databases è associata alla rete di hosting W
 
 ## Prerequisiti
 
-- Un'[istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un piano di [hosting Web Performance](https://www.ovhcloud.com/it/web-hosting/)).
+- Un'[istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un piano di [hosting Web](https://www.ovhcloud.com/it/web-hosting/) Performance, Agency, Agency Plus o Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/it/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
+++ b/docs/it/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Politica di fine vita dei database gestiti
-lastUpdated: 2023-03-07
+lastUpdated: 2026-06-08
 ---
 
 ## Obiettivo
@@ -14,7 +14,7 @@ I database gestiti OVHcloud propongono diversi Sistemi di Gestione Database (SGB
 Almeno una delle 3 offerte seguenti:
 
 - Uno dei database inclusi con un [Hosting Web](https://www.ovhcloud.com/it/web-hosting/).
-- Una [istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un'offerta di [Hosting Performance](https://www.ovhcloud.com/it/web-hosting/).
+- Una [istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un'offerta di [Hosting Web](https://www.ovhcloud.com/it/web-hosting/) Performance, Agency, Agency Plus o Agency Max).
 - Pack di database [Start SQL](https://www.ovhcloud.com/it/web-hosting/options/start-sql/).
 
 ## Procedura

--- a/docs/it/guides/web-cloud/databases/db-restore-import-database.mdx
+++ b/docs/it/guides/web-cloud/databases/db-restore-import-database.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ripristinare e importare un database sul tuo server di database
 description: Scopri come ripristinare e importare un database sul tuo server Web Cloud Databases dallo Spazio Cliente OVHcloud o tramite phpMyAdmin
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ In caso di errore sul database, è necessario essere in grado di ripristinare un
 
 ## Prerequisiti
 
-- Disporre di una [istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un'offerta di [hosting web Performance](https://www.ovhcloud.com/it/web-hosting/))
+- Disporre di una [istanza Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/) (inclusa in un'offerta di [hosting Web](https://www.ovhcloud.com/it/web-hosting/) Performance, Agency, Agency Plus o Agency Max)
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/it/guides/web-cloud/web-hosting/access-websites-view.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/access-websites-view.mdx
@@ -1,7 +1,7 @@
 ---
 title: Visualizzare e gestire tutti i siti Web dallo Spazio Cliente OVHcloud
 description: Scopri come consultare e gestire tutti i siti Web dallo Spazio Cliente OVHcloud
-lastUpdated: 2025-05-27
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -72,7 +72,7 @@ Cliccando sul tasto, verrai reindirizzato alla scheda <code className="action">I
 
 #### Piano
 
-Mostra il tipo di offerta associata all'hosting: Starter, Personale, Pro o Performance.
+Mostra il tipo di offerta associata all'hosting: Hosting gratuito, Starter, Personale, Startup, Pro, Performance, Agency, Agency Plus o Agency Max.
 
 Cliccando sul tasto, verrai reindirizzato alla scheda <code className="action">Informazioni generali</code> dell’hosting interessato.
 

--- a/docs/it/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aumentare la velocità di un sito Web con la CDN
 description: Questa guida ti mostra come ottimizzare il tuo sito accelerando la velocità di caricamento dell’hosting Web con la CDN
-lastUpdated: 2025-10-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,7 +39,7 @@ Per funzionare correttamente, ciascun server salva nella memoria cache una parte
 ###  Attiva l'opzione CDN
 
 :::info
-L’opzione CDN è già inclusa nei piani di hosting Web Performance.
+L’opzione CDN è già inclusa nei piani di hosting Web Performance, Agency, Agency Plus e Agency Max.
 
 :::
 
@@ -94,7 +94,7 @@ Clicca sulla scheda <code className="action">Multisito</code> del tuo hosting, c
 Clicca sulla scheda <code className="action">Multisito</code> del tuo hosting, clicca su <code className="action">...</code> a destra del nome di dominio o sottodominio interessato e quindi su <code className="action">Modifica la CDN</code>. 
 
 :::warning
-Alcune opzioni sono bloccate sull'offerta Basic e richiedono la sottoscrizione della [CDN security](https://www.ovhcloud.com/it/web-hosting/options/cdn/) o della [CDN Advanced](https://www.ovhcloud.com/it/web-hosting/options/cdn/)
+Alcune opzioni sono bloccate su CDN Basic e richiedono la sottoscrizione della [CDN security](https://www.ovhcloud.com/it/web-hosting/options/cdn/) o della [CDN Advanced](https://www.ovhcloud.com/it/web-hosting/options/cdn/)
 
 :::
 

--- a/docs/it/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: Come gestire il tuo modulo in 1 click?
 description: Questa guida ti mostra come gestire il tuo modulo in 1 click dallo Spazio Cliente OVHcloud
-lastUpdated: 2024-11-15
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -131,7 +131,7 @@ Consulta le nostre guide:
 :::warning
 L'eliminazione del modulo 1 click **non comporta automaticamente l'eliminazione del database**. Se avvii l'installazione di un nuovo CMS senza aver prima eliminato il database del precedente (e il tuo hosting non consente la creazione automatica di un nuovo database), il messaggio "[Si è verificato un errore durante il caricamento delle informazioni (You need at least one free database)](/guides/web-cloud/web-hosting/diagnostic-errors-module1clic#si-e-verificato-un-errore-durante-il-caricamento-delle-informazioni-you-need-at-least-one-free-database)" comparirà sul tuo Spazio Cliente.
 
-Se disponi di un abbonamento [Personale](https://www.ovhcloud.com/it/web-hosting/personal-offer/) o hai già creato quattro database sul tuo hosting [Pro](https://www.ovhcloud.com/it/web-hosting/professional-offer/) o [Performance](https://www.ovhcloud.com/it/web-hosting/performance-offer/), dovrai eliminare il database identificato nello [Step 1](#step1) **PRIMA** di poter creare un nuovo modulo in 1 click.
+Se hai raggiunto il numero massimo di database consentito dalla tua [offerta di hosting](https://www.ovhcloud.com/it/web-hosting/), dovrai eliminare il database identificato nello [Step 1](#step1) **PRIMA** di poter creare un nuovo modulo in 1 click.
 
 :::
 

--- a/docs/it/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -1,7 +1,7 @@
 ---
 title: Risolvi gli errori più comuni relativi ai CMS/moduli in 1 click
 description: Questa guida ti mostra come diagnostica i casi più comuni di errore associati alla creazione di moduli in 1 click
-lastUpdated: 2024-03-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -89,7 +89,7 @@ Nel tuo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, clicca su <co
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-Le offerte [Pro](https://www.ovhcloud.com/it/web-hosting/professional-offer/) e [Performance](https://www.ovhcloud.com/it/web-hosting/performance-offer/) permettono di creare fino a tre "moduli in 1 click" supplementari con un database indipendente per ciascuno di essi. Le offerte **Performance** ti permettono di attivare gratuitamente un server [Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/).
+Le offerte **Pro**, **Performance**, **Agency**, **Agency Plus** e **Agency Max** permettono di creare più "moduli in 1 click", ciascuno con un database indipendente. Le offerte **Performance**, **Agency**, **Agency Plus** e **Agency Max** ti permettono di attivare gratuitamente un server [Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/).
 
 Una volta terminato, sarà possibile installare un nuovo "modulo in 1 click".
 
@@ -187,7 +187,7 @@ Nel tuo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, accedi alla s
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-Le offerte [Pro](https://www.ovhcloud.com/it/web-hosting/professional-offer/) e [Performance](https://www.ovhcloud.com/it/web-hosting/performance-offer/) permettono di creare fino a tre "moduli in 1 click" supplementari con un database indipendente per ciascuno di essi. Le offerte **Performance** ti permettono di attivare gratuitamente un server [Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/).
+Le offerte **Pro**, **Performance**, **Agency**, **Agency Plus** e **Agency Max** permettono di creare più "moduli in 1 click", ciascuno con un database indipendente. Le offerte **Performance**, **Agency**, **Agency Plus** e **Agency Max** ti permettono di attivare gratuitamente un server [Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/).
 
 ### "Impossibile connettersi al database" <a name="delete-the-module"></a>
 

--- a/docs/it/guides/web-cloud/web-hosting/faq.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ Hosting web
 description: Rivivi le principali domande sugli hosting Web OVHcloud
-lastUpdated: 2025-11-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,7 +27,7 @@ Segui questi passaggi:
 È possibile gestire i certificati SSL, la versione PHP applicata all’hosting Web, l’opzione CDN, gli eventuali multisiti, i database, ecc.
 
 :::tip
-Per aiutarti a configurare il tuo hosting Web, consulta le sezioni "*Per iniziare*" e "*Configura il tuo hosting Web Personale, Pro o Performance*" di [questa pagina](/guides/web-cloud/web-hosting/overview).
+Per aiutarti a configurare il tuo hosting Web, consulta le sezioni "*Per iniziare*" e "*Configura il tuo hosting Web*" di [questa pagina](/guides/web-cloud/web-hosting/overview).
 
 :::
 
@@ -301,11 +301,11 @@ Segui questi passaggi:
 
 <details>
 
-<summary>In caso di disattivazione di un hosting Web "Performance", come conservare la soluzione "Web Cloud Databases" collegata?</summary>
+<summary>In caso di disattivazione di un hosting Web che include una soluzione "Web Cloud Databases" gratuita, come conservarla?</summary>
 
 
-Gli hosting Web **Performance** includono un'offerta Web Cloud Databases attivabile gratuitamente.<br/>
-Quando disattivi o elimini il tuo hosting Web **Performance**, viene disattivata anche la soluzione Web Cloud Databases eventualmente associata. Per conservare la soluzione Web Cloud Databases è necessario scollegarla **prima* della disattivazione dell’hosting.
+Gli hosting Web **Performance**, **Agency**, **Agency Plus** e **Agency Max** includono un'offerta Web Cloud Databases attivabile gratuitamente.<br/>
+Quando disattivi o elimini il tuo hosting Web, viene disattivata anche la soluzione Web Cloud Databases eventualmente associata. Per conservare la soluzione Web Cloud Databases è necessario scollegarla **prima** della disattivazione dell’hosting.
 
 Segui questi passaggi:
 
@@ -314,14 +314,14 @@ Segui questi passaggi:
 3. Nella nuova pagina e nel riquadro **Configurazione**, clicca sul pulsante <code className="action">...</code> a destra della voce `Web Cloud Databases` e poi su <code className="action">Scollega</code>.
 4. Segui le istruzioni per ordinare un'offerta Web Cloud Databases indipendente per conservare la tua soluzione Web Cloud Databases già creata.
 
-**Questa operazione è irreversibile e l'offerta Web Cloud Databases viene successivamente fatturata indipendentemente dall’hosting Web Performance.**
+**Questa operazione è irreversibile e l'offerta Web Cloud Databases viene successivamente fatturata indipendentemente dall’hosting Web.**
 
 </details>
 
 
 <details>
 
-<summary>Come aumentare la RAM di una soluzione "Web Cloud Databases" associata a un hosting Web "Performance"?</summary>
+<summary>Come aumentare la RAM di una soluzione "Web Cloud Databases" associata a un hosting Web Performance, Agency, Agency Plus o Agency Max?</summary>
 
 
 Segui questi passaggi:

--- a/docs/it/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ripristinare i dati dello spazio di storage di un hosting Web
 description: Questa guida ti mostra come recuperare un file o l’intero contenuto dello spazio di storage di un hosting Web OVHcloud
-lastUpdated: 2025-12-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,7 +27,7 @@ Quando effettui un backup di sicurezza per il tuo sito e utilizzi un database, f
 ## Prerequisiti
 
 <Region zones={['eu']}>
-- Disporre di un piano di [hosting Web OVHcloud](https://www.ovhcloud.com/it/web-hosting/) (escluso il servizio [Cloud Web](https://www.ovhcloud.com/it/web-hosting/cloud-web-offer/))
+- Disporre di un piano di [hosting Web OVHcloud](https://www.ovhcloud.com/it/web-hosting/) (escluso il servizio [Cloud Web](https://www.ovhcloud.com/it/web-hosting/))
 </Region>
 <Region zones={['ca', 'apac']}>
 - Disporre di un piano di [hosting Web OVHcloud](https://www.ovhcloud.com/it/web-hosting/).

--- a/docs/it/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hosting Web - Modificare un dominio già associato a un hosting
 description: Questa guida ti mostra come modificare le impostazioni di associazione di un dominio/sottodominio già dichiarato sul tuo piano di hosting Web
-lastUpdated: 2025-11-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -103,7 +103,7 @@ Se inserisci un nome di cartella inesistente nello spazio di storage FTP del tuo
 
 ##### L'opzione "Attiva la CDN"
 
-Per usufruire di questa opzione è necessario disporre di una soluzione CDN OVHcloud attiva o di un piano di hosting Web Performance attivo.
+Per usufruire di questa opzione è necessario disporre di una soluzione CDN OVHcloud attiva o di un piano di hosting Web Performance, Agency, Agency Plus o Agency Max attivo.
 
 Seleziona o deseleziona questa casella di controllo per attivare o disattivare l’opzione CDN per il tuo dominio o sottodominio.
 

--- a/docs/it/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Come eseguire le prime operazioni sul tuo hosting Web
 description: "Questa guida ti mostra come pubblicare un nuovo sito Internet con le nostre opzioni di \"CMS in 1 click\" e come creare un nuovo indirizzo email personalizzato con il tuo dominio, il tutto grazie alla nostra soluzione di hosting Web"
-lastUpdated: 2025-04-07
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -16,7 +16,7 @@ Vuoi creare un sito Internet per la tua azienda o un blog personale? Hai bisogno
 :::info
 - Vuoi migrare un sito Web esistente presso un altro provider? Consulta la nostra guida dedicata: [Migrare il proprio sito Web e i servizi associati a OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh).
 <Region zones={['eu']}>
-- Vuoi solo una semplice home page per la tua attività professionale? Consulta la nostra guida dedicata: [Hosting Web - Attiva l'hosting gratuito 100M](/guides/web-cloud/web-hosting/activate-start10m).
+- Vuoi solo una semplice home page per la tua attività professionale? Consulta la nostra guida dedicata: [Hosting Web - Attiva l'hosting gratuito](/guides/web-cloud/web-hosting/activate-start10m).
 </Region>
 
 :::
@@ -25,7 +25,7 @@ Vuoi creare un sito Internet per la tua azienda o un blog personale? Hai bisogno
 ## Prerequisiti
 
 <Region zones={['eu']}>
-- Disporre di una soluzione di [hosting Web OVHcloud](https://www.ovhcloud.com/it/web-hosting/) con almeno un database disponibile (escluso il servizio di hosting gratuito 100M).
+- Disporre di una soluzione di [hosting Web OVHcloud](https://www.ovhcloud.com/it/web-hosting/) con almeno un database disponibile (escluso il servizio di hosting gratuito).
 </Region>
 <Region zones={['ca','apac']}>
 - Disporre di una soluzione di [hosting Web OVHcloud](https://www.ovhcloud.com/it/web-hosting/) con almeno un database disponibile.

--- a/docs/it/guides/web-cloud/web-hosting/website-project.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/website-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Come creare un sito Web - Realizzare il tuo progetto in 5 tappe
 description: Questa guida ti mostra come definire il tuo progetto, pubblicare il tuo sito Internet e creare indirizzi email con la tua soluzione di hosting Web
-lastUpdated: 2025-04-25
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -214,7 +214,7 @@ Con gli hosting Web, OVHcloud propone 3 offerte CDN:
 Per maggiori informazioni sulle nostre offerte CDN, consulta la nostra guida "[Aumentare la velocità di un sito Web con la CDN](/guides/web-cloud/web-hosting/cdn-how-to-use-cdn)".
 
 :::info
-L'offerta **CDN Basic** è inclusa gratuitamente solo sugli hosting Web **Performance**.
+L'offerta **CDN Basic** è inclusa gratuitamente sugli hosting Web **Performance**, **Agency**, **Agency Plus** e **Agency Max**.
 
 Non è possibile cumulare diverse offerte CDN su uno stesso hosting Web.
 
@@ -226,7 +226,7 @@ Non è possibile cumulare diverse offerte CDN su uno stesso hosting Web.
 
 <summary>I server di database Web Cloud Databases</summary>
 
-Se hai attivato un hosting Web **Performance**, puoi attivare gratuitamente un server di database [Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/).
+Se hai attivato un hosting Web **Performance**, **Agency**, **Agency Plus** o **Agency Max**, puoi attivare gratuitamente un server di database [Web Cloud Databases](https://www.ovhcloud.com/it/web-cloud/databases/).
 
 Per maggiori informazioni sul suo utilizzo, consulta la nostra documentazione "[Inziare a utilizzare Web Cloud Databases](/guides/web-cloud/databases/db-getting-started)".
 

--- a/docs/pl/guides/web-cloud/databases/db-backup-export-database-server.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-backup-export-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tworzenie i eksportowanie kopii zapasowej bazy danych na serwerze baz danych
 description: Dowiedz się, jak tworzyć kopie zapasowe i eksportować bazę danych na serwerze Web Cloud Databases z poziomu Panelu klienta OVHcloud lub przez phpMyAdmin
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Baza danych może zawierać dużą liczbę informacji niezbędnych dla Twojej st
 
 ## Wymagania początkowe
 
-- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawartej w ofercie [hostingu www Performance](https://www.ovhcloud.com/pl/web-hosting/)).
+- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawartej w ofercie [hostingu www](https://www.ovhcloud.com/pl/web-hosting/) Performance, Agency, Agency Plus lub Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/pl/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja serwera baz danych
 description: Dowiedz się, jak skonfigurować i zoptymalizować serwer bazy danych
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Za pomocą serwerów baz Web Cloud Databases możesz wpłynąć na globalne para
 
 ## Wymagania początkowe
 
-- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawartej w ofercie [hostingu www Performance](https://www.ovhcloud.com/pl/web-hosting/)).
+- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawartej w ofercie [hostingu www](https://www.ovhcloud.com/pl/web-hosting/) Performance, Agency, Agency Plus lub Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---
@@ -130,11 +130,11 @@ Kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
 ### Zmiana oferty Web Cloud Databases <a name="modify-ram-web-cloud-db"></a>
 
 :::warning
-Jeśli Twoja usługa Web Cloud Databases jest powiązana z hostingiem **Performance**, musisz wcześniej odłączyć ofertę Web Cloud Databases od hostingu **Performance**, aby przejść na wyższą ofertę.
+Jeśli Twoja usługa Web Cloud Databases jest powiązana z hostingiem **Performance**, **Agency**, **Agency Plus** lub **Agency Max**, musisz wcześniej odłączyć ofertę Web Cloud Databases od hostingu, aby przejść na wyższą ofertę.
 
-Aby odłączyć usługę Web Cloud Databases od hostingu **Performance**, zapoznaj się z naszym przewodnikiem "[Odłączenie rozwiązania Web Cloud Databases od hostingu WWW](/guides/web-cloud/databases/db-detach-from-web-hosting)".
+Aby odłączyć usługę Web Cloud Databases od hostingu **Performance**, **Agency**, **Agency Plus** lub **Agency Max**, zapoznaj się z naszym przewodnikiem "[Odłączenie rozwiązania Web Cloud Databases od hostingu WWW](/guides/web-cloud/databases/db-detach-from-web-hosting)".
 
-**Operacja ta jest nieodwracalna, a usługa Web Cloud Databases będzie fakturowana niezależnie od hostingu Performance.**
+**Operacja ta jest nieodwracalna, a usługa Web Cloud Databases będzie fakturowana niezależnie od hostingu www Performance, Agency, Agency Plus lub Agency Max.**
 
 :::
 
@@ -164,7 +164,7 @@ Kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
     Po zatwierdzeniu regulaminów zostaniesz przekierowany do zamówienia, aby opłacić tę zmianę. Zmiana zostanie zastosowana w ciągu kilku godzin.
     
     :::warning
-    Jeśli aktualnie posiadasz darmową usługę Web Cloud Databases powiązaną z hostingiem Performance, zmiana oferty oznacza utratę jej bezpłatności.
+    Jeśli aktualnie posiadasz darmową usługę Web Cloud Databases powiązaną z hostingiem Performance, Agency, Agency Plus lub Agency Max, zmiana oferty oznacza utratę jej bezpłatności.
 
     :::
 

--- a/docs/pl/guides/web-cloud/databases/db-connecting-database-server.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-connecting-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Cloud Databases - Logowanie do bazy danych
 description: Dowiedz się, jak połączyć się z bazą danych w ramach rozwiązania Web Cloud Databases
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Zawartość bazy danych można przeglądać za pomocą interfejsu. Istnieje kilk
 
 ## Wymagania początkowe
 
-- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawartej w ofercie [hostingu www Performance](https://www.ovhcloud.com/pl/web-hosting/)).
+- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawartej w ofercie [hostingu www](https://www.ovhcloud.com/pl/web-hosting/) Performance, Agency, Agency Plus lub Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/pl/guides/web-cloud/databases/db-create-databases-users.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-create-databases-users.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tworzenie baz danych i użytkowników na serwerze baz danych
 description: Dowiedz się, jak utworzyć bazę danych na serwerze baz danych
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -15,7 +15,7 @@ Baza danych (DB) pozwala na przechowywanie elementów dynamicznych, takich jak k
 
 ## Wymagania początkowe
 
-- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawartej w ofercie [hostingu www Performance](https://www.ovhcloud.com/pl/web-hosting/)).
+- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawartej w ofercie [hostingu www](https://www.ovhcloud.com/pl/web-hosting/) Performance, Agency, Agency Plus lub Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/pl/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Odłączenie mojego rozwiązania Web Cloud Databases od hostingu WWW
 description: Dowiedz się, jak odłączyć rozwiązanie Web Cloud Databases od hostingu WWW
-lastUpdated: 2025-01-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -9,13 +9,13 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Wprowadzenie
 
-Rozwiązania [Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) można włączyć bezpłatnie w naszej [ofercie hostingu Performance](https://www.ovhcloud.com/pl/web-hosting/). W takim przypadku są one przypisane do hostingu, z którego zostały aktywowane. Może zaistnieć konieczność odłączenia rozwiązania Web Cloud Databases od hostingu Performance, do którego jest ono przypisane.
+Rozwiązania [Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) można włączyć bezpłatnie w naszej [ofercie hostingu](https://www.ovhcloud.com/pl/web-hosting/) Performance, Agency, Agency Plus i Agency Max. W takim przypadku są one przypisane do hostingu, z którego zostały aktywowane. Może zaistnieć konieczność odłączenia rozwiązania Web Cloud Databases od hostingu, do którego jest ono przypisane.
 
 **Dowiedz się, jak odłączyć rozwiązanie Web Cloud Databases od hostingu.**
 
 ## Wymagania początkowe
 
-- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) powiązanej z ofertą hostingu [Performance](https://www.ovhcloud.com/pl/web-hosting/).
+- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) powiązanej z ofertą [hostingu www](https://www.ovhcloud.com/pl/web-hosting/) Performance, Agency, Agency Plus lub Agency Max.
 - Posiadanie statusu przynajmniej kontaktu "[Administrator](/guides/account-and-service-management/account-information/managing-contacts)" dla usług, w odniesieniu do których chcesz podjąć działania.
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/pl/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
@@ -1,7 +1,7 @@
 ---
 title: MySQL i MariaDB
 description: Korzystanie z baz danych
-lastUpdated: 2023-07-26
+lastUpdated: 2026-06-08
 ---
 
 ## Wprowadzenie
@@ -24,7 +24,7 @@ Silnik ten jest w 100% kompatybilny. Wszystkie bugi oraz roadmapy są w pełni d
   
 ## Wymagania początkowe
 
-- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawartej w ofercie[hostingu www Performance](https://www.ovhcloud.com/pl/web-hosting/)
+- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawartej w ofercie [hostingu www](https://www.ovhcloud.com/pl/web-hosting/) Performance, Agency, Agency Plus lub Agency Max)
 - Dostęp do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>
 - Przeglądanie [przewodnik dotyczący uruchomienia usługi Web Cloud Databases](/guides/web-cloud/databases/db-getting-started)
 

--- a/docs/pl/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pierwsze kroki z usługą Web Cloud Databases
 description: Dowiedz się, jak rozpocząć korzystanie z rozwiązania Web Cloud Databases
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -16,7 +16,7 @@ Domyślnie rozwiązanie Web Cloud Databases jest powiązane z siecią hostingów
 
 ## Wymagania początkowe
 
-- [Instancja Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawarta w ofercie [hostingu WWW Performance](https://www.ovhcloud.com/pl/web-hosting/)).
+- [Instancja Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawarta w ofercie [hostingu www](https://www.ovhcloud.com/pl/web-hosting/) Performance, Agency, Agency Plus lub Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/pl/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Polityka wycofania z eksploatacji zarządzanych baz danych
-lastUpdated: 2023-03-07
+lastUpdated: 2026-06-08
 ---
 
 ## Wprowadzenie
@@ -14,7 +14,7 @@ Zarządzane bazy danych OVHcloud oferują kilka systemów zarządzania bazami da
 Posiadanie co najmniej jednej z 3 poniższych ofert:
 
 - Jedna z baz danych zawartych w ofercie [Hosting WWW](https://www.ovhcloud.com/pl/web-hosting/).
-- Jedna [instancja Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawarta w usłudze [Hosting www Performance](https://www.ovhcloud.com/pl/web-hosting/).
+- Jedna [instancja Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawarta w usłudze [hostingu www](https://www.ovhcloud.com/pl/web-hosting/) Performance, Agency, Agency Plus lub Agency Max).
 - Pakiet bazy danych [Start SQL](https://www.ovhcloud.com/pl/web-hosting/options/start-sql/).
 
 ## W praktyce

--- a/docs/pl/guides/web-cloud/databases/db-restore-import-database.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-restore-import-database.mdx
@@ -1,7 +1,7 @@
 ---
 title: Przywracanie i importowanie bazy danych na serwer baz danych
 description: Dowiedz się, jak przywrócić i importować bazę danych na serwerze Web Cloud Databases z poziomu Panelu klienta OVHcloud lub przez phpMyAdmin
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ W wyniku błędu bazy danych musisz mieć możliwość przywrócenia kopii zapas
 
 ## Wymagania początkowe
 
-- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawartej w ofercie [hostingu www Performance](https://www.ovhcloud.com/pl/web-hosting/))
+- Posiadanie [instancji Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/) (zawartej w ofercie [hostingu www](https://www.ovhcloud.com/pl/web-hosting/) Performance, Agency, Agency Plus lub Agency Max)
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/pl/guides/web-cloud/web-hosting/access-websites-view.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/access-websites-view.mdx
@@ -1,7 +1,7 @@
 ---
 title: Wyświetl wszystkie strony WWW w Panelu klienta OVHcloud i zarządzaj nimi
 description: Dowiedz się, jak wyświetlać wszystkie Twoje strony WWW i zarządzać nimi w Panelu klienta
-lastUpdated: 2025-05-27
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -72,7 +72,7 @@ Kliknięcie tego przycisku spowoduje przekierowanie do zakładki <code className
 
 #### Pakiet
 
-Pokazuje typ rozwiązania powiązanego z hostingiem: Starter, Perso, Pro lub Performance.
+Pokazuje typ rozwiązania powiązanego z hostingiem: Hosting darmowy, Starter, Perso, Startup, Pro, Performance, Agency, Agency Plus lub Agency Max.
 
 Kliknięcie tego przycisku spowoduje przekierowanie do zakładki <code className="action">Informacje ogólne</code> danego hostingu.
 

--- a/docs/pl/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
@@ -1,7 +1,7 @@
 ---
 title: Przewodnik dotyczący usługi CDN na hostingu www
 description: Dowiedz się, jak ulepszyć stronę WWW, przyspieszając jej ładowanie w hostingu WWW dzięki usłudze CDN
-lastUpdated: 2025-10-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,7 +39,7 @@ Każdy serwer przechowuje w pamięci podręcznej (cache) część Twojej witryny
 ###  Wdrożenie opcji CDN
 
 :::info
-Opcja GeoCache jest zawarta w ofertach hostingowych Performance.
+Opcja GeoCache jest zawarta w ofertach hostingowych Performance, Agency, Agency Plus i Agency Max.
 
 :::
 
@@ -94,7 +94,7 @@ Przejdź do karty <code className="action">MultiSite</code> Twojego hostingu, kl
 Przejdź do karty <code className="action">MultiSite</code> hostingu, kliknij <code className="action">...</code> obok nazwy domeny lub poddomeny, a następnie kliknij  <code className="action">Zmień CDN</code>. 
 
 :::warning
-Niektóre opcje są zablokowane dla oferty Basic i wymagają zamówienia usługi [CDN security](https://www.ovhcloud.com/pl/web-hosting/options/cdn/) lub [CDN Advanced](https://www.ovhcloud.com/pl/web-hosting/options/cdn/)
+Niektóre opcje są zablokowane dla CDN Basic i wymagają zamówienia usługi [CDN security](https://www.ovhcloud.com/pl/web-hosting/options/cdn/) lub [CDN Advanced](https://www.ovhcloud.com/pl/web-hosting/options/cdn/)
 
 :::
 

--- a/docs/pl/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: Jak zarządzać modułem za 1 kliknięciem?
 description: Dowiedz się, jak zarządzać modułem za pomocą 1 kliknięcia w Panelu klienta OVHcloud
-lastUpdated: 2024-11-15
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -131,7 +131,7 @@ Sprawdź nasze przewodniki:
 :::warning
 Usunięcie modułu 1 kliknięcia **nie spowoduje automatycznego usunięcia bazy danych**. Jeśli uruchomisz instalację nowego CMS bez wcześniejszego usunięcia bazy danych (a Twój hosting nie pozwala na automatyczne utworzenie nowej bazy), w Panelu klienta wyświetli się komunikat "[Wystąpił błąd podczas pobierania informacji (You need at least one free database)](/guides/web-cloud/web-hosting/diagnostic-errors-module1clic#wystapil-blad-podczas-pobierania-informacji-you-need-at-least-one-free-database)".
 
-Jeśli posiadasz hosting [Perso](https://www.ovhcloud.com/pl/web-hosting/personal-offer/) lub utworzyłeś już cztery bazy danych na hostingu [Hosting Pro](https://www.ovhcloud.com/pl/web-hosting/professional-offer/) lub [Hosting Performance](https://www.ovhcloud.com/pl/web-hosting/performance-offer/), usuń bazę danych zidentyfikowaną w [etapie 1](#step1) **PRZEDADP**, aby utworzyć nowy moduł za pomocą 1 kliknięcia.
+Jeśli osiągnąłeś maksymalną liczbę baz danych dozwoloną w Twojej [ofercie hostingu](https://www.ovhcloud.com/pl/web-hosting/), musisz **najpierw** usunąć bazę danych zidentyfikowaną w [etapie 1](#step1), aby utworzyć nowy moduł za pomocą 1 kliknięcia.
 
 :::
 

--- a/docs/pl/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -1,7 +1,7 @@
 ---
 title: Rozwiąż najczęstsze błędy związane z modułami za pomocą 1 kliknięcia
 description: Dowiedz się, jak za pomocą 1 kliknięcia zdiagnozować najczęstsze przypadki błędów związane z tworzeniem modułów
-lastUpdated: 2024-03-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -89,7 +89,7 @@ Zapoznaj się z porównaniem naszych ofert [pakiety hostingowe](https://www.ovhc
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-Oferty [Pro](https://www.ovhcloud.com/pl/web-hosting/professional-offer/) i [Performance](https://www.ovhcloud.com/pl/web-hosting/performance-offer/) pozwalają na utworzenie do trzech dodatkowych "modułów za 1 kliknięciem" z niezależną bazą danych dla każdego z nich. Oferty **Performance** pozwolą Ci również na bezpłatną aktywację serwera [Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/).
+Oferty **Pro**, **Performance**, **Agency**, **Agency Plus** i **Agency Max** pozwalają na utworzenie większej liczby "modułów za 1 kliknięciem", każdy z niezależną bazą danych. Oferty **Performance**, **Agency**, **Agency Plus** i **Agency Max** pozwolą Ci również na bezpłatną aktywację serwera [Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/).
 
 Po jego zakończeniu będziesz mógł zainstalować nowy "moduł za pomocą 1 kliknięcia".
 
@@ -187,7 +187,7 @@ Zapoznaj się z porównaniem naszych ofert [pakiety hostingowe](https://www.ovhc
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-Oferty [Pro](https://www.ovhcloud.com/pl/web-hosting/professional-offer/) i [Performance](https://www.ovhcloud.com/pl/web-hosting/performance-offer/) pozwalają na utworzenie do trzech dodatkowych "modułów za 1 kliknięciem" z niezależną bazą danych dla każdego z nich. Oferty **Performance** pozwolą Ci również na bezpłatną aktywację serwera [Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/).
+Oferty **Pro**, **Performance**, **Agency**, **Agency Plus** i **Agency Max** pozwalają na utworzenie większej liczby "modułów za 1 kliknięciem", każdy z niezależną bazą danych. Oferty **Performance**, **Agency**, **Agency Plus** i **Agency Max** pozwolą Ci również na bezpłatną aktywację serwera [Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/).
 
 ### "Nie można połączyć się z bazą danych" <a name="delete-the-module"></a>
 

--- a/docs/pl/guides/web-cloud/web-hosting/faq.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ Web Hosting
 description: Poznaj najważniejsze pytania dotyczące hostingu WWW OVHcloud
-lastUpdated: 2025-11-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,7 +27,7 @@ Postępuj zgodnie z poniższymi instrukcjami:
 Będziesz mógł zarządzać swoimi certyfikatami SSL, wersją PHP zastosowaną do twojego hostingu, opcją CDN, opcjami MultiSite, bazami danych, etc.
 
 :::tip
-Jeśli chcesz skonfigurować Twój hosting, sprawdź sekcje "*Pierwsze kroki*" i "*Konfiguracja swój hostingu WWW Perso, Pro lub Performance*" na [tej stronie](/guides/web-cloud/web-hosting/overview).
+Jeśli chcesz skonfigurować Twój hosting, sprawdź sekcje "*Pierwsze kroki*" i "*Konfiguracja hostingu WWW*" na [tej stronie](/guides/web-cloud/web-hosting/overview).
 
 :::
 
@@ -301,11 +301,11 @@ Postępuj zgodnie z poniższymi instrukcjami:
 
 <details>
 
-<summary>Jeśli zrezygnujesz z hostingu "Performance", jak zachować powiązaną ofertę "Web Cloud Databases"?</summary>
+<summary>Jeśli zrezygnujesz z hostingu obejmującego bezpłatną ofertę "Web Cloud Databases", jak ją zachować?</summary>
 
 
-Pakiety hostingowe **Performance** zawierają bezpłatną usługę Web Cloud Databases.<br/>
-W przypadku zakończenia lub usunięcia hostingu **Performance** oferta Web Cloud Databases, która może zostać dołączona, również zostaje rozwiązana. Aby zachować rozwiązanie Web Cloud Databases, odłącz je **przed** rezygnacją z hostingu.
+Pakiety hostingowe **Performance**, **Agency**, **Agency Plus** i **Agency Max** zawierają bezpłatną usługę Web Cloud Databases.<br/>
+W przypadku zakończenia lub usunięcia hostingu oferta Web Cloud Databases, która może zostać dołączona, również zostaje rozwiązana. Aby zachować rozwiązanie Web Cloud Databases, odłącz je **przed** rezygnacją z hostingu.
 
 Postępuj zgodnie z poniższymi instrukcjami:
 
@@ -314,14 +314,14 @@ Postępuj zgodnie z poniższymi instrukcjami:
 3. Na stronie, która się wyświetli i w ramce **Konfiguracja** kliknij przycisk <code className="action">...</code> po prawej stronie wzmianki `Web Cloud Databases`, a następnie <code className="action">Odłącz</code>.
 4. Postępuj zgodnie z instrukcjami, aby zamówić niezależną ofertę Web Cloud Databases i zachować utworzone rozwiązanie Web Cloud Databases.
 
-**Czynność ta jest nieodwracalna i usługa Web Cloud Databases będzie fakturowana niezależnie od hostingu Performance.**
+**Czynność ta jest nieodwracalna i usługa Web Cloud Databases będzie fakturowana niezależnie od hostingu.**
 
 </details>
 
 
 <details>
 
-<summary>Jak zwiększyć ilość pamięci RAM w ofercie "Web Cloud Databases" związanej z hostingiem "Performance"?</summary>
+<summary>Jak zwiększyć ilość pamięci RAM w ofercie "Web Cloud Databases" związanej z hostingiem Performance, Agency, Agency Plus lub Agency Max?</summary>
 
 
 Postępuj zgodnie z poniższymi instrukcjami:

--- a/docs/pl/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Przywracanie plików z kopii zapasowej OVHcloud
 description: Dowiedz się, jak przywrócić plik lub całą przestrzeń dyskową Twojego hostingu
-lastUpdated: 2025-12-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,7 +27,7 @@ Wykonując kopię zapasową bezpieczeństwa Twojej strony WWW i używając bazy 
 ## Wymagania początkowe
 
 <Region zones={['eu']}>
-- Posiadanie oferty [hostingu](https://www.ovhcloud.com/pl/web-hosting/) (nie dotyczy hostingu [Cloud Web](https://www.ovhcloud.com/pl/web-hosting/cloud-web-offer/)).
+- Posiadanie oferty [hostingu](https://www.ovhcloud.com/pl/web-hosting/) (nie dotyczy hostingu [Cloud Web](https://www.ovhcloud.com/pl/web-hosting/)).
 </Region>
 <Region zones={['ca', 'apac']}>
 - Posiadanie oferty [hostingu](https://www.ovhcloud.com/pl/web-hosting/).

--- a/docs/pl/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hosting WWW - Zmiana nazwy domeny powiązanej z hostingiem
 description: Dowiedz się, jak zmienić parametry powiązania domeny/subdomeny zadeklarowanej wcześniej w Twojej usłudze hostingu
-lastUpdated: 2025-11-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -103,7 +103,7 @@ Jeśli wpiszesz nieistniejącą nazwę katalogu z przestrzeni dyskowej FTP Twoje
 
 ##### Opcja "Włącz CDN"
 
-Aby skorzystać z tej opcji, należy najpierw wykupić ofertę CDN OVHcloud lub wykupić hosting Performance.
+Aby skorzystać z tej opcji, należy najpierw wykupić ofertę CDN OVHcloud lub wykupić hosting Performance, Agency, Agency Plus lub Agency Max.
 
 Zaznacz/usuń zaznaczenie tego pola, aby włączyć/wyłączyć opcję GeoCache dla Twojej domeny lub subdomeny.
 

--- a/docs/pl/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Jak rozpocząć korzystanie z hostingu WWW
 description: "Dowiedz się, jak zamieścić w Internecie nową stronę WWW za pomocą opcji\"Moduły za 1 kliknięciem\", jak utworzyć nowy spersonalizowany adres e-mail z nazwą domeny, a wszystko to za pomocą naszego rozwiązania hostingowego"
-lastUpdated: 2025-04-07
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -16,7 +16,7 @@ Chcesz stworzyć stronę WWW dla swojej firmy lub własny blog? Potrzebujesz skl
 :::info
 - Chcesz przenieść istniejącą stronę WWW do innego dostawcy hostingu? Sprawdź przewodnik: [Przeniesienie strony WWW i powiązanych z nią usług do OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh).
 <Region zones={['eu']}>
-- Chcesz mieć tylko jedną prostą stronę główną? Sprawdź przewodnik: [Hosting WWW - Włącz darmowy hosting 100M](/guides/web-cloud/web-hosting/activate-start10m).
+- Chcesz mieć tylko jedną prostą stronę główną? Sprawdź przewodnik: [Hosting WWW - Włącz darmowy hosting](/guides/web-cloud/web-hosting/activate-start10m).
 </Region>
 
 :::
@@ -25,7 +25,7 @@ Chcesz stworzyć stronę WWW dla swojej firmy lub własny blog? Potrzebujesz skl
 ## Wymagania początkowe
 
 <Region zones={['eu']}>
-- Posiadanie hostingu [OVHcloud](https://www.ovhcloud.com/pl/web-hosting/) z co najmniej jedną dostępną bazą danych (poza ofertą darmowego hostingu 100M).
+- Posiadanie hostingu [OVHcloud](https://www.ovhcloud.com/pl/web-hosting/) z co najmniej jedną dostępną bazą danych (poza ofertą darmowego hostingu).
 </Region>
 <Region zones={['ca','apac']}>
 - Posiadanie hostingu [OVHcloud](https://www.ovhcloud.com/pl/web-hosting/) z co najmniej jedną dostępną bazą danych.

--- a/docs/pl/guides/web-cloud/web-hosting/website-project.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/website-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Jak stworzyć stronę WWW - 5 etapów realizacji projektu
 description: Dowiedz się, jak zdefiniować projekt, opublikować stronę WWW i utworzyć konta e-mail w ramach hostingu
-lastUpdated: 2025-04-25
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -214,7 +214,7 @@ W ramach hostingu OVHcloud oferuje 3 oferty CDN:
 Więcej informacji na temat ofert CDN znajdziesz w przewodniku "[Przewodnik dotyczący usługi CDN na hostingu www](/guides/web-cloud/web-hosting/cdn-how-to-use-cdn)".
 
 :::info
-Oferta **CDN Basic** jest zawarta w cenie hostingu **Performance**.
+Oferta **CDN Basic** jest zawarta w cenie hostingu **Performance**, **Agency**, **Agency Plus** i **Agency Max**.
 
 Nie można połączyć kilku usług CDN na tym samym hostingu.
 
@@ -226,7 +226,7 @@ Nie można połączyć kilku usług CDN na tym samym hostingu.
 
 <summary>Serwery baz danych Web Cloud Databases</summary>
 
-Jeśli posiadasz hosting www **Performance**, możesz za darmo aktywować serwer bazy danych [Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/).
+Jeśli posiadasz hosting www **Performance**, **Agency**, **Agency Plus** lub **Agency Max**, możesz za darmo aktywować serwer bazy danych [Web Cloud Databases](https://www.ovhcloud.com/pl/web-cloud/databases/).
 
 Więcej szczegółów na temat korzystania z tej usługi znajdziesz w przewodniku "[Pierwsze kroki z usługą Web Cloud Databases](/guides/web-cloud/databases/db-getting-started)".
 

--- a/docs/pt/guides/web-cloud/databases/db-backup-export-database-server.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-backup-export-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Backup e exportação de uma base de dados no servidor de bases de dados
 description: Saiba como fazer o backup e a exportação de uma base de dados no servidor Web Cloud Databases a partir da Área de Cliente OVHcloud ou do phpMyAdmin
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ A sua base de dados pode conter um grande volume de informações essenciais par
 
 ## Requisitos
 
-- Dispor de uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web Performance](https://www.ovhcloud.com/pt/web-hosting/)).
+- Dispor de uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) Performance, Agency, Agency Plus ou Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/pt/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar o servidor de bases de dados
 description: Descubra como configurar e otimizar o servidor de bases de dados
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Os servidores de bases de dados Web Cloud Databases permitem-lhe modificar os pa
 
 ## Requisitos
 
-- Dispor de uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web Performance](https://www.ovhcloud.com/pt/web-hosting/)).
+- Dispor de uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) Performance, Agency, Agency Plus ou Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---
@@ -130,11 +130,11 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
 ### Alterar a sua oferta Web Cloud Databases <a name="modify-ram-web-cloud-db"></a>
 
 :::warning
-Se a sua oferta Web Cloud Databases está associada a uma oferta de alojamento web **Performance**, deverá obrigatoriamente e previamente desassociar a oferta Web Cloud Databases do seu alojamento **Performance** para migrar para uma oferta superior.
+Se a sua oferta Web Cloud Databases está associada a uma oferta de alojamento web **Performance**, **Agency**, **Agency Plus** ou **Agency Max**, deverá obrigatoriamente e previamente desassociar a oferta Web Cloud Databases do seu alojamento para migrar para uma oferta superior.
 
-Para desassociar uma oferta Web Cloud Databases de um alojamento web **Performance**, consulte o nosso guia "[Desassociar a minha solução Web Cloud Databases de um alojamento web](/guides/web-cloud/databases/db-detach-from-web-hosting)".
+Para desassociar uma oferta Web Cloud Databases de um alojamento web **Performance**, **Agency**, **Agency Plus** ou **Agency Max**, consulte o nosso guia "[Desassociar a minha solução Web Cloud Databases de um alojamento web](/guides/web-cloud/databases/db-detach-from-web-hosting)".
 
-**Esta ação é irreversível e a oferta Web Cloud Databases será depois faturada independentemente do seu alojamento web Performance.**
+**Esta ação é irreversível e a oferta Web Cloud Databases será depois faturada independentemente do seu alojamento web Performance, Agency, Agency Plus ou Agency Max.**
 
 :::
 
@@ -164,7 +164,7 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
     Após a validação dos contratos, será redirecionado para a nota de encomenda a fim de pagar pela alteração. Esta última produzirá efeitos em algumas horas.
     
     :::warning
-    Se dispõe atualmente de um Web Cloud Databases gratuito graças ao seu alojamento Performance, a alteração da oferta fará com que perca a sua gratuidade.
+    Se dispõe atualmente de um Web Cloud Databases gratuito graças ao seu alojamento Performance, Agency, Agency Plus ou Agency Max, a alteração da oferta fará com que perca a sua gratuidade.
 
     :::
 

--- a/docs/pt/guides/web-cloud/databases/db-connecting-database-server.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-connecting-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Cloud Databases - Ligar-se a uma base de dados
 description: Saiba como ligar-se a uma base de dados na sua solução Web Cloud Databases
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Pode consultar o conteúdo da sua base de dados através de uma interface. Exist
 
 ## Requisitos
 
-- Uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web Performance](https://www.ovhcloud.com/pt/web-hosting/)).
+- Uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) Performance, Agency, Agency Plus ou Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/pt/guides/web-cloud/databases/db-create-databases-users.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-create-databases-users.mdx
@@ -1,7 +1,7 @@
 ---
 title: Criar bases de dados e utilizadores no servidor de bases de dados
 description: Saiba como criar uma base de dados no servidor de bases de dados
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -15,7 +15,7 @@ Uma base de dados (DB) permite armazenar elementos ditos dinâmicos, como coment
 
 ## Requisitos
 
-- Dispor de uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web Performance](https://www.ovhcloud.com/pt/web-hosting/)).
+- Dispor de uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) Performance, Agency, Agency Plus ou Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/pt/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-detach-from-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Desassociar a minha solução Web Cloud Databases de um alojamento web
 description: Saiba como desassociar a sua solução Web Cloud Databases de um alojamento web
-lastUpdated: 2025-01-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -9,13 +9,13 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objetivo
 
-As soluções [Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) podem ser ativadas gratuitamente a partir dos nossos [planos de alojamento web Performance](https://www.ovhcloud.com/pt/web-hosting/). Neste caso, elas serão associadas ao alojamento web a partir do qual foram ativadas. Durante a utilização dos serviços, pode ser necessário desassociar a solução Web Cloud Databases do alojamento web Performance ao qual está associada.
+As soluções [Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) podem ser ativadas gratuitamente a partir das nossas [ofertas de alojamento web](https://www.ovhcloud.com/pt/web-hosting/) Performance, Agency, Agency Plus e Agency Max. Neste caso, elas serão associadas ao alojamento web a partir do qual foram ativadas. Durante a utilização dos serviços, pode ser necessário desassociar a solução Web Cloud Databases do alojamento web ao qual está associada.
 
 **Saiba como desassociar a sua solução Web Cloud Databases de um alojamento web.**
 
 ## Requisitos
 
-- Ter um [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) associado a uma oferta de [alojamento web Performance](https://www.ovhcloud.com/pt/web-hosting/).
+- Ter uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) associada a uma oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) Performance, Agency, Agency Plus ou Agency Max.
 - Ser, no mínimo, o contacto "[Administrador](/guides/account-and-service-management/account-information/managing-contacts)" dos serviços sobre os quais deseja agir.
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/pt/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-getting-started-mysql-mariadb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comecar com MySQL e MariaDB
 description: Utilize as suas bases de dados
-lastUpdated: 2023-07-26
+lastUpdated: 2026-06-08
 ---
 
 ## Objetivo
@@ -24,7 +24,7 @@ Este motor é 100% compatível, e é mais "livre" que o seu irmão mais velho My
 
 ## Pre-requisitos
 
-- Dispor de uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web performance](https://www.ovhcloud.com/pt/web-hosting/)
+- Dispor de uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) Performance, Agency, Agency Plus ou Agency Max)
 - Ter acesso à <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>
 - Consultar o [guia de arranque do Web Cloud Databases](/guides/web-cloud/databases/db-getting-started)
 

--- a/docs/pt/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Cloud Databases - Primeira utilização
 description: Saiba como começar a utilizar a solução Web Cloud Databases
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -16,7 +16,7 @@ Por predefinição, a solução Web Cloud Databases está associada à rede de a
 
 ## Requisitos
 
-- Uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída num plano de [alojamento web Performance](https://www.ovhcloud.com/pt/web-hosting/)).
+- Uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) Performance, Agency, Agency Plus ou Agency Max).
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/pt/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-managed-db-lifecycle-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Política de fim de vida das bases de dados geridas
-lastUpdated: 2023-03-07
+lastUpdated: 2026-06-08
 ---
 
 ## Objetivo
@@ -14,7 +14,7 @@ As bases de dados geridas pela OVHcloud propõem vários sistemas de gestão de 
 Dispor de, pelo menos, uma das 3 ofertas seguintes:
 
 - Uma das bases de dados incluídas com um [Alojamento web](https://www.ovhcloud.com/pt/web-hosting/).
-- Uma [instance Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/)  (incluída numa oferta de [Alojamento web Performance](https://www.ovhcloud.com/pt/web-hosting/).
+- Uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) Performance, Agency, Agency Plus ou Agency Max).
 - Um pack de bases de dados [Start SQL](https://www.ovhcloud.com/pt/web-hosting/options/start-sql/).
 
 ## Instruções

--- a/docs/pt/guides/web-cloud/databases/db-restore-import-database.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-restore-import-database.mdx
@@ -1,7 +1,7 @@
 ---
 title: Restaurar e importar uma base de dados no servidor de bases de dados
 description: Saiba como restaurar e importar uma base de dados no servidor Web Cloud Databases a partir da Área de Cliente OVHcloud ou do phpMyAdmin
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ No seguimento de um erro numa base de dados, deve estar preparado para restaurar
 
 ## Requisitos
 
-- Dispor de uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web Performance](https://www.ovhcloud.com/pt/web-hosting/))
+- Dispor de uma [instância Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/) (incluída numa oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) Performance, Agency, Agency Plus ou Agency Max)
 
 {/* CP-NAV-START:web-cloud-databases */}
 ---

--- a/docs/pt/guides/web-cloud/web-hosting/access-websites-view.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/access-websites-view.mdx
@@ -1,7 +1,7 @@
 ---
 title: Visualizar e gerir todos os seus websites a partir da Área de Cliente OVHcloud
 description: Descubra como consultar e gerir os seus websites a partir da Área de Cliente OVHcloud
-lastUpdated: 2025-05-27
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -72,7 +72,7 @@ Ao clicar, será redirecionado para o separador <code className="action">Informa
 
 ### Plano
 
-Apresenta o tipo de oferta associada ao alojamento: Starter, Perso, Pro ou Performance.
+Apresenta o tipo de oferta associada ao alojamento: Alojamento gratuito, Starter, Perso, Startup, Pro, Performance, Agency, Agency Plus ou Agency Max.
 
 Ao clicar, será redirecionado para o separador <code className="action">Informações gerais</code> do alojamento em causa.
 

--- a/docs/pt/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cdn-how-to-use-cdn.mdx
@@ -1,7 +1,7 @@
 ---
 title: Guia de utilização do acelerador CDN num alojamento web
 description: Saiba como melhorar o seu website acelerando o seu carregamento no seu alojamento Web graças ao CDN
-lastUpdated: 2025-10-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,7 +39,7 @@ Para funcionar, cada servidor guarda na sua memória cache uma parte do seu webs
 ### Implementar a opção CDN
 
 :::info
-A opção CDN já se encontra incluída nas soluções de alojamento web Performance.
+A opção CDN já se encontra incluída nas soluções de alojamento web Performance, Agency, Agency Plus e Agency Max.
 
 :::
 
@@ -94,7 +94,7 @@ Dirija-se ao separador <code className="action">Multisite</code> do seu alojamen
 Dirija-se ao separador <code className="action">Multisite</code> do seu alojamento, clique em <code className="action">...</code> à direita do nome de domínio ou subdomínio relevante e, em seguida, em <code className="action">Alterar a CDN</code>. 
 
 :::warning
-Algumas opções estão bloqueadas na oferta Basic e requerem a subscrição do [CDN security](https://www.ovhcloud.com/pt/web-hosting/options/cdn/) ou do [CDN Advanced](https://www.ovhcloud.com/pt/web-hosting/options/cdn/).
+Algumas opções estão bloqueadas no CDN Basic e requerem a subscrição do [CDN security](https://www.ovhcloud.com/pt/web-hosting/options/cdn/) ou do [CDN Advanced](https://www.ovhcloud.com/pt/web-hosting/options/cdn/).
 
 :::
 

--- a/docs/pt/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: Como gerir o seu módulo em 1 clique?
 description: Saiba como gerir o módulo 1 clique na Área de Cliente OVHcloud
-lastUpdated: 2024-11-15
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -131,7 +131,7 @@ Consulte os nossos manuais:
 :::warning
 A eliminação do módulo 1 clique **não levará automaticamente à eliminação da base de dados**. Se ativar a instalação de um novo CMS sem eliminar previamente a base de dados do anterior (e o alojamento não permitir a criação automática de uma nova base de dados), aparecerá a mensagem "[Ocorreu um erro aquando do carregamento das informações (You need at least one free database)](/guides/web-cloud/web-hosting/diagnostic-errors-module1clic#ocorreu-um-erro-aquando-do-carregamento-das-informacoes-you-need-at-least-one-free-database)" na sua Área de Cliente.
 
-Se dispõe de uma subscrição [Hosting Perso](https://www.ovhcloud.com/pt/web-hosting/personal-offer/) ou se já criou quatro bases de dados sobre o seu alojamento [Hosting Pro](https://www.ovhcloud.com/pt/web-hosting/professional-offer/) ou [Hosting Performance](https://www.ovhcloud.com/pt/web-hosting/performance-offer/), deverá eliminar a base de dados identificada [no passo 1](#step1) **ANTES** de poder criar um novo módulo 1 clique.
+Se atingiu o número máximo de bases de dados permitido pela sua [oferta de alojamento web](https://www.ovhcloud.com/pt/web-hosting/), deverá eliminar a base de dados identificada [no passo 1](#step1) **ANTES** de poder criar um novo módulo 1 clique.
 
 :::
 

--- a/docs/pt/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -1,7 +1,7 @@
 ---
 title: Resolver os erros mais frequentes associados aos módulos 1 clique
 description: Saiba como diagnosticar os casos mais comuns de erros associados à criação de módulos 1 clique
-lastUpdated: 2024-03-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -89,7 +89,7 @@ Na sua <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, clique em <c
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-As ofertas [Pro](https://www.ovhcloud.com/pt/web-hosting/professional-offer/) e [Performance](https://www.ovhcloud.com/pt/web-hosting/performance-offer/) permitem-lhe criar até três "módulos 1 clique" suplementares com uma base de dados independente para cada um deles. As ofertas **Performance** permitem-lhe também ativar gratuitamente um servidor [Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/).
+As ofertas **Pro**, **Performance**, **Agency**, **Agency Plus** e **Agency Max** permitem-lhe criar mais "módulos 1 clique", cada um com uma base de dados independente. As ofertas **Performance**, **Agency**, **Agency Plus** e **Agency Max** permitem-lhe também ativar gratuitamente um servidor [Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/).
 
 Uma vez concluído, poderá instalar um novo "módulo com 1 clique".
 
@@ -187,7 +187,7 @@ Na sua <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, aceda à sec
 
 <img className="thumbnail" alt="upgrade_hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/upgrade-perso.png" loading="lazy" />
 
-As ofertas [Pro](https://www.ovhcloud.com/pt/web-hosting/professional-offer/) e [Performance](https://www.ovhcloud.com/pt/web-hosting/performance-offer/) permitem-lhe criar até três "módulos 1 clique" suplementares com uma base de dados independente para cada um deles. As ofertas **Performance** permitem-lhe também ativar gratuitamente um servidor [Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/).
+As ofertas **Pro**, **Performance**, **Agency**, **Agency Plus** e **Agency Max** permitem-lhe criar mais "módulos 1 clique", cada um com uma base de dados independente. As ofertas **Performance**, **Agency**, **Agency Plus** e **Agency Max** permitem-lhe também ativar gratuitamente um servidor [Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/).
 
 ### "Não é possível estabelecer ligação à base de dados" <a name="delete-the-module"></a>
 

--- a/docs/pt/guides/web-cloud/web-hosting/faq.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alojamentos web - FAQ
 description: Encontre as principais questões colocadas sobre os alojamentos web da OVHcloud
-lastUpdated: 2025-11-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,7 +27,7 @@ Siga estes passos:
 Poderá gerir os seus certificados SSL, a versão PHP aplicada ao seu alojamento web, a opção CDN, os eventuais multi-sites, as bases de dados, etc.
 
 :::tip
-Para o ajudar a configurar o seu alojamento web, não hesite em consultar os tópicos "*Primeiros passos*" e "*Configurar o alojamento web Perso, Pro ou Performance*" de [esta página](/guides/web-cloud/web-hosting/overview).
+Para o ajudar a configurar o seu alojamento web, não hesite em consultar os tópicos "*Primeiros passos*" e "*Configurar o alojamento web*" de [esta página](/guides/web-cloud/web-hosting/overview).
 
 :::
 
@@ -301,11 +301,11 @@ Siga estes passos:
 
 <details>
 
-<summary>Quando rescindir um alojamento web "Performance", como conservar a oferta "Web Cloud Databases" associada?</summary>
+<summary>Quando rescindir um alojamento web que inclui uma oferta "Web Cloud Databases" gratuita, como conservá-la?</summary>
 
 
-Os alojamentos web **Performance** incluem uma oferta Web Cloud Databases ativável gratuitamente.<br/>
-Quando rescindir ou eliminar o seu alojamento web **Performance**, a oferta Web Cloud Databases eventualmente associada será igualmente rescindida. Para conservar a sua solução Web Cloud Databases, deverá desassociá-la **antes** da rescisão do alojamento.
+Os alojamentos web **Performance**, **Agency**, **Agency Plus** e **Agency Max** incluem uma oferta Web Cloud Databases ativável gratuitamente.<br/>
+Quando rescindir ou eliminar o seu alojamento web, a oferta Web Cloud Databases eventualmente associada será igualmente rescindida. Para conservar a sua solução Web Cloud Databases, deverá desassociá-la **antes** da rescisão do alojamento.
 
 Siga estes passos:
 
@@ -314,14 +314,14 @@ Siga estes passos:
 3. Na página que se abrir, na caixa **Configuração**, clique no botão <code className="action">...</code> à direita da menção `Web Cloud Databases` e, a seguir, em <code className="action">Desassociar</code>.
 4. Siga as instruções para encomendar uma oferta Web Cloud Databases independente para conservar a sua solução Web Cloud Databases já criada.
 
-**Esta ação é irreversível e a oferta Web Cloud Databases será faturada independentemente do seu alojamento web Performance.**
+**Esta ação é irreversível e a oferta Web Cloud Databases será faturada independentemente do seu alojamento web.**
 
 </details>
 
 
 <details>
 
-<summary>Como aumentar a RAM de uma oferta "Web Cloud Databases" associada a um alojamento web "Performance"?</summary>
+<summary>Como aumentar a RAM de uma oferta "Web Cloud Databases" associada a um alojamento web Performance, Agency, Agency Plus ou Agency Max?</summary>
 
 
 Siga estes passos:

--- a/docs/pt/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Restaurar o espaço de armazenamento do alojamento web
 description: Saiba como restaurar um ficheiro ou a totalidade do espaço de armazenamento do seu alojamento web
-lastUpdated: 2025-12-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -27,7 +27,7 @@ Quando efetuar um backup de segurança para o seu site e utilizar uma base de da
 ## Requisitos
 
 <Region zones={['eu']}>
-- Ter um [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) (não funciona com um alojamento [Cloud Web](https://www.ovhcloud.com/pt/web-hosting/cloud-web-offer/)).
+- Ter um [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) (não funciona com um alojamento [Cloud Web](https://www.ovhcloud.com/pt/web-hosting/)).
 </Region>
 <Region zones={['ca', 'apac']}>
 - Ter um [alojamento web](https://www.ovhcloud.com/pt/web-hosting/).

--- a/docs/pt/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/multisites-modify-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alojamento web - Alterar um nome de domínio já associado a um alojamento
 description: Saiba como alterar as configurações de associação de um domínio/subdomínio já declarado na sua oferta de alojamento web
-lastUpdated: 2025-11-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -103,7 +103,7 @@ Se indicar um nome de pasta inexistente no espaço de armazenamento FTP do seu a
 
 ##### A opção "Ativar o CDN"
 
-Para poder utilizar esta opção, deve ter previamente subscrito uma oferta CDN da OVHcloud ou dispor de um serviço de alojamento web Performance.
+Para poder utilizar esta opção, deve ter previamente subscrito uma oferta CDN da OVHcloud ou dispor de um serviço de alojamento web Performance, Agency, Agency Plus ou Agency Max.
 
 Selecione/desmarque esta caixa de verificação para ativar/desativar a opção CDN para o seu nome de domínio ou subdomínio.
 

--- a/docs/pt/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/web-hosting-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Como começar bem com o seu alojamento web
 description: "Saiba como publicar um novo site através das nossas opções de \"Módulos 1 clique\", como criar um novo endereço de e-mail personalizado com o seu nome de domínio, tudo graças à nossa solução de alojamento web"
-lastUpdated: 2025-04-07
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -16,7 +16,7 @@ Pretende criar um site para a sua empresa ou um blogue pessoal? Precisa de uma l
 :::info
 - Deseja migrar um site já existente para fornecedor de alojamento? Consulte diretamente o nosso guia dedicado: [Migrar o seu website e os seus serviços associados para a OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh).
 <Region zones={['eu']}>
-- Deseja apenas uma página inicial simples para a sua atividade profissional? Consulte o nosso guia dedicado: [Alojamento web - Ativar alojamento gratuito 100M](/guides/web-cloud/web-hosting/activate-start10m).
+- Deseja apenas uma página inicial simples para a sua atividade profissional? Consulte o nosso guia dedicado: [Alojamento web - Ativar alojamento gratuito](/guides/web-cloud/web-hosting/activate-start10m).
 </Region>
 
 :::
@@ -25,7 +25,7 @@ Pretende criar um site para a sua empresa ou um blogue pessoal? Precisa de uma l
 ## Requisitos
 
 <Region zones={['eu']}>
-- Ter um serviço de [alojamento web OVHcloud](https://www.ovhcloud.com/pt/web-hosting/) com, pelo menos, uma base de dados disponível (exceto a oferta de alojamento gratuita 100M).
+- Ter um serviço de [alojamento web OVHcloud](https://www.ovhcloud.com/pt/web-hosting/) com, pelo menos, uma base de dados disponível (exceto a oferta de alojamento gratuita).
 </Region>
 <Region zones={['ca','apac']}>
 - Ter um serviço de [alojamento web OVHcloud](https://www.ovhcloud.com/pt/web-hosting/) com, pelo menos, uma base de dados disponível.

--- a/docs/pt/guides/web-cloud/web-hosting/website-project.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/website-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Como criar um website - Realizar o seu projeto em 5 etapas
 description: Saiba como definir o seu projeto, publicar o seu website e criar endereços de e-mail com a sua solução de alojamento web
-lastUpdated: 2025-04-25
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -214,7 +214,7 @@ Com os alojamentos web, a OVHcloud propõe 3 ofertas CDN:
 Encontre mais informações sobre as nossas diferentes ofertas CDN no nosso guia "[Guia de utilização do acelerador CDN num alojamento web](/guides/web-cloud/web-hosting/cdn-how-to-use-cdn)".
 
 :::info
-A oferta **CDN Basic** está incluída gratuitamente nos alojamentos web **Performance**.
+A oferta **CDN Basic** está incluída gratuitamente nos alojamentos web **Performance**, **Agency**, **Agency Plus** e **Agency Max**.
 
 Não pode acumular várias ofertas CDN num mesmo alojamento web.
 
@@ -226,7 +226,7 @@ Não pode acumular várias ofertas CDN num mesmo alojamento web.
 
 <summary>Os servidores de bases de dados Web Cloud Databases</summary>
 
-Se dispõe de um alojamento web **Performance**, pode ativar gratuitamente um servidor de base de dados [Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/).
+Se dispõe de um alojamento web **Performance**, **Agency**, **Agency Plus** ou **Agency Max**, pode ativar gratuitamente um servidor de base de dados [Web Cloud Databases](https://www.ovhcloud.com/pt/web-cloud/databases/).
 
 Encontre mais detalhes sobre a sua utilização na nossa documentação "[Web Cloud Databases - primeira utilização](/guides/web-cloud/databases/db-getting-started)".
 


### PR DESCRIPTION
(docs: integrate new web-hosting offer range across multisite & WCDB guides)](docs: integrate new web-hosting offer range across multisite & WCDB guides)

Align offer names to the current range (Eco/Business/Agencies) and drop the obsolete 100M suffix.

Extend WCDB/CDN "included with Performance" mentions to the Agency range (Agency, Plus, Max).

Reformulate stale database-limit wording and neutralize broken offer and legacy links.

Covers 9 multisite web-hosting guides + 9 Web Cloud Databases guides, 7 locales each.