### PR TITLE
fix(docs): normalize community links batch 1: Manage and Operate

### DIFF
--- a/docs/de/guides/manage-and-operate/api/account.mdx
+++ b/docs/de/guides/manage-and-operate/api/account.mdx
@@ -52,4 +52,4 @@ With the previously created ConsumerKey.
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/manage-and-operate/api/console-preview.mdx
+++ b/docs/de/guides/manage-and-operate/api/console-preview.mdx
@@ -174,4 +174,4 @@ Three tabs are then available:
 
 How to manage a customer’s account via OVHcloud API
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/manage-and-operate/api/enterprise-payment.mdx
+++ b/docs/de/guides/manage-and-operate/api/enterprise-payment.mdx
@@ -57,4 +57,4 @@ Retrieve the detailed bill using the billID:
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/manage-and-operate/api/first-steps.mdx
+++ b/docs/de/guides/manage-and-operate/api/first-steps.mdx
@@ -228,4 +228,4 @@ Um Schlüssel aufzulisten und zu widerrufen, können Sie die [API-Konsole](https
 
 [OVHcloud Kunden-Account über die API verwalten](/guides/manage-and-operate/api/first-steps) (EN)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/manage-and-operate/api/manage-service-account.mdx
+++ b/docs/de/guides/manage-and-operate/api/manage-service-account.mdx
@@ -143,4 +143,4 @@ Service accounts are available in several APIs of our products. For each API, th
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/manage-and-operate/api/overview.mdx
+++ b/docs/de/guides/manage-and-operate/api/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: Besuchen Sie die OVHcloud Community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/manage-and-operate/api/services.mdx
+++ b/docs/de/guides/manage-and-operate/api/services.mdx
@@ -61,4 +61,4 @@ The call will delete the service and data and issue the invoice for the period b
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
+++ b/docs/de/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
@@ -248,4 +248,4 @@ openstack.exceptions.ForbiddenException: ForbiddenException: 403: Client Error f
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/manage-and-operate/iam/identities-management.mdx
+++ b/docs/de/guides/manage-and-operate/iam/identities-management.mdx
@@ -82,4 +82,4 @@ Umgekehrt empfehlen wir Ihnen, OVHcloud Identitäten zu verwenden, wenn Sie eine
 
 Die Verwaltung von Identitäten kann über die [OVHcloud API](/guides/manage-and-operate/api/first-steps) oder den [OVHcloud Terraform Provider](/guides/manage-and-operate/terraform/at-ovhcloud) automatisiert werden.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/manage-and-operate/iam/logs-forwarding.mdx
+++ b/docs/de/guides/manage-and-operate/iam/logs-forwarding.mdx
@@ -256,4 +256,4 @@ The three following Logs Data Platform API routes respectively allow you to:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/manage-and-operate/iam/overview.mdx
+++ b/docs/de/guides/manage-and-operate/iam/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Weiterführende Informationen"
   items:
     - title: "Besuchen Sie die OVHcloud Community"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: "Discord beitreten"

--- a/docs/de/guides/manage-and-operate/iam/troubleshooting.mdx
+++ b/docs/de/guides/manage-and-operate/iam/troubleshooting.mdx
@@ -56,4 +56,4 @@ You can also filter the search on `authorized_actions_array` to list the actions
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/manage-and-operate/kms/kms-etcd.mdx
+++ b/docs/de/guides/manage-and-operate/kms/kms-etcd.mdx
@@ -186,6 +186,6 @@ After all secrets have been re-encrypted with the new key, you can remove the ol
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Find out how to use [Kubernetes External Secrets Operator with Secret Manager](/guides/manage-and-operate/secret-manager/external-secret-operator).

--- a/docs/de/guides/manage-and-operate/kms/logs.mdx
+++ b/docs/de/guides/manage-and-operate/kms/logs.mdx
@@ -109,4 +109,4 @@ Elements that can be pushed to Logs Data Platform:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/manage-and-operate/kms/overview.mdx
+++ b/docs/de/guides/manage-and-operate/kms/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Weiterführende Informationen"
   items:
     - title: "OVHcloud Community besuchen"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog ansehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: "Discord beitreten"

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
@@ -144,5 +144,5 @@ Remember, that you can also use a special field X-OVH-TO-FREEZE on your logs to 
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
@@ -284,5 +284,5 @@ The Logs Data Platform team will then take care of your request.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovh.com/en/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs))

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
@@ -143,5 +143,5 @@ ltsv_logger.info("Bonjour '%s'", 'John', extra={"lang": 'fr'})
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
@@ -189,5 +189,5 @@ For your information, a **Log forwarder agent** is considered as a tool (full so
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
@@ -135,5 +135,5 @@ Don't hesitate to [explore the API](https://api.ovh.com/console/#/dbaas/logs), a
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
@@ -349,5 +349,5 @@ Here is an example of a dashboard that you can craft from the HAProxy logs. HAPr
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
@@ -188,5 +188,5 @@ We currently have specific documentation illustrating the usage of *aliases* in 
 - [Introduction to Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/introduction)
 - [Getting Started with Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - [Our documentation](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
@@ -163,5 +163,5 @@ And that's it. Your kubernetes activity is now perfectly logged in one place. Ha
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
@@ -200,5 +200,5 @@ As we can see:
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
@@ -227,4 +227,4 @@ Then, go to your **Graylog** interface (access via the OVHcloud Control Panel) a
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: Besuchen Sie die OVHcloud Community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Roadmap & Changelog einsehen
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
@@ -219,4 +219,4 @@ This means that:
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovh.com/de/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs)))
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
@@ -182,5 +182,5 @@ The Graylog Web Interface does not support legacy token authentication.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
@@ -190,5 +190,5 @@ All this information can help you to analyse the most difficult queries for your
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)

