### PR TITLE
feat(theme): remove the Duration badge from e-learning course pages

### DIFF
--- a/docs/de/guides/e-learning/ai-endpoints-plug-play-produce.mdx
+++ b/docs/de/guides/e-learning/ai-endpoints-plug-play-produce.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Erstellen Sie intelligente Anwendungen schneller als je zuvor mit AI Endpoints!"
   level: "Associate"
   language: "Englisch"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi1SprU2e9Xog4Kyd5mBg6wK"
   learn:
     title: "Das lernen Sie in diesem Kurs"

--- a/docs/de/guides/e-learning/ai-solutions-learn-train-launch.mdx
+++ b/docs/de/guides/e-learning/ai-solutions-learn-train-launch.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Erstellen Sie hochmoderne KI-Anwendungen mit den AI Solutions von OVHcloud!"
   level: "Associate"
   language: "Englisch"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi5md7xzMmX1UNaBtvaAGmNC"
   learn:
     title: "Das lernen Sie in diesem Kurs"

--- a/docs/de/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
+++ b/docs/de/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Erstellen Sie skalierbare, cloud-fähige Architekturen mit den Compute- und Network-Produkten und -Services von OVHcloud!"
   level: "Associate"
   language: "Englisch"
-  duration: "2h15"
   video: "https://embed.api.video/vod/viHcJlgwRwryv7mMhIgbYGq"
   learn:
     title: "Das lernen Sie in diesem Kurs"

--- a/docs/de/guides/e-learning/managed-databases-click-connect-query.mdx
+++ b/docs/de/guides/e-learning/managed-databases-click-connect-query.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Betreiben Sie SQL- und NoSQL-Datenbanken mit den Managed Databases von OVHcloud!"
   level: "Associate"
   language: "Englisch"
-  duration: "1h30"
   video: "https://embed.api.video/vod/vimrTOmmVUDuKGKrcTje4IX"
   learn:
     title: "Das lernen Sie in diesem Kurs"

--- a/docs/de/guides/e-learning/mks-code-ship-scale.mdx
+++ b/docs/de/guides/e-learning/mks-code-ship-scale.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Willkommen in der Cloud-Native-Welt mit dem Managed Kubernetes Service!"
   level: "Associate"
   language: "Englisch"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi4UbRCOfkkkhnNrfePmRVzH"
   learn:
     title: "Das lernen Sie in diesem Kurs"

--- a/docs/de/guides/e-learning/mrs-wrangle-rule-run.mdx
+++ b/docs/de/guides/e-learning/mrs-wrangle-rule-run.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Orchestrieren Sie eine Multi-Cluster-Infrastruktur mit dem Managed Rancher Service von OVHcloud!"
   level: "Associate"
   language: "Englisch"
-  duration: "2h"
   video: "https://embed.api.video/vod/viptdYNXaiqDKkW45CjHZor"
   learn:
     title: "Das lernen Sie in diesem Kurs"

--- a/docs/de/guides/e-learning/public-cloud-explore-build-grow.mdx
+++ b/docs/de/guides/e-learning/public-cloud-explore-build-grow.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Machen Sie Ihre ersten Schritte in der Public Cloud und entdecken Sie das Ökosystem von OVHcloud!"
   level: "Associate"
   language: "Englisch"
-  duration: "2h"
   learn:
     title: "Das lernen Sie in diesem Kurs"
     items:

--- a/docs/en/guides/e-learning/ai-endpoints-plug-play-produce.mdx
+++ b/docs/en/guides/e-learning/ai-endpoints-plug-play-produce.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Create intelligent applications faster than ever with AI Endpoints!"
   level: "Associate"
   language: "English"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi1SprU2e9Xog4Kyd5mBg6wK"
   learn:
     title: "What you will learn in this course"

--- a/docs/en/guides/e-learning/ai-solutions-learn-train-launch.mdx
+++ b/docs/en/guides/e-learning/ai-solutions-learn-train-launch.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Build cutting-edge AI applications with OVHcloud's AI solutions!"
   level: "Associate"
   language: "English"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi5md7xzMmX1UNaBtvaAGmNC"
   learn:
     title: "What you will learn in this course"

--- a/docs/en/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
+++ b/docs/en/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Build Cloud-ready scalable architectures with OVHcloud's Compute and Network products and services!"
   level: "Associate"
   language: "English"
