### PR TITLE
docs(regression): restore voucher + VPS SMTP content, tokenize links

### DIFF
--- a/docs/de/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/de/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cloud Guthaben aufladen
 description: Erfahren Sie hier, wie Sie Ihrem Public Cloud Projekt Guthaben oder Gutscheine hinzufügen
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-11
 ---
 
 ## Ziel
@@ -13,7 +13,7 @@ Das bedeutet, dass dieses Guthabenkonto zuerst belastet wird und dann noch verbl
 
 ## Voraussetzungen
 
-- Sie verfügen über ein [Public Cloud Projekt](https://www.ovhcloud.com/de/public-cloud/) in Ihrem OVHcloud Kunden-Account.
+- Sie verfügen über ein [Public Cloud Projekt](/links/public-cloud/public-cloud) in Ihrem OVHcloud Kunden-Account.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -65,7 +65,7 @@ Geben Sie im angezeigten Fenster den Code des Gutscheins ein und klicken Sie auf
 Der Gutschein-Saldo erscheint in der Liste <code className="action">Guthaben und Gutscheine</code>.
 
 :::info
-Da die Gültigkeitsdauer der Gutscheine in der Regel kürzer ist, wird der Guthaben des Gutscheins vor dem Public Cloud Guthaben verwendet.
+Gutscheine sind in der Regel einen Monat gültig. Verwenden Sie den Gutschein so schnell wie möglich. Der Gutschein-Saldo wird vor dem Public Cloud Guthaben verwendet.
 
 :::
 
@@ -76,4 +76,4 @@ Da die Gültigkeitsdauer der Gutscheine in der Regel kürzer ist, wird der Gutha
 Neukunden erhalten automatisch ein Gratis-Testguthaben von 200 €, sobald sie ihr erstes Public Cloud Projekt aktivieren. Lesen Sie hierzu unsere Anleitung "[Erstellung Ihres ersten OVHcloud Public Cloud Projekts](/guides/public-cloud/cross-functional/create-a-public-cloud-project)".
 :::
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud VPS FAQ
 description: Finden Sie Antworten auf die am häufigsten gestellten Fragen zu unseren VPS-Angeboten
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-11
 ---
 
 import Api from '@components/Api';
@@ -39,7 +39,7 @@ OVHcloud VPS-Angebote bieten hervorragenden Leistungspreis, mit unbegrenztem Dat
 
 Die Nutzung eines VPS erfordert grundlegende Kenntnisse der Server-Administration. Dies zu berücksichtigen ist entscheidend, um Ihr Betriebssystem (Linux oder Windows) effektiv zu verwalten und Ihre Anwendungen einzurichten, z. B. PrestaShop oder WordPress.
 
-Wenn Sie einen VPS benötigen, aber nicht über die technischen Kenntnisse verfügen, um ihn zu verwalten, wenden Sie sich an einen unserer [Partner](https://partner.ovhcloud.com/de/directory/) für Unterstützung.
+Wenn Sie einen VPS benötigen, aber nicht über die technischen Kenntnisse verfügen, um ihn zu verwalten, wenden Sie sich an einen unserer [Partner](/links/partner) für Unterstützung.
 
 Wenn Sie Ressourcen benötigen, aber nicht mit der Server-Administration umgehen möchten, empfehlen wir Ihnen, unsere Performance-Webhosting-Pläne in Betracht zu ziehen.
 
@@ -97,7 +97,7 @@ Zusätzlich bieten wir:
 
 Durch die Nutzung dieser Lösungen können Sie Ihre Backup-Verwaltung an Ihre Sicherheits- und Kontinuitätsanforderungen anpassen.
 
-Besuchen Sie unsere [VPS-Webseite](https://www.ovhcloud.com/de/vps/), um mehr über die verfügbaren Optionen zu erfahren.
+Besuchen Sie unsere [VPS-Webseite](/links/bare-metal/vps), um mehr über die verfügbaren Optionen zu erfahren.
 
 </details>
 
@@ -179,7 +179,7 @@ Ein VPS beseitigt die Notwendigkeit, physische Hardware wie Speicher, RAM und CP
 <summary>Welche Bandbreite ist meinem VPS zugeordnet? Ist sie garantiert?</summary>
 
 
-Die Bandbreite, die auf unserer [VPS-Webseite](https://www.ovhcloud.com/de/vps/) aufgelistet ist, ist garantiert. Es handelt sich um den minimalen Wert, der Ihrem Dienst zugeordnet wird.
+Die Bandbreite, die auf unserer [VPS-Webseite](/links/bare-metal/vps) aufgelistet ist, ist garantiert. Es handelt sich um den minimalen Wert, der Ihrem Dienst zugeordnet wird.
 
 </details>
 
@@ -261,7 +261,7 @@ Zum Beispiel bieten wir eine Vielzahl vorab konfigurierter Vorlagen und Images f
 
 Außerdem bietet unsere Dokumentation und Wissensdatenbank eine Fülle von Informationen zur Konfiguration und Verwaltung Ihres VPS.
 
-Für spezifische Unterstützung bei der Softwarekonfiguration empfehlen wir Ihnen, sich an unsere [Community](https://community.ovhcloud.com/community/en) zu wenden oder die Hilfe eines qualifizierten Systemadministrators oder Entwicklers über unser [Partnerportal](https://partner.ovhcloud.com/de/directory/) in Anspruch zu nehmen.
+Für spezifische Unterstützung bei der Softwarekonfiguration empfehlen wir Ihnen, sich an unsere [Community](/links/community) zu wenden oder die Hilfe eines qualifizierten Systemadministrators oder Entwicklers über unser [Partnerportal](/links/partner) in Anspruch zu nehmen.
 
 </details>
 
@@ -279,6 +279,8 @@ Dazu gehören:
 - Konfiguration des Reverse DNS (PTR),
 - Einhaltung der Best Practices der E-Mail-Anbieter.
 
+Wenn keine E-Mails gesendet werden oder der SMTP-Server nicht antwortet, prüfen Sie, ob die SMTP-Ports blockiert sind. Port 25 ist auf OVHcloud VPS standardmäßig blockiert, um Missbrauch zu verhindern. Verwenden Sie stattdessen Port 587 (STARTTLS) für den ausgehenden E-Mail-Versand oder beantragen Sie bei Bedarf die Entsperrung von Port 25, indem Sie [unser Support-Team kontaktieren](/links/support-contact).
+
 Weitere Informationen finden Sie in unserer Anleitung: [Wie Sie verhindern, dass Ihre E-Mails als Spam markiert werden](/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization).
 
 </details>
@@ -292,7 +294,7 @@ Weitere Informationen finden Sie in unserer Anleitung: [Wie Sie verhindern, dass
 OVHcloud Templates erlauben die Installation eines einzigen Betriebssystems.  
 Individuelle Anpassungen können vom Kunden vorgenommen werden und liegen in der Verantwortung des Server-Administrators. OVHcloud Dienste umfassen keine Verwaltungsaufgaben, wie z. B. Softwarekonfiguration oder externe Tools.
 
-Falls Sie bei der Konfiguration und Verwaltung Probleme haben, empfehlen wir Ihnen, sich an unsere [Community](https://community.ovhcloud.com/community/en) zu wenden oder die Hilfe eines qualifizierten Systemadministrators oder Entwicklers über unser [Partnerportal](https://partner.ovhcloud.com/de/directory/) in Anspruch zu nehmen.
+Falls Sie bei der Konfiguration und Verwaltung Probleme haben, empfehlen wir Ihnen, sich an unsere [Community](/links/community) zu wenden oder die Hilfe eines qualifizierten Systemadministrators oder Entwicklers über unser [Partnerportal](/links/partner) in Anspruch zu nehmen.
 
 </details>
 
@@ -306,7 +308,7 @@ OVHcloud Templates für VPS enthalten weder das Proxmox-Betriebssystem noch ein 
 
 Anpassungen können vom Kunden vorgenommen werden und liegen in der Verantwortung des Server-Administrators. OVHcloud Dienste umfassen keine Verwaltungsaufgaben, wie z. B. Softwarekonfiguration oder die Nutzung externer Tools.
 
-Falls Sie bei der Konfiguration und Verwaltung Schwierigkeiten haben, empfehlen wir Ihnen, sich an unsere [Community](https://community.ovhcloud.com/community/en) zu wenden oder die Hilfe eines qualifizierten Systemadministrators oder Entwicklers über unser [Partnerportal](https://partner.ovhcloud.com/de/directory/) in Anspruch zu nehmen.
+Falls Sie bei der Konfiguration und Verwaltung Schwierigkeiten haben, empfehlen wir Ihnen, sich an unsere [Community](/links/community) zu wenden oder die Hilfe eines qualifizierten Systemadministrators oder Entwicklers über unser [Partnerportal](/links/partner) in Anspruch zu nehmen.
 
 </details>
 
@@ -317,7 +319,7 @@ Falls Sie bei der Konfiguration und Verwaltung Schwierigkeiten haben, empfehlen 
 
 
 Ein VPS kann nicht auf der Hardware-Ebene angepasst oder geändert werden.  
-Wählen Sie im Bestellprozess ein [VPS-Modell](https://www.ovhcloud.com/de/vps/) aus, das Ihre Mindestanforderungen erfüllt, und stufen Sie es bei Bedarf hoch.
+Wählen Sie im Bestellprozess ein [VPS-Modell](/links/bare-metal/vps) aus, das Ihre Mindestanforderungen erfüllt, und stufen Sie es bei Bedarf hoch.
 
 </details>
 
@@ -331,7 +333,7 @@ Um Leistungsprobleme auf Ihrem VPS zu beheben, müssen Sie unserem Support-Team 
 
 Beachten Sie, dass Ihr VPS in den [Rescue-Modus](/guides/bare-metal-cloud/virtual-private-servers/rescue) gebootet werden muss, um mögliche Softwareprobleme auszuschließen.
 
-Wenden Sie sich an unser Support-Team, indem Sie [eine Anfrage im OVHcloud Help Center erstellen](https://help.ovhcloud.com/csm?id=csm_get_help), damit wir Ihnen die vollständige Liste der erforderlichen Tests für eine ordnungsgemäße Begutachtung bereitstellen können.
+Wenden Sie sich an unser Support-Team, indem Sie [eine Anfrage im OVHcloud Help Center erstellen](/links/support-contact), damit wir Ihnen die vollständige Liste der erforderlichen Tests für eine ordnungsgemäße Begutachtung bereitstellen können.
 
 </details>
 
@@ -341,7 +343,7 @@ Wenden Sie sich an unser Support-Team, indem Sie [eine Anfrage im OVHcloud Help 
 <summary>Ich habe einen neuen VPS bestellt, kann ich die verbleibende Vertragszeit meines alten VPS übertragen oder eine Rückerstattung erhalten?</summary>
 
 
-Dies ist in der Regel möglich, doch der Prozess erfordert eine [Anfrage an unser Support-Team über das OVHcloud Help Center](https://help.ovhcloud.com/csm?id=csm_get_help).
+Dies ist in der Regel möglich, doch der Prozess erfordert eine [Anfrage an unser Support-Team über das OVHcloud Help Center](/links/support-contact).
 
 Bevor Sie fortfahren, stellen Sie sicher, dass Sie [alle noch benötigten Daten migriert haben](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) oder erstellen Sie Backups Ihrer Daten.
 
@@ -368,7 +370,7 @@ Eine Migration eines VPS in ein anderes Rechenzentrum ist nicht möglich. Um die
 <summary>Wie viele zusätzliche IPs kann ich auf einem VPS konfigurieren?</summary>
 
 
-Ein VPS ist auf [16 zusätzliche IP-Adressen](https://www.ovhcloud.com/de/network/additional-ip/) beschränkt.
+Ein VPS ist auf [16 zusätzliche IP-Adressen](/links/network/additional-ip) beschränkt.
 
 Weitere Informationen zur IP-Konfiguration finden Sie in unserer Anleitung zur [Konfiguration von IP-Alias](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing).
 
@@ -381,7 +383,7 @@ Weitere Informationen zur IP-Konfiguration finden Sie in unserer Anleitung zur [
 
 
 Es ist nicht möglich, IP-Blöcke zu einem VPS hinzuzufügen.  
-Auf einem VPS können bis zu [16 zusätzliche IP-Adressen](https://www.ovhcloud.com/de/network/additional-ip/) konfiguriert werden.
+Auf einem VPS können bis zu [16 zusätzliche IP-Adressen](/links/network/additional-ip) konfiguriert werden.
 
 </details>
 
@@ -393,7 +395,7 @@ Auf einem VPS können bis zu [16 zusätzliche IP-Adressen](https://www.ovhcloud.
 
 Lizenzen können zwischen Servern übertragen werden, es gibt jedoch Einschränkungen.
 
-Die beste Option besteht darin, sich mit Ihren Login-Daten in unserer [API-Konsole](https://eu.api.ovh.com/) einzuloggen und zu prüfen, ob Ihre Lizenz auf einen anderen VPS übertragen werden kann. Weitere Informationen finden Sie in unserer Anleitung zu [den ersten Schritten mit der OVHcloud API](/guides/manage-and-operate/api/first-steps).
+Die beste Option besteht darin, sich mit Ihren Login-Daten in unserer [API-Konsole](/links/console) einzuloggen und zu prüfen, ob Ihre Lizenz auf einen anderen VPS übertragen werden kann. Weitere Informationen finden Sie in unserer Anleitung zu [den ersten Schritten mit der OVHcloud API](/guides/manage-and-operate/api/first-steps).
 
 Sobald Sie verbunden sind, verwenden Sie die folgenden Aufrufe, abhängig von der verwendeten Software:
 
@@ -472,7 +474,7 @@ Folgen Sie unserer Anleitung zur [Verwendung von Snapshots auf einem VPS](/guide
 
 Sie können die heruntergeladene Snapshot-Datei anschließend lokal in ein Format umwandeln, das Ihren Anforderungen entspricht.
 
-Für weitergehende Unterstützung können Sie sich an einen unserer [Partner](https://partner.ovhcloud.com/de/directory/) wenden.
+Für weitergehende Unterstützung können Sie sich an einen unserer [Partner](/links/partner) wenden.
 
 </details>
 
@@ -493,7 +495,7 @@ Nur OVHcloud IP-Adressen können autorisiert werden.
 :::
 
 
-Loggen Sie sich in die [OVHcloud API-Konsole](https://eu.api.ovh.com/) mit Ihren Login-Daten ein und verwenden Sie den folgenden Aufruf:
+Loggen Sie sich in die [OVHcloud API-Konsole](/links/console) mit Ihren Login-Daten ein und verwenden Sie den folgenden Aufruf:
 
 <Api version="v1" section="/vps" method="POST" route={"/vps/\{serviceName\}/backupftp/access"} />
 
@@ -537,7 +539,7 @@ Obwohl OVHcloud Sicherheitsmaßnahmen anwendet, um die gesamte Infrastruktur zu 
 
 OVHcloud bietet mehrere Sicherheitsfunktionen, um Ihren VPS vor schädlichem Traffic zu schützen:
 
-- Anti-DDoS-Schutz: Unsere VPS-Dienste sind standardmäßig durch unsere [Anti-DDoS-Infrastruktur](https://www.ovhcloud.com/de/security/anti-ddos/) geschützt, die DDoS-Angriffe in Echtzeit erkennt und abmildert.
+- Anti-DDoS-Schutz: Unsere VPS-Dienste sind standardmäßig durch unsere [Anti-DDoS-Infrastruktur](/links/security/antiddos) geschützt, die DDoS-Angriffe in Echtzeit erkennt und abmildert.
 - IP-Blockierung: Sie können [spezifische IP-Adressen oder IP-Bereiche](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps) blockieren, die auf Ihren VPS zugreifen.
 - Firewall-Regeln: Sie können [benutzerdefinierte Firewall-Regeln konfigurieren](/guides/bare-metal-cloud/dedicated-servers/firewall-network), um den eingehenden und ausgehenden Traffic direkt auf Ihrem VPS zu steuern.
 - VAC (VPS Anti-DDoS): Unser VAC-System bietet einen zusätzlichen Schutz vor DDoS-Angriffen, einschließlich Traffic-Filterung und Rate-Limiting.
@@ -559,6 +561,6 @@ Der Vorteil eines VPS gegenüber einem Dedicated Server ist die Möglichkeit, de
 
 ## Weiterführende Informationen
 
-Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
+Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](/links/support).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/en/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/en/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Adding cloud credit
 description: Find out how to add credit or vouchers to your Public Cloud project
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-11
 ---
 
 ## Objective
@@ -12,7 +12,7 @@ With the *cloud credit* option you can allocate a specific amount to your Public
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -64,7 +64,7 @@ Enter your voucher code in the window that appears and click on <code className=
 The voucher balance will appear in the <code className="action">Credits & Vouchers</code> list.
 
 :::info
-Since the validity periods of vouchers are usually more limited, the voucher balance will be used before the regular Public Cloud credit.
+Vouchers are generally valid for only one month; you should use the voucher as soon as possible. The voucher balance will be applied before the Public Cloud credit.
 
 :::
 
@@ -75,4 +75,4 @@ Since the validity periods of vouchers are usually more limited, the voucher bal
 New customers automatically receive £175 of free trial credit when they activate their first Public Cloud project. See our guide on [Creating your first OVHcloud Public Cloud project](/guides/public-cloud/cross-functional/create-a-public-cloud-project).
 :::
 
-Join our [community of users](https://community.ovhcloud.com/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud VPS FAQ
 description: Find the answers to the most frequently asked questions about our VPS offers
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-11
 ---
 
 import Api from '@components/Api';
@@ -38,7 +38,7 @@ OVHcloud VPS offers provide excellent value for performance, with unlimited traf
 
 Using a VPS requires basic knowledge of server administration. To bear this in mind is crucial for effectively managing your OS (Linux or Windows), and setting up your applications, like PrestaShop or WordPress, for example.
 
-If you need a VPS but lack the technical expertise to manage it, consider reaching out to one of our [partners](https://partner.ovhcloud.com/en-gb/directory/) for assistance. 
+If you need a VPS but lack the technical expertise to manage it, consider reaching out to one of our [partners](/links/partner) for assistance. 
 
 If you require provisioned resources but prefer not to deal with server administration, we recommend opting for our Performance web hosting plans.
 
@@ -96,7 +96,7 @@ In addition, we offer:
 
 By using these solutions, you can customize your backup management to fit your security and business continuity needs.
 
-Visit our [VPS web page](https://www.ovhcloud.com/en-gb/vps/) to learn more about the available options.
+Visit our [VPS web page](/links/bare-metal/vps) to learn more about the available options.
 
 </details>
 
@@ -178,7 +178,7 @@ A VPS eliminates the need to manage physical hardware such as storage, RAM, and 
 <summary>What bandwidth is allocated to my VPS? Is it guaranteed?</summary>
 
 
-The bandwidth listed on our [VPS web page](https://www.ovhcloud.com/en-gb/vps/) is guaranteed. It is the minimum amount allocated to your service.
+The bandwidth listed on our [VPS web page](/links/bare-metal/vps) is guaranteed. It is the minimum amount allocated to your service.
 
 </details>
 
@@ -261,7 +261,7 @@ For example, we offer a range of pre-configured templates and images for popular
 
 Additionally, our documentation and knowledge base contain a wealth of information on configuring and managing your VPS.
 
-However, for specific software configuration assistance, we recommend reaching out to our [community](https://community.ovhcloud.com/community/en) or seeking the help of a qualified system administrator or developer via our [partner portal](https://partner.ovhcloud.com/en-gb/directory/).
+However, for specific software configuration assistance, we recommend reaching out to our [community](/links/community) or seeking the help of a qualified system administrator or developer via our [partner portal](/links/partner).
 
 </details>
 
@@ -279,6 +279,8 @@ This includes:
 - reverse DNS (PTR) configuration,
 - following email providers’ best practices.
 
+If emails are not sending or SMTP is not responding, check whether SMTP ports are blocked. Port 25 is blocked by default on OVHcloud VPS to prevent abuse. Use port 587 (STARTTLS) for outbound mail instead or, if required, request port 25 to be unblocked by [contacting our support team](/links/support-contact).
+
 For more details, see our dedicated guide: [How to prevent your emails from being marked as spam](/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization).
 
 </details>
@@ -292,7 +294,7 @@ For more details, see our dedicated guide: [How to prevent your emails from bein
 OVHcloud installation templates only allow for one operating system.  
 Custom configurations can be applied from the customer's side and are the responsibility of the server's administrator. OVHcloud services do not include administration tasks, such as software configuration or external tools.
 
-If you encounter configuration and administration issues, we recommend reaching out to our [community](https://community.ovhcloud.com/community/en) or seeking the help of a qualified system administrator or developer via our [partner portal](https://partner.ovhcloud.com/en-gb/directory/). 
+If you encounter configuration and administration issues, we recommend reaching out to our [community](/links/community) or seeking the help of a qualified system administrator or developer via our [partner portal](/links/partner). 
 
 </details>
 
@@ -306,7 +308,7 @@ OVHcloud installation templates for VPS do not include the Proxmox Operating Sys
 
 Custom configurations can be applied from the customer's side and are the responsibility of the server's administrator. OVHcloud services do not include administration tasks, such as software configuration or using external tools.
 
-If you encounter configuration and administration issues, we recommend reaching out to our [community](https://community.ovhcloud.com/community/en) or seeking the help of a qualified system administrator or developer via our [partner portal](https://partner.ovhcloud.com/en-gb/directory/). 
+If you encounter configuration and administration issues, we recommend reaching out to our [community](/links/community) or seeking the help of a qualified system administrator or developer via our [partner portal](/links/partner). 
 
 </details>
 
@@ -317,7 +319,7 @@ If you encounter configuration and administration issues, we recommend reaching 
 
 
 A VPS cannot be customized or modified at the hardware level.  
-Select a [VPS model](https://www.ovhcloud.com/en-gb/vps/) in the order process that meets your minimum requirements, then you can upgrade it as required.  
+Select a [VPS model](/links/bare-metal/vps) in the order process that meets your minimum requirements, then you can upgrade it as required.  
 
 </details>
 
@@ -331,7 +333,7 @@ To resolve performance issues on your VPS, you will need to provide specific tes
 
 Note that your VPS must be booted into [rescue mode](/guides/bare-metal-cloud/virtual-private-servers/rescue) to rule out any possible software issues.
 
-Contact our support team by [creating a request in the OVHcloud Help Centre](https://help.ovhcloud.com/csm?id=csm_get_help) so we can provide you with the complete list of tests required for a proper assessment.
+Contact our support team by [creating a request in the OVHcloud Help Centre](/links/support-contact) so we can provide you with the complete list of tests required for a proper assessment.
 
 </details>
 
@@ -341,7 +343,7 @@ Contact our support team by [creating a request in the OVHcloud Help Centre](htt
 <summary>I ordered a new VPS, can I move the remaining subscription time from my old VPS or have it refunded?</summary>
 
 
-This is generally possible but the process requires a [request to our support team via the OVHcloud Help Centre](https://help.ovhcloud.com/csm?id=csm_get_help).
+This is generally possible but the process requires a [request to our support team via the OVHcloud Help Centre](/links/support-contact).
 
 Before you proceed, ensure that you have [migrated any data still needed](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) to your new service or create backups of your data.
 
@@ -368,7 +370,7 @@ It is not possible to migrate a VPS to another data centre. To achieve this, you
 <summary>How many Additional IPs can I configure on a VPS?</summary>
 
 
-A VPS is limited to [16 Additional IP addresses](https://www.ovhcloud.com/en-gb/network/additional-ip/).
+A VPS is limited to [16 Additional IP addresses](/links/network/additional-ip).
 
 Please refer to our guide on [how to configure IP aliasing](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing) for IP address configuration examples.
 
@@ -381,7 +383,7 @@ Please refer to our guide on [how to configure IP aliasing](/guides/bare-metal-c
 
 
 It is not possible to add IP blocks to a VPS.  
-You can configure up to [16 Additional IP addresses](https://www.ovhcloud.com/en-gb/network/additional-ip/) on a VPS.
+You can configure up to [16 Additional IP addresses](/links/network/additional-ip) on a VPS.
 
 </details>
 
@@ -393,7 +395,7 @@ You can configure up to [16 Additional IP addresses](https://www.ovhcloud.com/en
 
 Licenses can be moved between servers but there are limitations.
 
-The best option is to log in to our [API console](https://eu.api.ovh.com/) with your customer account credentials and check if your license can be moved to a different VPS. Find the basics in our guide on [how to get started with the OVHcloud API](/guides/manage-and-operate/api/first-steps).
+The best option is to log in to our [API console](/links/console) with your customer account credentials and check if your license can be moved to a different VPS. Find the basics in our guide on [how to get started with the OVHcloud API](/guides/manage-and-operate/api/first-steps).
 
 Once connected, use the following calls depending on the software in use:
 
@@ -473,7 +475,7 @@ Follow our guide on [how to use snapshots on a VPS](/guides/bare-metal-cloud/vir
 
 You can then locally convert the downloaded snapshot file into a format corresponding to your needs.
 
-Consider reaching out to one of our [partners](https://partner.ovhcloud.com/en-gb/directory/) for further assistance. 
+Consider reaching out to one of our [partners](/links/partner) for further assistance. 
 
 </details>
 
@@ -494,7 +496,7 @@ Only OVHcloud IP addresses can be authorized.
 :::
 
 
-Log in to the [OVHcloud API console](https://eu.api.ovh.com/) with your customer account credentials and use the following call:
+Log in to the [OVHcloud API console](/links/console) with your customer account credentials and use the following call:
 
 <Api version="v1" section="/vps" method="POST" route={"/vps/\{serviceName\}/backupftp/access"} />
 
@@ -538,7 +540,7 @@ Although OVHcloud applies security measures to protect the entire infrastructure
 
 OVHcloud provides several security features to protect your VPS against malicious traffic:
 
-- Anti-DDoS protection: Our VPS services are protected by default by our [Anti-DDoS infrastructure](https://www.ovhcloud.com/en-gb/security/anti-ddos/) that detects and mitigates DDoS attacks in real time.
+- Anti-DDoS protection: Our VPS services are protected by default by our [Anti-DDoS infrastructure](/links/security/antiddos) that detects and mitigates DDoS attacks in real time.
 - IP blocking: You can [prevent specific IP addresses or IP ranges](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps) from reaching your VPS.
 - Firewall rules: You can [configure custom firewall rules](/guides/bare-metal-cloud/dedicated-servers/firewall-network) to control incoming and outgoing traffic directly on your VPS.
 - VAC (VPS Anti-DDoS): Our VAC system provides an additional layer of protection against DDoS attacks, including traffic filtering and rate limiting.
@@ -560,6 +562,6 @@ The advantage of a VPS compared to a dedicated server is the possibility to scal
 
 ## Go further
 
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-gb/support-levels/).
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/es/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Añadir crédito Cloud
 description: Cómo añadir créditos o códigos promocionales a su proyecto de Public Cloud
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-11
 ---
 
 ## Objetivo
@@ -13,7 +13,7 @@ Esto significa que este crédito cloud se cargará en primer lugar y que, a cont
 
 ## Requisitos
 
-- Un proyecto de [Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud
+- Un proyecto de [Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -65,7 +65,7 @@ Se abrirá una ventana en la que deberá introducir el código promocional y hac
 El saldo del código promocional aparecerá en la lista <code className="action">Crédito y códigos promocionales</code>.
 
 :::info
-Los períodos de validez de los códigos promocionales suelen ser más limitados, por lo que el saldo del código promocional se utilizará antes que el crédito Public Cloud.
+Los períodos de validez de los códigos promocionales suelen estar limitados a 1 mes; se recomienda utilizarlos lo antes posible. El saldo del código promocional se utilizará antes que el crédito Public Cloud.
 
 :::
 
@@ -76,4 +76,4 @@ Los períodos de validez de los códigos promocionales suelen ser más limitados
 Los nuevos clientes reciben automáticamente 200 € de crédito de prueba al activar su primer proyecto Public Cloud. Consulte nuestra guía "[Creando tu primer proyecto de Public Cloud de OVHcloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project)".
 :::
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud VPS FAQ
 description: Encuentre las respuestas a las preguntas más frecuentes sobre nuestras ofertas de VPS
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-11
 ---
 
 import Api from '@components/Api';
@@ -38,7 +38,7 @@ Las ofertas de VPS de OVHcloud ofrecen un excelente rendimiento por precio, con 
 
 El uso de un VPS requiere conocimientos básicos de administración de servidores. Es crucial tener esto en cuenta para gestionar eficazmente su sistema operativo (Linux o Windows) y configurar sus aplicaciones, como por ejemplo PrestaShop o WordPress.
 
-Si necesita un VPS pero carece de la experiencia técnica para administrarlo, considere contactar con uno de nuestros [partners](https://partner.ovhcloud.com/es-es/directory/) para recibir ayuda. 
+Si necesita un VPS pero carece de la experiencia técnica para administrarlo, considere contactar con uno de nuestros [partners](/links/partner) para recibir ayuda. 
 
 Si requiere recursos provisionados pero prefiere no ocuparse de la administración del servidor, le recomendamos optar por nuestros planes de alojamiento web Performance.
 
@@ -96,7 +96,7 @@ Además, ofrecemos:
 
 Al utilizar estas soluciones, puede personalizar su gestión de copias de seguridad para adaptarla a sus necesidades de seguridad y continuidad empresarial.
 
-Visite nuestra [página web de VPS](https://www.ovhcloud.com/es-es/vps/) para obtener más información sobre las opciones disponibles.
+Visite nuestra [página web de VPS](/links/bare-metal/vps) para obtener más información sobre las opciones disponibles.
 
 </details>
 
@@ -178,7 +178,7 @@ Un VPS elimina la necesidad de gestionar hardware físico como el almacenamiento
 <summary>¿Qué ancho de banda se asigna a mi VPS? ¿Está garantizado?</summary>
 
 
-El ancho de banda que aparece en nuestra [página web de VPS](https://www.ovhcloud.com/es-es/vps/) está garantizado. Es la cantidad mínima asignada a su servicio.
+El ancho de banda que aparece en nuestra [página web de VPS](/links/bare-metal/vps) está garantizado. Es la cantidad mínima asignada a su servicio.
 
 </details>
 
@@ -261,7 +261,7 @@ Por ejemplo, ofrecemos una gama de plantillas y imágenes preconfiguradas para s
 
 Además, nuestra documentación y base de conocimientos contienen una gran cantidad de información sobre la configuración y gestión de tu VPS.
 
-Sin embargo, para asistencia específica en la configuración de software, te recomendamos contactar con nuestra [comunidad](https://community.ovhcloud.com/community/en) o buscar la ayuda de un administrador de sistemas o desarrollador cualificado a través de nuestro [portal de socios](https://partner.ovhcloud.com/es-es/directory/).
+Sin embargo, para asistencia específica en la configuración de software, te recomendamos contactar con nuestra [comunidad](/links/community) o buscar la ayuda de un administrador de sistemas o desarrollador cualificado a través de nuestro [portal de socios](/links/partner).
 
 </details>
 
@@ -279,6 +279,8 @@ Esto incluye:
 - la configuración del reverse DNS (PTR),
 - el cumplimiento de las buenas prácticas de los proveedores de correo electrónico.
 
+Si tus e-mails no se envían o el servidor SMTP no responde, comprueba si los puertos SMTP están bloqueados. El puerto 25 está bloqueado por defecto en los VPS de OVHcloud para prevenir abusos. Utiliza el puerto 587 (STARTTLS) para el envío saliente o, si es necesario, solicita el desbloqueo del puerto 25 [contactando con nuestro soporte](/links/support-contact).
+
 Para más información, consulta nuestra guía dedicada: [Cómo evitar que tus e-mails sean marcados como spam](/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization).
 
 </details>
@@ -292,7 +294,7 @@ Para más información, consulta nuestra guía dedicada: [Cómo evitar que tus e
 Las plantillas de instalación de OVHcloud solo permiten un sistema operativo.  
 Las configuraciones personalizadas pueden aplicarse desde el lado del cliente y son responsabilidad del administrador del servidor. Los servicios de OVHcloud no incluyen tareas de administración, como la configuración de software o el uso de herramientas externas.
 
-Si tienes problemas de configuración y administración, te recomendamos contactar con nuestra [comunidad](https://community.ovhcloud.com/community/en) o buscar la ayuda de un administrador de sistemas o desarrollador cualificado a través de nuestro [portal de socios](https://partner.ovhcloud.com/es-es/directory/). 
+Si tienes problemas de configuración y administración, te recomendamos contactar con nuestra [comunidad](/links/community) o buscar la ayuda de un administrador de sistemas o desarrollador cualificado a través de nuestro [portal de socios](/links/partner). 
 
 </details>
 
@@ -306,7 +308,7 @@ Las plantillas de instalación de VPS de OVHcloud no incluyen el Proxmox Operati
 
 Las configuraciones personalizadas pueden aplicarse desde el lado del cliente y son responsabilidad del administrador del servidor. Los servicios de OVHcloud no incluyen tareas de administración, como la configuración de software o el uso de herramientas externas.
 
-Si tienes problemas de configuración y administración, te recomendamos contactar con nuestra [comunidad](https://community.ovhcloud.com/community/en) o buscar la ayuda de un administrador de sistemas o desarrollador cualificado a través de nuestro [portal de socios](https://partner.ovhcloud.com/es-es/directory/). 
+Si tienes problemas de configuración y administración, te recomendamos contactar con nuestra [comunidad](/links/community) o buscar la ayuda de un administrador de sistemas o desarrollador cualificado a través de nuestro [portal de socios](/links/partner). 
 
 </details>
 
@@ -317,7 +319,7 @@ Si tienes problemas de configuración y administración, te recomendamos contact
 
 
 Un VPS no se puede personalizar ni modificar a nivel de hardware.  
-Selecciona un [modelo de VPS](https://www.ovhcloud.com/es-es/vps/) en el proceso de pedido que cumpla con tus requisitos mínimos, y luego podrás actualizarlo según sea necesario.  
+Selecciona un [modelo de VPS](/links/bare-metal/vps) en el proceso de pedido que cumpla con tus requisitos mínimos, y luego podrás actualizarlo según sea necesario.  
 
 </details>
 
@@ -331,7 +333,7 @@ Para resolver problemas de rendimiento en tu VPS, deberás proporcionar resultad
 
 Ten en cuenta que tu VPS debe arrancarse en [modo de rescate](/guides/bare-metal-cloud/virtual-private-servers/rescue) para descartar cualquier posible problema de software.
 
-Contacta con nuestro equipo de soporte creando una [solicitud en el Centro de ayuda de OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) para que podamos proporcionarte la lista completa de pruebas necesarias para una evaluación adecuada.
+Contacta con nuestro equipo de soporte creando una [solicitud en el Centro de ayuda de OVHcloud](/links/support-contact) para que podamos proporcionarte la lista completa de pruebas necesarias para una evaluación adecuada.
 
 </details>
 
@@ -342,7 +344,7 @@ Contacta con nuestro equipo de soporte creando una [solicitud en el Centro de ay
 <summary>He pedido un nuevo VPS, ¿puedo trasladar el tiempo restante de mi antiguo VPS o recibir un reembolso?</summary>
 
 
-Esto es generalmente posible, pero el proceso requiere una [solicitud a nuestro equipo de soporte a través del Centro de ayuda de OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help).
+Esto es generalmente posible, pero el proceso requiere una [solicitud a nuestro equipo de soporte a través del Centro de ayuda de OVHcloud](/links/support-contact).
 
 Antes de proceder, asegúrate de que hayas [migrado cualquier dato aún necesario](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) a tu nuevo servicio o hayas creado copias de seguridad de tus datos.
 
@@ -369,7 +371,7 @@ No es posible migrar un VPS a otro centro de datos. Para lograrlo, puedes realiz
 <summary>¿Cuántas IPs adicionales puedo configurar en un VPS?</summary>
 
 
-Un VPS está limitado a [16 direcciones IP adicionales](https://www.ovhcloud.com/es-es/network/additional-ip/).
+Un VPS está limitado a [16 direcciones IP adicionales](/links/network/additional-ip).
 
 Consulta nuestra guía sobre [cómo configurar alias de IP](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing) para ejemplos de configuración de direcciones IP.
 
@@ -382,7 +384,7 @@ Consulta nuestra guía sobre [cómo configurar alias de IP](/guides/bare-metal-c
 
 
 No es posible añadir bloques de IP a un VPS.  
-Puedes configurar hasta [16 direcciones IP adicionales](https://www.ovhcloud.com/es-es/network/additional-ip/) en un VPS.
+Puedes configurar hasta [16 direcciones IP adicionales](/links/network/additional-ip) en un VPS.
 
 </details>
 
@@ -394,7 +396,7 @@ Puedes configurar hasta [16 direcciones IP adicionales](https://www.ovhcloud.com
 
 Las licencias pueden moverse entre servidores, pero existen limitaciones.
 
-La mejor opción es iniciar sesión en nuestra [consola de API](https://eu.api.ovh.com/) con tus credenciales de cuenta de cliente y comprobar si tu licencia puede ser trasladada a un VPS diferente. Encuentra las bases en nuestra guía sobre [cómo empezar con la API de OVHcloud](/guides/manage-and-operate/api/first-steps).
+La mejor opción es iniciar sesión en nuestra [consola de API](/links/console) con tus credenciales de cuenta de cliente y comprobar si tu licencia puede ser trasladada a un VPS diferente. Encuentra las bases en nuestra guía sobre [cómo empezar con la API de OVHcloud](/guides/manage-and-operate/api/first-steps).
 
 Una vez conectado, utiliza las siguientes llamadas según el software que uses:
 
@@ -474,7 +476,7 @@ Sigue nuestra guía sobre [cómo usar instantáneas en un VPS](/guides/bare-meta
 
 Luego puedes convertir localmente el archivo de instantánea descargado en un formato correspondiente a tus necesidades.
 
-Considera contactar con uno de nuestros [socios](https://partner.ovhcloud.com/es-es/directory/) para obtener más ayuda. 
+Considera contactar con uno de nuestros [socios](/links/partner) para obtener más ayuda. 
 
 </details>
 
@@ -495,7 +497,7 @@ Solo se pueden autorizar direcciones IP de OVHcloud.
 :::
 
 
-Inicia sesión en la [consola de API de OVHcloud](https://eu.api.ovh.com/) con tus credenciales de cuenta de cliente y utiliza la siguiente llamada:
+Inicia sesión en la [consola de API de OVHcloud](/links/console) con tus credenciales de cuenta de cliente y utiliza la siguiente llamada:
 
 <Api version="v1" section="/vps" method="POST" route={"/vps/\{serviceName\}/backupftp/access"} />
 
@@ -539,7 +541,7 @@ Aunque OVHcloud aplica medidas de seguridad para proteger toda la infraestructur
 
 OVHcloud ofrece varias características de seguridad para proteger tu VPS contra tráfico malicioso:
 
-- Protección Anti-DDoS: Nuestros servicios de VPS están protegidos por defecto por nuestra [infraestructura Anti-DDoS](https://www.ovhcloud.com/es-es/security/anti-ddos/) que detecta y mitiga ataques DDoS en tiempo real.
+- Protección Anti-DDoS: Nuestros servicios de VPS están protegidos por defecto por nuestra [infraestructura Anti-DDoS](/links/security/antiddos) que detecta y mitiga ataques DDoS en tiempo real.
 - Bloqueo de IP: Puedes [evitar que direcciones IP específicas o rangos de IP](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps) lleguen a tu VPS.
 - Reglas de firewall: Puedes [configurar reglas de firewall personalizadas](/guides/bare-metal-cloud/dedicated-servers/firewall-network) para controlar el tráfico entrante y saliente directamente en tu VPS.
 - VAC (VPS Anti-DDoS): Nuestro sistema VAC proporciona una capa adicional de protección contra ataques DDoS, incluyendo filtrado de tráfico y limitación de velocidad.
@@ -562,6 +564,6 @@ La ventaja de un VPS frente a un servidor dedicado es la posibilidad de escalar 
 
 ## Más información
 
-Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas [ofertas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
+Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas [ofertas de soporte](/links/support).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ajouter du crédit cloud
 description: Découvrez comment ajouter du crédit ou des vouchers à votre projet Public Cloud
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-11
 ---
 
 ## Objectif
@@ -13,7 +13,7 @@ Cela signifie que ce crédit cloud est débité en premier et que toute dette se
 
 ## Prérequis
 
-- Un projet [Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
+- Un projet [Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -65,7 +65,7 @@ Dans la fenêtre qui apparaît, renseignez le code du voucher et cliquez sur <co
 Le solde du voucher apparaîtra dans la liste <code className="action">Crédits & Vouchers</code>.
 
 :::info
-Les périodes de validité des vouchers étant généralement plus limitées, le solde du voucher sera utilisé avant le crédit Public Cloud.
+Les périodes de validité des vouchers sont généralement limitées à 1 mois ; il est donc recommandé d'utiliser le voucher le plus tôt possible. Le solde du voucher sera utilisé avant le crédit Public Cloud.
 
 :::
 
@@ -76,4 +76,4 @@ Les périodes de validité des vouchers étant généralement plus limitées, le
 Les nouveaux clients reçoivent automatiquement 200 € de crédit d'essai lors de l'activation de leur premier projet Public Cloud. Consultez notre guide « [Créer votre premier projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) ».
 :::
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ sur les VPS OVHcloud
 description: Trouvez les réponses aux questions les plus fréquemment posées sur nos offres VPS
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-11
 ---
 
 import Api from '@components/Api';
@@ -38,7 +38,7 @@ Les VPS OVHcloud offrent un excellent rapport performance/prix, avec un trafic i
 
 L’utilisation d’un VPS nécessite des connaissances de base en administration de serveur. Garder cela à l’esprit est crucial pour gérer efficacement votre système d’exploitation (Linux ou Windows) et pour mettre en place vos applications, comme PrestaShop ou WordPress par exemple.
 
-Si vous avez besoin d’un VPS mais que vous n’avez pas les compétences techniques pour le gérer, contactez l’un de nos [partenaires](https://partner.ovhcloud.com/fr/directory/) pour obtenir de l’aide.
+Si vous avez besoin d’un VPS mais que vous n’avez pas les compétences techniques pour le gérer, contactez l’un de nos [partenaires](/links/partner) pour obtenir de l’aide.
 
 Si vous avez besoin de ressources allouées, mais que vous préférez ne pas vous occuper de l’administration du serveur, nous vous recommandons d’opter pour nos offres d’hébergement web Performance.
 
@@ -96,7 +96,7 @@ De plus, nous vous proposons :
 
 Grâce à ces solutions, vous pouvez personnaliser la gestion de vos sauvegardes en fonction de vos besoins en matière de sécurité et de continuité d’activité.
 
-Rendez-vous sur notre [page web VPS](https://www.ovhcloud.com/fr/vps/) pour en savoir plus sur les options disponibles.
+Rendez-vous sur notre [page web VPS](/links/bare-metal/vps) pour en savoir plus sur les options disponibles.
 
 </details>
 
@@ -178,7 +178,7 @@ Le VPS élimine la nécessité de gérer le matériel physique, comme le stockag
 <summary>Quelle bande passante est allouée à mon VPS ? Est-elle garantie ?</summary>
 
 
-La bande passante indiquée sur notre [page web VPS](https://www.ovhcloud.com/fr/vps/) est garantie. Il s’agit de la valeur minimale allouée à votre service.
+La bande passante indiquée sur notre [page web VPS](/links/bare-metal/vps) est garantie. Il s’agit de la valeur minimale allouée à votre service.
 
 </details>
 
@@ -262,7 +262,7 @@ Par exemple, nous proposons une gamme de modèles et d'images préconfigurés po
 
 De plus, notre documentation et notre base de connaissances contiennent de nombreuses informations sur la configuration et la gestion de votre VPS.
 
-Toutefois, pour obtenir une assistance spécifique en matière de configuration logicielle, nous vous recommandons de contacter notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr) ou de demander l'aide d'un administrateur système ou d'un développeur qualifié via notre [Portail Partenaires](https://partner.ovhcloud.com/fr/directory/).
+Toutefois, pour obtenir une assistance spécifique en matière de configuration logicielle, nous vous recommandons de contacter notre [communauté d'utilisateurs](/links/community) ou de demander l'aide d'un administrateur système ou d'un développeur qualifié via notre [Portail Partenaires](/links/partner).
 
 </details>
 
@@ -280,6 +280,8 @@ Cela inclut notamment :
 - la configuration du reverse DNS (PTR),
 - le respect des bonnes pratiques des fournisseurs de messagerie.
 
+Si vos e-mails ne s’envoient pas ou que le serveur SMTP ne répond pas, vérifiez si les ports SMTP sont bloqués. Le port 25 est bloqué par défaut sur les VPS OVHcloud afin de prévenir les abus. Utilisez le port 587 (STARTTLS) pour l’envoi sortant ou, si nécessaire, demandez le déblocage du port 25 en [contactant notre support](/links/support-contact).
+
 Pour plus de détails, consultez notre guide dédié : [Comment éviter que vos e-mails ne soient marqués comme spam](/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization).
 
 </details>
@@ -293,7 +295,7 @@ Pour plus de détails, consultez notre guide dédié : [Comment éviter que vos 
 Les modèles d'installation d'OVHcloud ne permettent qu'un seul système d'exploitation.  
 Les configurations personnalisées peuvent être appliquées du côté client et relèvent de la responsabilité de l'administrateur du serveur. Les services OVHcloud n'incluent pas de tâches d'administration, telles que la configuration logicielle ou des outils externes.
 
-Si vous rencontrez des problèmes de configuration et d'administration, nous vous recommandons de contacter notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr) ou de demander l'aide d'un administrateur système ou d'un développeur qualifié via notre [Portail Partenaires](https://partner.ovhcloud.com/fr/directory/).
+Si vous rencontrez des problèmes de configuration et d'administration, nous vous recommandons de contacter notre [communauté d'utilisateurs](/links/community) ou de demander l'aide d'un administrateur système ou d'un développeur qualifié via notre [Portail Partenaires](/links/partner).
 
 </details>
 
@@ -307,7 +309,7 @@ Les modèles d'installation OVHcloud pour VPS n'incluent pas le système d'explo
 
 Les configurations personnalisées peuvent être appliquées du côté client et relèvent de la responsabilité de l'administrateur du serveur. Les services OVHcloud n'incluent pas de tâches d'administration, telles que la configuration logicielle ou l'utilisation d'outils externes.
 
-Si vous rencontrez des problèmes de configuration et d'administration, nous vous recommandons de contacter notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr) ou de demander l'aide d'un administrateur système ou d'un développeur qualifié via notre [Portail Partenaires](https://partner.ovhcloud.com/fr/directory/). 
+Si vous rencontrez des problèmes de configuration et d'administration, nous vous recommandons de contacter notre [communauté d'utilisateurs](/links/community) ou de demander l'aide d'un administrateur système ou d'un développeur qualifié via notre [Portail Partenaires](/links/partner). 
 
 </details>
 
@@ -319,7 +321,7 @@ Si vous rencontrez des problèmes de configuration et d'administration, nous vou
 
 Un VPS ne peut être ni personnalisé, ni modifié au niveau du matériel.
 
-Sélectionnez un [modèle de VPS](https://www.ovhcloud.com/fr/vps/) dans le processus de commande qui répond à vos exigences minimales, vous pourrez ensuite le mettre à niveau si nécessaire.
+Sélectionnez un [modèle de VPS](/links/bare-metal/vps) dans le processus de commande qui répond à vos exigences minimales, vous pourrez ensuite le mettre à niveau si nécessaire.
 
 </details>
 
@@ -333,7 +335,7 @@ Pour résoudre les problèmes de performance de votre VPS, vous devrez fournir d
 
 Notez que votre VPS doit être démarré en [mode rescue](/guides/bare-metal-cloud/virtual-private-servers/rescue) pour exclure tout problème logiciel éventuel.
 
-Contactez notre support en [créant une demande dans le centre d’aide d’OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) afin que nous puissions vous fournir la liste complète des tests nécessaires pour une évaluation correcte.
+Contactez notre support en [créant une demande dans le centre d’aide d’OVHcloud](/links/support-contact) afin que nous puissions vous fournir la liste complète des tests nécessaires pour une évaluation correcte.
 
 </details>
 
@@ -343,7 +345,7 @@ Contactez notre support en [créant une demande dans le centre d’aide d’OVHc
 <summary>J’ai commandé un nouveau VPS, puis-je déplacer le temps d’engagement restant de mon ancien VPS ou me le faire rembourser ?</summary>
 
 
-Cela est généralement possible, mais le processus nécessite une demande à notre équipe support via le [centre d’aide d’OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help).
+Cela est généralement possible, mais le processus nécessite une demande à notre équipe support via le [centre d’aide d’OVHcloud](/links/support-contact).
 
 Avant de continuer, assurez-vous d’avoir [migré les données encore nécessaires](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) vers votre nouveau service ou créé des sauvegardes de vos données.
 
@@ -370,7 +372,7 @@ Il n’est pas possible de migrer un VPS vers un autre datacentre. Pour ce faire
 <summary>Combien d'Additional IP puis-je configurer sur un VPS ?</summary>
 
 
-Un VPS est limité à [16 Additional IP](https://www.ovhcloud.com/fr/network/additional-ip/).
+Un VPS est limité à [16 Additional IP](/links/network/additional-ip).
 
 Consultez notre guide « [Configurer une adresse IP en alias](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing) » pour des exemples de configuration d'adresses IP.
 
@@ -384,7 +386,7 @@ Consultez notre guide « [Configurer une adresse IP en alias](/guides/bare-metal
 
 Il n'est pas possible d'ajouter des blocs d’adresses IP à un VPS.
 
-Vous pouvez configurer jusqu'à [16 Additional IPs](https://www.ovhcloud.com/fr/network/additional-ip/) sur un VPS.
+Vous pouvez configurer jusqu'à [16 Additional IPs](/links/network/additional-ip) sur un VPS.
 
 </details>
 
@@ -396,7 +398,7 @@ Vous pouvez configurer jusqu'à [16 Additional IPs](https://www.ovhcloud.com/fr/
 
 Les licences peuvent être déplacées d’un serveur à l’autre, mais il existe des limitations.
 
-La meilleure option consiste à vous connecter à notre [console API](https://eu.api.ovh.com/console/) avec les informations d'identification de votre compte client OVHcloud et à vérifier si votre licence peut être déplacée vers un autre VPS. Retrouvez les bases dans notre guide « [Premiers pas avec les API OVHcloud](/guides/manage-and-operate/api/first-steps) ».
+La meilleure option consiste à vous connecter à notre [console API](/links/console) avec les informations d'identification de votre compte client OVHcloud et à vérifier si votre licence peut être déplacée vers un autre VPS. Retrouvez les bases dans notre guide « [Premiers pas avec les API OVHcloud](/guides/manage-and-operate/api/first-steps) ».
 
 Une fois connecté, utilisez les appels suivants en fonction du logiciel utilisé :
 
@@ -477,7 +479,7 @@ Suivez notre guide « [Utiliser les snapshots sur un VPS](/guides/bare-metal-clo
 
 Vous pouvez ensuite convertir localement le fichier de snapshot téléchargé dans un format correspondant à vos besoins.
 
-Envisagez de contacter l'un de nos [partenaires](https://partner.ovhcloud.com/fr/directory/) pour obtenir de l'aide.
+Envisagez de contacter l'un de nos [partenaires](/links/partner) pour obtenir de l'aide.
 
 </details>
 
@@ -498,7 +500,7 @@ Seules les adresses IP OVHcloud peuvent être autorisées.
 :::
 
 
-Connectez-vous à la [console API OVHcloud](https://eu.api.ovh.com/console/) avec les identifiants de votre compte client et utilisez l'appel suivant :
+Connectez-vous à la [console API OVHcloud](/links/console) avec les identifiants de votre compte client et utilisez l'appel suivant :
 
 <Api version="v1" section="/vps" method="POST" route={"/vps/\{serviceName\}/backupftp/access"} />
 
@@ -544,7 +546,7 @@ Bien qu’OVHcloud applique des mesures de sécurité pour protéger l’ensembl
 
 OVHcloud fournit plusieurs fonctionnalités de sécurité pour protéger votre VPS contre le trafic malveillant :
 
-- Protection anti-DDoS : Nos services VPS sont protégés par défaut par notre [infrastructure anti-DDoS](https://www.ovhcloud.com/fr/security/anti-ddos/) qui détecte et mitige les attaques DDoS en temps réel.
+- Protection anti-DDoS : Nos services VPS sont protégés par défaut par notre [infrastructure anti-DDoS](/links/security/antiddos) qui détecte et mitige les attaques DDoS en temps réel.
 - Blocage d'adresses IP : Vous pouvez [empêcher des adresses IP ou plages d’adresses IP spécifiques](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps) d’atteindre votre VPS.
 - Règles de pare-feu : Vous pouvez [configurer des règles de pare-feu personnalisées](/guides/bare-metal-cloud/dedicated-servers/firewall-network) pour contrôler le trafic entrant et sortant directement sur votre VPS.
 - VAC (VPS Anti-DDoS) : Notre système VAC fournit une couche supplémentaire de protection contre les attaques DDoS, y compris le filtrage du trafic et la limitation du débit.
@@ -567,6 +569,6 @@ L’avantage d’un VPS par rapport à un serveur dédié est la possibilité d�
 
 ## Aller plus loin
 
-Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr/support-levels/).
+Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/it/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/it/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aggiungi credito Cloud al tuo progetto
 description: Come aggiungere credito o voucher al tuo progetto Public Cloud
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-11
 ---
 
 ## Obiettivo
@@ -13,7 +13,7 @@ Questo significa che il credito Cloud viene addebitato per primo e che il debito
 
 ## Prerequisiti
 
-- Un progetto [Public Cloud](https://www.ovhcloud.com/it/public-cloud/) nel tuo account OVHcloud
+- Un progetto [Public Cloud](/links/public-cloud/public-cloud) nel tuo account OVHcloud
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -65,7 +65,7 @@ Nella nuova finestra, inserisci il codice del voucher e clicca su <code classNam
 Il saldo del voucher comparirà nella lista <code className="action">Crediti e voucher</code>.
 
 :::info
-Poiché i periodi di validità dei voucher sono generalmente più limitati, prima del credito Public Cloud verrà utilizzato il saldo del voucher.
+I periodi di validità dei voucher sono generalmente limitati a 1 mese; si consiglia di utilizzarli il prima possibile. Il saldo del voucher verrà utilizzato prima del credito Public Cloud.
 
 :::
 
@@ -76,4 +76,4 @@ Poiché i periodi di validità dei voucher sono generalmente più limitati, prim
 I nuovi clienti ricevono automaticamente 200 € di credito di prova al momento dell'attivazione del loro primo progetto Public Cloud. Consulta la nostra guida "[Creazione del tuo primo progetto Public Cloud OVHcloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project)".
 :::
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ su VPS OVHcloud
 description: Trovate le risposte alle domande più frequenti sulle nostre offerte VPS
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-11
 ---
 
 import Api from '@components/Api';
@@ -38,7 +38,7 @@ Le offerte VPS OVHcloud offrono un ottimo rapporto qualità/prestazione, con tra
 
 Utilizzare un VPS richiede conoscenze di base nella gestione dei server. È fondamentale tenerne conto per gestire efficacemente il tuo sistema operativo (Linux o Windows) e configurare le tue applicazioni, come ad esempio PrestaShop o WordPress.
 
-Se hai bisogno di un VPS ma ti mancano le competenze tecniche per gestirlo, valuta l'opzione di contattare uno dei nostri [partner](https://partner.ovhcloud.com/it/directory/) per ottenere assistenza.
+Se hai bisogno di un VPS ma ti mancano le competenze tecniche per gestirlo, valuta l'opzione di contattare uno dei nostri [partner](/links/partner) per ottenere assistenza.
 
 Se hai bisogno di risorse allocate ma preferisci non occuparti della gestione del server, ti consigliamo di optare per i nostri piani di hosting web Performance.
 
@@ -96,7 +96,7 @@ Inoltre, offriamo:
 
 Utilizzando queste soluzioni, puoi personalizzare la gestione dei backup in base alle tue esigenze di sicurezza e continuità aziendale.
 
-Visita la nostra [pagina web dei VPS](https://www.ovhcloud.com/it/vps/) per saperne di più sulle opzioni disponibili.
+Visita la nostra [pagina web dei VPS](/links/bare-metal/vps) per saperne di più sulle opzioni disponibili.
 
 </details>
 
@@ -178,7 +178,7 @@ Un VPS elimina la necessità di gestire hardware fisico come archiviazione, RAM 
 <summary>Quale larghezza di banda è allocata al mio VPS? È garantita?</summary>
 
 
-La larghezza di banda indicata nella nostra [pagina web dei VPS](https://www.ovhcloud.com/it/vps/) è garantita. Si tratta della quantità minima allocata al tuo servizio.
+La larghezza di banda indicata nella nostra [pagina web dei VPS](/links/bare-metal/vps) è garantita. Si tratta della quantità minima allocata al tuo servizio.
 
 </details>
 
@@ -260,7 +260,7 @@ Ad esempio, offriamo una gamma di modelli e immagini preconfigurati per sistemi 
 
 Inoltre, la nostra documentazione e la knowledge base contengono una vasta gamma di informazioni sulla configurazione e gestione del tuo VPS.
 
-Tuttavia, per assistenza specifica alla configurazione del software, ti consigliamo di contattare la nostra [community](https://community.ovhcloud.com/community/en) o di cercare l'aiuto di un amministratore di sistema o sviluppatore qualificato tramite il nostro [portale partner](https://partner.ovhcloud.com/it/directory/).
+Tuttavia, per assistenza specifica alla configurazione del software, ti consigliamo di contattare la nostra [community](/links/community) o di cercare l'aiuto di un amministratore di sistema o sviluppatore qualificato tramite il nostro [portale partner](/links/partner).
 
 </details>
 
@@ -278,6 +278,8 @@ Questo include:
 - la configurazione del reverse DNS (PTR),
 - il rispetto delle best practice dei provider di posta elettronica.
 
+Se le tue e-mail non vengono inviate o il server SMTP non risponde, verifica se le porte SMTP sono bloccate. La porta 25 è bloccata per impostazione predefinita sui VPS OVHcloud per prevenire abusi. Utilizza la porta 587 (STARTTLS) per l'invio in uscita o, se necessario, richiedi lo sblocco della porta 25 [contattando il nostro supporto](/links/support-contact).
+
 Per maggiori informazioni, consulta la nostra guida dedicata: [Come evitare che le tue e-mail vengano contrassegnate come spam](/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization).
 
 </details>
@@ -291,7 +293,7 @@ Per maggiori informazioni, consulta la nostra guida dedicata: [Come evitare che 
 I modelli di installazione OVHcloud consentono solo un singolo sistema operativo.  
 Le configurazioni personalizzate possono essere applicate dal lato del cliente e sono responsabilità dell'amministratore del server. I servizi OVHcloud non includono attività di amministrazione, come la configurazione del software o l'uso di strumenti esterni.
 
-Se incontri problemi di configurazione e amministrazione, ti consigliamo di contattare la nostra [community](https://community.ovhcloud.com/community/en) o di cercare l'aiuto di un amministratore di sistema o sviluppatore qualificato tramite il nostro [portale partner](https://partner.ovhcloud.com/it/directory/).
+Se incontri problemi di configurazione e amministrazione, ti consigliamo di contattare la nostra [community](/links/community) o di cercare l'aiuto di un amministratore di sistema o sviluppatore qualificato tramite il nostro [portale partner](/links/partner).
 
 </details>
 
@@ -305,7 +307,7 @@ I modelli di installazione OVHcloud per VPS non includono il sistema operativo P
 
 Le configurazioni personalizzate possono essere applicate dal lato del cliente e sono responsabilità dell'amministratore del server. I servizi OVHcloud non includono attività di amministrazione, come la configurazione del software o l'uso di strumenti esterni.
 
-Se incontri problemi di configurazione e amministrazione, ti consigliamo di contattare la nostra [community](https://community.ovhcloud.com/community/en) o di cercare l'aiuto di un amministratore di sistema o sviluppatore qualificato tramite il nostro [portale partner](https://partner.ovhcloud.com/it/directory/).
+Se incontri problemi di configurazione e amministrazione, ti consigliamo di contattare la nostra [community](/links/community) o di cercare l'aiuto di un amministratore di sistema o sviluppatore qualificato tramite il nostro [portale partner](/links/partner).
 
 </details>
 
@@ -316,7 +318,7 @@ Se incontri problemi di configurazione e amministrazione, ti consigliamo di cont
 
 
 Un VPS non può essere personalizzato o modificato a livello hardware.  
-Seleziona un [modello VPS](https://www.ovhcloud.com/it/vps/) nel processo d’ordine che soddisfi i tuoi requisiti minimi, poi puoi aggiornarlo in base alle tue necessità.
+Seleziona un [modello VPS](/links/bare-metal/vps) nel processo d’ordine che soddisfi i tuoi requisiti minimi, poi puoi aggiornarlo in base alle tue necessità.
 
 </details>
 
@@ -330,7 +332,7 @@ Per risolvere i problemi di prestazioni del tuo VPS, dovrai fornire risultati di
 
 Nota che il tuo VPS deve essere avviato in [modalità di recupero](/guides/bare-metal-cloud/virtual-private-servers/rescue) per escludere eventuali problemi software.
 
-Contatta il nostro team di supporto [creando una richiesta nel Centro assistenza di OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) affinché possiamo fornirti l'elenco completo dei test richiesti per una valutazione corretta.
+Contatta il nostro team di supporto [creando una richiesta nel Centro assistenza di OVHcloud](/links/support-contact) affinché possiamo fornirti l'elenco completo dei test richiesti per una valutazione corretta.
 
 </details>
 
@@ -340,7 +342,7 @@ Contatta il nostro team di supporto [creando una richiesta nel Centro assistenza
 <summary>Ho ordinato un nuovo VPS, posso trasferire il tempo residuo della sottoscrizione del mio vecchio VPS o ottenerne un rimborso?</summary>
 
 
-Questo è generalmente possibile ma il processo richiede una [richiesta al nostro team di supporto tramite il Centro assistenza di OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help).
+Questo è generalmente possibile ma il processo richiede una [richiesta al nostro team di supporto tramite il Centro assistenza di OVHcloud](/links/support-contact).
 
 Prima di procedere, assicurati di aver [migrato i dati ancora necessari](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) al tuo nuovo servizio o di aver creato backup dei tuoi dati.
 
@@ -367,7 +369,7 @@ Non è possibile migrare un VPS in un altro data center. Per ottenere questo ris
 <summary>Quanti Indirizzi Additional IP posso configurare su un VPS?</summary>
 
 
-Un VPS è limitato a [16 Indirizzi Additional IP](https://www.ovhcloud.com/it/network/additional-ip/).
+Un VPS è limitato a [16 Indirizzi Additional IP](/links/network/additional-ip).
 
 Consulta la nostra guida su [come configurare l'aliasing IP](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing) per esempi di configurazione degli indirizzi IP.
 
@@ -380,7 +382,7 @@ Consulta la nostra guida su [come configurare l'aliasing IP](/guides/bare-metal-
 
 
 Non è possibile aggiungere blocchi IP a un VPS.  
-Puoi configurare fino a [16 Indirizzi Additional IP](https://www.ovhcloud.com/it/network/additional-ip/) su un VPS.
+Puoi configurare fino a [16 Indirizzi Additional IP](/links/network/additional-ip) su un VPS.
 
 </details>
 
@@ -392,7 +394,7 @@ Puoi configurare fino a [16 Indirizzi Additional IP](https://www.ovhcloud.com/it
 
 Le licenze possono essere spostate tra server ma esistono limitazioni.
 
-L'opzione migliore è accedere alla nostra [console API](https://eu.api.ovh.com/) con le credenziali del tuo account cliente e verificare se la tua licenza può essere spostata su un diverso VPS. Trova le basi nella nostra guida su [come iniziare con l'API di OVHcloud](/guides/manage-and-operate/api/first-steps).
+L'opzione migliore è accedere alla nostra [console API](/links/console) con le credenziali del tuo account cliente e verificare se la tua licenza può essere spostata su un diverso VPS. Trova le basi nella nostra guida su [come iniziare con l'API di OVHcloud](/guides/manage-and-operate/api/first-steps).
 
 Una volta connesso, utilizza le seguenti chiamate in base al software utilizzato:
 
@@ -472,7 +474,7 @@ Segui la nostra guida su [come utilizzare gli snapshot su un VPS](/guides/bare-m
 
 Puoi quindi convertire localmente il file snapshot scaricato in un formato corrispondente alle tue esigenze.
 
-Considera di contattare uno dei nostri [partner](https://partner.ovhcloud.com/it/directory/) per ulteriore assistenza.
+Considera di contattare uno dei nostri [partner](/links/partner) per ulteriore assistenza.
 
 </details>
 
@@ -493,7 +495,7 @@ Solo gli indirizzi IP di OVHcloud possono essere autorizzati.
 :::
 
 
-Accedi alla [console API di OVHcloud](https://eu.api.ovh.com/) con le credenziali del tuo account cliente e utilizza la seguente chiamata:
+Accedi alla [console API di OVHcloud](/links/console) con le credenziali del tuo account cliente e utilizza la seguente chiamata:
 
 <Api version="v1" section="/vps" method="POST" route={"/vps/\{serviceName\}/backupftp/access"} />
 
@@ -537,7 +539,7 @@ Sebbene OVHcloud applichi misure di sicurezza per proteggere l'intera infrastrut
 
 OVHcloud fornisce diverse funzionalità di sicurezza per proteggere il tuo VPS dal traffico dannoso:
 
-- Protezione Anti-DDoS: I nostri servizi VPS sono protetti di default dalla nostra [infrastruttura Anti-DDoS](https://www.ovhcloud.com/it/security/anti-ddos/) che rileva e mitiga gli attacchi DDoS in tempo reale.
+- Protezione Anti-DDoS: I nostri servizi VPS sono protetti di default dalla nostra [infrastruttura Anti-DDoS](/links/security/antiddos) che rileva e mitiga gli attacchi DDoS in tempo reale.
 - Blocco IP: Puoi [prevenire l'accesso da indirizzi IP specifici o da intervalli di IP](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps) al tuo VPS.
 - Regole del firewall: Puoi [configurare regole personalizzate del firewall](/guides/bare-metal-cloud/dedicated-servers/firewall-network) per controllare il traffico in entrata e in uscita direttamente sul tuo VPS.
 - VAC (VPS Anti-DDoS): Il nostro sistema VAC fornisce un ulteriore livello di protezione dagli attacchi DDoS, incluso il filtraggio del traffico e il limitatore di velocità.
@@ -559,6 +561,6 @@ Il vantaggio di un VPS rispetto a un server dedicato è la possibilità di scala
 
 ## Per saperne di più
 
-Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
+Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre [offerte di supporto](/links/support).
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/pl/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/pl/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Korzystanie z vouchera
 description: Dowiedz się, jak dodać zasilenie lub vouchery do Twojego projektu Public Cloud
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-11
 ---
 
 ## Wprowadzenie
@@ -13,7 +13,7 @@ Oznacza to, że wszystkie zobowiązania z tytułu zasilenia konta cloud zostaną
 
 ## Wymagania początkowe
 
-- Projekt [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na Twoim koncie OVHcloud
+- Projekt [Public Cloud](/links/public-cloud/public-cloud) na Twoim koncie OVHcloud
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -65,7 +65,7 @@ W oknie, które się pojawi, wprowadź kod vouchera i kliknij <code className="a
 Pozostała część kodu pojawi się na liście <code className="action">Kredyty i vouchery</code>.
 
 :::info
-Ze względu na to, że kody promocyjne są ważne przez dłuższy czas, pozostała część kodu zostanie wykorzystana przed zasileniem Public Cloud.
+Vouchery są zazwyczaj ważne przez jeden miesiąc; należy z nich korzystać jak najszybciej. Saldo vouchera zostanie wykorzystane przed zasileniem Public Cloud.
 
 :::
 
@@ -76,4 +76,4 @@ Ze względu na to, że kody promocyjne są ważne przez dłuższy czas, pozosta�
 Nowi klienci automatycznie otrzymują 1 000 PLN bezpłatnego kredytu próbnego, gdy aktywują swój pierwszy projekt Public Cloud. Sprawdź nasz przewodnik "[Utworzenie pierwszego projektu Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project)".
 :::
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud VPS - często zadawane pytania
 description: Znajdź odpowiedzi na najczęściej zadawane pytania dotyczące ofert VPS
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-11
 ---
 
 import Api from '@components/Api';
@@ -38,7 +38,7 @@ Oferty VPS od OVHcloud oferują świetną wartość dla wydajności, z nieograni
 
 Użycie VPS wymaga podstawowej wiedzy na temat administracji serwerem. Ważne jest, aby to uwzględnić, skutecznie zarządzając swoim systemem operacyjnym (Linux lub Windows) oraz konfigurować swoje aplikacje, np. PrestaShop lub WordPress.
 
-Jeśli potrzebujesz VPS, ale brakuje Ci technicznej wiedzy, aby go zarządzać, rozważ kontakt z jednym z naszych [partnerów](https://partner.ovhcloud.com/pl/directory/) w celu uzyskania pomocy.
+Jeśli potrzebujesz VPS, ale brakuje Ci technicznej wiedzy, aby go zarządzać, rozważ kontakt z jednym z naszych [partnerów](/links/partner) w celu uzyskania pomocy.
 
 Jeśli potrzebujesz przydzielonych zasobów, ale nie chcesz mieć do czynienia z administracją serwerem, zalecamy wybór naszych planów hostingu webowego Performance.
 
@@ -96,7 +96,7 @@ Dodatkowo oferujemy:
 
 Korzystając z tych rozwiązań, możesz dostosować zarządzanie kopiami zapasowymi do swoich potrzeb bezpieczeństwa i ciągłości działania.
 
-Wizytuj naszą [stronę internetową VPS](https://www.ovhcloud.com/pl/vps/), aby dowiedzieć się więcej o dostępnych opcjach.
+Wizytuj naszą [stronę internetową VPS](/links/bare-metal/vps), aby dowiedzieć się więcej o dostępnych opcjach.
 
 </details>
 
@@ -178,7 +178,7 @@ VPS eliminuje konieczność zarządzania sprzętem fizycznym, takim jak pamięć
 <summary>Jaka przepustowość jest przydzielona do mojego VPS? Czy jest ona gwarantowana?</summary>
 
 
-Przepustowość wymieniona na naszej [stronie internetowej VPS](https://www.ovhcloud.com/pl/vps/) jest gwarantowana. Jest to minimalna ilość przydzielona do Twojej usługi.
+Przepustowość wymieniona na naszej [stronie internetowej VPS](/links/bare-metal/vps) jest gwarantowana. Jest to minimalna ilość przydzielona do Twojej usługi.
 
 </details>
 
@@ -261,7 +261,7 @@ Oferujemy na przykład gamę wstępnie skonfigurowanych szablonów i obrazów dl
 
 Ponadto, nasza dokumentacja i baza wiedzy zawierają wiele informacji dotyczących konfiguracji i zarządzania serwerem VPS.
 
-Jednak w przypadku specyficznej pomocy w konfiguracji oprogramowania, zalecamy skontaktowanie się z naszą [społecznością](https://community.ovhcloud.com/community/en) lub uzyskanie pomocy wykwalifikowanego administratora systemu lub programisty poprzez nasz [portal partnera](https://partner.ovhcloud.com/pl/directory/).
+Jednak w przypadku specyficznej pomocy w konfiguracji oprogramowania, zalecamy skontaktowanie się z naszą [społecznością](/links/community) lub uzyskanie pomocy wykwalifikowanego administratora systemu lub programisty poprzez nasz [portal partnera](/links/partner).
 
 </details>
 
@@ -279,6 +279,8 @@ Obejmuje to:
 - konfigurację reverse DNS (PTR),
 - przestrzeganie najlepszych praktyk dostawców poczty elektronicznej.
 
+Jeśli e-maile nie są wysyłane lub serwer SMTP nie odpowiada, sprawdź, czy porty SMTP nie są zablokowane. Port 25 jest domyślnie zablokowany na serwerach VPS OVHcloud, aby zapobiec nadużyciom. Zamiast tego użyj portu 587 (STARTTLS) do wysyłki e-maili wychodzących lub, w razie potrzeby, poproś o odblokowanie portu 25, [kontaktując się z naszym zespołem wsparcia](/links/support-contact).
+
 Więcej informacji znajdziesz w naszym przewodniku: [Jak zapobiec oznaczaniu e-maili jako spam](/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization).
 
 </details>
@@ -292,7 +294,7 @@ Więcej informacji znajdziesz w naszym przewodniku: [Jak zapobiec oznaczaniu e-m
 Instalacja OVHcloud jest możliwa tylko dla jednego systemu operacyjnego.  
 Konfiguracje spersonalizowane mogą być wdrażane po stronie klienta, za co odpowiedzialność ponosi administrator serwera. Usługi OVHcloud nie obejmują zadań administracyjnych, takich jak konfiguracja oprogramowania lub narzędzia zewnętrzne.
 
-W przypadku problemów z konfiguracją i administracją zalecamy kontakt z naszą [społecznością](https://community.ovhcloud.com/community/en) lub uzyskanie pomocy wykwalifikowanego administratora systemu lub programisty poprzez nasz [portal partnera](https://partner.ovhcloud.com/pl/directory/).
+W przypadku problemów z konfiguracją i administracją zalecamy kontakt z naszą [społecznością](/links/community) lub uzyskanie pomocy wykwalifikowanego administratora systemu lub programisty poprzez nasz [portal partnera](/links/partner).
 
 </details>
 
@@ -306,7 +308,7 @@ Szablony instalacyjne OVHcloud dla serwerów VPS nie zawierają systemu operacyj
 
 Konfiguracje spersonalizowane mogą być wdrażane po stronie klienta, za co odpowiedzialność ponosi administrator serwera. Usługi OVHcloud nie obejmują zadań administracyjnych, takich jak konfiguracja oprogramowania lub korzystanie z narzędzi zewnętrznych.
 
-W przypadku problemów z konfiguracją i administracją zalecamy kontakt z naszą [społecznością](https://community.ovhcloud.com/community/en) lub uzyskanie pomocy wykwalifikowanego administratora systemu lub programisty poprzez nasz [portal partnera](https://partner.ovhcloud.com/pl/directory/).
+W przypadku problemów z konfiguracją i administracją zalecamy kontakt z naszą [społecznością](/links/community) lub uzyskanie pomocy wykwalifikowanego administratora systemu lub programisty poprzez nasz [portal partnera](/links/partner).
 
 </details>
 
@@ -317,7 +319,7 @@ W przypadku problemów z konfiguracją i administracją zalecamy kontakt z nasz�
 
 
 Nie można spersonalizować ani zmodyfikować serwera VPS na poziomie sprzętowym.  
-Wybierz serwer [VPS model](https://www.ovhcloud.com/pl/vps/) zgodnie z Twoimi minimalnymi potrzebami i zaktualizuj go zgodnie z Twoimi potrzebami.
+Wybierz serwer [VPS model](/links/bare-metal/vps) zgodnie z Twoimi minimalnymi potrzebami i zaktualizuj go zgodnie z Twoimi potrzebami.
 
 </details>
 
@@ -331,7 +333,7 @@ Aby rozwiązać problemy z wydajnością na serwerze VPS, przekaż naszemu zespo
 
 Należy pamiętać, że serwer VPS musi zostać uruchomiony w [trybie rescue](/guides/bare-metal-cloud/virtual-private-servers/rescue), aby wykluczyć ewentualne problemy z oprogramowaniem.
 
-Skontaktuj się z zespołem pomocy, [tworząc zgłoszenie w Centrum pomocy OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help), aby uzyskać pełną listę testów niezbędnych do prawidłowej oceny.
+Skontaktuj się z zespołem pomocy, [tworząc zgłoszenie w Centrum pomocy OVHcloud](/links/support-contact), aby uzyskać pełną listę testów niezbędnych do prawidłowej oceny.
 
 </details>
 
@@ -341,7 +343,7 @@ Skontaktuj się z zespołem pomocy, [tworząc zgłoszenie w Centrum pomocy OVHcl
 <summary>Czy mogę zamówić nowy VPS, przenieść niewykorzystany abonament na stary VPS czy zwrócić należność?</summary>
 
 
-Jest to zazwyczaj możliwe, ale proces ten wymaga [zapytania do naszego zespołu wsparcia za pośrednictwem Centrum pomocy OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help).
+Jest to zazwyczaj możliwe, ale proces ten wymaga [zapytania do naszego zespołu wsparcia za pośrednictwem Centrum pomocy OVHcloud](/links/support-contact).
 
 Zanim przystąpisz do tej operacji, upewnij się, że [przeniosłeś wszystkie dane, których nadal potrzebujesz](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) do nowej usługi lub utworzyłeś kopie zapasowe danych.
 
@@ -368,7 +370,7 @@ Nie można przenieść VPS do innego centrum danych. W tym celu możesz przeprow
 <summary>Ile dodatkowych adresów IP mogę skonfigurować na serwerze VPS?</summary>
 
 
-Liczba adresów VPS jest ograniczona do [16 Additional IP](https://www.ovhcloud.com/pl/network/additional-ip/).
+Liczba adresów VPS jest ograniczona do [16 Additional IP](/links/network/additional-ip).
 
 Zapoznaj się z przewodnikiem [Skonfiguruj adres IP jako alias](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing) aby uzyskać przykłady konfiguracji adresów IP.
 
@@ -381,7 +383,7 @@ Zapoznaj się z przewodnikiem [Skonfiguruj adres IP jako alias](/guides/bare-met
 
 
 Nie można dodawać bloków IP do serwera VPS.  
-Na serwerze VPS można skonfigurować do [16 dodatkowych adresów IP](https://www.ovhcloud.com/pl/network/additional-ip/).
+Na serwerze VPS można skonfigurować do [16 dodatkowych adresów IP](/links/network/additional-ip).
 
 </details>
 
@@ -393,7 +395,7 @@ Na serwerze VPS można skonfigurować do [16 dodatkowych adresów IP](https://ww
 
 Licencje mogą być przenoszone między serwerami, ale istnieją ograniczenia.
 
-Najlepszą opcją jest zalogowanie się do naszego [API console](https://eu.api.ovh.com/) za pomocą danych identyfikacyjnych konta klienta i sprawdzenie, czy licencja może zostać przeniesiona na inny VPS. [Pierwsze kroki z API OVHcloud](/guides/manage-and-operate/api/first-steps).
+Najlepszą opcją jest zalogowanie się do naszego [API console](/links/console) za pomocą danych identyfikacyjnych konta klienta i sprawdzenie, czy licencja może zostać przeniesiona na inny VPS. [Pierwsze kroki z API OVHcloud](/guides/manage-and-operate/api/first-steps).
 
 Po zalogowaniu, skorzystaj z następujących wywołań w zależności od używanego programu:
 
@@ -473,7 +475,7 @@ Zapoznaj się z przewodnikiem [Jak używać migawek na serwerze VPS](/guides/bar
 
 Następnie możesz lokalnie przekonwertować pobrany plik snapshot na format odpowiadający Twoim potrzebom.
 
-Zastanów się nad skontaktowaniem z jednym z naszych [partnerów](https://partner.ovhcloud.com/pl/directory/) w celu uzyskania dalszej pomocy.
+Zastanów się nad skontaktowaniem z jednym z naszych [partnerów](/links/partner) w celu uzyskania dalszej pomocy.
 
 </details>
 
@@ -494,7 +496,7 @@ Można autoryzować wyłącznie adresy IP OVHcloud.
 :::
 
 
-Zaloguj się do [OVHcloud API console](https://eu.api.ovh.com/) za pomocą danych identyfikacyjnych konta klienta i użyj następującego wywołania:
+Zaloguj się do [OVHcloud API console](/links/console) za pomocą danych identyfikacyjnych konta klienta i użyj następującego wywołania:
 
 <Api version="v1" section="/vps" method="POST" route={"/vps/\{serviceName\}/backupftp/access"} />
 
@@ -538,7 +540,7 @@ Chociaż OVHcloud stosuje środki bezpieczeństwa w celu ochrony całej infrastr
 
 OVHcloud zapewnia kilka funkcji bezpieczeństwa, które chronią Twój VPS przed złośliwym ruchem:
 
-- Ochrona Anty-DDoS: nasze usługi VPS są domyślnie chronione przez naszą [infrastrukturę Anty-DDoS](https://www.ovhcloud.com/pl/security/anti-ddos/), która wykrywa i mityguje ataki DDoS w czasie rzeczywistym.
+- Ochrona Anty-DDoS: nasze usługi VPS są domyślnie chronione przez naszą [infrastrukturę Anty-DDoS](/links/security/antiddos), która wykrywa i mityguje ataki DDoS w czasie rzeczywistym.
 - Blokowanie IP: [Uniemożliwienie określonym adresom IP lub zakresom IP](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps) połączenia z Twoim VPS.
 - Reguły firewall: [skonfiguruj spersonalizowane reguły firewall](/guides/bare-metal-cloud/dedicated-servers/firewall-network) w celu monitorowania ruchu przychodzącego i wychodzącego bezpośrednio na serwerze VPS.
 - VAC (VPS Anty-DDoS): System VAC zapewnia dodatkową warstwę ochrony przed atakami DDoS, w tym filtrowanie ruchu i ograniczenie szybkości.
@@ -560,6 +562,6 @@ Zaletą VPS w porównaniu do serwera dedykowanego jest możliwość skalowania z
 
 ## Sprawdź również
 
-Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](https://www.ovhcloud.com/pl/support-levels/).
+Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](/links/support).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pt/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/pt/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Adicionar um crédito cloud
 description: Saiba como adicionar crédito ou vouchers ao seu projeto Public Cloud
-lastUpdated: 2026-05-28
+lastUpdated: 2026-06-11
 ---
 
 ## Objetivo
@@ -13,7 +13,7 @@ Isto significa que este crédito cloud é debitado em primeiro lugar e que qualq
 
 ## Requisitos
 
-- Um projeto [Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud
+- Um projeto [Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -65,7 +65,7 @@ Na nova janela, introduza o código do voucher e clique em <code className="acti
 O saldo do voucher aparecerá na lista <code className="action">Créditos e Vouchers</code>.
 
 :::info
-Uma vez que os prazos de validade dos vouchers são geralmente mais limitados, o saldo do voucher será utilizado antes do crédito Public Cloud.
+Os prazos de validade dos vouchers são geralmente limitados a 1 mês; recomenda-se que os utilize o mais cedo possível. O saldo do voucher será utilizado antes do crédito Public Cloud.
 
 :::
 
@@ -76,4 +76,4 @@ Uma vez que os prazos de validade dos vouchers são geralmente mais limitados, o
 Os novos clientes recebem automaticamente 200 € de crédito de teste aquando da ativação do seu primeiro projeto Public Cloud. Consulte o nosso guia "[Criar o seu primeiro projeto Public Cloud da OVHcloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project)".
 :::
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/).
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud VPS Perguntas frequentes
 description: Encontre as respostas às perguntas mais frequentes sobre nossas ofertas de VPS
-lastUpdated: 2026-03-24
+lastUpdated: 2026-06-11
 ---
 
 import Api from '@components/Api';
@@ -38,7 +38,7 @@ As ofertas de VPS da OVHcloud oferecem um excelente custo-benefício, com tráfe
 
 Usar um VPS requer conhecimentos básicos de administração de servidores. Lembrar disso é crucial para gerenciar efetivamente seu sistema operacional (Linux ou Windows) e configurar suas aplicações, como o PrestaShop ou o WordPress, por exemplo.
 
-Se você precisa de um VPS, mas não tem a expertise técnica para gerenciá-lo, considere entrar em contato com um de nossos [parceiros](https://partner.ovhcloud.com/pt/directory/) para obter assistência. 
+Se você precisa de um VPS, mas não tem a expertise técnica para gerenciá-lo, considere entrar em contato com um de nossos [parceiros](/links/partner) para obter assistência. 
 
 Se você precisa de recursos provisionados, mas prefere não lidar com a administração do servidor, recomendamos optar por nossos planos de hospedagem web Performance.
 
@@ -96,7 +96,7 @@ Além disso, oferecemos:
 
 Ao usar essas soluções, você pode personalizar o gerenciamento de backup para atender às suas necessidades de segurança e continuidade do negócio.
 
-Visite nossa [página web de VPS](https://www.ovhcloud.com/pt/vps/) para saber mais sobre as opções disponíveis.
+Visite nossa [página web de VPS](/links/bare-metal/vps) para saber mais sobre as opções disponíveis.
 
 </details>
 
@@ -179,7 +179,7 @@ Um VPS elimina a necessidade de gerenciar hardware físico, como armazenamento, 
 <summary>Qual largura de banda é alocada para meu VPS? É garantida?</summary>
 
 
-A largura de banda listada em nossa [página web de VPS](https://www.ovhcloud.com/pt/vps/) é garantida. É a quantidade mínima alocada para seu serviço.
+A largura de banda listada em nossa [página web de VPS](/links/bare-metal/vps) é garantida. É a quantidade mínima alocada para seu serviço.
 
 </details>
 
@@ -261,7 +261,7 @@ Por exemplo, oferecemos uma gama de modelos e imagens pré-configurados para sis
 
 Além disso, nossa documentação e base de conhecimento contêm uma riqueza de informações sobre como configurar e gerenciar seu VPS.
 
-No entanto, para assistência específica na configuração de software, recomendamos entrar em contato com nossa [comunidade](https://community.ovhcloud.com/community/en) ou buscar a ajuda de um administrador de sistema ou desenvolvedor qualificado por meio de nosso [portal de parceiros](https://partner.ovhcloud.com/pt/directory/).
+No entanto, para assistência específica na configuração de software, recomendamos entrar em contato com nossa [comunidade](/links/community) ou buscar a ajuda de um administrador de sistema ou desenvolvedor qualificado por meio de nosso [portal de parceiros](/links/partner).
 
 </details>
 
@@ -279,6 +279,8 @@ Isto inclui:
 - a configuração do reverse DNS (PTR),
 - o cumprimento das boas práticas dos fornecedores de correio eletrónico.
 
+Se os seus e-mails não estão a ser enviados ou o servidor SMTP não responde, verifique se as portas SMTP estão bloqueadas. A porta 25 está bloqueada por predefinição nos VPS OVHcloud para prevenir abusos. Utilize a porta 587 (STARTTLS) para o envio de saída ou, se necessário, peça o desbloqueio da porta 25 [contactando a nossa equipa de suporte](/links/support-contact).
+
 Para mais informações, consulte o nosso guia dedicado: [Como evitar que os seus e-mails sejam marcados como spam](/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization).
 
 </details>
@@ -292,7 +294,7 @@ Para mais informações, consulte o nosso guia dedicado: [Como evitar que os seu
 Os modelos de instalação da OVHcloud permitem apenas um sistema operacional.  
 Configurações personalizadas podem ser aplicadas do lado do cliente e são de responsabilidade do administrador do servidor. Os serviços da OVHcloud não incluem tarefas de administração, como configuração de software ou uso de ferramentas externas.
 
-Se você encontrar problemas de configuração e administração, recomendamos entrar em contato com nossa [comunidade](https://community.ovhcloud.com/community/en) ou buscar a ajuda de um administrador de sistema ou desenvolvedor qualificado por meio de nosso [portal de parceiros](https://partner.ovhcloud.com/pt/directory/). 
+Se você encontrar problemas de configuração e administração, recomendamos entrar em contato com nossa [comunidade](/links/community) ou buscar a ajuda de um administrador de sistema ou desenvolvedor qualificado por meio de nosso [portal de parceiros](/links/partner). 
 
 </details>
 
@@ -307,7 +309,7 @@ Os modelos de instalação da OVHcloud para VPS não incluem o Proxmox Operating
 
 Configurações personalizadas podem ser aplicadas do lado do cliente e são de responsabilidade do administrador do servidor. Os serviços da OVHcloud não incluem tarefas de administração, como configuração de software ou uso de ferramentas externas.
 
-Se você encontrar problemas de configuração e administração, recomendamos entrar em contato com nossa [comunidade](https://community.ovhcloud.com/community/en) ou buscar a ajuda de um administrador de sistema ou desenvolvedor qualificado por meio de nosso [portal de parceiros](https://partner.ovhcloud.com/pt/directory/). 
+Se você encontrar problemas de configuração e administração, recomendamos entrar em contato com nossa [comunidade](/links/community) ou buscar a ajuda de um administrador de sistema ou desenvolvedor qualificado por meio de nosso [portal de parceiros](/links/partner). 
 
 </details>
 
@@ -318,7 +320,7 @@ Se você encontrar problemas de configuração e administração, recomendamos e
 
 
 Um VPS não pode ser personalizado ou modificado no nível de hardware.  
-Selecione um [modelo de VPS](https://www.ovhcloud.com/pt/vps/) no processo de pedido que atenda aos seus requisitos mínimos, e depois você poderá atualizá-lo conforme necessário.  
+Selecione um [modelo de VPS](/links/bare-metal/vps) no processo de pedido que atenda aos seus requisitos mínimos, e depois você poderá atualizá-lo conforme necessário.  
 
 </details>
 
@@ -332,7 +334,7 @@ Para resolver problemas de desempenho no seu VPS, você precisará fornecer resu
 
 Observe que seu VPS deve ser inicializado no [modo de recuperação](/guides/bare-metal-cloud/virtual-private-servers/rescue) para descartar quaisquer possíveis problemas de software.
 
-Entre em contato com nossa equipe de suporte ao [criar uma solicitação no OVHcloud Centro de Ajuda](https://help.ovhcloud.com/csm?id=csm_get_help) para que possamos fornecer a você a lista completa de testes necessários para uma avaliação adequada.
+Entre em contato com nossa equipe de suporte ao [criar uma solicitação no OVHcloud Centro de Ajuda](/links/support-contact) para que possamos fornecer a você a lista completa de testes necessários para uma avaliação adequada.
 
 </details>
 
@@ -342,7 +344,7 @@ Entre em contato com nossa equipe de suporte ao [criar uma solicitação no OVHc
 <summary>Comprei um novo VPS, posso transferir o tempo restante da assinatura do meu VPS antigo ou terei um reembolso?</summary>
 
 
-Isso geralmente é possível, mas o processo requer uma [solicitação à nossa equipe de suporte via OVHcloud Centro de Ajuda](https://help.ovhcloud.com/csm?id=csm_get_help).
+Isso geralmente é possível, mas o processo requer uma [solicitação à nossa equipe de suporte via OVHcloud Centro de Ajuda](/links/support-contact).
 
 Antes de prosseguir, certifique-se de que você tenha [migrado qualquer dado ainda necessário](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) para seu novo serviço ou crie cópias de segurança dos seus dados.
 
@@ -369,7 +371,7 @@ Não é possível migrar um VPS para outro centro de dados. Para isso, você pod
 <summary>Quantos IPs Adicionais posso configurar em um VPS?</summary>
 
 
-Um VPS é limitado a [16 IPs Adicionais](https://www.ovhcloud.com/pt/network/additional-ip/).
+Um VPS é limitado a [16 IPs Adicionais](/links/network/additional-ip).
 
 Consulte nosso guia sobre [como configurar alias de IP](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing) para exemplos de configuração de endereços IP.
 
@@ -382,7 +384,7 @@ Consulte nosso guia sobre [como configurar alias de IP](/guides/bare-metal-cloud
 
 
 Não é possível adicionar blocos de IP a um VPS.  
-Você pode configurar até [16 IPs Adicionais](https://www.ovhcloud.com/pt/network/additional-ip/) em um VPS.
+Você pode configurar até [16 IPs Adicionais](/links/network/additional-ip) em um VPS.
 
 </details>
 
@@ -394,7 +396,7 @@ Você pode configurar até [16 IPs Adicionais](https://www.ovhcloud.com/pt/netwo
 
 Licenças podem ser movidas entre servidores, mas existem limitações.
 
-A melhor opção é fazer login em nossa [console da API](https://eu.api.ovh.com/) com suas credenciais de conta de cliente e verificar se sua licença pode ser movida para um VPS diferente. Encontre as bases em nosso guia sobre [como começar com a API da OVHcloud](/guides/manage-and-operate/api/first-steps).
+A melhor opção é fazer login em nossa [console da API](/links/console) com suas credenciais de conta de cliente e verificar se sua licença pode ser movida para um VPS diferente. Encontre as bases em nosso guia sobre [como começar com a API da OVHcloud](/guides/manage-and-operate/api/first-steps).
 
 Uma vez conectado, use as seguintes chamadas dependendo do software em uso:
 
@@ -474,7 +476,7 @@ Siga nosso guia sobre [como usar snapshots em um VPS](/guides/bare-metal-cloud/v
 
 Você pode então converter localmente o arquivo de snapshot baixado em um formato correspondente às suas necessidades.
 
-Considere entrar em contato com um de nossos [parceiros](https://partner.ovhcloud.com/pt/directory/) para obter assistência adicional. 
+Considere entrar em contato com um de nossos [parceiros](/links/partner) para obter assistência adicional. 
 
 </details>
 
@@ -495,7 +497,7 @@ Apenas endereços IP da OVHcloud podem ser autorizados.
 :::
 
 
-Faça login na [console da API da OVHcloud](https://eu.api.ovh.com/) com suas credenciais de conta de cliente e use a seguinte chamada:
+Faça login na [console da API da OVHcloud](/links/console) com suas credenciais de conta de cliente e use a seguinte chamada:
 
 <Api version="v1" section="/vps" method="POST" route={"/vps/\{serviceName\}/backupftp/access"} />
 
@@ -539,7 +541,7 @@ Embora a OVHcloud aplique medidas de segurança para proteger toda a infraestrut
 
 A OVHcloud oferece várias funcionalidades de segurança para proteger seu VPS contra tráfego malicioso:
 
-- Proteção Anti-DDoS: Nossos serviços de VPS são protegidos por padrão pela nossa [infraestrutura Anti-DDoS](https://www.ovhcloud.com/pt/security/anti-ddos/), que detecta e mitiga ataques DDoS em tempo real.
+- Proteção Anti-DDoS: Nossos serviços de VPS são protegidos por padrão pela nossa [infraestrutura Anti-DDoS](/links/security/antiddos), que detecta e mitiga ataques DDoS em tempo real.
 - Bloqueio de IP: Você pode [impedir endereços IP ou faixas específicas](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps) de acessar seu VPS.
 - Regras de firewall: Você pode [configurar regras de firewall personalizadas](/guides/bare-metal-cloud/dedicated-servers/firewall-network) para controlar o tráfego de entrada e saída diretamente no seu VPS.
 - VAC (VPS Anti-DDoS): Nosso sistema VAC oferece uma camada adicional de proteção contra ataques DDoS, incluindo filtragem de tráfego e limitação de taxa.
@@ -561,6 +563,6 @@ A vantagem de um VPS em comparação com um servidor dedicado é a possibilidade
 
 ## Quer saber mais?
 
-Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
+Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).


### PR DESCRIPTION
Restore content added on legacy (ovh/docs #9247, #9330) that was dropped during migration, and optimize external links to /links tokens.

- add-cloud-credit (7 locales): update voucher validity wording (1 month)
- vps-faq (7 locales): add blocked SMTP port (port 25) paragraph
- vps-faq + add-cloud-credit: replace external URLs with /links tokens
- bump lastUpdated to 2026-06-11 on all edited guides