--- a/docs/de/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
+++ b/docs/de/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
@@ -114,5 +114,5 @@ If you want to go further, don't hesitate to fly to the [NXlog documentation](ht
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/api/account.mdx
+++ b/docs/en/guides/manage-and-operate/api/account.mdx
@@ -54,4 +54,4 @@ With the previously created ConsumerKey.
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/api/apiv2.mdx
+++ b/docs/en/guides/manage-and-operate/api/apiv2.mdx
@@ -165,4 +165,4 @@ Several libraries are available to use the OVHcloud APIs:
 
 [Using Terraform with OVHcloud](/guides/manage-and-operate/terraform/at-ovhcloud) 
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/api/console-preview.mdx
+++ b/docs/en/guides/manage-and-operate/api/console-preview.mdx
@@ -174,4 +174,4 @@ Three tabs are then available:
 
 How to manage a customer’s account via OVHcloud API
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/api/enterprise-payment.mdx
+++ b/docs/en/guides/manage-and-operate/api/enterprise-payment.mdx
@@ -60,4 +60,4 @@ Retrieve the detailed bill using the billID:
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/api/first-steps.mdx
+++ b/docs/en/guides/manage-and-operate/api/first-steps.mdx
@@ -221,4 +221,4 @@ To list and revoke keys, you can use the [API portal](https://eu.api.ovh.com/) o
 
 [How to manage a customer’s account via OVHcloud API](/guides/manage-and-operate/api/first-steps)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/api/manage-service-account.mdx
+++ b/docs/en/guides/manage-and-operate/api/manage-service-account.mdx
@@ -143,4 +143,4 @@ Service accounts are available in several APIs of our products. For each API, th
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/api/overview.mdx
+++ b/docs/en/guides/manage-and-operate/api/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: View the roadmap & changelog
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/manage-and-operate/api/services.mdx
+++ b/docs/en/guides/manage-and-operate/api/services.mdx
@@ -64,4 +64,4 @@ The call will delete the service and data and issue the invoice for the period b
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
+++ b/docs/en/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
@@ -248,4 +248,4 @@ openstack.exceptions.ForbiddenException: ForbiddenException: 403: Client Error f
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/iam/identities-management.mdx
+++ b/docs/en/guides/manage-and-operate/iam/identities-management.mdx
@@ -75,4 +75,4 @@ On the other hand, if you want to have centralized management across all your pr
 
 Identity management can be automated via the [OVHcloud APIs](/guides/manage-and-operate/api/first-steps) or via the [provider Terraform OVHcloud](/guides/manage-and-operate/terraform/at-ovhcloud).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/iam/logs-forwarding.mdx
+++ b/docs/en/guides/manage-and-operate/iam/logs-forwarding.mdx
@@ -256,4 +256,4 @@ The three following Logs Data Platform API routes respectively allow you to:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/iam/overview.mdx
+++ b/docs/en/guides/manage-and-operate/iam/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Go further"
   items:
     - title: "Visit the OVHcloud community"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: "Join Discord"

--- a/docs/en/guides/manage-and-operate/iam/tag-manager.mdx
+++ b/docs/en/guides/manage-and-operate/iam/tag-manager.mdx
@@ -121,4 +121,4 @@ For example, the following policy grants rights to all VPS with the tag `Environ
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/iam/troubleshooting.mdx
+++ b/docs/en/guides/manage-and-operate/iam/troubleshooting.mdx
@@ -56,4 +56,4 @@ You can also filter the search on `authorized_actions_array` to list the actions
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/kms/architecture-overview.mdx
+++ b/docs/en/guides/manage-and-operate/kms/architecture-overview.mdx
@@ -140,4 +140,4 @@ Regions available for PCI-DSS certification:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/kms/kms-etcd.mdx
+++ b/docs/en/guides/manage-and-operate/kms/kms-etcd.mdx
@@ -186,6 +186,6 @@ After all secrets have been re-encrypted with the new key, you can remove the ol
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Find out how to use [Kubernetes External Secrets Operator with Secret Manager](/guides/manage-and-operate/secret-manager/external-secret-operator).

--- a/docs/en/guides/manage-and-operate/kms/kms-kmip.mdx
+++ b/docs/en/guides/manage-and-operate/kms/kms-kmip.mdx
@@ -263,4 +263,4 @@ Details of the coverage are available here:
 
 The [OASIS](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=kmip) website.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/kms/kms-usage.mdx
+++ b/docs/en/guides/manage-and-operate/kms/kms-usage.mdx
@@ -446,4 +446,4 @@ The API will then return the result of the verification:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/kms/logs.mdx
+++ b/docs/en/guides/manage-and-operate/kms/logs.mdx
@@ -109,4 +109,4 @@ Elements that can be pushed to Logs Data Platform:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/kms/okms-certificate-management.mdx
+++ b/docs/en/guides/manage-and-operate/kms/okms-certificate-management.mdx
@@ -292,4 +292,4 @@ Copy the value of the **certificatePEM** field to a **client.cert** file.
 
 [Using the OVHcloud KMS with your data](/guides/manage-and-operate/kms/kms-usage).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/kms/overview.mdx
+++ b/docs/en/guides/manage-and-operate/kms/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Go further"
   items:
     - title: "Visit the OVHcloud community"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: "Join Discord"

--- a/docs/en/guides/manage-and-operate/kms/quick-start.mdx
+++ b/docs/en/guides/manage-and-operate/kms/quick-start.mdx
@@ -191,4 +191,4 @@ Once your OVHcloud KMS is set up, there are two different ways to use it:
 ## Go further
 
 [Using the OVHcloud KMS with your data](/guides/manage-and-operate/kms/kms-usage)
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/alerting.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/alerting.mdx
@@ -201,5 +201,5 @@ You will then receive an email with the messages included. You can then directly
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/apache-logs.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/apache-logs.mdx
@@ -180,5 +180,5 @@ The complete procedure of its installation is described [on this page](/guides/m
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
@@ -144,5 +144,5 @@ Remember, that you can also use a special field X-OVH-TO-FREEZE on your logs to 
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/bonfire.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/bonfire.mdx
@@ -160,5 +160,5 @@ Enter password for `<USERNAME>`@`<YOUR-CLUSTER>`.logs.ovh.com:443/api:
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
@@ -284,5 +284,5 @@ The Logs Data Platform team will then take care of your request.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovh.com/en/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs))

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
@@ -143,6 +143,6 @@ ltsv_logger.info("Bonjour '%s'", 'John', extra={"lang": 'fr'})
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)
 

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/elastalert.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/elastalert.mdx
@@ -247,5 +247,5 @@ ElastAlert has a lot of integrations for alerting including Email, JIRA, OpsGeni
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/field-naming-conventions.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/field-naming-conventions.mdx
@@ -108,7 +108,7 @@ will become:
 }
 ```
 
-So this is everything you need to know to send valid messages format and not shoot yourself in the foot. If you have any question you can always reach us [on the community hub](https://community.ovh.com/en/c/Platform/data-platforms).
+So this is everything you need to know to send valid messages format and not shoot yourself in the foot. If you have any question you can always reach us [on the community hub](/links/community).
 
 Happy Logging
 
@@ -116,5 +116,5 @@ Happy Logging
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovh.com/fr/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs)))

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/filebeat-logs.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/filebeat-logs.mdx
@@ -320,5 +320,5 @@ Filebeat is a handy tool to send the content of your current log files to Logs D
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start.mdx
@@ -205,4 +205,4 @@ You have only scratched the surface of what Logs Data Platform can do for you. y
 - If you want to master Graylog, this is the place to go: [Graylog documentation](https://docs.graylog.org/docs/queries)
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovh.com/fr/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs)))
-- Join our community of users on [OVHcloud community](https://community.ovh.com/en/c/Platform/data-platforms) or on our [Discord channel](https://discord.com/channels/850031577277792286/1043179486776152147)
+- Join our community of users on [OVHcloud community](/links/community) or on our [Discord channel](https://discord.com/channels/850031577277792286/1043179486776152147)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
@@ -189,5 +189,5 @@ For your information, a **Log forwarder agent** is considered as a tool (full so
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
@@ -135,5 +135,5 @@ Don't hesitate to [explore the API](https://api.ovh.com/console/#/dbaas/logs), a
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
@@ -349,5 +349,5 @@ Here is an example of a dashboard that you can craft from the HAProxy logs. HAPr
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-access-management.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-access-management.mdx
@@ -215,5 +215,5 @@ For example, these two rights allow a local user to create indices/aliases direc
 - [Introduction to Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/introduction)
 - [IAM for Logs Data Platform - Presentation and FAQ](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - [Our documentation](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Join our [community of users](https://community.ovhcloud.com/community/en)
+- Join our [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
@@ -81,5 +81,5 @@ These features are replaced by [access management policies](/guides/manage-and-o
 - [Introduction to Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/introduction)
 - [IAM for Logs Data Platform - Presentation and FAQ](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - [Our documentation](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Join our [community of users](https://community.ovhcloud.com/community/en)
+- Join our [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-presentation-faq.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-presentation-faq.mdx
@@ -123,5 +123,5 @@ Similarly aliases created through OpenSearch APIs must be prefixed by one of you
 - [Introduction to Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/introduction)
 - [IAM for Logs Data Platform - Presentation and FAQ](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - [Our documentation](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Join our [community of users](https://community.ovhcloud.com/community/en)
+- Join our [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/index-as-a-service.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/index-as-a-service.mdx
@@ -585,11 +585,11 @@ Index as a service has some specificities on our platforms. This additional and 
 - You are not allowed to change the settings of your index.
 - You can create an **alias** on Logs Data Platform and attach it to one or several indices.
 - Unlike indices, aliases are **read-only**, you cannot write through an alias yet.
-- If there is a feature missing, feel free to contact us on the [community hub](https://community.ovh.com/en/c/Platform/data-platforms).
+- If there is a feature missing, feel free to contact us on the [community hub](/links/community).
 
 ## Go further
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
@@ -188,5 +188,5 @@ We currently have specific documentation illustrating the usage of *aliases* in 
 - [Introduction to Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/introduction)
 - [Getting Started with Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - [Our documentation](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
@@ -163,5 +163,5 @@ And that's it. Your kubernetes activity is now perfectly logged in one place. Ha
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/ldp-index.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/ldp-index.mdx
@@ -185,5 +185,5 @@ The logs from journald arrived fully parsed and ready to be explored. Use differ
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovh.com/fr/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs)))

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/ldp-tail.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/ldp-tail.mdx
@@ -141,7 +141,7 @@ Value="/dbaas/logs"
 Not=false
 ```
 
-If you have any difficulty understanding this pattern or if you want help creating your own, don't hesitate to reach us on the [Community Hub](https://community.ovh.com/en/c/Platform/data-platforms).
+If you have any difficulty understanding this pattern or if you want help creating your own, don't hesitate to reach us on the [Community Hub](/links/community).
 
 ### Replay tail
 
@@ -169,5 +169,5 @@ You can use the website [https://www.unixtimestamp.com/](https://www.unixtimesta
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/log-linux.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/log-linux.mdx
@@ -159,5 +159,5 @@ The best feature is the ability to mix criteria, based on what is important to y
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/de/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
@@ -200,5 +200,5 @@ As we can see:
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/logstash-input.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/logstash-input.mdx
@@ -212,7 +212,7 @@ This is an address of your collector for the cluster on Logs Data Platform. Send
 The version hosted by Logs Data Platform is the Latest Logstash 7 version (7.8 as of July 2020). Of course we will update to the new versions as soon as they become available.
 
 #### Logstash Plugins
-For your information, here is the list of Logstash plugins we support. Of course we will welcome any suggestion on additional plugins. Don't hesitate to contact us on the [community hub](https://community.ovh.com/en/c/Platform/data-platforms).
+For your information, here is the list of Logstash plugins we support. Of course we will welcome any suggestion on additional plugins. Don't hesitate to contact us on the [community hub](/links/community).
 
 ##### Inputs plugins
 
@@ -371,5 +371,5 @@ That's all you need to know about the Logstash Collector on Logs Data Platform.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
@@ -227,4 +227,4 @@ Then, go to your **Graylog** interface (access via the OVHcloud Control Panel) a
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/opensearch-dashboards.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/opensearch-dashboards.mdx
@@ -70,5 +70,5 @@ To know what you can do with OpenSearch Dashboards, read the [OpenSearch Dashboa
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: View the roadmap & changelog
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/rust-libs.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/rust-libs.mdx
@@ -209,5 +209,5 @@ You could also look at the [generated API documentation](https://docs.rs/log4rs-
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
@@ -219,4 +219,4 @@ This means that:
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovh.com/en/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs)))
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
@@ -182,5 +182,5 @@ The Graylog Web Interface does not support legacy token authentication.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
@@ -190,5 +190,5 @@ All this information can help you to analyse the most difficult queries for your
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/using-grafana-with-logs.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/using-grafana-with-logs.mdx
@@ -81,5 +81,5 @@ If you want to know what you can do with Grafana and OpenSearch, read the [offic
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
@@ -114,5 +114,5 @@ If you want to go further, don't hesitate to try the [NXlog documentation](https
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/en-gb/identity-security-operations/logs-data-platform/)

--- a/docs/en/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/en/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -290,4 +290,4 @@ For any additional information on how to manage the External Secret Operator, re
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/secret-manager/kv2-api.mdx
+++ b/docs/en/guides/manage-and-operate/secret-manager/kv2-api.mdx
@@ -238,4 +238,4 @@ A deleted version is no longer present in the Secret Manager and cannot be react
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/secret-manager/rest-api.mdx
+++ b/docs/en/guides/manage-and-operate/secret-manager/rest-api.mdx
@@ -210,4 +210,4 @@ The API expects the unique value:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/manage-and-operate/secret-manager/secret-manager-ui.mdx
+++ b/docs/en/guides/manage-and-operate/secret-manager/secret-manager-ui.mdx
@@ -137,4 +137,4 @@ Both APIs manipulate the same objects. A secret created by one method is accessi
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/manage-and-operate/api/account.mdx
+++ b/docs/es/guides/manage-and-operate/api/account.mdx
@@ -52,4 +52,4 @@ With the previously created ConsumerKey.
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/manage-and-operate/api/console-preview.mdx
+++ b/docs/es/guides/manage-and-operate/api/console-preview.mdx
@@ -174,4 +174,4 @@ Three tabs are then available:
 
 How to manage a customer’s account via OVHcloud API
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/manage-and-operate/api/enterprise-payment.mdx
+++ b/docs/es/guides/manage-and-operate/api/enterprise-payment.mdx
@@ -57,4 +57,4 @@ Retrieve the detailed bill using the billID:
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/manage-and-operate/api/first-steps.mdx
+++ b/docs/es/guides/manage-and-operate/api/first-steps.mdx
@@ -228,4 +228,4 @@ Para consultar y revocar las claves, puede utilizar el [portal API](https://eu.a
 
 [Cómo gestionar la cuenta de un cliente de OVHcloud a través de las API](/guides/manage-and-operate/api/first-steps) (guía en inglés)
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con [nuestra comunidad de usuarios](/links/community).

--- a/docs/es/guides/manage-and-operate/api/manage-service-account.mdx
+++ b/docs/es/guides/manage-and-operate/api/manage-service-account.mdx
@@ -143,4 +143,4 @@ Service accounts are available in several APIs of our products. For each API, th
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/manage-and-operate/api/overview.mdx
+++ b/docs/es/guides/manage-and-operate/api/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Más información"
   items:
     - title: Visite la comunidad de OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte la roadmap & changelog"
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: "Únase a Discord"

--- a/docs/es/guides/manage-and-operate/api/services.mdx
+++ b/docs/es/guides/manage-and-operate/api/services.mdx
@@ -61,4 +61,4 @@ The call will delete the service and data and issue the invoice for the period b
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
+++ b/docs/es/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
@@ -248,4 +248,4 @@ openstack.exceptions.ForbiddenException: ForbiddenException: 403: Client Error f
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/manage-and-operate/iam/identities-management.mdx
+++ b/docs/es/guides/manage-and-operate/iam/identities-management.mdx
@@ -82,4 +82,4 @@ Si, por el contrario, quiere disponer de una gestión centralizada en todos sus 
 
 La gestión de identidades puede automatizarse a través de las [API OVHcloud](/guides/manage-and-operate/api/first-steps) o a través del [provider Terraform OVHcloud](/guides/manage-and-operate/terraform/at-ovhcloud).
 
-Interactúe con [nuestra comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con [nuestra comunidad de usuarios](/links/community).

--- a/docs/es/guides/manage-and-operate/iam/logs-forwarding.mdx
+++ b/docs/es/guides/manage-and-operate/iam/logs-forwarding.mdx
@@ -256,4 +256,4 @@ The three following Logs Data Platform API routes respectively allow you to:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/manage-and-operate/iam/overview.mdx
+++ b/docs/es/guides/manage-and-operate/iam/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Más información"
   items:
     - title: "Visite la comunidad de OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte la roadmap & changelog"
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: "Únase a Discord"

--- a/docs/es/guides/manage-and-operate/iam/troubleshooting.mdx
+++ b/docs/es/guides/manage-and-operate/iam/troubleshooting.mdx
@@ -56,4 +56,4 @@ You can also filter the search on `authorized_actions_array` to list the actions
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/manage-and-operate/kms/kms-etcd.mdx
+++ b/docs/es/guides/manage-and-operate/kms/kms-etcd.mdx
@@ -186,6 +186,6 @@ After all secrets have been re-encrypted with the new key, you can remove the ol
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Find out how to use [Kubernetes External Secrets Operator with Secret Manager](/guides/manage-and-operate/secret-manager/external-secret-operator).

--- a/docs/es/guides/manage-and-operate/kms/logs.mdx
+++ b/docs/es/guides/manage-and-operate/kms/logs.mdx
@@ -109,4 +109,4 @@ Elements that can be pushed to Logs Data Platform:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/manage-and-operate/kms/overview.mdx
+++ b/docs/es/guides/manage-and-operate/kms/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Más información"
   items:
     - title: "Visitar la comunidad OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Ver la hoja de ruta y el changelog"
       link: https://www.ovhcloud.com/es-es/roadmap-changelog/
     - title: "Unirse a Discord"

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
@@ -144,5 +144,5 @@ Remember, that you can also use a special field X-OVH-TO-FREEZE on your logs to 
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/es-es/identity-security-operations/logs-data-platform/)

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
@@ -284,5 +284,5 @@ The Logs Data Platform team will then take care of your request.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovh.com/en/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs))

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
@@ -143,5 +143,5 @@ ltsv_logger.info("Bonjour '%s'", 'John', extra={"lang": 'fr'})
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/es-es/identity-security-operations/logs-data-platform/)

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
@@ -189,5 +189,5 @@ For your information, a **Log forwarder agent** is considered as a tool (full so
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/es-es/identity-security-operations/logs-data-platform/)

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
@@ -135,5 +135,5 @@ Don't hesitate to [explore the API](https://api.ovh.com/console/#/dbaas/logs), a
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/es-es/identity-security-operations/logs-data-platform/)

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
@@ -349,5 +349,5 @@ Here is an example of a dashboard that you can craft from the HAProxy logs. HAPr
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/es-es/identity-security-operations/logs-data-platform/)

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
@@ -188,5 +188,5 @@ We currently have specific documentation illustrating the usage of *aliases* in 
 - [Introduction to Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/introduction)
 - [Getting Started with Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - [Our documentation](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/es-es/identity-security-operations/logs-data-platform/)

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
@@ -163,5 +163,5 @@ And that's it. Your kubernetes activity is now perfectly logged in one place. Ha
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/es-es/identity-security-operations/logs-data-platform/)

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
@@ -200,5 +200,5 @@ As we can see:
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/es-es/identity-security-operations/logs-data-platform/)

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
@@ -227,4 +227,4 @@ Then, go to your **Graylog** interface (access via the OVHcloud Control Panel) a
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovhcloud.com/es/identity-security-operations/logs-data-platform/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: "Más información"
   items:
     - title: Visite la comunidad de OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulte la roadmap & changelog
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: "Únase a Discord"

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
@@ -219,4 +219,4 @@ This means that:
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovh.com/es/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs)))
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
@@ -182,5 +182,5 @@ The Graylog Web Interface does not support legacy token authentication.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/es-es/identity-security-operations/logs-data-platform/)

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
@@ -190,5 +190,5 @@ All this information can help you to analyse the most difficult queries for your
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/es-es/identity-security-operations/logs-data-platform/)

--- a/docs/es/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
+++ b/docs/es/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
@@ -114,5 +114,5 @@ If you want to go further, don't hesitate to fly to the [NXlog documentation](ht
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/es-es/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/api/account.mdx
+++ b/docs/fr/guides/manage-and-operate/api/account.mdx
@@ -55,4 +55,4 @@ Avec la ConsumerKey précédemment obtenue
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/api/apiv2.mdx
+++ b/docs/fr/guides/manage-and-operate/api/apiv2.mdx
@@ -164,4 +164,4 @@ Plusieurs bibliothèques sont disponibles pour utiliser les API OVHcloud :
 
 [Using Terraform with OVHcloud](/guides/manage-and-operate/terraform/at-ovhcloud) (guide en anglais)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/api/console-preview.mdx
+++ b/docs/fr/guides/manage-and-operate/api/console-preview.mdx
@@ -173,4 +173,4 @@ Trois onglets sont disponibles dans cette vue :
 
 Comment gérer le compte d'un client OVHcloud via les API (guide en anglais)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/api/enterprise-payment.mdx
+++ b/docs/fr/guides/manage-and-operate/api/enterprise-payment.mdx
@@ -59,4 +59,4 @@ Récupérez la facture détaillée grâce à l'identifiant de votre facture bill
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/api/first-steps.mdx
+++ b/docs/fr/guides/manage-and-operate/api/first-steps.mdx
@@ -222,4 +222,4 @@ Pour lister et révoquer les clés, il est possible d'utiliser le [portail API](
 
 [Comment gérer le compte d'un client OVHcloud via les API](/guides/manage-and-operate/api/first-steps) (guide en anglais)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/api/manage-service-account.mdx
+++ b/docs/fr/guides/manage-and-operate/api/manage-service-account.mdx
@@ -143,4 +143,4 @@ Les comptes de services sont disponible dans plusieurs API de nos produits. Pour
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/api/overview.mdx
+++ b/docs/fr/guides/manage-and-operate/api/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Visitez la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultez la roadmap & changelog
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoignez Discord

--- a/docs/fr/guides/manage-and-operate/api/services.mdx
+++ b/docs/fr/guides/manage-and-operate/api/services.mdx
@@ -65,4 +65,4 @@ L'appel entraîne la suppression du service et des données et l'édition de la 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
+++ b/docs/fr/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
@@ -248,4 +248,4 @@ openstack.exceptions.ForbiddenException: ForbiddenException: 403: Client Error f
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/iam/identities-management.mdx
+++ b/docs/fr/guides/manage-and-operate/iam/identities-management.mdx
@@ -75,4 +75,4 @@ A l'inverse, si vous souhaitez disposer d'une gestion centralisée à travers to
 
 La gestion des identités peut être automatisée via les [API OVHcloud](/guides/manage-and-operate/api/first-steps) ou via le [provider Terraform OVHcloud](/guides/manage-and-operate/terraform/at-ovhcloud).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/iam/logs-forwarding.mdx
+++ b/docs/fr/guides/manage-and-operate/iam/logs-forwarding.mdx
@@ -254,4 +254,4 @@ Les trois routes API Logs Data Platform suivantes vous permettent respectivement
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/iam/overview.mdx
+++ b/docs/fr/guides/manage-and-operate/iam/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Aller plus loin"
   items:
     - title: "Visitez la communauté OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consultez la roadmap & changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: "Rejoignez Discord"

--- a/docs/fr/guides/manage-and-operate/iam/tag-manager.mdx
+++ b/docs/fr/guides/manage-and-operate/iam/tag-manager.mdx
@@ -121,4 +121,4 @@ Par exemple, la politique suivante accorde des droits à tous les VPS portant le
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/iam/troubleshooting.mdx
+++ b/docs/fr/guides/manage-and-operate/iam/troubleshooting.mdx
@@ -55,4 +55,4 @@ Il est aussi possible de filtrer la recherche sur `authorized_actions_array` pou
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/kms/architecture-overview.mdx
+++ b/docs/fr/guides/manage-and-operate/kms/architecture-overview.mdx
@@ -141,4 +141,4 @@ Les régions concernées par la certification PCI-DSS sont :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/kms/kms-etcd.mdx
+++ b/docs/fr/guides/manage-and-operate/kms/kms-etcd.mdx
@@ -186,6 +186,6 @@ Une fois que tous les secrets ont été réchiffrés avec la nouvelle clé, vous
 
 ## Aller plus loin
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Rejoignez notre [communauté d'utilisateurs](/links/community).
 
 Découvrez comment utiliser [Kubernetes External Secrets Operator avec Secret Manager](/guides/manage-and-operate/secret-manager/external-secret-operator).

--- a/docs/fr/guides/manage-and-operate/kms/kms-kmip.mdx
+++ b/docs/fr/guides/manage-and-operate/kms/kms-kmip.mdx
@@ -261,4 +261,4 @@ Le détail de la couverture est disponible ci-dessous.
 
 Le site de l'[OASIS](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=kmip).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/kms/kms-usage.mdx
+++ b/docs/fr/guides/manage-and-operate/kms/kms-usage.mdx
@@ -446,4 +446,4 @@ L'API renverra ensuite le résultat de la vérification :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/kms/logs.mdx
+++ b/docs/fr/guides/manage-and-operate/kms/logs.mdx
@@ -110,4 +110,4 @@ Les éléments pouvant être transmis à Logs Data Platform étant :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/kms/okms-certificate-management.mdx
+++ b/docs/fr/guides/manage-and-operate/kms/okms-certificate-management.mdx
@@ -290,4 +290,4 @@ Copiez la valeur du champ **certificatePEM** dans un fichier **client.cert**.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/kms/overview.mdx
+++ b/docs/fr/guides/manage-and-operate/kms/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Aller plus loin"
   items:
     - title: "Rejoindre la communauté OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Voir la roadmap & changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: "Rejoindre Discord"

--- a/docs/fr/guides/manage-and-operate/kms/quick-start.mdx
+++ b/docs/fr/guides/manage-and-operate/kms/quick-start.mdx
@@ -192,4 +192,4 @@ Une fois votre KMS OVHcloud initialisé, il est possible de l'utiliser de deux m
 ## Aller plus loin
 
 [Utiliser le KMS OVHcloud avec vos données](/guides/manage-and-operate/kms/kms-usage)
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/alerting.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/alerting.mdx
@@ -201,5 +201,5 @@ You will then receive an email with the messages included. You can then directly
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/apache-logs.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/apache-logs.mdx
@@ -180,5 +180,5 @@ The complete procedure of its installation is described [on this page](/guides/m
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
@@ -144,5 +144,5 @@ Remember, that you can also use a special field X-OVH-TO-FREEZE on your logs to 
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/bonfire.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/bonfire.mdx
@@ -160,5 +160,5 @@ Enter password for `<USERNAME>`@`<YOUR-CLUSTER>`.logs.ovh.com:443/api:
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
@@ -284,5 +284,5 @@ The Logs Data Platform team will then take care of your request.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovh.com/en/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs))

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
@@ -143,5 +143,5 @@ ltsv_logger.info("Bonjour '%s'", 'John', extra={"lang": 'fr'})
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/elastalert.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/elastalert.mdx
@@ -247,5 +247,5 @@ ElastAlert has a lot of integrations for alerting including Email, JIRA, OpsGeni
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/filebeat-logs.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/filebeat-logs.mdx
@@ -320,5 +320,5 @@ Filebeat is a handy tool to send the content of your current log files to Logs D
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
@@ -189,5 +189,5 @@ For your information, a **Log forwarder agent** is considered as a tool (full so
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
@@ -135,5 +135,5 @@ Don't hesitate to [explore the API](https://api.ovh.com/console/#/dbaas/logs), a
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
@@ -349,5 +349,5 @@ Here is an example of a dashboard that you can craft from the HAProxy logs. HAPr
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
@@ -188,5 +188,5 @@ We currently have specific documentation illustrating the usage of *aliases* in 
 - [Introduction to Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/introduction)
 - [Getting Started with Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - [Our documentation](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
@@ -163,5 +163,5 @@ And that's it. Your kubernetes activity is now perfectly logged in one place. Ha
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/ldp-tail.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/ldp-tail.mdx
@@ -141,7 +141,7 @@ Value="/dbaas/logs"
 Not=false
 ```
 
-If you have any difficulty understanding this pattern or if you want help creating your own, don't hesitate to reach us on the [Community Hub](https://community.ovh.com/en/c/Platform/data-platforms).
+If you have any difficulty understanding this pattern or if you want help creating your own, don't hesitate to reach us on the [Community Hub](/links/community).
 
 ### Replay tail
 
@@ -169,5 +169,5 @@ You can use the website [https://www.unixtimestamp.com/](https://www.unixtimesta
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
@@ -200,5 +200,5 @@ As we can see:
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/logstash-input.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/logstash-input.mdx
@@ -212,7 +212,7 @@ This is an address of your collector for the cluster on Logs Data Platform. Send
 The version hosted by Logs Data Platform is the Latest Logstash 7 version (7.8 as of July 2020). Of course we will update to the new versions as soon as they become available.
 
 #### Logstash Plugins
-For your information, here is the list of Logstash plugins we support. Of course we will welcome any suggestion on additional plugins. Don't hesitate to contact us on the [community hub](https://community.ovh.com/en/c/Platform/data-platforms).
+For your information, here is the list of Logstash plugins we support. Of course we will welcome any suggestion on additional plugins. Don't hesitate to contact us on the [community hub](/links/community).
 
 ##### Inputs plugins
 
@@ -371,5 +371,5 @@ That's all you need to know about the Logstash Collector on Logs Data Platform.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
@@ -227,4 +227,4 @@ Then, go to your **Graylog** interface (access via the OVHcloud Control Panel) a
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/opensearch-dashboards.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/opensearch-dashboards.mdx
@@ -70,5 +70,5 @@ To know what you can do with OpenSearch Dashboards, read the [OpenSearch Dashboa
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Visitez la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultez la roadmap & changelog
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoignez Discord

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/rust-libs.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/rust-libs.mdx
@@ -209,5 +209,5 @@ You could also look at the [generated API documentation](https://docs.rs/log4rs-
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
@@ -219,4 +219,4 @@ This means that:
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovh.com/fr/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs)))
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
@@ -182,5 +182,5 @@ The Graylog Web Interface does not support legacy token authentication.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
@@ -190,5 +190,5 @@ All this information can help you to analyse the most difficult queries for your
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/using-grafana-with-logs.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/using-grafana-with-logs.mdx
@@ -81,5 +81,5 @@ If you want to know what you can do with Grafana and OpenSearch, read the [offic
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
@@ -114,5 +114,5 @@ If you want to go further, don't hesitate to fly to the [NXlog documentation](ht
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/fr/identity-security-operations/logs-data-platform/)

--- a/docs/fr/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/fr/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -289,4 +289,4 @@ Pour plus d'informations sur la gestion de l'External Secret Operator, veuillez 
 
 ## Aller plus loin
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Rejoignez notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/secret-manager/kv2-api.mdx
+++ b/docs/fr/guides/manage-and-operate/secret-manager/kv2-api.mdx
@@ -238,4 +238,4 @@ Une version supprimée n'est plus présente dans le Secret Manager et ne peut pl
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/secret-manager/rest-api.mdx
+++ b/docs/fr/guides/manage-and-operate/secret-manager/rest-api.mdx
@@ -210,4 +210,4 @@ L'API attendant l'unique valeur :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/secret-manager/secret-manager-ui.mdx
+++ b/docs/fr/guides/manage-and-operate/secret-manager/secret-manager-ui.mdx
@@ -137,4 +137,4 @@ Les deux API manipulent les mêmes objets. Un secret créé par une méthode est
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/it/guides/manage-and-operate/api/account.mdx
+++ b/docs/it/guides/manage-and-operate/api/account.mdx
@@ -52,4 +52,4 @@ With the previously created ConsumerKey.
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/manage-and-operate/api/console-preview.mdx
+++ b/docs/it/guides/manage-and-operate/api/console-preview.mdx
@@ -174,4 +174,4 @@ Three tabs are then available:
 
 How to manage a customer’s account via OVHcloud API
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/manage-and-operate/api/enterprise-payment.mdx
+++ b/docs/it/guides/manage-and-operate/api/enterprise-payment.mdx
@@ -57,4 +57,4 @@ Retrieve the detailed bill using the billID:
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/manage-and-operate/api/first-steps.mdx
+++ b/docs/it/guides/manage-and-operate/api/first-steps.mdx
@@ -228,4 +228,4 @@ Per visualizzare e rimuovere le chiavi è possibile utilizzare il [portale API](
 
 [Come gestire l'account di un cliente OVHcloud tramite le API](/guides/manage-and-operate/api/first-steps) (guida in inglese)
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en](https://community.ovh.com/en/)
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/manage-and-operate/api/manage-service-account.mdx
+++ b/docs/it/guides/manage-and-operate/api/manage-service-account.mdx
@@ -143,4 +143,4 @@ Service accounts are available in several APIs of our products. For each API, th
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/manage-and-operate/api/overview.mdx
+++ b/docs/it/guides/manage-and-operate/api/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: Per saperne di più
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulta la roadmap & changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/manage-and-operate/api/services.mdx
+++ b/docs/it/guides/manage-and-operate/api/services.mdx
@@ -61,4 +61,4 @@ The call will delete the service and data and issue the invoice for the period b
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
+++ b/docs/it/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
@@ -248,4 +248,4 @@ openstack.exceptions.ForbiddenException: ForbiddenException: 403: Client Error f
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/manage-and-operate/iam/identities-management.mdx
+++ b/docs/it/guides/manage-and-operate/iam/identities-management.mdx
@@ -82,4 +82,4 @@ Per una gestione centralizzata su tutti i prodotti, consigliamo di utilizzare le
 
 La gestione delle identità può essere automatizzata tramite le [API OVHcloud](/guides/manage-and-operate/api/first-steps) o tramite il [provider Terraform OVHcloud](/guides/manage-and-operate/terraform/at-ovhcloud).
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/manage-and-operate/iam/logs-forwarding.mdx
+++ b/docs/it/guides/manage-and-operate/iam/logs-forwarding.mdx
@@ -256,4 +256,4 @@ The three following Logs Data Platform API routes respectively allow you to:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/manage-and-operate/iam/overview.mdx
+++ b/docs/it/guides/manage-and-operate/iam/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Per saperne di più"
   items:
     - title: "Visita la community OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulta la roadmap & changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: "Unisciti a Discord"

--- a/docs/it/guides/manage-and-operate/iam/troubleshooting.mdx
+++ b/docs/it/guides/manage-and-operate/iam/troubleshooting.mdx
@@ -56,4 +56,4 @@ You can also filter the search on `authorized_actions_array` to list the actions
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/manage-and-operate/kms/kms-etcd.mdx
+++ b/docs/it/guides/manage-and-operate/kms/kms-etcd.mdx
@@ -186,6 +186,6 @@ After all secrets have been re-encrypted with the new key, you can remove the ol
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Find out how to use [Kubernetes External Secrets Operator with Secret Manager](/guides/manage-and-operate/secret-manager/external-secret-operator).

--- a/docs/it/guides/manage-and-operate/kms/logs.mdx
+++ b/docs/it/guides/manage-and-operate/kms/logs.mdx
@@ -109,4 +109,4 @@ Elements that can be pushed to Logs Data Platform:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/manage-and-operate/kms/overview.mdx
+++ b/docs/it/guides/manage-and-operate/kms/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Per saperne di più"
   items:
     - title: "Visita la community OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Visualizza la roadmap e il changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: "Unisciti a Discord"

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
@@ -144,5 +144,5 @@ Remember, that you can also use a special field X-OVH-TO-FREEZE on your logs to 
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/it/identity-security-operations/logs-data-platform/)

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
@@ -284,5 +284,5 @@ The Logs Data Platform team will then take care of your request.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovh.com/en/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs))

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
@@ -143,5 +143,5 @@ ltsv_logger.info("Bonjour '%s'", 'John', extra={"lang": 'fr'})
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/it/identity-security-operations/logs-data-platform/)

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
@@ -189,5 +189,5 @@ For your information, a **Log forwarder agent** is considered as a tool (full so
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/it/identity-security-operations/logs-data-platform/)

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
@@ -135,5 +135,5 @@ Don't hesitate to [explore the API](https://api.ovh.com/console/#/dbaas/logs), a
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/it/identity-security-operations/logs-data-platform/)

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
@@ -349,5 +349,5 @@ Here is an example of a dashboard that you can craft from the HAProxy logs. HAPr
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/it/identity-security-operations/logs-data-platform/)

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
@@ -188,5 +188,5 @@ We currently have specific documentation illustrating the usage of *aliases* in 
 - [Introduction to Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/introduction)
 - [Getting Started with Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - [Our documentation](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/it/identity-security-operations/logs-data-platform/)

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
@@ -163,5 +163,5 @@ And that's it. Your kubernetes activity is now perfectly logged in one place. Ha
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/it/identity-security-operations/logs-data-platform/)

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
@@ -200,5 +200,5 @@ As we can see:
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/it/identity-security-operations/logs-data-platform/)

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
@@ -227,4 +227,4 @@ Then, go to your **Graylog** interface (access via the OVHcloud Control Panel) a
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovhcloud.com/it/identity-security-operations/logs-data-platform/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Per saperne di più
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap & changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
@@ -219,4 +219,4 @@ This means that:
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovh.com/it/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs)))
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
@@ -182,5 +182,5 @@ The Graylog Web Interface does not support legacy token authentication.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/it/identity-security-operations/logs-data-platform/)

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
@@ -190,5 +190,5 @@ All this information can help you to analyse the most difficult queries for your
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/it/identity-security-operations/logs-data-platform/)

--- a/docs/it/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
+++ b/docs/it/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
@@ -114,5 +114,5 @@ If you want to go further, don't hesitate to fly to the [NXlog documentation](ht
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/it/identity-security-operations/logs-data-platform/)

--- a/docs/pl/guides/manage-and-operate/api/account.mdx
+++ b/docs/pl/guides/manage-and-operate/api/account.mdx
@@ -52,4 +52,4 @@ With the previously created ConsumerKey.
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/manage-and-operate/api/console-preview.mdx
+++ b/docs/pl/guides/manage-and-operate/api/console-preview.mdx
@@ -174,4 +174,4 @@ Three tabs are then available:
 
 How to manage a customer’s account via OVHcloud API
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/manage-and-operate/api/enterprise-payment.mdx
+++ b/docs/pl/guides/manage-and-operate/api/enterprise-payment.mdx
@@ -57,4 +57,4 @@ Retrieve the detailed bill using the billID:
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/manage-and-operate/api/first-steps.mdx
+++ b/docs/pl/guides/manage-and-operate/api/first-steps.mdx
@@ -228,4 +228,4 @@ Do wyświetlania i odwoływania kluczy możesz użyć [portalu API](https://eu.a
 
 [Jak zarządzać kontem klienta OVHcloud za pomocą API](/guides/manage-and-operate/api/first-steps) (przewodnik po angielsku)
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/)
+Przyłącz się do [społeczności naszych użytkowników](/links/community).

--- a/docs/pl/guides/manage-and-operate/api/manage-service-account.mdx
+++ b/docs/pl/guides/manage-and-operate/api/manage-service-account.mdx
@@ -143,4 +143,4 @@ Service accounts are available in several APIs of our products. For each API, th
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/manage-and-operate/api/overview.mdx
+++ b/docs/pl/guides/manage-and-operate/api/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz roadmapę i changelog"
       link: https://www.ovhcloud.com/pl-pl/roadmap-changelog/
     - title: "Dołącz do Discorda"

--- a/docs/pl/guides/manage-and-operate/api/services.mdx
+++ b/docs/pl/guides/manage-and-operate/api/services.mdx
@@ -61,4 +61,4 @@ The call will delete the service and data and issue the invoice for the period b
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
+++ b/docs/pl/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
@@ -248,4 +248,4 @@ openstack.exceptions.ForbiddenException: ForbiddenException: 403: Client Error f
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/manage-and-operate/iam/identities-management.mdx
+++ b/docs/pl/guides/manage-and-operate/iam/identities-management.mdx
@@ -82,4 +82,4 @@ Jeśli chcesz, aby wszystkie Twoje produkty były zarządzane centralnie, zaleca
 
 Zarządzanie tożsamością można zautomatyzować za pośrednictwem interfejsów [API OVHcloud](/guides/manage-and-operate/api/first-steps) lub za pośrednictwem [provider Terraform OVHcloud](/guides/manage-and-operate/terraform/at-ovhcloud).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/manage-and-operate/iam/logs-forwarding.mdx
+++ b/docs/pl/guides/manage-and-operate/iam/logs-forwarding.mdx
@@ -256,4 +256,4 @@ The three following Logs Data Platform API routes respectively allow you to:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/manage-and-operate/iam/overview.mdx
+++ b/docs/pl/guides/manage-and-operate/iam/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz roadmapę i changelog"
       link: https://www.ovhcloud.com/pl-pl/roadmap-changelog/
     - title: "Dołącz do Discorda"

--- a/docs/pl/guides/manage-and-operate/iam/troubleshooting.mdx
+++ b/docs/pl/guides/manage-and-operate/iam/troubleshooting.mdx
@@ -56,4 +56,4 @@ You can also filter the search on `authorized_actions_array` to list the actions
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/manage-and-operate/kms/kms-etcd.mdx
+++ b/docs/pl/guides/manage-and-operate/kms/kms-etcd.mdx
@@ -186,6 +186,6 @@ After all secrets have been re-encrypted with the new key, you can remove the ol
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Find out how to use [Kubernetes External Secrets Operator with Secret Manager](/guides/manage-and-operate/secret-manager/external-secret-operator).

--- a/docs/pl/guides/manage-and-operate/kms/logs.mdx
+++ b/docs/pl/guides/manage-and-operate/kms/logs.mdx
@@ -109,4 +109,4 @@ Elements that can be pushed to Logs Data Platform:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/manage-and-operate/kms/overview.mdx
+++ b/docs/pl/guides/manage-and-operate/kms/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz harmonogram i dziennik zmian"
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: "Dołącz do Discorda"

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
@@ -144,5 +144,5 @@ Remember, that you can also use a special field X-OVH-TO-FREEZE on your logs to 
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pl/identity-security-operations/logs-data-platform/)

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
@@ -284,5 +284,5 @@ The Logs Data Platform team will then take care of your request.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovh.com/en/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs))

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
@@ -143,5 +143,5 @@ ltsv_logger.info("Bonjour '%s'", 'John', extra={"lang": 'fr'})
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pl/identity-security-operations/logs-data-platform/)

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
@@ -189,5 +189,5 @@ For your information, a **Log forwarder agent** is considered as a tool (full so
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pl/identity-security-operations/logs-data-platform/)

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
@@ -135,5 +135,5 @@ Don't hesitate to [explore the API](https://api.ovh.com/console/#/dbaas/logs), a
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pl/identity-security-operations/logs-data-platform/)

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
@@ -349,5 +349,5 @@ Here is an example of a dashboard that you can craft from the HAProxy logs. HAPr
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pl/identity-security-operations/logs-data-platform/)

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
@@ -188,5 +188,5 @@ We currently have specific documentation illustrating the usage of *aliases* in 
 - [Introduction to Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/introduction)
 - [Getting Started with Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - [Our documentation](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pl/identity-security-operations/logs-data-platform/)

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
@@ -163,5 +163,5 @@ And that's it. Your kubernetes activity is now perfectly logged in one place. Ha
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pl/identity-security-operations/logs-data-platform/)

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
@@ -200,5 +200,5 @@ As we can see:
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pl/identity-security-operations/logs-data-platform/)

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
@@ -227,4 +227,4 @@ Then, go to your **Graylog** interface (access via the OVHcloud Control Panel) a
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovhcloud.com/pl/identity-security-operations/logs-data-platform/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz roadmapę i changelog"
       link: https://www.ovhcloud.com/pl-pl/roadmap-changelog/
     - title: "Dołącz do Discorda"

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
@@ -219,4 +219,4 @@ This means that:
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovh.com/pl/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs)))
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
@@ -182,5 +182,5 @@ The Graylog Web Interface does not support legacy token authentication.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pl/identity-security-operations/logs-data-platform/)

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
@@ -190,5 +190,5 @@ All this information can help you to analyse the most difficult queries for your
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pl/identity-security-operations/logs-data-platform/)

