### PR TITLE
fix: fix node upgrade informations in understanding-mks-architecture

### DIFF
--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
@@ -1,0 +1,1 @@
+../../../../../en/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
@@ -1,7 +1,7 @@
 ---
 title: Understanding OVHcloud Managed Kubernetes architecture
 description: "Learn how OVHcloud Managed Kubernetes Service works under the hood: control plane, worker nodes, networking, and storage"
-lastUpdated: 2026-02-25
+lastUpdated: 2026-06-15
 ---
 
 ## Objective
@@ -262,7 +262,7 @@ When upgrading Kubernetes versions, MKS offers two strategies for updating worke
 +=============================================================================+
 |                                                                             |
 |  IN-PLACE UPGRADE                         ROLLING UPGRADE                   |
-|  (Free & Standard)                        (Standard only for now)           |
+|  (Free)                                   (Standard only for now)           |
 |                                                                             |
 |  Same instance,                           New instances replace             |
 |  components updated                       old ones                          |
@@ -342,6 +342,12 @@ With rolling upgrades (currently available on Standard plan only), new worker no
 - Faster upgrades with higher availability
 - Clean node state (fresh instances)
 - Better handling of workload migration
+
+:::warning
+Rolling upgrade will roll on all nodepools simultaneously.
+
+Using PodDisruptionBudgets and topologySpreadConstraints will avoid any issue with a deployment spread across nodepools.
+:::
 
 :::info
 In the future roadmap, rolling upgrades will support Kubernetes-style `maxSurge` and `maxUnavailable` settings to control how many nodes can be added or taken offline simultaneously.

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
@@ -1,7 +1,7 @@
 ---
 title: Understanding OVHcloud Managed Kubernetes architecture
 description: "Learn how OVHcloud Managed Kubernetes Service works under the hood: control plane, worker nodes, networking, and storage"
-lastUpdated: 2026-06-15
+lastUpdated: 2026-06-16
 ---
 
 ## Objective
@@ -344,7 +344,7 @@ With rolling upgrades (currently available on Standard plan only), new worker no
 - Better handling of workload migration
 
 :::warning
-Rolling upgrade will roll on all nodepools simultaneously.
+A rolling upgrade rolls out across all nodepools simultaneously.
 
 Using PodDisruptionBudgets and topologySpreadConstraints will avoid any issue with a deployment spread across nodepools.
 :::
@@ -844,6 +844,6 @@ For the complete version matrix, see [Kubernetes Plugins & Software versions](/g
 - [Persistent Volumes](/guides/public-cloud/containers-orchestration/managed-kubernetes/set-up-persistent-volume)
 - [Expose your applications using Load Balancer](/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analyzed by our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
@@ -1,0 +1,1 @@
+../../../../../en/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
@@ -263,7 +263,7 @@ Lors de la mise à jour des versions Kubernetes, MKS propose deux stratégies po
 +===============================================================================+
 |                                                                               |
 |  MISE À JOUR IN-PLACE                     ROLLING UPGRADE                     |
-|  (Free & Standard)                        (Standard uniquement pour l'instant)|
+|  (Free)                                   (Standard uniquement pour l'instant)|
 |                                                                               |
 |  Même instance, composants                Nouvelles instances remplacent      |
 |  mis à jour                               les anciennes                       |
@@ -343,6 +343,12 @@ Avec les rolling upgrades (actuellement disponibles uniquement sur le plan Stand
 - Mises à jour plus rapides avec une meilleure disponibilité
 - État propre des nodes (instances fraîches)
 - Meilleure gestion de la migration des workloads
+
+:::warning
+Rolling upgrade will roll on all nodepools simultaneously.
+
+Using PodDisruptionBudgets and topologySpreadConstraints will avoid any issue with a deployment spread across nodepools.
+:::
 
 :::info
 Dans la roadmap future, les rolling upgrades supporteront les paramètres Kubernetes `maxSurge` et `maxUnavailable` pour contrôler combien de nodes peuvent être ajoutés ou mis hors ligne simultanément.

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Comprendre l'architecture d'OVHcloud Managed Kubernetes"
 description: "Découvrez le fonctionnement d'OVHcloud Managed Kubernetes Service : control plane, worker nodes, réseau et stockage"
-lastUpdated: 2026-02-25
+lastUpdated: 2026-06-16
 ---
 
 ## Objectif
@@ -345,9 +345,9 @@ Avec les rolling upgrades (actuellement disponibles uniquement sur le plan Stand
 - Meilleure gestion de la migration des workloads
 
 :::warning
-Rolling upgrade will roll on all nodepools simultaneously.
+Le rolling upgrade s'applique simultanément à tous les nodepools.
 
-Using PodDisruptionBudgets and topologySpreadConstraints will avoid any issue with a deployment spread across nodepools.
+L'utilisation de PodDisruptionBudgets et topologySpreadConstraints permet d'éviter tout problème avec un déploiement réparti sur plusieurs nodepools.
 :::
 
 :::info
@@ -846,6 +846,6 @@ Pour la matrice complète des versions, consultez [Plugins Kubernetes et version
 - [Volumes persistants](/guides/public-cloud/containers-orchestration/managed-kubernetes/set-up-persistent-volume)
 - [Exposer vos applications avec le Load Balancer](/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre Technical Account Manager ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l'équipe Professional Services.
+Pour une formation ou une assistance technique sur la mise en œuvre de nos solutions, contactez votre commercial ou consultez la page [Professional Services](/links/professional-services) pour obtenir un devis et faire analyser votre projet par nos experts.
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
@@ -1,0 +1,1 @@
+../../../../../en/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
@@ -1,0 +1,1 @@
+../../../../../en/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx
@@ -1,0 +1,1 @@
+../../../../../en/guides/public-cloud/containers-orchestration/managed-kubernetes/understanding-mks-architecture.mdx


### PR DESCRIPTION
- Remove standard plan in in-place upgrade table
- Add warning about rolling upgrade strategy