### PR TITLE
feat(sidebar): add clickable category landing pages

### DIFF
--- a/components/CardGrid/CardGrid.css
+++ b/components/CardGrid/CardGrid.css
@@ -1,0 +1,17 @@
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.card-grid[data-columns='3'] {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+@media (max-width: 768px) {
+  .card-grid,
+  .card-grid[data-columns='3'] {
+    grid-template-columns: 1fr;
+  }
+}

--- a/components/CardGrid/CardGrid.tsx
+++ b/components/CardGrid/CardGrid.tsx
@@ -1,0 +1,35 @@
+import type React from 'react';
+import './CardGrid.css';
+
+interface CardGridProps {
+  /**
+   * Cards to lay out — typically a set of <LinkCard> elements.
+   */
+  children: React.ReactNode;
+  /**
+   * Number of columns on wide viewports. Defaults to 2.
+   * Collapses to a single column on narrow screens.
+   */
+  columns?: 2 | 3;
+  style?: React.CSSProperties;
+}
+
+/**
+ * Responsive multi-column grid for landing/overview pages. Drop a few
+ * <LinkCard> children inside it to replicate the previous front-end's
+ * two-column index layout. Available globally in MDX (no import needed) —
+ * see `markdown.globalComponents` in rspress.config(.build).ts.
+ */
+export function CardGrid({ children, columns = 2, style }: CardGridProps) {
+  return (
+    <div
+      className="card-grid"
+      data-columns={columns}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default CardGrid;

--- a/components/CardGrid/index.ts
+++ b/components/CardGrid/index.ts
@@ -1,0 +1,1 @@
+export { default, CardGrid } from './CardGrid';

--- a/components/CategoryColumns/CategoryColumns.css
+++ b/components/CategoryColumns/CategoryColumns.css
@@ -1,0 +1,62 @@
+.rp-category-columns {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  column-gap: 3rem;
+  row-gap: 2.5rem;
+  margin: 1.5rem 0;
+}
+
+@media (max-width: 768px) {
+  .rp-category-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+.rp-category-columns__heading {
+  margin: 0 0 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--rp-c-divider);
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--rp-c-text-1);
+  line-height: 1.4;
+}
+
+.rp-category-columns__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.rp-category-columns__list li {
+  margin: 0;
+}
+
+.rp-category-columns__link {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.4rem 0;
+  text-decoration: none;
+  color: var(--rp-c-link);
+  transition: color 0.2s ease;
+}
+
+.rp-category-columns__link:hover {
+  color: var(--rp-c-brand-light, #6696e7);
+}
+
+.rp-category-columns__link-text {
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.rp-category-columns__link-arrow {
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.rp-category-columns__link:hover .rp-category-columns__link-arrow {
+  transform: translateX(4px);
+}

--- a/components/CategoryColumns/CategoryColumns.tsx
+++ b/components/CategoryColumns/CategoryColumns.tsx
@@ -1,0 +1,70 @@
+import { useLocalizeHref } from '../../theme/hooks/useLocalizedHref';
+import './CategoryColumns.css';
+
+interface CategoryItem {
+  title: string;
+  link?: string;
+}
+
+interface Category {
+  title: string;
+  items: CategoryItem[];
+}
+
+interface CategoryColumnsProps {
+  /**
+   * Categories to display. Each becomes a column; columns flow two per row
+   * and collapse to a single column on narrow screens.
+   */
+  categories: Category[];
+}
+
+const isExternal = (href: string) =>
+  href.startsWith('http://') || href.startsWith('https://');
+
+/**
+ * Condensed two-column directory of guide links grouped by category.
+ *
+ * Categories flow row by row (1 2 / 3 4 …); within a category the guide
+ * titles stack as a light vertical list. The only separator is a thin rule
+ * under each category heading — no per-item dividers — to keep it uncluttered.
+ */
+export function CategoryColumns({ categories }: CategoryColumnsProps) {
+  const localizeHref = useLocalizeHref();
+
+  if (!categories || categories.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rp-category-columns">
+      {categories.map((cat) => (
+        <section className="rp-category-columns__col" key={cat.title}>
+          <h3 className="rp-category-columns__heading">{cat.title}</h3>
+          <ul className="rp-category-columns__list">
+            {cat.items.map((item) => (
+              <li key={item.title}>
+                <a
+                  href={item.link ? localizeHref(item.link) : '#'}
+                  className="rp-category-columns__link"
+                  {...(item.link &&
+                    isExternal(item.link) && {
+                      target: '_blank',
+                      rel: 'noopener noreferrer',
+                    })}
+                >
+                  <span className="rp-category-columns__link-text">
+                    {item.title}
+                  </span>
+                  <span className="rp-category-columns__link-arrow">→</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+export default CategoryColumns;

--- a/components/CategoryColumns/index.ts
+++ b/components/CategoryColumns/index.ts
@@ -1,0 +1,1 @@
+export { default, CategoryColumns } from './CategoryColumns';

--- a/components/ProductBanner/ProductBanner.css
+++ b/components/ProductBanner/ProductBanner.css
@@ -1,0 +1,38 @@
+.rp-product-banner {
+  margin: 0 0 2rem;
+  padding: 2.5rem 2rem;
+  background: linear-gradient(
+    135deg,
+    var(--rp-c-brand, #0050d7) 0%,
+    #001a8c 100%
+  );
+  border-radius: 12px;
+}
+
+.rp-product-banner__inner {
+  max-width: 72rem;
+  margin: 0 auto;
+}
+
+.rp-product-banner__title {
+  margin: 0;
+  color: #fff;
+  font-size: 2.25rem;
+  font-weight: 700;
+  line-height: 1.2;
+  border: none;
+}
+
+.rp-product-banner__tagline {
+  margin: 0.75rem 0 0;
+  max-width: 700px;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 1.125rem;
+  line-height: 1.6;
+}
+
+@media (max-width: 768px) {
+  .rp-product-banner__title {
+    font-size: 1.75rem;
+  }
+}

--- a/components/ProductBanner/ProductBanner.tsx
+++ b/components/ProductBanner/ProductBanner.tsx
@@ -1,0 +1,42 @@
+import { useFrontmatter } from '@rspress/core/runtime';
+import './ProductBanner.css';
+
+interface ProductBannerFrontmatter {
+  title?: string;
+  tagline?: string;
+}
+
+interface ProductBannerProps {
+  /** Override the heading (defaults to the page's frontmatter `title`). */
+  title?: string;
+  /** Override the tagline (defaults to the page's frontmatter `tagline`). */
+  tagline?: string;
+}
+
+/**
+ * Opt-in product-identity banner for the top of a landing page. It is NOT
+ * applied automatically — a page only gets it by placing `<ProductBanner />`
+ * in its MDX, so lower-category landing pages can simply omit it.
+ *
+ * By default it shows the page `title` and an optional `tagline` frontmatter
+ * key; both can be overridden via props.
+ */
+export function ProductBanner({ title, tagline }: ProductBannerProps) {
+  const { frontmatter } = useFrontmatter();
+  const fm = frontmatter as ProductBannerFrontmatter;
+  const heading = title ?? fm?.title;
+  const sub = tagline ?? fm?.tagline;
+
+  if (!heading) return null;
+
+  return (
+    <header className="rp-product-banner">
+      <div className="rp-product-banner__inner">
+        <h1 className="rp-product-banner__title">{heading}</h1>
+        {sub && <p className="rp-product-banner__tagline">{sub}</p>}
+      </div>
+    </header>
+  );
+}
+
+export default ProductBanner;

--- a/components/ProductBanner/index.ts
+++ b/components/ProductBanner/index.ts
@@ -1,0 +1,1 @@
+export { default, ProductBanner } from './ProductBanner';

--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -2092,8 +2092,7 @@
                     + [Créer manuellement une interface modem](web-cloud/internet/overthebox/advanced-creer-une-interface-modem-manuellement)
                     + [Installer l'image OverTheBox sur votre matériel](web-cloud/internet/overthebox/advanced-installer-limage-overthebox-sur-votre-materiel)
                     + [Configurer un ancien appareil OverTheBox v1 (Intel & IT v1)](web-cloud/internet/overthebox/intel-itv1-installation)
-    + [Phone and Fax](products/web-cloud-phone-and-fax)
-            + [VoIP - Présentation de la documentation](web-cloud/phone-and-fax/voip/landing-page-voip)
+    + [Phone and Fax](products/web-cloud-phone-and-fax){landing=web-cloud/phone-and-fax/voip/landing-page-voip}
             + [Getting started](web-cloud-phone-and-fax-voip-getting-started)
                 + [FAQ](web-cloud/phone-and-fax/voip/faq-voip)
                 + [Gérer vos services VoIP](web-cloud/phone-and-fax/voip/changer-l-offre-et-les-options-d-une-ligne-voip)

--- a/config/sidebar/parser.ts
+++ b/config/sidebar/parser.ts
@@ -150,6 +150,10 @@ interface ParsedLine {
   label: string;
   ref: string | null;
   kind: 'universe' | 'product' | 'section' | 'guide';
+  // Optional landing-page slug declared via a `{landing=<slug>}` marker on a
+  // product/section line. When set, the resulting SidebarGroup gets a `link`
+  // so clicking the category navigates to that page (and still expands).
+  landing?: string;
 }
 
 interface StackEntry {
@@ -334,6 +338,13 @@ export function parseIndexMd(
           collapsible: true,
           items: items as SidebarItem[],
         };
+        // A `{landing=<slug>}` marker turns this category into a clickable
+        // node: set `link` so the sidebar navigates to the landing page
+        // (SidebarGroup keeps the group expanded on click). Reached only for
+        // non-empty groups — pruned FR-only categories never get here.
+        if (parsed.landing) {
+          node.link = slugToLink(parsed.landing);
+        }
       }
 
       // Add to parent or to root
@@ -350,13 +361,26 @@ export function parseIndexMd(
 
     const leadingSpaces = line.match(/^(\s*)/)?.[1].length || 0;
     const indent = Math.floor(leadingSpaces / 4);
-    const stripped = line.replace(/^\s*\+\s+/, '');
+    let stripped = line.replace(/^\s*\+\s+/, '');
+
+    // Extract an optional trailing `{landing=<slug>}` marker before parsing the
+    // `[label](ref)` so it doesn't pollute the label/ref. Only meaningful on
+    // product/section lines (groups); ignored on guide leaves.
+    let landing: string | undefined;
+    const landingMatch = stripped.match(/\s*\{landing=([^}]+)\}\s*$/);
+    if (landingMatch) {
+      landing = landingMatch[1].trim();
+      stripped = stripped.slice(0, landingMatch.index).trimEnd();
+    }
 
     const linkMatch = stripped.match(/^\[([^\]]+)\]\(([^)]+)\)/);
     const label = linkMatch ? linkMatch[1] : stripped.trim();
     const ref = linkMatch ? linkMatch[2] : null;
 
     const parsed = classifyLine(indent, label, ref);
+    if (landing && (parsed.kind === 'product' || parsed.kind === 'section')) {
+      parsed.landing = landing;
+    }
 
     // Flush stack entries at the same or deeper indent
     flushTo(indent);

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
@@ -4,6 +4,7 @@ lastUpdated: 2026-06-11
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
+import { LinkCard } from '@components/LinkCard';
 
 ## Guides VoIP OVHcloud
 
@@ -28,10 +29,12 @@ Avec les services VoIP d’OVHcloud, vous pouvez :
 
 ### Premiers pas avec la VoIP
 
-- [VoIP – FAQ](/guides/web-cloud/phone-and-fax/voip/faq-voip)
-- [Gérer vos services VoIP](/guides/web-cloud/phone-and-fax/voip/changer-l-offre-et-les-options-d-une-ligne-voip)
-- [Gérer vos groupes de téléphonie](/guides/web-cloud/phone-and-fax/voip/regrouper-services-telephonie)
-- [Renseigner les coordonnées d'une ligne ou d'un numéro et les faire paraître en ligne](/guides/web-cloud/phone-and-fax/voip/publication-annuaire)
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/phone-and-fax/voip/faq-voip" title="VoIP – FAQ" description="Les réponses aux questions les plus fréquentes sur la VoIP OVHcloud." />
+  <LinkCard href="/guides/web-cloud/phone-and-fax/voip/changer-l-offre-et-les-options-d-une-ligne-voip" title="Gérer vos services VoIP" description="Changer l'offre et les options d'une ligne VoIP." />
+  <LinkCard href="/guides/web-cloud/phone-and-fax/voip/regrouper-services-telephonie" title="Gérer vos groupes de téléphonie" description="Regrouper vos services de téléphonie." />
+  <LinkCard href="/guides/web-cloud/phone-and-fax/voip/publication-annuaire" title="Publication dans l'annuaire" description="Renseigner les coordonnées d'une ligne ou d'un numéro et les faire paraître en ligne." />
+</CardGrid>
 
 #### Administration
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
@@ -1,12 +1,32 @@
 ---
 title: VoIP - Présentation de la documentation
+description: "Toute la documentation de la téléphonie VoIP OVHcloud : configuration des lignes SIP, administration, numéros, sécurité et dépannage de vos services."
 lastUpdated: 2026-06-11
+pageType: landing
+banner: true
+tagline: "Configurez, utilisez et administrez vos services de téléphonie VoIP OVHcloud."
+goFurther:
+  title: Aller plus loin
+  items:
+    - title: Échangez avec notre communauté d'utilisateurs
+      link: https://community.ovhcloud.com/
+    - title: "Roadmap VoIP"
+      link: https://github.com/orgs/ovh/projects/18/views/1?sliceBy%5Bvalue%5D=VoIP
+    - title: "Changelog VoIP"
+      link: https://github.com/orgs/ovh/projects/18/views/2?sliceBy%5Bvalue%5D=VoIP
+    - title: Rejoignez le Discord OVHcloud
+      link: https://discord.gg/ovhcloud
+cta:
+  title: "Une question ? Contactez le support OVHcloud"
+  description: Trouvez la réponse à vos questions dans notre centre d'aide.
+  actions:
+    - text: Accéder au support
+      link: https://help.ovhcloud.com/
+      theme: brand
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
 import { LinkCard } from '@components/LinkCard';
-
-## Guides VoIP OVHcloud
 
 Bienvenue dans la documentation dédiée à la [téléphonie VoIP (Voice over IP) d’OVHcloud](https://www.ovhcloud.com/fr/phone/).
 La VoIP permet de passer et recevoir des appels téléphoniques via Internet plutôt que par un réseau téléphonique traditionnel. Vous trouverez ici tous les guides disponibles pour configurer, utiliser et administrer vos services VoIP.
@@ -24,8 +44,6 @@ Avec les services VoIP d’OVHcloud, vous pouvez :
 - Utiliser des téléphones IP ou des applications softphone
 - Configurer des fonctionnalités avancées (répondeur, redirections, numéros abrégés)
 - Exploiter des fonctionnalités telles que des serveurs vocaux interactifs ou des files d’attente.
-
-## Guides VoIP
 
 ### Premiers pas avec la VoIP
 
@@ -92,34 +110,36 @@ Retrouvez les questions les plus fréquemment posées sur les services VoIP OVHc
   </Tab>
 </Tabs>
 
-### Tutoriels
-
-- [Ligne SIP - Configuration sur un softphone / téléphone personnel](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone)
-- [Enregistrer une ligne SIP OVHcloud sur Zoiper](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper)
-- [Tutoriel - Utiliser une ligne SIP OVHcloud sur Linphone](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone)
-
-### Sécurité
-
-- [Sécuriser sa ligne SIP OVHcloud](/guides/web-cloud/phone-and-fax/voip/secure-sip-line)
-- [Modifier le mot de passe d'une ligne SIP](/guides/web-cloud/phone-and-fax/voip/modifier-mot-de-passe-ligne-sip)
-- [Restreindre sa ligne SIP OVHcloud par IP](/guides/web-cloud/phone-and-fax/voip/sip-ip-restriction)
-
-### Diagnostic
-
-- [Tutoriel - Diagnostic du réseau local](/guides/web-cloud/phone-and-fax/voip/troubleshoot-local-network)
-- [Dépanner son téléphone OVHcloud](/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel)
-
-### Ressources additionnelles
-
-- [Guides d'utilisation de nos précédentes gammes de téléphones](/guides/web-cloud/phone-and-fax/voip/previous-phones)
-
-## Changelog et Roadmap
-
-OVHcloud publie un Changelog (parfois également appelé « Release Notes ») qui liste toutes les nouvelles fonctionnalités, améliorations et localisations rendues disponibles pour chacun de nos produits. Vous pouvez le consulter sur GitHub, et le filtrer pour le ou les produits de votre choix :
-
-- [Roadmap VoIP](https://github.com/orgs/ovh/projects/18/views/1?sliceBy%5Bvalue%5D=VoIP)
-- [Changelog VoIP](https://github.com/orgs/ovh/projects/18/views/2?sliceBy%5Bvalue%5D=VoIP)
-
-## Aller plus loin
-
-Échangez avec notre [communauté d'utilisateurs](/links/community).
+<CategoryColumns
+  categories={[
+    {
+      title: 'Tutoriels',
+      items: [
+        { title: 'Ligne SIP - Configuration sur un softphone / téléphone personnel', link: '/guides/web-cloud/phone-and-fax/voip/register-sip-softphone' },
+        { title: 'Enregistrer une ligne SIP OVHcloud sur Zoiper', link: '/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper' },
+        { title: 'Tutoriel - Utiliser une ligne SIP OVHcloud sur Linphone', link: '/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone' },
+      ],
+    },
+    {
+      title: 'Sécurité',
+      items: [
+        { title: 'Sécuriser sa ligne SIP OVHcloud', link: '/guides/web-cloud/phone-and-fax/voip/secure-sip-line' },
+        { title: "Modifier le mot de passe d'une ligne SIP", link: '/guides/web-cloud/phone-and-fax/voip/modifier-mot-de-passe-ligne-sip' },
+        { title: 'Restreindre sa ligne SIP OVHcloud par IP', link: '/guides/web-cloud/phone-and-fax/voip/sip-ip-restriction' },
+      ],
+    },
+    {
+      title: 'Diagnostic',
+      items: [
+        { title: 'Tutoriel - Diagnostic du réseau local', link: '/guides/web-cloud/phone-and-fax/voip/troubleshoot-local-network' },
+        { title: 'Dépanner son téléphone OVHcloud', link: '/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel' },
+      ],
+    },
+    {
+      title: 'Ressources additionnelles',
+      items: [
+        { title: "Guides d'utilisation de nos précédentes gammes de téléphones", link: '/guides/web-cloud/phone-and-fax/voip/previous-phones' },
+      ],
+    },
+  ]}
+/>

--- a/rspress.config.build.ts
+++ b/rspress.config.build.ts
@@ -100,6 +100,7 @@ export default defineConfig({
       path.join(BASE_DIR, 'components/ManagerLink/ManagerLink.tsx'),
       path.join(BASE_DIR, 'components/Tooltip/Tooltip.tsx'),
       path.join(BASE_DIR, 'components/CardGrid/CardGrid.tsx'),
+      path.join(BASE_DIR, 'components/CategoryColumns/CategoryColumns.tsx'),
     ],
     link: {
       checkDeadLinks: true,

--- a/rspress.config.build.ts
+++ b/rspress.config.build.ts
@@ -99,6 +99,7 @@ export default defineConfig({
       path.join(BASE_DIR, 'components/Api/index.tsx'),
       path.join(BASE_DIR, 'components/ManagerLink/ManagerLink.tsx'),
       path.join(BASE_DIR, 'components/Tooltip/Tooltip.tsx'),
+      path.join(BASE_DIR, 'components/CardGrid/CardGrid.tsx'),
     ],
     link: {
       checkDeadLinks: true,

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -131,6 +131,7 @@ export default defineConfig({
       path.join(__dirname, 'components/Api/index.tsx'),
       path.join(__dirname, 'components/ManagerLink/ManagerLink.tsx'),
       path.join(__dirname, 'components/Tooltip/Tooltip.tsx'),
+      path.join(__dirname, 'components/CardGrid/CardGrid.tsx'),
     ],
     link: {
       checkDeadLinks: true,

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -132,6 +132,7 @@ export default defineConfig({
       path.join(__dirname, 'components/ManagerLink/ManagerLink.tsx'),
       path.join(__dirname, 'components/Tooltip/Tooltip.tsx'),
       path.join(__dirname, 'components/CardGrid/CardGrid.tsx'),
+      path.join(__dirname, 'components/CategoryColumns/CategoryColumns.tsx'),
     ],
     link: {
       checkDeadLinks: true,

--- a/theme/components/Sidebar/SidebarGroup.tsx
+++ b/theme/components/Sidebar/SidebarGroup.tsx
@@ -5,11 +5,7 @@ import type {
   SidebarSectionHeader as SidebarSectionHeaderType,
 } from '@rspress/core';
 import { useActiveMatcher } from '@rspress/core/runtime';
-import {
-  IconArrowRight as ArrowRight,
-  SvgWrapper,
-  useLinkNavigate,
-} from '@theme-original';
+import { IconArrowRight as ArrowRight, SvgWrapper } from '@theme-original';
 import clsx from 'clsx';
 import type React from 'react';
 import { SidebarDivider } from './SidebarDivider';
@@ -22,16 +18,29 @@ import {
   isSidebarSectionHeader,
 } from './utils';
 
-const CollapsibleIcon = ({ collapsed }: { collapsed: boolean }) => (
-  <div
+const CollapsibleIcon = ({
+  collapsed,
+  onClick,
+}: {
+  collapsed: boolean;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+}) => (
+  <button
+    type="button"
+    aria-label={collapsed ? 'Expand' : 'Collapse'}
+    onClick={onClick}
     style={{
+      background: 'none',
+      border: 'none',
+      padding: 0,
+      display: 'flex',
       cursor: 'pointer',
       transition: 'transform 0.2s ease-out',
       transform: collapsed ? 'rotate(0deg)' : 'rotate(90deg)',
     }}
   >
     <SvgWrapper icon={ArrowRight} />
-  </div>
+  </button>
 );
 
 export interface SidebarGroupProps {
@@ -54,7 +63,6 @@ export interface SidebarGroupProps {
 export function SidebarGroup(props: SidebarGroupProps) {
   const activeMatcher = useActiveMatcher();
   const { item, depth, id, setSidebarData, className } = props;
-  const navigate = useLinkNavigate();
   const active = item.link && activeMatcher(item.link);
   const { collapsed = false, collapsible = true } =
     item as NormalizedSidebarGroup;
@@ -89,21 +97,34 @@ export function SidebarGroup(props: SidebarGroupProps) {
         className={clsx('rp-sidebar-group', className)}
         depth={depth}
         onClick={(e) => {
-          if (!active && item.link && !collapsed) {
-            navigate(item.link);
-            return;
-          }
+          // Linked category (has a landing page): let the underlying <Link>
+          // handle navigation. We only ensure the group expands — clicking the
+          // row never collapses it (the chevron does that). This gives the
+          // "navigate + keep expanded" behaviour for landing categories.
           if (item.link) {
-            e.stopPropagation();
-            navigate(item.link).then(() => {
-              collapsible && toggleCollapse();
-            });
+            if (collapsible && collapsed) {
+              toggleCollapse();
+            }
             return;
           }
+          // Container-only category: clicking the row toggles expand/collapse.
           e.stopPropagation();
           collapsible && toggleCollapse();
         }}
-        right={collapsible && <CollapsibleIcon collapsed={collapsed} />}
+        right={
+          collapsible && (
+            <CollapsibleIcon
+              collapsed={collapsed}
+              onClick={(e) => {
+                // The chevron is an independent collapse control: stop the
+                // click from triggering the row's <Link> navigation.
+                e.preventDefault();
+                e.stopPropagation();
+                toggleCollapse();
+              }}
+            />
+          )
+        }
       />
 
       <div

--- a/theme/components/Sidebar/SidebarItem.tsx
+++ b/theme/components/Sidebar/SidebarItem.tsx
@@ -63,6 +63,7 @@ export function SidebarItemRaw({
       <Link
         href={link}
         startTransition={startTransition}
+        onClick={onClick}
         className={clsx(
           'rp-sidebar-item',
           {

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -38,6 +38,7 @@ const LazySurveyWidget = lazy(() =>
 
 import { ELearningLayout } from 'theme/layouts/ELearningLayout';
 import { HomeLayout } from 'theme/layouts/HomeLayout/HomeLayout';
+import { LandingLayout } from 'theme/layouts/LandingLayout';
 import { MigrationLayout } from 'theme/layouts/MigrationLayout';
 import { OverviewLayout } from 'theme/layouts/OverviewLayout';
 
@@ -52,6 +53,12 @@ const DocLayout = (props: React.ComponentProps<typeof OriginalDocLayout>) => {
   // If pageType is 'overview', use our custom OverviewLayout
   if (pageType === 'overview') {
     return <OverviewLayout {...props} />;
+  }
+
+  // If pageType is 'landing', use our custom LandingLayout (product/category
+  // landing pages: single H1, banner opt-in, overview-style footer, no outline)
+  if (pageType === 'landing') {
+    return <LandingLayout {...props} />;
   }
 
   // If pageType is 'elearning', use our custom ELearningLayout
@@ -146,6 +153,7 @@ export {
   ELearningLayout,
   FallbackHeading,
   HomeLayout,
+  LandingLayout,
   Layout,
   LlmsCopyButton,
   LlmsViewOptions,

--- a/theme/layouts/LandingLayout/index.scss
+++ b/theme/layouts/LandingLayout/index.scss
@@ -1,0 +1,96 @@
+.rp-landing-layout__content {
+  flex: 1;
+  width: 100%;
+  overflow-x: hidden;
+  display: flex;
+  justify-content: center;
+  max-width: 80rem;
+}
+
+.rp-landing-layout__main {
+  min-height: calc(100vh - var(--rp-nav-height));
+  padding: var(--rp-content-padding-y, 48px) var(--rp-content-padding-x, 80px);
+  padding-bottom: 80px;
+  width: 100%;
+}
+
+/* Plain header (used when no opt-in banner) — single H1 + optional tagline. */
+.rp-landing-header {
+  margin-bottom: 1.5rem;
+  padding: 1rem 0;
+  max-width: 72rem;
+}
+
+.rp-landing-title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--rp-c-text-1);
+  margin-bottom: 0.75rem;
+}
+
+.rp-landing-tagline {
+  font-size: 1.125rem;
+  color: var(--rp-c-text-2);
+  max-width: 700px;
+  line-height: 1.6;
+}
+
+/* The MDX body keeps the normal doc-content styling. */
+.rp-landing-layout__body {
+  max-width: 72rem;
+}
+
+/* Rspress draws a divider before the first content <h2>
+   (`.rp-doc h2:first-of-type::before`). On a default guide it sits under the
+   page H1; on a landing page the header is the banner/title above, so this
+   line reads as a stray separator — remove it. */
+.rp-landing-layout__body.rp-doc h2:first-of-type::before {
+  content: none;
+}
+
+@media (max-width: 768px) {
+  .rp-landing-layout__main {
+    padding: 24px;
+  }
+  .rp-landing-header {
+    padding: 1rem 0;
+  }
+}
+
+/*
+ * Footer tidy-ups for the reused overview components in this layout. (On
+ * overview pages OverviewLayout renders them in its own context; here the body
+ * sits in a doc-content area whose anchor styles would otherwise bleed in.)
+ */
+
+/* Clean "Go further" list — no per-item grey dividers. */
+.rp-landing-layout__main .rp-overview-go-further__item {
+  border-bottom: none;
+}
+
+/* CTA action is an <a>; neutralise doc-content link bleed: keep white label,
+   suppress the external-link ↗ (the CTA appends its own →), and force the
+   button to shrink-wrap + centre (Firefox renders a.rp-link as display:inline,
+   which left-aligns the label). */
+.rp-landing-layout__main .rp-overview-cta__actions {
+  align-items: center;
+}
+
+.rp-landing-layout__main .rp-overview-cta .rp-button--brand,
+.rp-landing-layout__main .rp-overview-cta .rp-button--brand:hover {
+  color: #fff;
+}
+
+.rp-landing-layout__main .rp-overview-cta .rp-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: center;
+  width: auto;
+  max-width: 100%;
+  text-align: center;
+}
+
+.rp-landing-layout__main .rp-overview-cta .rp-button::after {
+  content: none;
+}

--- a/theme/layouts/LandingLayout/index.tsx
+++ b/theme/layouts/LandingLayout/index.tsx
@@ -1,0 +1,197 @@
+import { useFrontmatter, useI18n } from '@rspress/core/runtime';
+import { DocContent, getCustomMDXComponent } from '@rspress/core/theme';
+import { DocFooter, IconMenu, SvgWrapper } from '@rspress/core/theme-original';
+import clsx from 'clsx';
+import type React from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ProductBanner } from '@components/ProductBanner';
+import { OverviewCTA } from 'theme/components/OverviewCTA';
+import { OverviewGoFurther } from 'theme/components/OverviewGoFurther';
+import { Sidebar } from 'theme/components/Sidebar';
+import { usePageTitle } from 'theme/hooks/usePageTitle';
+import './index.scss';
+
+interface GoFurtherData {
+  title?: string;
+  items?: { title: string; link: string }[];
+}
+
+interface CTAData {
+  title?: string;
+  description?: string;
+  actions?: { text: string; link: string; theme?: 'brand' | 'alt' }[];
+}
+
+interface LandingFrontmatter {
+  title?: string;
+  tagline?: string;
+  // Opt-in product banner. `true` renders the gradient ProductBanner as the
+  // page header (and its <h1>). Absent/false → a plain title <h1> is rendered
+  // instead, so lower-level landing pages need no banner. Either way the page
+  // has exactly one <h1>.
+  banner?: boolean;
+  goFurther?: GoFurtherData;
+  cta?: CTAData;
+}
+
+function useLandingSidebarMenu() {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const sidebarMenuRef = useRef<HTMLDivElement>(null);
+  const sidebarLayoutRef = useRef<HTMLDivElement>(null);
+  const t = useI18n();
+
+  useEffect(() => {
+    setIsSidebarOpen(false);
+  }, []);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as Node;
+      if (
+        isSidebarOpen &&
+        sidebarMenuRef.current &&
+        sidebarLayoutRef.current &&
+        !sidebarMenuRef.current.contains(target) &&
+        !sidebarLayoutRef.current.contains(target)
+      ) {
+        setIsSidebarOpen(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isSidebarOpen]);
+
+  const sidebarMenu = useMemo(
+    () => (
+      <>
+        <div className="rp-sidebar-menu" ref={sidebarMenuRef}>
+          <button
+            type="button"
+            onClick={() => setIsSidebarOpen(true)}
+            className="rp-sidebar-menu__left"
+          >
+            <SvgWrapper icon={IconMenu} />
+            <span>{t('menuTitle')}</span>
+          </button>
+          <div className="rp-sidebar-menu__right" />
+        </div>
+        {isSidebarOpen &&
+          typeof document !== 'undefined' &&
+          createPortal(
+            <button
+              type="button"
+              onClick={() => setIsSidebarOpen(false)}
+              onKeyUp={() => setIsSidebarOpen(false)}
+              className="rp-sidebar-menu__mask"
+              aria-label="Close sidebar"
+            />,
+            document.getElementById('__rspress_modal_container') ||
+              document.body,
+          )}
+      </>
+    ),
+    [isSidebarOpen, t],
+  );
+
+  return { sidebarMenu, isSidebarOpen, sidebarLayoutRef };
+}
+
+export interface LandingLayoutProps {
+  beforeDocFooter?: React.ReactNode;
+  afterDocFooter?: React.ReactNode;
+  beforeDocContent?: React.ReactNode;
+  afterDocContent?: React.ReactNode;
+}
+
+/**
+ * Layout for product / category landing pages (`pageType: landing`).
+ *
+ * Unlike the default doc layout it renders its own single <h1> (so there is
+ * no duplicate auto-title and the frontmatter `description` is used for meta
+ * only, never shown in the body) and reuses the overview footer
+ * (OverviewGoFurther + OverviewCTA) from the `goFurther`/`cta` frontmatter.
+ * The right-hand outline is not rendered. The MDX body is rendered via
+ * <Content>, so authors keep writing normal MDX (CardGrid, CategoryColumns…).
+ *
+ * The product banner is opt-in (`banner: true`); without it a plain title
+ * heading is shown, which suits landing pages applied at lower levels.
+ */
+export function LandingLayout(props: LandingLayoutProps) {
+  const { beforeDocFooter, afterDocFooter, beforeDocContent, afterDocContent } =
+    props;
+  const t = useI18n();
+  const { frontmatter } = useFrontmatter();
+  const { title, tagline, banner, goFurther, cta } =
+    frontmatter as LandingFrontmatter;
+  const { sidebarMenu, isSidebarOpen, sidebarLayoutRef } =
+    useLandingSidebarMenu();
+  usePageTitle(title);
+
+  return (
+    <>
+      <div className="rp-doc-layout__menu">{sidebarMenu}</div>
+      <div className="rp-doc-layout__container">
+        <aside
+          className={clsx(
+            'rp-doc-layout__sidebar',
+            'rp-scrollbar',
+            isSidebarOpen && 'rp-doc-layout__sidebar--open',
+          )}
+          ref={sidebarLayoutRef}
+        >
+          <Sidebar />
+        </aside>
+        <div className="rp-landing-layout__content">
+          <main className="rp-landing-layout__main">
+            {beforeDocContent}
+
+            {/* Single H1: the banner (opt-in) or a plain title heading. */}
+            {banner ? (
+              <ProductBanner title={title} tagline={tagline} />
+            ) : (
+              <div className="rp-landing-header">
+                {title && <h1 className="rp-landing-title">{title}</h1>}
+                {tagline && <p className="rp-landing-tagline">{tagline}</p>}
+              </div>
+            )}
+
+            {/* MDX body — rendered through DocContent so markdown headings,
+                lists, callouts, etc. keep their styling and the custom MDX
+                component mapping. `.rp-doc` scopes the doc-content styles;
+                isOverviewPage suppresses the fallback auto-H1 (the banner /
+                landing header is our single H1). */}
+            <div className="rp-landing-layout__body rp-doc rspress-doc">
+              <DocContent
+                components={getCustomMDXComponent()}
+                isOverviewPage
+              />
+            </div>
+
+            {/* Reused overview footer */}
+            {goFurther?.items && goFurther.items.length > 0 && (
+              <OverviewGoFurther
+                title={goFurther.title || t('overview.goFurtherTitle')}
+                items={goFurther.items}
+              />
+            )}
+            {cta?.title && (
+              <OverviewCTA
+                title={cta.title}
+                description={cta.description}
+                actions={cta.actions}
+              />
+            )}
+
+            {afterDocContent}
+
+            {beforeDocFooter}
+            <DocFooter />
+            {afterDocFooter}
+          </main>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Categories flagged with a `{landing=<slug>}` marker in config/sidebar/index.md now render a landing page when clicked, while still expanding in the sidebar.

- parser.ts: parse the marker and set `link` on the category SidebarGroup
- SidebarGroup: linked categories navigate + keep expanded; the chevron becomes an independent collapse control. Container-only categories keep toggling.
- SidebarItem: forward onClick to the underlying <Link> so a group can expand on navigation.
- Add a global <CardGrid> component for 2-column card layouts in free-form MDX.
- Wire the VoIP page as the "Phone and Fax" landing page and demo <CardGrid>.