--- a/docs/pl/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
+++ b/docs/pl/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
@@ -114,5 +114,5 @@ If you want to go further, don't hesitate to fly to the [NXlog documentation](ht
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pl/identity-security-operations/logs-data-platform/)

--- a/docs/pt/guides/manage-and-operate/api/account.mdx
+++ b/docs/pt/guides/manage-and-operate/api/account.mdx
@@ -52,4 +52,4 @@ With the previously created ConsumerKey.
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/manage-and-operate/api/console-preview.mdx
+++ b/docs/pt/guides/manage-and-operate/api/console-preview.mdx
@@ -174,4 +174,4 @@ Three tabs are then available:
 
 How to manage a customer’s account via OVHcloud API
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/manage-and-operate/api/enterprise-payment.mdx
+++ b/docs/pt/guides/manage-and-operate/api/enterprise-payment.mdx
@@ -57,4 +57,4 @@ Retrieve the detailed bill using the billID:
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/manage-and-operate/api/first-steps.mdx
+++ b/docs/pt/guides/manage-and-operate/api/first-steps.mdx
@@ -228,4 +228,4 @@ Para listar e revogar as chaves, é possível utilizar o [portal API](https://eu
 
 [Como gerir a conta de um cliente OVHcloud através das API](/guides/manage-and-operate/api/first-steps) (guia em inglês)
 
-Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/manage-and-operate/api/manage-service-account.mdx
+++ b/docs/pt/guides/manage-and-operate/api/manage-service-account.mdx
@@ -143,4 +143,4 @@ Service accounts are available in several APIs of our products. For each API, th
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/manage-and-operate/api/overview.mdx
+++ b/docs/pt/guides/manage-and-operate/api/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: Visite a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte a roadmap & changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Junte-se ao Discord"

--- a/docs/pt/guides/manage-and-operate/api/services.mdx
+++ b/docs/pt/guides/manage-and-operate/api/services.mdx
@@ -61,4 +61,4 @@ The call will delete the service and data and issue the invoice for the period b
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
+++ b/docs/pt/guides/manage-and-operate/iam/authenticate-api-openstack-with-service-account.mdx
@@ -248,4 +248,4 @@ openstack.exceptions.ForbiddenException: ForbiddenException: 403: Client Error f
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/manage-and-operate/iam/identities-management.mdx
+++ b/docs/pt/guides/manage-and-operate/iam/identities-management.mdx
@@ -82,4 +82,4 @@ Pelo contrário, se pretender dispor de uma gestão centralizada através de tod
 
 A gestão das identidades pode ser automatizada através das API [OVHcloud API](/guides/manage-and-operate/api/first-steps) ou através do [provider Terraform OVHcloud](/guides/manage-and-operate/terraform/at-ovhcloud).
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/manage-and-operate/iam/logs-forwarding.mdx
+++ b/docs/pt/guides/manage-and-operate/iam/logs-forwarding.mdx
@@ -256,4 +256,4 @@ The three following Logs Data Platform API routes respectively allow you to:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/manage-and-operate/iam/overview.mdx
+++ b/docs/pt/guides/manage-and-operate/iam/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: "Visite a comunidade OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte a roadmap & changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Junte-se ao Discord"

--- a/docs/pt/guides/manage-and-operate/iam/troubleshooting.mdx
+++ b/docs/pt/guides/manage-and-operate/iam/troubleshooting.mdx
@@ -56,4 +56,4 @@ You can also filter the search on `authorized_actions_array` to list the actions
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/manage-and-operate/kms/kms-etcd.mdx
+++ b/docs/pt/guides/manage-and-operate/kms/kms-etcd.mdx
@@ -186,6 +186,6 @@ After all secrets have been re-encrypted with the new key, you can remove the ol
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Find out how to use [Kubernetes External Secrets Operator with Secret Manager](/guides/manage-and-operate/secret-manager/external-secret-operator).

--- a/docs/pt/guides/manage-and-operate/kms/logs.mdx
+++ b/docs/pt/guides/manage-and-operate/kms/logs.mdx
@@ -109,4 +109,4 @@ Elements that can be pushed to Logs Data Platform:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/manage-and-operate/kms/overview.mdx
+++ b/docs/pt/guides/manage-and-operate/kms/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: "Visite a comunidade OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte o roadmap e o changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Junte-se ao Discord"

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/archive-cold-storage.mdx
@@ -144,5 +144,5 @@ Remember, that you can also use a special field X-OVH-TO-FREEZE on your logs to 
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pt/identity-security-operations/logs-data-platform/)

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/cold-storage-encryption.mdx
@@ -284,5 +284,5 @@ The Logs Data Platform team will then take care of your request.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovh.com/en/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs))

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/djehouty.mdx
@@ -143,5 +143,5 @@ ltsv_logger.info("Bonjour '%s'", 'John', extra={"lang": 'fr'})
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pt/identity-security-operations/logs-data-platform/)

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/getting-started-responsibility-model.mdx
@@ -189,5 +189,5 @@ For your information, a **Log forwarder agent** is considered as a tool (full so
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pt/identity-security-operations/logs-data-platform/)

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/getting-started-roles-permission.mdx
@@ -135,5 +135,5 @@ Don't hesitate to [explore the API](https://api.ovh.com/console/#/dbaas/logs), a
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pt/identity-security-operations/logs-data-platform/)

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/haproxy.mdx
@@ -349,5 +349,5 @@ Here is an example of a dashboard that you can craft from the HAProxy logs. HAPr
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pt/identity-security-operations/logs-data-platform/)

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/integration-opensearch.mdx
@@ -188,5 +188,5 @@ We currently have specific documentation illustrating the usage of *aliases* in 
 - [Introduction to Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/introduction)
 - [Getting Started with Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - [Our documentation](/guides/manage-and-operate/observability/logs-data-platform/overview)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pt/identity-security-operations/logs-data-platform/)

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/kubernetes-fluent-bit.mdx
@@ -163,5 +163,5 @@ And that's it. Your kubernetes activity is now perfectly logged in one place. Ha
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pt/identity-security-operations/logs-data-platform/)

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/logging-ldp.mdx
@@ -200,5 +200,5 @@ As we can see:
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pt/identity-security-operations/logs-data-platform/)

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/nodejs.mdx
@@ -227,4 +227,4 @@ Then, go to your **Graylog** interface (access via the OVHcloud Control Panel) a
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovhcloud.com/pt/identity-security-operations/logs-data-platform/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visite a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulte a roadmap & changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Junte-se ao Discord"

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/service-logs.mdx
@@ -219,4 +219,4 @@ This means that:
 - Documentation: [Guides](/guides/manage-and-operate/observability/logs-data-platform/overview)
 - Create an account: [Try it!](https://www.ovh.com/pt/order/express/#/express/review?products=~(~(planCode~'logs-account~productId~'logs)))
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/tokens.mdx
@@ -182,5 +182,5 @@ The Graylog Web Interface does not support legacy token authentication.
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pt/identity-security-operations/logs-data-platform/)

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/usecase-mysql-slow-queries.mdx
@@ -190,5 +190,5 @@ All this information can help you to analyse the most difficult queries for your
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pt/identity-security-operations/logs-data-platform/)

--- a/docs/pt/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
+++ b/docs/pt/guides/manage-and-operate/observability/logs-data-platform/windows-nxlog.mdx
@@ -114,5 +114,5 @@ If you want to go further, don't hesitate to fly to the [NXlog documentation](ht
 
 - Getting Started: [Quick Start](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - Documentation: Guides
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
+- Community hub: [community of users](/links/community)
 - Create an account: [Try it!](https://www.ovhcloud.com/pt/identity-security-operations/logs-data-platform/)


### PR DESCRIPTION
### Scope: Manage and Operate

- Replace (dead) links to legacy community page with proper keys
- Fix hard URL in Overview pages to the correct one