-  duration: "2h15"
   video: "https://embed.api.video/vod/viHcJlgwRwryv7mMhIgbYGq"
   learn:
     title: "What you will learn in this course"

--- a/docs/en/guides/e-learning/managed-databases-click-connect-query.mdx
+++ b/docs/en/guides/e-learning/managed-databases-click-connect-query.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Run SQL and NoSQL databases with OVHcloud's Managed Databases!"
   level: "Associate"
   language: "English"
-  duration: "1h30"
   video: "https://embed.api.video/vod/vimrTOmmVUDuKGKrcTje4IX"
   learn:
     title: "What you will learn in this course"

--- a/docs/en/guides/e-learning/mks-code-ship-scale.mdx
+++ b/docs/en/guides/e-learning/mks-code-ship-scale.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Welcome to the Cloud Native world with Managed Kubernetes Service!"
   level: "Associate"
   language: "English"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi4UbRCOfkkkhnNrfePmRVzH"
   learn:
     title: "What you will learn in this course"

--- a/docs/en/guides/e-learning/mrs-wrangle-rule-run.mdx
+++ b/docs/en/guides/e-learning/mrs-wrangle-rule-run.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Orchestrate a multi-cluster infrastructure with OVHcloud's Managed Rancher Service!"
   level: "Associate"
   language: "English"
-  duration: "2h"
   video: "https://embed.api.video/vod/viptdYNXaiqDKkW45CjHZor"
   learn:
     title: "What you will learn in this course"

--- a/docs/en/guides/e-learning/public-cloud-explore-build-grow.mdx
+++ b/docs/en/guides/e-learning/public-cloud-explore-build-grow.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Get started in Public Cloud and discover OVHcloud's ecosystem!"
   level: "Associate"
   language: "English"
-  duration: "2h"
   learn:
     title: "What you will learn in this course"
     items:

--- a/docs/es/guides/e-learning/ai-endpoints-plug-play-produce.mdx
+++ b/docs/es/guides/e-learning/ai-endpoints-plug-play-produce.mdx
@@ -19,7 +19,6 @@ overview:
   description: "¡Cree aplicaciones inteligentes más rápido que nunca con AI Endpoints!"
   level: "Associate"
   language: "Inglés"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi1SprU2e9Xog4Kyd5mBg6wK"
   learn:
     title: "Lo que aprenderá en este curso"

--- a/docs/es/guides/e-learning/ai-solutions-learn-train-launch.mdx
+++ b/docs/es/guides/e-learning/ai-solutions-learn-train-launch.mdx
@@ -19,7 +19,6 @@ overview:
   description: "¡Cree aplicaciones de IA de vanguardia con las soluciones AI de OVHcloud!"
   level: "Associate"
   language: "Inglés"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi5md7xzMmX1UNaBtvaAGmNC"
   learn:
     title: "Lo que aprenderá en este curso"

--- a/docs/es/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
+++ b/docs/es/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
@@ -19,7 +19,6 @@ overview:
   description: "¡Diseñe arquitecturas escalables y listas para el cloud con los productos y servicios Compute y Network de OVHcloud!"
   level: "Associate"
   language: "Inglés"
-  duration: "2h15"
   video: "https://embed.api.video/vod/viHcJlgwRwryv7mMhIgbYGq"
   learn:
     title: "Lo que aprenderá en este curso"

--- a/docs/es/guides/e-learning/managed-databases-click-connect-query.mdx
+++ b/docs/es/guides/e-learning/managed-databases-click-connect-query.mdx
@@ -19,7 +19,6 @@ overview:
   description: "¡Gestione bases de datos SQL y NoSQL con las Managed Databases de OVHcloud!"
   level: "Associate"
   language: "Inglés"
-  duration: "1h30"
   video: "https://embed.api.video/vod/vimrTOmmVUDuKGKrcTje4IX"
   learn:
     title: "Lo que aprenderá en este curso"

--- a/docs/es/guides/e-learning/mks-code-ship-scale.mdx
+++ b/docs/es/guides/e-learning/mks-code-ship-scale.mdx
@@ -19,7 +19,6 @@ overview:
   description: "¡Bienvenido al mundo Cloud Native con el Managed Kubernetes Service!"
   level: "Associate"
   language: "Inglés"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi4UbRCOfkkkhnNrfePmRVzH"
   learn:
     title: "Lo que aprenderá en este curso"

