### PR TITLE
docs: drop obsolete 100M suffix and align web-hosting label in DNS zone guides

### DIFF
--- a/docs/de/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Sicherheit durch DKIM-Eintrag verbessern
 description: Erfahren Sie hier, wie Sie einen DKIM-Eintrag für Domainnamen und E-Mail-Dienste bei OVHcloud einrichten
-lastUpdated: 2026-02-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ Der DKIM-Eintrag (**D**omain**K**eys **I**dentified **M**ail) ermöglicht die Si
 
 - Sie verfügen über einen der folgenden E-Mail-Dienste:
     <Region zones={['eu']}>
-    - OVHcloud MX Plan E-Mail, verfügbar mit den Angeboten [Webhosting](https://www.ovhcloud.com/de/web-hosting/), [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/) oder als separater Dienst
+    - OVHcloud MX Plan E-Mail, verfügbar mit den Angeboten [Webhosting](https://www.ovhcloud.com/de/web-hosting/), [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) oder als separater Dienst
     </Region>
     <Region zones={['ca', 'apac']}>
     - OVHcloud MX Plan E-Mail, verfügbar mit dem Angebot [Webhosting](https://www.ovhcloud.com/de/web-hosting/) oder als separater Dienst
@@ -192,7 +192,7 @@ Der Empfänger **recipient@otherdomain.ovh** kann diese Signatur mit dem in der 
 Die automatische DKIM-Konfiguration ist für alle unsere E-Mail-Angebote verfügbar:
 
 <Region zones={['eu']}>
-- MX Plan enthalten in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/), [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/) oder separat bestellt
+- MX Plan enthalten in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/), [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) oder separat bestellt
 </Region>
 <Region zones={['ca', 'apac']}>
 - MX Plan enthalten in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) oder separat bestellt

--- a/docs/de/guides/web-cloud/domains/dns-zone-mx.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zone-mx.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX-Eintrag für die E-Mail-Verwaltung konfigurieren
 description: Erfahren Sie hier, wie Sie mit OVHcloud MX-Einträge für Ihren Domainnamen konfigurieren
-lastUpdated: 2026-03-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ Der Eintrag vom Typ MX legt den für die E-Mail-Adressen eines Domainnamens zust
 - Der Domainname verwendet die OVHcloud Konfiguration (die OVHcloud DNS-Server).
 <Region zones={['eu']}>
 
-- Sie verfügen über einen MX Plan (enthalten in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) oder [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/) oder separat bestellt), einen unserer [OVHcloud E-Mail-Dienste](https://www.ovhcloud.com/de/emails/) oder einen externen E-Mail-Dienst.
+- Sie verfügen über einen MX Plan (enthalten in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) oder [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) oder separat bestellt), einen unserer [OVHcloud E-Mail-Dienste](https://www.ovhcloud.com/de/emails/) oder einen externen E-Mail-Dienst.
 
 </Region>
 

--- a/docs/en/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to improve email security with a DKIM record
 description: Find out how to configure a DKIM record on your OVHcloud domain name and email service
-lastUpdated: 2026-02-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,7 +23,7 @@ The DKIM (**D**omain**K**eys **I**dentified **M**ail) record allows you to sign 
 
 - You have signed up to one of these email offers:
     <Region zones={['eu']}>
-    - OVHcloud MX Plan Email, available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), a [100M free hosting plan](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/), or a separate MX Plan solution
+    - OVHcloud MX Plan Email, available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), a [free hosting plan](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/), or a separate MX Plan solution
     </Region>
     <Region zones={['ca', 'apac']}>
     - OVHcloud MX Plan Email, available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/) or a separate MX Plan solution
@@ -192,10 +192,10 @@ The recipient **recipient@otherdomain.ovh** can decrypt this signature with the 
 Automatic DKIM configuration is available for all our email offers:
 
 <Region zones={['eu']}>
-- MX Plan included with a [Cloud Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/), a [free 100M hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) or ordered separately
+- MX Plan included with a [Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/), a [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) or ordered separately
 </Region>
 <Region zones={['ca', 'apac']}>
