### PR TITLE
docs(pcc): translate fr in en path files & fixes

### DIFF
--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
@@ -1,12 +1,12 @@
 ---
 title: Ersatz von Prism Central vom Small Modus im X-LARGE Modus (EN)
 description: How to replace Prism Central with three X-Large VMs
-lastUpdated: 2023-12-18
+lastUpdated: 2026-06-11
 ---
 
 :::warning
 This guide is only intended for customers who are in **Bring Your Own License** mode on their Nutanix cluster.
-If you are not in this configuration, contact the [OVHcloud support teams](https://help.ovhcloud.com/csm?id=csm_get_help) to change the size of your Prism Central.
+If you are not in this configuration, contact the [OVHcloud support teams](/links/support-contact) to change the size of your Prism Central.
 
 :::
 
@@ -17,14 +17,14 @@ Before you make any changes, you must unregister your Prism Central license on y
 :::
 
 
-## Objectif
+## Objective
 
 **This guide will show you how to redeploy Prism-Central in X-LARGE mode across three virtual machines.**
 
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 
 :::
 
@@ -32,7 +32,6 @@ If you encounter any difficulties performing these actions, please contact a [sp
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -63,13 +62,13 @@ In the configuration pages for your Load Balancer, go to the <code className="ac
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 02" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer02.png" loading="lazy" />
 
-Enter this information :
+Enter this information:
 
-- **Name (optional)** : `PE SSH`.
-- **Protocol** : `TCP`.
-- **Port** : `22`.
-- **Datacenter** : `ALL`.
-- **Private network** : `nutanix`.
+- **Name (optional)**: `PE SSH`.
+- **Protocol**: `TCP`.
+- **Port**: `22`.
+- **Datacenter**: `ALL`.
+- **Private network**: `nutanix`.
 
 Then click <code className="action">Add</code>.
 
@@ -79,11 +78,11 @@ Within the server cluster, click <code className="action">Add server</code>.
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 04" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer04.png" loading="lazy" />
 
-Fill in these values :
+Fill in these values:
 
-- **Name (Optional)** : `PE SSH`.
-- **IPv4 address** : `Private IP address of Prism Element`.
-- **Port** : `22`.
+- **Name (Optional)**: `PE SSH`.
+- **IPv4 address**: `Private IP address of Prism Element`.
+- **Port**: `22`.
 
 And click <code className="action">Add</code>.
 
@@ -111,9 +110,9 @@ When the task is finished, go to the <code className="action">Front-ends</code> 
 
 Enter the following information:
 
-- **Name(Optional)** : `PE-FRONTEND`.
-- **Port** : `22`.
-- **Datacenter** : `ALL`.
+- **Name(Optional)**: `PE-FRONTEND`.
+- **Port**: `22`.
+- **Datacenter**: `ALL`.
 
 Then click <code className="action">Show</code>.
 
@@ -141,7 +140,7 @@ Go to the <code className="action">Tasks</code> tab to see the progress of the c
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 16" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer16.png" loading="lazy" />
 
-You have finished configuring the Load Balancer. You can now log in via SSH to the Prism Element console, with this information :
+You have finished configuring the Load Balancer. You can now log in via SSH to the Prism Element console, with this information:
 
 ```bash
 ssh admin@nutanix-cluster-ovhcloud-fqdn
@@ -157,9 +156,9 @@ ssh nutanix@nutanix-cluster-ovhcloud-fqdn
 
 Run these commands after you have modified the following information:
 
-- **\<Prism-Central-Private-IP-address\>** : Private IP address of Prism Central
-- **\<Prism-Element-Admin-Password\>** : Prism Element admin account password
-- **\<Prism-Central-VM-Name\>** : Prism Central VM name
+- **\<Prism-Central-Private-IP-address\>**: Private IP address of Prism Central
+- **\<Prism-Element-Admin-Password\>**: Prism Element admin account password
+- **\<Prism-Central-VM-Name\>**: Prism Central VM name
 
 ```bash
 # Disconnect Prism Element in Prism Central
@@ -176,8 +175,8 @@ ssh root@private-ip-address-of-one-ahv-servers
 
 Run this command to retrieve the UUID of your default storage, once you have modified the following information:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-IP\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-IP\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X GET "https://<Prism-Element-Ip>:9440/PrismGateway/services/rest/v2.0/storage_containers/" | jq -r '[.entities[] | select( .name | contains("default-container")) | .storage_container_uuid][0]'
@@ -189,7 +188,7 @@ Next, run this other command to retrieve the UUID of your cluster’s administra
 curl -s -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST https://<prism6element-IP>:9440/api/nutanix/v3/subnets/list -d {} | jq -r "[.entities[] | select( .spec.name | contains(\"<subnet name>\")) | .metadata.uuid][0]"
 ```
 
-Create a file named **PrismCentralXlarge.json** with the information below :
+Create a file named **PrismCentralXlarge.json** with the information below:
 
 ```json
 {
@@ -222,19 +221,19 @@ Create a file named **PrismCentralXlarge.json** with the information below :
 }
 ```
 
-Replace these items in the file :
+Replace these items in the file:
 
-- **\<Prism-Central-Password\>** : Password for the future Prism Central virtual machine.
-- **\<Default-Container-UUID\>** : UUID of the default storage retrieved earlier.
-- **\<Prism-Central-Private-IP-Address\>** : Private IP address of Prism Central.
-- **\<Nutanix-Network-Admin-UUID\>** : Nutanix Cluster Administration Network UUID.
-- **\<Nutanix-Network-Admin-mask\>** : Nutanix cluster administration network subnet mask.
-- **\<Nutanix-Network-Admin-Gateway\>** : Nutanix cluster administration network default gateway.
+- **\<Prism-Central-Password\>**: Password for the future Prism Central virtual machine.
+- **\<Default-Container-UUID\>**: UUID of the default storage retrieved earlier.
+- **\<Prism-Central-Private-IP-Address\>**: Private IP address of Prism Central.
+- **\<Nutanix-Network-Admin-UUID\>**: Nutanix Cluster Administration Network UUID.
+- **\<Nutanix-Network-Admin-mask\>**: Nutanix cluster administration network subnet mask.
+- **\<Nutanix-Network-Admin-Gateway\>**: Nutanix cluster administration network default gateway.
 
 Run this command to deploy your Prism Central virtual machine in X-Large mode, once you changed these settings:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-Private-IP-Address\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-Private-IP-Address\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST "https://<Prism-Element-Private-IP-Address>:9440/api/nutanix/v3/prism_central" -d @PrismCentralXlarge.json
@@ -248,17 +247,17 @@ Wait thirty minutes for this virtual machine to deploy.
 
 Enter the following command by editing these options to create a **pcregister.json** file:
 
-- **\<Prism-Central-Password\>** : Prism Central Password.
-- **\<Prism-Central-Private-IP-Address\>** : Private IP address of Prism Central.
+- **\<Prism-Central-Password\>**: Prism Central Password.
+- **\<Prism-Central-Private-IP-Address\>**: Private IP address of Prism Central.
 
 ```bash
 echo "{\"username\":\"admin\",\"password\":\"<Prism-Central-Password>\",\"port\":9440,\"ipAddresses\":[\"<Prism-Central-Private-IP-Address>\"]}" > pcregister.json
 ```
 
-Run this command to save Prism Element into your new Prism Central virtual machine, after changing these settings :
+Run this command to save Prism Element into your new Prism Central virtual machine, after changing these settings:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-Private-IP-Address\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-Private-IP-Address\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST "https://<Prism-Element-Private-IP-Address>:9440/PrismGateway/services/rest/v1/multicluster/prism_central/register" -d @pcregister.json
@@ -294,13 +293,13 @@ Click <code className="action">Confirm</code>.
 
 Expansion of Prism Central requires three additional private IP addresses, one for the virtual IP address and two for the new virtual machines.
 
-Scroll through the window and enter this information :
+Scroll through the window and enter this information:
 
-- **Virtual IP** : Prism Central virtual private IP address.
-- **VM Name** : Name of the second Prism Central virtual machine.
-- **IP** : Private IP address of the second virtual machine.
-- **VM Name** : Name of the third Prism Central virtual machine.
-- **IP** : Private IP address of the third virtual machine.
+- **Virtual IP**: Prism Central virtual private IP address.
+- **VM Name**: Name of the second Prism Central virtual machine.
+- **IP**: Private IP address of the second virtual machine.
+- **VM Name**: Name of the third Prism Central virtual machine.
+- **IP**: Private IP address of the third virtual machine.
 
 Click <code className="action">Expand</code>.
 
@@ -330,11 +329,11 @@ Click <code className="action">Add Server</code>.
 
 <img className="thumbnail" alt="03 Modify Prism Central Https Address 02" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/03-modify-prism-central-https-address02.png" loading="lazy" />
 
-Enter this information :
+Enter this information:
 
-- **Name (Optional)** : PC VIP as Prism Central Virtual IP address.
-- **IPv4 address** : Virtual Private IP address 
-- **Port** : 9440.
+- **Name (Optional)**: PC VIP as Prism Central Virtual IP address.
+- **IPv4 address**: Virtual Private IP address 
+- **Port**: 9440.
 
 Click <code className="action">Add</code>.
 
@@ -368,6 +367,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
@@ -1,10 +1,10 @@
 ---
 title: NCM Self Service (CALM) einrichten (EN)
 description: How to enable Self Service (CALM) in your Prism Central
-lastUpdated: 2024-05-13
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
 **Find out how to set up NCM Self-Service (Calm) on your Prism Central.**
 
@@ -73,7 +73,7 @@ An error message appears during CALM deployment, ignore it, exit the window and 
 :::
 
 
-![00 Activate CALM 08](/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png)
+<img className="thumbnail" alt="00 Activate CALM 08" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png" loading="lazy" />
 
 ### Creating a project
 
@@ -153,7 +153,7 @@ Enter this information:
 - **vCPUs**: `4`
 - **Core per vCPU**: `1`
 - **Memory (GiB)**: `4`
-- **Image** : `WS2022EN-SYSPREPED`
+- **Image**: `WS2022EN-SYSPREPED`
 
 :::info
 The image is generated from a VM WINDOWS Server 2022 on which a sysprep was applied to reset the default configuration. When used with CALM, it is possible to automate the installation of a Windows OS from this type of image and apply settings stored in an XML file to it.

--- a/docs/de/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
+++ b/docs/de/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
@@ -1,10 +1,10 @@
 ---
 title: Konfigurieren von NAT für Port-Weiterleitungen mit NSX (EN)
 description: Learn how to configure NAT to create port redirections
-lastUpdated: 2023-02-27
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
 **Learn how to configure NAT to create port redirections with NSX.**
 
@@ -32,13 +32,13 @@ In the NSX interface, go to the <code className="action">Networking</code> tab, 
 
 <img className="thumbnail" alt="01 Create DNAT rule 01" src="/images/hosted-private-cloud/powered-by-vmware/nsx-07-configure-nat-redirection/01-create-dnat-rules01.png" loading="lazy" />
 
-Fill in this information :
+Fill in this information:
 
-- **Action** : Select <code className="action">DNAT</code>.
-- **Source IP** : Enter the IP address or range of addresses that can use this redirection.
-- **Destination IP** : Public virtual IP address of NSX.
-- **Destination PORT** : Listening port on public address such as `2222`.
-- **Translated IP** : IP address of the virtual machine being redirected to.
+- **Action**: Select <code className="action">DNAT</code>.
+- **Source IP**: Enter the IP address or range of addresses that can use this redirection.
+- **Destination IP**: Public virtual IP address of NSX.
+- **Destination PORT**: Listening port on public address such as `2222`.
+- **Translated IP**: IP address of the virtual machine being redirected to.
 
 Then click on the <code className="action">three vertical dots</code> to the right of **Select Services**.
 
@@ -52,11 +52,11 @@ Click <code className="action">ADD SERVICE ENTRY</code>.
 
 <img className="thumbnail" alt="01 Create DNAT rule 04" src="/images/hosted-private-cloud/powered-by-vmware/nsx-07-configure-nat-redirection/01-create-dnat-rules04.png" loading="lazy" />
 
-Fill in these values :
+Fill in these values:
 
-- **Name** : Enter `SSH22`.
-- **Service Type** : Select <code className="action">TCP</code>.
-- **Source Ports** : Write the number `22`.
+- **Name**: Enter `SSH22`.
+- **Service Type**: Select <code className="action">TCP</code>.
+- **Source Ports**: Write the number `22`.
 
 Then click <code className="action">APPLY</code>.
 

--- a/docs/en/guides/hosted-private-cloud/cloud-platform/getting-started.mdx
+++ b/docs/en/guides/hosted-private-cloud/cloud-platform/getting-started.mdx
@@ -1,147 +1,148 @@
 ---
-title: "Mise en route de votre projet SNC Cloud Platform"
-excerpt: "Découvrez comment prendre en main et configurer votre environnement SNC Cloud Platform"
-updated: 2025-12-29
+title: Getting started with your SNC Cloud Platform project
+description: Find out how to get started with and configure your SNC Cloud Platform environment
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
-Ce guide a été conçu pour vous présenter la manière de vous connecter aux interfaces graphiques de la **SNC Cloud Platform** en tant qu'administrateur du service.
+This guide shows you how to connect to the graphical interfaces of the **SNC Cloud Platform** as a service administrator.
 
-## Prérequis
+## Requirements
 
-Afin de suivre ce guide, vous aurez besoin des informations suivantes :
+To follow this guide, you will need the following information:
 
-- Adresse **URL** de l'interface de gestion fournie lors de la livraison du service.
-- Identifiants (ID d'organisation, login et mot de passe) fournis lors de la livraison du service.
+- The management interface **URL** provided when the service was delivered.
+- The credentials (organisation ID, login and password) provided when the service was delivered.
 
-## En pratique
+## Instructions
 
-### Composition de l'interface utilisateur
+### User interface layout
 
-L'adresse **URL** fournie vous permet d'accéder à l'interface du Regional Manager de la **SNC Cloud Platform**.
+The **URL** provided gives you access to the Regional Manager interface of the **SNC Cloud Platform**.
 
-![Page de connexion du Regional Manager](/images/guides/hosted-private-cloud/cloud-platform/getting-started/regional_manager_login.png)
+<img className="thumbnail" alt="Regional Manager login page" src="/images/hosted-private-cloud/cloud-platform/getting-started/regional_manager_login.png" loading="lazy" />
 
-Une fois connecté à l'aide de vos identifiants, vous aurez accès au tableau de bord du produit.
+Once you are logged in with your credentials, you will have access to the product dashboard.
 
-![Dashboard visible une fois identifié](/images/guides/hosted-private-cloud/cloud-platform/getting-started/regional_manager_dashboard.png)
+<img className="thumbnail" alt="Dashboard visible once logged in" src="/images/hosted-private-cloud/cloud-platform/getting-started/regional_manager_dashboard.png" loading="lazy" />
 
-Votre interface vous permet d'accéder :
+Your interface gives you access to:
 
-- à l'interface de gestion d'OpenStack, *Horizon*. Il s'agit d'une interface web graphique pour gérer l'ensemble de l'infrastructure OpenStack. Elle permet à l'utilisateur d'exploiter les ressources machines mises à disposition par les administrateurs, ainsi que de créer, lancer et arrêter des instances, configurer des réseaux et gérer leur accessibilité.
-- à l'interface de gestion Object Storage.
+- the OpenStack management interface, *Horizon*. This is a graphical web interface for managing the entire OpenStack infrastructure. It allows the user to make use of the machine resources made available by the administrators, as well as to create, start and stop instances, configure networks and manage their accessibility.
+- the Object Storage management interface.
 
-### Présentation de l'Interface OpenStack Horizon
+### Overview of the OpenStack Horizon interface
 
-L'interface graphique d'OpenStack Horizon offre la possibilité de réaliser différentes actions en fonction de leurs autorisations et du projet auquel ils appartiennent. Parmi les principales fonctionnalités disponibles pour un utilisateur final, on peut citer : la gestion des instances, la gestion des réseaux, le suivi des ressources.
+The OpenStack Horizon graphical interface offers the ability to perform various actions depending on users' permissions and the project they belong to. The main features available to an end user include: instance management, network management and resource monitoring.
 
-#### Accès à l'interface d'administration OpenStack Horizon
+#### Accessing the OpenStack Horizon administration interface
 
-Depuis l'interface du Regional Manager de la **SNC Cloud Platform**, l'interface OpenStack Horizon est accessible via le lien dans le tableau de bord.
+From the Regional Manager interface of the **SNC Cloud Platform**, the OpenStack Horizon interface is accessible via the link in the dashboard.
 
-![Emplacement du raccourci vers Horizon](/images/guides/hosted-private-cloud/cloud-platform/getting-started/dashboard_login_horizon.png)
+<img className="thumbnail" alt="Location of the shortcut to Horizon" src="/images/hosted-private-cloud/cloud-platform/getting-started/dashboard_login_horizon.png" loading="lazy" />
 
-Après s'être connecté, l'interface Horizon OpenStack se présente de la manière suivante :
+Once you are logged in, the OpenStack Horizon interface appears as follows:
 
-![Interface Horizon OpenStack](/images/guides/hosted-private-cloud/cloud-platform/getting-started/horizon_dashboard.png)
+<img className="thumbnail" alt="OpenStack Horizon interface" src="/images/hosted-private-cloud/cloud-platform/getting-started/horizon_dashboard.png" loading="lazy" />
 
-Le menu latéral situé à gauche de l'interface offre un accès aux divers éléments de l'interface. Il y a deux entrées parentes dans ce menu :
+The side menu on the left of the interface provides access to the various elements of the interface. There are two parent entries in this menu:
 
-- **Projet (Project)**, qui comprend quatre éléments : *Aperçu* (Overview), *Compute*, *Volumes* et *Réseau* (Network). Ces éléments rassemblent l'ensemble des fonctionnalités de gestion des instances, de leurs réseaux, dans les limites de quotas définis.
-- **Identité (Identity)**, qui inclut les éléments Projets, Utilisateurs et identifiants d'application qui contiennent les fonctionnalités de gestion des utilisateurs.
+- **Project**, which includes four elements: *Overview*, *Compute*, *Volumes* and *Network*. These elements bring together all the features for managing instances and their networks, within the defined quota limits.
+- **Identity**, which includes the Projects, Users and Application Credentials elements, which contain the user management features.
 
-![Menu de l'interface OpenStack Horizon](/images/guides/hosted-private-cloud/cloud-platform/getting-started/horizon_menu.png)
+<img className="thumbnail" alt="Menu of the OpenStack Horizon interface" src="/images/hosted-private-cloud/cloud-platform/getting-started/horizon_menu.png" loading="lazy" />
 
-#### Vue projet
+#### Project view
 
-L'élément principal *Projet* est composé de divers sous-éléments qui permettent d'accéder à toutes les fonctionnalités de gestion des ressources.  Le premier sous-élément, appelé *Aperçu* (Overview), offre une vision globale des quotas de ressources, attribuées du projet, ainsi qu'un suivi visuel de la consommation globale des ressources. 
+The main *Project* element is made up of various sub-elements that provide access to all the resource management features. The first sub-element, called *Overview*, provides a global view of the resource quotas allocated to the project, as well as visual monitoring of overall resource consumption.
 
-##### Section Overview
+##### Overview section
 
-![Capture d'écran de la section Overview (vue d'ensemble)](/images/guides/hosted-private-cloud/cloud-platform/getting-started/horizon_project_overview.png)
+<img className="thumbnail" alt="Screenshot of the Overview section" src="/images/hosted-private-cloud/cloud-platform/getting-started/horizon_project_overview.png" loading="lazy" />
 
-La section *Overview* (Aperçu) est composée de deux parties principales :
+The *Overview* section is made up of two main parts:
 
-- **Limit Summary** : Les limites de quotas attribuées au projet pour chaque type de ressource. Ceci permet également de visualiser le niveau de consommation des ressources par rapport aux capacités disponibles. Les quotas sont regroupés en deux catégories, telles que représentées dans l'image ci-dessous :
+- **Limit Summary**: The quota limits allocated to the project for each type of resource. This also makes it possible to view the level of resource consumption in relation to the available capacities. The quotas are grouped into two categories, as shown in the image below:
 
-    ![Capture d'écran de la section Limit Summary](/images/guides/hosted-private-cloud/cloud-platform/getting-started/horizon_quota_categories.png)
+    <img className="thumbnail" alt="Screenshot of the Limit Summary section" src="/images/hosted-private-cloud/cloud-platform/getting-started/horizon_quota_categories.png" loading="lazy" />
 
-    - **Compute** qui comprend les limites des instances, les vCPUs et la RAM.
-    - **Network** qui surveille les quotas des ressources réseau : les IP flottantes, les groupes de sécurité, les règles de sécurité des groupes, les réseaux et les ports.
+    - **Compute**, which includes the instance limits, the vCPUs and the RAM.
+    - **Network**, which monitors the network resource quotas: floating IPs, security groups, security group rules, networks and ports.
 
-- **Usage Summary** (Résumé de l'utilisation) : historique d'utilisation des ressources sur une période qui permet d'observer l'évolution de l'usage des ressources dans le temps.
+- **Usage Summary**: a usage history of the resources over a period of time that lets you observe how resource usage evolves over time.
 
-![Capture d'écran de la section Usage Summary](/images/guides/hosted-private-cloud/cloud-platform/getting-started/horizon_quota_historical.png)
+<img className="thumbnail" alt="Screenshot of the Usage Summary section" src="/images/hosted-private-cloud/cloud-platform/getting-started/horizon_quota_historical.png" loading="lazy" />
 
-#### Vue Compute
+#### Compute view
 
-La section **Compute** regroupe les fonctionnalités permettant de configurer les instances de votre projet. Cette section est divisée en différentes interfaces : 
+The **Compute** section brings together the features used to configure the instances of your project. This section is divided into different interfaces:
 
-##### Section Instances
+##### Instances section
 
-Interface permettant de lister et de gérer les instances déjà configurées.
+An interface for listing and managing instances that are already configured.
 
-![Capture d'écran de la section Instances](/images/guides/hosted-private-cloud/cloud-platform/getting-started/horizon_instance_list.png)
+<img className="thumbnail" alt="Screenshot of the Instances section" src="/images/hosted-private-cloud/cloud-platform/getting-started/horizon_instance_list.png" loading="lazy" />
 
-##### Section Images
+##### Images section
 
-Vous avez la possibilité de gérer les images des OS disponibles pour créer des instances. Il est aussi possible de télécharger de nouvelles images ou de sélectionner parmi les images déjà disponibles afin de mettre en place des instances. Vous pouvez ainsi générer vos propres images pour gérer des systèmes d'exploitation supplémentaires.
+You can manage the OS images available for creating instances. It is also possible to upload new images or select from the images already available in order to set up instances. You can thus generate your own images to manage additional operating systems.
 
-![Capture d'écran de la section Images](/images/guides/hosted-private-cloud/cloud-platform/getting-started/horizon_image_list.png)
+<img className="thumbnail" alt="Screenshot of the Images section" src="/images/hosted-private-cloud/cloud-platform/getting-started/horizon_image_list.png" loading="lazy" />
 
-##### Section Key Pairs
+##### Key Pairs section
 
-Afin de vous authentifier en SSH sur vos machines après l'installation, il faut utiliser des clés de chiffrement asymétriques. Cette interface permet d'importer les clés publiques qui seront déployées durant l'installation des serveurs dédiés afin de vous assurer une connexion SSH.
+In order to authenticate via SSH on your machines after installation, you need to use asymmetric encryption keys. This interface allows you to import the public keys that will be deployed during the installation of the dedicated servers to ensure you have an SSH connection.
 
-![Capture d'écran de la section Key Pairs](/images/guides/hosted-private-cloud/cloud-platform/getting-started/horizon_sshkey_list.png)
+<img className="thumbnail" alt="Screenshot of the Key Pairs section" src="/images/hosted-private-cloud/cloud-platform/getting-started/horizon_sshkey_list.png" loading="lazy" />
 
-#### Vue Network
+#### Network view
 
-La Vue Network (réseau) vous permet de visualiser et de gérer les réseaux de votre projet. Cette interface permet de créer des réseaux mutualisés ou distincts entre vos instances.
+The Network view allows you to view and manage the networks of your project. This interface lets you create shared or separate networks between your instances.
 
 :::info
-L'ensemble de votre configuration réseau est piloté par cette interface graphique ou via les API d'**OpenStack** avec le composant réseau **Neutron**. Les switchs de votre infrastructure seront automatiquement configuré à partir des informations provenant d'OpenStack.
+Your entire network configuration is controlled by this graphical interface or via the **OpenStack** APIs with the **Neutron** network component. The switches of your infrastructure will be automatically configured based on the information coming from OpenStack.
 :::
 
-##### Section Network Topology 
 
-Cette section vous représente l'ensemble des réseaux créés sur ce projet via une ligne verticale de couleur. Les carrés correspondent à des services ou des instances connectées à un ou plusieurs de ces réseaux
+##### Network Topology section
 
-![Capture d'écran de la section Network Topology](/images/guides/hosted-private-cloud/cloud-platform/getting-started/horizon_network_topology.png)
+This section represents all the networks created on this project via a coloured vertical line. The squares correspond to services or instances connected to one or more of these networks.
 
-##### Section Networks
+<img className="thumbnail" alt="Screenshot of the Network Topology section" src="/images/hosted-private-cloud/cloud-platform/getting-started/horizon_network_topology.png" loading="lazy" />
 
-Cette section contient la liste des réseaux disponibles pour les instances sur votre projet.
+##### Networks section
 
-![Capture d'écran de la section Networks](/images/guides/hosted-private-cloud/cloud-platform/getting-started/horizon_network_list.png)
+This section contains the list of networks available for the instances on your project.
 
-Pour en savoir plus sur le fonctionnement des réseaux avec OpenStack, nous vous conseillons de consulter la documentation [OpenStack Networking](https://docs.openstack.org/neutron/2024.1/admin/intro-os-networking.html).
+<img className="thumbnail" alt="Screenshot of the Networks section" src="/images/hosted-private-cloud/cloud-platform/getting-started/horizon_network_list.png" loading="lazy" />
 
-### Présentation de l'interface Object Storage
+To find out more about how networks work with OpenStack, we recommend that you consult the [OpenStack Networking](https://docs.openstack.org/neutron/2024.1/admin/intro-os-networking.html) documentation.
 
-Depuis l'interface du Regional Manager de la **SNC Cloud Platform**, l'interface Object Storage est accessible via le lien dans le tableau de bord.
+### Overview of the Object Storage interface
 
-![Emplacement du raccourci vers Object Storage](/images/guides/hosted-private-cloud/cloud-platform/getting-started/dashboard_objet_storage.png)
+From the Regional Manager interface of the **SNC Cloud Platform**, the Object Storage interface is accessible via the link in the dashboard.
 
-#### Onglet Buckets
+<img className="thumbnail" alt="Location of the shortcut to Object Storage" src="/images/hosted-private-cloud/cloud-platform/getting-started/dashboard_objet_storage.png" loading="lazy" />
 
-Dans cet onglet, vous trouverez la liste des buckets Object Storage créés sur votre projet.
+#### Buckets tab
 
-![Liste des buckets Object Storage](/images/guides/hosted-private-cloud/cloud-platform/getting-started/buckets_objet_storage.png)
+In this tab, you will find the list of Object Storage buckets created on your project.
 
-Il est aussi possible d'en créer de nouveau via le bouton **Create bucket**
+<img className="thumbnail" alt="List of Object Storage buckets" src="/images/hosted-private-cloud/cloud-platform/getting-started/buckets_objet_storage.png" loading="lazy" />
 
-#### Onglet Access Keys
+You can also create new ones via the **Create bucket** button.
 
-Dans cet onglet, vous trouverez la liste des Access Keys Object Storage créés sur votre projet. Cela permet l'usage d'outils externes pour envoyer ou récupérer des objets sur Object Storage.
+#### Access Keys tab
 
-![Liste des Access Keys Object Storage](/images/guides/hosted-private-cloud/cloud-platform/getting-started/access_keys_objet_storage.png)
+In this tab, you will find the list of Object Storage Access Keys created on your project. This allows external tools to be used to send or retrieve objects on Object Storage.
 
-Il est aussi possible d'en créer de nouveau via le bouton **Request new Access Key**
+<img className="thumbnail" alt="List of Object Storage Access Keys" src="/images/hosted-private-cloud/cloud-platform/getting-started/access_keys_objet_storage.png" loading="lazy" />
 
-## Aller plus loin
+You can also create new ones via the **Request new Access Key** button.
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l'équipe Professional Services.
+## Go further
 
-Échangez avec notre [communauté d'utilisateurs](/links/community).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and request a personalised analysis of your project from our Professional Services experts.
+
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-backup-object-storage-bucket.mdx
+++ b/docs/en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-backup-object-storage-bucket.mdx
@@ -1,48 +1,44 @@
 ---
-title: Comment sauvegarder un bucket Object Storage SNC Cloud Platform
-description: Découvrez comment sauvegarder un bucket Object Storage SNC Cloud Platform sur un Object Storage distant
-lastUpdated: 2026-01-29
+title: How to back up an SNC Cloud Platform Object Storage bucket
+description: Find out how to back up an SNC Cloud Platform Object Storage bucket to a remote Object Storage
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
-Vous pouvez mettre en œuvre un outil comme [Rclone](https://rclone.org/) afin d'automatiser les sauvegardes des données de vos buckets vers un Object Storage distant. Les sauvegardes peuvent être utilisées pour restaurer vos données en cas de problème.
+You can use a tool such as [Rclone](https://rclone.org/) to automate backups of your bucket data to a remote Object Storage. The backups can be used to restore your data in the event of a problem.
 
-## Prérequis
+## Requirements
 
-- Avoir un [bucket Object Storage](/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage)
-- Avoir généré des Access Keys pour les stockages objets source et destination
-- Avoir installé **Rclone**
-- Avoir installé **S3cmd** et configuré celui-ci avec les Access Keys
+- An [Object Storage bucket](/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage)
+- Access Keys generated for the source and destination Object Storages
+- **Rclone** installed
+- **S3cmd** installed and configured with the Access Keys
 
-## En pratique
+## Instructions
 
 :::info
-
-L'outil de sauvegarde Rclone est utilisé pour décrire une méthode possible pour faire des sauvegardes.
-L'utilisateur est libre de choisir la solution qui lui convient.
-
+The Rclone backup tool is used here to describe one possible method for performing backups.
+Users are free to choose the solution that suits them.
 :::
 
 
-### Créer un bucket pour stocker les sauvegardes
+### Create a bucket to store the backups
 
-Saisissez la commande suivante :
+Enter the following command:
 
 ```bash
 $ s3cmd mb s3://backup
 ```
 
 :::info
-
-Afin de pouvoir récupérer différentes versions d'un fichier envoyé sur ce bucket, vous pouvez activer le [versioning des objets](/guides/storage-and-backup/object-storage/s3-versioning) de ce bucket.
-
+To be able to retrieve different versions of a file sent to this bucket, you can enable [object versioning](/guides/storage-and-backup/object-storage/s3-versioning) for this bucket.
 :::
 
 
-### Configurer la source et la destination de Rclone
+### Configure the Rclone source and destination
 
-Créez un fichier de configuration `~/.config/rclone/rclone.conf` :
+Create a `~/.config/rclone/rclone.conf` configuration file:
 
 ```bash
 [source-s3]
@@ -68,9 +64,9 @@ acl = private
 force_path_style = true
 ```
 
-Configurez le `source-s3` et le `target-s3` si possible entre 2 régions SNC Cloud Platform.
+Configure the `source-s3` and the `target-s3`, ideally across two SNC Cloud Platform regions.
 
-Une fois l'environnement configuré, la commande rclone suivante peut être utilisée pour valider la confifguration avant une sauvegarde :
+Once the environment is configured, the following rclone command can be used to validate the configuration before a backup:
 
 ```bash
 $ rclone sync source-s3:source-bucket target-s3:backup \
@@ -80,11 +76,11 @@ $ rclone sync source-s3:source-bucket target-s3:backup \
   --dry-run
 ```
 
-### Planifier une tâche récurrente
+### Schedule a recurring task
 
-Une fois la commande testée, il est possible de planifier une tâche récurrente.
+Once the command has been tested, you can schedule a recurring task.
 
-1\. Créez l'unité de service systemd :
+1\. Create the systemd service unit:
 
 ```bash
 sudo tee /etc/systemd/system/rclone-backup.service > /dev/null <<'EOF'
@@ -108,7 +104,7 @@ ExecStart=/usr/bin/rclone sync \
 EOF
 ```
 
-2\. Créez l'unité de timer systemd :
+2\. Create the systemd timer unit:
 
 ```bash
 sudo tee /etc/systemd/system/rclone-backup.timer > /dev/null <<'EOF'
@@ -125,14 +121,14 @@ WantedBy=timers.target
 EOF
 ```
 
-3\. Rechargez la configuration systemd et activez le timer :
+3\. Reload the systemd configuration and enable the timer:
 
 ```bash
 sudo systemctl daemon-reload
 sudo systemctl enable --now rclone-backup.timer
 ```
 
-4\. Vérifiez la configuration :
+4\. Check the configuration:
 
 ```bash
 systemctl list-timers --all | grep rclone
@@ -141,8 +137,8 @@ systemctl status rclone-backup.service
 journalctl -u rclone-backup.service
 ```
 
-## Aller plus loin
+## Go further
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and request a personalised analysis of your project from our Professional Services experts.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-save-instance.mdx
+++ b/docs/en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-save-instance.mdx
@@ -1,46 +1,47 @@
 ---
-title: "Comment sauvegarder une instance SNC Cloud Platform"
-excerpt: "Découvrez comment sauvegarder une instance SNC Cloud Platform sur Object Storage"
-updated: 2025-12-29
+title: How to back up an SNC Cloud Platform instance
+description: Find out how to back up an SNC Cloud Platform instance to Object Storage
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
-Vous pouvez mettre en œuvre un outil comme [Restic](https://restic.readthedocs.io/en/stable/) afin d'automatiser les sauvegardes des données de vos instances vers Object Storage. Les sauvegardes peuvent être utilisées pour restaurer vos données en cas de problème.
+You can use a tool such as [Restic](https://restic.readthedocs.io/en/stable/) to automate backups of your instance data to Object Storage. The backups can be used to restore your data in the event of a problem.
 
-## Prérequis
+## Requirements
 
-- Avoir une instance
-- Avoir généré une Access Key pour Object Storage
-- Avoir installé **Restic**
-- Avoir installé **S3cmd** et configuré celui-ci avec l'Access Key
+- An instance
+- An Access Key generated for Object Storage
+- **Restic** installed
+- **S3cmd** installed and configured with the Access Key
 
-## En pratique
+## Instructions
 
 :::info
-L'outil de sauvegarde Restic est utilisé pour décrire une méthode possible pour faire des sauvegardes.
-L'utilisateur est libre de choisir la solution qui lui convient.
+The Restic backup tool is used to describe one possible method for performing backups.
+You are free to choose the solution that suits you best.
 :::
 
-### Créer un bucket pour stocker les sauvegardes
 
-Renseignez la commande suivante :
+### Creating a bucket to store the backups
 
-```sh
+Enter the following command:
+
+```bash
 $ s3cmd mb s3://backup
 ```
 
-### Initialiser le dépôt de sauvegarde
+### Initialising the backup repository
 
-Commencez par choisir un mot de passe pour chiffrer vos sauvegardes. Dans ce guide, GPG est utilisé à cette fin :
+Start by choosing a password to encrypt your backups. In this guide, GPG is used for this purpose:
 
-```sh
-$ gpg --gen-random --armor 1 16
+```bash
+$ gpg --gen-random --armor 1 20
 ```
 
-Notez ce mot de passe dans un endroit sûr, avec vos informations d'identification S3<sup>1</sup>. Ensuite, la configuration de Restic sera placée dans des variables d'environnement. Cela inclut des informations sensibles, comme votre secret S3 et le mot de passe du dépôt. Par conséquent, assurez-vous que les commandes suivantes **n'apparaissent pas** dans le fichier d'historique de votre shell. Ajustez le contenu des variables d'environnement en fonction du nom de votre bucket, de la région et des informations d'identification API de votre utilisateur.
+Make a note of this password in a safe place, along with your S3<sup>1</sup> credentials. Next, the Restic configuration will be placed in environment variables. This includes sensitive information, such as your S3 secret and the repository password. As a result, make sure that the following commands **do not appear** in your shell history file. Adjust the contents of the environment variables according to your bucket name, the region, and your user's API credentials.
 
-```sh
+```bash
 unset HISTFILE
 export AWS_DEFAULT_REGION="eu-west-rbx-snc"
 export AWS_ACCESS_KEY_ID="06bd244758d047eea26eb9cc1e572be7"
@@ -49,9 +50,9 @@ export RESTIC_REPOSITORY="s3:https://s3-beta.eu-west-rbx-snc.cloud.snc.ovh.net/b
 export RESTIC_PASSWORD="BYhISmzRvIPMwvbzgl8ROQ=="
 ```
 
-Une fois l'environnement configuré, la commande Restic peut être appelée pour initialiser le dépôt :
+Once the environment is configured, the Restic command can be called to initialise the repository:
 
-```sh
+```bash
 $ restic init
 created restic repository 821bcf92bf at s3:https://s3-beta.eu-west-rbx-snc.cloud.snc.ovh.net/backup
 
@@ -60,9 +61,9 @@ the repository. Losing your password means that your data is
 irrecoverably lost.
 ```
 
-Restic est maintenant prêt à être utilisé avec S3. Essayez de créer une sauvegarde :
+Restic is now ready to be used with S3. Try creating a backup:
 
-```sh
+```bash
 $ restic backup /var/log/
 repository 821bcf92 opened (repository version 2) successfully, password is correct
 no parent snapshot found, will read all files
@@ -77,7 +78,7 @@ processed 30 files, 750.189 MiB in 0:04
 snapshot 38e47b16 saved
 ```
 
-```sh
+```bash
 $ restic snapshots
 repository 821bcf92 opened (repository version 2) successfully, password is correct
 ID        Time                 Host        Tags        Paths
@@ -88,12 +89,13 @@ ID        Time                 Host        Tags        Paths
 ```
 
 :::info
-Un snapshot a été créé.
+A snapshot has been created.
 :::
 
-Vérifiez le contenu du bucket :
 
-```sh
+Check the contents of the bucket:
+
+```bash
 $ s3cmd la
                           DIR  s3://backup/data/
                           DIR  s3://backup/index/
@@ -103,13 +105,14 @@ $ s3cmd la
 ```
 
 :::info
-Une sauvegarde a été créée et stockée dans le bucket S3.
+A backup has been created and stored in the S3 bucket.
 :::
 
-## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l'équipe Professional Services.
+## Go further
 
-Échangez avec notre [communauté d'utilisateurs](/links/community).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and request a personalised analysis of your project from our Professional Services experts.
 
-<sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.
+Join our [community of users](/links/community).
+
+<sup>1</sup>: S3 is a trademark belonging to Amazon Technologies, Inc. OVHcloud's services are not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
@@ -1,12 +1,12 @@
 ---
 title: Replacing Prism Central from Small Mode to X-Large Mode
 description: How to replace Prism Central with three X-Large VMs
-lastUpdated: 2023-12-18
+lastUpdated: 2026-06-11
 ---
 
 :::warning
 This guide is only intended for customers who are in **Bring Your Own License** mode on their Nutanix cluster.
-If you are not in this configuration, contact the [OVHcloud support teams](https://help.ovhcloud.com/csm?id=csm_get_help) to change the size of your Prism Central.
+If you are not in this configuration, contact the [OVHcloud support teams](/links/support-contact) to change the size of your Prism Central.
 :::
 
 
@@ -15,21 +15,20 @@ Before you make any changes, you must unregister your Prism Central license on y
 :::
 
 
-## Objectif
+## Objective
 
 **This guide will show you how to redeploy Prism-Central in X-LARGE mode across three virtual machines.**
 
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 :::
 
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -71,13 +70,13 @@ In the configuration pages for your Load Balancer, go to the <code className="ac
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 02" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer02.png" loading="lazy" />
 
-Enter this information :
+Enter this information:
 
-- **Name (optional)** : `PE SSH`.
-- **Protocol** : `TCP`.
-- **Port** : `22`.
-- **Datacenter** : `ALL`.
-- **Private network** : `nutanix`.
+- **Name (optional)**: `PE SSH`.
+- **Protocol**: `TCP`.
+- **Port**: `22`.
+- **Datacenter**: `ALL`.
+- **Private network**: `nutanix`.
 
 Then click <code className="action">Add</code>.
 
@@ -87,11 +86,11 @@ Within the server cluster, click <code className="action">Add server</code>.
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 04" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer04.png" loading="lazy" />
 
-Fill in these values :
+Fill in these values:
 
-- **Name (Optional)** : `PE SSH`.
-- **IPv4 address** : `Private IP address of Prism Element`.
-- **Port** : `22`.
+- **Name (Optional)**: `PE SSH`.
+- **IPv4 address**: `Private IP address of Prism Element`.
+- **Port**: `22`.
 
 And click <code className="action">Add</code>.
 
@@ -119,9 +118,9 @@ When the task is finished, go to the <code className="action">Front-ends</code> 
 
 Enter the following information:
 
-- **Name(Optional)** : `PE-FRONTEND`.
-- **Port** : `22`.
-- **Datacenter** : `ALL`.
+- **Name(Optional)**: `PE-FRONTEND`.
+- **Port**: `22`.
+- **Datacenter**: `ALL`.
 
 Then click <code className="action">Show</code>.
 
@@ -149,7 +148,7 @@ Go to the <code className="action">Tasks</code> tab to see the progress of the c
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 16" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer16.png" loading="lazy" />
 
-You have finished configuring the Load Balancer. You can now log in via SSH to the Prism Element console, with this information :
+You have finished configuring the Load Balancer. You can now log in via SSH to the Prism Element console, with this information:
 
 ```bash
 ssh admin@nutanix-cluster-ovhcloud-fqdn
@@ -165,9 +164,9 @@ ssh nutanix@nutanix-cluster-ovhcloud-fqdn
 
 Run these commands after you have modified the following information:
 
-- **\<Prism-Central-Private-IP-address\>** : Private IP address of Prism Central
-- **\<Prism-Element-Admin-Password\>** : Prism Element admin account password
-- **\<Prism-Central-VM-Name\>** : Prism Central VM name
+- **\<Prism-Central-Private-IP-address\>**: Private IP address of Prism Central
+- **\<Prism-Element-Admin-Password\>**: Prism Element admin account password
+- **\<Prism-Central-VM-Name\>**: Prism Central VM name
 
 ```bash
 # Disconnect Prism Element in Prism Central
@@ -184,8 +183,8 @@ ssh root@private-ip-address-of-one-ahv-servers
 
 Run this command to retrieve the UUID of your default storage, once you have modified the following information:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-IP\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-IP\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X GET "https://<Prism-Element-Ip>:9440/PrismGateway/services/rest/v2.0/storage_containers/" | jq -r '[.entities[] | select( .name | contains("default-container")) | .storage_container_uuid][0]'
@@ -197,7 +196,7 @@ Next, run this other command to retrieve the UUID of your cluster’s administra
 curl -s -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST https://<prism6element-IP>:9440/api/nutanix/v3/subnets/list -d {} | jq -r "[.entities[] | select( .spec.name | contains(\"<subnet name>\")) | .metadata.uuid][0]"
 ```
 
-Create a file named **PrismCentralXlarge.json** with the information below :
+Create a file named **PrismCentralXlarge.json** with the information below:
 
 ```json
 {
@@ -230,19 +229,19 @@ Create a file named **PrismCentralXlarge.json** with the information below :
 }
 ```
 
-Replace these items in the file :
+Replace these items in the file:
 
-- **\<Prism-Central-Password\>** : Password for the future Prism Central virtual machine.
-- **\<Default-Container-UUID\>** : UUID of the default storage retrieved earlier.
-- **\<Prism-Central-Private-IP-Address\>** : Private IP address of Prism Central.
-- **\<Nutanix-Network-Admin-UUID\>** : Nutanix Cluster Administration Network UUID.
-- **\<Nutanix-Network-Admin-mask\>** : Nutanix cluster administration network subnet mask.
-- **\<Nutanix-Network-Admin-Gateway\>** : Nutanix cluster administration network default gateway.
+- **\<Prism-Central-Password\>**: Password for the future Prism Central virtual machine.
+- **\<Default-Container-UUID\>**: UUID of the default storage retrieved earlier.
+- **\<Prism-Central-Private-IP-Address\>**: Private IP address of Prism Central.
+- **\<Nutanix-Network-Admin-UUID\>**: Nutanix Cluster Administration Network UUID.
+- **\<Nutanix-Network-Admin-mask\>**: Nutanix cluster administration network subnet mask.
+- **\<Nutanix-Network-Admin-Gateway\>**: Nutanix cluster administration network default gateway.
 
 Run this command to deploy your Prism Central virtual machine in X-Large mode, once you changed these settings:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-Private-IP-Address\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-Private-IP-Address\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST "https://<Prism-Element-Private-IP-Address>:9440/api/nutanix/v3/prism_central" -d @PrismCentralXlarge.json
@@ -255,17 +254,17 @@ Wait thirty minutes for this virtual machine to deploy.
 
 Enter the following command by editing these options to create a **pcregister.json** file:
 
-- **\<Prism-Central-Password\>** : Prism Central Password.
-- **\<Prism-Central-Private-IP-Address\>** : Private IP address of Prism Central.
+- **\<Prism-Central-Password\>**: Prism Central Password.
+- **\<Prism-Central-Private-IP-Address\>**: Private IP address of Prism Central.
 
 ```bash
 echo "{\"username\":\"admin\",\"password\":\"<Prism-Central-Password>\",\"port\":9440,\"ipAddresses\":[\"<Prism-Central-Private-IP-Address>\"]}" > pcregister.json
 ```
 
-Run this command to save Prism Element into your new Prism Central virtual machine, after changing these settings :
+Run this command to save Prism Element into your new Prism Central virtual machine, after changing these settings:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-Private-IP-Address\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-Private-IP-Address\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST "https://<Prism-Element-Private-IP-Address>:9440/PrismGateway/services/rest/v1/multicluster/prism_central/register" -d @pcregister.json
@@ -301,13 +300,13 @@ Click <code className="action">Confirm</code>.
 
 Expansion of Prism Central requires three additional private IP addresses, one for the virtual IP address and two for the new virtual machines.
 
-Scroll through the window and enter this information :
+Scroll through the window and enter this information:
 
-- **Virtual IP** : Prism Central virtual private IP address.
-- **VM Name** : Name of the second Prism Central virtual machine.
-- **IP** : Private IP address of the second virtual machine.
-- **VM Name** : Name of the third Prism Central virtual machine.
-- **IP** : Private IP address of the third virtual machine.
+- **Virtual IP**: Prism Central virtual private IP address.
+- **VM Name**: Name of the second Prism Central virtual machine.
+- **IP**: Private IP address of the second virtual machine.
+- **VM Name**: Name of the third Prism Central virtual machine.
+- **IP**: Private IP address of the third virtual machine.
 
 Click <code className="action">Expand</code>.
 
@@ -336,11 +335,11 @@ Click <code className="action">Add Server</code>.
 
 <img className="thumbnail" alt="03 Modify Prism Central Https Address 02" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/03-modify-prism-central-https-address02.png" loading="lazy" />
 
-Enter this information :
+Enter this information:
 
-- **Name (Optional)** : PC VIP as Prism Central Virtual IP address.
-- **IPv4 address** : Virtual Private IP address 
-- **Port** : 9440.
+- **Name (Optional)**: PC VIP as Prism Central Virtual IP address.
+- **IPv4 address**: Virtual Private IP address 
+- **Port**: 9440.
 
 Click <code className="action">Add</code>.
 
@@ -374,6 +373,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
@@ -1,17 +1,17 @@
 ---
 title: Setting up NCM Self Service (CALM)
 description: How to enable Self Service (CALM) in your Prism Central
-lastUpdated: 2024-05-13
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
 **Find out how to set up NCM Self-Service (Calm) on your Prism Central.**
 
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 :::
 
 
@@ -71,7 +71,7 @@ An error message appears during CALM deployment, ignore it, exit the window and 
 :::
 
 
-![00 Activate CALM 08](/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png)
+<img className="thumbnail" alt="00 Activate CALM 08" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png" loading="lazy" />
 
 ### Creating a project
 
@@ -151,7 +151,7 @@ Enter this information:
 - **vCPUs**: `4`
 - **Core per vCPU**: `1`
 - **Memory (GiB)**: `4`
-- **Image** : `WS2022EN-SYSPREPED`
+- **Image**: `WS2022EN-SYSPREPED`
 
 :::info
 The image is generated from a VM WINDOWS Server 2022 on which a sysprep was applied to reset the default configuration. When used with CALM, it is possible to automate the installation of a Windows OS from this type of image and apply settings stored in an XML file to it.
@@ -1001,8 +1001,8 @@ The application is completely deleted.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 [Nutanix NCM Self Service (CALM)](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Calm-Admin-Operations-Guide-v3_6_0:Nutanix-Calm-Admin-Operations-Guide-v3_6_0).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights.mdx
@@ -1,7 +1,7 @@
 ---
-title: Activer NSX-T dans un Hosted Private Cloud VMware on OVHcloud
-description: Découvrez comment ajouter les droits à un utilisateur et aux Datacentres pour NSX-T
-lastUpdated: 2024-05-22
+title: Enabling NSX-T in a Hosted Private Cloud VMware on OVHcloud
+description: Find out how to add the rights to a user and to the Datacentres for NSX-T
+lastUpdated: 2026-06-11
 ---
 
 import Api from '@components/Api';
@@ -9,11 +9,11 @@ import Api from '@components/Api';
 
 
 
-## Objectif
+## Objective
 
-Ce guide vous détaille comment ajouter les droits de lecture à un utilisateur pour accéder à la console Web NSX-T de votre Hosted Private Cloud - VMware on OVHcloud.
+This guide explains how to add read rights to a user so they can access the NSX-T web console of your Hosted Private Cloud - VMware on OVHcloud.
 
-Ces droits sont accordés depuis l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>.
+These rights are granted from the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
 
 {/* CP-NAV-START:privatecloud-vmware-vsphere */}
 ---
@@ -26,40 +26,24 @@ Ces droits sont accordés depuis l'<ManagerLink to="/">espace client OVHcloud</M
 ---
 {/* CP-NAV-END:privatecloud-vmware-vsphere */}
 
-## Prérequis
+## Requirements
 
-- Avoir souscrit une offre [Hosted Private Cloud](https://www.ovhcloud.com/fr/hosted-private-cloud/vmware/) avec les options **"Network Security Virtualization"** ou **"Software-Defined Datacenter"** 
-- Etre connecté à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>
-- Être contact administrateur de l'infrastructure VMware sur OVHcloud, celui-ci recevant les identifiants de connexion.
-- Avoir suivi les étapes de cette documentation : [Premiers pas avec NSX](/guides/hosted-private-cloud/powered-by-vmware/nsx-first-steps)
+- A subscription to a [Hosted Private Cloud](/links/hosted-private-cloud/vmware) plan with the **"Network Security Virtualization"** or **"Software-Defined Datacenter"** options
+- You must be the administrator contact of the VMware infrastructure on OVHcloud, as this contact receives the login credentials.
+- You must have completed the steps in this documentation: [Getting started with NSX](/guides/hosted-private-cloud/powered-by-vmware/nsx-first-steps)
 
 ## Instructions
 
-### Etape 1 - Accéder à votre Hosted Private Cloud
+### Step 1 - Enabling NSX-T
 
 <details>
 
-<summary>Comment accéder à votre Hosted Private Cloud - VMware On OVHcloud ?</summary>
+<summary>How do I enable the NSX-T interface for my user?</summary>
 
-Une fois connecté à l'espace client OVHcloud, cliquez sur l'onglet <code className="action">Hosted Private Cloud</code>.
+Edit the user with whom you want to access the NSX-T web interface:
 <br/><br/>
 
-- Lien OVHcloud : `https://www.ovh.com/manager/#/dedicated/dedicated_cloud/pcc-xxx-xxx-xxx-xxx` > Remplacez-le par le nom de votre service VMware on OVHcloud.
-
-<p><img alt="NSX screenshot" className="thumbnail" src="/images/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights/nsx_user_rights_7.png" loading="lazy"/></p>
-
-</details>
-
-### Etape 2 - Activer NSX-T
-
-<details>
-
-<summary>Comment activer l'interface NSX-T pour votre utilisateur ?</summary>
-
-Depuis la page précedente, éditez l'utilisateur avec lequel vous souhaitez accéder à l'interface Web NSX-T : 
-<br/><br/>
-
-<code className="action">VMware</code> > <code className="action">PCC-XXX.XXX.XXX.XXX</code> > <code className="action">Utilisateur</code> > <code className="action">Modifier</code> puis activez le bouton <code className="action">NSX Interface</code>.
+<code className="action">VMware</code> > <code className="action">PCC-XXX.XXX.XXX.XXX</code> > <code className="action">Users</code> > <code className="action">Modify</code> then enable the <code className="action">NSX Interface</code> button.
 
 <p><img alt="NSX screenshot" className="thumbnail" src="/images/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights/nsx_user_rights_3.png" loading="lazy"/></p>
 <p><img alt="NSX screenshot" className="thumbnail" src="/images/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights/nsx_user_rights_13.png" loading="lazy"/></p>
@@ -67,51 +51,51 @@ Depuis la page précedente, éditez l'utilisateur avec lequel vous souhaitez acc
 
 </details>
 
-### Etape 3 - Ajouter les droits NSX-T
+### Step 2 - Adding NSX-T rights
 
 <details>
 
-<summary>Comment ajouter les droits pour votre utilisateur ?</summary>
+<summary>How do I add the rights for my user?</summary>
 
-Cliquez sur : <code className="action">VMware</code> > <code className="action">PCC-XXX-XXX-XXX-XXX</code> > <code className="action">Utilisateur</code> > <code className="action">Modifier</code>.
+Click: <code className="action">VMware</code> > <code className="action">PCC-XXX-XXX-XXX-XXX</code> > <code className="action">Users</code> > <code className="action">Modify</code>.
 
 <p><img alt="NSX screenshot" className="thumbnail" src="/images/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights/nsx_user_rights_7.png" loading="lazy"/></p>
 
 </details>
 
 
-### Etape 4 - Ajouter les droits NSX-T aux Datacentres
+### Step 3 - Adding NSX-T rights to the Datacentres
 
 <details>
 
-<summary>Comment ajoutez les droits aux Datacentres ?</summary>
+<summary>How do I add the rights to the Datacentres?</summary>
 
-Il ne vous reste plus que à modifier les droits de chaque Datacenter souhaité en cliquant sur : <code className="action">VMware</code> > <code className="action">PCC-XXX-XXX-XXX-XXX</code> > <code className="action">Utilisateur</code> > <code className="action">Voir / Modifier les droits par DC</code> > <code className="action">Modifier</code>.
+All that is left to do is modify the rights for each desired Datacenter by clicking: <code className="action">VMware</code> > <code className="action">PCC-XXX-XXX-XXX-XXX</code> > <code className="action">Users</code> > <code className="action">View/Edit the rights for each DC</code> > <code className="action">Modify</code>.
 
-Une fenetre s'ouvre alors. Choisissez les droits nécessaires parmi les 3 sections principales > <code className="action">Accès vSphere</code> / <code className="action">Accès au vmNetwork</code> / <code className="action">Accès aux V(x)Lans</code>.
+A window then opens. Choose the necessary rights from the 3 main sections > <code className="action">vSphere access</code> / <code className="action">Access to the VM Network</code> / <code className="action">Access to V(X)LANs</code>.
 
 <br/><br/>
-Les droits suivants sont disponibles : <strong>Operateur</strong> / <strong>Administrateur</strong> / <strong>Aucun</strong> / <strong>Lecture seule</strong>
+The following rights are available: <strong>Operator</strong> / <strong>Administrator</strong> / <strong>None</strong> / <strong>Read-only</strong>
 <br/><br/>
-Uniquement l'accès aux <code className="action">V(x)Lans</code> en <strong>Lecture seule</strong> est nécessaire pour accéder à l'interface Web NSX-T.
+Only <strong>Read-only</strong> access to the <code className="action">V(X)LANs</code> is required to access the NSX-T web interface.
 <br/><br/>
-Choisissez <code className="action">Lecture seule</code>.
+Choose <code className="action">Read-only</code>.
 <br/><br/>
-Si vous voulez faire des modifications dans l'interface Web NSX-T, des droits supplémentaires seront alors nécessaires, tels que <strong>Opérateur</strong> ou <strong>Administrateur</strong>.
+If you want to make changes in the NSX-T web interface, additional rights will then be required, such as <strong>Operator</strong> or <strong>Administrator</strong>.
 
 <p><img alt="NSX screenshot" className="thumbnail" src="/images/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights/nsx_user_rights_8.png" loading="lazy"/></p>
 
 </details>
 
-### Etape 5 - Accéder à l'interface NSX-T
+### Step 4 - Accessing the NSX-T interface
 
 <details>
 
-<summary>Comment accéder à l'interface Web NSX-T ?</summary>
+<summary>How do I access the NSX-T web interface?</summary>
 
-Toujours depuis votre arborescence Hosted Private Cloud, cliquez sur <code className="action">VMware</code> > <code className="action">PCC-XXX-XXX-XXX-XXX</code>.
+Still from your Hosted Private Cloud tree, click <code className="action">VMware</code> > <code className="action">PCC-XXX-XXX-XXX-XXX</code>.
 <br/><br/>
-- Lien OVHcloud : `https://www.ovh.com/manager/#/dedicated/dedicated_cloud/PCC-XXX-XXX-XXX-XXX` > Remplacez PCC-XXX-XXX-XXX-XXX par le nom de votre service PCC.
+- OVHcloud link: `https://www.ovh.com/manager/#/dedicated/dedicated_cloud/PCC-XXX-XXX-XXX-XXX` > Replace PCC-XXX-XXX-XXX-XXX with the name of your PCC service.
 
 <p><img alt="NSX screenshot" className="thumbnail" src="/images/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights/nsx_user_rights_9.png" loading="lazy"/></p>
 <p><img alt="NSX screenshot" className="thumbnail" src="/images/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights/nsx_user_rights_10.png" loading="lazy"/></p>
@@ -120,21 +104,21 @@ Toujours depuis votre arborescence Hosted Private Cloud, cliquez sur <code class
 
 </details>
 
-### Etape 6 - Informations utiles
+### Step 5 - Useful information
 
-Vous pouvez vérifier si NSX-T est activé sur votre Datacenter. Vous pouvez également retrouver votre URL NSX-T et sa version :
+You can check whether NSX-T is enabled on your Datacenter. You can also find your NSX-T URL and its version:
 
-#### Via l'API OVHcloud
+#### Via the OVHcloud API
 
-<Api version="v1" section="/dedicatedCloud" method="GET" route={"/dedicatedCloud/\\{serviceName\\}/nsxt"} />
+<Api version="v1" section="/dedicatedCloud" method="GET" route={"/dedicatedCloud/\{serviceName\}/nsxt"} />
 
 
-> **Paramètres:**
+> **Parameters:**
 >
-> serviceName: La référence de votre PCC sous la forme `pcc-XX-XX-XX-XX`.
+> serviceName: The reference of your PCC in the form `pcc-XX-XX-XX-XX`.
 >
 
-Exemple de retour :
+Example response:
 
 ```shell
 {
@@ -155,16 +139,16 @@ Exemple de retour :
 ```
 
 :::info
-Retrouvez plus d’informations sur l’API OVHcloud dans notre guide « [Premiers pas avec l’API OVHcloud](/guides/manage-and-operate/api/first-steps) ».
+Find out more about the OVHcloud API in our guide "[Getting started with the OVHcloud API](/guides/manage-and-operate/api/first-steps)".
 
 :::
 
 
-## Aller plus loin
+## Go further
 
-- [Gestion des segments dans NSX](/guides/hosted-private-cloud/powered-by-vmware/nsx-segment-management)
-- [FAQ NSX](/guides/hosted-private-cloud/powered-by-vmware/nsx-faq)
+- [Managing segments in NSX](/guides/hosted-private-cloud/powered-by-vmware/nsx-segment-management)
+- [NSX FAQ](/guides/hosted-private-cloud/powered-by-vmware/nsx-faq)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+If you need training or technical assistance to implement our solutions, please contact your sales representative or click [this link](/links/professional-services) to get a quote and request a personalised analysis of your project from our Professional Services team.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
@@ -1,17 +1,17 @@
 ---
 title: Configuring NAT for port redirections with NSX
 description: Learn how to configure NAT to create port redirections
-lastUpdated: 2023-02-27
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
 **Learn how to configure NAT to create port redirections with NSX.**
 
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they work properly.
 
-This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/en-gb/directory/) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
+This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
 
 :::
 
@@ -32,13 +32,13 @@ In the NSX interface, go to the <code className="action">Networking</code> tab, 
 
 <img className="thumbnail" alt="01 Create DNAT rule 01" src="/images/hosted-private-cloud/powered-by-vmware/nsx-07-configure-nat-redirection/01-create-dnat-rules01.png" loading="lazy" />
 
-Fill in this information :
+Fill in this information:
 
-- **Action** : Select <code className="action">DNAT</code>.
-- **Source IP** : Enter the IP address or range of addresses that can use this redirection.
-- **Destination IP** : Public virtual IP address of NSX.
-- **Destination PORT** : Listening port on public address such as `2222`.
-- **Translated IP** : IP address of the virtual machine being redirected to.
+- **Action**: Select <code className="action">DNAT</code>.
+- **Source IP**: Enter the IP address or range of addresses that can use this redirection.
+- **Destination IP**: Public virtual IP address of NSX.
+- **Destination PORT**: Listening port on public address such as `2222`.
+- **Translated IP**: IP address of the virtual machine being redirected to.
 
 Then click on the <code className="action">three vertical dots</code> to the right of **Select Services**.
 
@@ -52,11 +52,11 @@ Click <code className="action">ADD SERVICE ENTRY</code>.
 
 <img className="thumbnail" alt="01 Create DNAT rule 04" src="/images/hosted-private-cloud/powered-by-vmware/nsx-07-configure-nat-redirection/01-create-dnat-rules04.png" loading="lazy" />
 
-Fill in these values :
+Fill in these values:
 
-- **Name** : Enter `SSH22`.
-- **Service Type** : Select <code className="action">TCP</code>.
-- **Source Ports** : Write the number `22`.
+- **Name**: Enter `SSH22`.
+- **Service Type**: Select <code className="action">TCP</code>.
+- **Source Ports**: Write the number `22`.
 
 Then click <code className="action">APPLY</code>.
 
@@ -82,6 +82,6 @@ The rule is created and active.
 
 [VMware NAT in NSX documentation](https://docs.vmware.com/en/VMware-NSX-T-Data-Center/3.2/administration/GUID-7AD2C384-4303-4D6C-A44A-DEF45AA18A92.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/snc-responsibility-sharing.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/snc-responsibility-sharing.mdx
@@ -1,194 +1,194 @@
 ---
-title: "Partage de responsabilité sur le service Hosted Private Cloud by VMware sous la qualification SecNumCloud"
-excerpt: "Partage de responsabilité entre OVHcloud et le client pour l'utilisation du produit VMware on OVHcloud sous la qualification SecNumCloud"
-updated: 2024-01-22
+title: Responsibility sharing for the Hosted Private Cloud by VMware service under the SecNumCloud qualification
+description: "Responsibility sharing between OVHcloud and the customer for the use of the VMware on OVHcloud product under the SecNumCloud qualification"
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
-Le RACI ci-dessous détaille le partage des responsabilités entre OVHcloud et le client pour le service Hosted Private Cloud by VMware sous la qualifcation SecNumCloud. Ce modèle peut aider le client à utiliser le service VMware on OVHcloud au mieux.
+The RACI below details shared responsibilities between OVHcloud and the customer for the Hosted Private Cloud by VMware service under the SecNumCloud qualification. This model is designed to help the customer make the best use of the VMware on OVHcloud service.
 
-| Rôles |
+| Roles |
 | --- |
-|R : Est en charge de la Réalisation du processus|
-|A : Est Approbateur de la réalisation du processus|
-|C : Est Consulté pendant le processus|
-|I : Est Informé des résultats du processus|
+|R: Is in charge of carrying out the process|
+|A: is Accountable for the successful completion of the process|
+|C: Is Consulted during the process|
+|I: Is Informed of the results of the process|
 
-### 1. Avant la souscription
+### 1. Before subscription
 
-#### 1.1. Spécifier le service en fonction des besoins
+#### 1.1. Specify service as needed
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Choisir la localisation des infrastructures | RA | I |
-| Dimensionner les infrastructures en fonction des besoins | RA | I |
-| Choisir les options en fonction des besoins | RA | I |
+| Choose the location of infrastructures | RA | I |
+| Size infrastructures as needed | RA | I |
+| Choose options as needed | RA | I |
 
-### 2. Mise à disposition du service
+### 2. Service availability
 
-#### 2.1. Installer le service
+#### 2.1. Install service
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Produire, acheminer, livrer et maintenir les machines physiques et les datacentres | CI | RA |
-| Acheter et détenir les licences et droits d'utilisation pour les OS achetés chez OVHcloud | RI | RA  |
-| Acheter et détenir les licences et droits d'utilisation pour les softwares fournis par OVHcloud | I | RA  |
-| Acheter et détenir les licences et droits d'utilisation pour la solution VMware (Private Cloud) | I | RA  |
-| Acheter et détenir les licences et droits d'utilisation pour les solutions de backup fournies par OVHcloud | I | RA  |
-| Déployer le service initial en conformité avec le Référentiel SecNumCloud | I | RA |
-| Déployer la configuration réseau initiale sur les équipements | I | RA |
+| Produce, route, deliver and maintain physical machines and hosting buildings | CI | RA |
+| Purchase and own the licences and rights of use for the OS purchased from OVHcloud | RI | RA  |
+| Purchase and own the licences and rights of use for softwares provided by OVHcloud | I | RA  |
+| Purchase and own the licences and rights of use for the VMware solution (Private Cloud) | I | RA  |
+| Purchase and own the licences and rights of use for the backup solutions provided by OVHcloud | I | RA  |
+| Deploy the initial service in compliance with the SecNumCloud framework | I | RA |
+| Deploy the initial network configuration to devices | I | RA |
 
-#### 2.2. Modèle de réversibilité
+#### 2.2. Reversibility
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Fournir la documentation technique correspondant à l'offre SecNumCloud | I | RA |
-| Rédiger un plan de continuité d'activité et le plan de reprise d'activité pour le SI hébergé, en cohérence avec la sensibilité du SI hébergé | RA |  |
+| Provide the technical documentation corresponding to the SecNumCloud offer | I | RA |
+| Draft a business continuity and disaster recovery plan for the hosted IS, in line with the sensitivity of the hosted IS | RA |  |
 
-#### 2.3. Installation du SI client
+#### 2.3. Customer's IS installation
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Créer / installer / optimiser de nouvelles VMs | RA |  I |
-| Installer et configurer les softwares et middlewares sur l'Infrastructure as a Service | RA |   |
-| Acheter et détenir les licences et droits d'utilisation pour les OS en mode Bring Your Own Licence | RA |   |
-| Configurer l'ensemble des instances virtuelles déployées sur le IaaS | RA |  I |
+| Create / install / optimise new VMs | RA |  I |
+| Install and configure softwares and middlewares on the Infrastructure as a Service | RA |   |
+| Purchase and own the licences and rights of use for OS with Bring Your Own Licence mode | RA |   |
+| Configure virtual instances deployed on the IaaS | RA |  I |
 
-### 3. Utilisation du service
+### 3. Service Usage
 
-#### 3.1. Opérations
+#### 3.1. Operations
 
-##### **3.1.1. Opérations quotidiennes**
+##### **3.1.1. Daily operations**
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Exploiter l'ensemble des instances virtuelles déployées dans l'IaaS | RA | I |
-| Décider d'ajouter / supprimer des ressources au datacentre virtuel | RA | I |
-| Réaliser l'ajout / suppression des ressources au datacentre virtuel | I | RA |
-| Ajouter / supprimer des ressources aux VMs | RA |  |
+| Operate all the virtual instances deployed in the IaaS | RA | I |
+| Decide to add/remove resources on the virtual datacentre | RA | I |
+| Add/remove resources on the virtual datacentre | I | RA |
+| Add/remove resources on VMs | RA |  |
 
-##### **3.1.2. Gestion des accès**
+##### **3.1.2. Access management**
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Gérer les accès et la politique de sécurité des utilisateurs du Service | RA |  |
-| Gérer les accès physiques et logiques des équipes OVHcloud aux infrastructures | I | RA |
-| Gérer les accès à l'espace client | RA | I |
-| Gérer les accès à l'interface de gestion de la virtualisation | RA | I |
+| Manage access and security policy of the Service users | RA |  |
+| Manage physical and logical access of OVHcloud teams to the infrastructures | I | RA |
+| Manage access to the Control Panel | RA | I |
+| Manage access to the virtualisation management interface | RA | I |
 
 ##### **3.1.3. Monitoring**
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Surveiller le bon fonctionnement des dispositifs physiques (utilités) en support de l'Infrastructure as a Service | I | RA |
-| Suivre les performances des ressources physiques | RI | A |
-| Suivre les performances des VMs | RA | I |
-| Traiter et acquitter les alarmes provenant des dispositifs managés de l'Infrastructure as a Service  | I | RA |
-| Conserver les logs générés par l'Infrastructure as a Service | I | RA |
-| Conserver les logs du système d'information hébergé sur l'Infrastructure as a Service | RA | I |
+| Monitor the proper functioning of physical devices (utilities) supporting the Infrastructure as a Service | I | RA |
+| Monitor physical resource performances | RI | A |
+| Monitor VMs performances | RA | I |
+| Process and acknowledge alarms from managed devices of the Infrastructure as a Service | I | RA |
+| Keep logs generated by the Infrastructure as a Service | I | RA |
+| Keep logs of the information system hosted on the Infrastructure as a Service | RA | I |
 
-##### **3.1.4. Stockage**
+##### **3.1.4. Storage**
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Créer, modifier, contrôler, restaurer, supprimer les jobs de backups | RA |  |
-| Gérer le contenu hébergé sur les infrastructures | RA |  |
-| Gérer la continuité et l'intégrité des données | RA |  |
-| Réaliser la maintenance des dispositifs de stockage et de sauvegarde fournis par OVHcloud | C | RA |
+| Create, modify, control, restore, delete backup jobs | RA |  |
+| Manage content hosted on infrastructures | RA |  |
+| Manage data continuity and integrity | RA |  |
+| Carry out maintenance on the storage and backup devices provided by OVHcloud | C | RA |
 
-##### **3.1.5. Connectivité**
+##### **3.1.5. Connectivity**
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Assurer le fonctionnement des systèmes automatiques de gestion du réseau (architecture, mise en œuvre, maintenance logicielle et matérielle pour les réseaux publics et privés déployés)| I | RA |
-| Gérer le plan d'adressage IP | RA | I |
+| Manage the functioning of automatic network management systems (architecture, implementation, software and hardware maintenance for deployed public and private networks) | I | RA |
+| Manage IP addressing plan | RA | I |
 
-##### **3.1.6. Gestion**
+##### **3.1.6. Management**
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Tenir un inventaire des dispositifs fournis par OVHcloud | I | RA |
-| Tenir un inventaire complet de l'ensemble des dispositifs | RA |  |
-| Rédiger et fournir un rapport mensuel de traitement des incidents, changements et demandes pris en charge par OVHcloud| I | RA |
-| Maintenir et fournir la  documentation technique correspondant à l'offre SecNumCloud| I | RA |
-| Gérer la sécurité des infrastructures de gestion (API, Gateway SSL) de l'IaaS | I | RA |
-| Gérer la sécurité des infrastructures de gestion (API, bastion, etc.) hébergées | RA | I |
-| Gérer la sécurité des VMs | RA | I |
-| Gérer la sécurité des Softwares et Middlewares installés sur les VMs | RA | I |
-| Gérer la sécurité des données déposées par le Client sur l'IaaS | RA | I |
-| Gérer la sécurité physique des équipements et infrastructures hébergés chez OVHcloud | I | RA |
-| Gérer la maintenance de la solution VMware managée et ses extensions | C | RA |
-| Réaliser le suivi commercial et contractuel du Client (devis, commande, livraison et facturation) | I | RA  |
-| Réaliser le suivi commercial et contractuel de la prestation fournie (devis, commande, livraison et facturation) | RA | I  |
-| Obtenir le support d'experts par l'intermédiaire du Techical Account Manager | A | R  |
+| Maintain an inventory of devices provided by OVHcloud | I | RA |
+| Maintain a complete inventory of all devices | RA |  |
+| Draft and provide a monthly report on the handling of incidents, changes and requests handled by OVHcloud | I | RA |
+| Maintain and provide the technical documentation corresponding to the SecNumCloud offer | I | RA |
+| Manage security of the management infrastructures (API, SSL Gateway) of the IaaS | I | RA |
+| Manage security of the hosted management infrastructures (API, bastion, etc.) | RA | I |
+| Manage security of VMs | RA | I |
+| Manage security of softwares and middlewares installed on VMs | RA | I |
+| Manage security of data placed by the Customer on the IaaS | RA | I |
+| Manage physical security of equipment and infrastructures hosted at OVHcloud | I | RA |
+| Maintain the VMware managed solution and its extensions | C | RA |
+| Carry out the commercial and contractual follow-up of the Customer (quote, order, delivery and invoicing) | I | RA  |
+| Carry out the commercial and contractual follow-up of the service provided (quote, order, delivery and invoicing) | RA | I  |
+| Obtain expert support through the Technical Account Manager | A | R  |
 
-##### **3.1.7. Continuité d'activité**
+##### **3.1.7. Business continuity**
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Gérer les systèmes de gestion automatiques de l'infrastructure mise à disposition | I | RA |
-| Maintenir un plan de continuité d'activité et de reprise d'activité pour le SI hébergé | RA | C |
+| Manage automatic management systems for the infrastructure provided | I | RA |
+| Maintain a business continuity and disaster recovery plan for the hosted IS | RA | C |
 
-#### 3.2. Gestion des évènements
+#### 3.2. Event management
 
 ##### **3.2.1. Incidents**
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Remplacer les éléments défectueux sur les dispositifs physiques supportant l'Infrastructure as a Service | I | RA |
-| Intervenir sur les éléments managés de l'IaaS | C | RA |
-| Qualifier les incidents survenus sur les éléments managés de l'IaaS | C | RA |
-| Rédiger et fournir une analyse post mortem | C | RA |
-| Coopérer avec OVHcloud dans le cadre de la résolution des incidents | RA | CI |
-| Coopérer avec le Client dans le cadre de la résolution des incidents | CI | RA |
+| Replace the defective hardware elements in support of the IaaS | I | RA |
+| Intervene on the managed elements of the IaaS | C | RA |
+| Qualify incidents occurring on the managed elements of the IaaS | C | RA |
+| Draft and provide a post-mortem analysis | C | RA |
+| Cooperate with OVHcloud as part of incident resolution | RA | CI |
+| Cooperate with the Customer as part of incident resolution | CI | RA |
 
-#### **3.2.2. Changements**
+#### **3.2.2. Change**
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Déployer les correctifs, mettre à jour et configurer les softwares, middlewares et systèmes d'information hébergés sur l'Infrastructure as a Service | RA | C |
-| Optimiser les VMs | RA | C |
-| Valider la demande d'un changement de matériel d'infrastructure soumise par OVHcloud | A | R |
-| Mettre à jour les composants embarqués dans les instances virtuelles  | RA | C |
-| Planifier les changements demandés par le client | C | RA |
-| Réaliser les changements nécessaires pour maintenir la conformité de l'IaaS à SecNumCloud| I | RA |
-| Prononcer la recette | RA | C |
-| Déployer les correctifs, mettre à jour et configurer l'ensemble des éléments constitutifs de l'Infrastructure as a Service | I | RA |
-| Déployer les correctifs, mettre à jour et configurer l'ensemble des éléments constitutifs du système d'information hébergé sur l'IaaS | RA | C |
-| Réaliser les interventions préventives sur les éléments managés de l'IaaS  | A | R |
-| Mettre à jour l'hyperviseur  | I | RA |
-| Mettre à jour les VMs | RA | I |
+| Deploy patches, updates and configurations on softwares, middlewares and IS hosted on the IaaS | RA | C |
+| Optimise VMs | RA | C |
+| Validate the request for an infrastructure hardware change submitted by OVHcloud | A | R |
+| Update the components embedded in the virtual instances | RA | C |
+| Plan changes requested by the customer | C | RA |
+| Carry out the changes required to maintain the compliance of the IaaS with SecNumCloud | I | RA |
+| Issue the acceptance | RA | C |
+| Deploy patches, updates and configurations on all the constituent elements of the Infrastructure as a Service | I | RA |
+| Deploy patches, updates and configurations on all the constituent elements of the information system hosted on the IaaS | RA | C |
+| Carry out preventive interventions on the managed elements of the IaaS | A | R |
+| Update the hypervisor | I | RA |
+| Update VMs | RA | I |
 
-### 4. Réversibilité
+### 4. Reversibility
 
-#### 4.1. Modèle de réversibilité
+#### 4.1. Reversibility model
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Planifier les opérations de réversibilité | RA | I |
-| Choisir les infrastructures de repli | RA |  |
+| Schedule reversibility operations | RA | I |
+| Choose fallback infrastructures | RA |  |
 
-#### 4.2. Récupération des données
+#### 4.2. Data recovery
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Gérer les opérations de réversibilité | RA | I |
-| Migrer / transférer les données | RA |  |
+| Manage reversibility operations | RA | I |
+| Migrate/transfer data | RA |  |
 
-### 5. Fin de service
+### 5. End of service
 
-#### 5.1. Destruction des configurations
+#### 5.1. Destroying configurations
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Demander la fin de tout ou partie du Service | RA | I |
-| Décommissionner les configurations du Cloud Privé et options associées au client suite à la rupture du contrat | I | RA |
+| Request the end of all or part of the Service | RA | I |
+| Uncommission the Private Cloud configurations and options associated with the customer following contract termination | I | RA |
 
-#### 5.2. Destruction des données
+#### 5.2. Data destruction
 
-| **Activité** | **Client** | **OVHcloud** |
+| **Activity** | **Customer** | **OVHcloud** |
 | --- | --- | --- |
-| Opérer la destruction sécurisée des données sur les supports de stockage |  | RA |
-| Détruire les supports de stockage arrivés en fin de vie ou sur lesquels les processus de destruction sécurisée génèrent des erreurs |  | RA |
-| Fournir une attestation de destruction (sur demande) | I | RA |
+| Securely destroy data on storage media |  | RA |
+| Destroy storage media that has reached their end of life or when the secure destruction processes are generating errors |  | RA |
+| Provide a certificate of destruction (upon request) | I | RA |

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
@@ -1,12 +1,12 @@
 ---
 title: Reemplazo de Prism Central del modo Small al modo X-LARGE (EN)
 description: How to replace Prism Central with three X-Large VMs
-lastUpdated: 2023-12-18
+lastUpdated: 2026-06-11
 ---
 
 :::warning
 This guide is only intended for customers who are in **Bring Your Own License** mode on their Nutanix cluster.
-If you are not in this configuration, contact the [OVHcloud support teams](https://help.ovhcloud.com/csm?id=csm_get_help) to change the size of your Prism Central.
+If you are not in this configuration, contact the [OVHcloud support teams](/links/support-contact) to change the size of your Prism Central.
 
 :::
 
@@ -17,14 +17,14 @@ Before you make any changes, you must unregister your Prism Central license on y
 :::
 
 
-## Objectif
+## Objective
 
 **This guide will show you how to redeploy Prism-Central in X-LARGE mode across three virtual machines.**
 
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 
 :::
 
@@ -32,7 +32,6 @@ If you encounter any difficulties performing these actions, please contact a [sp
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -63,13 +62,13 @@ In the configuration pages for your Load Balancer, go to the <code className="ac
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 02" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer02.png" loading="lazy" />
 
-Enter this information :
+Enter this information:
 
-- **Name (optional)** : `PE SSH`.
-- **Protocol** : `TCP`.
-- **Port** : `22`.
-- **Datacenter** : `ALL`.
-- **Private network** : `nutanix`.
+- **Name (optional)**: `PE SSH`.
+- **Protocol**: `TCP`.
+- **Port**: `22`.
+- **Datacenter**: `ALL`.
+- **Private network**: `nutanix`.
 
 Then click <code className="action">Add</code>.
 
@@ -79,11 +78,11 @@ Within the server cluster, click <code className="action">Add server</code>.
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 04" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer04.png" loading="lazy" />
 
-Fill in these values :
+Fill in these values:
 
-- **Name (Optional)** : `PE SSH`.
-- **IPv4 address** : `Private IP address of Prism Element`.
-- **Port** : `22`.
+- **Name (Optional)**: `PE SSH`.
+- **IPv4 address**: `Private IP address of Prism Element`.
+- **Port**: `22`.
 
 And click <code className="action">Add</code>.
 
@@ -111,9 +110,9 @@ When the task is finished, go to the <code className="action">Front-ends</code> 
 
 Enter the following information:
 
-- **Name(Optional)** : `PE-FRONTEND`.
-- **Port** : `22`.
-- **Datacenter** : `ALL`.
+- **Name(Optional)**: `PE-FRONTEND`.
+- **Port**: `22`.
+- **Datacenter**: `ALL`.
 
 Then click <code className="action">Show</code>.
 
@@ -141,7 +140,7 @@ Go to the <code className="action">Tasks</code> tab to see the progress of the c
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 16" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer16.png" loading="lazy" />
 
-You have finished configuring the Load Balancer. You can now log in via SSH to the Prism Element console, with this information :
+You have finished configuring the Load Balancer. You can now log in via SSH to the Prism Element console, with this information:
 
 ```bash
 ssh admin@nutanix-cluster-ovhcloud-fqdn
@@ -157,9 +156,9 @@ ssh nutanix@nutanix-cluster-ovhcloud-fqdn
 
 Run these commands after you have modified the following information:
 
-- **\<Prism-Central-Private-IP-address\>** : Private IP address of Prism Central
-- **\<Prism-Element-Admin-Password\>** : Prism Element admin account password
-- **\<Prism-Central-VM-Name\>** : Prism Central VM name
+- **\<Prism-Central-Private-IP-address\>**: Private IP address of Prism Central
+- **\<Prism-Element-Admin-Password\>**: Prism Element admin account password
+- **\<Prism-Central-VM-Name\>**: Prism Central VM name
 
 ```bash
 # Disconnect Prism Element in Prism Central
@@ -176,8 +175,8 @@ ssh root@private-ip-address-of-one-ahv-servers
 
 Run this command to retrieve the UUID of your default storage, once you have modified the following information:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-IP\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-IP\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X GET "https://<Prism-Element-Ip>:9440/PrismGateway/services/rest/v2.0/storage_containers/" | jq -r '[.entities[] | select( .name | contains("default-container")) | .storage_container_uuid][0]'
@@ -189,7 +188,7 @@ Next, run this other command to retrieve the UUID of your cluster’s administra
 curl -s -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST https://<prism6element-IP>:9440/api/nutanix/v3/subnets/list -d {} | jq -r "[.entities[] | select( .spec.name | contains(\"<subnet name>\")) | .metadata.uuid][0]"
 ```
 
-Create a file named **PrismCentralXlarge.json** with the information below :
+Create a file named **PrismCentralXlarge.json** with the information below:
 
 ```json
 {
@@ -222,19 +221,19 @@ Create a file named **PrismCentralXlarge.json** with the information below :
 }
 ```
 
-Replace these items in the file :
+Replace these items in the file:
 
-- **\<Prism-Central-Password\>** : Password for the future Prism Central virtual machine.
-- **\<Default-Container-UUID\>** : UUID of the default storage retrieved earlier.
-- **\<Prism-Central-Private-IP-Address\>** : Private IP address of Prism Central.
-- **\<Nutanix-Network-Admin-UUID\>** : Nutanix Cluster Administration Network UUID.
-- **\<Nutanix-Network-Admin-mask\>** : Nutanix cluster administration network subnet mask.
-- **\<Nutanix-Network-Admin-Gateway\>** : Nutanix cluster administration network default gateway.
+- **\<Prism-Central-Password\>**: Password for the future Prism Central virtual machine.
+- **\<Default-Container-UUID\>**: UUID of the default storage retrieved earlier.
+- **\<Prism-Central-Private-IP-Address\>**: Private IP address of Prism Central.
+- **\<Nutanix-Network-Admin-UUID\>**: Nutanix Cluster Administration Network UUID.
+- **\<Nutanix-Network-Admin-mask\>**: Nutanix cluster administration network subnet mask.
+- **\<Nutanix-Network-Admin-Gateway\>**: Nutanix cluster administration network default gateway.
 
 Run this command to deploy your Prism Central virtual machine in X-Large mode, once you changed these settings:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-Private-IP-Address\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-Private-IP-Address\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST "https://<Prism-Element-Private-IP-Address>:9440/api/nutanix/v3/prism_central" -d @PrismCentralXlarge.json
@@ -248,17 +247,17 @@ Wait thirty minutes for this virtual machine to deploy.
 
 Enter the following command by editing these options to create a **pcregister.json** file:
 
-- **\<Prism-Central-Password\>** : Prism Central Password.
-- **\<Prism-Central-Private-IP-Address\>** : Private IP address of Prism Central.
+- **\<Prism-Central-Password\>**: Prism Central Password.
+- **\<Prism-Central-Private-IP-Address\>**: Private IP address of Prism Central.
 
 ```bash
 echo "{\"username\":\"admin\",\"password\":\"<Prism-Central-Password>\",\"port\":9440,\"ipAddresses\":[\"<Prism-Central-Private-IP-Address>\"]}" > pcregister.json
 ```
 
-Run this command to save Prism Element into your new Prism Central virtual machine, after changing these settings :
+Run this command to save Prism Element into your new Prism Central virtual machine, after changing these settings:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-Private-IP-Address\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-Private-IP-Address\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST "https://<Prism-Element-Private-IP-Address>:9440/PrismGateway/services/rest/v1/multicluster/prism_central/register" -d @pcregister.json
@@ -294,13 +293,13 @@ Click <code className="action">Confirm</code>.
 
 Expansion of Prism Central requires three additional private IP addresses, one for the virtual IP address and two for the new virtual machines.
 
-Scroll through the window and enter this information :
+Scroll through the window and enter this information:
 
-- **Virtual IP** : Prism Central virtual private IP address.
-- **VM Name** : Name of the second Prism Central virtual machine.
-- **IP** : Private IP address of the second virtual machine.
-- **VM Name** : Name of the third Prism Central virtual machine.
-- **IP** : Private IP address of the third virtual machine.
+- **Virtual IP**: Prism Central virtual private IP address.
+- **VM Name**: Name of the second Prism Central virtual machine.
+- **IP**: Private IP address of the second virtual machine.
+- **VM Name**: Name of the third Prism Central virtual machine.
+- **IP**: Private IP address of the third virtual machine.
 
 Click <code className="action">Expand</code>.
 
@@ -330,11 +329,11 @@ Click <code className="action">Add Server</code>.
 
 <img className="thumbnail" alt="03 Modify Prism Central Https Address 02" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/03-modify-prism-central-https-address02.png" loading="lazy" />
 
-Enter this information :
+Enter this information:
 
-- **Name (Optional)** : PC VIP as Prism Central Virtual IP address.
-- **IPv4 address** : Virtual Private IP address 
-- **Port** : 9440.
+- **Name (Optional)**: PC VIP as Prism Central Virtual IP address.
+- **IPv4 address**: Virtual Private IP address 
+- **Port**: 9440.
 
 Click <code className="action">Add</code>.
 
@@ -368,6 +367,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
@@ -1,10 +1,10 @@
 ---
 title: Configuración de NCM Self Service (CALM) (EN)
 description: How to enable Self Service (CALM) in your Prism Central
-lastUpdated: 2024-05-13
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
 **Find out how to set up NCM Self-Service (Calm) on your Prism Central.**
 
@@ -73,7 +73,7 @@ An error message appears during CALM deployment, ignore it, exit the window and 
 :::
 
 
-![00 Activate CALM 08](/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png)
+<img className="thumbnail" alt="00 Activate CALM 08" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png" loading="lazy" />
 
 ### Creating a project
 
@@ -153,7 +153,7 @@ Enter this information:
 - **vCPUs**: `4`
 - **Core per vCPU**: `1`
 - **Memory (GiB)**: `4`
-- **Image** : `WS2022EN-SYSPREPED`
+- **Image**: `WS2022EN-SYSPREPED`
 
 :::info
 The image is generated from a VM WINDOWS Server 2022 on which a sysprep was applied to reset the default configuration. When used with CALM, it is possible to automate the installation of a Windows OS from this type of image and apply settings stored in an XML file to it.

--- a/docs/es/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
+++ b/docs/es/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
@@ -1,10 +1,10 @@
 ---
 title: Configuración de NAT para redirecciones de puertos con NSX (EN)
 description: Learn how to configure NAT to create port redirections
-lastUpdated: 2023-02-27
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
 **Learn how to configure NAT to create port redirections with NSX.**
 
@@ -32,13 +32,13 @@ In the NSX interface, go to the <code className="action">Networking</code> tab, 
 
 <img className="thumbnail" alt="01 Create DNAT rule 01" src="/images/hosted-private-cloud/powered-by-vmware/nsx-07-configure-nat-redirection/01-create-dnat-rules01.png" loading="lazy" />
 
-Fill in this information :
+Fill in this information:
 
-- **Action** : Select <code className="action">DNAT</code>.
-- **Source IP** : Enter the IP address or range of addresses that can use this redirection.
-- **Destination IP** : Public virtual IP address of NSX.
-- **Destination PORT** : Listening port on public address such as `2222`.
-- **Translated IP** : IP address of the virtual machine being redirected to.
+- **Action**: Select <code className="action">DNAT</code>.
+- **Source IP**: Enter the IP address or range of addresses that can use this redirection.
+- **Destination IP**: Public virtual IP address of NSX.
+- **Destination PORT**: Listening port on public address such as `2222`.
+- **Translated IP**: IP address of the virtual machine being redirected to.
 
 Then click on the <code className="action">three vertical dots</code> to the right of **Select Services**.
 
@@ -52,11 +52,11 @@ Click <code className="action">ADD SERVICE ENTRY</code>.
 
 <img className="thumbnail" alt="01 Create DNAT rule 04" src="/images/hosted-private-cloud/powered-by-vmware/nsx-07-configure-nat-redirection/01-create-dnat-rules04.png" loading="lazy" />
 
-Fill in these values :
+Fill in these values:
 
-- **Name** : Enter `SSH22`.
-- **Service Type** : Select <code className="action">TCP</code>.
-- **Source Ports** : Write the number `22`.
+- **Name**: Enter `SSH22`.
+- **Service Type**: Select <code className="action">TCP</code>.
+- **Source Ports**: Write the number `22`.
 
 Then click <code className="action">APPLY</code>.
 

--- a/docs/fr/guides/hosted-private-cloud/cloud-platform/getting-started.mdx
+++ b/docs/fr/guides/hosted-private-cloud/cloud-platform/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mise en route de votre projet SNC Cloud Platform
 description: Découvrez comment prendre en main et configurer votre environnement SNC Cloud Platform
-lastUpdated: 2025-12-29
+lastUpdated: 2026-06-11
 ---
 
 ## Objectif

--- a/docs/fr/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-backup-object-storage-bucket.mdx
+++ b/docs/fr/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-backup-object-storage-bucket.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comment sauvegarder un bucket Object Storage SNC Cloud Platform
 description: Découvrez comment sauvegarder un bucket Object Storage SNC Cloud Platform sur un Object Storage distant
-lastUpdated: 2026-01-29
+lastUpdated: 2026-06-11
 ---
 
 ## Objectif

--- a/docs/fr/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-save-instance.mdx
+++ b/docs/fr/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-save-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comment sauvegarder une instance SNC Cloud Platform
 description: Découvrez comment sauvegarder une instance SNC Cloud Platform sur Object Storage
-lastUpdated: 2025-12-29
+lastUpdated: 2026-06-11
 ---
 
 ## Objectif

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
@@ -1,12 +1,12 @@
 ---
 title: Remplacement de Prism Central du mode Small au mode X-LARGE
 description: Comment remplacer Prism Central par trois machines virtuelles en mode X-LARGE
-lastUpdated: 2023-12-18
+lastUpdated: 2026-06-11
 ---
 
 :::warning
 Ce guide est destiné uniquement aux client en mode **Bring Your Own Licence** sur leur cluster Nutanix.
-Si vous n'êtes pas dans cette configuration, contactez le [support OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help) pour modifier la taille de votre Prism Central.
+Si vous n'êtes pas dans cette configuration, contactez le [support OVHcloud](/links/support-contact) pour modifier la taille de votre Prism Central.
 :::
 
 
@@ -29,7 +29,6 @@ Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néa
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>
 - Être connecté sur le cluster via Prism Central
 - Connaître le mot de passe admin de Prism Element (lors du déploiement d'un cluster Nutanix by OVHcloud; ce mot de passe est créé à l'identique de celui de Prism Central mais il peut être changé par la suite).
 
@@ -374,7 +373,7 @@ Vous disposez maintenant de Prism Central en mode X-LARGE avec trois machines vi
 
 ## Aller plus loin <a name="gofurther"></a>
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mise en place de NCM Self Service (CALM)
 description: Comment activer Self Service (CALM) dans votre Prism Central
-lastUpdated: 2024-05-13
+lastUpdated: 2026-06-11
 ---
 
 ## Objectif
@@ -71,7 +71,7 @@ Un message d'erreur apparait pendant le déploiement de CALM. N'en tenez pas com
 :::
 
 
-![00 Activate CALM 08](/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png)
+<img className="thumbnail" alt="00 Activate CALM 08" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png" loading="lazy" />
 
 ### Création d'un projet
 

--- a/docs/fr/guides/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights.mdx
+++ b/docs/fr/guides/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights.mdx
@@ -1,7 +1,7 @@
 ---
 title: Activer NSX-T dans un Hosted Private Cloud VMware on OVHcloud
 description: Découvrez comment ajouter les droits à un utilisateur et aux Datacentres pour NSX-T
-lastUpdated: 2024-05-22
+lastUpdated: 2026-06-11
 ---
 
 import Api from '@components/Api';
@@ -28,35 +28,19 @@ Ces droits sont accordés depuis l'<ManagerLink to="/">espace client OVHcloud</M
 
 ## Prérequis
 
-- Avoir souscrit une offre [Hosted Private Cloud](https://www.ovhcloud.com/fr/hosted-private-cloud/vmware/) avec les options **"Network Security Virtualization"** ou **"Software-Defined Datacenter"** 
-- Etre connecté à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>
+- Avoir souscrit une offre [Hosted Private Cloud](/links/hosted-private-cloud/vmware) avec les options **"Network Security Virtualization"** ou **"Software-Defined Datacenter"** 
 - Être contact administrateur de l'infrastructure VMware sur OVHcloud, celui-ci recevant les identifiants de connexion.
 - Avoir suivi les étapes de cette documentation : [Premiers pas avec NSX](/guides/hosted-private-cloud/powered-by-vmware/nsx-first-steps)
 
 ## Instructions
 
-### Etape 1 - Accéder à votre Hosted Private Cloud
-
-<details>
-
-<summary>Comment accéder à votre Hosted Private Cloud - VMware On OVHcloud ?</summary>
-
-Une fois connecté à l'espace client OVHcloud, cliquez sur l'onglet <code className="action">Hosted Private Cloud</code>.
-<br/><br/>
-
-- Lien OVHcloud : `https://www.ovh.com/manager/#/dedicated/dedicated_cloud/pcc-xxx-xxx-xxx-xxx` > Remplacez-le par le nom de votre service VMware on OVHcloud.
-
-<p><img alt="NSX screenshot" className="thumbnail" src="/images/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights/nsx_user_rights_7.png" loading="lazy"/></p>
-
-</details>
-
-### Etape 2 - Activer NSX-T
+### Etape 1 - Activer NSX-T
 
 <details>
 
 <summary>Comment activer l'interface NSX-T pour votre utilisateur ?</summary>
 
-Depuis la page précedente, éditez l'utilisateur avec lequel vous souhaitez accéder à l'interface Web NSX-T : 
+Éditez l'utilisateur avec lequel vous souhaitez accéder à l'interface Web NSX-T : 
 <br/><br/>
 
 <code className="action">VMware</code> > <code className="action">PCC-XXX.XXX.XXX.XXX</code> > <code className="action">Utilisateur</code> > <code className="action">Modifier</code> puis activez le bouton <code className="action">NSX Interface</code>.
@@ -67,7 +51,7 @@ Depuis la page précedente, éditez l'utilisateur avec lequel vous souhaitez acc
 
 </details>
 
-### Etape 3 - Ajouter les droits NSX-T
+### Etape 2 - Ajouter les droits NSX-T
 
 <details>
 
@@ -80,7 +64,7 @@ Cliquez sur : <code className="action">VMware</code> > <code className="action">
 </details>
 
 
-### Etape 4 - Ajouter les droits NSX-T aux Datacentres
+### Etape 3 - Ajouter les droits NSX-T aux Datacentres
 
 <details>
 
@@ -103,7 +87,7 @@ Si vous voulez faire des modifications dans l'interface Web NSX-T, des droits su
 
 </details>
 
-### Etape 5 - Accéder à l'interface NSX-T
+### Etape 4 - Accéder à l'interface NSX-T
 
 <details>
 
@@ -120,7 +104,7 @@ Toujours depuis votre arborescence Hosted Private Cloud, cliquez sur <code class
 
 </details>
 
-### Etape 6 - Informations utiles
+### Etape 5 - Informations utiles
 
 Vous pouvez vérifier si NSX-T est activé sur votre Datacenter. Vous pouvez également retrouver votre URL NSX-T et sa version :
 
@@ -165,6 +149,6 @@ Retrouvez plus d’informations sur l’API OVHcloud dans notre guide « [Premie
 - [Gestion des segments dans NSX](/guides/hosted-private-cloud/powered-by-vmware/nsx-segment-management)
 - [FAQ NSX](/guides/hosted-private-cloud/powered-by-vmware/nsx-faq)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
+++ b/docs/fr/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mise en place du NAT pour des redirections de ports avec NSX
 description: Découvrez comment configurer le NAT pour créer une redirection de port
-lastUpdated: 2023-02-27
+lastUpdated: 2026-06-11
 ---
 
 ## Objectif

--- a/docs/fr/guides/hosted-private-cloud/powered-by-vmware/snc-responsibility-sharing.mdx
+++ b/docs/fr/guides/hosted-private-cloud/powered-by-vmware/snc-responsibility-sharing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Partage de responsabilité sur le service Hosted Private Cloud by VMware sous la qualification SecNumCloud
 description: "Partage de responsabilité entre OVHcloud et le client pour l'utilisation du produit VMware on OVHcloud sous la qualification SecNumCloud"
-lastUpdated: 2024-01-22
+lastUpdated: 2026-06-11
 ---
 
 ## Objectif

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
@@ -1,12 +1,12 @@
 ---
 title: Sostituzione di Prism Central dalla modalità Small alla modalità X-LARGE (EN)
 description: How to replace Prism Central with three X-Large VMs
-lastUpdated: 2023-12-18
+lastUpdated: 2026-06-11
 ---
 
 :::warning
 This guide is only intended for customers who are in **Bring Your Own License** mode on their Nutanix cluster.
-If you are not in this configuration, contact the [OVHcloud support teams](https://help.ovhcloud.com/csm?id=csm_get_help) to change the size of your Prism Central.
+If you are not in this configuration, contact the [OVHcloud support teams](/links/support-contact) to change the size of your Prism Central.
 
 :::
 
@@ -17,14 +17,14 @@ Before you make any changes, you must unregister your Prism Central license on y
 :::
 
 
-## Objectif
+## Objective
 
 **This guide will show you how to redeploy Prism-Central in X-LARGE mode across three virtual machines.**
 
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 
 :::
 
@@ -32,7 +32,6 @@ If you encounter any difficulties performing these actions, please contact a [sp
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -63,13 +62,13 @@ In the configuration pages for your Load Balancer, go to the <code className="ac
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 02" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer02.png" loading="lazy" />
 
-Enter this information :
+Enter this information:
 
-- **Name (optional)** : `PE SSH`.
-- **Protocol** : `TCP`.
-- **Port** : `22`.
-- **Datacenter** : `ALL`.
-- **Private network** : `nutanix`.
+- **Name (optional)**: `PE SSH`.
+- **Protocol**: `TCP`.
+- **Port**: `22`.
+- **Datacenter**: `ALL`.
+- **Private network**: `nutanix`.
 
 Then click <code className="action">Add</code>.
 
@@ -79,11 +78,11 @@ Within the server cluster, click <code className="action">Add server</code>.
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 04" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer04.png" loading="lazy" />
 
-Fill in these values :
+Fill in these values:
 
-- **Name (Optional)** : `PE SSH`.
-- **IPv4 address** : `Private IP address of Prism Element`.
-- **Port** : `22`.
+- **Name (Optional)**: `PE SSH`.
+- **IPv4 address**: `Private IP address of Prism Element`.
+- **Port**: `22`.
 
 And click <code className="action">Add</code>.
 
@@ -111,9 +110,9 @@ When the task is finished, go to the <code className="action">Front-ends</code> 
 
 Enter the following information:
 
-- **Name(Optional)** : `PE-FRONTEND`.
-- **Port** : `22`.
-- **Datacenter** : `ALL`.
+- **Name(Optional)**: `PE-FRONTEND`.
+- **Port**: `22`.
+- **Datacenter**: `ALL`.
 
 Then click <code className="action">Show</code>.
 
@@ -141,7 +140,7 @@ Go to the <code className="action">Tasks</code> tab to see the progress of the c
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 16" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer16.png" loading="lazy" />
 
-You have finished configuring the Load Balancer. You can now log in via SSH to the Prism Element console, with this information :
+You have finished configuring the Load Balancer. You can now log in via SSH to the Prism Element console, with this information:
 
 ```bash
 ssh admin@nutanix-cluster-ovhcloud-fqdn
@@ -157,9 +156,9 @@ ssh nutanix@nutanix-cluster-ovhcloud-fqdn
 
 Run these commands after you have modified the following information:
 
-- **\<Prism-Central-Private-IP-address\>** : Private IP address of Prism Central
-- **\<Prism-Element-Admin-Password\>** : Prism Element admin account password
-- **\<Prism-Central-VM-Name\>** : Prism Central VM name
+- **\<Prism-Central-Private-IP-address\>**: Private IP address of Prism Central
+- **\<Prism-Element-Admin-Password\>**: Prism Element admin account password
+- **\<Prism-Central-VM-Name\>**: Prism Central VM name
 
 ```bash
 # Disconnect Prism Element in Prism Central
@@ -176,8 +175,8 @@ ssh root@private-ip-address-of-one-ahv-servers
 
 Run this command to retrieve the UUID of your default storage, once you have modified the following information:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-IP\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-IP\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X GET "https://<Prism-Element-Ip>:9440/PrismGateway/services/rest/v2.0/storage_containers/" | jq -r '[.entities[] | select( .name | contains("default-container")) | .storage_container_uuid][0]'
@@ -189,7 +188,7 @@ Next, run this other command to retrieve the UUID of your cluster’s administra
 curl -s -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST https://<prism6element-IP>:9440/api/nutanix/v3/subnets/list -d {} | jq -r "[.entities[] | select( .spec.name | contains(\"<subnet name>\")) | .metadata.uuid][0]"
 ```
 
-Create a file named **PrismCentralXlarge.json** with the information below :
+Create a file named **PrismCentralXlarge.json** with the information below:
 
 ```json
 {
@@ -222,19 +221,19 @@ Create a file named **PrismCentralXlarge.json** with the information below :
 }
 ```
 
-Replace these items in the file :
+Replace these items in the file:
 
-- **\<Prism-Central-Password\>** : Password for the future Prism Central virtual machine.
-- **\<Default-Container-UUID\>** : UUID of the default storage retrieved earlier.
-- **\<Prism-Central-Private-IP-Address\>** : Private IP address of Prism Central.
-- **\<Nutanix-Network-Admin-UUID\>** : Nutanix Cluster Administration Network UUID.
-- **\<Nutanix-Network-Admin-mask\>** : Nutanix cluster administration network subnet mask.
-- **\<Nutanix-Network-Admin-Gateway\>** : Nutanix cluster administration network default gateway.
+- **\<Prism-Central-Password\>**: Password for the future Prism Central virtual machine.
+- **\<Default-Container-UUID\>**: UUID of the default storage retrieved earlier.
+- **\<Prism-Central-Private-IP-Address\>**: Private IP address of Prism Central.
+- **\<Nutanix-Network-Admin-UUID\>**: Nutanix Cluster Administration Network UUID.
+- **\<Nutanix-Network-Admin-mask\>**: Nutanix cluster administration network subnet mask.
+- **\<Nutanix-Network-Admin-Gateway\>**: Nutanix cluster administration network default gateway.
 
 Run this command to deploy your Prism Central virtual machine in X-Large mode, once you changed these settings:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-Private-IP-Address\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-Private-IP-Address\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST "https://<Prism-Element-Private-IP-Address>:9440/api/nutanix/v3/prism_central" -d @PrismCentralXlarge.json
@@ -248,17 +247,17 @@ Wait thirty minutes for this virtual machine to deploy.
 
 Enter the following command by editing these options to create a **pcregister.json** file:
 
-- **\<Prism-Central-Password\>** : Prism Central Password.
-- **\<Prism-Central-Private-IP-Address\>** : Private IP address of Prism Central.
+- **\<Prism-Central-Password\>**: Prism Central Password.
+- **\<Prism-Central-Private-IP-Address\>**: Private IP address of Prism Central.
 
 ```bash
 echo "{\"username\":\"admin\",\"password\":\"<Prism-Central-Password>\",\"port\":9440,\"ipAddresses\":[\"<Prism-Central-Private-IP-Address>\"]}" > pcregister.json
 ```
 
-Run this command to save Prism Element into your new Prism Central virtual machine, after changing these settings :
+Run this command to save Prism Element into your new Prism Central virtual machine, after changing these settings:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-Private-IP-Address\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-Private-IP-Address\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST "https://<Prism-Element-Private-IP-Address>:9440/PrismGateway/services/rest/v1/multicluster/prism_central/register" -d @pcregister.json
@@ -294,13 +293,13 @@ Click <code className="action">Confirm</code>.
 
 Expansion of Prism Central requires three additional private IP addresses, one for the virtual IP address and two for the new virtual machines.
 
-Scroll through the window and enter this information :
+Scroll through the window and enter this information:
 
-- **Virtual IP** : Prism Central virtual private IP address.
-- **VM Name** : Name of the second Prism Central virtual machine.
-- **IP** : Private IP address of the second virtual machine.
-- **VM Name** : Name of the third Prism Central virtual machine.
-- **IP** : Private IP address of the third virtual machine.
+- **Virtual IP**: Prism Central virtual private IP address.
+- **VM Name**: Name of the second Prism Central virtual machine.
+- **IP**: Private IP address of the second virtual machine.
+- **VM Name**: Name of the third Prism Central virtual machine.
+- **IP**: Private IP address of the third virtual machine.
 
 Click <code className="action">Expand</code>.
 
@@ -330,11 +329,11 @@ Click <code className="action">Add Server</code>.
 
 <img className="thumbnail" alt="03 Modify Prism Central Https Address 02" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/03-modify-prism-central-https-address02.png" loading="lazy" />
 
-Enter this information :
+Enter this information:
 
-- **Name (Optional)** : PC VIP as Prism Central Virtual IP address.
-- **IPv4 address** : Virtual Private IP address 
-- **Port** : 9440.
+- **Name (Optional)**: PC VIP as Prism Central Virtual IP address.
+- **IPv4 address**: Virtual Private IP address 
+- **Port**: 9440.
 
 Click <code className="action">Add</code>.
 
@@ -368,6 +367,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
@@ -1,10 +1,10 @@
 ---
 title: Configurazione NCM Self Service (CALM) (EN)
 description: How to enable Self Service (CALM) in your Prism Central
-lastUpdated: 2024-05-13
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
 **Find out how to set up NCM Self-Service (Calm) on your Prism Central.**
 
@@ -73,7 +73,7 @@ An error message appears during CALM deployment, ignore it, exit the window and 
 :::
 
 
-![00 Activate CALM 08](/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png)
+<img className="thumbnail" alt="00 Activate CALM 08" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png" loading="lazy" />
 
 ### Creating a project
 
@@ -153,7 +153,7 @@ Enter this information:
 - **vCPUs**: `4`
 - **Core per vCPU**: `1`
 - **Memory (GiB)**: `4`
-- **Image** : `WS2022EN-SYSPREPED`
+- **Image**: `WS2022EN-SYSPREPED`
 
 :::info
 The image is generated from a VM WINDOWS Server 2022 on which a sysprep was applied to reset the default configuration. When used with CALM, it is possible to automate the installation of a Windows OS from this type of image and apply settings stored in an XML file to it.

--- a/docs/it/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
+++ b/docs/it/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
@@ -1,10 +1,10 @@
 ---
 title: Configurazione di NAT per i reindirizzamenti delle porte con NSX (EN)
 description: Learn how to configure NAT to create port redirections
-lastUpdated: 2023-02-27
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
 **Learn how to configure NAT to create port redirections with NSX.**
 
@@ -32,13 +32,13 @@ In the NSX interface, go to the <code className="action">Networking</code> tab, 
 
 <img className="thumbnail" alt="01 Create DNAT rule 01" src="/images/hosted-private-cloud/powered-by-vmware/nsx-07-configure-nat-redirection/01-create-dnat-rules01.png" loading="lazy" />
 
-Fill in this information :
+Fill in this information:
 
-- **Action** : Select <code className="action">DNAT</code>.
-- **Source IP** : Enter the IP address or range of addresses that can use this redirection.
-- **Destination IP** : Public virtual IP address of NSX.
-- **Destination PORT** : Listening port on public address such as `2222`.
-- **Translated IP** : IP address of the virtual machine being redirected to.
+- **Action**: Select <code className="action">DNAT</code>.
+- **Source IP**: Enter the IP address or range of addresses that can use this redirection.
+- **Destination IP**: Public virtual IP address of NSX.
+- **Destination PORT**: Listening port on public address such as `2222`.
+- **Translated IP**: IP address of the virtual machine being redirected to.
 
 Then click on the <code className="action">three vertical dots</code> to the right of **Select Services**.
 
@@ -52,11 +52,11 @@ Click <code className="action">ADD SERVICE ENTRY</code>.
 
 <img className="thumbnail" alt="01 Create DNAT rule 04" src="/images/hosted-private-cloud/powered-by-vmware/nsx-07-configure-nat-redirection/01-create-dnat-rules04.png" loading="lazy" />
 
-Fill in these values :
+Fill in these values:
 
-- **Name** : Enter `SSH22`.
-- **Service Type** : Select <code className="action">TCP</code>.
-- **Source Ports** : Write the number `22`.
+- **Name**: Enter `SSH22`.
+- **Service Type**: Select <code className="action">TCP</code>.
+- **Source Ports**: Write the number `22`.
 
 Then click <code className="action">APPLY</code>.
 

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
@@ -1,12 +1,12 @@
 ---
 title: Wymiana Prism Central z trybu Small w trybie X-LARGE (EN)
 description: How to replace Prism Central with three X-Large VMs
-lastUpdated: 2023-12-18
+lastUpdated: 2026-06-11
 ---
 
 :::warning
 This guide is only intended for customers who are in **Bring Your Own License** mode on their Nutanix cluster.
-If you are not in this configuration, contact the [OVHcloud support teams](https://help.ovhcloud.com/csm?id=csm_get_help) to change the size of your Prism Central.
+If you are not in this configuration, contact the [OVHcloud support teams](/links/support-contact) to change the size of your Prism Central.
 
 :::
 
@@ -17,14 +17,14 @@ Before you make any changes, you must unregister your Prism Central license on y
 :::
 
 
-## Objectif
+## Objective
 
 **This guide will show you how to redeploy Prism-Central in X-LARGE mode across three virtual machines.**
 
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 
 :::
 
@@ -32,7 +32,6 @@ If you encounter any difficulties performing these actions, please contact a [sp
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -63,13 +62,13 @@ In the configuration pages for your Load Balancer, go to the <code className="ac
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 02" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer02.png" loading="lazy" />
 
-Enter this information :
+Enter this information:
 
-- **Name (optional)** : `PE SSH`.
-- **Protocol** : `TCP`.
-- **Port** : `22`.
-- **Datacenter** : `ALL`.
-- **Private network** : `nutanix`.
+- **Name (optional)**: `PE SSH`.
+- **Protocol**: `TCP`.
+- **Port**: `22`.
+- **Datacenter**: `ALL`.
+- **Private network**: `nutanix`.
 
 Then click <code className="action">Add</code>.
 
@@ -79,11 +78,11 @@ Within the server cluster, click <code className="action">Add server</code>.
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 04" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer04.png" loading="lazy" />
 
-Fill in these values :
+Fill in these values:
 
-- **Name (Optional)** : `PE SSH`.
-- **IPv4 address** : `Private IP address of Prism Element`.
-- **Port** : `22`.
+- **Name (Optional)**: `PE SSH`.
+- **IPv4 address**: `Private IP address of Prism Element`.
+- **Port**: `22`.
 
 And click <code className="action">Add</code>.
 
@@ -111,9 +110,9 @@ When the task is finished, go to the <code className="action">Front-ends</code> 
 
 Enter the following information:
 
-- **Name(Optional)** : `PE-FRONTEND`.
-- **Port** : `22`.
-- **Datacenter** : `ALL`.
+- **Name(Optional)**: `PE-FRONTEND`.
+- **Port**: `22`.
+- **Datacenter**: `ALL`.
 
 Then click <code className="action">Show</code>.
 
@@ -141,7 +140,7 @@ Go to the <code className="action">Tasks</code> tab to see the progress of the c
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 16" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer16.png" loading="lazy" />
 
-You have finished configuring the Load Balancer. You can now log in via SSH to the Prism Element console, with this information :
+You have finished configuring the Load Balancer. You can now log in via SSH to the Prism Element console, with this information:
 
 ```bash
 ssh admin@nutanix-cluster-ovhcloud-fqdn
@@ -157,9 +156,9 @@ ssh nutanix@nutanix-cluster-ovhcloud-fqdn
 
 Run these commands after you have modified the following information:
 
-- **\<Prism-Central-Private-IP-address\>** : Private IP address of Prism Central
-- **\<Prism-Element-Admin-Password\>** : Prism Element admin account password
-- **\<Prism-Central-VM-Name\>** : Prism Central VM name
+- **\<Prism-Central-Private-IP-address\>**: Private IP address of Prism Central
+- **\<Prism-Element-Admin-Password\>**: Prism Element admin account password
+- **\<Prism-Central-VM-Name\>**: Prism Central VM name
 
 ```bash
 # Disconnect Prism Element in Prism Central
@@ -176,8 +175,8 @@ ssh root@private-ip-address-of-one-ahv-servers
 
 Run this command to retrieve the UUID of your default storage, once you have modified the following information:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-IP\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-IP\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X GET "https://<Prism-Element-Ip>:9440/PrismGateway/services/rest/v2.0/storage_containers/" | jq -r '[.entities[] | select( .name | contains("default-container")) | .storage_container_uuid][0]'
@@ -189,7 +188,7 @@ Next, run this other command to retrieve the UUID of your cluster’s administra
 curl -s -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST https://<prism6element-IP>:9440/api/nutanix/v3/subnets/list -d {} | jq -r "[.entities[] | select( .spec.name | contains(\"<subnet name>\")) | .metadata.uuid][0]"
 ```
 
-Create a file named **PrismCentralXlarge.json** with the information below :
+Create a file named **PrismCentralXlarge.json** with the information below:
 
 ```json
 {
@@ -222,19 +221,19 @@ Create a file named **PrismCentralXlarge.json** with the information below :
 }
 ```
 
-Replace these items in the file :
+Replace these items in the file:
 
-- **\<Prism-Central-Password\>** : Password for the future Prism Central virtual machine.
-- **\<Default-Container-UUID\>** : UUID of the default storage retrieved earlier.
-- **\<Prism-Central-Private-IP-Address\>** : Private IP address of Prism Central.
-- **\<Nutanix-Network-Admin-UUID\>** : Nutanix Cluster Administration Network UUID.
-- **\<Nutanix-Network-Admin-mask\>** : Nutanix cluster administration network subnet mask.
-- **\<Nutanix-Network-Admin-Gateway\>** : Nutanix cluster administration network default gateway.
+- **\<Prism-Central-Password\>**: Password for the future Prism Central virtual machine.
+- **\<Default-Container-UUID\>**: UUID of the default storage retrieved earlier.
+- **\<Prism-Central-Private-IP-Address\>**: Private IP address of Prism Central.
+- **\<Nutanix-Network-Admin-UUID\>**: Nutanix Cluster Administration Network UUID.
+- **\<Nutanix-Network-Admin-mask\>**: Nutanix cluster administration network subnet mask.
+- **\<Nutanix-Network-Admin-Gateway\>**: Nutanix cluster administration network default gateway.
 
 Run this command to deploy your Prism Central virtual machine in X-Large mode, once you changed these settings:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-Private-IP-Address\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-Private-IP-Address\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST "https://<Prism-Element-Private-IP-Address>:9440/api/nutanix/v3/prism_central" -d @PrismCentralXlarge.json
@@ -248,17 +247,17 @@ Wait thirty minutes for this virtual machine to deploy.
 
 Enter the following command by editing these options to create a **pcregister.json** file:
 
-- **\<Prism-Central-Password\>** : Prism Central Password.
-- **\<Prism-Central-Private-IP-Address\>** : Private IP address of Prism Central.
+- **\<Prism-Central-Password\>**: Prism Central Password.
+- **\<Prism-Central-Private-IP-Address\>**: Private IP address of Prism Central.
 
 ```bash
 echo "{\"username\":\"admin\",\"password\":\"<Prism-Central-Password>\",\"port\":9440,\"ipAddresses\":[\"<Prism-Central-Private-IP-Address>\"]}" > pcregister.json
 ```
 
-Run this command to save Prism Element into your new Prism Central virtual machine, after changing these settings :
+Run this command to save Prism Element into your new Prism Central virtual machine, after changing these settings:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-Private-IP-Address\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-Private-IP-Address\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST "https://<Prism-Element-Private-IP-Address>:9440/PrismGateway/services/rest/v1/multicluster/prism_central/register" -d @pcregister.json
@@ -294,13 +293,13 @@ Click <code className="action">Confirm</code>.
 
 Expansion of Prism Central requires three additional private IP addresses, one for the virtual IP address and two for the new virtual machines.
 
-Scroll through the window and enter this information :
+Scroll through the window and enter this information:
 
-- **Virtual IP** : Prism Central virtual private IP address.
-- **VM Name** : Name of the second Prism Central virtual machine.
-- **IP** : Private IP address of the second virtual machine.
-- **VM Name** : Name of the third Prism Central virtual machine.
-- **IP** : Private IP address of the third virtual machine.
+- **Virtual IP**: Prism Central virtual private IP address.
+- **VM Name**: Name of the second Prism Central virtual machine.
+- **IP**: Private IP address of the second virtual machine.
+- **VM Name**: Name of the third Prism Central virtual machine.
+- **IP**: Private IP address of the third virtual machine.
 
 Click <code className="action">Expand</code>.
 
@@ -330,11 +329,11 @@ Click <code className="action">Add Server</code>.
 
 <img className="thumbnail" alt="03 Modify Prism Central Https Address 02" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/03-modify-prism-central-https-address02.png" loading="lazy" />
 
-Enter this information :
+Enter this information:
 
-- **Name (Optional)** : PC VIP as Prism Central Virtual IP address.
-- **IPv4 address** : Virtual Private IP address 
-- **Port** : 9440.
+- **Name (Optional)**: PC VIP as Prism Central Virtual IP address.
+- **IPv4 address**: Virtual Private IP address 
+- **Port**: 9440.
 
 Click <code className="action">Add</code>.
 
@@ -368,6 +367,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
@@ -1,10 +1,10 @@
 ---
 title: Uruchomienie NCM Self Service (CALM) (EN)
 description: How to enable Self Service (CALM) in your Prism Central
-lastUpdated: 2024-05-13
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
 **Find out how to set up NCM Self-Service (Calm) on your Prism Central.**
 
@@ -73,7 +73,7 @@ An error message appears during CALM deployment, ignore it, exit the window and 
 :::
 
 
-![00 Activate CALM 08](/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png)
+<img className="thumbnail" alt="00 Activate CALM 08" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png" loading="lazy" />
 
 ### Creating a project
 
@@ -153,7 +153,7 @@ Enter this information:
 - **vCPUs**: `4`
 - **Core per vCPU**: `1`
 - **Memory (GiB)**: `4`
-- **Image** : `WS2022EN-SYSPREPED`
+- **Image**: `WS2022EN-SYSPREPED`
 
 :::info
 The image is generated from a VM WINDOWS Server 2022 on which a sysprep was applied to reset the default configuration. When used with CALM, it is possible to automate the installation of a Windows OS from this type of image and apply settings stored in an XML file to it.

--- a/docs/pl/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
+++ b/docs/pl/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
@@ -1,10 +1,10 @@
 ---
 title: Konfigurowanie NAT do przekierowań portów za pomocą NSX (EN)
 description: Learn how to configure NAT to create port redirections
-lastUpdated: 2023-02-27
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
 **Learn how to configure NAT to create port redirections with NSX.**
 
@@ -32,13 +32,13 @@ In the NSX interface, go to the <code className="action">Networking</code> tab, 
 
 <img className="thumbnail" alt="01 Create DNAT rule 01" src="/images/hosted-private-cloud/powered-by-vmware/nsx-07-configure-nat-redirection/01-create-dnat-rules01.png" loading="lazy" />
 
-Fill in this information :
+Fill in this information:
 
-- **Action** : Select <code className="action">DNAT</code>.
-- **Source IP** : Enter the IP address or range of addresses that can use this redirection.
-- **Destination IP** : Public virtual IP address of NSX.
-- **Destination PORT** : Listening port on public address such as `2222`.
-- **Translated IP** : IP address of the virtual machine being redirected to.
+- **Action**: Select <code className="action">DNAT</code>.
+- **Source IP**: Enter the IP address or range of addresses that can use this redirection.
+- **Destination IP**: Public virtual IP address of NSX.
+- **Destination PORT**: Listening port on public address such as `2222`.
+- **Translated IP**: IP address of the virtual machine being redirected to.
 
 Then click on the <code className="action">three vertical dots</code> to the right of **Select Services**.
 
@@ -52,11 +52,11 @@ Click <code className="action">ADD SERVICE ENTRY</code>.
 
 <img className="thumbnail" alt="01 Create DNAT rule 04" src="/images/hosted-private-cloud/powered-by-vmware/nsx-07-configure-nat-redirection/01-create-dnat-rules04.png" loading="lazy" />
 
-Fill in these values :
+Fill in these values:
 
-- **Name** : Enter `SSH22`.
-- **Service Type** : Select <code className="action">TCP</code>.
-- **Source Ports** : Write the number `22`.
+- **Name**: Enter `SSH22`.
+- **Service Type**: Select <code className="action">TCP</code>.
+- **Source Ports**: Write the number `22`.
 
 Then click <code className="action">APPLY</code>.
 

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-central-expansion.mdx
@@ -1,12 +1,12 @@
 ---
 title: Substituição de Prism Central do modo Small pelo modo X-LARGE (EN)
 description: How to replace Prism Central with three X-Large VMs
-lastUpdated: 2023-12-18
+lastUpdated: 2026-06-11
 ---
 
 :::warning
 This guide is only intended for customers who are in **Bring Your Own License** mode on their Nutanix cluster.
-If you are not in this configuration, contact the [OVHcloud support teams](https://help.ovhcloud.com/csm?id=csm_get_help) to change the size of your Prism Central.
+If you are not in this configuration, contact the [OVHcloud support teams](/links/support-contact) to change the size of your Prism Central.
 
 :::
 
@@ -17,14 +17,14 @@ Before you make any changes, you must unregister your Prism Central license on y
 :::
 
 
-## Objectif
+## Objective
 
 **This guide will show you how to redeploy Prism-Central in X-LARGE mode across three virtual machines.**
 
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 
 :::
 
@@ -32,7 +32,6 @@ If you encounter any difficulties performing these actions, please contact a [sp
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -63,13 +62,13 @@ In the configuration pages for your Load Balancer, go to the <code className="ac
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 02" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer02.png" loading="lazy" />
 
-Enter this information :
+Enter this information:
 
-- **Name (optional)** : `PE SSH`.
-- **Protocol** : `TCP`.
-- **Port** : `22`.
-- **Datacenter** : `ALL`.
-- **Private network** : `nutanix`.
+- **Name (optional)**: `PE SSH`.
+- **Protocol**: `TCP`.
+- **Port**: `22`.
+- **Datacenter**: `ALL`.
+- **Private network**: `nutanix`.
 
 Then click <code className="action">Add</code>.
 
@@ -79,11 +78,11 @@ Within the server cluster, click <code className="action">Add server</code>.
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 04" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer04.png" loading="lazy" />
 
-Fill in these values :
+Fill in these values:
 
-- **Name (Optional)** : `PE SSH`.
-- **IPv4 address** : `Private IP address of Prism Element`.
-- **Port** : `22`.
+- **Name (Optional)**: `PE SSH`.
+- **IPv4 address**: `Private IP address of Prism Element`.
+- **Port**: `22`.
 
 And click <code className="action">Add</code>.
 
@@ -111,9 +110,9 @@ When the task is finished, go to the <code className="action">Front-ends</code> 
 
 Enter the following information:
 
-- **Name(Optional)** : `PE-FRONTEND`.
-- **Port** : `22`.
-- **Datacenter** : `ALL`.
+- **Name(Optional)**: `PE-FRONTEND`.
+- **Port**: `22`.
+- **Datacenter**: `ALL`.
 
 Then click <code className="action">Show</code>.
 
@@ -141,7 +140,7 @@ Go to the <code className="action">Tasks</code> tab to see the progress of the c
 
 <img className="thumbnail" alt="01 Add ssh PE on Load Balancer 16" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/01-add-pe-ssh-on-loadbalancer16.png" loading="lazy" />
 
-You have finished configuring the Load Balancer. You can now log in via SSH to the Prism Element console, with this information :
+You have finished configuring the Load Balancer. You can now log in via SSH to the Prism Element console, with this information:
 
 ```bash
 ssh admin@nutanix-cluster-ovhcloud-fqdn
@@ -157,9 +156,9 @@ ssh nutanix@nutanix-cluster-ovhcloud-fqdn
 
 Run these commands after you have modified the following information:
 
-- **\<Prism-Central-Private-IP-address\>** : Private IP address of Prism Central
-- **\<Prism-Element-Admin-Password\>** : Prism Element admin account password
-- **\<Prism-Central-VM-Name\>** : Prism Central VM name
+- **\<Prism-Central-Private-IP-address\>**: Private IP address of Prism Central
+- **\<Prism-Element-Admin-Password\>**: Prism Element admin account password
+- **\<Prism-Central-VM-Name\>**: Prism Central VM name
 
 ```bash
 # Disconnect Prism Element in Prism Central
@@ -176,8 +175,8 @@ ssh root@private-ip-address-of-one-ahv-servers
 
 Run this command to retrieve the UUID of your default storage, once you have modified the following information:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-IP\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-IP\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X GET "https://<Prism-Element-Ip>:9440/PrismGateway/services/rest/v2.0/storage_containers/" | jq -r '[.entities[] | select( .name | contains("default-container")) | .storage_container_uuid][0]'
@@ -189,7 +188,7 @@ Next, run this other command to retrieve the UUID of your cluster’s administra
 curl -s -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST https://<prism6element-IP>:9440/api/nutanix/v3/subnets/list -d {} | jq -r "[.entities[] | select( .spec.name | contains(\"<subnet name>\")) | .metadata.uuid][0]"
 ```
 
-Create a file named **PrismCentralXlarge.json** with the information below :
+Create a file named **PrismCentralXlarge.json** with the information below:
 
 ```json
 {
@@ -222,19 +221,19 @@ Create a file named **PrismCentralXlarge.json** with the information below :
 }
 ```
 
-Replace these items in the file :
+Replace these items in the file:
 
-- **\<Prism-Central-Password\>** : Password for the future Prism Central virtual machine.
-- **\<Default-Container-UUID\>** : UUID of the default storage retrieved earlier.
-- **\<Prism-Central-Private-IP-Address\>** : Private IP address of Prism Central.
-- **\<Nutanix-Network-Admin-UUID\>** : Nutanix Cluster Administration Network UUID.
-- **\<Nutanix-Network-Admin-mask\>** : Nutanix cluster administration network subnet mask.
-- **\<Nutanix-Network-Admin-Gateway\>** : Nutanix cluster administration network default gateway.
+- **\<Prism-Central-Password\>**: Password for the future Prism Central virtual machine.
+- **\<Default-Container-UUID\>**: UUID of the default storage retrieved earlier.
+- **\<Prism-Central-Private-IP-Address\>**: Private IP address of Prism Central.
+- **\<Nutanix-Network-Admin-UUID\>**: Nutanix Cluster Administration Network UUID.
+- **\<Nutanix-Network-Admin-mask\>**: Nutanix cluster administration network subnet mask.
+- **\<Nutanix-Network-Admin-Gateway\>**: Nutanix cluster administration network default gateway.
 
 Run this command to deploy your Prism Central virtual machine in X-Large mode, once you changed these settings:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-Private-IP-Address\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-Private-IP-Address\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST "https://<Prism-Element-Private-IP-Address>:9440/api/nutanix/v3/prism_central" -d @PrismCentralXlarge.json
@@ -248,17 +247,17 @@ Wait thirty minutes for this virtual machine to deploy.
 
 Enter the following command by editing these options to create a **pcregister.json** file:
 
-- **\<Prism-Central-Password\>** : Prism Central Password.
-- **\<Prism-Central-Private-IP-Address\>** : Private IP address of Prism Central.
+- **\<Prism-Central-Password\>**: Prism Central Password.
+- **\<Prism-Central-Private-IP-Address\>**: Private IP address of Prism Central.
 
 ```bash
 echo "{\"username\":\"admin\",\"password\":\"<Prism-Central-Password>\",\"port\":9440,\"ipAddresses\":[\"<Prism-Central-Private-IP-Address>\"]}" > pcregister.json
 ```
 
-Run this command to save Prism Element into your new Prism Central virtual machine, after changing these settings :
+Run this command to save Prism Element into your new Prism Central virtual machine, after changing these settings:
 
-- **\<Prism-Element-Password\>** : Prism Element admin account password.
-- **\<Prism-Element-Private-IP-Address\>** : Private IP address of Prism Element.
+- **\<Prism-Element-Password\>**: Prism Element admin account password.
+- **\<Prism-Element-Private-IP-Address\>**: Private IP address of Prism Element.
 
 ```bash
 curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:<Prism-Element-Password>" -X POST "https://<Prism-Element-Private-IP-Address>:9440/PrismGateway/services/rest/v1/multicluster/prism_central/register" -d @pcregister.json
@@ -294,13 +293,13 @@ Click <code className="action">Confirm</code>.
 
 Expansion of Prism Central requires three additional private IP addresses, one for the virtual IP address and two for the new virtual machines.
 
-Scroll through the window and enter this information :
+Scroll through the window and enter this information:
 
-- **Virtual IP** : Prism Central virtual private IP address.
-- **VM Name** : Name of the second Prism Central virtual machine.
-- **IP** : Private IP address of the second virtual machine.
-- **VM Name** : Name of the third Prism Central virtual machine.
-- **IP** : Private IP address of the third virtual machine.
+- **Virtual IP**: Prism Central virtual private IP address.
+- **VM Name**: Name of the second Prism Central virtual machine.
+- **IP**: Private IP address of the second virtual machine.
+- **VM Name**: Name of the third Prism Central virtual machine.
+- **IP**: Private IP address of the third virtual machine.
 
 Click <code className="action">Expand</code>.
 
@@ -330,11 +329,11 @@ Click <code className="action">Add Server</code>.
 
 <img className="thumbnail" alt="03 Modify Prism Central Https Address 02" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/35-prism-central-expansion/03-modify-prism-central-https-address02.png" loading="lazy" />
 
-Enter this information :
+Enter this information:
 
-- **Name (Optional)** : PC VIP as Prism Central Virtual IP address.
-- **IPv4 address** : Virtual Private IP address 
-- **Port** : 9440.
+- **Name (Optional)**: PC VIP as Prism Central Virtual IP address.
+- **IPv4 address**: Virtual Private IP address 
+- **Port**: 9440.
 
 Click <code className="action">Add</code>.
 
@@ -368,6 +367,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
@@ -1,10 +1,10 @@
 ---
 title: Criação de NCM Self Service (CALM) (EN)
 description: How to enable Self Service (CALM) in your Prism Central
-lastUpdated: 2024-05-13
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
 **Find out how to set up NCM Self-Service (Calm) on your Prism Central.**
 
@@ -73,7 +73,7 @@ An error message appears during CALM deployment, ignore it, exit the window and 
 :::
 
 
-![00 Activate CALM 08](/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png)
+<img className="thumbnail" alt="00 Activate CALM 08" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/36-self-service-calm/00-activate-calm08.png" loading="lazy" />
 
 ### Creating a project
 
@@ -153,7 +153,7 @@ Enter this information:
 - **vCPUs**: `4`
 - **Core per vCPU**: `1`
 - **Memory (GiB)**: `4`
-- **Image** : `WS2022EN-SYSPREPED`
+- **Image**: `WS2022EN-SYSPREPED`
 
 :::info
 The image is generated from a VM WINDOWS Server 2022 on which a sysprep was applied to reset the default configuration. When used with CALM, it is possible to automate the installation of a Windows OS from this type of image and apply settings stored in an XML file to it.

--- a/docs/pt/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
+++ b/docs/pt/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-nat-redirection.mdx
@@ -1,10 +1,10 @@
 ---
 title: Configurando NAT para redirecionamentos de porta com NSX (EN)
 description: Learn how to configure NAT to create port redirections
-lastUpdated: 2023-02-27
+lastUpdated: 2026-06-11
 ---
 
-## Objectif
+## Objective
 
 **Learn how to configure NAT to create port redirections with NSX.**
 
@@ -32,13 +32,13 @@ In the NSX interface, go to the <code className="action">Networking</code> tab, 
 
 <img className="thumbnail" alt="01 Create DNAT rule 01" src="/images/hosted-private-cloud/powered-by-vmware/nsx-07-configure-nat-redirection/01-create-dnat-rules01.png" loading="lazy" />
 
-Fill in this information :
+Fill in this information:
 
-- **Action** : Select <code className="action">DNAT</code>.
-- **Source IP** : Enter the IP address or range of addresses that can use this redirection.
-- **Destination IP** : Public virtual IP address of NSX.
-- **Destination PORT** : Listening port on public address such as `2222`.
-- **Translated IP** : IP address of the virtual machine being redirected to.
+- **Action**: Select <code className="action">DNAT</code>.
+- **Source IP**: Enter the IP address or range of addresses that can use this redirection.
+- **Destination IP**: Public virtual IP address of NSX.
+- **Destination PORT**: Listening port on public address such as `2222`.
+- **Translated IP**: IP address of the virtual machine being redirected to.
 
 Then click on the <code className="action">three vertical dots</code> to the right of **Select Services**.
 
@@ -52,11 +52,11 @@ Click <code className="action">ADD SERVICE ENTRY</code>.
 
 <img className="thumbnail" alt="01 Create DNAT rule 04" src="/images/hosted-private-cloud/powered-by-vmware/nsx-07-configure-nat-redirection/01-create-dnat-rules04.png" loading="lazy" />
 
-Fill in these values :
+Fill in these values:
 
-- **Name** : Enter `SSH22`.
-- **Service Type** : Select <code className="action">TCP</code>.
-- **Source Ports** : Write the number `22`.
+- **Name**: Enter `SSH22`.
+- **Service Type**: Select <code className="action">TCP</code>.
+- **Source Ports**: Write the number `22`.
 
 Then click <code className="action">APPLY</code>.
 


### PR DESCRIPTION
Translations & fixes:

- 5 FR guides in EN tree translated to EN
- Heading fixes (Objectif)
- CP-NAV redundancy cleanup (nsx, prism + their locales)
- RACI EN page aligned to the approved sibling (VMware) and verified faithful to the French source with every responsibility code preserved
- External links normalized to uniform new-format
- EN fixes