--- a/docs/es/guides/e-learning/mrs-wrangle-rule-run.mdx
+++ b/docs/es/guides/e-learning/mrs-wrangle-rule-run.mdx
@@ -19,7 +19,6 @@ overview:
   description: "¡Orqueste una infraestructura multiclúster con el Managed Rancher Service de OVHcloud!"
   level: "Associate"
   language: "Inglés"
-  duration: "2h"
   video: "https://embed.api.video/vod/viptdYNXaiqDKkW45CjHZor"
   learn:
     title: "Lo que aprenderá en este curso"

--- a/docs/es/guides/e-learning/public-cloud-explore-build-grow.mdx
+++ b/docs/es/guides/e-learning/public-cloud-explore-build-grow.mdx
@@ -19,7 +19,6 @@ overview:
   description: "¡Dé sus primeros pasos en el Public Cloud y descubra el ecosistema de OVHcloud!"
   level: "Associate"
   language: "Inglés"
-  duration: "2h"
   learn:
     title: "Lo que aprenderá en este curso"
     items:

--- a/docs/fr/guides/e-learning/ai-endpoints-plug-play-produce.mdx
+++ b/docs/fr/guides/e-learning/ai-endpoints-plug-play-produce.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Créez des applications intelligentes plus rapidement que jamais avec AI Endpoints !"
   level: "Associate"
   language: "Anglais"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi1SprU2e9Xog4Kyd5mBg6wK"
   learn:
     title: "Ce que vous apprendrez dans ce cours"

--- a/docs/fr/guides/e-learning/ai-solutions-learn-train-launch.mdx
+++ b/docs/fr/guides/e-learning/ai-solutions-learn-train-launch.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Créez des applications d'IA de pointe avec les solutions AI d'OVHcloud !"
   level: "Associate"
   language: "Anglais"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi5md7xzMmX1UNaBtvaAGmNC"
   learn:
     title: "Ce que vous apprendrez dans ce cours"

--- a/docs/fr/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
+++ b/docs/fr/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Concevez des architectures évolutives et prêtes pour le cloud avec les produits et services Compute et Network d'OVHcloud !"
   level: "Associate"
   language: "Anglais"
-  duration: "2h15"
   video: "https://embed.api.video/vod/viHcJlgwRwryv7mMhIgbYGq"
   learn:
     title: "Ce que vous apprendrez dans ce cours"

--- a/docs/fr/guides/e-learning/managed-databases-click-connect-query.mdx
+++ b/docs/fr/guides/e-learning/managed-databases-click-connect-query.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Exploitez des bases de données SQL et NoSQL avec les Managed Databases d'OVHcloud !"
   level: "Associate"
   language: "Anglais"
-  duration: "1h30"
   video: "https://embed.api.video/vod/vimrTOmmVUDuKGKrcTje4IX"
   learn:
     title: "Ce que vous apprendrez dans ce cours"

--- a/docs/fr/guides/e-learning/mks-code-ship-scale.mdx
+++ b/docs/fr/guides/e-learning/mks-code-ship-scale.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Bienvenue dans le monde Cloud Native avec le Managed Kubernetes Service !"
   level: "Associate"
   language: "Anglais"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi4UbRCOfkkkhnNrfePmRVzH"
   learn:
     title: "Ce que vous apprendrez dans ce cours"

--- a/docs/fr/guides/e-learning/mrs-wrangle-rule-run.mdx
+++ b/docs/fr/guides/e-learning/mrs-wrangle-rule-run.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Orchestrez une infrastructure multicluster avec le Managed Rancher Service d'OVHcloud !"
   level: "Associate"
   language: "Anglais"
-  duration: "2h"
   video: "https://embed.api.video/vod/viptdYNXaiqDKkW45CjHZor"
   learn:
     title: "Ce que vous apprendrez dans ce cours"

--- a/docs/fr/guides/e-learning/public-cloud-explore-build-grow.mdx
+++ b/docs/fr/guides/e-learning/public-cloud-explore-build-grow.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Faites vos premiers pas dans le Public Cloud et découvrez l'écosystème OVHcloud !"
   level: "Associate"
   language: "Anglais"
