### PR TITLE
fix(content): repoint hub-spoke vRack APIv6 link to consolidated vrack guide

### DIFF
--- a/docs/de/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
@@ -632,7 +632,7 @@ Die Bereitstellung und der Betrieb dieser Architektur erfordern solide Cloud- un
 - [Architektur-Referenz — Aufbau einer Landing Zone mit OVHcloud Public Cloud](/guides/public-cloud/cross-functional/landing-zone-migration)
 - [Best Practices zum Absichern und Strukturieren von OVHcloud Public Cloud Projekten](/guides/public-cloud/cross-functional/security-structure-best-practices)
 - [Verwendung von Terraform mit OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform)
-- [vRack für Public Cloud mit OVHcloud APIv6 konfigurieren](/guides/public-cloud/network-services/vrack-apiv6)
+- [vRack für Public Cloud mit OVHcloud APIv6 konfigurieren](/guides/public-cloud/network-services/vrack)
 - [Erste Schritte mit Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 
 Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/en/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
@@ -632,7 +632,7 @@ Deploying and operating this architecture requires solid cloud and network skill
 - [Architecture Reference — Building a Landing Zone with OVHcloud Public Cloud](/guides/public-cloud/cross-functional/landing-zone-migration)
 - [Best Practices for securing & structuring OVHcloud Public Cloud Projects](/guides/public-cloud/cross-functional/security-structure-best-practices)
 - [How to use Terraform with OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform)
-- [Configuring vRack for Public Cloud using OVHcloud APIv6](/guides/public-cloud/network-services/vrack-apiv6)
+- [Configuring vRack for Public Cloud using OVHcloud APIv6](/guides/public-cloud/network-services/vrack)
 - [Getting started with Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 
 Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
@@ -632,7 +632,7 @@ El despliegue y la explotación de esta arquitectura requieren sólidas competen
 - [Referencia de arquitectura — Construir una landing zone con OVHcloud Public Cloud](/guides/public-cloud/cross-functional/landing-zone-migration)
 - [Buenas prácticas para proteger y estructurar sus proyectos OVHcloud Public Cloud](/guides/public-cloud/cross-functional/security-structure-best-practices)
 - [Cómo utilizar Terraform con OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform)
-- [Configurar el vRack para Public Cloud mediante la API de OVHcloud v6](/guides/public-cloud/network-services/vrack-apiv6)
+- [Configurar el vRack para Public Cloud mediante la API de OVHcloud v6](/guides/public-cloud/network-services/vrack)
 - [Primeros pasos con Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
@@ -632,7 +632,7 @@ Le déploiement et l'exploitation de cette architecture requièrent de solides c
 - [Référence d'architecture — Construire une landing zone avec OVHcloud Public Cloud](/guides/public-cloud/cross-functional/landing-zone-migration)
 - [Meilleures pratiques pour sécuriser et structurer vos projets OVHcloud Public Cloud](/guides/public-cloud/cross-functional/security-structure-best-practices)
 - [Comment utiliser Terraform avec OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform)
-- [Configurer le vRack pour Public Cloud via l'API OVHcloud v6](/guides/public-cloud/network-services/vrack-apiv6)
+- [Configurer le vRack pour Public Cloud via l'API OVHcloud v6](/guides/public-cloud/network-services/vrack)
 - [Débuter avec Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
@@ -632,7 +632,7 @@ L'implementazione e la gestione di questa architettura richiedono solide compete
 - [Riferimento di architettura — Costruire una landing zone con OVHcloud Public Cloud](/guides/public-cloud/cross-functional/landing-zone-migration)
 - [Best practice per proteggere e strutturare i progetti OVHcloud Public Cloud](/guides/public-cloud/cross-functional/security-structure-best-practices)
 - [Come utilizzare Terraform con OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform)
-- [Configurare il vRack per Public Cloud tramite l'API OVHcloud v6](/guides/public-cloud/network-services/vrack-apiv6)
+- [Configurare il vRack per Public Cloud tramite l'API OVHcloud v6](/guides/public-cloud/network-services/vrack)
 - [Iniziare con Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 
 Contatta la nostra [Community di utenti](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
@@ -632,7 +632,7 @@ Wdrożenie i eksploatacja tej architektury wymaga solidnych umiejętności w zak
 - [Referencja architektury — budowa landing zone z OVHcloud Public Cloud](/guides/public-cloud/cross-functional/landing-zone-migration)
 - [Najlepsze praktyki zabezpieczania i strukturyzowania projektów OVHcloud Public Cloud](/guides/public-cloud/cross-functional/security-structure-best-practices)
 - [Jak używać Terraform z OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform)
-- [Konfigurowanie vRack dla Public Cloud przy użyciu OVHcloud APIv6](/guides/public-cloud/network-services/vrack-apiv6)
+- [Konfigurowanie vRack dla Public Cloud przy użyciu OVHcloud APIv6](/guides/public-cloud/network-services/vrack)
 - [Pierwsze kroki z Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 
 Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/landing-zone-hub-spoke-cloud-architects.mdx
@@ -632,7 +632,7 @@ A implementação e a exploração desta arquitetura requerem sólidas competên
 - [Referência de arquitetura — Construir uma landing zone com a OVHcloud Public Cloud](/guides/public-cloud/cross-functional/landing-zone-migration)
 - [Melhores práticas para proteger e estruturar os seus projetos OVHcloud Public Cloud](/guides/public-cloud/cross-functional/security-structure-best-practices)
 - [Como utilizar o Terraform com a OVHcloud Public Cloud](/guides/public-cloud/cross-functional/how-to-use-terraform)
-- [Configurar o vRack para Public Cloud através da API OVHcloud v6](/guides/public-cloud/network-services/vrack-apiv6)
+- [Configurar o vRack para Public Cloud através da API OVHcloud v6](/guides/public-cloud/network-services/vrack)
 - [Começar com a Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 
 Fale com a nossa [comunidade de utilizadores](/links/community).


### PR DESCRIPTION
The landing-zone hub-spoke guide linked to network-services/vrack-apiv6, which was deleted and 301-redirected to network-services/vrack (vrack consolidation). The dead link broke the Rspress build link checker. Repoint to /vrack in all 7 locales.