### PR TITLE
fix(chatbot): point linkPolicy at localized legal-information page

### DIFF
--- a/components/AIChatbot/index.tsx
+++ b/components/AIChatbot/index.tsx
@@ -69,7 +69,9 @@ function AIChatbotClient({
           containerRef.current,
           {
             locale: locale ?? 'fr',
-            linkPolicy: linkPolicy ?? 'https://www.ovhcloud.com/',
+            linkPolicy:
+              linkPolicy ??
+              `https://www.ovhcloud.com/${locale ?? 'fr'}/compliance/informations-legales/`,
             darkTheme: darkTheme ?? false,
             onClose,
             onTracking,
@@ -119,7 +121,7 @@ function AIChatbotClient({
 // Wrapper that skips SSG - only renders on client
 export function AIChatbot({
   locale = 'fr',
-  linkPolicy = 'https://www.ovhcloud.com/',
+  linkPolicy = 'https://www.ovhcloud.com/fr/compliance/informations-legales/',
   onClose,
   onTracking,
 }: AIChatbotProps) {

--- a/theme/components/AIChatbotDrawer/AIChatbotDrawer.tsx
+++ b/theme/components/AIChatbotDrawer/AIChatbotDrawer.tsx
@@ -29,7 +29,13 @@ export function AIChatbotDrawer() {
         className={`ai-drawer-panel ${isOpen ? 'ai-drawer-panel--open' : ''}`}
       >
         <div className="ai-drawer-content">
-          {hasBeenOpened && <AIChatbot locale={lang} onClose={close} />}
+          {hasBeenOpened && (
+            <AIChatbot
+              locale={lang}
+              linkPolicy={`https://www.ovhcloud.com/${lang}/compliance/informations-legales/`}
+              onClose={close}
+            />
+          )}
         </div>
       </div>
     </>


### PR DESCRIPTION
The AI chatbot's linkPolicy defaulted to the bare https://www.ovhcloud.com/ instead of the legal-information notice. Derive it per-locale from the active lang so each locale links to its own page.

https://www.ovhcloud.com/{lang}/compliance/informations-legales/