-  duration: "2h"
   learn:
     title: "Ce que vous apprendrez dans ce cours"
     items:

--- a/docs/it/guides/e-learning/ai-endpoints-plug-play-produce.mdx
+++ b/docs/it/guides/e-learning/ai-endpoints-plug-play-produce.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Crea applicazioni intelligenti più velocemente che mai con AI Endpoints!"
   level: "Associate"
   language: "Inglese"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi1SprU2e9Xog4Kyd5mBg6wK"
   learn:
     title: "Cosa imparerai in questo corso"

--- a/docs/it/guides/e-learning/ai-solutions-learn-train-launch.mdx
+++ b/docs/it/guides/e-learning/ai-solutions-learn-train-launch.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Crea applicazioni di IA all'avanguardia con le soluzioni AI di OVHcloud!"
   level: "Associate"
   language: "Inglese"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi5md7xzMmX1UNaBtvaAGmNC"
   learn:
     title: "Cosa imparerai in questo corso"

--- a/docs/it/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
+++ b/docs/it/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Progetta architetture scalabili e pronte per il cloud con i prodotti e i servizi Compute e Network di OVHcloud!"
   level: "Associate"
   language: "Inglese"
-  duration: "2h15"
   video: "https://embed.api.video/vod/viHcJlgwRwryv7mMhIgbYGq"
   learn:
     title: "Cosa imparerai in questo corso"

--- a/docs/it/guides/e-learning/managed-databases-click-connect-query.mdx
+++ b/docs/it/guides/e-learning/managed-databases-click-connect-query.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Gestisci database SQL e NoSQL con i Managed Databases di OVHcloud!"
   level: "Associate"
   language: "Inglese"
-  duration: "1h30"
   video: "https://embed.api.video/vod/vimrTOmmVUDuKGKrcTje4IX"
   learn:
     title: "Cosa imparerai in questo corso"

--- a/docs/it/guides/e-learning/mks-code-ship-scale.mdx
+++ b/docs/it/guides/e-learning/mks-code-ship-scale.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Benvenuto nel mondo Cloud Native con il Managed Kubernetes Service!"
   level: "Associate"
   language: "Inglese"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi4UbRCOfkkkhnNrfePmRVzH"
   learn:
     title: "Cosa imparerai in questo corso"

--- a/docs/it/guides/e-learning/mrs-wrangle-rule-run.mdx
+++ b/docs/it/guides/e-learning/mrs-wrangle-rule-run.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Orchestra un'infrastruttura multicluster con il Managed Rancher Service di OVHcloud!"
   level: "Associate"
   language: "Inglese"
-  duration: "2h"
   video: "https://embed.api.video/vod/viptdYNXaiqDKkW45CjHZor"
   learn:
     title: "Cosa imparerai in questo corso"

--- a/docs/it/guides/e-learning/public-cloud-explore-build-grow.mdx
+++ b/docs/it/guides/e-learning/public-cloud-explore-build-grow.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Muovi i primi passi nel Public Cloud e scopri l'ecosistema di OVHcloud!"
   level: "Associate"
   language: "Inglese"
-  duration: "2h"
   learn:
     title: "Cosa imparerai in questo corso"
     items:

--- a/docs/pl/guides/e-learning/ai-endpoints-plug-play-produce.mdx
+++ b/docs/pl/guides/e-learning/ai-endpoints-plug-play-produce.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Twórz inteligentne aplikacje szybciej niż kiedykolwiek dzięki AI Endpoints!"
   level: "Associate"
   language: "Angielski"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi1SprU2e9Xog4Kyd5mBg6wK"
   learn:
     title: "Czego nauczysz się w tym kursie"

--- a/docs/pl/guides/e-learning/ai-solutions-learn-train-launch.mdx
+++ b/docs/pl/guides/e-learning/ai-solutions-learn-train-launch.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Twórz najnowocześniejsze aplikacje SI z rozwiązaniami AI od OVHcloud!"
   level: "Associate"
   language: "Angielski"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi5md7xzMmX1UNaBtvaAGmNC"
   learn:
     title: "Czego nauczysz się w tym kursie"

--- a/docs/pl/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
+++ b/docs/pl/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Projektuj skalowalne, gotowe na chmurę architektury z produktami i usługami Compute oraz Network od OVHcloud!"
   level: "Associate"
   language: "Angielski"
