### PR TITLE
fix(seo): obfuscate example/localhost links + stop /{lang}/index on language switch

### DIFF
--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -106,9 +106,9 @@ ssh -L 18789:127.0.0.1:18789 user@YOUR_VPS_IP
 cat ~/openclaw/data/openclaw.json | grep '"token":'
 ```
 
-Open your browser and go to: [http://127.0.0.1:18789](http://127.0.0.1:18789).
+Open your browser and go to: `http://127.0.0.1:18789`.
 
-*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN*
+*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN`*
 
 The rest takes place in the **Overview** menu: enter your **Gateway Token** to log in.
 

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -349,7 +349,7 @@ Press the <code className="action">Enter</code> key to complete the command line
 <a name="configurepfsenseoptions"></a>
 #### Step 2.9 Configure some options through the web interface
 
-Connect to the pfSense Web Console with the URL [https://192.168.10.254](https://192.168.10.254) from a cluster virtual machine on the **AHV LAN: Base**.
+Connect to the pfSense Web Console with the URL `https://192.168.10.254` from a cluster virtual machine on the **AHV LAN: Base**.
 
 Enter the following information:
 

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -320,7 +320,7 @@ Press the <code className="action">Enter</code> key to complete the command line
 
 ### Configure some options through the web interface
 
-Connect to the pfSense Web Console with the URL [https://192.168.10.254](https://192.168.10.254) from a cluster virtual machine on the **AHV LAN: Base**.
+Connect to the pfSense Web Console with the URL `https://192.168.10.254` from a cluster virtual machine on the **AHV LAN: Base**.
 
 Enter the following information:
 

--- a/docs/de/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
+++ b/docs/de/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
@@ -101,7 +101,7 @@ Open a terminal, move to the project folder (`ai-training-examples/apps/flask/co
 docker compose -f "flask-docker-compose.yml" up -d --build
 ```
 
-This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your [localhost](http://0.0.0.0:5000/) on port 5000, the port of your frontend app. 
+This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your `http://localhost:5000` on port 5000, the port of your frontend app. 
 
 To stop the containers, run this command: 
 

--- a/docs/de/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
+++ b/docs/de/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
@@ -68,7 +68,7 @@ public class PublicCloudUserTool {
 At the time of writing, there are two types of MCP servers: [stdio](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio) and [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).
 This blog post uses the Streamable mode thanks to Quarkus with the quarkus-mcp-server-sse extension.
 
-Run your server with the quarkus dev command. Your MCP server will be used on [http://localhost:8080](http://localhost:8080).
+Run your server with the quarkus dev command. Your MCP server will be used on `http://localhost:8080`.
 
 ### Using the MCP server with LangChain4J
 

--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
@@ -294,7 +294,7 @@ Let's try to access our new web page:
 kubectl proxy
 ```
 
-and open the URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and open the URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 Now let's try to see if the data is persistent by deleting our current Nginx pod:
 
@@ -314,7 +314,7 @@ We should now check that our web page is still accessible:
 kubectl proxy
 ```
 
-and browse the same URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and browse the same URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 ## Clean your cluster
 

--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
@@ -185,7 +185,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-[http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/)
+`http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/`
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/docs/de/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -434,7 +434,7 @@ Create your first administrator 💻 by going to the administration panel at:
 [2021-12-31 13:26:36.173] http: GET /admin/fde9b1ad0670d29a2516.png (1 ms) 200
 ```
 
-Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page http://localhost:1337/admin/auth/register-admin.
+Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page `http://localhost:1337/admin/auth/register-admin`.
 
 <img className="thumbnail" alt="Strapi admin login creation page" src="/images/public-cloud/databases/postgresql-tuto-01-connect-strapi-to-managed-postgresql/postgresql-tuto-01-connect-strapi-to-managed-postgresql12.png" loading="lazy" />
 

--- a/docs/de/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
@@ -170,7 +170,7 @@ Geben Sie die folgenden Informationenein, um das Modul zu konfigurieren:
 Zur Erinnerung: Dieses Verzeichnis muss vollständig leer sein.
 
 Wenn Sie zusätzlich ein Unterverzeichnis im `Installationspfad` eingeben, erscheint es in der URL unter der Ihr 1-Klick-Modul abrufbar sein wird.
-Wird also beispielsweise ein Verzeichnis namens *test* in das Formular eingetragen, erhält die URL für das 1-Klick-Modul die Form **http://domain.tld/test/**.
+Wird also beispielsweise ein Verzeichnis namens *test* in das Formular eingetragen, erhält die URL für das 1-Klick-Modul die Form `http://domain.tld/test/`.
 
 Wenn nötig, lesen Sie unsere Anleitung „[Mehrere Websites auf einem Webhosting einrichten](/guides/web-cloud/web-hosting/multisites-configure-multisite)“, um das Zielverzeichnis Ihres Domainnamens zu ändern.
 

--- a/docs/de/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -108,7 +108,7 @@ Lesen Sie unsere Anleitung zur [Einrichtung einer Multisite auf einem Webhosting
 
 Eine Website muss nicht im obersten Wurzelverzeichnis abgelegt werden. Sie können auch einen Unterordner darin erstellen (z. B. **MyWebsite**), und darin die Dateien der Website platzieren.
 
-In diesem Fall hat die URL für den Zugriff auf die Website folgende Form: **http://domain.tld/MyWebsite**.
+In diesem Fall hat die URL für den Zugriff auf die Website folgende Form: `http://domain.tld/MyWebsite`.
 
 Wenn sich Ihre Website-Dateien nicht direkt im Wurzelverzeichnis befinden, der für Ihren Domainnamen als Multisite deklariert wurde, und Sie den Namen des Unterordners nicht in der URL Ihrer Website anzeigen möchten, bearbeiten Sie die Datei ".htaccess" im Wurzelverzeichnis der Website. 
 
@@ -121,7 +121,7 @@ RewriteCond %{REQUEST_URI} !^/MyWebsite
 RewriteRule ^(.*)$ /MyWebsite/
 ```
 
-In unserem Beispiel wird die Adresse Ihrer Website dann als **http://domain.tld** angezeigt, während die aufgerufene Seite in Wirklichkeit **http://domain.tld/MyWebsite** ist.
+In unserem Beispiel wird die Adresse Ihrer Website dann als `http://domain.tld` angezeigt, während die aufgerufene Seite in Wirklichkeit `http://domain.tld/MyWebsite` ist.
 
 ### Automatische Umleitung zur Verwendung von HTTPS, wenn die Website über eine HTTP-URL aufgerufen wurde
 

--- a/docs/de/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -47,7 +47,7 @@ Duplicate Content bedeutet, dass der gleiche Inhalt über verschiedene URLs vorh
 
 Um dies zu vermeiden, empfehlen wir, bei einer korrekten Funktion Ihrer Website mit HTTPS alle URLs auf HTTPS umzuschreiben. So können Ihre Besucher automatisch auf die HTTPS-Adresse Ihres Webinhalts weitergeleitet werden, und es ist nur eine Adresse für den gleichen Inhalt verfügbar.
 
-Hier ein Beispiel für eine Weiterleitung, die Sie in die Datei „[.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite)“ im Wurzelverzeichnis Ihrer Website einfügen können (ersetzen Sie die URL *https://www.yourdomain.tld* durch Ihre eigene):
+Hier ein Beispiel für eine Weiterleitung, die Sie in die Datei „[.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite)“ im Wurzelverzeichnis Ihrer Website einfügen können (ersetzen Sie die URL `https://www.yourdomain.tld` durch Ihre eigene):
 
 ```
 RewriteEngine On

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -349,7 +349,7 @@ Press the <code className="action">Enter</code> key to complete the command line
 <a name="configurepfsenseoptions"></a>
 #### Step 2.9 Configure some options through the web interface
 
-Connect to the pfSense Web Console with the URL [https://192.168.10.254](https://192.168.10.254) from a cluster virtual machine on the **AHV LAN: Base**.
+Connect to the pfSense Web Console with the URL `https://192.168.10.254` from a cluster virtual machine on the **AHV LAN: Base**.
 
 Enter the following information:
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -320,7 +320,7 @@ Press the <code className="action">Enter</code> key to complete the command line
 
 ### Configure some options through the web interface
 
-Connect to the pfSense Web Console with the URL [https://192.168.10.254](https://192.168.10.254) from a cluster virtual machine on the **AHV LAN: Base**.
+Connect to the pfSense Web Console with the URL `https://192.168.10.254` from a cluster virtual machine on the **AHV LAN: Base**.
 
 Enter the following information:
 

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/using-grafana-with-logs.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/using-grafana-with-logs.mdx
@@ -53,7 +53,7 @@ Then follow the Grafana installation guide according to your platform: [http://d
 
 ### Launch it!
 
-If everything is setup properly, launch your favorite browser, and point it to [http://localhost:3000](http://localhost:3000) Once logged in with your grafana credentials, reach data sources panel to setup your Logs Data Platform datasource:
+If everything is setup properly, launch your favorite browser, and point it to `http://localhost:3000` Once logged in with your grafana credentials, reach data sources panel to setup your Logs Data Platform datasource:
 
 <img className="thumbnail" alt="Data source_1" src="/images/manage-and-operate/observability/logs-data-platform/visualization-grafana/datasource_1.png" loading="lazy" />
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
@@ -101,7 +101,7 @@ Open a terminal, move to the project folder (`ai-training-examples/apps/flask/co
 docker compose -f "flask-docker-compose.yml" up -d --build
 ```
 
-This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your [localhost](http://0.0.0.0:5000/) on port 5000, the port of your frontend app. 
+This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your `http://localhost:5000` on port 5000, the port of your frontend app. 
 
 To stop the containers, run this command: 
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
@@ -68,7 +68,7 @@ public class PublicCloudUserTool {
 At the time of writing, there are two types of MCP servers: [stdio](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio) and [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).
 This blog post uses the Streamable mode thanks to Quarkus with the quarkus-mcp-server-sse extension.
 
-Run your server with the quarkus dev command. Your MCP server will be used on [http://localhost:8080](http://localhost:8080).
+Run your server with the quarkus dev command. Your MCP server will be used on `http://localhost:8080`.
 
 ### Using the MCP server with LangChain4J
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
@@ -294,7 +294,7 @@ Let's try to access our new web page:
 kubectl proxy
 ```
 
-and open the URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and open the URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 Now let's try to see if the data is persistent by deleting our current Nginx pod:
 
@@ -314,7 +314,7 @@ We should now check that our web page is still accessible:
 kubectl proxy
 ```
 
-and browse the same URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and browse the same URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 ## Clean your cluster
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
@@ -185,7 +185,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-[http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/)
+`http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/`
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -434,7 +434,7 @@ Create your first administrator 💻 by going to the administration panel at:
 [2021-12-31 13:26:36.173] http: GET /admin/fde9b1ad0670d29a2516.png (1 ms) 200
 ```
 
-Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page http://localhost:1337/admin/auth/register-admin.
+Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page `http://localhost:1337/admin/auth/register-admin`.
 
 <img className="thumbnail" alt="Strapi admin login creation page" src="/images/public-cloud/databases/postgresql-tuto-01-connect-strapi-to-managed-postgresql/postgresql-tuto-01-connect-strapi-to-managed-postgresql12.png" loading="lazy" />
 

--- a/docs/en/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
@@ -170,7 +170,7 @@ Check that the `Installation path` contains the directory where you want to inst
 As a reminder, this directory must be completely empty.
 
 In addition, if you enter a subdirectory in the `Installation path` field, it will appear in the URL used to access your 1-click module.
-For example, if you enter the subdirectory *test*, the URL to access the 1-click module will look like this: **http://domain.tld/test/**.
+For example, if you enter the subdirectory *test*, the URL to access the 1-click module will look like this: `http://domain.tld/test/`.
 
 If you need assistance, please refer to our guide on [Hosting multiple websites on your web hosting plan](/guides/web-cloud/web-hosting/multisites-configure-multisite) to modify your domain name’s target directory.
 

--- a/docs/en/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -109,7 +109,7 @@ Please refer to our guide on [Hosting multiple websites on your Web Hosting plan
 
 Some users do not place their websites directly in the `root folder`, but inside a subfolder (for example: **MyWebsite**) inside this `root folder`.
 
-In this case, the URL to access the site will be as follows: **http://domain.tld/MyWebsite**.
+In this case, the URL to access the site will be as follows: `http://domain.tld/MyWebsite`.
 
 If your website is not located directly in the `root folder` declared for your domain name in `Multisites`, and you do not want to display the folder name in your website’s URL, edit the ".htaccess" file located in the root directory of your website. 
 
@@ -122,7 +122,7 @@ RewriteCond %{REQUEST_URI} !^/MyWebsite
 RewriteRule ^(.*)$ /MyWebsite/
 ```
 
-In our example, this forces your website address to be displayed as **http://domain.tld**, whereas in reality the page called is **http://domain.tld/MyWebsite**.
+In our example, this forces your website address to be displayed as `http://domain.tld`, whereas in reality the page called is `http://domain.tld/MyWebsite`.
 
 ### Automatically redirect a visitor to use HTTPS when the website was accessed using a HTTP URL 
 

--- a/docs/en/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -47,7 +47,7 @@ Duplicating content means having the same content on multiple different URLs. Se
 
 To avoid this type of situation, when your website works properly in HTTPS, we recommend redirecting the content from HTTP to HTTPS. This will allow your visitors to be automatically redirected to the address of your web content in HTTPS and only one address will be available for this same content. 
 
-Here is an example of a redirection that you can add to the file "[.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite)", at the root of your website (by replacing the URL *https://www.yourdomain.tld* with your own):
+Here is an example of a redirection that you can add to the file "[.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite)", at the root of your website (by replacing the URL `https://www.yourdomain.tld` with your own):
 
 ```
 RewriteEngine On

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -106,9 +106,9 @@ ssh -L 18789:127.0.0.1:18789 user@YOUR_VPS_IP
 cat ~/openclaw/data/openclaw.json | grep '"token":'
 ```
 
-Open your browser and go to: [http://127.0.0.1:18789](http://127.0.0.1:18789).
+Open your browser and go to: `http://127.0.0.1:18789`.
 
-*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN*
+*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN`*
 
 The rest takes place in the **Overview** menu: enter your **Gateway Token** to log in.
 

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -349,7 +349,7 @@ Press the <code className="action">Enter</code> key to complete the command line
 <a name="configurepfsenseoptions"></a>
 #### Step 2.9 Configure some options through the web interface
 
-Connect to the pfSense Web Console with the URL [https://192.168.10.254](https://192.168.10.254) from a cluster virtual machine on the **AHV LAN: Base**.
+Connect to the pfSense Web Console with the URL `https://192.168.10.254` from a cluster virtual machine on the **AHV LAN: Base**.
 
 Enter the following information:
 

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -320,7 +320,7 @@ Press the <code className="action">Enter</code> key to complete the command line
 
 ### Configure some options through the web interface
 
-Connect to the pfSense Web Console with the URL [https://192.168.10.254](https://192.168.10.254) from a cluster virtual machine on the **AHV LAN: Base**.
+Connect to the pfSense Web Console with the URL `https://192.168.10.254` from a cluster virtual machine on the **AHV LAN: Base**.
 
 Enter the following information:
 

--- a/docs/es/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
+++ b/docs/es/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
@@ -101,7 +101,7 @@ Open a terminal, move to the project folder (`ai-training-examples/apps/flask/co
 docker compose -f "flask-docker-compose.yml" up -d --build
 ```
 
-This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your [localhost](http://0.0.0.0:5000/) on port 5000, the port of your frontend app. 
+This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your `http://localhost:5000` on port 5000, the port of your frontend app. 
 
 To stop the containers, run this command: 
 

--- a/docs/es/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
+++ b/docs/es/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
@@ -68,7 +68,7 @@ public class PublicCloudUserTool {
 At the time of writing, there are two types of MCP servers: [stdio](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio) and [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).
 This blog post uses the Streamable mode thanks to Quarkus with the quarkus-mcp-server-sse extension.
 
-Run your server with the quarkus dev command. Your MCP server will be used on [http://localhost:8080](http://localhost:8080).
+Run your server with the quarkus dev command. Your MCP server will be used on `http://localhost:8080`.
 
 ### Using the MCP server with LangChain4J
 

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
@@ -294,7 +294,7 @@ Let's try to access our new web page:
 kubectl proxy
 ```
 
-and open the URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and open the URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 Now let's try to see if the data is persistent by deleting our current Nginx pod:
 
@@ -314,7 +314,7 @@ We should now check that our web page is still accessible:
 kubectl proxy
 ```
 
-and browse the same URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and browse the same URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 ## Clean your cluster
 

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
@@ -185,7 +185,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-[http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/)
+`http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/`
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/docs/es/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -434,7 +434,7 @@ Create your first administrator 💻 by going to the administration panel at:
 [2021-12-31 13:26:36.173] http: GET /admin/fde9b1ad0670d29a2516.png (1 ms) 200
 ```
 
-Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page http://localhost:1337/admin/auth/register-admin.
+Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page `http://localhost:1337/admin/auth/register-admin`.
 
 <img className="thumbnail" alt="Strapi admin login creation page" src="/images/public-cloud/databases/postgresql-tuto-01-connect-strapi-to-managed-postgresql/postgresql-tuto-01-connect-strapi-to-managed-postgresql12.png" loading="lazy" />
 

--- a/docs/es/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
@@ -171,7 +171,7 @@ Compruebe, para el formulario `Ruta de instalación`, que el directorio pre-comp
 Le recordamos que este directorio debe estar completamente vacío.
 
 Además, si introduce un subdirectorio en la `Ruta de instalación`, aparecerá en la URL de acceso a su módulo en un clic.
-Por ejemplo, si introduzco un subdirectorio *test* en el formulario, la URL de acceso a mi "módulo en un clic" tendrá el siguiente formato: **http://domain.tld/test/**.
+Por ejemplo, si introduzco un subdirectorio *test* en el formulario, la URL de acceso a mi "módulo en un clic" tendrá el siguiente formato: `http://domain.tld/test/`.
 
 Si lo necesita, consulte nuestra guía "[Cómo compartir un alojamiento web con varios sitios web](/guides/web-cloud/web-hosting/multisites-configure-multisite)" para modificar el directorio de destino de su dominio.
 

--- a/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-pico.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-pico.mdx
@@ -60,7 +60,7 @@ Después de la instalación, hay varias carpetas y archivos en el directorio pri
 
 #### Agregar contenido
 
-**1. Crear páginas** : Para añadir una nueva página al sitio web, cree un nuevo archivo Markdown (.md) en la carpeta `content/`. El nombre del archivo determinará la dirección URL de la página. Por ejemplo, `about.md` estará disponible en http://yourdomain.tld/about.
+**1. Crear páginas** : Para añadir una nueva página al sitio web, cree un nuevo archivo Markdown (.md) en la carpeta `content/`. El nombre del archivo determinará la dirección URL de la página. Por ejemplo, `about.md` estará disponible en `http://yourdomain.tld/about`.
 
 **2. Escribir contenido**: abra el archivo Markdown con un editor de texto y comience a escribir el contenido. Utilice la sintaxis Markdown para dar formato al texto, crear vínculos, insertar imágenes, etc. Por ejemplo, si desea editar la página principal (home) de su sitio web, abra el archivo `index.md` e inserte el contenido que desee.
 

--- a/docs/es/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -105,7 +105,7 @@ Si desea más información sobre el asunto, consulte nuestra guía sobre la [con
 
 Algunos usuarios no ubican su sitio web directamente en la base de la `carpeta raíz`. Crean una subcarpeta (por ejemplo: **MyWebsite**) en su `carpeta raíz` para poner su sitio web en ella.
 
-En ese caso, la URL para acceder al sitio tendrá la forma siguiente: **http://domain.tld/MyWebsite**.
+En ese caso, la URL para acceder al sitio tendrá la forma siguiente: `http://domain.tld/MyWebsite`.
 
 Si su sitio web no está directamente en el `carpeta raíz` declarado en multisitios para su nombre de dominio y no desea mostrar el nombre de la carpeta en la URL de su sitio, edite el archivo ".htaccess" situado en la raíz del repertorio que contiene su sitio web. 
 
@@ -118,7 +118,7 @@ RewriteCond %{REQUEST_URI} !^/MyWebsite
 RewriteRule ^(.*)$ /MyWebsite/
 ```
 
-En nuestro ejemplo, fuerza la dirección del sitio web a ser de tipo **http://domain.tld**, mientras que en realidad la página es **http://domain.tld/MyWebsite**.
+En nuestro ejemplo, fuerza la dirección del sitio web a ser de tipo `http://domain.tld`, mientras que en realidad la página es `http://domain.tld/MyWebsite`.
 
 ### Redirigir automáticamente a un visitante hacia su sitio web en HTTPS cuando lo consulta con una URL en HTTP
 

--- a/docs/es/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -47,7 +47,7 @@ Las herramientas de depuración proporcionadas por *Mozilla Firefox* y *Google C
 
 Para evitar esta situación, le recomendamos que, cuando su sitio web funcione correctamente en HTTPS, redirija el contenido "HTTP" hacia "HTTPS". Esto permitirá que sus visitantes sean redirigidos automáticamente a la dirección de su contenido web en HTTPS y que solo haya una dirección disponible para ese mismo contenido. 
 
-A continuación ofrecemos un ejemplo de redirección que puede añadir a un archivo "[.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite)", en la raíz de su sitio web (sustituyendo la URL *https://www.yourdomain.tld* por la suya):
+A continuación ofrecemos un ejemplo de redirección que puede añadir a un archivo "[.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite)", en la raíz de su sitio web (sustituyendo la URL `https://www.yourdomain.tld` por la suya):
 
 ```
 RewriteEngine On

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -685,7 +685,7 @@ Appuyez sur la touche <code className="action">Entrée</code> pour terminer la c
 <a name="configurepfsenseoptionsfr"></a>
 #### Etape 3.9 Configuration de certaines options au travers de l'interface Web
 
-Connectez-vous sur la console Web de pfSense avec cette URL https://192.168.0.254 à partir d'une machine virtuelle se trouvant sur le réseau local **AHV : Base**.
+Connectez-vous sur la console Web de pfSense avec cette URL `https://192.168.0.254` à partir d'une machine virtuelle se trouvant sur le réseau local **AHV : Base**.
 
 Saisissez ces informations :
 

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/using-grafana-with-logs.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/using-grafana-with-logs.mdx
@@ -53,7 +53,7 @@ Then follow the Grafana installation guide according to your platform: [http://d
 
 ### Launch it!
 
-If everything is setup properly, launch your favorite browser, and point it to [http://localhost:3000](http://localhost:3000) Once logged in with your grafana credentials, reach data sources panel to setup your Logs Data Platform datasource:
+If everything is setup properly, launch your favorite browser, and point it to `http://localhost:3000` Once logged in with your grafana credentials, reach data sources panel to setup your Logs Data Platform datasource:
 
 <img className="thumbnail" alt="Data source_1" src="/images/manage-and-operate/observability/logs-data-platform/visualization-grafana/datasource_1.png" loading="lazy" />
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
@@ -101,7 +101,7 @@ Open a terminal, move to the project folder (`ai-training-examples/apps/flask/co
 docker compose -f "flask-docker-compose.yml" up -d --build
 ```
 
-This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your [localhost](http://0.0.0.0:5000/) on port 5000, the port of your frontend app. 
+This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your `http://localhost:5000` on port 5000, the port of your frontend app. 
 
 To stop the containers, run this command: 
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
@@ -68,7 +68,7 @@ public class PublicCloudUserTool {
 At the time of writing, there are two types of MCP servers: [stdio](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio) and [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).
 This blog post uses the Streamable mode thanks to Quarkus with the quarkus-mcp-server-sse extension.
 
-Run your server with the quarkus dev command. Your MCP server will be used on [http://localhost:8080](http://localhost:8080).
+Run your server with the quarkus dev command. Your MCP server will be used on `http://localhost:8080`.
 
 ### Using the MCP server with LangChain4J
 

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
@@ -294,7 +294,7 @@ Let's try to access our new web page:
 kubectl proxy
 ```
 
-and open the URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and open the URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 Now let's try to see if the data is persistent by deleting our current Nginx pod:
 
@@ -314,7 +314,7 @@ We should now check that our web page is still accessible:
 kubectl proxy
 ```
 
-and browse the same URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and browse the same URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 ## Clean your cluster
 

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
@@ -185,7 +185,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-[http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/)
+`http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/`
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/docs/fr/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -434,7 +434,7 @@ Create your first administrator 💻 by going to the administration panel at:
 [2021-12-31 13:26:36.173] http: GET /admin/fde9b1ad0670d29a2516.png (1 ms) 200
 ```
 
-Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page http://localhost:1337/admin/auth/register-admin.
+Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page `http://localhost:1337/admin/auth/register-admin`.
 
 <img className="thumbnail" alt="Strapi admin login creation page" src="/images/public-cloud/databases/postgresql-tuto-01-connect-strapi-to-managed-postgresql/postgresql-tuto-01-connect-strapi-to-managed-postgresql12.png" loading="lazy" />
 

--- a/docs/fr/guides/web-cloud/internet/overthebox/intel-itv1-installation.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/intel-itv1-installation.mdx
@@ -198,7 +198,7 @@ Votre **OverTheBox** est maintenant prête à la configuration :
 
 <img className="thumbnail" alt="overthebox" src="/images/web-cloud/internet/overthebox/intel-itv1-installation/installationV1-step4-2.png" loading="lazy" />
 
-- Connectez-vous au modem principal sur une nouvelle page du navigateur via l'adresse IP indiquée (dans notre exemple **http://192.168.0.1** ) et désactivez le DHCP de ce modem.
+- Connectez-vous au modem principal sur une nouvelle page du navigateur via l'adresse IP indiquée (dans notre exemple **`http://192.168.0.1`** ) et désactivez le DHCP de ce modem.
 
 - Revenez sur [http://overthebox.ovh (192.168.100.1)](http://overthebox.ovh) et cliquez sur **recheck**.
 
@@ -262,7 +262,7 @@ Votre **OverTheBox** va détecter le deuxième modem :
 
 <img className="thumbnail" alt="overthebox" src="/images/web-cloud/internet/overthebox/intel-itv1-installation/installationV1-step5-2.png" loading="lazy" />
 
-- Connectez-vous au deuxième modem sur une nouvelle page du navigateur via l'adresse IP indiquée (dans notre exemple **http://192.168.1.1** ) et désactivez le DHCP de ce modem.    
+- Connectez-vous au deuxième modem sur une nouvelle page du navigateur via l'adresse IP indiquée (dans notre exemple **`http://192.168.1.1`** ) et désactivez le DHCP de ce modem.    
 
 - Revenez sur [http://overthebox.ovh (192.168.100.1)](http://overthebox.ovh) et cliquez sur **recheck**.
 

--- a/docs/fr/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
@@ -171,7 +171,7 @@ Vérifiez, pour le formulaire `chemin d’installation`, que le répertoire pré
 Pour rappel, ce répertoire doit être totalement vide.
 
 De plus, si vous renseignez un sous-répertoire dans le `chemin d’installation`, celui-ci apparaîtra dans l'URL d'accès à votre « module en 1 clic ».
-Par exemple, si je renseigne dans le formulaire un sous répertoire *test*, l'URL d'accès à mon « module en 1 clic » aura cette forme : **http://domain.tld/test/**.
+Par exemple, si je renseigne dans le formulaire un sous répertoire *test*, l'URL d'accès à mon « module en 1 clic » aura cette forme : `http://domain.tld/test/`.
 
 Si besoin, consulter notre guide « [Comment partager mon hébergement web entre plusieurs sites](/guides/web-cloud/web-hosting/multisites-configure-multisite) » pour modifier le répertoire cible de votre nom de domaine.
 

--- a/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-pico.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-pico.mdx
@@ -60,7 +60,7 @@ Après l'installation, vous trouverez plusieurs dossiers et fichiers dans le ré
 
 #### Ajouter du contenu
 
-**1. Créer des pages** : pour ajouter une nouvelle page à votre site web, créez un nouveau fichier Markdown (.md) dans le dossier `content/`. Le nom du fichier déterminera l'URL de la page. Par exemple, `about.md` sera accessible à http://yourdomain.tld/about.
+**1. Créer des pages** : pour ajouter une nouvelle page à votre site web, créez un nouveau fichier Markdown (.md) dans le dossier `content/`. Le nom du fichier déterminera l'URL de la page. Par exemple, `about.md` sera accessible à `http://yourdomain.tld/about`.
 
 **2. Écrire du contenu** : ouvrez le fichier Markdown avec un éditeur de texte et commencez à écrire votre contenu. Utilisez la syntaxe Markdown pour formater votre texte, créer des liens, insérer des images, etc. Par exemple, si vous voulez éditer la page principale (home) de votre site web, ouvrez le fichier `index.md` et insérez le contenu de votre choix.
 

--- a/docs/fr/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -106,7 +106,7 @@ Consultez notre guide sur la [configuration d'un multisite sur un hébergement m
 
 Certains utilisateurs ne placent pas leur site web directement à la base du `dossier racine`. Ils créent alors un sous-dossier (par exemple : **MyWebsite**) dans leur `dossier racine` pour y placer leur site web.
 
-Dans ce cas, l'URL pour accéder au site aura la forme suivante : **http://domain.tld/MyWebsite**.
+Dans ce cas, l'URL pour accéder au site aura la forme suivante : `http://domain.tld/MyWebsite`.
 
 Si votre site web n'est pas présent directement dans le `dossier racine` déclaré en multisites pour votre nom de domaine et que vous ne souhaitez pas afficher le nom du dossier dans l'URL de votre site, éditez le fichier « .htaccess » présent à la racine du répertoire contenant votre site web. 
 
@@ -119,7 +119,7 @@ RewriteCond %{REQUEST_URI} !^/MyWebsite
 RewriteRule ^(.*)$ /MyWebsite/
 ```
 
-Dans notre exemple, cela force l'adresse de votre site à être de type **http://domain.tld**, alors qu'en réalité la page appelée est **http://domain.tld/MyWebsite**.
+Dans notre exemple, cela force l'adresse de votre site à être de type `http://domain.tld`, alors qu'en réalité la page appelée est `http://domain.tld/MyWebsite`.
 
 ### Rediriger automatiquement un visiteur vers votre site web en HTTPS lorsqu'il le consulte avec une URL en HTTP
 

--- a/docs/fr/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -47,7 +47,7 @@ Les outils de débogage fournis par *Mozilla Firefox* et *Google Chrome* peuvent
 
 Afin d'éviter ce type de situation, nous vous suggérons, lorsque votre site fonctionne correctement en « HTTPS », de rediriger le contenu « HTTP » vers « HTTPS ». Cela permettra à vos visiteurs d'être automatiquement redirigés vers l'adresse de votre contenu web en « HTTPS » et qu'une seule adresse soit disponible pour ce même contenu. 
 
-Voici un exemple de redirection que vous pouvez ajouter dans un fichier « [.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite) », à la racine de votre site web (en remplacant l'URL *https://www.yourdomain.tld* par la vôtre):
+Voici un exemple de redirection que vous pouvez ajouter dans un fichier « [.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite) », à la racine de votre site web (en remplacant l'URL `https://www.yourdomain.tld` par la vôtre):
 
 ```
 RewriteEngine On

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -106,9 +106,9 @@ ssh -L 18789:127.0.0.1:18789 user@YOUR_VPS_IP
 cat ~/openclaw/data/openclaw.json | grep '"token":'
 ```
 
-Open your browser and go to: [http://127.0.0.1:18789](http://127.0.0.1:18789).
+Open your browser and go to: `http://127.0.0.1:18789`.
 
-*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN*
+*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN`*
 
 The rest takes place in the **Overview** menu: enter your **Gateway Token** to log in.
 

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -349,7 +349,7 @@ Press the <code className="action">Enter</code> key to complete the command line
 <a name="configurepfsenseoptions"></a>
 #### Step 2.9 Configure some options through the web interface
 
-Connect to the pfSense Web Console with the URL [https://192.168.10.254](https://192.168.10.254) from a cluster virtual machine on the **AHV LAN: Base**.
+Connect to the pfSense Web Console with the URL `https://192.168.10.254` from a cluster virtual machine on the **AHV LAN: Base**.
 
 Enter the following information:
 

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -320,7 +320,7 @@ Press the <code className="action">Enter</code> key to complete the command line
 
 ### Configure some options through the web interface
 
-Connect to the pfSense Web Console with the URL [https://192.168.10.254](https://192.168.10.254) from a cluster virtual machine on the **AHV LAN: Base**.
+Connect to the pfSense Web Console with the URL `https://192.168.10.254` from a cluster virtual machine on the **AHV LAN: Base**.
 
 Enter the following information:
 

--- a/docs/it/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
+++ b/docs/it/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
@@ -101,7 +101,7 @@ Open a terminal, move to the project folder (`ai-training-examples/apps/flask/co
 docker compose -f "flask-docker-compose.yml" up -d --build
 ```
 
-This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your [localhost](http://0.0.0.0:5000/) on port 5000, the port of your frontend app. 
+This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your `http://localhost:5000` on port 5000, the port of your frontend app. 
 
 To stop the containers, run this command: 
 

--- a/docs/it/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
+++ b/docs/it/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
@@ -68,7 +68,7 @@ public class PublicCloudUserTool {
 At the time of writing, there are two types of MCP servers: [stdio](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio) and [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).
 This blog post uses the Streamable mode thanks to Quarkus with the quarkus-mcp-server-sse extension.
 
-Run your server with the quarkus dev command. Your MCP server will be used on [http://localhost:8080](http://localhost:8080).
+Run your server with the quarkus dev command. Your MCP server will be used on `http://localhost:8080`.
 
 ### Using the MCP server with LangChain4J
 

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
@@ -294,7 +294,7 @@ Let's try to access our new web page:
 kubectl proxy
 ```
 
-and open the URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and open the URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 Now let's try to see if the data is persistent by deleting our current Nginx pod:
 
@@ -314,7 +314,7 @@ We should now check that our web page is still accessible:
 kubectl proxy
 ```
 
-and browse the same URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and browse the same URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 ## Clean your cluster
 

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
@@ -185,7 +185,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-[http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/)
+`http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/`
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/docs/it/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -434,7 +434,7 @@ Create your first administrator 💻 by going to the administration panel at:
 [2021-12-31 13:26:36.173] http: GET /admin/fde9b1ad0670d29a2516.png (1 ms) 200
 ```
 
-Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page http://localhost:1337/admin/auth/register-admin.
+Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page `http://localhost:1337/admin/auth/register-admin`.
 
 <img className="thumbnail" alt="Strapi admin login creation page" src="/images/public-cloud/databases/postgresql-tuto-01-connect-strapi-to-managed-postgresql/postgresql-tuto-01-connect-strapi-to-managed-postgresql12.png" loading="lazy" />
 

--- a/docs/it/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
@@ -173,7 +173,7 @@ Verifica, per il modulo `Percorso di installazione`, che la directory precompila
 Ti ricordiamo che questa directory deve essere completamente vuota.
 
 Inoltre, se inserisci una sottodirectory nel `Percorso di installazione`, questa comparirà nell’URL di accesso al tuo "modulo in 1 click".
-Ad esempio, se inserisci nel modulo una sottodirectory *test*, l’URL di accesso al tuo "modulo in 1 click" avrà questo formato: **http://domain.tld/test/**.
+Ad esempio, se inserisci nel modulo una sottodirectory *test*, l’URL di accesso al tuo "modulo in 1 click" avrà questo formato: `http://domain.tld/test/`.
 
 Se necessario, consulta la nostra guida "[Come condividere il tuo hosting Web tra più siti](/guides/web-cloud/web-hosting/multisites-configure-multisite)" per modificare la directory di destinazione del tuo dominio.
 

--- a/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-pico.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-pico.mdx
@@ -60,7 +60,7 @@ Dopo l'installazione, troverai diverse cartelle e file nella directory principal
 
 #### Aggiungi contenuto
 
-**1. Crea pagine** : per aggiungere una nuova pagina al sito Web, crea un nuovo file Markdown (.md) nella cartella `content/`. Il nome del file determinerà l'URL della pagina. Ad esempio, `about.md` sarà accessibile all’indirizzo http://yourdomain.tld/about.
+**1. Crea pagine** : per aggiungere una nuova pagina al sito Web, crea un nuovo file Markdown (.md) nella cartella `content/`. Il nome del file determinerà l'URL della pagina. Ad esempio, `about.md` sarà accessibile all’indirizzo `http://yourdomain.tld/about`.
 
 **2. Scrivi contenuti**: apri il file Markdown con un editor di testo e inizia a scrivere il contenuto. Utilizzare la sintassi Markdown per formattare il testo, creare collegamenti, inserire immagini e così via. Se ad esempio si desidera modificare la pagina principale (home) del sito Web, aprire il file `index.md` e inserire il contenuto desiderato.
 

--- a/docs/it/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -108,7 +108,7 @@ Per maggiori informazioni sull'argomento, consulta la nostra guida sulla [config
 
 Alcuni utenti non caricano il loro sito direttamente alla base della `Cartella di root` e creano una sottocartella (ad esempio: **MyWebsite**) nella loro `Cartella di root` per creare il tuo sito Web.
 
-In questo caso, l'URL per accedere al sito avrà la forma seguente: **http://domain.tld/MyWebsite**
+In questo caso, l'URL per accedere al sito avrà la forma seguente: `http://domain.tld/MyWebsite`
 
 Se il tuo sito Web non è presente direttamente nella `Cartella di root` dichiarata in multisito per il tuo dominio e se non vuoi visualizzare il nome della cartella nell'URL del tuo sito, modifica il file ".htaccess" presente nella cartella che contiene il tuo sito Web. 
 
@@ -121,7 +121,7 @@ RewriteCond %{REQUEST_URI} !^/MyWebsite
 RewriteRule ^(.*)$ /MyWebsite/
 ```
 
-Nel nostro esempio, questo costringe l'indirizzo del tuo sito ad essere di tipo **http://domain.tld**, mentre in realtà la pagina è **http://domain.tld/MyWebsite**.
+Nel nostro esempio, questo costringe l'indirizzo del tuo sito ad essere di tipo `http://domain.tld`, mentre in realtà la pagina è `http://domain.tld/MyWebsite`.
 
 ### Reindirizzare automaticamente un visitatore verso il tuo sito Web in HTTPS quando lo consulta con un URL in HTTP
 

--- a/docs/it/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -47,7 +47,7 @@ Gli strumenti di debug disponibili in *Mozilla Firefox* e *Google Chrome* posson
 
 Per evitare situazioni di questo tipo, ti consigliamo di reindirizzare il contenuto "HTTP" verso "HTTPS" quando il sito funziona correttamente in "HTTPS". In questo modo i tuoi visitatori saranno automaticamente reindirizzati verso l’indirizzo del tuo contenuto Web in "HTTPS" e sarà disponibile un solo indirizzo per lo stesso contenuto. 
 
-Ecco un esempio di reindirizzamento che potete aggiungere a un file "[.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite)", alla radice del vostro sito web (sostituendo l'URL *https://www.yourdomain.tld* con il vostro):
+Ecco un esempio di reindirizzamento che potete aggiungere a un file "[.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite)", alla radice del vostro sito web (sostituendo l'URL `https://www.yourdomain.tld` con il vostro):
 
 ```
 RewriteEngine On

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -106,9 +106,9 @@ ssh -L 18789:127.0.0.1:18789 user@YOUR_VPS_IP
 cat ~/openclaw/data/openclaw.json | grep '"token":'
 ```
 
-Open your browser and go to: [http://127.0.0.1:18789](http://127.0.0.1:18789).
+Open your browser and go to: `http://127.0.0.1:18789`.
 
-*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN*
+*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN`*
 
 The rest takes place in the **Overview** menu: enter your **Gateway Token** to log in.
 

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -349,7 +349,7 @@ Press the <code className="action">Enter</code> key to complete the command line
 <a name="configurepfsenseoptions"></a>
 #### Step 2.9 Configure some options through the web interface
 
-Connect to the pfSense Web Console with the URL [https://192.168.10.254](https://192.168.10.254) from a cluster virtual machine on the **AHV LAN: Base**.
+Connect to the pfSense Web Console with the URL `https://192.168.10.254` from a cluster virtual machine on the **AHV LAN: Base**.
 
 Enter the following information:
 

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -320,7 +320,7 @@ Press the <code className="action">Enter</code> key to complete the command line
 
 ### Configure some options through the web interface
 
-Connect to the pfSense Web Console with the URL [https://192.168.10.254](https://192.168.10.254) from a cluster virtual machine on the **AHV LAN: Base**.
+Connect to the pfSense Web Console with the URL `https://192.168.10.254` from a cluster virtual machine on the **AHV LAN: Base**.
 
 Enter the following information:
 

--- a/docs/pl/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
+++ b/docs/pl/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
@@ -101,7 +101,7 @@ Open a terminal, move to the project folder (`ai-training-examples/apps/flask/co
 docker compose -f "flask-docker-compose.yml" up -d --build
 ```
 
-This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your [localhost](http://0.0.0.0:5000/) on port 5000, the port of your frontend app. 
+This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your `http://localhost:5000` on port 5000, the port of your frontend app. 
 
 To stop the containers, run this command: 
 

--- a/docs/pl/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
+++ b/docs/pl/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
@@ -68,7 +68,7 @@ public class PublicCloudUserTool {
 At the time of writing, there are two types of MCP servers: [stdio](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio) and [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).
 This blog post uses the Streamable mode thanks to Quarkus with the quarkus-mcp-server-sse extension.
 
-Run your server with the quarkus dev command. Your MCP server will be used on [http://localhost:8080](http://localhost:8080).
+Run your server with the quarkus dev command. Your MCP server will be used on `http://localhost:8080`.
 
 ### Using the MCP server with LangChain4J
 

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
@@ -294,7 +294,7 @@ Let's try to access our new web page:
 kubectl proxy
 ```
 
-and open the URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and open the URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 Now let's try to see if the data is persistent by deleting our current Nginx pod:
 
@@ -314,7 +314,7 @@ We should now check that our web page is still accessible:
 kubectl proxy
 ```
 
-and browse the same URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and browse the same URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 ## Clean your cluster
 

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
@@ -185,7 +185,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-[http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/)
+`http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/`
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/docs/pl/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -434,7 +434,7 @@ Create your first administrator 💻 by going to the administration panel at:
 [2021-12-31 13:26:36.173] http: GET /admin/fde9b1ad0670d29a2516.png (1 ms) 200
 ```
 
-Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page http://localhost:1337/admin/auth/register-admin.
+Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page `http://localhost:1337/admin/auth/register-admin`.
 
 <img className="thumbnail" alt="Strapi admin login creation page" src="/images/public-cloud/databases/postgresql-tuto-01-connect-strapi-to-managed-postgresql/postgresql-tuto-01-connect-strapi-to-managed-postgresql12.png" loading="lazy" />
 

--- a/docs/pl/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
@@ -173,7 +173,7 @@ Sprawdź, czy w formularzu `Ścieżka instalacji` wstępnie wypełniony katalog 
 Przypominamy, że ten katalog musi być całkowicie pusty.
 
 Ponadto, jeśli podasz podkatalog w `Ścieżka instalacji`, pojawi się on w adresie URL dostępu do Twojego "modułu za 1 kliknięciem".
-Na przykład, jeśli wpiszę do formularza podkatalog *test*, adres URL dostępu do mojego "modułu za 1 kliknięciem" będzie wyglądał następująco: **http://domain.tld/test/**.
+Na przykład, jeśli wpiszę do formularza podkatalog *test*, adres URL dostępu do mojego "modułu za 1 kliknięciem" będzie wyglądał następująco: `http://domain.tld/test/`.
 
 W razie potrzeby sprawdź przewodnik "[Jak rozdzielić swój hosting WWW na kilka stron](/guides/web-cloud/web-hosting/multisites-configure-multisite)", aby zmienić katalog docelowy Twojej domeny.
 

--- a/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-pico.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-pico.mdx
@@ -60,7 +60,7 @@ Po zakończeniu instalacji w katalogu głównym Pico znajdziesz kilka folderów 
 
 #### Dodaj zawartość
 
-**1. Tworzenie stron** : Aby dodać nową stronę do serwisu WWW, utwórz nowy plik Markdown (.md) w folderze `content/`. Nazwa pliku określa adres URL strony. Na przykład `about.md` będzie dostępne pod adresem http://yourdomain.tld/about.
+**1. Tworzenie stron** : Aby dodać nową stronę do serwisu WWW, utwórz nowy plik Markdown (.md) w folderze `content/`. Nazwa pliku określa adres URL strony. Na przykład `about.md` będzie dostępne pod adresem `http://yourdomain.tld/about`.
 
 **2. Zapisz zawartość**: Otwórz plik Markdown w edytorze tekstu i zacznij zapisywać zawartość. Składnia Markdown służy do formatowania tekstu, tworzenia łączy, wstawiania obrazów itp. Na przykład, jeśli chcesz edytować stronę główną (home) serwisu WWW, otwórz plik `index.md` i wstaw dowolną zawartość.
 

--- a/docs/pl/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -107,7 +107,7 @@ Zapoznaj się z naszym przewodnikiem dotyczącym [konfiguracji strony podpiętej
 
 Niektórzy użytkownicy nie umieszczają swojej strony internetowej bezpośrednio na podstawie `Katalog główny`. Następnie tworzą podfolder (np.: **MyWebsite**) w `Katalog główny`, aby umieścić na nim swoją stronę internetową.
 
-W takim przypadku URL dostępu do strony będzie wyglądał następująco: **http://domain.tld/MyWebsite**
+W takim przypadku URL dostępu do strony będzie wyglądał następująco: `http://domain.tld/MyWebsite`
 
 Jeśli Twoja strona WWW nie jest widoczna bezpośrednio w `Katalog główny` zadeklarowanym w opcji MultiSite i nie chcesz wyświetlać nazwy folderu w adresie URL Twojej strony, edytuj plik ".htaccess" w katalogu zawierającym Twoją stronę WWW. 
 
@@ -120,7 +120,7 @@ RewriteCond %{REQUEST_URI} !^/MyWebsite
 RewriteRule ^(.*)$ /MyWebsite/
 ```
 
-W naszym przykładzie adres Twojej strony internetowej musi być typu **http://domain.tld**, natomiast w rzeczywistości strona wywoływana jest **http://domain.tld/MyWebsite**.
+W naszym przykładzie adres Twojej strony internetowej musi być typu `http://domain.tld`, natomiast w rzeczywistości strona wywoływana jest `http://domain.tld/MyWebsite`.
 
 ### Automatyczne przekierowanie osoby odwiedzającej stronę przez HTTPS na stronę WWW podczas wyświetlania jej przez adres URL za pomocą HTTP
 

--- a/docs/pl/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -47,7 +47,7 @@ Narzędzia do debugowania dostarczone przez *Mozilla Firefox* i *Google Chrome* 
 
 Aby tego uniknąć, sugerujemy, aby, jeśli Twoja strona WWW działa poprawnie jako "HTTPS", przekierować zawartość "HTTP" na "HTTPS". Dzięki temu użytkownicy Twojej strony będą automatycznie przekierowywani na adres Twojej zawartości sieci Web przy użyciu protokołu "HTTPS", a w przypadku tej samej treści będzie dostępny tylko jeden adres. 
 
-Oto przykład przekierowania, które możesz dodać w pliku "[.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite)" w katalogu głównym Twojej strony WWW (zamieniając adres URL *https://www.yourdomain.tld* na Twój):
+Oto przykład przekierowania, które możesz dodać w pliku "[.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite)" w katalogu głównym Twojej strony WWW (zamieniając adres URL `https://www.yourdomain.tld` na Twój):
 
 ```
 RewriteEngine On

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -106,9 +106,9 @@ ssh -L 18789:127.0.0.1:18789 user@YOUR_VPS_IP
 cat ~/openclaw/data/openclaw.json | grep '"token":'
 ```
 
-Open your browser and go to: [http://127.0.0.1:18789](http://127.0.0.1:18789).
+Open your browser and go to: `http://127.0.0.1:18789`.
 
-*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN*
+*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN`*
 
 The rest takes place in the **Overview** menu: enter your **Gateway Token** to log in.
 

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -349,7 +349,7 @@ Press the <code className="action">Enter</code> key to complete the command line
 <a name="configurepfsenseoptions"></a>
 #### Step 2.9 Configure some options through the web interface
 
-Connect to the pfSense Web Console with the URL [https://192.168.10.254](https://192.168.10.254) from a cluster virtual machine on the **AHV LAN: Base**.
+Connect to the pfSense Web Console with the URL `https://192.168.10.254` from a cluster virtual machine on the **AHV LAN: Base**.
 
 Enter the following information:
 

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -320,7 +320,7 @@ Press the <code className="action">Enter</code> key to complete the command line
 
 ### Configure some options through the web interface
 
-Connect to the pfSense Web Console with the URL [https://192.168.10.254](https://192.168.10.254) from a cluster virtual machine on the **AHV LAN: Base**.
+Connect to the pfSense Web Console with the URL `https://192.168.10.254` from a cluster virtual machine on the **AHV LAN: Base**.
 
 Enter the following information:
 

--- a/docs/pt/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
+++ b/docs/pt/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
@@ -101,7 +101,7 @@ Open a terminal, move to the project folder (`ai-training-examples/apps/flask/co
 docker compose -f "flask-docker-compose.yml" up -d --build
 ```
 
-This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your [localhost](http://0.0.0.0:5000/) on port 5000, the port of your frontend app. 
+This command will create 2 containers, one for the Rasa model backend and one for the frontend server handled by Flask. Once the two containers are running (it will take 5 minutes max), you can go directly on your `http://localhost:5000` on port 5000, the port of your frontend app. 
 
 To stop the containers, run this command: 
 

--- a/docs/pt/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
+++ b/docs/pt/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
@@ -68,7 +68,7 @@ public class PublicCloudUserTool {
 At the time of writing, there are two types of MCP servers: [stdio](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio) and [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).
 This blog post uses the Streamable mode thanks to Quarkus with the quarkus-mcp-server-sse extension.
 
-Run your server with the quarkus dev command. Your MCP server will be used on [http://localhost:8080](http://localhost:8080).
+Run your server with the quarkus dev command. Your MCP server will be used on `http://localhost:8080`.
 
 ### Using the MCP server with LangChain4J
 

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
@@ -294,7 +294,7 @@ Let's try to access our new web page:
 kubectl proxy
 ```
 
-and open the URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and open the URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 Now let's try to see if the data is persistent by deleting our current Nginx pod:
 
@@ -314,7 +314,7 @@ We should now check that our web page is still accessible:
 kubectl proxy
 ```
 
-and browse the same URL [http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/](http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/)
+and browse the same URL `http://localhost:8001/api/v1/namespaces/default/pods/http:local-nvme-nginx:/proxy/`
 
 ## Clean your cluster
 

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
@@ -185,7 +185,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-[http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/)
+`http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/`
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/docs/pt/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -434,7 +434,7 @@ Create your first administrator 💻 by going to the administration panel at:
 [2021-12-31 13:26:36.173] http: GET /admin/fde9b1ad0670d29a2516.png (1 ms) 200
 ```
 
-Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page http://localhost:1337/admin/auth/register-admin.
+Congratulations! You have just finished the setup, the server starts end open your browser on the admin login creation page `http://localhost:1337/admin/auth/register-admin`.
 
 <img className="thumbnail" alt="Strapi admin login creation page" src="/images/public-cloud/databases/postgresql-tuto-01-connect-strapi-to-managed-postgresql/postgresql-tuto-01-connect-strapi-to-managed-postgresql12.png" loading="lazy" />
 

--- a/docs/pt/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-install-1-click-modules.mdx
@@ -171,7 +171,7 @@ Verifique, para o formulário `Caminho da instalação`, se o diretório pré-pr
 Nota: este diretório deve estar totalmente vazio.
 
 Além disso, se introduzir um subdiretório no `Caminho da instalação`, este aparecerá no URL de acesso ao seu "módulo em 1 clique".
-Por exemplo, se introduzir no formulário um subdiretório *test*, o URL de acesso ao meu "módulo 1 clique" terá esta forma: **http://domain.tld/test/**.
+Por exemplo, se introduzir no formulário um subdiretório *test*, o URL de acesso ao meu "módulo 1 clique" terá esta forma: `http://domain.tld/test/`.
 
 Se necessário, consulte o nosso guia "[Como partilhar o meu alojamento web entre vários sites](/guides/web-cloud/web-hosting/multisites-configure-multisite)" para modificar o diretório alvo do seu domínio.
 

--- a/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-pico.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-pico.mdx
@@ -60,7 +60,7 @@ Após a instalação, você encontrará várias pastas e arquivos no diretório 
 
 #### Adicionar conteúdo
 
-**1. Criar páginas** : para adicionar uma nova página ao seu website, crie um novo ficheiro Markdown (.md) na pasta `content/`. O nome do ficheiro irá determinar o URL da página. Por exemplo, `about.md` estará acessível a http://yourdomain.tld/about.
+**1. Criar páginas** : para adicionar uma nova página ao seu website, crie um novo ficheiro Markdown (.md) na pasta `content/`. O nome do ficheiro irá determinar o URL da página. Por exemplo, `about.md` estará acessível a `http://yourdomain.tld/about`.
 
 **2. Escrever conteúdo** : abra o ficheiro Markdown com um editor de texto e comece a escrever o seu conteúdo. Utilize a sintaxe Markdown para formatar o texto, criar links, inserir imagens, etc. Por exemplo, se pretender editar a página principal (home) do seu website, abra o ficheiro `index.md` e insira o conteúdo à sua escolha.
 

--- a/docs/pt/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -107,7 +107,7 @@ Para mais informações, consulte o nosso manual sobre a [configuração de um m
 
 Alguns utilizadores não colocam os seus websites diretamente na base do `Pasta raiz`. Eles criam uma sub-pasta (por exemplo: **MyWebsite**) no seu `Pasta raiz` para colocar o seu website.
 
-Neste caso, o URL para aceder ao site terá a seguinte forma: **http://domain.tld/MyWebsite**
+Neste caso, o URL para aceder ao site terá a seguinte forma: `http://domain.tld/MyWebsite`
 
 Se o seu website não está presente diretamente no `Pasta raiz` que foi declarado em multi-sites para o seu domínio e não deseja apresentar o nome da pasta no URL do seu website, edite o ficheiro ".htaccess" presente na raiz do diretório que contém o seu website. 
 
@@ -120,7 +120,7 @@ RewriteCond %{REQUEST_URI} !^/MyWebsite
 RewriteRule ^(.*)$ /MyWebsite/
 ```
 
-No nosso exemplo, isto obriga o endereço do seu site a ser do tipo **http://domain.tld**, ao passo que a página chamada é **http://domain.tld/MyWebsite**.
+No nosso exemplo, isto obriga o endereço do seu site a ser do tipo `http://domain.tld`, ao passo que a página chamada é `http://domain.tld/MyWebsite`.
 
 ### Reencaminhar automaticamente um visitante para o seu website em HTTPS quando o consulta com um URL em HTTP
 

--- a/docs/pt/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -47,7 +47,7 @@ As ferramentas de depuração fornecidas por *Mozilla Firefox* e *Google Chrome*
 
 Para evitar este tipo de situação, sugerimos que, quando o website funciona corretamente em "HTTPS", reencaminhe o conteúdo "HTTP" para "HTTPS". Isto permitirá que os seus visitantes sejam automaticamente reencaminhados para o endereço do seu conteúdo web em "HTTPS" e que apenas um endereço esteja disponível para esse mesmo conteúdo. 
 
-Eis um exemplo de reencaminhamento que pode adicionar num ficheiro "[.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite)", na raiz do seu website (substituindo o URL *https://www.yourdomain.tld* pelo seu):
+Eis um exemplo de reencaminhamento que pode adicionar num ficheiro "[.htaccess](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite)", na raiz do seu website (substituindo o URL `https://www.yourdomain.tld` pelo seu):
 
 ```
 RewriteEngine On

--- a/theme/components/Nav/hooks.tsx
+++ b/theme/components/Nav/hooks.tsx
@@ -67,8 +67,18 @@ function replaceLang(
 
   purePathPart = parts.join('/') || '';
 
+  // Home of a locale/version: with cleanUrls the canonical home is the bare
+  // prefix with a trailing slash (e.g. `/en/`), NOT `/en/index`. Emitting
+  // `index` here produced a duplicate, indexable `/en/index` URL and pointed
+  // the language switcher (incl. its rel="alternate" hreflang href) at it.
+  // Only without cleanUrls do we need the literal `index.html`.
   if ((versionPart || langPart) && !purePathPart) {
-    purePathPart = cleanUrls ? 'index' : 'index.html';
+    if (cleanUrls) {
+      return addLeadingSlash(
+        `${[versionPart, langPart].filter(Boolean).join('/')}/`,
+      );
+    }
+    purePathPart = 'index.html';
   }
 
   return addLeadingSlash(

--- a/theme/hooks/useLocaleAvailability.ts
+++ b/theme/hooks/useLocaleAvailability.ts
@@ -28,7 +28,12 @@ export function useLocaleAvailability() {
     targetLocale: string,
   ): string {
     const key = pathWithoutLocale.replace(/^\//, '').replace(/\/$/, '');
-    if (!key) return `/${targetLocale}/`;
+    // The locale home: empty path, or a leftover `index`/`index.html` that some
+    // callers (Rspress replaceLang) synthesise. Canonical home is `/{locale}/`,
+    // never `/{locale}/index` (which is a duplicate, indexable URL).
+    if (!key || key === 'index' || key === 'index.html') {
+      return `/${targetLocale}/`;
+    }
     const available = LOCALE_AVAILABILITY[key];
     if (!available) return `/${targetLocale}${pathWithoutLocale}`;
     return available.includes(targetLocale)


### PR DESCRIPTION
Replacing PR #182 

## What & why

Two SEO fixes for crawlable/indexable URLs. **Target branch: `develop`.**

### 1. Obfuscate example / localhost / private-IP links (82 files)

Crawlable placeholder URLs in guides rendered as live `<a href>` in the built HTML, so robots followed and indexed them. Confirmed live on prod via a crawler export (e.g. `https://docs.ovhcloud.com/en/guides/.../using-grafana-with-logs` → `http://localhost:3000/`).

Fix: wrap each crawlable placeholder URL in inline code (or collapse a redundant `[url](url)` link), so it no longer auto-links. Scope is **live links only** — occurrences inside ``` code fences ``` and `inline code` were already non-crawlable and left untouched.

- **HIGH** — registrable placeholder domains in prose (the real leak): `**http://domain.tld/...**`, `*https://www.yourdomain.tld*` in web-hosting htaccess / 1-click / SSL guides; plus `cms-manual-installation-pico` where 5 translations had dropped the backticks EN/DE already had.
- **LOW** — non-routable but still live `<a href>`: redundant `[localhost-url](localhost-url)` links (k8s dashboard/nvme, grafana, mcp-langchain4j, strapi-postgresql) collapsed to inline code; bare prose URLs wrapped; broken `[localhost](http://0.0.0.0:5000/)` fixed to `` `http://localhost:5000` ``.
- **Kept clickable on purpose:** 10 OverTheBox `192.168.100.1` router-admin links (real LAN UX, crawl-safe). RFC5737 doc IPs (`192.0.2.x`, `198.51.100.x`) left as-is — already correct.

### 2. Language switch on a locale home → `/{lang}/`, not `/{lang}/index` (2 files)

On a locale home, switching language landed on `/en/index` instead of `/en/`. `/en/index` returns 200 — a duplicate, indexable home — and the switcher's `rel="alternate"` hreflang href pointed robots at it too.

Root cause: the nav switcher builds its target via Rspress's `replaceLang`, which synthesised `index` for an empty path even under `cleanUrls: true`.

- `replaceLang`: under `cleanUrls`, return the bare prefix with a trailing slash (`/en/`) for the home; keep `index.html` only when `cleanUrls` is off.
- `resolveLocaleSwitchUrl`: treat a leftover `index` / `index.html` key as the home and return `/{locale}/` (defence in depth).

Both the desktop (`NavLangs`) and mobile (`NavScreenLangs`) switchers consume this.

## Verification

- **Links:** repo-wide scan (code-fence + inline-code aware, symlinks resolved) → **0 crawlable `localhost`/`127.0.0.1`/`0.0.0.0` links remain across 10,370 source files**. All touched `.mdx` compile via `@mdx-js/mdx`.
- **Switcher:** 8/8 logic cases pass — home → each locale, normal-guide switch, unavailable-page fallback, no-`cleanUrls` branch, stray `/index` normalization. Confirmed in `pnpm dev`.
- Untranslated locales are symlinks to EN, so one EN edit propagates to all 7 — the crawler's per-locale duplicates are all covered.

## Notes

- The link list came from **production (`master`)**; these changes are on `develop`, so the live/indexed URLs clear once this releases and the site rebuilds.
- The guides in the crawler export use older slugs than `develop` (renamed since the last prod build) — all map 1:1 to files fixed here.
