### PR TITLE
fix(theme): enable responsive embedded videos

### DIFF
--- a/docs/de/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
+++ b/docs/de/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
@@ -663,7 +663,7 @@ With the API, ask for the vDC deletion:
 
 You can find all the information on setting up an advanced NSX-v architecture on NSX by watching this video.
 
-<iframe src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 <p><a href="https://vimeo.com/891113062">Recreate an advanced NSX-v architecture on NSX</a> from <a href="https://vimeo.com/ovhcloud">OVHcloud</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
 
 ## FAQ

--- a/docs/de/guides/hosted-private-cloud/powered-by-vmware/service-migration.mdx
+++ b/docs/de/guides/hosted-private-cloud/powered-by-vmware/service-migration.mdx
@@ -86,7 +86,7 @@ Please consult our guide to [Migrate an IP block between two Hosted Private Clou
 
 The video below also shows how to migrate an IP block between two Hosted Private Cloud services.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Gemao3Fd7rI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Gemao3Fd7rI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ### VMware context
 
@@ -255,11 +255,11 @@ Please refer to our guide on setting up [Veeam Backup & Replication](/guides/sto
 
 The video below shows how to configure Hosted Private Cloud with the Veeam Backup & Replication solution.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/f8ufrsP4PQw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/f8ufrsP4PQw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <br />The following video explains how to replicate your Hosted Private Cloud infrastructure with the Veeam Backup & Replication solution.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/NqNtKrJSH8w" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/NqNtKrJSH8w" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <br />You can also refer to the [Veeam documentation](https://www.veeam.com/veeam_backup_10_0_user_guide_vsphere_pg.pdf) (PDF).
 

--- a/docs/de/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -19,7 +19,7 @@ This guide aims to provide a clear and detailed method for creating and updating
 - Modify a Savings Plan.
 - Automate the management of Savings Plans via the API or Terraform for greater efficiency and flexibility.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Requirements
 

--- a/docs/de/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -14,7 +14,7 @@ This guide will also detail the use of the Savings Plans dashboard, which will a
 
 ## How do Savings Plans work?
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### What is a Savings Plan?
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -12,7 +12,7 @@ Object Storage is a family of storage solutions offering high-performance, scala
 
 Object storage solutions allow static files (videos, images, web files, etc.) to be stored in an unlimited space via a public access point called the "endpoint", so that they can be used from an application or made accessible on the web. These storage spaces are accessed through a standard S3<sup>1</sup>-compatible API interface for the Object Storage classes and Swift for the Swift Object Storage classes.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### In what use case should an object storage solution be used?
 

--- a/docs/de/guides/web-cloud/domains/dns-server-general-information.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-server-general-information.mdx
@@ -11,7 +11,7 @@ availableIn: [eu, ca, apac]
 
 **Diese Anleitung erklärt die Rolle der DNS-Server, was sie enthalten und wie sie mit einem Domainnamen zusammenarbeiten.**
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## In der praktischen Anwendung
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
@@ -192,7 +192,7 @@ Sie können die E-Mail auch per **Drag & Drop** aus Ihrem Posteingang direkt auf
 
 Sehen Sie auch unser Video-Tutorial:
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ##### **.eml-Datei abrufen**
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -52,7 +52,7 @@ Gegebenenfalls sind manche Elemente nicht wiederherstellbar, insbesondere bei ei
 
 ### Wiederherstellung gelöschter Elemente
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=117" title="YouTube Video Player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=117" title="YouTube Video Player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Loggen Sie sich in den Account über Webmail (OWA) ein: [Webmail](https://www.ovhcloud.com/de/mail/).
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -155,7 +155,7 @@ Um **mehrere E-Mails gleichzeitig zu verschieben**, wählen Sie alle über ihre 
 
 #### Posteingangsregeln erstellen
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Um Regeln zu erstellen und zu verwalten, klicken Sie zunächst oben auf das Zahnradsymbol und dann auf <code className="action">Optionen</code>.
 
@@ -175,7 +175,7 @@ Detailliertere Anweisungen zum Erstellen von Posteingangsregeln finden Sie in un
 
 #### Einen Absender blockieren
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Klicken Sie oben rechts auf das Zahnradsymbol und dann auf <code className="action">Optionen</code>. Folgen Sie weiterhin in der linken Spalte der Baumstruktur "E-Mail" unter "Konten" und dann "Blockieren oder zulassen".
 
@@ -205,7 +205,7 @@ Klicken Sie auf den Pfeil nach unten neben <code className="action">Neu</code> u
 
 ### Ihr Passwort ändern
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Sie können das Passwort Ihres Accounts ändern, während Sie bei OWA angemeldet sind. Klicken Sie hierzu oben auf das Zahnradsymbol und dann auf <code className="action">Optionen</code>.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
@@ -700,7 +700,7 @@ With the API, ask for the vDC deletion:
 
 You can find all the information on setting up an advanced NSX-v architecture on NSX by watching this video.
 
-<iframe src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameBorder="0" allow="autoplay; fullscreen; picture-in-picture" allowFullScreen={true}></iframe>
+<iframe className="video" src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameBorder="0" allow="autoplay; fullscreen; picture-in-picture" allowFullScreen={true}></iframe>
 <p><a href="https://vimeo.com/891113062">Recreate an advanced NSX-v architecture on NSX</a> from <a href="https://vimeo.com/ovhcloud">OVHcloud</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
 
 ## FAQ

--- a/docs/en/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -19,7 +19,7 @@ This guide aims to provide a clear and detailed method for creating and updating
 - Modify a Savings Plan.
 - Automate the management of Savings Plans via the API or Terraform for greater efficiency and flexibility.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Requirements
 

--- a/docs/en/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -14,7 +14,7 @@ This guide will also detail the use of the Savings Plans dashboard, which will a
 
 ## How do Savings Plans work?
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### What is a Savings Plan?
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -12,7 +12,7 @@ Object Storage is a family of storage solutions offering high-performance, scala
 
 Object storage solutions allow static files (videos, images, web files, etc.) to be stored in an unlimited space via a public access point called the "endpoint", so that they can be used from an application or made accessible on the web. These storage spaces are accessed through a standard S3<sup>1</sup>-compatible API interface for the Object Storage classes and Swift for the Swift Object Storage classes.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### In what use case should an object storage solution be used?
 

--- a/docs/en/guides/web-cloud/domains/dns-server-general-information.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-server-general-information.mdx
@@ -11,7 +11,7 @@ availableIn: [eu, ca, apac]
 
 **This guide explains what DNS servers do, what they contain, and how they work with a domain name.**
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Instructions
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
@@ -192,7 +192,7 @@ You can also **drag and drop** the email from your inbox directly onto your Desk
 
 Also see our video tutorial:
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ##### **Retrieving the .eml file**
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -52,7 +52,7 @@ Some deletions are not recoverable from retention, particularly if there is a sy
 
 ### How to restore deleted items
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=117" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=117" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Log in to your email account via webmail (OWA): [Webmail](https://www.ovhcloud.com/en-gb/mail/).
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -155,7 +155,7 @@ To **move multiple emails** at once, select them all using their tick boxes. The
 
 #### Creating inbox rules
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 To create and manage rules, first click the gear icon at the top, then click <code className="action">Options</code>.
 
@@ -175,7 +175,7 @@ For more detailed instructions on creating inbox rules, please refer to our guid
 
 #### Blocking a sender
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Click the gear icon at the top right, then click <code className="action">Options</code>. Still in the left-hand column, browse the "Mail" tree under "Accounts", then "Block or allow".
 
@@ -205,7 +205,7 @@ Click the down arrow next to <code className="action">New</code>, then click <co
 
 ### Changing your password
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 You can change your account password while logged in to OWA. To do so, click the gear icon at the top, then click <code className="action">Options</code>.
 

--- a/docs/en/internal/format-reference.mdx
+++ b/docs/en/internal/format-reference.mdx
@@ -337,7 +337,7 @@ Independent local state only.
 
 ### 12 — Embedded video
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/dfpPCa0mUyo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/dfpPCa0mUyo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ---
 

--- a/docs/es/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
+++ b/docs/es/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
@@ -663,7 +663,7 @@ With the API, ask for the vDC deletion:
 
 You can find all the information on setting up an advanced NSX-v architecture on NSX by watching this video.
 
-<iframe src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 <p><a href="https://vimeo.com/891113062">Recreate an advanced NSX-v architecture on NSX</a> from <a href="https://vimeo.com/ovhcloud">OVHcloud</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
 
 ## FAQ

--- a/docs/es/guides/hosted-private-cloud/powered-by-vmware/service-migration.mdx
+++ b/docs/es/guides/hosted-private-cloud/powered-by-vmware/service-migration.mdx
@@ -86,7 +86,7 @@ Please consult our guide to [Migrate an IP block between two Hosted Private Clou
 
 The video below also shows how to migrate an IP block between two Hosted Private Cloud services.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Gemao3Fd7rI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Gemao3Fd7rI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ### VMware context
 
@@ -255,11 +255,11 @@ Please refer to our guide on setting up [Veeam Backup & Replication](/guides/sto
 
 The video below shows how to configure Hosted Private Cloud with the Veeam Backup & Replication solution.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/f8ufrsP4PQw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/f8ufrsP4PQw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <br />The following video explains how to replicate your Hosted Private Cloud infrastructure with the Veeam Backup & Replication solution.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/NqNtKrJSH8w" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/NqNtKrJSH8w" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <br />You can also refer to the [Veeam documentation](https://www.veeam.com/veeam_backup_10_0_user_guide_vsphere_pg.pdf) (PDF).
 

--- a/docs/es/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -19,7 +19,7 @@ This guide aims to provide a clear and detailed method for creating and updating
 - Modify a Savings Plan.
 - Automate the management of Savings Plans via the API or Terraform for greater efficiency and flexibility.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Requirements
 

--- a/docs/es/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -14,7 +14,7 @@ This guide will also detail the use of the Savings Plans dashboard, which will a
 
 ## How do Savings Plans work?
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### What is a Savings Plan?
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -12,7 +12,7 @@ Object Storage is a family of storage solutions offering high-performance, scala
 
 Object storage solutions allow static files (videos, images, web files, etc.) to be stored in an unlimited space via a public access point called the "endpoint", so that they can be used from an application or made accessible on the web. These storage spaces are accessed through a standard S3<sup>1</sup>-compatible API interface for the Object Storage classes and Swift for the Swift Object Storage classes.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### In what use case should an object storage solution be used?
 

--- a/docs/es/guides/web-cloud/domains/dns-server-general-information.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-server-general-information.mdx
@@ -11,7 +11,7 @@ Las siglas **DNS**, que significan **D**omain **N**ame **S**ystem, son un conjun
 
 **Descubra el papel de los servidores DNS, su contenido y cómo funcionan con un dominio.**
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Procedimiento
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
@@ -192,7 +192,7 @@ También puede **arrastrar y soltar** el correo electrónico desde su bandeja de
 
 Consulte también nuestro tutorial en vídeo:
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ##### **Obtener el archivo .eml**
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -47,7 +47,7 @@ Algunas eliminaciones no se pueden recuperar desde la retención, especialmente 
 
 ### ¿Cómo restaurar elementos eliminados?
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/xnq6wvANUFs?start=117" title="Vídeo de YouTube" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/xnq6wvANUFs?start=117" title="Vídeo de YouTube" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Conéctese a la dirección de correo electrónico correspondiente a través del webmail (OWA): [Webmail](https://www.ovhcloud.com/es-es/mail/).
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -155,7 +155,7 @@ Para **mover varios correos electrónicos** simultáneamente, selecciónelos tod
 
 #### Crear reglas de gestión del correo
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Para crear y gestionar reglas, haga clic primero en el icono del engranaje en la parte superior y, a continuación, en <code className="action">Opciones</code>.
 
@@ -175,7 +175,7 @@ Para obtener instrucciones más detalladas sobre la creación de reglas de gesti
 
 #### Bloquear a un remitente
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Haga clic en el icono del engranaje en la parte superior derecha y, a continuación, en <code className="action">Opciones</code>. Igualmente en la columna de la izquierda, recorra el árbol "Correo" en "Cuentas" y, después, "Bloquear o permitir".
 
@@ -205,7 +205,7 @@ Haga clic en la flecha hacia abajo junto a <code className="action">Nuevo</code>
 
 ### Cambiar la contraseña
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Puede cambiar la contraseña de su cuenta cuando haya iniciado sesión en OWA. Para ello, haga clic en el icono del engranaje en la parte superior y, a continuación, en <code className="action">Opciones</code>.
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -24,7 +24,7 @@ L'alias d'IP (*IP aliasing* en anglais) est une configuration spéciale du rése
 
 **Ce guide vous explique comment réaliser cet ajout.**
 
-<iframe class="video" width="560" height="315" src="https://www.youtube.com/embed/s1qDqQ0p07Q" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube.com/embed/s1qDqQ0p07Q" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
 :::warning
 OVHcloud met à votre disposition des services dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d'assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/raid-hard.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/raid-hard.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2025-03-19
 
 Sur un serveur disposant d'une configuration RAID matériel, la matrice RAID est gérée par un composant physique appelé contrôleur RAID.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube.com/embed/t_BL_uOXQVA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube.com/embed/t_BL_uOXQVA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Prérequis
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/raid-soft.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/raid-soft.mdx
@@ -17,7 +17,7 @@ Le niveau RAID par défaut pour les installations de serveurs OVHcloud est RAID 
 
 **Ce guide explique comment gérer et reconstruire un RAID logiciel en cas de remplacement d'un disque sur votre serveur en mode legacy boot (BIOS).**
 
-<iframe class="video" width="560" height="315" src="https://www.youtube.com/embed/t_BL_uOXQVA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube.com/embed/t_BL_uOXQVA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Avant de commencer, veuillez noter que ce guide se concentre sur les serveurs dédiés qui utilisent le mode legacy boot (BIOS). Si votre serveur utilise le mode UEFI (cartes mères plus récentes), reportez-vous à ce guide [Gestion et reconstruction du RAID logiciel sur les serveurs en mode boot UEFI](/guides/bare-metal-cloud/dedicated-servers/raid-soft-uefi).
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/securing-a-dedicated-server.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/securing-a-dedicated-server.mdx
@@ -10,7 +10,7 @@ Lorsque vous commandez votre serveur dédié, vous pouvez choisir une distributi
 
 **Ce guide vous propose quelques conseils généraux pour sécuriser un serveur basé sur GNU/Linux.**
 
-<iframe class="video" width="560" height="315" src="https://www.youtube.com/embed/gi7JqUvcEt0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube.com/embed/gi7JqUvcEt0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 :::warning
 OVHcloud vous met à disposition des services dont la configuration, la sécurité et la responsabilité vous appartiennent.

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
@@ -12,7 +12,7 @@ L'option Backup Automatisé pour les VPS offre un moyen pratique de disposer de 
 
 **Ce guide vous présente en détail l'option Backup automatisé pour votre VPS OVHcloud.**
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Pazh9ozbkEk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Pazh9ozbkEk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 :::info
 Avant d'appliquer une option de sauvegarde, nous vous recommandons de consulter les [options VPS disponibles](https://www.ovhcloud.com/fr/vps/options/) afin de comparer les détails et tarifs de chaque option.

--- a/docs/fr/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
+++ b/docs/fr/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
@@ -719,7 +719,7 @@ Avec l'API, demandez la suppression du vDC :
 
 Vous trouverez toutes les informations relatives à la mise en place d'une architecture NSX-v avancée sur NSX en visionnant cette vidéo.
 
-<iframe src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameBorder="0" allow="autoplay; fullscreen; picture-in-picture" allowFullScreen={true}></iframe>
+<iframe className="video" src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameBorder="0" allow="autoplay; fullscreen; picture-in-picture" allowFullScreen={true}></iframe>
 <p><a href="https://vimeo.com/891113062">Recreate an advanced NSX-v architecture on NSX</a> from <a href="https://vimeo.com/ovhcloud">OVHcloud</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
 
 ## FAQ

--- a/docs/fr/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -19,7 +19,7 @@ Ce guide a pour objectif de fournir une méthode claire et détaillée pour la c
 - Modifier un Savings Plan.
 - Automatiser la gestion des Savings Plans via l'API OVHcloud ou Terraform pour une plus grande efficacité et flexibilité.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Mjllp_3rkOA?si=nsuEH33N4Q7xEHmS" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Mjllp_3rkOA?si=nsuEH33N4Q7xEHmS" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Prérequis
 

--- a/docs/fr/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -14,7 +14,7 @@ Le guide détaillera également l'utilisation du tableau de bord associé aux Sa
 
 ## Fonctionnement des Savings Plans
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Mjllp_3rkOA?si=nsuEH33N4Q7xEHmS" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Mjllp_3rkOA?si=nsuEH33N4Q7xEHmS" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### Qu'est ce qu'un Savings Plan ?
 

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -12,7 +12,7 @@ Le stockage objet «Object Storage» est une famille d’offres de stockage prop
 
 Les offres de stockage objet permettent de déposer, à travers un point d’accès public appelé « endpoint », des fichiers statiques (vidéos, images, fichiers web, etc...) dans un espace illimité, pour les exploiter depuis une application ou pour les rendre accessibles sur le web. Ces espaces de stockages sont accessibles via une interface d’API standard compatible S3<sup>1</sup> pour les classes de stockage Object Storage et Swift pour les classes de stockage Object Storage Swift.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### Dans quel cas d'usage utiliser une solution de stockage objet ?
 

--- a/docs/fr/guides/web-cloud/domains/dns-server-general-information.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-server-general-information.mdx
@@ -11,7 +11,7 @@ Le sigle **DNS**, signifiant **D**omain **N**ame **S**ystem, est un ensemble d�
 
 **Découvrez le rôle des serveurs DNS, ce qu’ils contiennent et comment ils fonctionnent avec un nom de domaine.**
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## En pratique
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
@@ -192,7 +192,7 @@ Vous pouvez également **glisser-déposer** l’e-mail depuis votre boîte de r�
 
 Consultez également notre tutoriel vidéo :
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ##### **Récupérer le fichier .eml**
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -48,7 +48,7 @@ Certaines suppressions ne sont pas récupérables depuis la rétention, notammen
 
 ### Comment restaurer des éléments supprimés ?
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=117" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=117" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Connectez-vous à l'adresse e-mail concernée via le webmail (OWA) : [Webmail](https://www.ovhcloud.com/fr/mail/).
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/creating-inbox-rules-in-owa-mx-plan.mdx
@@ -13,7 +13,7 @@ Avec l’option « Règles de gestion de la boîte de réception », vous pouvez
 
 **Découvrez comment créer des filtres et des redirections e-mails depuis Outlook Web App (OWA).**
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -155,7 +155,7 @@ Pour simultanément **déplacer plusieurs e-mails**, sélectionnez-les tous grâ
 
 #### Créer des règles de gestion de la messagerie
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Pour créer et gérer des règles, cliquez d’abord sur l'icône d'engrenage en haut, puis sur <code className="action">Options</code>.
 
@@ -175,7 +175,7 @@ Pour des instructions plus détaillées sur la création des règles de gestion 
 
 #### Bloquer un expéditeur
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Cliquez sur l'icône de l'engrenage en haut à droite, puis cliquez sur <code className="action">Options</code>. Toujours dans la colonne de gauche, parcourez l'arborescence « Courrier » sous « Comptes », puis « Bloquer ou autoriser ».
 
@@ -205,7 +205,7 @@ Cliquez sur la flèche vers le bas à côté de <code className="action">Nouveau
 
 ### Modifier le mot de passe
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Vous pouvez modifier le mot de passe de votre compte lorsque vous êtes connecté à OWA. Pour ce faire, cliquez sur l'icône d'engrenage en haut, puis cliquez sur <code className="action">Options</code>.
 

--- a/docs/fr/guides/web-cloud/internet/overthebox/plus-itv2-lte.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/plus-itv2-lte.mdx
@@ -37,7 +37,7 @@ Avant de réaliser ces manipulations, vous devez :
 
 :::
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/eSX1XWrMHPY?si=_6zsyN5hkkbnC9fN" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/eSX1XWrMHPY?si=_6zsyN5hkkbnC9fN" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 <Tabs>
   <Tab label="Étape 1">

--- a/docs/it/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
+++ b/docs/it/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
@@ -663,7 +663,7 @@ With the API, ask for the vDC deletion:
 
 You can find all the information on setting up an advanced NSX-v architecture on NSX by watching this video.
 
-<iframe src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 <p><a href="https://vimeo.com/891113062">Recreate an advanced NSX-v architecture on NSX</a> from <a href="https://vimeo.com/ovhcloud">OVHcloud</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
 
 ## FAQ

--- a/docs/it/guides/hosted-private-cloud/powered-by-vmware/service-migration.mdx
+++ b/docs/it/guides/hosted-private-cloud/powered-by-vmware/service-migration.mdx
@@ -86,7 +86,7 @@ Please consult our guide to [Migrate an IP block between two Hosted Private Clou
 
 The video below also shows how to migrate an IP block between two Hosted Private Cloud services.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Gemao3Fd7rI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Gemao3Fd7rI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ### VMware context
 
@@ -255,11 +255,11 @@ Please refer to our guide on setting up [Veeam Backup & Replication](/guides/sto
 
 The video below shows how to configure Hosted Private Cloud with the Veeam Backup & Replication solution.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/f8ufrsP4PQw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/f8ufrsP4PQw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <br />The following video explains how to replicate your Hosted Private Cloud infrastructure with the Veeam Backup & Replication solution.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/NqNtKrJSH8w" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/NqNtKrJSH8w" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <br />You can also refer to the [Veeam documentation](https://www.veeam.com/veeam_backup_10_0_user_guide_vsphere_pg.pdf) (PDF).
 

--- a/docs/it/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -19,7 +19,7 @@ This guide aims to provide a clear and detailed method for creating and updating
 - Modify a Savings Plan.
 - Automate the management of Savings Plans via the API or Terraform for greater efficiency and flexibility.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Requirements
 

--- a/docs/it/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -14,7 +14,7 @@ This guide will also detail the use of the Savings Plans dashboard, which will a
 
 ## How do Savings Plans work?
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### What is a Savings Plan?
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -12,7 +12,7 @@ Object Storage is a family of storage solutions offering high-performance, scala
 
 Object storage solutions allow static files (videos, images, web files, etc.) to be stored in an unlimited space via a public access point called the "endpoint", so that they can be used from an application or made accessible on the web. These storage spaces are accessed through a standard S3<sup>1</sup>-compatible API interface for the Object Storage classes and Swift for the Swift Object Storage classes.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### In what use case should an object storage solution be used?
 

--- a/docs/it/guides/web-cloud/domains/dns-server-general-information.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-server-general-information.mdx
@@ -11,7 +11,7 @@ L'acronimo **DNS**, che sta per **D**omain **N**ame **S**ystem, è un insieme di
 
 **Informazioni sul ruolo dei server DNS, sul loro contenuto e sul loro funzionamento con un dominio**
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
@@ -192,7 +192,7 @@ Puoi anche **trascinare** l'e-mail dalla tua casella di posta direttamente sul D
 
 Consulta anche il nostro video tutorial:
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ##### **Recuperare il file .eml**
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -48,7 +48,7 @@ Alcune soppressioni non possono essere recuperate dalla retention, soprattutto i
 
 ### Come ripristinare gli elementi eliminati?
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=117" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=117" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Accedi alla Webmail (OWA) al tuo indirizzo email: [Webmail](https://www.ovhcloud.com/it/mail/).
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -155,7 +155,7 @@ Per **spostare più e-mail** contemporaneamente, selezionale tutte tramite la re
 
 #### Creare regole di gestione della posta
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Per creare e gestire le regole, clicca prima sull'icona a forma di ingranaggio in alto, quindi su <code className="action">Opzioni</code>.
 
@@ -175,7 +175,7 @@ Per istruzioni più dettagliate sulla creazione di regole di gestione della post
 
 #### Bloccare un mittente
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Clicca sull'icona dell'ingranaggio in alto a destra, quindi clicca su <code className="action">Opzioni</code>. Sempre nella colonna di sinistra, sfoglia la struttura ad albero "Posta" sotto "Account", quindi "Blocca o autorizza".
 
@@ -205,7 +205,7 @@ Clicca sulla freccia verso il basso accanto a <code className="action">Nuovo</co
 
 ### Modificare la password
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Puoi modificare la password del tuo account quando sei connesso a OWA. Per farlo, clicca sull'icona a forma di ingranaggio in alto, quindi clicca su <code className="action">Opzioni</code>.
 

--- a/docs/pl/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
+++ b/docs/pl/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
@@ -663,7 +663,7 @@ With the API, ask for the vDC deletion:
 
 You can find all the information on setting up an advanced NSX-v architecture on NSX by watching this video.
 
-<iframe src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 <p><a href="https://vimeo.com/891113062">Recreate an advanced NSX-v architecture on NSX</a> from <a href="https://vimeo.com/ovhcloud">OVHcloud</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
 
 ## FAQ

--- a/docs/pl/guides/hosted-private-cloud/powered-by-vmware/service-migration.mdx
+++ b/docs/pl/guides/hosted-private-cloud/powered-by-vmware/service-migration.mdx
@@ -86,7 +86,7 @@ Please consult our guide to [Migrate an IP block between two Hosted Private Clou
 
 The video below also shows how to migrate an IP block between two Hosted Private Cloud services.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Gemao3Fd7rI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Gemao3Fd7rI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ### VMware context
 
@@ -255,11 +255,11 @@ Please refer to our guide on setting up [Veeam Backup & Replication](/guides/sto
 
 The video below shows how to configure Hosted Private Cloud with the Veeam Backup & Replication solution.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/f8ufrsP4PQw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/f8ufrsP4PQw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <br />The following video explains how to replicate your Hosted Private Cloud infrastructure with the Veeam Backup & Replication solution.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/NqNtKrJSH8w" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/NqNtKrJSH8w" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <br />You can also refer to the [Veeam documentation](https://www.veeam.com/veeam_backup_10_0_user_guide_vsphere_pg.pdf) (PDF).
 

--- a/docs/pl/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -19,7 +19,7 @@ This guide aims to provide a clear and detailed method for creating and updating
 - Modify a Savings Plan.
 - Automate the management of Savings Plans via the API or Terraform for greater efficiency and flexibility.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Requirements
 

--- a/docs/pl/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -14,7 +14,7 @@ This guide will also detail the use of the Savings Plans dashboard, which will a
 
 ## How do Savings Plans work?
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### What is a Savings Plan?
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -12,7 +12,7 @@ Object Storage is a family of storage solutions offering high-performance, scala
 
 Object storage solutions allow static files (videos, images, web files, etc.) to be stored in an unlimited space via a public access point called the "endpoint", so that they can be used from an application or made accessible on the web. These storage spaces are accessed through a standard S3<sup>1</sup>-compatible API interface for the Object Storage classes and Swift for the Swift Object Storage classes.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### In what use case should an object storage solution be used?
 

--- a/docs/pl/guides/web-cloud/domains/dns-server-general-information.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-server-general-information.mdx
@@ -11,7 +11,7 @@ Skrót **DNS** oznaczający **D**omain **N**ame **S**ystem to zbiór elementów 
 
 **Dowiedz się więcej o rolach serwerów DNS, ich zawartości oraz ich sposobie działania z nazwą domeny.**
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## W praktyce
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
@@ -192,7 +192,7 @@ Możesz również **przeciągnąć i upuścić** wiadomość e-mail ze skrzynki 
 
 Zobacz także nasz samouczek wideo:
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ##### **Pobranie pliku .eml**
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -46,7 +46,7 @@ Niektóre usunięcia nie są możliwe do pobrania z retencji, zwłaszcza w przyp
 
 ### Jak przywrócić usunięte elementy?
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=117" title="YouTube wideo player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=117" title="YouTube wideo player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Zaloguj się na odpowiedni adres e-mail poprzez Webmail (OWA): [Webmail](https://www.ovhcloud.com/pl/mail/).
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -155,7 +155,7 @@ Aby utworzyć nowy folder, kliknij prawym przyciskiem myszy nazwę adresu e-mail
 
 #### Tworzenie reguł skrzynki odbiorczej
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Aby tworzyć reguły i nimi zarządzać, najpierw kliknij ikonę koła zębatego u góry, a następnie kliknij <code className="action">Opcje</code>.
 
@@ -175,7 +175,7 @@ Aby uzyskać bardziej szczegółowe instrukcje dotyczące tworzenia reguł skrzy
 
 #### Blokowanie nadawcy
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Kliknij ikonę koła zębatego w prawym górnym rogu, a następnie kliknij <code className="action">Opcje</code>. Nadal w lewej kolumnie przejdź drzewem "Poczta" w sekcji "Konta", a następnie "Blokuj lub zezwalaj".
 
@@ -205,7 +205,7 @@ Kliknij strzałkę w dół obok przycisku <code className="action">Nowy</code>, 
 
 ### Zmiana hasła
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Po zalogowaniu się do OWA możesz zmienić hasło do konta. W tym celu kliknij ikonę koła zębatego u góry, a następnie kliknij <code className="action">Opcje</code>.
 

--- a/docs/pt/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
+++ b/docs/pt/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
@@ -663,7 +663,7 @@ With the API, ask for the vDC deletion:
 
 You can find all the information on setting up an advanced NSX-v architecture on NSX by watching this video.
 
-<iframe src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" src="https://player.vimeo.com/video/891113062?h=dfd1a3d5dc&title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 <p><a href="https://vimeo.com/891113062">Recreate an advanced NSX-v architecture on NSX</a> from <a href="https://vimeo.com/ovhcloud">OVHcloud</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
 
 ## FAQ

--- a/docs/pt/guides/hosted-private-cloud/powered-by-vmware/service-migration.mdx
+++ b/docs/pt/guides/hosted-private-cloud/powered-by-vmware/service-migration.mdx
@@ -86,7 +86,7 @@ Please consult our guide to [Migrate an IP block between two Hosted Private Clou
 
 The video below also shows how to migrate an IP block between two Hosted Private Cloud services.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Gemao3Fd7rI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Gemao3Fd7rI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ### VMware context
 
@@ -255,11 +255,11 @@ Please refer to our guide on setting up [Veeam Backup & Replication](/guides/sto
 
 The video below shows how to configure Hosted Private Cloud with the Veeam Backup & Replication solution.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/f8ufrsP4PQw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/f8ufrsP4PQw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <br />The following video explains how to replicate your Hosted Private Cloud infrastructure with the Veeam Backup & Replication solution.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/NqNtKrJSH8w" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/NqNtKrJSH8w" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <br />You can also refer to the [Veeam documentation](https://www.veeam.com/veeam_backup_10_0_user_guide_vsphere_pg.pdf) (PDF).
 

--- a/docs/pt/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -19,7 +19,7 @@ This guide aims to provide a clear and detailed method for creating and updating
 - Modify a Savings Plan.
 - Automate the management of Savings Plans via the API or Terraform for greater efficiency and flexibility.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Requirements
 

--- a/docs/pt/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -14,7 +14,7 @@ This guide will also detail the use of the Savings Plans dashboard, which will a
 
 ## How do Savings Plans work?
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dd7P7CUN21M?si=OvK6Gec1BLFFB25O" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### What is a Savings Plan?
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -12,7 +12,7 @@ Object Storage is a family of storage solutions offering high-performance, scala
 
 Object storage solutions allow static files (videos, images, web files, etc.) to be stored in an unlimited space via a public access point called the "endpoint", so that they can be used from an application or made accessible on the web. These storage spaces are accessed through a standard S3<sup>1</sup>-compatible API interface for the Object Storage classes and Swift for the Swift Object Storage classes.
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8xXbL3Ftgwk?si=OaRx5koocA-OyRXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### In what use case should an object storage solution be used?
 

--- a/docs/pt/guides/web-cloud/domains/dns-server-general-information.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-server-general-information.mdx
@@ -11,7 +11,7 @@ A sigla **DNS**, que significa **D**omain **N**ame **S**ystem, é um conjunto de
 
 **Descubra o papel dos servidores DNS, o que estes contêm e como funcionam com um domínio.**
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/BvrUi26ShzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Instruções
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers.mdx
@@ -192,7 +192,7 @@ Também pode **arrastar e largar** o e-mail da sua caixa de entrada diretamente 
 
 Consulte também o nosso tutorial em vídeo:
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No?start=36" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ##### **Obter o ficheiro .eml**
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention.mdx
@@ -48,7 +48,7 @@ Algumas supressões não podem ser recuperadas a partir da retenção, nomeadame
 
 ### Como restaurar elementos eliminados?
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=117" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=117" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Ligue-se ao endereço de e-mail em causa através do webmail (OWA): [Webmail](https://www.ovhcloud.com/pt/mail/).
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa.mdx
@@ -155,7 +155,7 @@ Para **mover vários e-mails** simultaneamente, selecione-os todos através da r
 
 #### Criar regras de gestão da caixa de correio
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Para criar e gerir regras, clique primeiro no ícone de engrenagem na parte superior e, em seguida, em <code className="action">Opções</code>.
 
@@ -175,7 +175,7 @@ Para instruções mais detalhadas sobre a criação de regras de gestão da caix
 
 #### Bloquear um remetente
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Clique no ícone de engrenagem no canto superior direito e, em seguida, clique em <code className="action">Opções</code>. Sempre na coluna da esquerda, percorra a árvore "Mail" em "Contas" e, em seguida, "Bloquear ou autorizar".
 
@@ -205,7 +205,7 @@ Clique na seta para baixo junto a <code className="action">Novo</code> e, em seg
 
 ### Alterar a palavra-passe
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe className="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Pode alterar a palavra-passe da sua conta quando tiver iniciado sessão no OWA. Para o fazer, clique no ícone de engrenagem na parte superior e, em seguida, clique em <code className="action">Opções</code>.
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -457,6 +457,18 @@ details:not(.rp-callout) > summary {
   margin: 0 auto;
 }
 
+/* Embedded videos: responsive 16:9 block, sized and spaced like doc prose. */
+.rp-doc iframe.video {
+  display: block;
+  width: min(100%, 640px);
+  aspect-ratio: 16 / 9;
+  height: auto;
+  margin: 1.25rem 0;
+  border: none;
+  background-color: #000; /* letterbox backdrop; hides white iframe default */
+  border-radius: var(--rp-radius-small);
+}
+
 /* TO REMOVE ONCE THE CHATBOT IS READY */
 ._appRoot_m3srs_1 h4 {
   margin: 0;


### PR DESCRIPTION
CSS-level improvement:

- Add a `.rp-doc iframe.video` rule so embedded videos render as responsive 16:9 blocks with proper vertical spacing
- Set BG to black (for proper dark mode display of YT embeds)
- Normalize `class="video"` → `className="video"` (no real impact, except on one Vimeo embed; old syntax handled by Rspress)