-  duration: "2h15"
   video: "https://embed.api.video/vod/viHcJlgwRwryv7mMhIgbYGq"
   learn:
     title: "Czego nauczysz się w tym kursie"

--- a/docs/pl/guides/e-learning/managed-databases-click-connect-query.mdx
+++ b/docs/pl/guides/e-learning/managed-databases-click-connect-query.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Obsługuj bazy danych SQL i NoSQL za pomocą Managed Databases od OVHcloud!"
   level: "Associate"
   language: "Angielski"
-  duration: "1h30"
   video: "https://embed.api.video/vod/vimrTOmmVUDuKGKrcTje4IX"
   learn:
     title: "Czego nauczysz się w tym kursie"

--- a/docs/pl/guides/e-learning/mks-code-ship-scale.mdx
+++ b/docs/pl/guides/e-learning/mks-code-ship-scale.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Witaj w świecie Cloud Native z Managed Kubernetes Service!"
   level: "Associate"
   language: "Angielski"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi4UbRCOfkkkhnNrfePmRVzH"
   learn:
     title: "Czego nauczysz się w tym kursie"

--- a/docs/pl/guides/e-learning/mrs-wrangle-rule-run.mdx
+++ b/docs/pl/guides/e-learning/mrs-wrangle-rule-run.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Zarządzaj infrastrukturą wieloklastrową za pomocą Managed Rancher Service od OVHcloud!"
   level: "Associate"
   language: "Angielski"
-  duration: "2h"
   video: "https://embed.api.video/vod/viptdYNXaiqDKkW45CjHZor"
   learn:
     title: "Czego nauczysz się w tym kursie"

--- a/docs/pl/guides/e-learning/public-cloud-explore-build-grow.mdx
+++ b/docs/pl/guides/e-learning/public-cloud-explore-build-grow.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Postaw pierwsze kroki w Public Cloud i odkryj ekosystem OVHcloud!"
   level: "Associate"
   language: "Angielski"
-  duration: "2h"
   learn:
     title: "Czego nauczysz się w tym kursie"
     items:

--- a/docs/pt/guides/e-learning/ai-endpoints-plug-play-produce.mdx
+++ b/docs/pt/guides/e-learning/ai-endpoints-plug-play-produce.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Crie aplicações inteligentes mais rápido do que nunca com o AI Endpoints!"
   level: "Associate"
   language: "Inglês"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi1SprU2e9Xog4Kyd5mBg6wK"
   learn:
     title: "O que vai aprender neste curso"

--- a/docs/pt/guides/e-learning/ai-solutions-learn-train-launch.mdx
+++ b/docs/pt/guides/e-learning/ai-solutions-learn-train-launch.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Crie aplicações de IA de vanguarda com as soluções AI da OVHcloud!"
   level: "Associate"
   language: "Inglês"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi5md7xzMmX1UNaBtvaAGmNC"
   learn:
     title: "O que vai aprender neste curso"

--- a/docs/pt/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
+++ b/docs/pt/guides/e-learning/compute-solutions-design-deploy-deliver.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Conceba arquiteturas escaláveis e prontas para o cloud com os produtos e serviços Compute e Network da OVHcloud!"
   level: "Associate"
   language: "Inglês"
-  duration: "2h15"
   video: "https://embed.api.video/vod/viHcJlgwRwryv7mMhIgbYGq"
   learn:
     title: "O que vai aprender neste curso"

--- a/docs/pt/guides/e-learning/managed-databases-click-connect-query.mdx
+++ b/docs/pt/guides/e-learning/managed-databases-click-connect-query.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Utilize bases de dados SQL e NoSQL com as Managed Databases da OVHcloud!"
   level: "Associate"
   language: "Inglês"
-  duration: "1h30"
   video: "https://embed.api.video/vod/vimrTOmmVUDuKGKrcTje4IX"
   learn:
     title: "O que vai aprender neste curso"

--- a/docs/pt/guides/e-learning/mks-code-ship-scale.mdx
+++ b/docs/pt/guides/e-learning/mks-code-ship-scale.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Bem-vindo ao mundo Cloud Native com o Managed Kubernetes Service!"
   level: "Associate"
   language: "Inglês"
-  duration: "1h45"
   video: "https://embed.api.video/vod/vi4UbRCOfkkkhnNrfePmRVzH"
   learn:
     title: "O que vai aprender neste curso"

