### PR TITLE
docs: drop obsolete 100M suffix from free-hosting mentions in email guides

### DIFF
--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -1,7 +1,7 @@
 ---
 title: Löschen eines E-Mail-Accounts
 description: Erfahren Sie hier, wie Sie einen Account Ihrer E-Mail-Lösung löschen oder zurücksetzen
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ Sie möchten:
 
 - Sie verfügen über eine bereits konfigurierte OVHcloud E-Mail-Lösung:
     <Region zones={['eu']}>
-    - **MX Plan** (enthalten in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) oder [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/) oder separat bestellt).
+    - **MX Plan** (enthalten in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) oder [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) oder separat bestellt).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** (enthalten in einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) oder separat bestellt).

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail Alias und Weiterleitung verwenden
 description: Erfahren Sie hier, wie Sie E-Mail Aliase und Weiterleitungen verwalten
-lastUpdated: 2025-06-03
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -91,7 +91,7 @@ Es ist möglich, eine Weiterleitung auf mehrere E-Mail-Adressen einzurichten. Da
 
 - Sie verfügen über eine vorkonfigurierte OVHcloud E-Mail-Lösung, darunter:
     <Region zones={['eu']}>
-    - **MX Plan** mit unseren [Webhosting Angeboten](https://www.ovhcloud.com/de/web-hosting/) oder in einem [100M Gratis-Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) inklusive.
+    - **MX Plan** mit unseren [Webhosting Angeboten](https://www.ovhcloud.com/de/web-hosting/) oder in einem [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) inklusive.
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** mit unseren [Webhosting Angeboten](https://www.ovhcloud.com/de/web-hosting/) inklusive.

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Passwort eines E-Mail-Accounts ändern
 description: Erfahren Sie hier, wie Sie das Passwort eines OVHcloud E-Mail-Accounts ändern
-lastUpdated: 2025-08-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ Die Accounts Ihrer OVHcloud E-Mail-Dienste sind nur mit dem zugehörigen Passwor
 
 - Sie verfügen über eine vorkonfigurierte OVHcloud E-Mail-Lösung, darunter:
     <Region zones={['eu']}>
-    - **MX Plan** mit unseren [Webhosting Angeboten](https://www.ovhcloud.com/de/web-hosting/) oder in einem [100M Gratis-Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) inklusive.
+    - **MX Plan** mit unseren [Webhosting Angeboten](https://www.ovhcloud.com/de/web-hosting/) oder in einem [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) inklusive.
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** mit unseren [Webhosting Angeboten](https://www.ovhcloud.com/de/web-hosting/).

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Accounts mit MX Plan erstellen
 description: Erfahren Sie hier, wie Sie einen MX Plan E-Mail-Account erstellen
-lastUpdated: 2025-08-26
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ Sie haben gerade eine MX Plan E-Mail-Lösung erworben. Diese bietet Ihnen E-Mail
 - Sie verfügen über ein MX Plan Angebot. Dieses ist verfügbar über:
     - Ein [Webhosting](https://www.ovhcloud.com/de/web-hosting/).
     <Region zones={['eu']}>
-    - Ein aktiviertes [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/), inklusive mit einem Domainnamen.
+    - Ein aktiviertes [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/), inklusive mit einem Domainnamen.
     </Region>
     - Ein separat bestelltes MX Plan Angebot.
 
@@ -32,7 +32,7 @@ Sie haben gerade eine MX Plan E-Mail-Lösung erworben. Diese bietet Ihnen E-Mail
 **Sonderfälle**
 
 <Region zones={['eu']}>
-- Hinweis zu Kostenloses Hosting 100M: Es muss zuerst [aktiviert werden](/guides/web-cloud/web-hosting/activate-start10m), um einen E-Mail-Account zu erstellen. Sie können diese Operation über Ihr <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> durchführen, indem Sie die betreffende Domain auswählen.
+- Hinweis zu Kostenloses Hosting: Es muss zuerst [aktiviert werden](/guides/web-cloud/web-hosting/activate-start10m), um einen E-Mail-Account zu erstellen. Sie können diese Operation über Ihr <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> durchführen, indem Sie die betreffende Domain auswählen.
 </Region>
 - Bei einem Webhosting muss der [inkludierte MX Plan aktiviert werden](https://www.ovhcloud.com/de/web-hosting/), bevor Sie die übrigen Schritte dieser Anleitung durchführen. Lesen Sie hierzu unsere Anleitung zur [Aktivierung der im Webhosting enthaltenen E-Mail-Accounts](/guides/web-cloud/web-hosting/activate-email-hosting).
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Erste Schritte mit MX Plan
 description: Erfahren Sie hier, wie Sie Ihr MX Plan Angebot verwenden
-lastUpdated: 2026-03-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ Mit der MX Plan Lösung verfügen Sie über E-Mail-Adressen, mit denen Sie Nachr
 ## Voraussetzungen
 
 <Region zones={['eu']}>
-- Sie verfügen über ein MX Plan Angebot, entweder in einem [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) enthalten, separat bestellt, oder enthalten in [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/).
+- Sie verfügen über ein MX Plan Angebot, entweder in einem [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) enthalten, separat bestellt, oder enthalten in [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/).
 </Region>
 
 <Region zones={['ca', 'apac']}>

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -1,6 +1,6 @@
 ---
 title: Verwendung Ihres E-Mail-Accounts mit Roundcube Webmail
-lastUpdated: 2026-06-01
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -12,7 +12,7 @@ Mit der OVHcloud MX Plan Lösung können Sie E-Mails über eine Drittanbieter-So
 
 ## Voraussetzungen
 
-- Sie verfügen über eine OVHcloud E-Mail-Lösung **MX Plan**, die in unseren [Webhosting-Angeboten](/links/web/hosting) enthalten ist, in einem [kostenlosen Hosting-Angebot 100M](/links/web/domains-free-hosting) inbegriffen ist oder separat als eigenständige Lösung bestellt wurde.
+- Sie verfügen über eine OVHcloud E-Mail-Lösung **MX Plan**, die in unseren [Webhosting-Angeboten](/links/web/hosting) enthalten ist, in einem [kostenlosen Hosting-Angebot](/links/web/domains-free-hosting) inbegriffen ist oder separat als eigenständige Lösung bestellt wurde.
 - Sie verfügen über die Logindaten der MX Plan E-Mail-Adresse, die Sie verwenden möchten. Weitere Informationen finden Sie in unserer Anleitung [Erste Schritte mit der MX Plan Lösung](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Ihre OVHcloud E-Mail-Lösung **MX Plan** muss die Webmail-Technologie **Roundcube** verwenden. Folgen Sie den nachstehenden Anweisungen, um dies zu identifizieren.
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zimbra Webmail verwenden
 description: Erfahren Sie hier, wie Sie das Zimbra Webmail-Interface mit OVHcloud MX Plan E-Mail-Accounts verwenden
-lastUpdated: 2026-02-26
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -19,7 +19,7 @@ OVHcloud bietet den Webmail-Dienst Zimbra an, um auf MX Plan E-Mail-Accounts zuz
 
 ## Voraussetzungen
 
-- Sie verfügen über ein **MX Plan** Angebot, entweder in einem [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) enthalten, separat bestellt, oder enthalten in [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/).
+- Sie verfügen über ein **MX Plan** Angebot, entweder in einem [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) enthalten, separat bestellt, oder enthalten in [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/).
 - Sie verfügen über die Logindaten des MX Plan E-Mail-Accounts, den Sie verwenden möchten. Weitere Informationen finden Sie in unserer Anleitung "[Erste Schritte mit MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)".
 
 ## In der praktischen Anwendung

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Einrichten von Auto-Antworten für E-Mails
 description: Erfahren Sie hier, wie Sie E-Mail-Responder für E-Mail-Adressen einrichten
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -17,7 +17,7 @@ Mit diesem OVHcloud Feature können Sie einen E-Mail-Responder einrichten, der a
 
 <Region zones={['eu']}>
 
-- Sie verfügen über einen MX Plan, als E-Mail-Dienst enthalten in einem [OVHcloud Webhosting-Angebot](https://www.ovhcloud.com/de/web-hosting/) oder [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/), oder als eigenständige Lösung bestellbar.
+- Sie verfügen über einen MX Plan, als E-Mail-Dienst enthalten in einem [OVHcloud Webhosting-Angebot](https://www.ovhcloud.com/de/web-hosting/) oder [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/), oder als eigenständige Lösung bestellbar.
 
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Die Verwaltung Ihrer E-Mail-Accounts einer anderen Person übertragen
 description: Erfahren Sie hier, wie Sie die Verwaltung der E-Mail-Accounts Ihres MX Plan Angebots delegieren
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ Die Delegation gibt dem Benutzer eines E-Mail-Accounts die Möglichkeit, verschi
 
 <Region zones={['eu']}>
 
-- Sie verfügen über ein MX Plan Angebot, entweder in einem [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) enthalten, separat bestellt, oder enthalten in [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/).
+- Sie verfügen über ein MX Plan Angebot, entweder in einem [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) enthalten, separat bestellt, oder enthalten in [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/).
 
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan / Zimbra Starter - Konfigurieren Sie Ihre E-Mail-Adresse auf klassischem Outlook für Windows
 description: Erfahren Sie, wie Sie Ihre MX Plan E-Mail-Adresse mit dem klassischen Outlook für Windows konfigurieren
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,7 +23,7 @@ Die E-Mail-Adressen der Angebote **MX Plan** und [Zimbra](https://www.ovhcloud.c
 
 - Sie benötigen eine OVHcloud E-Mail-Lösung, wie:
     <Region zones={['eu']}>
-    - **MX Plan**, angeboten mit unseren [Webhostings](https://www.ovhcloud.com/de/web-hosting/) oder enthalten in [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/).
+    - **MX Plan**, angeboten mit unseren [Webhostings](https://www.ovhcloud.com/de/web-hosting/) oder enthalten in [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan**, angeboten mit unseren [Webhostings](https://www.ovhcloud.com/de/web-hosting/).

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - E-Mail-Account in Thunderbird für macOS konfigurieren
 description: Erfahren Sie, wie Sie Ihre MX Plan E-Mail-Adresse in Thunderbird für macOS konfigurieren
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,7 +20,7 @@ MX Plan E-Mail-Accounts können auf verschiedenen kompatiblen E-Mail-Clients ein
 - Sie verwenden einen MX Plan E-Mail-Account. Dies ist der Fall für die folgenden Dienstleistungen:
 	<Region zones={['eu']}>
 	- [Webhosting](https://www.ovhcloud.com/de/web-hosting/) (inkludiert in allen Angeboten)
-	- [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/) (inkludiert bei Bestellung eines Domainnamens)
+	- [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) (inkludiert bei Bestellung eines Domainnamens)
 	- Separat abonnierter MX Plan Dienst
 	- [Zimbra Starter E-Mail-Account](https://www.ovhcloud.com/de/emails/zimbra-emails/)
 	</Region>

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan – E-Mail-Account in Thunderbird für Windows konfigurieren
 description: Erfahren Sie, wie Sie Ihre MX Plan E-Mail-Adresse in Thunderbird für Windows konfigurieren
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,7 +20,7 @@ MX Plan E-Mail-Accounts können auf verschiedenen kompatiblen E-Mail-Clients ein
 - Sie verwenden einen MX Plan E-Mail-Account. Dies ist der Fall für die folgenden Dienstleistungen:
 	<Region zones={['eu']}>
 	- [Webhosting](https://www.ovhcloud.com/de/web-hosting/) (inkludiert in allen Angeboten)
-	- [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/) (inkludiert bei Bestellung eines Domainnamens)
+	- [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) (inkludiert bei Bestellung eines Domainnamens)
 	- Separat abonnierter MX Plan Dienst
 	- [Zimbra Starter E-Mail-Account](https://www.ovhcloud.com/de/emails/zimbra-emails/)
 	</Region>

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan / Zimbra Starter - Konfigurieren eines E-Mail-Accounts im neuen Outlook für Windows
 description: Erfahren Sie, wie Sie Ihre E-Mail-Adresse im neuen Outlook für Windows konfigurieren
-lastUpdated: 2026-01-09
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ Das **neue Outlook** ersetzt die **Mail**-Anwendung in Windows seit dem 1. Janua
 
 - Sie benötigen eine OVHcloud E-Mail-Lösung, wie:
     <Region zones={['eu']}>
-    - **MX Plan**, angeboten mit unseren [Webhostings](https://www.ovhcloud.com/de/web-hosting/) oder enthalten in [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/).
+    - **MX Plan**, angeboten mit unseren [Webhostings](https://www.ovhcloud.com/de/web-hosting/) oder enthalten in [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan**, angeboten mit unseren [Webhostings](https://www.ovhcloud.com/de/web-hosting/).

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -1,7 +1,7 @@
 ---
 title: Die aus Ihrem E-Mail-Account gelöschten Elemente wiederherstellen
 description: Erfahren Sie hier, wie Sie gelöschte Elemente Ihres E-Mail-Accounts über Webmail (OWA) wiederherstellen
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -19,7 +19,7 @@ Sie haben versehentlich ein oder mehrere Elemente (E-Mail, Kontakt, Kalender) ge
  
 - Sie haben eine OVHcloud E-Mail-Lösung:
     <Region zones={['eu']}>
-    - **MX Plan** ([nur neue Version](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)), enthalten in unseren [Webhosting-Angeboten](https://www.ovhcloud.com/de/web-hosting/) oder in [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/)
+    - **MX Plan** ([nur neue Version](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)), enthalten in unseren [Webhosting-Angeboten](https://www.ovhcloud.com/de/web-hosting/) oder in [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/)
     </Region>
     <Region zones={['ca']}>
     - **MX Plan** ([nur neue Version](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)), enthalten in unseren [Webhosting-Angeboten](https://www.ovhcloud.com/de/web-hosting/)

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: Speicherplatz eines E-Mail-Accounts verwalten
 description: Erfahren Sie hier, wie Sie den Speicherplatz von E-Mail-Accounts verwalten und optimieren
-lastUpdated: 2025-08-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ Jeder OVHcloud E-Mail-Account verfügt über einen dedizierten Speicherplatz. Ei
 
 - Sie verfügen über eine vorkonfigurierte OVHcloud E-Mail-Lösung, darunter:
     <Region zones={['eu']}>
-    - **MX Plan** mit unseren [Webhosting Angeboten](https://www.ovhcloud.com/de/web-hosting/) oder in einem [100M Gratis-Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) inklusive.
+    - **MX Plan** mit unseren [Webhosting Angeboten](https://www.ovhcloud.com/de/web-hosting/) oder in einem [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) inklusive.
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** mit unseren [Webhosting Angeboten](https://www.ovhcloud.com/de/web-hosting/) inklusive.
@@ -68,7 +68,7 @@ Jeder OVHcloud E-Mail-Account verfügt über einen dedizierten Speicherplatz. Ei
 **Sonderfälle**
 
 <Region zones={['eu']}>
-- Hinweis zu Kostenloses Hosting 100M: Dieses muss zuerst aktiviert werden, um einen E-Mail-Account zu erstellen. Sie können diese Operation über Ihr <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> durchführen, indem Sie den betreffenden Domainnamen aufrufen.
+- Hinweis zu Kostenloses Hosting: Dieses muss zuerst aktiviert werden, um einen E-Mail-Account zu erstellen. Sie können diese Operation über Ihr <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> durchführen, indem Sie den betreffenden Domainnamen aufrufen.
 </Region>
 - Bei einem [Webhosting](https://www.ovhcloud.com/de/web-hosting/) müssen Sie den zugehörigen MX Plan aktivieren, bevor Sie mit dieser Anleitung fortfahren. Lesen Sie hierzu unsere Anleitung "[Die in Ihrem Webhosting enthaltenen E-Mail-Accounts aktivieren](/guides/web-cloud/web-hosting/activate-email-hosting)".
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
@@ -1,7 +1,7 @@
 ---
 title: Posteingangsregeln in OWA erstellen
 description: Erfahren Sie hier, wie Sie E-Mail-Weiterleitungen und Eingangsfilter in OWA verwenden
-lastUpdated: 2020-03-11
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -16,7 +16,7 @@ Unter der Option „Posteingangsregeln“ können Sie ein umfangreiches Regelwer
 ## Voraussetzungen
 
 <Region zones={['eu']}>
-- Sie haben bereits einen OVHcloud E-Mail-Dienst eingerichtet ([**Exchange**](https://www.ovhcloud.com/de/emails/), [**E-Mail Pro**](https://www.ovhcloud.com/de/emails/email-pro/) oder **MX Plan**, aus dem MX Plan Angebot oder enthalten in [OVHcloud Webhostings](https://www.ovhcloud.com/de/web-hosting/) und [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/)).
+- Sie haben bereits einen OVHcloud E-Mail-Dienst eingerichtet ([**Exchange**](https://www.ovhcloud.com/de/emails/), [**E-Mail Pro**](https://www.ovhcloud.com/de/emails/email-pro/) oder **MX Plan**, aus dem MX Plan Angebot oder enthalten in [OVHcloud Webhostings](https://www.ovhcloud.com/de/web-hosting/) und [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/)).
 - Sie verfügen über Anmeldeinformationen für die E-Mail-Adresse, die Sie konfigurieren möchten.
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Adresse über das Webmail Outlook Web App (OWA) verwenden
 description: Erfahren Sie, wie Sie Ihre E-Mail-Adresse über das Webmail OWA verwenden
-lastUpdated: 2026-05-04
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -30,7 +30,7 @@ Alle aktiven E-Mail-Accounts auf MX Plan teilen sich einen einzigen Zugangspunkt
 
 - Sie verfügen über eine bereits eingerichtete OVHcloud E-Mail-Lösung aus den folgenden Angeboten:
     <Region zones={['eu']}>
-    - [**MX Plan**](https://www.ovhcloud.com/de/web-hosting/), verfügbar mit unseren Webhosting-Angeboten, im [100M Free Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) enthalten oder als eigenständige Lösung bestellt;
+    - [**MX Plan**](https://www.ovhcloud.com/de/web-hosting/), verfügbar mit unseren Webhosting-Angeboten, im [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) enthalten oder als eigenständige Lösung bestellt;
     </Region>
     <Region zones={['ca', 'apac']}>
     - [**MX Plan**](https://www.ovhcloud.com/de/web-hosting/), verfügbar mit unseren Webhosting-Angeboten oder als eigenständige Lösung bestellt;

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
@@ -1,7 +1,7 @@
 ---
 title: Einrichten einer automatischen Antwort in OWA
 description: Erfahren Sie hier, wie Sie automatische Antworten in OWA erstellen
-lastUpdated: 2024-10-22
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -29,7 +29,7 @@ Mit dieser Exchange-Funktion können Sie für verschiedene Anwendungsfälle auto
 
 :::warning
 <Region zones={['eu']}>
-Wenn Ihre E-Mail-Adresse mit einem **MX Plan** (in [Webhosting](https://www.ovhcloud.com/de/web-hosting/) und [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/) inklusive) verbunden ist, enthält Ihr Kundencenter einen Bereich mit dem Titel <code className="action">Verwaltung der Auto-Antworten</code>. In diesem Fall erstellen Sie automatische Antworten in Ihrem OVHcloud Kundencenter. Nutzen Sie dazu die Dokumentation [„MX Plan - Eine automatische Antwort für eine E-Mail-Adresse erstellen“](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).
+Wenn Ihre E-Mail-Adresse mit einem **MX Plan** (in [Webhosting](https://www.ovhcloud.com/de/web-hosting/) und [Kostenloses Hosting](https://www.ovhcloud.com/de/domains/free-web-hosting/) inklusive) verbunden ist, enthält Ihr Kundencenter einen Bereich mit dem Titel <code className="action">Verwaltung der Auto-Antworten</code>. In diesem Fall erstellen Sie automatische Antworten in Ihrem OVHcloud Kundencenter. Nutzen Sie dazu die Dokumentation [„MX Plan - Eine automatische Antwort für eine E-Mail-Adresse erstellen“](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).
 </Region>
 <Region zones={['ca']}>
 Wenn Ihre E-Mail-Adresse mit einem **MX Plan** (in [Webhosting](https://www.ovhcloud.com/de/web-hosting/) inklusive) verbunden ist, enthält Ihr Kundencenter einen Bereich mit dem Titel <code className="action">Verwaltung der Auto-Antworten</code>. In diesem Fall erstellen Sie automatische Antworten in Ihrem OVHcloud Kundencenter. Nutzen Sie dazu die Dokumentation [„MX Plan - Eine automatische Antwort für eine E-Mail-Adresse erstellen“](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deleting an email account
 description: Find out how to delete or reset an email account of your email solution
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ You want to:
 
 - A preconfigured OVHcloud email solution:
     <Region zones={['eu']}>
-    - **MX Plan**, available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), included in a [100M free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/), or ordered separately.
+    - **MX Plan**, available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), included in a [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/), or ordered separately.
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan**, available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), or ordered separately.

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Using email aliases and redirections
 description: Find out how to manage aliases and email redirections
-lastUpdated: 2025-06-03
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -91,7 +91,7 @@ Note that you can configure redirections to multiple email addresses. To do this
 
 - A preconfigured OVHcloud email solution:
     <Region zones={['eu']}>
-    - **MX Plan** available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), or included in a [100M free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/).
+    - **MX Plan** available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), or included in a [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/).

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Changing the password of an email account
 description: Find out how to change the password for an OVHcloud email account
-lastUpdated: 2025-08-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ You can access your OVHcloud email accounts using the password associated with t
 - Access to the email account via [webmail](https://www.ovhcloud.com/en-gb/mail/), depending on the method used.
 - A preconfigured OVHcloud email solution:
     <Region zones={['eu']}>
-    - **MX Plan** available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), or included in a [100M free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/).
+    - **MX Plan** available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), or included in a [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/).

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creating an email address with an MX Plan solution
 description: Find out how to create an email address with an MX Plan solution
-lastUpdated: 2025-08-26
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ You have just purchased an MX Plan email solution. It allows you to benefit from
 - An MX Plan solution. This is available via:
     - A [Web Hosting](https://www.ovhcloud.com/en-gb/web-hosting/) offer.
     <Region zones={['eu']}>
-    - A [100M free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) included with a domain name (activated beforehand).
+    - A [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) included with a domain name (activated beforehand).
     </Region>
     - An MX Plan solution ordered separately.
 
@@ -43,7 +43,7 @@ You have just purchased an MX Plan email solution. It allows you to benefit from
 **Special cases**
 
 <Region zones={['eu']}>
-- Regarding the 100M free hosting solution, you will need to [activate it](/guides/web-cloud/web-hosting/activate-start10m) in order to create an email account. You can do this from your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> by selecting the domain name concerned.
+- Regarding the free hosting solution, you will need to [activate it](/guides/web-cloud/web-hosting/activate-start10m) in order to create an email account. You can do this from your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> by selecting the domain name concerned.
 </Region>
 - For [Web Hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/), you will need to activate your MX Plan package before continuing to follow this guide. To do this, please refer to our guide on [Activating the email addresses included in your web hosting plan](/guides/web-cloud/web-hosting/activate-email-hosting).
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting started with the MX Plan solution
 description: Find out how to get started with an MX Plan solution
-lastUpdated: 2026-03-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ If you have just purchased an MX Plan solution, this means you have email addres
 ## Requirements
 
 <Region zones={['eu']}>
-- An MX plan solution, available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), a [100M free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/), or ordered separately
+- An MX plan solution, available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), a [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/), or ordered separately
 </Region>
 
 <Region zones={['ca', 'apac']}>

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using your email account via the Roundcube webmail interface
-lastUpdated: 2026-06-01
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -15,7 +15,7 @@ With the OVHcloud MX Plan solution, you can send and receive emails from third-p
 
 ## Requirements
 
-- An OVHcloud **MX Plan** email solution, included in our [web hosting plans](/links/web/hosting), included with a [100M free hosting plan](/links/web/domains-free-hosting), or ordered separately as a standalone solution.
+- An OVHcloud **MX Plan** email solution, included in our [web hosting plans](/links/web/hosting), included with a [free hosting plan](/links/web/domains-free-hosting), or ordered separately as a standalone solution.
 - Access to the login details for the MX Plan email address you want to consult. For more information, see our guide [Getting started with the MX Plan solution](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Your OVHcloud **MX Plan** email solution must use the **Roundcube** webmail technology. To identify it, follow the instructions below.
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to use Zimbra webmail
 description: Discover the Zimbra webmail interface for your OVHcloud MX Plan email accounts
-lastUpdated: 2026-02-26
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -22,7 +22,7 @@ OVHcloud provides a webmail service called Zimbra to access MX Plan email accoun
 
 ## Requirements
 
-- You have an OVHcloud **MX Plan** email solution, included in our [web hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/), included in a [100M free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) hosting plan, or ordered separately as a standalone solution.
+- You have an OVHcloud **MX Plan** email solution, included in our [web hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/), included in a [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) hosting plan, or ordered separately as a standalone solution.
 - You have the login details for the MX Plan email account you would like to use. For more information, please read our guide on [Getting started with the MX Plan solution](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 
 ## Instructions

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - How to create an automatic reply on an email address
 description: Find out how to set up an automatic reply on an email address
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -17,7 +17,7 @@ This OVHcloud feature allows you to set up an automatic email responder (auto-re
 
 <Region zones={['eu']}>
 
-- An OVHcloud MX Plan, available as part of our [web hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/), the [100M free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) included with a domain name (activated in advance), or ordered separately as a standalone solution
+- An OVHcloud MX Plan, available as part of our [web hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/), the [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) included with a domain name (activated in advance), or ordered separately as a standalone solution
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Delegating the management of your email accounts to another person
 description: Find out how to delegate the management of email accounts for your MX Plan solution
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ By creating a delegation, you can enable an email account user to manage their o
 
 <Region zones={['eu']}>
 
-- an MX Plan solution, available as part of our [Web Hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/), the [100M free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/), or ordered separately as a standalone solution
+- an MX Plan solution, available as part of our [Web Hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/), the [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/), or ordered separately as a standalone solution
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Setting up your e-mail address on Classic Outlook for Windows
 description: Find out how to configure your MX Plan email address in Classic Outlook for Windows
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,7 +23,7 @@ Email addresses from the **MX Plan** and [Zimbra Starter](https://www.ovhcloud.c
 
 - Have an OVHcloud email solution already configured, from the following:
     <Region zones={['eu']}>
-    - **MX Plan** offered with our [web hosting offers](https://www.ovhcloud.com/en-gb/web-hosting/) or included in a [free 100M hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/).
+    - **MX Plan** offered with our [web hosting offers](https://www.ovhcloud.com/en-gb/web-hosting/) or included in a [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** offered with our [web hosting offers](https://www.ovhcloud.com/en-gb/web-hosting/).

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Configure your email account on Thunderbird for macOS
 description: Find out how to configure your MX Plan email address on Thunderbird for macOS
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ MX Plan email accounts can be configured on different compatible email clients. 
 - You are using an MX Plan email account. This applies to the following services:
     <Region zones={['eu']}>
     - [Web hosting](https://www.ovhcloud.com/en-gb/web-hosting/) (included in all offers)
-    - [Free 100M hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) (included with a domain name subscription)
+    - [Free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) (included with a domain name subscription)
     - A separately ordered MX Plan service
     - A [Zimbra Starter email account](https://www.ovhcloud.com/en-gb/emails/zimbra-emails/)
     </Region>

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Setting up your email account on Thunderbird for Windows
 description: Find out how to set up your MX Plan email address on Thunderbird for Windows
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ MX Plan email accounts can be configured on compatible email clients. This allow
 - You are using an MX Plan email account. This applies to the following services:
 	<Region zones={['eu']}>
 	- [Web hosting](https://www.ovhcloud.com/en-gb/web-hosting/) (included in all offers)
-	- [Free 100M hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) (included with a domain name subscription)
+	- [Free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) (included with a domain name subscription)
 	- A separately ordered MX Plan service
 	- A [Zimbra Starter email account](https://www.ovhcloud.com/en-gb/emails/zimbra-emails/)
 	</Region>

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - How to add an email account to the New Outlook for Windows
 description: Find out how to configure your MX Plan email address on the New Outlook for Windows
-lastUpdated: 2026-01-09
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ The **New Outlook** replaces the **Mail** application on Windows starting from J
 
 - You have an OVHcloud email solution such as:
     <Region zones={['eu']}>
-    - **MX Plan** offered with our [web hosting services](https://www.ovhcloud.com/en-gb/web-hosting/) or included in a [free 100M hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/).
+    - **MX Plan** offered with our [web hosting services](https://www.ovhcloud.com/en-gb/web-hosting/) or included in a [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** offered with our [web hosting services](https://www.ovhcloud.com/en-gb/web-hosting/).

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -1,7 +1,7 @@
 ---
 title: Restoring deleted items from your email account
 description: Find out how to restore deleted items from your email account via webmail (OWA)
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -19,7 +19,7 @@ You have mistakenly deleted one or more items (email, contact, calendar appointm
  
 - An OVHcloud email solution:
     <Region zones={['eu']}>
-    - **MX Plan** ([new version only](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)), available as part of our [web hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/) or included in a [100M free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/)
+    - **MX Plan** ([new version only](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)), available as part of our [web hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/) or included in a [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/)
     </Region>
     <Region zones={['ca']}>
     - **MX Plan** ([new version only](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)), available as part of our [web hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/)

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: Managing the storage space for an email account
 description: Find out how to manage and optimise an email account storage space
-lastUpdated: 2025-08-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ Every OVHcloud email account has a dedicated storage space. By managing your sto
 
 - A preconfigured OVHcloud email solution:
     <Region zones={['eu']}>
-    - **MX Plan** available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), or included in a [100M free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/).
+    - **MX Plan** available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/), or included in a [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** available with a [web hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/).
@@ -68,7 +68,7 @@ Every OVHcloud email account has a dedicated storage space. By managing your sto
 **Special cases**
 
 <Region zones={['eu']}>
-- Regarding the 100M free hosting solution, you will need to activate it beforehand in order to create an email account. You can do this from your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> by going to the domain name concerned.
+- Regarding the free hosting solution, you will need to activate it beforehand in order to create an email account. You can do this from your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> by going to the domain name concerned.
 </Region>
 - For [web hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/), you will need to activate your MX Plan before continuing with this guide. To do this, please refer to our guide on [Activating the email addresses included in your web hosting plan](/guides/web-cloud/web-hosting/activate-email-hosting).
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creating inbox rules in OWA (MX Plan)
 description: Find out how to create email redirections and filters using OWA
-lastUpdated: 2020-03-11
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -16,7 +16,7 @@ With the "Inbox rules" option, you can create an elaborate set of rules to handl
 ## Requirements
 
 <Region zones={['eu']}>
-- an OVHcloud email solution already set up (**MX Plan**, available as part of our [Web Hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/), included in a [100M free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) or ordered separately as a standalone solution; [**Hosted Exchange**](https://www.ovhcloud.com/en-gb/emails/hosted-exchange/) or [**Email Pro**](https://www.ovhcloud.com/en-gb/emails/email-pro/))
+- an OVHcloud email solution already set up (**MX Plan**, available as part of our [Web Hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/), included in a [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) or ordered separately as a standalone solution; [**Hosted Exchange**](https://www.ovhcloud.com/en-gb/emails/hosted-exchange/) or [**Email Pro**](https://www.ovhcloud.com/en-gb/emails/email-pro/))
 - login credentials for the email address you want to configure
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -1,7 +1,7 @@
 ---
 title: Using your email address from the Outlook Web App (OWA) webmail
 description: Find out how to use your email address from OWA webmail
-lastUpdated: 2026-05-04
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -30,7 +30,7 @@ All active email accounts on MX Plan share a single point of access to their OWA
 
 - An OVHcloud email solution already set up, from the following offers:
     <Region zones={['eu']}>
-    - [**MX Plan**](https://www.ovhcloud.com/en-gb/web-hosting/), available with our Web Hosting plans, included with [100M free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) or ordered as a standalone solution;
+    - [**MX Plan**](https://www.ovhcloud.com/en-gb/web-hosting/), available with our Web Hosting plans, included with [free hosting](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/) or ordered as a standalone solution;
     </Region>
     <Region zones={['ca', 'apac']}>
     - [**MX Plan**](https://www.ovhcloud.com/en-gb/web-hosting/), available with our Web Hosting plans or ordered as a standalone solution;

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creating automatic replies in OWA
 description: Find out how to set up automatic replies in OWA
-lastUpdated: 2024-10-22
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -30,7 +30,7 @@ This Exchange feature allows you to set up automatic responses to emails sent to
 
 :::warning
 <Region zones={['eu']}>
-If your email address is linked to an **MX Plan** solution (included with [web hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/) and [100M free hosting plans](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/)), your Control Panel will contain a section called <code className="action">Manage auto-replies</code>. You will then need to create an automatic response via the OVHcloud Control Panel. You can do this using the documentation ["MX Plan - Create an automatic response via an email address"](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).
+If your email address is linked to an **MX Plan** solution (included with [web hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/) and [free hosting plans](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/)), your Control Panel will contain a section called <code className="action">Manage auto-replies</code>. You will then need to create an automatic response via the OVHcloud Control Panel. You can do this using the documentation ["MX Plan - Create an automatic response via an email address"](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).
 </Region>
 <Region zones={['ca']}>
 If your email address is linked to an **MX Plan** solution (included with [web hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/)), your Control Panel will contain a section called <code className="action">Manage auto-replies</code>. You will then need to create an automatic response via the OVHcloud Control Panel. You can do this using the documentation ["MX Plan - Create an automatic response via an email address"](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -1,7 +1,7 @@
 ---
 title: Eliminar una cuenta de correo
 description: Cómo eliminar o restaurar una dirección de correo electrónico en un servicio de correo
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ Quiere:
 
 - Disponer de una solución de correo electrónico de OVHcloud previamente configurada:
     <Region zones={['eu']}>
-    - **MX Plan**, incluida en nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/), incluida en un [Alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o contratada por separado como solución autónoma.
+    - **MX Plan**, incluida en nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/), incluida en un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o contratada por separado como solución autónoma.
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan**, incluida en nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/) o contratada por separado como solución autónoma.

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizar los alias y redirecciones de correo
 description: Cómo gestionar los alias y redirecciones de correo
-lastUpdated: 2025-06-03
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -91,7 +91,7 @@ Tenga en cuenta que es posible configurar una redirección hacia varias direccio
 
 - Disponer de una solución de correo de OVHcloud previamente configurada, que incluya:
     <Region zones={['eu']}>
-    - **MX Plan** ofrecido con nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/) o incluido en un [alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/).
+    - **MX Plan** ofrecido con nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/) o incluido en un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** ofrecido con nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/).

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cambiar la contraseña de una dirección de correo
 description: Cómo cambiar la contraseña de una dirección de correo de OVHcloud
-lastUpdated: 2025-08-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ Es posible acceder a las cuentas de correo de su solución de OVHcloud mediante 
 
 - Disponer de una solución de correo de OVHcloud previamente configurada, que incluya:
     <Region zones={['eu']}>
-    - **MX Plan** ofrecido con nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/) o incluido en un [alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/).
+    - **MX Plan** ofrecido con nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/) o incluido en un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** ofrecido con nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/).

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Crear una dirección de correo electrónico en un MX Plan
 description: Cómo crear una dirección de correo electrónico en la solución MX Plan
-lastUpdated: 2025-08-26
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ La solución MX Plan le permite disfrutar de direcciones de correo asociadas a u
 - Tener una solución MX Plan. Esta está disponible a través de:
     - Un [plan de hosting](https://www.ovhcloud.com/es-es/web-hosting/).
     <Region zones={['eu']}>
-    - Un [alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) incluido con un dominio (activado previamente).
+    - Un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) incluido con un dominio (activado previamente).
     </Region>
     - Una solución MX Plan contratada por separado.
 
@@ -32,7 +32,7 @@ La solución MX Plan le permite disfrutar de direcciones de correo asociadas a u
 **Casos particulares**
 
 <Region zones={['eu']}>
-- En el caso del Alojamiento gratuito 100M, es necesario activar previamente el alojamiento para poder crear una dirección de correo. Puede realizar esta operación desde el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, accediendo al dominio correspondiente.
+- En el caso del Hosting gratuito, es necesario activar previamente el alojamiento para poder crear una dirección de correo. Puede realizar esta operación desde el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, accediendo al dominio correspondiente.
 </Region>
 - Si tiene un [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/), deberá activar su solución MX Plan incluida antes de continuar la lectura de esta guía. Para ello, consulte nuestra guía [Activar las direcciones de correo incluidas en su alojamiento web](/guides/web-cloud/web-hosting/activate-email-hosting).
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Primeros pasos con la solución MX Plan
 description: Cómo empezar a utilizar la solución de correo electrónico MX Plan
-lastUpdated: 2026-03-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ Usted acaba de adquirir una solución MX Plan que permite disfrutar de direccion
 ## Requisitos
 
 <Region zones={['eu']}>
-- Tener una solución MX Plan, que está disponible en un [plan de hosting](https://www.ovhcloud.com/es-es/web-hosting/), el [Alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o la solución MX Plan.
+- Tener una solución MX Plan, que está disponible en un [plan de hosting](https://www.ovhcloud.com/es-es/web-hosting/), el [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o la solución MX Plan.
 </Region>
 
 <Region zones={['ca', 'apac']}>

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Webmail: Guía de uso de Roundcube"
-lastUpdated: 2026-06-01
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -12,7 +12,7 @@ Con la solución MX Plan de OVHcloud, puede enviar y recibir correos electrónic
 
 ## Requisitos
 
-- Disponer de una solución de correo **MX Plan** de OVHcloud, propuesta entre nuestras [ofertas de alojamiento web](/links/web/hosting), incluida en un [alojamiento gratuito 100M](/links/web/domains-free-hosting), o contratada por separado como solución autónoma.
+- Disponer de una solución de correo **MX Plan** de OVHcloud, propuesta entre nuestras [ofertas de alojamiento web](/links/web/hosting), incluida en un [hosting gratuito](/links/web/domains-free-hosting), o contratada por separado como solución autónoma.
 - Disponer de los datos de conexión a la dirección de correo electrónico MX Plan que desea consultar. Para más información, consulte nuestra guía [Primeros pasos con la solución MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Su solución de correo electrónico **MX Plan** de OVHcloud debe utilizar la tecnología de webmail **Roundcube**. Para identificarla, siga las siguientes instrucciones.
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizar el webmail Zimbra
 description: Descubra la interfaz del webmail Zimbra para sus cuentas MX Plan OVHcloud
-lastUpdated: 2026-02-26
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -19,7 +19,7 @@ OVHcloud ofrece un servicio de webmail denominado Zimbra para acceder a una cuen
 
 ## Requisitos
 
-- Disponer de una solución de correo electrónico **MX Plan** de OVHcloud, incluida en nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/), incluida en un [alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o contratada como solución independiente.
+- Disponer de una solución de correo electrónico **MX Plan** de OVHcloud, incluida en nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/), incluida en un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o contratada como solución independiente.
 - Disponer de los datos de conexión a la dirección de correo electrónico MX Plan que quiera consultar. Para más información, consulte nuestra guía [Primeros pasos con la solución MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 
 ## Procedimiento

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Crear una respuesta automática en una dirección de correo electrónico
 description: Cómo configurar una respuesta automática en una dirección de correo electrónico
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -17,7 +17,7 @@ Si está ausente y no puede consultar su dirección de correo, puede implementar
 
 <Region zones={['eu']}>
 
-- Tener una solución MX Plan. Esta está disponible a través de: un plan de hosting [web hosting](https://www.ovhcloud.com/es-es/web-hosting/), el [alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) incluido con un dominio (activado previamente) o el MX Plan contratado por separado.
+- Tener una solución MX Plan. Esta está disponible a través de: un plan de hosting [web hosting](https://www.ovhcloud.com/es-es/web-hosting/), el [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) incluido con un dominio (activado previamente) o el MX Plan contratado por separado.
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Transferir la gestión de sus cuentas de correo a otra persona
 description: Cómo delegar la gestión de las cuentas de correo de su solución MX Plan
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ La delegación ofrece al usuario de una cuenta de correo la posibilidad de gesti
 
 <Region zones={['eu']}>
 
-- Tener una solución MX Plan  (disponible en: un [plan de hosting Cloud](https://www.ovhcloud.com/es-es/web-hosting/), un [Alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o un MX Plan contratado por separado).
+- Tener una solución MX Plan  (disponible en: un [plan de hosting Cloud](https://www.ovhcloud.com/es-es/web-hosting/), un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o un MX Plan contratado por separado).
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-filters.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-filters.mdx
@@ -1,7 +1,7 @@
 ---
 title: Crear filtros para sus direcciones de correo
 description: Cómo crear y configurar un filtro en una dirección de correo electrónico
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ Por ejemplo: desea que se elimine todo email que contenga "[SPAM]" en el asunto.
 
 <Region zones={['eu']}>
 
-- Disponer de una solución de correo MX Plan (disponible a través de: un [plan de hosting](https://www.ovhcloud.com/es-es/web-hosting/), el [Alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) incluido con un dominio o la solución MX Plan contratada por separado).
+- Disponer de una solución de correo MX Plan (disponible a través de: un [plan de hosting](https://www.ovhcloud.com/es-es/web-hosting/), el [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) incluido con un dominio o la solución MX Plan contratada por separado).
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan / Zimbra Starter - Configurar una dirección de correo electrónico en Outlook clásico para Windows
 description: Cómo configurar una cuenta MX Plan en Outlook clásico para Windows
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,7 +23,7 @@ Las direcciones de correo electrónico de la oferta **MX Plan** y [Zimbra Starte
 
 - Disponer de una solución de correo electrónico OVHcloud configurada previamente, entre las siguientes:
     <Region zones={['eu']}>
-    - **Plan MX** ofrecido con nuestras [ofertas de hosting web](https://www.ovhcloud.com/es-es/web-hosting/) o incluido en un [hosting gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/).
+    - **Plan MX** ofrecido con nuestras [ofertas de hosting web](https://www.ovhcloud.com/es-es/web-hosting/) o incluido en un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **Plan MX** ofrecido con nuestras [ofertas de hosting web](https://www.ovhcloud.com/es-es/web-hosting/).

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Configurar su dirección de correo electrónico en Thunderbird para macOS
 description: "Descubra cómo configurar su dirección de correo electrónico MX Plan en Thunderbird para macOS'"
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,7 +20,7 @@ Las cuentas de correo electrónico MX Plan pueden configurarse en diferentes cli
 - Tener una oferta MX Plan. Esta está disponible a través de:
     <Region zones={['eu']}>
     - Una oferta de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/).
-    - Un [alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) incluido con un nombre de dominio (previamente activado).
+    - Un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) incluido con un nombre de dominio (previamente activado).
     - Una oferta MX Plan pedida por separado.
     - Tener una dirección de correo electrónico [Zimbra Starter](https://www.ovhcloud.com/es-es/emails/zimbra-emails/).
     </Region>

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Configurar su dirección de correo electrónico en Thunderbird para Windows
 description: Descubra cómo configurar su dirección de correo electrónico MX Plan en Thunderbird para Windows
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,7 +20,7 @@ Las cuentas de correo electrónico MX Plan pueden configurarse en diferentes cli
 - Tener una oferta MX Plan. Esta está disponible a través de:
     <Region zones={['eu']}>
     - Una oferta de [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/).
-    - Un [alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) incluido con un nombre de dominio (previamente activado).
+    - Un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) incluido con un nombre de dominio (previamente activado).
     - Una oferta MX Plan pedida por separado.
     - Tener una dirección de correo electrónico [Zimbra Starter](https://www.ovhcloud.com/es-es/emails/zimbra-emails/).
     </Region>

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan / Zimbra Starter - Agregar una cuenta de correo electrónico en el nuevo Outlook para Windows
 description: Aprenda a configurar su dirección de correo electrónico en el nuevo Outlook para Windows.
-lastUpdated: 2026-01-09
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ El **nuevo Outlook** reemplaza desde el 1 de enero de 2025 a la aplicación **Co
 
 - Disponer de una solución de correo electrónico OVHcloud configurada previamente, entre las siguientes:
     <Region zones={['eu']}>
-    - **Plan MX** ofrecido con nuestras [ofertas de hosting web](https://www.ovhcloud.com/es-es/web-hosting/) o incluido en un [hosting gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/).
+    - **Plan MX** ofrecido con nuestras [ofertas de hosting web](https://www.ovhcloud.com/es-es/web-hosting/) o incluido en un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **Plan MX** ofrecido con nuestras [ofertas de hosting web](https://www.ovhcloud.com/es-es/web-hosting/).

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -1,7 +1,7 @@
 ---
 title: Restaurar los elementos eliminados de su cuenta de correo
 description: Cómo restaurar elementos eliminados de su cuenta de correo a través del webmail (OWA)
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -18,7 +18,7 @@ Ha eliminado por error uno o varios elementos (correo electrónico, contacto, ci
  
 - Disponer de una solución de correo de OVHcloud:
     <Region zones={['eu']}>
-    - **MX Plan** ([solo la nueva versión](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)) incluido entre nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/), incluido en un [Alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/)
+    - **MX Plan** ([solo la nueva versión](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)) incluido entre nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/), incluido en un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/)
     </Region>
     <Region zones={['ca']}>
     - **MX Plan** ([solo la nueva versión](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)) incluido entre nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/)

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: Gestionar el espacio de almacenamiento de una cuenta de correo
 description: Cómo gestionar y optimizar el espacio de almacenamiento de una dirección de correo
-lastUpdated: 2025-08-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ Cada cuenta de correo de OVHcloud dispone de un espacio de almacenamiento dedica
 
 - Disponer de una solución de correo de OVHcloud previamente configurada, que incluya:
     <Region zones={['eu']}>
-    - **MX Plan** ofrecido con nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/) o incluido en un [alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/).
+    - **MX Plan** ofrecido con nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/) o incluido en un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** ofrecido con nuestros [planes de hosting](https://www.ovhcloud.com/es-es/web-hosting/).
@@ -68,7 +68,7 @@ Cada cuenta de correo de OVHcloud dispone de un espacio de almacenamiento dedica
 **Casos particulares**
 
 <Region zones={['eu']}>
-- En el caso del alojamiento gratuito 100M, es necesario activar previamente el alojamiento para poder crear una dirección de correo. Puede realizar esta operación desde el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, accediendo al dominio correspondiente.
+- En el caso del hosting gratuito, es necesario activar previamente el alojamiento para poder crear una dirección de correo. Puede realizar esta operación desde el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, accediendo al dominio correspondiente.
 </Region>
 - Si tiene un [alojamiento web](https://www.ovhcloud.com/es-es/web-hosting/), deberá activar su solución MX Plan incluida antes de continuar la lectura de esta guía. Para ello, consulte nuestra guía [Activar las direcciones de correo incluidas en su alojamiento web](/guides/web-cloud/web-hosting/activate-email-hosting).
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
@@ -1,7 +1,7 @@
 ---
 title: Crear reglas de la bandeja de entrada en OWA
 description: Cómo crear redirecciones y filtros de correo electrónico con OWA
-lastUpdated: 2020-03-11
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -16,7 +16,7 @@ Con la opción «Reglas de la bandeja de entrada», puede crear un elaborado con
 ## Requisitos
 
 <Region zones={['eu']}>
-- Tener una solución de correo electrónico de OVHcloud configurada (**solución MX Plan**, disponible como parte de nuestros [planes de hospedaje web](https://www.ovhcloud.com/es-es/web-hosting/), incluida en un [Alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o contratada por separado como una solución independiente; [**Hosted Exchange**](https://www.ovhcloud.com/es-es/emails/hosted-exchange/) o [**Email Pro**](https://www.ovhcloud.com/es-es/emails/email-pro/))
+- Tener una solución de correo electrónico de OVHcloud configurada (**solución MX Plan**, disponible como parte de nuestros [planes de hospedaje web](https://www.ovhcloud.com/es-es/web-hosting/), incluida en un [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o contratada por separado como una solución independiente; [**Hosted Exchange**](https://www.ovhcloud.com/es-es/emails/hosted-exchange/) o [**Email Pro**](https://www.ovhcloud.com/es-es/emails/email-pro/))
 - Tener las credenciales de acceso de la dirección de correo electrónico que quiere configurar
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizar una dirección de correo desde el webmail Outlook Web App (OWA)
 description: Cómo utilizar una dirección de correo electrónico desde el webmail OWA
-lastUpdated: 2026-05-04
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -30,7 +30,7 @@ Todas las cuentas de correo activas en MX Plan tienen un único punto de acceso 
 
 - Disponer de una solución de correo electrónico de OVHcloud previamente configurada, entre las siguientes ofertas:
     <Region zones={['eu']}>
-    - [**MX Plan**](https://www.ovhcloud.com/es-es/web-hosting/), incluida en nuestros planes de alojamiento web, en el [alojamiento gratuito 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o contratada como solución independiente;
+    - [**MX Plan**](https://www.ovhcloud.com/es-es/web-hosting/), incluida en nuestros planes de alojamiento web, en el [hosting gratuito](https://www.ovhcloud.com/es-es/domains/free-web-hosting/) o contratada como solución independiente;
     </Region>
     <Region zones={['ca', 'apac']}>
     - [**MX Plan**](https://www.ovhcloud.com/es-es/web-hosting/), incluida en nuestros planes de alojamiento web o contratada como solución independiente;

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
@@ -1,7 +1,7 @@
 ---
 title: Crear respuestas automáticas en OWA
 description: Cómo configurar respuestas automáticas en OWA
-lastUpdated: 2024-10-22
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -29,7 +29,7 @@ Esta herramienta de Exchange le permite configurar respuestas automáticas, de m
 
 :::warning
 <Region zones={['eu']}>
-Si su dirección de correo electrónico está asociada a un producto **MX Plan** (incluida con los [alojamientos web](https://www.ovhcloud.com/es-es/web-hosting/) y los [alojamientos gratuitos 100M](https://www.ovhcloud.com/es-es/domains/free-web-hosting/), su área de cliente ofrece una sección titulada <code className="action">Gestión de los contestadores</code>. En ese caso, deberá crear una respuesta automática desde el área de cliente de OVHcloud, utilizando la documentación "[MX Plan - Crear una respuesta automática en una dirección de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses)".
+Si su dirección de correo electrónico está asociada a un producto **MX Plan** (incluida con los [alojamientos web](https://www.ovhcloud.com/es-es/web-hosting/) y los [hosting gratuitos](https://www.ovhcloud.com/es-es/domains/free-web-hosting/)), su área de cliente ofrece una sección titulada <code className="action">Gestión de los contestadores</code>. En ese caso, deberá crear una respuesta automática desde el área de cliente de OVHcloud, utilizando la documentación "[MX Plan - Crear una respuesta automática en una dirección de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses)".
 </Region>
 <Region zones={['ca']}>
 Si su dirección de correo electrónico está asociada a un producto **MX Plan** (incluida con los [alojamientos web](https://www.ovhcloud.com/es-es/web-hosting/)), su área de cliente ofrece una sección titulada <code className="action">Gestión de los contestadores</code>. En ese caso, deberá crear una respuesta automática desde el área de cliente de OVHcloud, utilizando la documentación "[MX Plan - Crear una respuesta automática en una dirección de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses)".

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -1,7 +1,7 @@
 ---
 title: Supprimer un compte e-mail
 description: Découvrez comment supprimer ou réinitialiser une adresse e-mail sur votre offre e-mail
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ Vous souhaitez :
 
 - Disposer d'une solution e-mail OVHcloud préalablement configurée :
     <Region zones={['eu']}>
-    - **MX Plan**, proposée parmi nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/), incluse dans un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou commandée séparément comme solution autonome.
+    - **MX Plan**, proposée parmi nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/), incluse dans un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou commandée séparément comme solution autonome.
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan**, proposée parmi nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou commandée séparément comme solution autonome.

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utiliser les alias et redirections e-mail
 description: Découvrez comment gérer vos alias et redirections e-mail
-lastUpdated: 2025-06-03
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -91,7 +91,7 @@ Il est possible de configurer une redirection vers plusieurs adresses e-mail. Ce
 
 - Disposer d’une solution e-mail OVHcloud préalablement configurée, parmi les suivantes :
     <Region zones={['eu']}>
-    - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou incluse dans un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/).
+    - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou incluse dans un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Modifier le mot de passe d'une adresse e-mail"
 description: "Découvrez comment modifier le mot de passe d'une adresse e-mail OVHcloud"
-lastUpdated: 2025-08-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ Les comptes e-mail de votre offre OVHcloud sont accessibles grâce au mot de pas
 - Selon la méthode que vous utilisez : être connecté à l'adresse e-mail depuis le [webmail](https://www.ovhcloud.com/fr/mail/).
 - Disposer d'une solution e-mail OVHcloud préalablement configurée, parmi les suivantes :
     <Region zones={['eu']}>
-    - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou incluse dans un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/).
+    - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou incluse dans un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Créer une adresse e-mail avec son offre MX Plan
 description: Découvrez comment créer une adresse e-mail avec votre offre MX Plan
-lastUpdated: 2025-08-26
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ Vous venez d'acquérir une solution e-mail MX Plan. Celle-ci vous permet de bén
 - Disposer d'une offre MX Plan. Celle-ci est disponible via :
     - Une offre d’[hébergement web](https://www.ovhcloud.com/fr/web-hosting/).
     <Region zones={['eu']}>
-    - Un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/) compris avec un nom de domaine (activé au préalable).
+    - Un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/) compris avec un nom de domaine (activé au préalable).
     </Region>
     - Une offre MX Plan commandée séparément.
 
@@ -43,7 +43,7 @@ Vous venez d'acquérir une solution e-mail MX Plan. Celle-ci vous permet de bén
 **Cas particuliers**
 
 <Region zones={['eu']}>
-- Concernant l’hébergement gratuit 100M : il est impératif de l’activer au préalable afin de pouvoir créer une adresse e-mail. Vous pouvez effectuer cette opération depuis votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, en vous positionnant sur le nom de domaine concerné.
+- Concernant l’hébergement gratuit : il est impératif de l’activer au préalable afin de pouvoir créer une adresse e-mail. Vous pouvez effectuer cette opération depuis votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, en vous positionnant sur le nom de domaine concerné.
 </Region>
 - Dans le cadre d'un [hébergement web](https://www.ovhcloud.com/fr/web-hosting/), il est nécessaire d'activer votre offre MX Plan incluse avant de poursuivre la lecture de cette documentation. Pour cela, consultez notre guide « [Activer les adresses e-mail incluses dans votre hébergement web](/guides/web-cloud/web-hosting/activate-email-hosting) ».
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Premiers pas avec l'offre MX Plan"
 description: Découvrez comment bien débuter avec votre offre MX Plan
-lastUpdated: 2026-03-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ Vous venez d'acquérir une solution MX Plan. Celle-ci vous permet de bénéficie
 ## Prérequis
 
 <Region zones={['eu']}>
-- Posséder une offre MX Plan liée à une offre d’[hébergement web](https://www.ovhcloud.com/fr/web-hosting/), un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/), ou seule.
+- Posséder une offre MX Plan liée à une offre d’[hébergement web](https://www.ovhcloud.com/fr/web-hosting/), un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/), ou seule.
 </Region>
 
 <Region zones={['ca', 'apac']}>

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -1,6 +1,6 @@
 ---
 title: Utiliser son adresse e-mail depuis le webmail Roundcube
-lastUpdated: 2026-06-01
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -12,7 +12,7 @@ Avec l'offre MX Plan OVHcloud, vous pouvez envoyer et recevoir des e-mails depui
 
 ## Prérequis
 
-- Disposer d'une solution e-mail OVHcloud **MX Plan**, proposée parmi nos [offres d'hébergement web](/links/web/hosting), incluse dans un [hébergement gratuit 100M](/links/web/domains-free-hosting), ou commandée séparément comme solution autonome.
+- Disposer d'une solution e-mail OVHcloud **MX Plan**, proposée parmi nos [offres d'hébergement web](/links/web/hosting), incluse dans un [hébergement gratuit](/links/web/domains-free-hosting), ou commandée séparément comme solution autonome.
 - Disposer des informations de connexion à l'adresse e-mail MX Plan que vous souhaitez consulter. Pour plus d'informations, consultez notre guide [Premiers pas avec l'offre MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Votre solution e-mail OVHcloud **MX Plan** doit utiliser la technologie webmail **Roundcube**. Pour l'identifier, suivez les instructions ci-dessous.
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utiliser le webmail Zimbra
 description: "Découvrez l'interface du webmail Zimbra pour vos adresses e-mail MX Plan OVHcloud"
-lastUpdated: 2026-02-26
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -19,7 +19,7 @@ OVHcloud fournit un service de webmail appelé Zimbra pour accéder à un compte
 
 ## Prérequis
 
-- Disposer d'une solution e-mail OVHcloud **MX Plan**, proposée parmi nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/), incluse dans un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/), ou commandée séparément comme solution autonome.
+- Disposer d'une solution e-mail OVHcloud **MX Plan**, proposée parmi nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/), incluse dans un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/), ou commandée séparément comme solution autonome.
 - Disposer des informations de connexion à l’adresse e-mail MX Plan que vous souhaitez consulter. Pour plus d'informations, consultez notre guide « [Premiers pas avec l'offre MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities) ».
 
 ## En pratique

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Créer une réponse automatique sur une adresse e-mail
 description: Découvrez comment mettre en place une réponse automatique sur une adresse e-mail
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -17,7 +17,7 @@ Lorsque vous êtes absent et que vous n'êtes pas en mesure de consulter votre a
 
 <Region zones={['eu']}>
 
-- Disposer d’une offre MX Plan. Celle-ci est disponible via : une offre d’[hébergement web](https://www.ovhcloud.com/fr/web-hosting/), l’[hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/) compris avec un nom de domaine (activé au préalable) ou l’offre MX Plan commandée séparément.
+- Disposer d’une offre MX Plan. Celle-ci est disponible via : une offre d’[hébergement web](https://www.ovhcloud.com/fr/web-hosting/), l’[hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/) compris avec un nom de domaine (activé au préalable) ou l’offre MX Plan commandée séparément.
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Déléguer la gestion de vos comptes e-mails à une autre personne
 description: Découvrez comment déléguer la gestion des comptes e-mail de votre offre MX Plan
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ La délégation donne la possibilité à l'utilisateur d'un compte e-mail de gé
 
 <Region zones={['eu']}>
 
-- Posséder une offre MX Plan. Celle-ci est disponible via : une [offre d’hébergement Web Cloud](https://www.ovhcloud.com/fr/web-hosting/), un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou une offre MX Plan commandée séparément.
+- Posséder une offre MX Plan. Celle-ci est disponible via : une [offre d’hébergement Web Cloud](https://www.ovhcloud.com/fr/web-hosting/), un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou une offre MX Plan commandée séparément.
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-filters.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-filters.mdx
@@ -1,7 +1,7 @@
 ---
 title: Créer des filtres pour vos adresses e-mail
 description: Découvrez comment créer et configurer un filtre sur votre adresse e-mail
-lastUpdated: 2024-03-20
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ Par exemple : vous souhaitez que tout e-mail contenant « [SPAM] » dans le suje
 
 <Region zones={['eu']}>
 
-- Disposer d'une offre e-mail MX Plan (disponible via : une offre d’[hébergement web](https://www.ovhcloud.com/fr/web-hosting/), l'[hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/) compris avec un nom de domaine, ou l'offre MX Plan commandée séparément).
+- Disposer d'une offre e-mail MX Plan (disponible via : une offre d’[hébergement web](https://www.ovhcloud.com/fr/web-hosting/), l'[hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/) compris avec un nom de domaine, ou l'offre MX Plan commandée séparément).
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan / Zimbra Starter - Configurer son adresse e-mail sur Outlook classique pour Windows
 description: Découvrez comment configurer votre adresse e-mail MX Plan sur Outlook classique pour Windows
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,7 +23,7 @@ Les adresses e-mail de l'offre **MX Plan** et [Zimbra Starter](https://www.ovhcl
 
 - Disposer d'une solution e-mail OVHcloud préalablement configurée, parmi les suivantes :
     <Region zones={['eu']}>
-    - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou incluse dans un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/).
+    - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou incluse dans un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Configurer son adresse e-mail sur Thunderbird pour macOS
 description: Découvrez comment configurer votre adresse e-mail MX Plan sur Thunderbird pour macOS
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,7 +20,7 @@ Les comptes e-mail MX Plan peuvent être configurés sur différents logiciels d
 - Disposer d'une offre MX Plan. Celle-ci est disponible via :
     <Region zones={['eu']}>
     - Une offre d’[hébergement web](https://www.ovhcloud.com/fr/web-hosting/).
-    - Un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/) compris avec un nom de domaine (activé au préalable).
+    - Un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/) compris avec un nom de domaine (activé au préalable).
     - Une offre MX Plan commandée séparément.
     - Disposer d’une adresse e-mail [Zimbra Starter](https://www.ovhcloud.com/fr/emails/zimbra-emails/).
     </Region>

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Configurer son adresse e-mail sur Thunderbird pour Windows
 description: Découvrez comment configurer votre adresse e-mail MX Plan sur Thunderbird pour Windows
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,7 +23,7 @@ Les comptes e-mail MX Plan peuvent être configurés sur différents logiciels d
 - Disposer d'une offre MX Plan. Celle-ci est disponible via :
     <Region zones={['eu']}>
     - Une offre d’[hébergement web](https://www.ovhcloud.com/fr/web-hosting/).
-    - Un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/) compris avec un nom de domaine (activé au préalable).
+    - Un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/) compris avec un nom de domaine (activé au préalable).
     - Une offre MX Plan commandée séparément.
     - Disposer d’une adresse e-mail [Zimbra Starter](https://www.ovhcloud.com/fr/emails/zimbra-emails/).
     </Region>

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan / Zimbra Starter - Ajouter un compte e-mail sur le nouvel Outlook pour Windows
 description: Apprenez à configurer votre adresse e-mail sur le nouvel Outlook pour Windowss
-lastUpdated: 2026-01-09
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ Le **nouvel Outlook** remplace depuis le 1 janvier 2025 l'application **Courrier
 
 - Disposer d'une solution e-mail OVHcloud préalablement configurée, parmi les suivantes :
     <Region zones={['eu']}>
-    - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou incluse dans un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/).
+    - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou incluse dans un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -1,7 +1,7 @@
 ---
 title: Restaurer les éléments supprimés de votre compte e-mail
 description: Découvrez comment restaurer des éléments supprimés depuis votre compte e-mail via le webmail (OWA)
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -19,7 +19,7 @@ Vous avez supprimé par erreur un ou plusieurs éléments (e-mail, contact, rend
  
 - Disposer d'une solution e-mail OVHcloud:
     <Region zones={['eu']}>
-    - **MX Plan** ([nouvelle version uniquement](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities#en-pratique)) proposée parmi nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/), incluse dans un [Hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/)
+    - **MX Plan** ([nouvelle version uniquement](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities#en-pratique)) proposée parmi nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/), incluse dans un [Hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/)
     </Region>
     <Region zones={['ca']}>
     - **MX Plan** ([nouvelle version uniquement](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities#en-pratique)) proposée parmi nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/)

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Gérer l'espace de stockage d'un compte e-mail"
 description: "Découvrez comment gérer et optimiser l'espace de stockage d'une adresse e-mail "
-lastUpdated: 2025-08-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ Chaque compte e-mail OVHcloud dispose d'un espace de stockage dédié. Bien gér
 
 - Disposer d’une solution e-mail OVHcloud préalablement configurée, parmi les suivantes :
     <Region zones={['eu']}>
-    - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou incluse dans un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/).
+    - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou incluse dans un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/).
@@ -68,7 +68,7 @@ Chaque compte e-mail OVHcloud dispose d'un espace de stockage dédié. Bien gér
 **Cas particuliers**
 
 <Region zones={['eu']}>
-- Concernant l’hébergement gratuit 100M : il est impératif de l’activer au préalable afin de pouvoir créer une adresse e-mail. Vous pouvez effectuer cette opération depuis votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, en vous positionnant sur le nom de domaine concerné.
+- Concernant l’hébergement gratuit : il est impératif de l’activer au préalable afin de pouvoir créer une adresse e-mail. Vous pouvez effectuer cette opération depuis votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, en vous positionnant sur le nom de domaine concerné.
 </Region>
 - Dans le cadre d'un [hébergement web](https://www.ovhcloud.com/fr/web-hosting/), il est nécessaire d'activer votre offre MX Plan incluse avant de poursuivre la lecture de cette documentation. Pour cela, consultez notre guide « [Activer les adresses e-mail incluses dans votre hébergement web](/guides/web-cloud/web-hosting/activate-email-hosting) ».
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Règles de boîte de réception depuis l'interface OWA"
 description: "Comment créer des filtres et des redirections e-mail depuis l'interface OWA"
-lastUpdated: 2020-03-11
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -18,7 +18,7 @@ Avec l’option « Règles de gestion de la boîte de réception », vous pouvez
 ## Prérequis
 
 <Region zones={['eu']}>
-- une solution e-mail OVHcloud doit avoir été configurée au préalable (**MX Plan**, proposé parmi nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/), inclus dans un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou commandé séparément comme solution autonome ; [**Hosted Exchange**](https://www.ovhcloud.com/fr/emails/hosted-exchange/) ou [**Email Pro**](https://www.ovhcloud.com/fr/emails/email-pro/))
+- une solution e-mail OVHcloud doit avoir été configurée au préalable (**MX Plan**, proposé parmi nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/), inclus dans un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou commandé séparément comme solution autonome ; [**Hosted Exchange**](https://www.ovhcloud.com/fr/emails/hosted-exchange/) ou [**Email Pro**](https://www.ovhcloud.com/fr/emails/email-pro/))
 - les paramètres de connexion de l’adresse e-mail que vous souhaitez configurer
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utiliser son adresse e-mail depuis le webmail Outlook Web App (OWA)
 description: Découvrez comment utiliser votre adresse e-mail depuis le webmail OWA
-lastUpdated: 2026-05-04
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -30,7 +30,7 @@ Tous les comptes de messagerie actifs sur MX Plan ont un seul point d’accès �
 
 - Disposer d'une solution e-mail OVHcloud configurée au préalable, parmi les offres suivantes :
     <Region zones={['eu']}>
-    - [**MX Plan**](https://www.ovhcloud.com/fr/web-hosting/), proposée avec nos offres d'hébergement web, incluse dans l'[hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou commandée comme solution autonome ;
+    - [**MX Plan**](https://www.ovhcloud.com/fr/web-hosting/), proposée avec nos offres d'hébergement web, incluse dans l'[hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou commandée comme solution autonome ;
     </Region>
     <Region zones={['ca', 'apac']}>
     - [**MX Plan**](https://www.ovhcloud.com/fr/web-hosting/), proposée avec nos offres d'hébergement web ou commandée comme solution autonome ;

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mettre en place un répondeur automatique depuis l’interface OWA
 description: Découvrez comment mettre en place une réponse automatique sous OWA
-lastUpdated: 2024-10-22
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -29,7 +29,7 @@ Cette fonctionnalité d’Exchange vous permet de configurer des réponses autom
 
 :::warning
 <Region zones={['eu']}>
-Si votre adresse e-mail est liée à une offre **MX Plan** (incluse avec les [hébergements web](https://www.ovhcloud.com/fr/web-hosting/) et les [hébergements gratuits 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/)),  votre espace client propose une section intitulée <code className="action">Gestion des répondeurs</code>. Vous devez alors créer une réponse automatique depuis votre espace client OVHcloud en vous aidant de la documentation [« MX Plan - Créer une réponse automatique sur une adresse e-mail »](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).
+Si votre adresse e-mail est liée à une offre **MX Plan** (incluse avec les [hébergements web](https://www.ovhcloud.com/fr/web-hosting/) et les [hébergements gratuits](https://www.ovhcloud.com/fr/domains/free-web-hosting/)),  votre espace client propose une section intitulée <code className="action">Gestion des répondeurs</code>. Vous devez alors créer une réponse automatique depuis votre espace client OVHcloud en vous aidant de la documentation [« MX Plan - Créer une réponse automatique sur une adresse e-mail »](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).
 </Region>
 <Region zones={['ca']}>
 Si votre adresse e-mail est liée à une offre **MX Plan** (incluse avec les [hébergements web](https://www.ovhcloud.com/fr/web-hosting/)), votre espace client propose une section intitulée <code className="action">Gestion des répondeurs</code>. Vous devez alors créer une réponse automatique depuis votre espace client OVHcloud en vous aidant de la documentation [« MX Plan - Créer une réponse automatique sur une adresse e-mail »](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -1,7 +1,7 @@
 ---
 title: Elimina un account email
 description: Come eliminare o reimpostare un indirizzo email sul servizio di posta
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ Vuoi:
 
 - Disporre di una soluzione email OVHcloud configurata precedentemente:
     <Region zones={['eu']}>
-    - **MX Plan**, inclusa nelle nostre [soluzioni di hosting Web](https://www.ovhcloud.com/it/web-hosting/), inclusa in un [Hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/) o ordinata separatamente come soluzione autonoma.
+    - **MX Plan**, inclusa nelle nostre [soluzioni di hosting Web](https://www.ovhcloud.com/it/web-hosting/), inclusa in un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/) o ordinata separatamente come soluzione autonoma.
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan**, inclusa nelle nostre [soluzioni di hosting Web](https://www.ovhcloud.com/it/web-hosting/) o ordinata separatamente come soluzione autonoma.

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizzare gli alias e i reindirizzamenti email
 description: Come gestire gli alias e i reindirizzamenti email
-lastUpdated: 2025-06-03
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -91,7 +91,7 @@ Ti ricordiamo che è possibile configurare un reindirizzamento verso più indiri
 
 - Disporre di una soluzione email OVHcloud precedentemente configurata, tra le seguenti:
     <Region zones={['eu']}>
-    - **MX Plan** proposta con le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/) o inclusa in un [hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/).
+    - **MX Plan** proposta con le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/) o inclusa in un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** proposta con le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/).

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Modifica la password di un indirizzo email
 description: Come modificare la password di un indirizzo email OVHcloud
-lastUpdated: 2025-08-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ Gli account email del servizio OVHcloud sono accessibili tramite la password ass
 
 - Disporre di una soluzione email OVHcloud precedentemente configurata, tra le seguenti:
     <Region zones={['eu']}>
-    - **MX Plan** proposta con le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/) o inclusa in un [hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/).
+    - **MX Plan** proposta con le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/) o inclusa in un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** proposta con le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/).

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creare un account email con MX Plan
 description: Questa guide ti mostra come aggiungere una casella di posta elettronica sulla soluzione MX Plan
-lastUpdated: 2025-08-26
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ Una soluzione email MX Plan è stata appena creata per usufruire di indirizzi em
 - Disporre di una soluzione MX Plan. Questa offerta è disponibile via:
     - un piano di [hosting Web](https://www.ovhcloud.com/it/web-hosting/).
     <Region zones={['eu']}>
-    - [hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/) incluso con un dominio (attivato in precedenza).
+    - [Hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/) incluso con un dominio (attivato in precedenza).
     </Region>
     - Offerta MX Plan ordinata separatamente.
 
@@ -32,7 +32,7 @@ Una soluzione email MX Plan è stata appena creata per usufruire di indirizzi em
 **Casi particolari**
 
 <Region zones={['eu']}>
-- Se disponi di un Hosting gratuito 100M, prima di creare un indirizzo email è necessario attivarlo. Questa operazione è disponibile nello <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, selezionando il dominio interessato.
+- Se disponi di un Hosting gratuito, prima di creare un indirizzo email è necessario attivarlo. Questa operazione è disponibile nello <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, selezionando il dominio interessato.
 </Region>
 - Prima di continuare la lettura di questa guida, è necessario attivare il servizio di [hosting Web](https://www.ovhcloud.com/it/web-hosting/). Per farlo, consulta la guida [Attiva gli indirizzi email inclusi nel tuo hosting Web](/guides/web-cloud/web-hosting/activate-email-hosting).
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Iniziare a utilizzare la soluzione MX Plan
 description: Come eseguire le prime operazioni sul servizio MX Plan
-lastUpdated: 2026-03-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ La soluzione MX Plan di OVHcloud con cui potrai inviare e ricevere messaggi dal 
 ## Prerequisiti
 
 <Region zones={['eu']}>
-- Disporre di una soluzione MX Plan Puoi effettuare questa operazione tramite: un'offerta di [hosting Web](https://www.ovhcloud.com/it/web-hosting/), l'[Hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/) o la soluzione MX Plan da sola.
+- Disporre di una soluzione MX Plan Puoi effettuare questa operazione tramite: un'offerta di [hosting Web](https://www.ovhcloud.com/it/web-hosting/), l'[hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/) o la soluzione MX Plan da sola.
 </Region>
 
 <Region zones={['ca', 'apac']}>

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Webmail: guida all’utilizzo di Roundcube"
-lastUpdated: 2026-06-01
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -12,7 +12,7 @@ Con la soluzione MX Plan OVHcloud, puoi inviare e ricevere e-mail da un software
 
 ## Prerequisiti
 
-- Disporre di una soluzione e-mail OVHcloud **MX Plan**, proposta tra le nostre [offerte di hosting Web](/links/web/hosting), inclusa in un [hosting gratuito 100M](/links/web/domains-free-hosting), o ordinata separatamente come soluzione autonoma.
+- Disporre di una soluzione e-mail OVHcloud **MX Plan**, proposta tra le nostre [offerte di hosting Web](/links/web/hosting), inclusa in un [hosting gratuito](/links/web/domains-free-hosting), o ordinata separatamente come soluzione autonoma.
 - Disporre delle informazioni di connessione all'indirizzo e-mail MX Plan che desideri consultare. Per maggiori informazioni, consulta la nostra guida [Iniziare a utilizzare la soluzione MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - La tua soluzione e-mail OVHcloud **MX Plan** deve utilizzare la tecnologia webmail **Roundcube**. Per identificarla, segui le istruzioni riportate di seguito.
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizzare la webmail Zimbra
 description: "Scopri l'interfaccia della Webmail Zimbra per i tuoi indirizzi email MX Plan di OVHcloud"
-lastUpdated: 2026-02-26
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -19,7 +19,7 @@ OVHcloud fornisce un servizio di webmail chiamato Zimbra per accedere a un accou
 
 ## Prerequisiti
 
-- Disporre di una soluzione email OVHcloud **MX Plan**, disponibile tra le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/), inclusa in un [hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/), o ordinata separatamente come soluzione autonoma.
+- Disporre di una soluzione email OVHcloud **MX Plan**, disponibile tra le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/), inclusa in un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/), o ordinata separatamente come soluzione autonoma.
 - Disporre delle credenziali di accesso all’indirizzo email MX Plan da consultare. Per maggiori informazioni, consulta la nostra guida "[Iniziare a utilizzare il servizio MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)".
 
 ## Procedura

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Crea risposta automatica su un indirizzo email
 description: Come impostare una risposta automatica su un indirizzo email
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -17,7 +17,7 @@ Quando sei assente e non sei in grado di consultare il tuo indirizzo email, puoi
 
 <Region zones={['eu']}>
 
-- Disporre di una soluzione MX Plan. Puoi effettuare questa operazione scegliendo tra una soluzione di [hosting Web](https://www.ovhcloud.com/it/web-hosting/), l’[hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/) incluso con un dominio (attivato in precedenza) o l’offerta MX Plan ordinata separatamente.
+- Disporre di una soluzione MX Plan. Puoi effettuare questa operazione scegliendo tra una soluzione di [hosting Web](https://www.ovhcloud.com/it/web-hosting/), l’[hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/) incluso con un dominio (attivato in precedenza) o l’offerta MX Plan ordinata separatamente.
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "MX Plan - Delegare la gestione dei tuoi account email a un'altra persona"
 description: Come delegare la gestione degli account email della tua soluzione MX Plan
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ La delega offre all'utente di un account email la possibilità di gestire autono
 
 <Region zones={['eu']}>
 
-- Disporre di una soluzione MX Plan Puoi effettuare questa operazione tramite: un'[offerta di hosting Web Cloud](https://www.ovhcloud.com/it/web-hosting/), un [Hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/) o una soluzione MX Plan ordinata separatamente.
+- Disporre di una soluzione MX Plan Puoi effettuare questa operazione tramite: un'[offerta di hosting Web Cloud](https://www.ovhcloud.com/it/web-hosting/), un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/) o una soluzione MX Plan ordinata separatamente.
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-filters.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-filters.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creare filtri per i tuoi indirizzi email
 description: Come creare e configurare un filtro sul tuo indirizzo email
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ Ad esempio: vuoi che tutte le email contenenti "[SPAM]" nell'oggetto siano elimi
 
 <Region zones={['eu']}>
 
-- Disporre di una soluzione email MX Plan (disponibile tramite: un'offerta di [hosting Web](https://www.ovhcloud.com/it/web-hosting/), l'[Hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/) incluso con un dominio o l'offerta MX Plan ordinata separatamente).
+- Disporre di una soluzione email MX Plan (disponibile tramite: un'offerta di [hosting Web](https://www.ovhcloud.com/it/web-hosting/), l'[hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/) incluso con un dominio o l'offerta MX Plan ordinata separatamente).
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: "MX Plan / Zimbra Starter - Configurare l'indirizzo e-mail su Outlook classico per Windows"
 description: Scopri come configurare il tuo indirizzo e-mail MX Plan su Outlook classico per Windows
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,7 +23,7 @@ Gli indirizzi e-mail delle offerte **MX Plan** e [Zimbra Starter](https://www.ov
 
 - Disporre di una soluzione e-mail OVHcloud precedentemente configurata, tra le seguenti:
     <Region zones={['eu']}>
-    - **MX Plan** proposta con le nostre [offerte di hosting web](https://www.ovhcloud.com/it/web-hosting/) o incluse in un [hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/).
+    - **MX Plan** proposta con le nostre [offerte di hosting web](https://www.ovhcloud.com/it/web-hosting/) o incluse in un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** proposta con le nostre [offerte di hosting web](https://www.ovhcloud.com/it/web-hosting/).

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
@@ -1,7 +1,7 @@
 ---
 title: "MX Plan - Configurare l'indirizzo e-mail in Thunderbird per macOS"
 description: Scopri come configurare il tuo indirizzo e-mail  MX Plan in Thunderbird per macOS
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,7 +20,7 @@ Gli account email  MX Plan possono essere configurati su diversi client di posta
 - Disporre di un'offerta  MX Plan. Questa è disponibile tramite:
     <Region zones={['eu']}>
     - Un'offerta di [hosting Web](https://www.ovhcloud.com/it/web-hosting/).
-    - Un [hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/) incluso con un nome di dominio (precedentemente attivato).
+    - Un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/) incluso con un nome di dominio (precedentemente attivato).
     - Un'offerta  MX Plan ordinata separatamente.
     - Disporre di un indirizzo email [Zimbra Starter](https://www.ovhcloud.com/it/emails/zimbra-emails/).
     </Region>

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
@@ -1,7 +1,7 @@
 ---
 title: "MX Plan - Configurare l'indirizzo email su Thunderbird per Windows"
 description: Scopri come configurare il tuo indirizzo email MX Plan su Thunderbird per Windows
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,7 +23,7 @@ Gli account email MX Plan possono essere configurati su diversi client di posta 
 - Disporre di un'offerta MX Plan. Questa è disponibile tramite:
     <Region zones={['eu']}>
     - Un'offerta di [hosting Web](https://www.ovhcloud.com/it/web-hosting/).
-    - Un [hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/) incluso con un nome di dominio (precedentemente attivato).
+    - Un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/) incluso con un nome di dominio (precedentemente attivato).
     - Un'offerta MX Plan ordinata separatamente.
     - Disporre di un indirizzo email [Zimbra Starter](https://www.ovhcloud.com/it/emails/zimbra-emails/).
     </Region>

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan / Zimbra Starter - Aggiungere un account e-mail sul nuovo Outlook per Windows
 description: Scopri come configurare il tuo indirizzo e-mail sul nuovo Outlook per Windows
-lastUpdated: 2026-01-09
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ Il **nuovo Outlook** sostituisce dall'1 gennaio 2025 l'applicazione **Posta** su
 
 - Disporre di una soluzione e-mail OVHcloud precedentemente configurata, tra le seguenti:
     <Region zones={['eu']}>
-    - **MX Plan** proposta con le nostre [offerte di hosting web](https://www.ovhcloud.com/it/web-hosting/) o incluse in un [hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/).
+    - **MX Plan** proposta con le nostre [offerte di hosting web](https://www.ovhcloud.com/it/web-hosting/) o incluse in un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** proposta con le nostre [offerte di hosting web](https://www.ovhcloud.com/it/web-hosting/).

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ripristina gli elementi eliminati dal tuo account email
 description: Come ripristinare gli elementi eliminati dal tuo account email tramite la Webmail (OWA)
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -19,7 +19,7 @@ Hai eliminato per errore uno o più elementi (email, contatti, appuntamento con 
  
 - Disporre di una soluzione email OVHcloud
     <Region zones={['eu']}>
-    - **MX Plan** ([solo nuova versione](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)) proposto tra le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/), incluso in un [Hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/)
+    - **MX Plan** ([solo nuova versione](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)) proposto tra le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/), incluso in un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/)
     </Region>
     <Region zones={['ca']}>
     - **MX Plan** ([solo nuova versione](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)) proposto tra le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/)

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: Gestire lo spazio di storage di un account email
 description: Come gestire e ottimizzare lo spazio di storage di un indirizzo email
-lastUpdated: 2025-08-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ Ogni account email OVHcloud dispone di uno spazio di storage dedicato. Gestire c
 
 - Disporre di una soluzione email OVHcloud precedentemente configurata, tra le seguenti:
     <Region zones={['eu']}>
-    - **MX Plan** proposta con le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/) o inclusa in un [hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/).
+    - **MX Plan** proposta con le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/) o inclusa in un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** proposta con le nostre [offerte di hosting Web](https://www.ovhcloud.com/it/web-hosting/).
@@ -68,7 +68,7 @@ Ogni account email OVHcloud dispone di uno spazio di storage dedicato. Gestire c
 **Casi particolari**
 
 <Region zones={['eu']}>
-- Se disponi di un hosting gratuito 100M, prima di creare un indirizzo email è necessario attivarlo. Questa operazione è disponibile nello <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, selezionando il dominio interessato.
+- Se disponi di un hosting gratuito, prima di creare un indirizzo email è necessario attivarlo. Questa operazione è disponibile nello <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, selezionando il dominio interessato.
 </Region>
 - Prima di continuare la lettura di questa guida, è necessario attivare il servizio di [hosting Web](https://www.ovhcloud.com/it/web-hosting/). Per farlo, consulta la guida [Attiva gli indirizzi email inclusi nel tuo hosting Web](/guides/web-cloud/web-hosting/activate-email-hosting).
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creare regole di posta in arrivo in Outlook Web App (OWA)
 description: Come impostare l’inoltro delle email e creare filtri in OWA
-lastUpdated: 2020-03-11
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -16,7 +16,7 @@ Tramite l’opzione “Regole Posta in arrivo” è possibile creare una serie d
 ## Prerequisiti
 
 <Region zones={['eu']}>
-- Disporre di una soluzione di posta elettronica OVHcloud attiva (**MX Plan**, disponibile nell'ambito delle nostre offerte di [hosting Web](https://www.ovhcloud.com/it/web-hosting/), inclusa in un [Hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/) oppure ordinata separatamente con una soluzione indipendente; [**Hosted Exchange**](https://www.ovhcloud.com/it/emails/hosted-exchange/)o ancora [**Email Pro**](https://www.ovhcloud.com/it/emails/email-pro/))
+- Disporre di una soluzione di posta elettronica OVHcloud attiva (**MX Plan**, disponibile nell'ambito delle nostre offerte di [hosting Web](https://www.ovhcloud.com/it/web-hosting/), inclusa in un [hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/) oppure ordinata separatamente con una soluzione indipendente; [**Hosted Exchange**](https://www.ovhcloud.com/it/emails/hosted-exchange/)o ancora [**Email Pro**](https://www.ovhcloud.com/it/emails/email-pro/))
 - Disporre delle credenziali di accesso dell’indirizzo email da configurare
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizzare il proprio indirizzo e-mail dalla webmail Outlook Web App (OWA)
 description: Scopri come utilizzare il tuo indirizzo e-mail dalla webmail OWA
-lastUpdated: 2026-05-04
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -30,7 +30,7 @@ Tutti gli account di posta attivi su MX Plan dispongono di un unico punto di acc
 
 - Disporre di una soluzione e-mail OVHcloud preconfigurata, tra le seguenti offerte:
     <Region zones={['eu']}>
-    - [**MX Plan**](https://www.ovhcloud.com/it/web-hosting/), proposta con le nostre offerte di hosting web, inclusa nell'[hosting gratuito 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/) o ordinata come soluzione autonoma;
+    - [**MX Plan**](https://www.ovhcloud.com/it/web-hosting/), proposta con le nostre offerte di hosting web, inclusa nell'[hosting gratuito](https://www.ovhcloud.com/it/domains/free-web-hosting/) o ordinata come soluzione autonoma;
     </Region>
     <Region zones={['ca', 'apac']}>
     - [**MX Plan**](https://www.ovhcloud.com/it/web-hosting/), proposta con le nostre offerte di hosting web o ordinata come soluzione autonoma;

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
@@ -1,7 +1,7 @@
 ---
 title: Imposta risposte automatiche con OWA
 description: Scopri come impostare risposte automatiche con OWA
-lastUpdated: 2024-10-22
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -29,7 +29,7 @@ Questa funzionalità di Exchange consente di impostare risposte automatiche alle
 
 :::warning
 <Region zones={['eu']}>
-Se il tuo indirizzo email è associato a una soluzione **MX Plan** (inclusa con gli [hosting Web](https://www.ovhcloud.com/it/web-hosting/) e gli [hosting gratuiti 100M](https://www.ovhcloud.com/it/domains/free-web-hosting/), lo Spazio Cliente OVH propone una sezione intitolata <code className="action">Gestione delle risposte automatiche</code>. In questo caso, è necessario creare una risposta automatica dallo Spazio Cliente OVHcloud consultando la documentazione ["MX Plan - Crea una risposta automatica su un indirizzo email"](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).
+Se il tuo indirizzo email è associato a una soluzione **MX Plan** (inclusa con gli [hosting Web](https://www.ovhcloud.com/it/web-hosting/) e gli [hosting gratuiti](https://www.ovhcloud.com/it/domains/free-web-hosting/)), lo Spazio Cliente OVH propone una sezione intitolata <code className="action">Gestione delle risposte automatiche</code>. In questo caso, è necessario creare una risposta automatica dallo Spazio Cliente OVHcloud consultando la documentazione ["MX Plan - Crea una risposta automatica su un indirizzo email"](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).
 </Region>
 <Region zones={['ca']}>
 Se il tuo indirizzo email è associato a una soluzione **MX Plan** (inclusa con gli [hosting Web](https://www.ovhcloud.com/it/web-hosting/)), lo Spazio Cliente OVH propone una sezione intitolata <code className="action">Gestione delle risposte automatiche</code>. In questo caso, è necessario creare una risposta automatica dallo Spazio Cliente OVHcloud consultando la documentazione ["MX Plan - Crea una risposta automatica su un indirizzo email"](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -1,7 +1,7 @@
 ---
 title: Usuń konto e-mail
 description: Dowiedz się, jak usunąć lub zresetować konto e-mail w Twojej usłudze e-mail
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ Chcesz:
 
 - Posiadanie wcześniej skonfigurowanego rozwiązania poczty elektronicznej OVHcloud:
     <Region zones={['eu']}>
-    - **MX Plan**, zaproponowanego w naszej [ofercie hostingu](https://www.ovhcloud.com/pl/web-hosting/), zawartego w [Darmowy hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub zamówionym oddzielnie jako rozwiązanie autonomiczne.
+    - **MX Plan**, zaproponowanego w naszej [ofercie hostingu](https://www.ovhcloud.com/pl/web-hosting/), zawartego w [hosting darmowy](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub zamówionym oddzielnie jako rozwiązanie autonomiczne.
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan**, zaproponowanego w naszej [ofercie hostingu](https://www.ovhcloud.com/pl/web-hosting/) lub zamówionym oddzielnie jako rozwiązanie autonomiczne.

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Korzystanie z aliasów i przekierowań e-mail
 description: Dowiedz się, jak zarządzać aliasami i przekierowaniami e-mail
-lastUpdated: 2025-06-03
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -91,7 +91,7 @@ Pamiętaj, że możliwa jest konfiguracja przekierowania na kilka adresów e-mai
 
 - Posiadanie skonfigurowanego wcześniej rozwiązania e-mail OVHcloud, spośród następujących:
     <Region zones={['eu']}>
-    - **MX Plan** w ofercie [pakietów hostingowych](https://www.ovhcloud.com/pl/web-hosting/) lub zawarta w ofercie [darmowy hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/).
+    - **MX Plan** w ofercie [pakietów hostingowych](https://www.ovhcloud.com/pl/web-hosting/) lub zawarta w ofercie [hosting darmowy](https://www.ovhcloud.com/pl/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** w ofercie [pakietów hostingowych](https://www.ovhcloud.com/pl/web-hosting/).

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zmiana hasła do konta e-mail
 description: Dowiedz się, jak zmienić hasło do konta e-mail OVHcloud
-lastUpdated: 2025-08-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ Konta e-mail w ramach Twojej usługi OVHcloud są dostępne za pomocą przypisan
 
 - Posiadanie skonfigurowanego wcześniej rozwiązania e-mail OVHcloud, spośród następujących:
     <Region zones={['eu']}>
-    - **MX Plan** w ofercie [pakietów hostingowych](https://www.ovhcloud.com/pl/web-hosting/) lub zawarta w ofercie [darmowy hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/).
+    - **MX Plan** w ofercie [pakietów hostingowych](https://www.ovhcloud.com/pl/web-hosting/) lub zawarta w ofercie [hosting darmowy](https://www.ovhcloud.com/pl/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** w ofercie [pakietów hostingowych](https://www.ovhcloud.com/pl/web-hosting/).

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tworzenie konta e-mail w ramach usługi MX Plan
 description: Dowiedz się, jak utworzyć konto e-mail w ramach pakietu MX Plan
-lastUpdated: 2025-08-26
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ Właśnie zakupiłeś usługę e-mail MX Plan. Umożliwia ona korzystanie z kont
 - Wykupienie usługi MX Plan. Usługa jest dostępna w:
     - Oferta [hostingu](https://www.ovhcloud.com/pl/web-hosting/).
     <Region zones={['eu']}>
-    - Darmowy [hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/) zawarty w ofercie domeny (uprzednio aktywowany).
+    - Darmowy [hosting](https://www.ovhcloud.com/pl/domains/free-web-hosting/) zawarty w ofercie domeny (uprzednio aktywowany).
     </Region>
     - Usługa MX Plan zamówiona oddzielnie.
 
@@ -32,7 +32,7 @@ Właśnie zakupiłeś usługę e-mail MX Plan. Umożliwia ona korzystanie z kont
 **Szczególne przypadki**
 
 <Region zones={['eu']}>
-- Jeśli chodzi o bezpłatny Darmowy hosting 100M, konieczne jest wcześniejsze aktywowanie go przed utworzeniem konta e-mail. Operację tę możesz przeprowadzić w <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, przechodząc do odpowiedniej domeny.
+- Jeśli chodzi o bezpłatny Hosting darmowy, konieczne jest wcześniejsze aktywowanie go przed utworzeniem konta e-mail. Operację tę możesz przeprowadzić w <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, przechodząc do odpowiedniej domeny.
 </Region>
 - Zanim przejdziesz do niniejszego przewodnika, należy aktywować Twój pakiet MX Plan zawarty w [ofercie hostingu](https://www.ovhcloud.com/pl/web-hosting/). W tym celu zapoznaj się z naszym przewodnikiem "[Aktywuj konta e-mail zawarte w Twoim hostingu](/guides/web-cloud/web-hosting/activate-email-hosting)".
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pierwsze kroki z usługą MX Plan
 description: Dowiedz się, jak rozpocząć korzystanie z usługi MX Plan
-lastUpdated: 2026-03-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ Właśnie zakupiłeś usługę MX Plan. Pozwala ona na korzystanie z kont e-mail
 ## Wymagania początkowe
 
 <Region zones={['eu']}>
-- Posiadanie pakietu MX Plan Jest ona dostępna przez: oferta [hostingu](https://www.ovhcloud.com/pl/web-hosting/), bezpłatny [Darmowy hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub oferta MX Plan.
+- Posiadanie pakietu MX Plan Jest ona dostępna przez: oferta [hostingu](https://www.ovhcloud.com/pl/web-hosting/), bezpłatny [hosting darmowy](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub oferta MX Plan.
 </Region>
 
 <Region zones={['ca', 'apac']}>

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -1,6 +1,6 @@
 ---
 title: Korzystanie z konta e-mail w interfejsie Webmail Roundcube
-lastUpdated: 2026-06-01
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -12,7 +12,7 @@ Dzięki rozwiązaniu OVHcloud MX Plan możesz wysyłać i odbierać e-maile za p
 
 ## Wymagania początkowe
 
-- Posiadanie rozwiązania pocztowego OVHcloud **MX Plan**, zawartego w naszych [ofertach hostingu www](/links/web/hosting), zawartego w [darmowej ofercie hostingu 100M](/links/web/domains-free-hosting) lub zamówionego oddzielnie jako rozwiązanie autonomiczne.
+- Posiadanie rozwiązania pocztowego OVHcloud **MX Plan**, zawartego w naszych [ofertach hostingu www](/links/web/hosting), zawartego w [darmowej ofercie hostingu](/links/web/domains-free-hosting) lub zamówionego oddzielnie jako rozwiązanie autonomiczne.
 - Posiadanie danych logowania do adresu e-mail MX Plan, który chcesz sprawdzić. Więcej informacji znajdziesz w naszym przewodniku [Pierwsze kroki z rozwiązaniem MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Twoje rozwiązanie pocztowe OVHcloud **MX Plan** musi korzystać z technologii webmail **Roundcube**. Aby to sprawdzić, postępuj zgodnie z poniższymi wskazówkami.
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Korzystaj z interfejsu Webmail Zimbra
 description: Poznaj interfejs Zimbra Webmail dla Twoich kont e-mail MX Plan OVHcloud
-lastUpdated: 2026-02-26
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -19,7 +19,7 @@ OVHcloud dostarcza usługę webmail o nazwie Zimbra umożliwiającą dostęp do 
 
 ## Wymagania początkowe
 
-- Posiadanie rozwiązania e-mail OVHcloud **MX Plan**, dostępnego w ramach naszej [oferty hostingu](https://www.ovhcloud.com/pl/web-hosting/), zawartego w bezpłatnym [hostingu 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub zamówionego oddzielnie jako samodzielne rozwiązanie.
+- Posiadanie rozwiązania e-mail OVHcloud **MX Plan**, dostępnego w ramach naszej [oferty hostingu](https://www.ovhcloud.com/pl/web-hosting/), zawartego w bezpłatnym [hostingu](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub zamówionego oddzielnie jako samodzielne rozwiązanie.
 - Dane do logowania do konta e-mail MX Plan, które chcesz sprawdzić. Aby uzyskać więcej informacji, zapoznaj się z przewodnikiem "[Pierwsze kroki z ofertą MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)".
 
 ## W praktyce

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Tworzenie automatycznej odpowiedzi na adres e-mail
 description: Dowiedz się, jak skonfigurować automatyczną odpowiedź na adres e-mail
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -17,7 +17,7 @@ Jeśli jesteś nieobecny i nie możesz sprawdzić Twojego adresu e-mail, możesz
 
 <Region zones={['eu']}>
 
-- Wykupienie usługi MX Plan. Jest ona dostępna w ramach: oferty [hosting www](https://www.ovhcloud.com/pl/web-hosting/), [bezpłatny hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/) zawartej w ofercie domeny (aktywowanej wcześniej) lub oferty MX Plan zamówionej oddzielnie.
+- Wykupienie usługi MX Plan. Jest ona dostępna w ramach: oferty [hosting www](https://www.ovhcloud.com/pl/web-hosting/), [bezpłatny hosting](https://www.ovhcloud.com/pl/domains/free-web-hosting/) zawartej w ofercie domeny (aktywowanej wcześniej) lub oferty MX Plan zamówionej oddzielnie.
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Delegowanie zarządzania kontami e-mail innej osobie
 description: Dowiedz się, jak delegować uprawnienia do zarządzania kontami e-mail w ramach usługi MX Plan
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ Delegacja uprawnień daje użytkownikowi konta e-mail możliwość samodzielnego
 
 <Region zones={['eu']}>
 
-- Posiadanie pakietu MX Plan Jest ona dostępna przez: ofertę [hostingu WWW Cloud](https://www.ovhcloud.com/pl/web-hosting/), bezpłatnego [Darmowy hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub ofertę MX Plan zamówioną oddzielnie.
+- Posiadanie pakietu MX Plan Jest ona dostępna przez: ofertę [hostingu WWW Cloud](https://www.ovhcloud.com/pl/web-hosting/), bezpłatnego [hosting darmowy](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub ofertę MX Plan zamówioną oddzielnie.
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-filters.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-filters.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja filtrów e-mail w Panelu klienta
 description: Dowiedz się, jak utworzyć i skonfigurować filtr na Twoim koncie e-mail
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,7 +23,7 @@ Na przykład: chcesz, aby wszystkie e-maile zawierające "[SPAM]" w temacie zost
 
 <Region zones={['eu']}>
 
-- Posiadanie usługi e-mail MX Plan (dostępnej poprzez: [oferta hostingu](https://www.ovhcloud.com/pl/web-hosting/), bezpłatny [Darmowy hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/) zawarty w ofercie domeny lub oferta MX Plan zamówiona oddzielnie).
+- Posiadanie usługi e-mail MX Plan (dostępnej poprzez: [oferta hostingu](https://www.ovhcloud.com/pl/web-hosting/), bezpłatny [hosting darmowy](https://www.ovhcloud.com/pl/domains/free-web-hosting/) zawarty w ofercie domeny lub oferta MX Plan zamówiona oddzielnie).
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan / Zimbra Starter - Konfigurowanie adresu e-mail w klasycznym Outlooku dla Windows
 description: Dowiedz się, jak skonfigurować adres e-mail MX Plan w klasycznym Outlooku dla Windows
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,7 +23,7 @@ Konta MX Plan mogą być skonfigurowane w jednym z kompatybilnych programów poc
 
 - Posiadanie wcześniej skonfigurowanego rozwiązania e-mail OVHcloud, takiego jak:
     <Region zones={['eu']}>
-    - **MX Plan** oferowany wraz z naszymi [ofertami hostingowymi](https://www.ovhcloud.com/pl/web-hosting/) lub włączonym w [bezpłatnym hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/).
+    - **MX Plan** oferowany wraz z naszymi [ofertami hostingowymi](https://www.ovhcloud.com/pl/web-hosting/) lub włączonym w [bezpłatnym hosting](https://www.ovhcloud.com/pl/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** oferowany wraz z naszymi [ofertami hostingowymi](https://www.ovhcloud.com/pl/web-hosting/).

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Konfigurowanie adresu e-mail w Thunderbird na macOS
 description: Dowiedz się, jak skonfigurować adres e-mail MX Plan w Thunderbird na macOS
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,7 +20,7 @@ Konta e-mail MX Plan można skonfigurować w różnych kompatybilnych klientach 
 - Posiadanie oferty MX Plan. Jest ona dostępna poprzez:
     <Region zones={['eu']}>
     - Ofertę [hostingu WWW](https://www.ovhcloud.com/pl/web-hosting/).
-    - [Darmowy hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/) wraz z nazwą domeny (wcześniej aktywowaną).
+    - [Hosting darmowy](https://www.ovhcloud.com/pl/domains/free-web-hosting/) wraz z nazwą domeny (wcześniej aktywowaną).
     - Oddzielną ofertę MX Plan.
     - Posiadanie adresu e-mail [Zimbra Starter](https://www.ovhcloud.com/pl/emails/zimbra-emails/).
     </Region>

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Skonfigurowanie adresu e-mail w Thunderbird na Windows
 description: Dowiedz się, jak skonfigurować adres e-mail MX Plan w Thunderbird na Windows
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,7 +20,7 @@ Konta e-mail MX Plan można skonfigurować w różnych kompatybilnych klientach 
 - Posiadanie oferty MX Plan. Jest ona dostępna poprzez:
     <Region zones={['eu']}>
     - Ofertę [hostingu WWW](https://www.ovhcloud.com/pl/web-hosting/).
-    - [Darmowy hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/) wraz z nazwą domeny (wcześniej aktywowaną).
+    - [Hosting darmowy](https://www.ovhcloud.com/pl/domains/free-web-hosting/) wraz z nazwą domeny (wcześniej aktywowaną).
     - Oddzielną ofertę MX Plan.
     - Posiadanie adresu e-mail [Zimbra Starter](https://www.ovhcloud.com/pl/emails/zimbra-emails/).
     </Region>

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan / Zimbra Starter - Dodanie konta e-mail w nowym Outlook na Windows
 description: Dowiedz się, jak skonfigurować swój adres e-mail w nowym Outlook na Windows
-lastUpdated: 2026-01-09
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ Od dnia 1 stycznia 2025 roku **nowy Outlook** zastąpił aplikację **Poczta** w
 
 - Posiadanie wcześniej skonfigurowanego rozwiązania e-mail OVHcloud, takiego jak:
     <Region zones={['eu']}>
-    - **MX Plan** oferowany wraz z naszymi [ofertami hostingowymi](https://www.ovhcloud.com/pl/web-hosting/) lub włączonym w [bezpłatnym hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/).
+    - **MX Plan** oferowany wraz z naszymi [ofertami hostingowymi](https://www.ovhcloud.com/pl/web-hosting/) lub włączonym w [bezpłatnym hosting](https://www.ovhcloud.com/pl/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** oferowany wraz z naszymi [ofertami hostingowymi](https://www.ovhcloud.com/pl/web-hosting/).

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -1,7 +1,7 @@
 ---
 title: Przywróć usunięte elementy konta e-mail
 description: Dowiedz się, jak przywrócić usunięte elementy z konta e-mail poprzez Webmail (OWA)
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -17,7 +17,7 @@ Wykreśliłeś przez przypadek jeden lub kilka elementów (e-mail, kontakt, spot
  
 - Posiadanie rozwiązania poczty elektronicznej OVHcloud:
     <Region zones={['eu']}>
-    - **MX Plan** ([tylko nowa wersja](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)) proponowany w naszej [ofercie hostingu www](https://www.ovhcloud.com/pl/web-hosting/) zawartej w darmowym [Darmowy hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/)
+    - **MX Plan** ([tylko nowa wersja](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)) proponowany w naszej [ofercie hostingu www](https://www.ovhcloud.com/pl/web-hosting/) zawartej w darmowym [hosting darmowy](https://www.ovhcloud.com/pl/domains/free-web-hosting/)
     </Region>
     <Region zones={['ca']}>
     - **MX Plan** ([tylko nowa wersja](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)) proponowany w naszej [ofercie hostingu www](https://www.ovhcloud.com/pl/web-hosting/)

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zarządzanie przestrzenią dyskową konta e-mail
 description: Dowiedz się, jak zarządzać przestrzenią dyskową konta e-mail i jej optymalizować
-lastUpdated: 2025-08-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ Każde konto e-mail OVHcloud dysponuje dedykowaną przestrzenią dyskową. Zarz�
 
 - Posiadanie skonfigurowanego wcześniej rozwiązania e-mail OVHcloud, spośród następujących:
     <Region zones={['eu']}>
-    - **MX Plan** w ofercie [pakietów hostingowych](https://www.ovhcloud.com/pl/web-hosting/) lub zawarta w ofercie [darmowy hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/).
+    - **MX Plan** w ofercie [pakietów hostingowych](https://www.ovhcloud.com/pl/web-hosting/) lub zawarta w ofercie [hosting darmowy](https://www.ovhcloud.com/pl/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** w ofercie [pakietów hostingowych](https://www.ovhcloud.com/pl/web-hosting/).
@@ -68,7 +68,7 @@ Każde konto e-mail OVHcloud dysponuje dedykowaną przestrzenią dyskową. Zarz�
 **Szczególne przypadki**
 
 <Region zones={['eu']}>
-- Jeśli chodzi o bezpłatny Darmowy hosting 100M, konieczne jest wcześniejsze aktywowanie go przed utworzeniem konta e-mail. Operację tę możesz przeprowadzić w <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, przechodząc do odpowiedniej domeny.
+- Jeśli chodzi o bezpłatny Hosting darmowy, konieczne jest wcześniejsze aktywowanie go przed utworzeniem konta e-mail. Operację tę możesz przeprowadzić w <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, przechodząc do odpowiedniej domeny.
 </Region>
 - Zanim przejdziesz do niniejszego przewodnika, należy aktywować Twój pakiet MX Plan zawarty w [ofercie hostingu](https://www.ovhcloud.com/pl/web-hosting/). W tym celu zapoznaj się z naszym przewodnikiem "[Aktywuj konta e-mail zawarte w Twoim hostingu](/guides/web-cloud/web-hosting/activate-email-hosting)".
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tworzenie reguł skrzynki odbiorczej w aplikacji OWA
 description: Dowiedz się, jak utworzyć reguły przekierowania e-maili i filtry przy użyciu aplikacji OWA
-lastUpdated: 2020-03-11
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -16,7 +16,7 @@ Przy użyciu opcji „Reguły skrzynki odbiorczej” można utworzyć złożone 
 ## Wymagania początkowe
 
 <Region zones={['eu']}>
-- skonfigurowane rozwiązanie poczty elektronicznej OVHcloud (**usługa MX Plan** dostępna w ramach [hostingu WWW](https://www.ovhcloud.com/pl/web-hosting/), zawarta w [Darmowy hosting 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub zamówiona oddzielnie jako rozwiązanie autonomiczne; [**Hosted Exchange**](https://www.ovhcloud.com/pl/emails/hosted-exchange/) lub [**E-mail Pro**](https://www.ovhcloud.com/pl/emails/email-pro/))
+- skonfigurowane rozwiązanie poczty elektronicznej OVHcloud (**usługa MX Plan** dostępna w ramach [hostingu WWW](https://www.ovhcloud.com/pl/web-hosting/), zawarta w [hosting darmowy](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub zamówiona oddzielnie jako rozwiązanie autonomiczne; [**Hosted Exchange**](https://www.ovhcloud.com/pl/emails/hosted-exchange/) lub [**E-mail Pro**](https://www.ovhcloud.com/pl/emails/email-pro/))
 - dane do logowania dla adresu e-mail, który chcesz skonfigurować
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -1,7 +1,7 @@
 ---
 title: Korzystanie z konta e-mail w interfejsie Webmail Outlook Web App (OWA)
 description: Dowiedz się, jak korzystać z konta e-mail w interfejsie Webmail OWA
-lastUpdated: 2026-05-04
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -30,7 +30,7 @@ Wszystkie aktywne konta e-mail w usłudze MX Plan korzystają ze wspólnego punk
 
 - Skonfigurowane rozwiązanie poczty elektronicznej OVHcloud z poniższych ofert:
     <Region zones={['eu']}>
-    - [**MX Plan**](https://www.ovhcloud.com/pl/web-hosting/), dostępne w ramach hostingu WWW, zawarte w [darmowym hostingu 100M](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub zamówione oddzielnie jako rozwiązanie autonomiczne;
+    - [**MX Plan**](https://www.ovhcloud.com/pl/web-hosting/), dostępne w ramach hostingu WWW, zawarte w [darmowym hostingu](https://www.ovhcloud.com/pl/domains/free-web-hosting/) lub zamówione oddzielnie jako rozwiązanie autonomiczne;
     </Region>
     <Region zones={['ca', 'apac']}>
     - [**MX Plan**](https://www.ovhcloud.com/pl/web-hosting/), dostępne w ramach hostingu WWW lub zamówione oddzielnie jako rozwiązanie autonomiczne;

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tworzenie odpowiedzi automatycznych w interfejsie OWA
 description: Dowiedz się, jak skonfigurować odpowiedzi automatyczne w interfejsie OWA
-lastUpdated: 2024-10-22
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -29,7 +29,7 @@ Ta funkcja programu Exchange umożliwia skonfigurowanie automatycznych odpowiedz
 
 :::warning
 <Region zones={['eu']}>
-Jeśli Twój adres e-mail jest związany z ofertą **MX Plan** (zawarty w ofercie [hosting www](https://www.ovhcloud.com/pl/web-hosting/) i [hosting 100M za darmo](https://www.ovhcloud.com/pl/domains/free-web-hosting/)), w Panelu klienta znajduje się sekcja zatytułowana <code className="action">Zarządzanie autoresponderami</code>. Utwórz automatyczną odpowiedź w Panelu klienta OVHcloud, korzystając z dokumentacji ["MX Plan - Tworzenie automatycznej odpowiedzi na adres e-mail"](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).
+Jeśli Twój adres e-mail jest związany z ofertą **MX Plan** (zawarty w ofercie [hosting www](https://www.ovhcloud.com/pl/web-hosting/) i [hosting za darmo](https://www.ovhcloud.com/pl/domains/free-web-hosting/)), w Panelu klienta znajduje się sekcja zatytułowana <code className="action">Zarządzanie autoresponderami</code>. Utwórz automatyczną odpowiedź w Panelu klienta OVHcloud, korzystając z dokumentacji ["MX Plan - Tworzenie automatycznej odpowiedzi na adres e-mail"](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).
 </Region>
 <Region zones={['ca']}>
 Jeśli Twój adres e-mail jest związany z ofertą **MX Plan** (zawarty w ofercie [hosting www](https://www.ovhcloud.com/pl/web-hosting/)), w Panelu klienta znajduje się sekcja zatytułowana <code className="action">Zarządzanie autoresponderami</code>. Utwórz automatyczną odpowiedź w Panelu klienta OVHcloud, korzystając z dokumentacji ["MX Plan - Tworzenie automatycznej odpowiedzi na adres e-mail"](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses).

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -1,7 +1,7 @@
 ---
 title: Eliminar uma conta de e-mail
 description: Saiba como eliminar ou reinicializar um endereço de e-mail na sua oferta de e-mail
-lastUpdated: 2026-02-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ Deseja:
 
 - Dispor de uma solução de e-mail OVHcloud previamente configurada:
     <Region zones={['eu']}>
-    - **MX Plan**, proposta entre as nossas [ofertas de alojamento web](https://www.ovhcloud.com/pt/web-hosting/), incluída num [Alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou encomendada separadamente como solução autónoma.
+    - **MX Plan**, proposta entre as nossas [ofertas de alojamento web](https://www.ovhcloud.com/pt/web-hosting/), incluída num [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou encomendada separadamente como solução autónoma.
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan**, proposta entre as nossas [ofertas de alojamento web](https://www.ovhcloud.com/pt/web-hosting/) ou encomendada separadamente como solução autónoma.

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizar os alias e reencaminhamentos de e-mail
 description: Saiba como gerir os seus alias e reencaminhamentos de e-mail
-lastUpdated: 2025-06-03
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -91,7 +91,7 @@ Tenha em atenção que é possível configurar um reencaminhamento para vários 
 
 - Ter uma solução de e-mail OVHcloud previamente configurada, entre as seguintes:
     <Region zones={['eu']}>
-    - **MX Plan** proposta com os nossos [oferta de alojamento web](https://www.ovhcloud.com/pt/web-hosting/) ou incluída num [alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/).
+    - **MX Plan** proposta com os nossos [oferta de alojamento web](https://www.ovhcloud.com/pt/web-hosting/) ou incluída num [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** proposta com os nossos [oferta de alojamento web](https://www.ovhcloud.com/pt/web-hosting/).

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alterar a palavra-passe de um endereço de e-mail
 description: Saiba como alterar a palavra-passe de um endereço de e-mail da OVHcloud
-lastUpdated: 2025-08-12
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ As contas de e-mail da sua oferta OVHcloud são acessíveis graças à palavra-p
 
 - Ter uma solução de e-mail OVHcloud previamente configurada, entre as seguintes:
     <Region zones={['eu']}>
-    - **MX Plan** proposta com os nossos [oferta de alojamento web](https://www.ovhcloud.com/pt/web-hosting/) ou incluída num [alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/).
+    - **MX Plan** proposta com os nossos [oferta de alojamento web](https://www.ovhcloud.com/pt/web-hosting/) ou incluída num [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** proposta com os nossos [oferta de alojamento web](https://www.ovhcloud.com/pt/web-hosting/).

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Criar um endereço de e-mail com a oferta MX Plan
 description: Saiba como criar um endereço de e-mail com a oferta MX Plan
-lastUpdated: 2025-08-26
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,7 +24,7 @@ Adquiriu um serviço de e-mail MX Plan. que lhe permite beneficiar de endereços
 - Dispor de uma oferta MX Plan. Esta última está disponível através de:
     - Uma oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/).
     <Region zones={['eu']}>
-    - Um [alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/) incluído com um nome de domínio (ativado anteriormente).
+    - Um [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/) incluído com um nome de domínio (ativado anteriormente).
     </Region>
     - Uma oferta MX Plan encomendada separadamente.
 
@@ -32,7 +32,7 @@ Adquiriu um serviço de e-mail MX Plan. que lhe permite beneficiar de endereços
 **Casos especiais**
 
 <Region zones={['eu']}>
-- Relativamente ao alojamento gratuito 100M: é obrigatório ativá-lo antes para poder criar um endereço de e-mail. Pode efetuar esta operação a partir da <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, posicionando-se no domínio em questão.
+- Relativamente ao alojamento gratuito: é obrigatório ativá-lo antes para poder criar um endereço de e-mail. Pode efetuar esta operação a partir da <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, posicionando-se no domínio em questão.
 </Region>
 - No âmbito de um [alojamento web](https://www.ovhcloud.com/pt/web-hosting/), é necessário ativar a oferta MX Plan incluída antes de continuar a ler este manual. Para isso, consulte o nosso manual "[Ativar os endereços de e-mail incluídos no seu alojamento web](/guides/web-cloud/web-hosting/activate-email-hosting)".
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Introdução à oferta MX Plan
 description: Saiba como começar a usar a oferta MX Plan
-lastUpdated: 2026-03-05
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ Adquiriu um serviço MX Plan, que lhe permite beneficiar de endereços de e-mail
 ## Requisitos
 
 <Region zones={['eu']}>
-- Dispor de uma oferta MX Plan Está disponível através de: uma oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/), o [Alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou a oferta MX Plan sozinha.
+- Dispor de uma oferta MX Plan Está disponível através de: uma oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/), o [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou a oferta MX Plan sozinha.
 </Region>
 
 <Region zones={['ca', 'apac']}>

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Webmail: Guia de utilização do Roundcube"
-lastUpdated: 2026-06-01
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -12,7 +12,7 @@ Com a oferta MX Plan da OVHcloud, pode enviar e receber e-mails a partir de um s
 
 ## Requisitos
 
-- Dispor de uma solução de e-mail OVHcloud **MX Plan**, proposta entre as nossas [ofertas de alojamento web](/links/web/hosting), incluída num [alojamento gratuito 100M](/links/web/domains-free-hosting), ou encomendada separadamente como solução autónoma.
+- Dispor de uma solução de e-mail OVHcloud **MX Plan**, proposta entre as nossas [ofertas de alojamento web](/links/web/hosting), incluída num [alojamento gratuito](/links/web/domains-free-hosting), ou encomendada separadamente como solução autónoma.
 - Dispor das informações de ligação ao endereço de e-mail MX Plan que pretende consultar. Para mais informações, consulte o nosso guia [Primeiros passos com a oferta MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - A sua solução de e-mail OVHcloud **MX Plan** deve utilizar a tecnologia de webmail **Roundcube**. Para a identificar, siga as instruções abaixo.
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizar o webmail Zimbra
 description: Descubra a interface do webmail Zimbra para os endereços de e-mail MX Plan da OVHcloud
-lastUpdated: 2026-02-26
+lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
@@ -19,7 +19,7 @@ A OVHcloud fornece um serviço de webmail chamado Zimbra para aceder a uma conta
 
 ## Requisitos
 
-- Dispor de uma solução de e-mail OVHcloud **MX Plan**, proposta entre as nossas [ofertas de alojamento web](https://www.ovhcloud.com/pt/web-hosting/), incluída num [alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/), ou encomendada separadamente como solução autónoma.
+- Dispor de uma solução de e-mail OVHcloud **MX Plan**, proposta entre as nossas [ofertas de alojamento web](https://www.ovhcloud.com/pt/web-hosting/), incluída num [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/), ou encomendada separadamente como solução autónoma.
 - Ter acesso às informações de início de sessão do endereço de e-mail MX Plan que pretende consultar. Para mais informações, consulte o nosso guia "[Primeiros passos com a oferta MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)".
 
 ## Instruções

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Criar uma resposta automática em um endereço de e-mail
 description: Saiba como ativar uma resposta automática num endereço de e-mail
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -17,7 +17,7 @@ Quando estiver em falta e não conseguir consultar o seu endereço de e-mail, po
 
 <Region zones={['eu']}>
 
-- Dispor de uma oferta MX Plan. Esta última está disponível através de: uma oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/), o [alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/) incluído com um domínio (ativado anteriormente) ou a oferta MX Plan encomendada separadamente.
+- Dispor de uma oferta MX Plan. Esta última está disponível através de: uma oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/), o [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/) incluído com um domínio (ativado anteriormente) ou a oferta MX Plan encomendada separadamente.
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-delegation.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Delegue a gestão das suas contas de e-mail a outra pessoa
 description: Saiba como delegar a gestão das contas de e-mail da sua oferta MX Plan
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ A delegação dá ao utilizador de uma conta de e-mail a possibilidade de gerir 
 
 <Region zones={['eu']}>
 
-- Dispor de uma oferta MX Plan Está disponível através de: uma [oferta de alojamento Web Cloud](https://www.ovhcloud.com/pt/web-hosting/), um [Alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou uma oferta MX Plan encomendada separadamente.
+- Dispor de uma oferta MX Plan Está disponível através de: uma [oferta de alojamento Web Cloud](https://www.ovhcloud.com/pt/web-hosting/), um [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou uma oferta MX Plan encomendada separadamente.
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-filters.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-filters.mdx
@@ -1,7 +1,7 @@
 ---
 title: Criar filtros para os seus endereços de e-mail
 description: Saiba como criar e configurar um filtro no seu endereço de e-mail
-lastUpdated: 2025-04-28
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,13 +22,13 @@ Por exemplo: deseja que todo o e-mail que contenha "\[SPAM]" no assumpto seja el
 
 <Region zones={['eu']}>
 
-- Ter um serviço de e-mail MX Plan (disponível através de: um plano de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/), o [Alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/) incluído com um domínio ou a oferta MX Plan (encomendada separadamente).
+- Ter um serviço de e-mail MX Plan (disponível através de: um plano de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/), o [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/) incluído com um domínio ou a oferta MX Plan (encomendada separadamente)).
 
 </Region>
 
 <Region zones={['ca', 'apac']}>
 
-- Ter um serviço de e-mail MX Plan (disponível através de: um plano de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) ou a oferta MX Plan (encomendada separadamente).
+- Ter um serviço de e-mail MX Plan (disponível através de: um plano de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) ou a oferta MX Plan (encomendada separadamente)).
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list.mdx
@@ -36,7 +36,7 @@ O remetente (sender) transmite o e-mail à mailing list. O moderador (moderator)
 
 ## Requisitos
 
-- Ter uma oferta de e-mail MX Plan 100 no mínimo ou um [Alojamento web](https://www.ovhcloud.com/pt/web-hosting/) elegível para as listas de difusão.
+- Ter uma oferta de e-mail MX Plan 100 no mínimo ou um [alojamento web](https://www.ovhcloud.com/pt/web-hosting/) elegível para as listas de difusão.
 
 {/* CP-NAV-START:web-mx-plan */}
 ---

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan / Zimbra Starter - Configurar o seu endereço de e-mail no Outlook clássico para Windows
 description: Descubra como configurar o seu endereço de e-mail MX Plan no Outlook clássico para Windows
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,7 +23,7 @@ Os endereços de e-mail das ofertas **MX Plan** e [Zimbra Starter](https://www.o
 
 - Ter uma solução de e-mail OVHcloud previamente configurada, dentre as seguintes:
     <Region zones={['eu']}>
-    - **MX Plan** oferecido com nossas [ofertas de alojamento web](https://www.ovhcloud.com/pt/web-hosting/) ou incluído em um [alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/).
+    - **MX Plan** oferecido com nossas [ofertas de alojamento web](https://www.ovhcloud.com/pt/web-hosting/) ou incluído em um [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** oferecido com nossas [ofertas de alojamento web](https://www.ovhcloud.com/pt/web-hosting/).

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Configurar seu endereço de e-mail no Thunderbird para macOS
 description: Descubra como configurar seu endereço de e-mail MX Plan no Thunderbird para macOS
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,7 +20,7 @@ As contas de e-mail MX Plan podem ser configuradas em diferentes clientes de e-m
 - Ter uma oferta MX Plan. Esta está disponível por meio de:
     <Region zones={['eu']}>
     - Uma oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/).
-    - Um [alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/) incluída com um nome de domínio (ativado previamente).
+    - Um [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/) incluída com um nome de domínio (ativado previamente).
     - Uma oferta MX Plan encomendada separadamente.
     - Ter um endereço de e-mail [Zimbra Starter](https://www.ovhcloud.com/pt/emails/zimbra-emails/).
     </Region>

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Configurar seu endereço de e-mail no Thunderbird para Windows
 description: Descubra como configurar seu endereço de e-mail MX Plan no Thunderbird para Windows
-lastUpdated: 2025-09-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,7 +20,7 @@ As contas de e-mail MX Plan podem ser configuradas em diferentes clientes de e-m
 - Ter uma oferta MX Plan. Esta está disponível por meio de:
     <Region zones={['eu']}>
     - Uma oferta de [alojamento web](https://www.ovhcloud.com/pt/web-hosting/).
-    - Um [alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/) incluída com um nome de domínio (ativado previamente).
+    - Um [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/) incluída com um nome de domínio (ativado previamente).
     - Uma oferta MX Plan encomendada separadamente.
     - Ter um endereço de e-mail [Zimbra Starter](https://www.ovhcloud.com/pt/emails/zimbra-emails/).
     </Region>

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan / Zimbra Starter - Adicionar uma conta de e-mail no novo Outlook para Windows
 description: Saiba como configurar seu endereço de e-mail no novo Outlook para Windows
-lastUpdated: 2026-01-09
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -25,7 +25,7 @@ O **novo Outlook** substitui, desde 1º de janeiro de 2025, o aplicativo **Corre
 
 - Ter uma solução de e-mail OVHcloud previamente configurada, dentre as seguintes:
     <Region zones={['eu']}>
-    - **MX Plan** oferecido com nossas [ofertas de hospedagem web](https://www.ovhcloud.com/pt/web-hosting/) ou incluído em um [hospedagem gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/).
+    - **MX Plan** oferecido com nossas [ofertas de hospedagem web](https://www.ovhcloud.com/pt/web-hosting/) ou incluído em um [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** oferecido com nossas [ofertas de hospedagem web](https://www.ovhcloud.com/pt/web-hosting/).

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -1,7 +1,7 @@
 ---
 title: Restaurar os elementos eliminados da sua conta de e-mail
 description: Saiba como restaurar os elementos eliminados a partir da sua conta de e-mail através do webmail (OWA)
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -19,7 +19,7 @@ Eliminou por erro um ou vários elementos (e-mail, contacto, calendário) e esva
  
 - Ter uma solução de e-mail OVHcloud:
     <Region zones={['eu']}>
-    - **MX Plan** ([nova versão apenas](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)) proposto entre as nossas [ofertas de alojamento web](https://www.ovhcloud.com/pt/web-hosting/), incluído num [Alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/)
+    - **MX Plan** ([nova versão apenas](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)) proposto entre as nossas [ofertas de alojamento web](https://www.ovhcloud.com/pt/web-hosting/), incluído num [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/)
     </Region>
     <Region zones={['ca']}>
     - **MX Plan** ([nova versão apenas](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)) proposto entre as nossas [ofertas de alojamento web](https://www.ovhcloud.com/pt/web-hosting/)

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: Gerir o espaço de armazenamento de uma conta de e-mail
 description: Saiba como gerir e otimizar o espaço de armazenamento de um endereço de e-mail 
-lastUpdated: 2025-08-19
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -21,7 +21,7 @@ Cada conta de e-mail da OVHcloud dispõe de um espaço de armazenamento dedicado
 
 - Ter uma solução de e-mail OVHcloud previamente configurada, entre as seguintes:
     <Region zones={['eu']}>
-    - **MX Plan** proposta com os nossos [oferta de alojamento web](https://www.ovhcloud.com/pt/web-hosting/) ou incluída num [alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/).
+    - **MX Plan** proposta com os nossos [oferta de alojamento web](https://www.ovhcloud.com/pt/web-hosting/) ou incluída num [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/).
     </Region>
     <Region zones={['ca', 'apac']}>
     - **MX Plan** proposta com os nossos [oferta de alojamento web](https://www.ovhcloud.com/pt/web-hosting/).
@@ -68,7 +68,7 @@ Cada conta de e-mail da OVHcloud dispõe de um espaço de armazenamento dedicado
 **Casos especiais**
 
 <Region zones={['eu']}>
-- Relativamente ao Alojamento gratuito 100M: é obrigatório ativá-lo antes para poder criar um endereço de e-mail. Pode efetuar esta operação a partir da <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, posicionando-se no domínio em questão.
+- Relativamente ao Alojamento gratuito: é obrigatório ativá-lo antes para poder criar um endereço de e-mail. Pode efetuar esta operação a partir da <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, posicionando-se no domínio em questão.
 </Region>
 - No âmbito de um [alojamento web](https://www.ovhcloud.com/pt/web-hosting/), é necessário ativar a oferta MX Plan incluída antes de continuar a ler este manual. Para isso, consulte o nosso manual "[Ativar os endereços de e-mail incluídos no seu alojamento web](/guides/web-cloud/web-hosting/activate-email-hosting)".
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
@@ -1,7 +1,7 @@
 ---
 title: Criar regras inbox no OWA
 description: Saiba como redirecionar e-mails e criar filtros através do OWA
-lastUpdated: 2020-03-11
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -16,7 +16,7 @@ Através da opção "Regras inbox", poderá criar um conjunto elaborado de regra
 ## Requisitos
 
 <Region zones={['eu']}>
-- uma solução de e-mail OVHcloud já configurada (**MX Plan**, disponível como parte dos nossos [planos Web Hosting](https://www.ovhcloud.com/pt/web-hosting/), incluída num [Alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou encomendada separadamente como solução autónoma; [**Hosted Exchange**](https://www.ovhcloud.com/pt/emails/hosted-exchange/) ou [**E-mail Pro**](https://www.ovhcloud.com/pt/emails/email-pro/))
+- uma solução de e-mail OVHcloud já configurada (**MX Plan**, disponível como parte dos nossos [planos Web Hosting](https://www.ovhcloud.com/pt/web-hosting/), incluída num [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou encomendada separadamente como solução autónoma; [**Hosted Exchange**](https://www.ovhcloud.com/pt/emails/hosted-exchange/) ou [**E-mail Pro**](https://www.ovhcloud.com/pt/emails/email-pro/))
 - credenciais de login para o endereço de e-mail que deseja configurar
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizar o endereço de e-mail a partir do webmail Outlook Web App (OWA)
 description: Saiba como utilizar o seu endereço de e-mail a partir do webmail OWA
-lastUpdated: 2026-05-04
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -30,7 +30,7 @@ Todas as contas de e-mail ativas no MX Plan têm um único ponto de acesso à re
 
 - Dispor de uma solução de e-mail OVHcloud previamente configurada, entre as ofertas seguintes:
     <Region zones={['eu']}>
-    - [**MX Plan**](https://www.ovhcloud.com/pt/web-hosting/), proposto com as nossas ofertas de alojamento web, incluído no [alojamento gratuito 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou encomendado como solução autónoma;
+    - [**MX Plan**](https://www.ovhcloud.com/pt/web-hosting/), proposto com as nossas ofertas de alojamento web, incluído no [alojamento gratuito](https://www.ovhcloud.com/pt/domains/free-web-hosting/) ou encomendado como solução autónoma;
     </Region>
     <Region zones={['ca', 'apac']}>
     - [**MX Plan**](https://www.ovhcloud.com/pt/web-hosting/), proposto com as nossas ofertas de alojamento web ou encomendado como solução autónoma;

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/owa-automatic-replies.mdx
@@ -1,7 +1,7 @@
 ---
 title: Criar respostas automáticas no OWA
 description: Saiba como configurar respostas automáticas no OWA
-lastUpdated: 2024-10-22
+lastUpdated: 2026-06-08
 availableIn: [eu, ca]
 ---
 
@@ -29,7 +29,7 @@ Esta funcionalidade do Exchange permite-lhe configurar respostas automáticas ao
 
 :::warning
 <Region zones={['eu']}>
-Se o seu endereço de e-mail estiver associado a uma oferta **MX Plan** (incluída com os [alojamentos web](https://www.ovhcloud.com/pt/web-hosting/) e os [alojamentos gratuitos 100M](https://www.ovhcloud.com/pt/domains/free-web-hosting/)), o seu espaço cliente propõe uma secção intitulada <code className="action">Gestão das respostas automáticas</code>. Deverá criar uma resposta automática a partir da Área de Cliente OVHcloud, recorrendo à documentação "[MX Plan - Criar uma resposta automática num endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses)".
+Se o seu endereço de e-mail estiver associado a uma oferta **MX Plan** (incluída com os [alojamentos web](https://www.ovhcloud.com/pt/web-hosting/) e os [alojamentos gratuitos](https://www.ovhcloud.com/pt/domains/free-web-hosting/)), o seu espaço cliente propõe uma secção intitulada <code className="action">Gestão das respostas automáticas</code>. Deverá criar uma resposta automática a partir da Área de Cliente OVHcloud, recorrendo à documentação "[MX Plan - Criar uma resposta automática num endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses)".
 </Region>
 <Region zones={['ca']}>
 Se o seu endereço de e-mail estiver associado a uma oferta **MX Plan** (incluída com os [alojamentos web](https://www.ovhcloud.com/pt/web-hosting/)), o seu espaço cliente propõe uma secção intitulada <code className="action">Gestão das respostas automáticas</code>. Deverá criar uma resposta automática a partir da Área de Cliente OVHcloud, recorrendo à documentação "[MX Plan - Criar uma resposta automática num endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-auto-responses)".


### PR DESCRIPTION


Remove the obsolete "100M" suffix from free-hosting references across the MX Plan and

collaborative email guides (7 locales) and align the free-hosting offer name to the

web-hosting range page wording.

Also fix a few pre-existing markdown (unbalanced parentheses) and capitalisation issues.