-- MX Plan included with a [Cloud Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) or ordered separately
+- MX Plan included with a [Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) or ordered separately
 </Region>
 <Region zones={['eu', 'ca']}>
 - [Exchange](https://www.ovhcloud.com/en-gb/emails-exchange/)

--- a/docs/en/guides/web-cloud/domains/dns-zone-mx.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-mx.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure an MX record for email management
 description: Find out how to configure an MX record on your domain name at OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,7 +23,7 @@ With an MX record, you can link a domain name to the server on your email platfo
 
 <Region zones={['eu']}>
 
-- You have an MX Plan solution (included in the [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), a [free 100M hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/), or the MX Plan solution ordered separately), one of our [OVHcloud email offers](https://www.ovhcloud.com/en-gb/emails/), or an external email service.
+- You have an MX Plan solution (included in the [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), a [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/), or the MX Plan solution ordered separately), one of our [OVHcloud email offers](https://www.ovhcloud.com/en-gb/emails/), or an external email service.
 
 </Region>
 

--- a/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -25,7 +25,7 @@ El registro DKIM (**D**omain**K**eys **I**dentified **M**ail) permite firmar los
 
 - Haber contratado una de las siguientes soluciones de correo electrónico:
     <Region zones={['eu']}>
-    - MX Plan de OVHcloud (disponible a través de un [plan de hosting web](https://www.ovhcloud.com/es-es/web-hosting/), un [alojamiento gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o un MX Plan contratado por separado).
+    - MX Plan de OVHcloud (disponible a través de un [plan de hosting web](https://www.ovhcloud.com/es-es/web-hosting/), un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o un MX Plan contratado por separado).
     </Region>
     <Region zones={['ca', 'apac']}>
     - MX Plan de OVHcloud (disponible a través de un [plan de hosting web](https://www.ovhcloud.com/es-es/web-hosting/) o un MX Plan contratado por separado).
@@ -192,7 +192,7 @@ El destinatario **recipient@otherdomain.ovh** podrá descifrar esta firma con la
 La configuración automática del DKIM está disponible para todas nuestras ofertas de correo electrónico:
 
 <Region zones={['eu']}>
-- MX Plan incluida con un [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/), un [alojamiento gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o adquirida por separado.
+- MX Plan incluida con un [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/), un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o adquirida por separado.
 </Region>
 <Region zones={['ca', 'apac']}>
 - MX Plan incluida con un [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/) o adquirida por separado.

--- a/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mejorar la seguridad del correo electrónico mediante un registro DKIM
 description: Cómo configurar un registro DKIM en un nombre de dominio y una plataforma de correo electrónico de OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,10 +25,10 @@ El registro DKIM (**D**omain**K**eys **I**dentified **M**ail) permite firmar los
 
 - Haber contratado una de las siguientes soluciones de correo electrónico:
     <Region zones={['eu']}>
-    - MX Plan de OVHcloud (disponible a través de un [plan de hosting Web Cloud](https://www.ovhcloud.com/es-es/web-hosting/), un [alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o un MX Plan contratado por separado).
+    - MX Plan de OVHcloud (disponible a través de un [plan de hosting web](https://www.ovhcloud.com/es-es/web-hosting/), un [alojamiento gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o un MX Plan contratado por separado).
     </Region>
     <Region zones={['ca', 'apac']}>
-    - MX Plan de OVHcloud (disponible a través de un [plan de hosting Web Cloud](https://www.ovhcloud.com/es-es/web-hosting/) o un MX Plan contratado por separado).
+    - MX Plan de OVHcloud (disponible a través de un [plan de hosting web](https://www.ovhcloud.com/es-es/web-hosting/) o un MX Plan contratado por separado).
     </Region>
     <Region zones={['eu', 'ca']}>
     - [Exchange](https://www.ovhcloud.com/es-es/emails/hosted-exchange/) o [Private Exchange](https://www.ovhcloud.com/es-es/emails/hosted-exchange/).
@@ -192,10 +192,10 @@ El destinatario **recipient@otherdomain.ovh** podrá descifrar esta firma con la
 La configuración automática del DKIM está disponible para todas nuestras ofertas de correo electrónico:
 
 <Region zones={['eu']}>
-- MX Plan incluida con un [alojamiento Web Cloud](https://www.ovhcloud.com/es-es/web-hosting/), un [alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o adquirida por separado.
+- MX Plan incluida con un [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/), un [alojamiento gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o adquirida por separado.
 </Region>
 <Region zones={['ca', 'apac']}>
-- MX Plan incluida con un [alojamiento Web Cloud](https://www.ovhcloud.com/es-es/web-hosting/) o adquirida por separado.
+- MX Plan incluida con un [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/) o adquirida por separado.
 </Region>
 <Region zones={['eu', 'ca']}>
 - [Exchange](https://www.ovhcloud.com/es-es/emails-exchange/).

--- a/docs/es/guides/web-cloud/domains/dns-zone-mx.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-mx.mdx
@@ -22,7 +22,7 @@ El registro MX permite asociar un nombre de dominio al servidor de su plataforma
 - El nombre de dominio debe utilizar la configuración de OVHcloud (es decir, los servidores DNS de OVHcloud).
 <Region zones={['eu']}>
 
-- Tener una solución MX Plan (incluida en el plan de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/), el [alojamiento gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o la solución MX Plan contratada por separado), una de nuestras [soluciones de correo de OVHcloud](https://www.ovhcloud.com/es-es/emails/) o un servicio de correo externo.
+- Tener una solución MX Plan (incluida en el plan de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/), el [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o la solución MX Plan contratada por separado), una de nuestras [soluciones de correo de OVHcloud](https://www.ovhcloud.com/es-es/emails/) o un servicio de correo externo.
 
 </Region>
 

--- a/docs/es/guides/web-cloud/domains/dns-zone-mx.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-mx.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar un registro MX para la gestión del correo
 description: Descubra cómo configurar un registro MX en un nombre de dominio en OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ El registro MX permite asociar un nombre de dominio al servidor de su plataforma
 - El nombre de dominio debe utilizar la configuración de OVHcloud (es decir, los servidores DNS de OVHcloud).
 <Region zones={['eu']}>
 
-- Tener una solución MX Plan (incluida en el plan de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/), el [alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o la solución MX Plan contratada por separado), una de nuestras [soluciones de correo de OVHcloud](https://www.ovhcloud.com/es-es/emails/) o un servicio de correo externo.
+- Tener una solución MX Plan (incluida en el plan de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/), el [alojamiento gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o la solución MX Plan contratada por separado), una de nuestras [soluciones de correo de OVHcloud](https://www.ovhcloud.com/es-es/emails/) o un servicio de correo externo.
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Améliorer la sécurité des e-mails via un enregistrement DKIM
 description: Découvrez comment configurer un enregistrement DKIM sur votre nom de domaine et votre plateforme e-mail OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,10 +25,10 @@ L'enregistrement DKIM (**D**omain**K**eys **I**dentified **M**ail) permet de sig
 
 - Avoir souscrit à l'une des offres e-mail ci-dessous :
     <Region zones={['eu']}>
-    - MX Plan OVHcloud (disponible via une [offre d’hébergement Web Cloud](https://www.ovhcloud.com/fr/web-hosting/), un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou une offre MX Plan commandée séparément).
+    - MX Plan OVHcloud (disponible via une [offre d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/), un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou une offre MX Plan commandée séparément).
     </Region>
     <Region zones={['ca', 'apac']}>
-    - MX Plan OVHcloud (disponible via une [offre d’hébergement Web Cloud](https://www.ovhcloud.com/fr/web-hosting/) ou une offre MX Plan commandée séparément).
+    - MX Plan OVHcloud (disponible via une [offre d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou une offre MX Plan commandée séparément).
     </Region>
     <Region zones={['eu', 'ca']}>
     - [Exchange](https://www.ovhcloud.com/fr/emails/hosted-exchange/) ou [Private Exchange](https://www.ovhcloud.com/fr/emails/hosted-exchange/).
@@ -192,10 +192,10 @@ Le destinataire **recipient@otherdomain.ovh** pourra déchiffrer cette signature
 La configuration automatique du DKIM est accessible pour toutes nos offres e-mail :
 
 <Region zones={['eu']}>
-- MX Plan incluse avec un [hébergement Web Cloud](https://www.ovhcloud.com/fr/web-hosting/), un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou commandée séparément.
+- MX Plan incluse avec un [hébergement web](https://www.ovhcloud.com/fr/web-hosting/), un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou commandée séparément.
 </Region>
 <Region zones={['ca', 'apac']}>
-- MX Plan incluse avec un [hébergement Web Cloud](https://www.ovhcloud.com/fr/web-hosting/) ou commandée séparément.
+- MX Plan incluse avec un [hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou commandée séparément.
 </Region>
 <Region zones={['eu', 'ca']}>
 - [Exchange](https://www.ovhcloud.com/fr/emails-exchange/).

--- a/docs/fr/guides/web-cloud/domains/dns-zone-mx.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-mx.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer un enregistrement MX pour la gestion des emails
 description: Découvrez comment configurer un enregistrement MX sur votre nom de domaine chez OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,7 +23,7 @@ L'enregistrement MX permet de relier un nom de domaine au serveur de sa platefor
 
 <Region zones={['eu']}>
 
-- Disposer d'une offre MX Plan (incluse dans l'offre d’[hébergement web](https://www.ovhcloud.com/fr/web-hosting/), l'[hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou l'offre MX Plan commandée séparément), une de nos [offres e-mail OVHcloud](https://www.ovhcloud.com/fr/emails/), ou un service e-mail externe.
+- Disposer d'une offre MX Plan (incluse dans l'offre d’[hébergement web](https://www.ovhcloud.com/fr/web-hosting/), l'[hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou l'offre MX Plan commandée séparément), une de nos [offres e-mail OVHcloud](https://www.ovhcloud.com/fr/emails/), ou un service e-mail externe.
 
 </Region>
 

--- a/docs/it/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migliora la sicurezza delle email con un record DKIM
 description: Come configurare un record DKIM sul tuo nome di dominio e sulla tua piattaforma email OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,10 +25,10 @@ Il record DKIM (**D**omain**K**eys **I**dentified **M**ail) permette di firmare 
 
 - Aver sottoscritto una delle soluzioni email disponibili:
     <Region zones={['eu']}>
-    - MX Plan OVHcloud. È disponibile tramite una [offerta di hosting Web Cloud](https://www.ovhcloud.com/it/web-hosting/), un [hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/) o una soluzione MX Plan ordinata separatamente.
+    - MX Plan OVHcloud. È disponibile tramite una [offerta di hosting Web](https://www.ovhcloud.com/it/web-hosting/), un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/) o una soluzione MX Plan ordinata separatamente.
     </Region>
     <Region zones={['ca', 'apac']}>
-    - MX Plan OVHcloud. È disponibile tramite una [offerta di hosting Web Cloud](https://www.ovhcloud.com/it/web-hosting/) o una soluzione MX Plan ordinata separatamente.
+    - MX Plan OVHcloud. È disponibile tramite una [offerta di hosting Web](https://www.ovhcloud.com/it/web-hosting/) o una soluzione MX Plan ordinata separatamente.
     </Region>
     <Region zones={['eu', 'ca']}>
     - [Exchange](https://www.ovhcloud.com/it/emails/hosted-exchange/) o [Private Exchange](https://www.ovhcloud.com/it/emails/hosted-exchange/).
@@ -192,10 +192,10 @@ Il destinatario **recipient@otherdomain.ovh** potrà decifrare questa firma con 
 La configurazione automatica del DKIM è disponibile per tutte le nostre offerte e-mail:
 
 <Region zones={['eu']}>
-- MX Plan inclusa con un [hosting Web Cloud](https://www.ovhcloud.com/it/web-hosting/), un [hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/) o ordinata separatamente.
+- MX Plan inclusa con un [hosting Web](https://www.ovhcloud.com/it/web-hosting/), un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/) o ordinata separatamente.
 </Region>
 <Region zones={['ca', 'apac']}>
-- MX Plan inclusa con un [hosting Web Cloud](https://www.ovhcloud.com/it/web-hosting/) o ordinata separatamente.
+- MX Plan inclusa con un [hosting Web](https://www.ovhcloud.com/it/web-hosting/) o ordinata separatamente.
 </Region>
 <Region zones={['eu', 'ca']}>
 - [Exchange](https://www.ovhcloud.com/it/emails-exchange/).

--- a/docs/it/guides/web-cloud/domains/dns-zone-mx.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zone-mx.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurare un record MX per la gestione delle email
 description: Come configurare un record MX su un nome di dominio in OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ Il record MX permette di collegare un nome di dominio al server della sua piatta
 - Il nome di dominio in questione deve utilizzare la configurazione OVHcloud (ad esempio i server DNS di OVHcloud).
 <Region zones={['eu']}>
 
-- Disporre di una soluzione MX Plan (inclusa nelle soluzioni di [hosting Web](https://www.ovhcloud.com/it/web-hosting/), [hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/) o MX Plan ordinati separatamente), una delle nostre [offerte di posta elettronica OVHcloud](https://www.ovhcloud.com/it/emails/) o un servizio di posta esterna.
+- Disporre di una soluzione MX Plan (inclusa nelle soluzioni di [hosting Web](https://www.ovhcloud.com/it/web-hosting/), [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/) o MX Plan ordinati separatamente), una delle nostre [offerte di posta elettronica OVHcloud](https://www.ovhcloud.com/it/emails/) o un servizio di posta esterna.
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -26,7 +26,7 @@ Wpis DKIM (**D**omain**K**eys **I**dentified **M**ail) pozwala na podpisanie e-m
 - Posiadanie dostępu do interfejsu zarządzania domeną w <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink> lub u operatora domeny, jeśli jest zarejestrowany poza OVHcloud.
 - Zamówienie jednej z poniższych ofert e-mail:
     <Region zones={['eu']}>
-    - MX Plan OVHcloud (dostępny w ramach [oferty hostingu](https://www.ovhcloud.com/pl/web-hosting/), [bezpłatny hosting](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub w ramach oferty MX Plan zamówionej oddzielnie).
+    - MX Plan OVHcloud (dostępny w ramach [oferty hostingu](https://www.ovhcloud.com/pl/web-hosting/), [hosting darmowy](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub w ramach oferty MX Plan zamówionej oddzielnie).
     </Region>
     <Region zones={['ca', 'apac']}>
     - MX Plan OVHcloud (dostępny w ramach [oferty hostingu](https://www.ovhcloud.com/pl/web-hosting/) lub w ramach oferty MX Plan zamówionej oddzielnie).
@@ -193,7 +193,7 @@ Odbiorca **recipient@otherdomain.ovh** będzie mógł odszyfrować ten podpis kl
 Automatyczna konfiguracja DKIM jest dostępna dla wszystkich naszych ofert e-mail:
 
 <Region zones={['eu']}>
-- MX Plan wchodzący w skład [hostingu](https://www.ovhcloud.com/pl/web-hosting/), [darmowego hostingu](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub zamówiony osobno.
+- MX Plan wchodzący w skład [hostingu](https://www.ovhcloud.com/pl/web-hosting/), [hostingu darmowego](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub zamówiony osobno.
 </Region>
 <Region zones={['ca', 'apac']}>
 - MX Plan wchodzący w skład [hostingu](https://www.ovhcloud.com/pl/web-hosting/) lub zamówiony osobno.

--- a/docs/pl/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Poprawa bezpieczeństwa e-maili dzięki rejestracji DKIM
 description: Dowiedz się, jak skonfigurować rekord DKIM w Twojej nazwy domeny i platformie e-mail OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -26,10 +26,10 @@ Wpis DKIM (**D**omain**K**eys **I**dentified **M**ail) pozwala na podpisanie e-m
 - Posiadanie dostępu do interfejsu zarządzania domeną w <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink> lub u operatora domeny, jeśli jest zarejestrowany poza OVHcloud.
 - Zamówienie jednej z poniższych ofert e-mail:
     <Region zones={['eu']}>
-    - MX Plan OVHcloud (dostępny w ramach [oferty hostingu Cloud](https://www.ovhcloud.com/pl/web-hosting/), [bezpłatny hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub w ramach oferty MX Plan zamówionej oddzielnie).
+    - MX Plan OVHcloud (dostępny w ramach [oferty hostingu](https://www.ovhcloud.com/pl/web-hosting/), [bezpłatny hosting](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub w ramach oferty MX Plan zamówionej oddzielnie).
     </Region>
     <Region zones={['ca', 'apac']}>
-    - MX Plan OVHcloud (dostępny w ramach [oferty hostingu Cloud](https://www.ovhcloud.com/pl/web-hosting/) lub w ramach oferty MX Plan zamówionej oddzielnie).
+    - MX Plan OVHcloud (dostępny w ramach [oferty hostingu](https://www.ovhcloud.com/pl/web-hosting/) lub w ramach oferty MX Plan zamówionej oddzielnie).
     </Region>
     <Region zones={['eu', 'ca']}>
     - [Exchange](https://www.ovhcloud.com/pl/emails/hosted-exchange/) lub [Private Exchange](https://www.ovhcloud.com/pl/emails/hosted-exchange/).
@@ -193,10 +193,10 @@ Odbiorca **recipient@otherdomain.ovh** będzie mógł odszyfrować ten podpis kl
 Automatyczna konfiguracja DKIM jest dostępna dla wszystkich naszych ofert e-mail:
 
 <Region zones={['eu']}>
-- MX Plan wchodzący w skład [hostingu Web Cloud](https://www.ovhcloud.com/pl/web-hosting/), [darmowego 100M hostingu](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub zamówiony osobno.
+- MX Plan wchodzący w skład [hostingu](https://www.ovhcloud.com/pl/web-hosting/), [darmowego hostingu](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub zamówiony osobno.
 </Region>
 <Region zones={['ca', 'apac']}>
-- MX Plan wchodzący w skład [hostingu Web Cloud](https://www.ovhcloud.com/pl/web-hosting/) lub zamówiony osobno.
+- MX Plan wchodzący w skład [hostingu](https://www.ovhcloud.com/pl/web-hosting/) lub zamówiony osobno.
 </Region>
 <Region zones={['eu', 'ca']}>
 - [Exchange](https://www.ovhcloud.com/pl/emails-exchange/).

--- a/docs/pl/guides/web-cloud/domains/dns-zone-mx.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-mx.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja rekordu MX dla emaili
 description: Dowiedz się, jak skonfigurować rekord MX dla Twojej nazwy domeny w OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ Rekord MX umożliwia powiązanie nazwy domeny z serwerem platformy e-mail. Jest 
 - Wybrana nazwa domeny musi korzystać z konfiguracji OVHcloud (tzn. z serwerów DNS OVHcloud).
 <Region zones={['eu']}>
 
-- Posiadanie konta e-mail MX Plan (zawartego w pakiecie [hostingowym](https://www.ovhcloud.com/pl/web-hosting/), [bezpłatnym hostingu 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub w ofercie MX Plan zamówionej oddzielnie), jednej z naszych [ofert e-mail OVHcloud](https://www.ovhcloud.com/pl/emails/) lub zewnętrznej usługi e-mail.
+- Posiadanie konta e-mail MX Plan (zawartego w pakiecie [hostingowym](https://www.ovhcloud.com/pl/web-hosting/), [bezpłatnym hostingu](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub w ofercie MX Plan zamówionej oddzielnie), jednej z naszych [ofert e-mail OVHcloud](https://www.ovhcloud.com/pl/emails/) lub zewnętrznej usługi e-mail.
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/domains/dns-zone-mx.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-mx.mdx
@@ -22,7 +22,7 @@ Rekord MX umożliwia powiązanie nazwy domeny z serwerem platformy e-mail. Jest 
 - Wybrana nazwa domeny musi korzystać z konfiguracji OVHcloud (tzn. z serwerów DNS OVHcloud).
 <Region zones={['eu']}>
 
-- Posiadanie konta e-mail MX Plan (zawartego w pakiecie [hostingowym](https://www.ovhcloud.com/pl/web-hosting/), [bezpłatnym hostingu](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub w ofercie MX Plan zamówionej oddzielnie), jednej z naszych [ofert e-mail OVHcloud](https://www.ovhcloud.com/pl/emails/) lub zewnętrznej usługi e-mail.
+- Posiadanie konta e-mail MX Plan (zawartego w pakiecie [hostingowym](https://www.ovhcloud.com/pl/web-hosting/), [hostingu darmowym](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub w ofercie MX Plan zamówionej oddzielnie), jednej z naszych [ofert e-mail OVHcloud](https://www.ovhcloud.com/pl/emails/) lub zewnętrznej usługi e-mail.
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Melhorar a segurança dos e-mails através do registo DKIM
 description: Saiba como configurar um registo DKIM no seu nome de domínio e na sua plataforma de e-mail OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,10 +25,10 @@ O registo DKIM (**D**omain**K**eys **I**dentified **M**ail) permite assinar os e
 
 - Ter adquirido uma das ofertas de correio eletrónico abaixo:
     <Region zones={['eu']}>
-    - MX Plan OVHcloud (disponível através de uma [oferta de alojamento Web Cloud](https://www.ovhcloud.com/pt/web-hosting/), um [alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou uma oferta MX Plan encomendada separadamente).
+    - MX Plan OVHcloud (disponível através de uma [oferta de alojamento web](https://www.ovhcloud.com/pt/web-hosting/), um [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou uma oferta MX Plan encomendada separadamente).
     </Region>
     <Region zones={['ca', 'apac']}>
-    - MX Plan OVHcloud (disponível através de uma [oferta de alojamento Web Cloud](https://www.ovhcloud.com/pt/web-hosting/) ou uma oferta MX Plan encomendada separadamente).
+    - MX Plan OVHcloud (disponível através de uma [oferta de alojamento web](https://www.ovhcloud.com/pt/web-hosting/) ou uma oferta MX Plan encomendada separadamente).
     </Region>
     <Region zones={['eu', 'ca']}>
     - [Exchange](https://www.ovhcloud.com/pt/emails/hosted-exchange/) ou [Private Exchange](https://www.ovhcloud.com/pt/emails/hosted-exchange/).
@@ -192,10 +192,10 @@ O destinatário **recipient@otherdomain.ovh** poderá decifrar esta assinatura c
 A configuração automática do DKIM está disponível para todas as nossas ofertas de correio eletrónico:
 
 <Region zones={['eu']}>
-- MX Plan incluída com um [alojamento Web Cloud](https://www.ovhcloud.com/pt/web-hosting/), um [alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou adquirida separadamente.
+- MX Plan incluída com um [alojamento web](https://www.ovhcloud.com/pt/web-hosting/), um [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou adquirida separadamente.
 </Region>
 <Region zones={['ca', 'apac']}>
-- MX Plan incluída com um [alojamento Web Cloud](https://www.ovhcloud.com/pt/web-hosting/) ou adquirida separadamente.
+- MX Plan incluída com um [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) ou adquirida separadamente.
 </Region>
 <Region zones={['eu', 'ca']}>
 - [Exchange](https://www.ovhcloud.com/pt/emails-exchange/).

--- a/docs/pt/guides/web-cloud/domains/dns-zone-mx.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zone-mx.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar um registo MX para a gestão dos e-mails
 description: Saiba como configurar um registo MX no seu nome de domínio da OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ O registo MX permite associar um nome de domínio ao servidor da sua plataforma 
 - O nome de domínio em questão deve utilizar a configuração da OVHcloud (ou seja, os servidores DNS da OVHcloud).
 <Region zones={['eu']}>
 
-- Dispor de uma oferta MX Plan (incluída na oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/), no [alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou na oferta MX Plan encomendada separadamente), uma das nossas [ofertas de e-mail OVHcloud](https://www.ovhcloud.com/pt/emails/), ou um serviço de e-mail externo.
+- Dispor de uma oferta MX Plan (incluída na oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/), no [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou na oferta MX Plan encomendada separadamente), uma das nossas [ofertas de e-mail OVHcloud](https://www.ovhcloud.com/pt/emails/), ou um serviço de e-mail externo.
 
 </Region>
 


### PR DESCRIPTION


Remove the obsolete "100M" suffix from the free-hosting link label in dns-zone-dkim

and dns-zone-mx, and harmonize the web-hosting offer label ("Web Cloud" to plain web

hosting), across 7 locales. Free-hosting mention kept EU-only.