--- a/docs/pt/guides/e-learning/mrs-wrangle-rule-run.mdx
+++ b/docs/pt/guides/e-learning/mrs-wrangle-rule-run.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Orquestre uma infraestrutura multicluster com o Managed Rancher Service da OVHcloud!"
   level: "Associate"
   language: "Inglês"
-  duration: "2h"
   video: "https://embed.api.video/vod/viptdYNXaiqDKkW45CjHZor"
   learn:
     title: "O que vai aprender neste curso"

--- a/docs/pt/guides/e-learning/public-cloud-explore-build-grow.mdx
+++ b/docs/pt/guides/e-learning/public-cloud-explore-build-grow.mdx
@@ -19,7 +19,6 @@ overview:
   description: "Dê os seus primeiros passos no Public Cloud e descubra o ecossistema da OVHcloud!"
   level: "Associate"
   language: "Inglês"
-  duration: "2h"
   learn:
     title: "O que vai aprender neste curso"
     items:

--- a/i18n.json
+++ b/i18n.json
@@ -23236,14 +23236,5 @@
     "it": "Il programma dettagliato di questo corso sarà presto disponibile.",
     "pl": "Szczegółowy program tego kursu będzie wkrótce dostępny.",
     "pt": "O programa detalhado deste curso estará disponível em breve."
-  },
-  "elearningCourseDurationLabel": {
-    "en": "Duration:",
-    "fr": "Durée:",
-    "de": "Dauer:",
-    "es": "Duración:",
-    "it": "Durata:",
-    "pl": "Czas trwania:",
-    "pt": "Duração:"
   }
 }

--- a/theme/components/ELearningCourseOverview/index.tsx
+++ b/theme/components/ELearningCourseOverview/index.tsx
@@ -21,8 +21,6 @@ export interface ELearningCourseOverviewProps {
   level?: string;
   /** Course language, shown as a badge next to the level. */
   language?: string;
-  /** Total course duration, shown as a badge next to the language. */
-  duration?: string;
   learn?: CourseLearnData;
   /** Embed URL for the course video (iframe src). */
   video?: string;
@@ -37,13 +35,9 @@ export function CourseDescription({
   description,
   level,
   language,
-  duration,
-}: Pick<
-  ELearningCourseOverviewProps,
-  'description' | 'level' | 'language' | 'duration'
->) {
+}: Pick<ELearningCourseOverviewProps, 'description' | 'level' | 'language'>) {
   const t = useI18n();
-  if (!description && !level && !language && !duration) return null;
+  if (!description && !level && !language) return null;
   return (
     <section className="rp-elearning-course-overview__section">
       <h2 className="rp-elearning-course-overview__heading">
@@ -55,7 +49,7 @@ export function CourseDescription({
           {...renderHtmlOrText(description)}
         />
       )}
-      {(level || language || duration) && (
+      {(level || language) && (
         <p className="rp-elearning-course-overview__badges">
           {level && (
             <span className="rp-elearning-course-overview__badge-group">
@@ -74,16 +68,6 @@ export function CourseDescription({
               </span>
               <span className="rp-elearning-course-overview__badge">
                 {language}
-              </span>
-            </span>
-          )}
-          {duration && (
-            <span className="rp-elearning-course-overview__badge-group">
-              <span className="rp-elearning-course-overview__badge-label">
-                {t('elearningCourseDurationLabel')}
-              </span>
-              <span className="rp-elearning-course-overview__badge">
-                {duration}
               </span>
             </span>
           )}

--- a/theme/layouts/ELearningCourseLayout/index.tsx
+++ b/theme/layouts/ELearningCourseLayout/index.tsx
@@ -149,7 +149,6 @@ export function ELearningCourseLayout(props: ELearningCourseLayoutProps) {
                   description={overview?.description}
                   level={overview?.level}
                   language={overview?.language}
-                  duration={overview?.duration}
                 />
                 <CourseLearn learn={overview?.learn} />
                 <CourseVideo video={overview?.video} />


### PR DESCRIPTION
Drop the Duration badge added previously: remove the duration prop and badge from the course overview, the layout pass-through, the duration value from all 7 courses in 7 locales (49 files), and the i18n label. Level and Language badges are unchanged.