### PR TITLE
fix(theme): enable responsive table wrapping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -318,7 +318,6 @@ Cells wrap automatically and the theme makes tables responsive, so a few guideli
 - Write naturally — cells wrap on their own. **Don't add `<br/>` just to force wrapping;** use it only for genuinely separate lines (e.g. several IP addresses in one cell).
 - **Long URLs and paths can't word-break and will widen the table.** Use link text — `[label](url)` — or a `/links/<key>` (see *Links*) instead of pasting a bare long URL.
 - **Never write a bare angle-bracket placeholder** like `<SID>` or `<region>` in a cell — MDX parses it as an unknown HTML tag and drops it. Backtick it (`` `<SID>` ``) or escape it (`&lt;SID&gt;`).
-- A cell can be forced onto one line with `<td className="nowrap">…</td>` (requires writing that cell as HTML) — rarely needed.
 
 **Format** — always include the header row; align columns with `:---` (left), `:---:` (center), `---:` (right). Prefer Markdown tables; reserve a raw HTML `<table>` for merged cells (`rowspan`/`colspan`) that Markdown can't express.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,6 +310,18 @@ Standard GitHub-flavored Markdown tables work as-is:
 | value | value |
 ```
 
+Cells wrap automatically and the theme makes tables responsive, so a few guidelines keep them readable on every screen:
+
+**Width** — prefer **≤4 columns**; they fit any screen. **6+ columns scroll horizontally on phones** (acceptable for reference tables, but check each column earns its place). For a genuinely wide table (**8+ columns**), **transpose** it (if it has few rows and many columns) or **split** it into smaller grouped tables. There is no mobile "card" layout — wide tables scroll horizontally by design (a matrix can't be stacked without losing the grid).
+
+**Cell content**
+- Write naturally — cells wrap on their own. **Don't add `<br/>` just to force wrapping;** use it only for genuinely separate lines (e.g. several IP addresses in one cell).
+- **Long URLs and paths can't word-break and will widen the table.** Use link text — `[label](url)` — or a `/links/<key>` (see *Links*) instead of pasting a bare long URL.
+- **Never write a bare angle-bracket placeholder** like `<SID>` or `<region>` in a cell — MDX parses it as an unknown HTML tag and drops it. Backtick it (`` `<SID>` ``) or escape it (`&lt;SID&gt;`).
+- A cell can be forced onto one line with `<td className="nowrap">…</td>` (requires writing that cell as HTML) — rarely needed.
+
+**Format** — always include the header row; align columns with `:---` (left), `:---:` (center), `---:` (right). Prefer Markdown tables; reserve a raw HTML `<table>` for merged cells (`rowspan`/`colspan`) that Markdown can't express.
+
 ### Code blocks
 
 Same triple-backtick syntax as before, with language tags. Common languages used across the repo: `bash`, `console`, `json`, `yaml`, `ini`, `sql`, `python`, `go`, `javascript`, `typescript`, `dockerfile`, `nginx`, `apache`, `terraform`. Avoid `markdown` and `mdx` — they disable Shiki's lazy loading and slow the dev server.

--- a/styles/index.css
+++ b/styles/index.css
@@ -386,12 +386,6 @@ details:not(.rp-callout) > summary {
   min-width: 4rem;
 }
 
-/* Authoring opt-out: add class="nowrap" to a cell that must stay on one line
-   (e.g. a short code, command, or status value). */
-.rp-doc :where(th, td).nowrap {
-  white-space: nowrap;
-}
-
 /* Thumbnail tables (e.g. modem/router lineups): equal-width columns so every
    image cell has the same room and lines up uniformly. */
 .rp-doc table:has(img.thumbnail) {

--- a/styles/index.css
+++ b/styles/index.css
@@ -358,14 +358,37 @@ details:not(.rp-callout) > summary {
   -webkit-mask-repeat: no-repeat;
 }
 
-/* Tables: first column takes available space, others shrink to content */
+/* Tables — responsive sizing (feat/responsive-tables)
+   ---------------------------------------------------------------------------
+   Goal: tables shrink to fit their column instead of forcing a wide scroll.
+   We removed the old `width: 1%; white-space: nowrap` rule on every column
+   after the first — it forbade wrapping, so long content (hostnames, IPs,
+   API paths) forced the table wider than its container. Genuinely wide tables
+   (many columns) still scroll *inside* Rspress's per-table
+   `.rp-table-scroll-container`, never at the page level. */
 .rp-doc table {
   width: 100%;
 }
 
-.rp-doc table:not(:has(img.thumbnail)) th:not(:first-child),
-.rp-doc table:not(:has(img.thumbnail)) td:not(:first-child) {
-  width: 1%;
+/* Let cells wrap, and break otherwise-unbreakable tokens (long hostnames,
+   IPs, /api/paths). `break-word` (not `anywhere`): a column won't shrink
+   below its longest word, so moderately-wide tables still fit while
+   genuinely-wide ones (10+ cols) expand to a readable width and scroll inside
+   .rp-table-scroll-container — instead of crushing every column to a few
+   characters and breaking words mid-letter, which `anywhere` did. */
+.rp-doc :where(th, td) {
+  overflow-wrap: break-word;
+}
+
+/* Relax the base theme's 8rem-per-cell floor (a 5-col table is otherwise
+   ≥40rem before any content). Image cells keep their room for the image. */
+.rp-doc :where(th, td):not(:has(img)) {
+  min-width: 4rem;
+}
+
+/* Authoring opt-out: add class="nowrap" to a cell that must stay on one line
+   (e.g. a short code, command, or status value). */
+.rp-doc :where(th, td).nowrap {
   white-space: nowrap;
 }
 


### PR DESCRIPTION
Tables now wrap properly on window squeeze, no word break allowed, horizontal scroll enabled when applicable.

- **Removed** `width: 1%; white-space: nowrap` on non-first cells
- **Added** `overflow-wrap: break-word` on all cells
- **Lowered** the base-theme per-cell floor 8rem → 4rem (non-image cells)
