### PR TITLE
fix(theme): amend tabs component to automate no-sync of sequential "steps"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,6 +249,21 @@ import { Tab, Tabs } from '@rspress/core/theme';
 </Tabs>
 ```
 
+**Tab selection syncs by default.** Tab blocks that share the same labels sync their selected tab and remember it across pages — so all "Via the OVHcloud Control Panel" / "Via the OVHcloud API" blocks (or `Linux` / `Windows`, etc.) switch together. This is automatic; you don't add anything.
+
+**Sequential "Step" tabs are never synced.** Numbered sets — `Step 1` / `Step 2` / `Step 3` (including branched ones like `Step 3 - IMAP` / `Step 3 - POP3`), `Option 1` / `Option 2`, `Étape 1…` — are detected automatically and kept independent, so picking a step in one block won't move another block (on the page or across navigation). No action needed.
+
+**Opting a block out of sync (`noSync`)** — for the rare *non-sequential* block that still shouldn't sync, add the `noSync` prop:
+
+```mdx
+<Tabs noSync>
+  <Tab label="Plan A">…</Tab>
+  <Tab label="Plan B">…</Tab>
+</Tabs>
+```
+
+(Detection and the `noSync` opt-out live in `theme/components/SyncedTabs/index.tsx`.)
+
 ### Images
 
 Inline images use the standard Markdown syntax with an absolute `/images/...` path:

--- a/docs/en/internal/format-reference.mdx
+++ b/docs/en/internal/format-reference.mdx
@@ -318,6 +318,21 @@ Open PuTTY and enter `192.0.2.1` in the **Host Name** field. Under **Connection 
 </Tab>
 </Tabs>
 
+**Tab sync & the `noSync` opt-out:** tab blocks that share the same labels stay in sync and remember the choice across pages — this is automatic, no `groupId` needed. Numbered "Step" sets (e.g. `Step 1` / `Step 2` / `Step 3 - IMAP`) are detected and kept independent so they never sync. To stop a *non-sequential* block from syncing, add `noSync`:
+
+<Tabs noSync>
+<Tab label="Plan A">
+
+This block keeps purely local state — it will not sync with other `Plan A` / `Plan B` blocks, nor persist the selection across navigation.
+
+</Tab>
+<Tab label="Plan B">
+
+Independent local state only.
+
+</Tab>
+</Tabs>
+
 ---
 
 ### 12 — Embedded video

--- a/theme/components/SyncedTabs/index.tsx
+++ b/theme/components/SyncedTabs/index.tsx
@@ -3,6 +3,14 @@ import type { ComponentProps, ReactElement } from 'react';
 import { Children, isValidElement } from 'react';
 
 type BaseTabsProps = ComponentProps<typeof BaseTabs>;
+type TabsProps = BaseTabsProps & {
+  /**
+   * Opt this block OUT of cross-block sync + persistence (renders purely local).
+   * Escape hatch for the rare non-sequential block that still shouldn't sync —
+   * sequential "Step N" tabs are excluded automatically (see isSequential).
+   */
+  noSync?: boolean;
+};
 
 /**
  * Build a stable groupId from the set of tab labels.
@@ -25,8 +33,33 @@ function groupIdFromLabels(labels: string[]): string {
     .replace(/^-+|-+$/g, '')}`;
 }
 
-export function Tabs(props: BaseTabsProps): ReactElement {
-  // Respect an explicit groupId if a guide sets one.
+/**
+ * A "sequential" label-set is a numbered series — every label starts with the
+ * same word(s) followed by a number: "Step 1" / "Step 2" / "Step 3 - IMAP",
+ * "Étape 1…", "Option 1…". These are ordered/branching content, not a user
+ * preference, so they must NOT sync or persist across blocks (otherwise picking
+ * "Step 3" in one block flips every other step block on the page and remembers
+ * it across navigation).
+ *
+ * Detection is purely structural — same leading text + a trailing number, with
+ * any suffix allowed — so it is locale-agnostic (no word list) and also catches
+ * branched steps like "Step 3 - IMAP" / "Step 3 - POP3".
+ */
+function isSequential(labels: string[]): boolean {
+  if (labels.length < 2) return false;
+  const leads = labels.map((label) =>
+    /^(.+?)\s+\d+\b/.exec(label.trim())?.[1]?.trim().toLowerCase(),
+  );
+  return leads.every((lead) => Boolean(lead)) && new Set(leads).size === 1;
+}
+
+export function Tabs({ noSync, ...props }: TabsProps): ReactElement {
+  // 1. Explicit opt-out → keep this block local (no sync, no persistence).
+  if (noSync) {
+    return <BaseTabs {...props} />;
+  }
+
+  // 2. Respect an explicit groupId if a guide sets one.
   if (props.groupId) {
     return <BaseTabs {...props} />;
   }
@@ -38,8 +71,12 @@ export function Tabs(props: BaseTabsProps): ReactElement {
       (label): label is string => typeof label === 'string' && label.length > 0,
     );
 
-  // No usable labels (e.g. index-keyed tabs) → leave default local behaviour.
-  const groupId = labels.length > 0 ? groupIdFromLabels(labels) : undefined;
+  // 3. Sequential (numbered) tabs — e.g. "Step 1/2/3" — must stay local.
+  // 4. Otherwise derive a stable groupId so identical-label blocks sync.
+  const groupId =
+    labels.length > 0 && !isSequential(labels)
+      ? groupIdFromLabels(labels)
+      : undefined;
 
   return <BaseTabs {...props} groupId={groupId} />;
 }


### PR DESCRIPTION
- Problem: SyncedTabs (PR #127) gives every <Tabs> block a groupId derived from its tab labels, so all same-labelled blocks sync their selection and persist it across pages. This wrongly hits sequential Step tabs; pick "Step 3" in one block and every other step block jumps to 3 and remembers it.

 - Solution: In the wrapper, skip the groupId when the labels are a numbered sequence (every label = same leading word + a number, suffix allowed → locale-agnostic). Such blocks stay local (no sync/persist). Everything else (languages, interfaces, OS, content tabs) keeps syncing. Plus a <Tabs noSync> opt-out for any future non-sequential exception.

Verified compile (Biome + tsc --noEmit: 0 errors).