### PR TITLE
fix(docs): normalize community links batch 2: Network

### DIFF
--- a/docs/de/guides/network/additional-ip/additional-ip-cancellation.mdx
+++ b/docs/de/guides/network/additional-ip/additional-ip-cancellation.mdx
@@ -47,4 +47,4 @@ You will then receive an email asking you to confirm the cancellation. After con
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/network/additional-ip/blocklist-ip-delist.mdx
+++ b/docs/de/guides/network/additional-ip/blocklist-ip-delist.mdx
@@ -175,4 +175,4 @@ Um [eine IP aus MIPSpace zu entfernen](https://www.mipspace.com/removal.php), lo
 
 Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](https://partner.ovhcloud.com/de/directory/).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/network/additional-ip/overview.mdx
+++ b/docs/de/guides/network/additional-ip/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Weiterführende Informationen"
   items:
     - title: "Besuchen Sie die OVHcloud Community"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: "Discord beitreten"

--- a/docs/de/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/de/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -311,4 +311,4 @@ Yes, but once the BYOIP service has been delivered, you must immediately cancel 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
+++ b/docs/de/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
@@ -103,4 +103,4 @@ Wenn die Domain korrekt in Ihrem Webservice reagiert, müssen Sie nur den HTML-C
  
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
+++ b/docs/de/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
@@ -41,4 +41,4 @@ Hier die Liste der IP-Adressen:
 
 ## Weiterführende Informationen <a name="go-further"></a>
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
+++ b/docs/de/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
@@ -61,4 +61,4 @@ Wenn das Zertifikat aktiviert ist, erkennen Sie dies am neuen Status:
 
 [Erste Konfiguration einer Domain](/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration)
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/network/content-delivery-network-infrastructure/quota.mdx
+++ b/docs/de/guides/network/content-delivery-network-infrastructure/quota.mdx
@@ -48,4 +48,4 @@ Unabhängig davon, ob die Dateien in den Cache gelegt oder vom *Backend* aus üb
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/network/load-balancer/case-http2.mdx
+++ b/docs/de/guides/network/load-balancer/case-http2.mdx
@@ -157,4 +157,4 @@ HTTP/2 200
 
 Wenn Sie weitere Informationen zum HTTP/2-Protokoll wünschen, besuchen Sie [https://http2.github.io/](https://http2.github.io/).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/network/load-balancer/create-proxyprotocol.mdx
+++ b/docs/de/guides/network/load-balancer/create-proxyprotocol.mdx
@@ -268,4 +268,4 @@ service haproxy reload
 
 ## Go Further
 
-Discuss with our [user community](/links/community).
+Join our [community of users](/links/community).

--- a/docs/de/guides/network/load-balancer/overview.mdx
+++ b/docs/de/guides/network/load-balancer/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: Besuchen Sie die OVHcloud Community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Roadmap & Changelog einsehen
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/network/load-balancer/use-api-details.mdx
+++ b/docs/de/guides/network/load-balancer/use-api-details.mdx
@@ -2689,4 +2689,4 @@ Table of farm identifiers that you wish to attach to this private network. The V
 
 ## Go further
 
-Interact with our user community on [https://community.ovh.com](https://community.ovh.com).
+Join our [community of users](/links/community).

--- a/docs/de/guides/network/load-balancer/use-lb.mdx
+++ b/docs/de/guides/network/load-balancer/use-lb.mdx
@@ -131,4 +131,4 @@ Wenn Sie bereits über ein eigenes SSL-Zertifikat verfügen, können Sie es dire
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/network/load-balancer/use-presentation.mdx
+++ b/docs/de/guides/network/load-balancer/use-presentation.mdx
@@ -105,4 +105,4 @@ Balance your databases, and make them redundant.
 - [HAProxy official site](http://www.haproxy.org/#desc)
 - [Nginx documentation](https://nginx.org/en/docs/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/network/load-balancer/zones.mdx
+++ b/docs/de/guides/network/load-balancer/zones.mdx
@@ -124,4 +124,4 @@ Don't forget to deploy the configuration. To do this, click <code className="act
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/network/network-tools.mdx
+++ b/docs/de/guides/network/network-tools.mdx
@@ -91,4 +91,4 @@ For more information and tutorials, please see our other [Networking and Securit
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/network/ovhcloud-connect/overview.mdx
+++ b/docs/de/guides/network/ovhcloud-connect/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Weiterführende Informationen"
   items:
     - title: Besuchen Sie die OVHcloud Community
-      link: /links/community
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/network/vrack-services/global.mdx
+++ b/docs/de/guides/network/vrack-services/global.mdx
@@ -502,4 +502,4 @@ Please note that creating vRack Services, Subnets, or Service Endpoints on a pro
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/network/vrack/overview.mdx
+++ b/docs/de/guides/network/vrack/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Weiterführende Informationen"
   items:
     - title: "Besuchen Sie die OVHcloud Community"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: "Discord beitreten"

--- a/docs/de/guides/network/whois-ip.mdx
+++ b/docs/de/guides/network/whois-ip.mdx
@@ -48,4 +48,4 @@ Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.
 
 Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/en/guides/network/additional-ip/additional-ip-cancellation.mdx
+++ b/docs/en/guides/network/additional-ip/additional-ip-cancellation.mdx
@@ -51,4 +51,4 @@ You will then receive an email asking you to confirm the cancellation. After con
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/additional-ip/blocklist-ip-delist.mdx
+++ b/docs/en/guides/network/additional-ip/blocklist-ip-delist.mdx
@@ -177,4 +177,4 @@ To [delist an IP from MIPSpace](https://www.mipspace.com/removal.php), first log
 
 For specialized services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/additional-ip/overview.mdx
+++ b/docs/en/guides/network/additional-ip/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Go further"
   items:
     - title: "Visit the OVHcloud community"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: "Join Discord"

--- a/docs/en/guides/network/additional-ip/primary-additional-ip-concepts.mdx
+++ b/docs/en/guides/network/additional-ip/primary-additional-ip-concepts.mdx
@@ -95,4 +95,4 @@ Additional IP addresses can be attached to OVHcloud services in two primary ways
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/bgp-service/bgp-service-config.mdx
+++ b/docs/en/guides/network/bgp-service/bgp-service-config.mdx
@@ -708,4 +708,4 @@ If you encounter issues with your BGP session:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/en/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -311,4 +311,4 @@ Yes, but once the BYOIP service has been delivered, you must immediately cancel 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
+++ b/docs/en/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
@@ -106,4 +106,4 @@ If the domain responds correctly to your web service, you simply need to modify 
  
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
+++ b/docs/en/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
@@ -41,4 +41,4 @@ Below is the list of IP addresses:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
+++ b/docs/en/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
@@ -61,4 +61,4 @@ If you already have a Let's Encrypt certificate, then you can use the <code clas
 
 [Configuring a domain name for the first time](/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/content-delivery-network-infrastructure/quota.mdx
+++ b/docs/en/guides/network/content-delivery-network-infrastructure/quota.mdx
@@ -48,4 +48,4 @@ Whether the files are stored in the cache or called from the back-end through th
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/case-blue-green.mdx
+++ b/docs/en/guides/network/load-balancer/case-blue-green.mdx
@@ -299,4 +299,4 @@ Another way to consolidate your infrastructure even further is by multiplying th
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/case-http2.mdx
+++ b/docs/en/guides/network/load-balancer/case-http2.mdx
@@ -159,4 +159,4 @@ HTTP/2 200
 
 If you want more information about the HTTP/2 protocol, please visit [https://http2.github.io/](https://http2.github.io/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/case-smtp.mdx
+++ b/docs/en/guides/network/load-balancer/case-smtp.mdx
@@ -232,4 +232,4 @@ Upon completing these steps, you will have a functional Load Balancer service fo
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/create-balancing.mdx
+++ b/docs/en/guides/network/load-balancer/create-balancing.mdx
@@ -100,4 +100,4 @@ Use this api call to edit the settings of a server farm given its ID. In this ex
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/create-faq.mdx
+++ b/docs/en/guides/network/load-balancer/create-faq.mdx
@@ -132,4 +132,4 @@ An SSL certificate appearing as `built_not_routed` is a certificate that has bee
 
 Find details about all the API calls related to the OVHcloud Load Balancer in [this guide](/guides/network/load-balancer/use-api-details).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/create-headers.mdx
+++ b/docs/en/guides/network/load-balancer/create-headers.mdx
@@ -251,4 +251,4 @@ If you integrate the API into your code, this corresponds to a JSON list of the 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/create-http-https.mdx
+++ b/docs/en/guides/network/load-balancer/create-http-https.mdx
@@ -325,4 +325,4 @@ Once all these steps are completed, you should have a functional load balancing 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/create-probes.mdx
+++ b/docs/en/guides/network/load-balancer/create-probes.mdx
@@ -308,4 +308,4 @@ A new configuration window will appear, with the probe’s settings.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/create-proxyprotocol.mdx
+++ b/docs/en/guides/network/load-balancer/create-proxyprotocol.mdx
@@ -283,4 +283,4 @@ service haproxy reload
 
 ## Go Further
 
-Discuss with our [user community](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/create-redirectlocation.mdx
+++ b/docs/en/guides/network/load-balancer/create-redirectlocation.mdx
@@ -110,4 +110,4 @@ In the [OVHcloud API](https://eu.api.ovh.com/), redirects are specified in the r
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/create-route.mdx
+++ b/docs/en/guides/network/load-balancer/create-route.mdx
@@ -848,4 +848,4 @@ This rule allows filtering requests based on the existence or value of a specifi
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/create-stickiness.mdx
+++ b/docs/en/guides/network/load-balancer/create-stickiness.mdx
@@ -115,4 +115,4 @@ This API call is required to deploy the configuration changes to the Load Balanc
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/howto-route-ipfo.mdx
+++ b/docs/en/guides/network/load-balancer/howto-route-ipfo.mdx
@@ -128,4 +128,4 @@ Remember to deploy the configuration. There are two ways to do this:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/order-freecertificate.mdx
+++ b/docs/en/guides/network/load-balancer/order-freecertificate.mdx
@@ -90,4 +90,4 @@ Once the order is complete, the SSL Certificate is automatically installed on yo
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/overview.mdx
+++ b/docs/en/guides/network/load-balancer/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: View the roadmap & changelog
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/network/load-balancer/retrieve-servers-state.mdx
+++ b/docs/en/guides/network/load-balancer/retrieve-servers-state.mdx
@@ -83,4 +83,4 @@ For each instance, we have the following information:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/use-api-details.mdx
+++ b/docs/en/guides/network/load-balancer/use-api-details.mdx
@@ -1271,4 +1271,4 @@ Access the UDP protocol elements (Frontend, Farm, etc.).
 
 ## Go further
 
-Interact with our user community on [https://community.ovh.com](https://community.ovh.com).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/use-api-logs-customers.mdx
+++ b/docs/en/guides/network/load-balancer/use-api-logs-customers.mdx
@@ -201,4 +201,4 @@ To delete your subscription you can use the following API call:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/use-lb.mdx
+++ b/docs/en/guides/network/load-balancer/use-lb.mdx
@@ -132,4 +132,4 @@ If you already have your own SSL certificate, you can add it directly:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/use-presentation.mdx
+++ b/docs/en/guides/network/load-balancer/use-presentation.mdx
@@ -105,4 +105,4 @@ Balance your databases, and make them redundant.
 - [HAProxy official site](http://www.haproxy.org/#desc)
 - [Nginx documentation](https://nginx.org/en/docs/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/load-balancer/zones.mdx
+++ b/docs/en/guides/network/load-balancer/zones.mdx
@@ -123,4 +123,4 @@ Don't forget to deploy the configuration. To do this, click <code className="act
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/network-tools.mdx
+++ b/docs/en/guides/network/network-tools.mdx
@@ -91,4 +91,4 @@ For more information and tutorials, please see our other Networking and Security
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/ovhcloud-connect/overview.mdx
+++ b/docs/en/guides/network/ovhcloud-connect/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: /links/community
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/network/vrack-services/global.mdx
+++ b/docs/en/guides/network/vrack-services/global.mdx
@@ -502,4 +502,4 @@ Please note that creating vRack Services, Subnets, or Service Endpoints on a pro
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/network/vrack/overview.mdx
+++ b/docs/en/guides/network/vrack/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Go further"
   items:
     - title: "Visit the OVHcloud community"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: "Join Discord"

--- a/docs/en/guides/network/whois-ip.mdx
+++ b/docs/en/guides/network/whois-ip.mdx
@@ -48,4 +48,4 @@ For specialised services (SEO, development, etc.), contact [OVHcloud partners](h
 
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-gb/support-levels/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/network/additional-ip/additional-ip-cancellation.mdx
+++ b/docs/es/guides/network/additional-ip/additional-ip-cancellation.mdx
@@ -47,4 +47,4 @@ You will then receive an email asking you to confirm the cancellation. After con
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/network/additional-ip/blocklist-ip-delist.mdx
+++ b/docs/es/guides/network/additional-ip/blocklist-ip-delist.mdx
@@ -173,4 +173,4 @@ Para [retirar una IP de MIPSpace](https://www.mipspace.com/removal.php), conéct
 
 Para servicios especializados (posicionamiento web, desarrollo...), póngase en contacto con los [partners de OVHcloud](https://partner.ovhcloud.com/es-es/directory/).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/network/additional-ip/overview.mdx
+++ b/docs/es/guides/network/additional-ip/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Más información"
   items:
     - title: "Visite la comunidad de OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte la roadmap & changelog"
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: "Únase a Discord"

--- a/docs/es/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/es/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -311,4 +311,4 @@ Yes, but once the BYOIP service has been delivered, you must immediately cancel 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
+++ b/docs/es/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
@@ -103,4 +103,4 @@ Si el dominio responde correctamente en su servicio web, solo tendrá que editar
  
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
+++ b/docs/es/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
@@ -41,4 +41,4 @@ Consulte a continuación la lista de direcciones IP:
 
 ## Más información <a name="go-further"></a>
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
+++ b/docs/es/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
@@ -61,4 +61,4 @@ Una vez activado el certificado, podrá ver lo siguiente en el área de cliente:
 
 [Primera configuración de un dominio](/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration)
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/network/content-delivery-network-infrastructure/quota.mdx
+++ b/docs/es/guides/network/content-delivery-network-infrastructure/quota.mdx
@@ -50,4 +50,4 @@ En ambos casos, tanto si los archivos se recuperan de la caché como si proceden
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/network/load-balancer/case-http2.mdx
+++ b/docs/es/guides/network/load-balancer/case-http2.mdx
@@ -159,4 +159,4 @@ HTTP/2 200
 
 Si desea obtener más información sobre el protocolo HTTP/2, visite [https://http2.github.io/](https://http2.github.io/).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/network/load-balancer/create-proxyprotocol.mdx
+++ b/docs/es/guides/network/load-balancer/create-proxyprotocol.mdx
@@ -268,4 +268,4 @@ service haproxy reload
 
 ## Go Further
 
-Discuss with our [user community](/links/community).
+Join our [community of users](/links/community).

--- a/docs/es/guides/network/load-balancer/overview.mdx
+++ b/docs/es/guides/network/load-balancer/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Más información"
   items:
     - title: Visite la comunidad de OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulte la roadmap & changelog
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: "Únase a Discord"

--- a/docs/es/guides/network/load-balancer/use-api-details.mdx
+++ b/docs/es/guides/network/load-balancer/use-api-details.mdx
@@ -2689,4 +2689,4 @@ Table of farm identifiers that you wish to attach to this private network. The V
 
 ## Go further
 
-Interact with our user community on [https://community.ovh.com](https://community.ovh.com).
+Join our [community of users](/links/community).

--- a/docs/es/guides/network/load-balancer/use-lb.mdx
+++ b/docs/es/guides/network/load-balancer/use-lb.mdx
@@ -135,4 +135,4 @@ Si ya tiene su propio certificado SSL, puede añadirlo directamente:
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/network/load-balancer/use-presentation.mdx
+++ b/docs/es/guides/network/load-balancer/use-presentation.mdx
@@ -105,4 +105,4 @@ Balance your databases, and make them redundant.
 - [HAProxy official site](http://www.haproxy.org/#desc)
 - [Nginx documentation](https://nginx.org/en/docs/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/network/load-balancer/zones.mdx
+++ b/docs/es/guides/network/load-balancer/zones.mdx
@@ -124,4 +124,4 @@ Don't forget to deploy the configuration. To do this, click <code className="act
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/network/network-tools.mdx
+++ b/docs/es/guides/network/network-tools.mdx
@@ -91,4 +91,4 @@ For more information and tutorials, please see our other [Networking and Securit
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/network/ovhcloud-connect/overview.mdx
+++ b/docs/es/guides/network/ovhcloud-connect/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Más información"
   items:
     - title: Visite la comunidad de OVHcloud
-      link: /links/community
+      link: https://community.ovhcloud.com/
     - title: "Consulte la roadmap & changelog"
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: "Únase a Discord"

--- a/docs/es/guides/network/vrack-services/global.mdx
+++ b/docs/es/guides/network/vrack-services/global.mdx
@@ -502,4 +502,4 @@ Please note that creating vRack Services, Subnets, or Service Endpoints on a pro
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/network/vrack/overview.mdx
+++ b/docs/es/guides/network/vrack/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Más información"
   items:
     - title: "Visite la comunidad de OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte la roadmap & changelog"
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: "Únase a Discord"

--- a/docs/es/guides/network/whois-ip.mdx
+++ b/docs/es/guides/network/whois-ip.mdx
@@ -48,4 +48,4 @@ Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con 
 
 Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/fr/guides/network/additional-ip/additional-ip-cancellation.mdx
+++ b/docs/fr/guides/network/additional-ip/additional-ip-cancellation.mdx
@@ -51,4 +51,4 @@ Vous recevrez ensuite un e-mail vous demandant de confirmer la résiliation. La 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/additional-ip/blocklist-ip-delist.mdx
+++ b/docs/fr/guides/network/additional-ip/blocklist-ip-delist.mdx
@@ -164,4 +164,4 @@ Pour [retirer une IP de MIPSpace](https://www.mipspace.com/removal.php), connect
 
 Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/additional-ip/overview.mdx
+++ b/docs/fr/guides/network/additional-ip/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Aller plus loin"
   items:
     - title: "Visitez la communauté OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consultez la roadmap & changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: "Rejoignez Discord"

--- a/docs/fr/guides/network/additional-ip/primary-additional-ip-concepts.mdx
+++ b/docs/fr/guides/network/additional-ip/primary-additional-ip-concepts.mdx
@@ -95,4 +95,4 @@ Les adresses Additional IP peuvent être attachées aux services OVHcloud de deu
 
 ## Pour aller plus loin
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/bgp-service/bgp-service-config.mdx
+++ b/docs/fr/guides/network/bgp-service/bgp-service-config.mdx
@@ -708,4 +708,4 @@ Si vous recontrez des problèmes avec votre session BGP :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/fr/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -312,4 +312,4 @@ Oui, mais une fois la livraison du service BYOIP effectuée, vous devrez immédi
 
 ## Allez plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
+++ b/docs/fr/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
@@ -104,4 +104,4 @@ Si le domaine répond correctement au niveau de votre service web, vous n'avez p
  
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
+++ b/docs/fr/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
@@ -41,4 +41,4 @@ Retrouvez ci-dessous la liste des adresses IP :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
+++ b/docs/fr/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
@@ -61,4 +61,4 @@ Une fois le certificat activé, voici ce que vous obtiendrez :
 
 [Première configuration d'un nom de domaine](/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/content-delivery-network-infrastructure/quota.mdx
+++ b/docs/fr/guides/network/content-delivery-network-infrastructure/quota.mdx
@@ -48,4 +48,4 @@ Que les fichiers soient pris en cache ou appelés sur le *back end* en passant p
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/case-blue-green.mdx
+++ b/docs/fr/guides/network/load-balancer/case-blue-green.mdx
@@ -297,4 +297,4 @@ Une autre façon de consolider davantage votre infrastructure est de multiplier 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/case-http2.mdx
+++ b/docs/fr/guides/network/load-balancer/case-http2.mdx
@@ -159,4 +159,4 @@ HTTP/2 200
 
 Si vous souhaitez obtenir plus d'informations sur le protocole HTTP/2, rendez-vous sur [https://http2.github.io/](https://http2.github.io/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/case-smtp.mdx
+++ b/docs/fr/guides/network/load-balancer/case-smtp.mdx
@@ -239,4 +239,4 @@ Une fois toutes ces étapes terminées, vous devriez disposer d'un service de r�
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/configure-vrack.mdx
+++ b/docs/fr/guides/network/load-balancer/configure-vrack.mdx
@@ -98,4 +98,4 @@ Pour rappel, un guide de configuration du Load Balancer est disponible : [Config
  
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/create-balancing.mdx
+++ b/docs/fr/guides/network/load-balancer/create-balancing.mdx
@@ -100,4 +100,4 @@ Cet appel API permet de modifier la configuration d'une ferme en connaissant son
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/create-faq.mdx
+++ b/docs/fr/guides/network/load-balancer/create-faq.mdx
@@ -141,4 +141,4 @@ Pour obtenir les détails d'un certificat SSL, vous pouvez utiliser l'appel API 
 
 Trouvez les détails de tous les appels API liés à l'OVHcloud Load Balancer dans [ce guide](/guides/network/load-balancer/use-api-details).
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/create-headers.mdx
+++ b/docs/fr/guides/network/load-balancer/create-headers.mdx
@@ -253,4 +253,4 @@ Si vous intégrez l'API dans votre code, cela correspond à une liste JSON du ty
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/create-http-https.mdx
+++ b/docs/fr/guides/network/load-balancer/create-http-https.mdx
@@ -333,4 +333,4 @@ Une fois toutes ces étapes terminées, vous devriez disposer d'un service de r�
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/create-probes.mdx
+++ b/docs/fr/guides/network/load-balancer/create-probes.mdx
@@ -308,4 +308,4 @@ Une nouvelle fenêtre de configuration apparaît avec les paramètres de la sond
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/create-proxyprotocol.mdx
+++ b/docs/fr/guides/network/load-balancer/create-proxyprotocol.mdx
@@ -284,4 +284,4 @@ service haproxy reload
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/create-redirectlocation.mdx
+++ b/docs/fr/guides/network/load-balancer/create-redirectlocation.mdx
@@ -109,4 +109,4 @@ Dans l'[API OVHcloud](https://eu.api.ovh.com/), les redirections sont spécifié
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/create-route.mdx
+++ b/docs/fr/guides/network/load-balancer/create-route.mdx
@@ -845,4 +845,4 @@ Cette règle permet de filtrer les requêtes en fonction de l'existence ou de la
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/create-stickiness.mdx
+++ b/docs/fr/guides/network/load-balancer/create-stickiness.mdx
@@ -115,4 +115,4 @@ Cette requête API est nécessaire pour déployer les modifications de configura
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/howto-route-ipfo.mdx
+++ b/docs/fr/guides/network/load-balancer/howto-route-ipfo.mdx
@@ -128,4 +128,4 @@ N’oubliez pas de déployer la configuration. Il existe deux façons de le fair
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/order-freecertificate.mdx
+++ b/docs/fr/guides/network/load-balancer/order-freecertificate.mdx
@@ -88,4 +88,4 @@ Une fois la commande finie, le certificat SSL est automatiquement installé sur 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/overview.mdx
+++ b/docs/fr/guides/network/load-balancer/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Visitez la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultez la roadmap & changelog
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoignez Discord

--- a/docs/fr/guides/network/load-balancer/retrieve-servers-state.mdx
+++ b/docs/fr/guides/network/load-balancer/retrieve-servers-state.mdx
@@ -83,4 +83,4 @@ Pour chaque instance, nous disposons des informations suivantes :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/use-api-details.mdx
+++ b/docs/fr/guides/network/load-balancer/use-api-details.mdx
@@ -1281,4 +1281,4 @@ Pour plus d'informations sur la gestion des contacts OVHcloud, consultez le guid
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/use-api-logs-customers.mdx
+++ b/docs/fr/guides/network/load-balancer/use-api-logs-customers.mdx
@@ -201,4 +201,4 @@ Pour supprimer votre abonnement, vous pouvez utiliser l'appel API suivant :
 
 Si vous avez besoin d'une formation ou d'assistance technique pour mettre en œuvre nos solutions, contactez votre représentant commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demandez à nos experts Professional Services de vous aider sur votre cas d'utilisation spécifique de votre projet.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/use-api-reference.mdx
+++ b/docs/fr/guides/network/load-balancer/use-api-reference.mdx
@@ -176,4 +176,4 @@ Il est nécessaire de bien exécuter la fonction API qui correspond au protocole
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/use-lb.mdx
+++ b/docs/fr/guides/network/load-balancer/use-lb.mdx
@@ -132,4 +132,4 @@ Si vous possédez déjà votre propre certificat SSL, il vous est possible de l'
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/use-presentation.mdx
+++ b/docs/fr/guides/network/load-balancer/use-presentation.mdx
@@ -105,4 +105,4 @@ Prenez en charge de multiples services via du trafic HTTP(S), TCP et UDP.
 - [Site officiel HAProxy](http://www.haproxy.org/#desc)
 - [Documentation Nginx](https://nginx.org/en/docs/)
 
-Rejoignez notre [communauté d’utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/load-balancer/zones.mdx
+++ b/docs/fr/guides/network/load-balancer/zones.mdx
@@ -123,4 +123,4 @@ N'oubliez pas de déployer la configuration. Pour cela, cliquez sur <code classN
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/network-tools.mdx
+++ b/docs/fr/guides/network/network-tools.mdx
@@ -91,4 +91,4 @@ Pour plus d'informations et de tutoriels, veuillez consulter nos autres guides d
 
 ## Aller plus loin
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/ovhcloud-connect/overview.mdx
+++ b/docs/fr/guides/network/ovhcloud-connect/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Visitez la communauté OVHcloud
-      link: /links/community
+      link: https://community.ovhcloud.com/
     - title: "Consultez la roadmap & changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoignez Discord

--- a/docs/fr/guides/network/vrack-services/global.mdx
+++ b/docs/fr/guides/network/vrack-services/global.mdx
@@ -502,4 +502,4 @@ Veuillez noter que la création de vRack Services, de sous-réseaux ou de Servic
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/network/vrack/overview.mdx
+++ b/docs/fr/guides/network/vrack/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Aller plus loin"
   items:
     - title: "Visitez la communauté OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consultez la roadmap & changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: "Rejoignez Discord"

--- a/docs/fr/guides/network/whois-ip.mdx
+++ b/docs/fr/guides/network/whois-ip.mdx
@@ -48,4 +48,4 @@ Pour des prestations spécialisées (référencement, développement, etc.), con
 
 Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr/support-levels/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/it/guides/network/additional-ip/additional-ip-cancellation.mdx
+++ b/docs/it/guides/network/additional-ip/additional-ip-cancellation.mdx
@@ -47,4 +47,4 @@ You will then receive an email asking you to confirm the cancellation. After con
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/network/additional-ip/blocklist-ip-delist.mdx
+++ b/docs/it/guides/network/additional-ip/blocklist-ip-delist.mdx
@@ -173,4 +173,4 @@ Per [rimuovere un IP da MIPSpace](https://www.mipspace.com/removal.php), accedi 
 
 Per prestazioni specializzate (referenziazione, sviluppo, etc.), contatta i [partner OVHcloud](https://partner.ovhcloud.com/it/directory/).
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/network/additional-ip/overview.mdx
+++ b/docs/it/guides/network/additional-ip/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Per saperne di più"
   items:
     - title: "Visita la community OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulta la roadmap & changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: "Unisciti a Discord"

--- a/docs/it/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/it/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -311,4 +311,4 @@ Yes, but once the BYOIP service has been delivered, you must immediately cancel 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
+++ b/docs/it/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
@@ -101,4 +101,4 @@ Se il dominio risponde correttamente nel tuo servizio Web, sarà sufficiente mod
  
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
+++ b/docs/it/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
@@ -41,4 +41,4 @@ Qui sotto trovi la lista degli indirizzi IP:
 
 ## Per saperne di più <a name="go-further"></a>
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
+++ b/docs/it/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
@@ -61,4 +61,4 @@ Una volta attivato il certificato otterrai questo risultato:
 
 [Prima configurazione di un dominio](/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration)
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/network/content-delivery-network-infrastructure/quota.mdx
+++ b/docs/it/guides/network/content-delivery-network-infrastructure/quota.mdx
@@ -48,4 +48,4 @@ I contenuti salvati in cache e quelli richiesti direttamente al *backend* dipend
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/network/load-balancer/case-http2.mdx
+++ b/docs/it/guides/network/load-balancer/case-http2.mdx
@@ -159,4 +159,4 @@ HTTP/2 200
 
 Per ulteriori informazioni sul protocollo HTTP/2, visitare il sito [https://http2.github.io/](https://http2.github.io/).
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/network/load-balancer/create-proxyprotocol.mdx
+++ b/docs/it/guides/network/load-balancer/create-proxyprotocol.mdx
@@ -268,4 +268,4 @@ service haproxy reload
 
 ## Go Further
 
-Discuss with our [user community](/links/community).
+Join our [community of users](/links/community).

--- a/docs/it/guides/network/load-balancer/overview.mdx
+++ b/docs/it/guides/network/load-balancer/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Per saperne di più
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap & changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/network/load-balancer/use-api-details.mdx
+++ b/docs/it/guides/network/load-balancer/use-api-details.mdx
@@ -2689,4 +2689,4 @@ Table of farm identifiers that you wish to attach to this private network. The V
 
 ## Go further
 
-Interact with our user community on [https://community.ovh.com](https://community.ovh.com).
+Join our [community of users](/links/community).

--- a/docs/it/guides/network/load-balancer/use-lb.mdx
+++ b/docs/it/guides/network/load-balancer/use-lb.mdx
@@ -132,4 +132,4 @@ Se hai già attivato il tuo certificato SSL, è possibile aggiungerlo direttamen
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/network/load-balancer/use-presentation.mdx
+++ b/docs/it/guides/network/load-balancer/use-presentation.mdx
@@ -105,4 +105,4 @@ Balance your databases, and make them redundant.
 - [HAProxy official site](http://www.haproxy.org/#desc)
 - [Nginx documentation](https://nginx.org/en/docs/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/network/load-balancer/zones.mdx
+++ b/docs/it/guides/network/load-balancer/zones.mdx
@@ -124,4 +124,4 @@ Don't forget to deploy the configuration. To do this, click <code className="act
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/network/network-tools.mdx
+++ b/docs/it/guides/network/network-tools.mdx
@@ -91,4 +91,4 @@ For more information and tutorials, please see our other [Networking and Securit
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/network/ovhcloud-connect/overview.mdx
+++ b/docs/it/guides/network/ovhcloud-connect/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Per saperne di più"
   items:
     - title: Visita la community OVHcloud
-      link: /links/community
+      link: https://community.ovhcloud.com/
     - title: "Consulta la roadmap & changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/network/vrack-services/global.mdx
+++ b/docs/it/guides/network/vrack-services/global.mdx
@@ -502,4 +502,4 @@ Please note that creating vRack Services, Subnets, or Service Endpoints on a pro
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/network/vrack/overview.mdx
+++ b/docs/it/guides/network/vrack/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Per saperne di più"
   items:
     - title: "Visita la community OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulta la roadmap & changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: "Unisciti a Discord"

--- a/docs/it/guides/network/whois-ip.mdx
+++ b/docs/it/guides/network/whois-ip.mdx
@@ -48,4 +48,4 @@ Per prestazioni specializzate (referenziamento, sviluppo, ecc.), contatta i [par
 
 Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre soluzioni [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/pl/guides/network/additional-ip/additional-ip-cancellation.mdx
+++ b/docs/pl/guides/network/additional-ip/additional-ip-cancellation.mdx
@@ -47,4 +47,4 @@ You will then receive an email asking you to confirm the cancellation. After con
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/network/additional-ip/blocklist-ip-delist.mdx
+++ b/docs/pl/guides/network/additional-ip/blocklist-ip-delist.mdx
@@ -173,4 +173,4 @@ Aby [usunąć adres IP z MIPSpace](https://www.mipspace.com/removal.php), najpie
 
 W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj się z [partnerami OVHcloud](https://partner.ovhcloud.com/pl/directory/).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/network/additional-ip/overview.mdx
+++ b/docs/pl/guides/network/additional-ip/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz roadmapę i changelog"
       link: https://www.ovhcloud.com/pl-pl/roadmap-changelog/
     - title: "Dołącz do Discorda"

--- a/docs/pl/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/pl/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -311,4 +311,4 @@ Yes, but once the BYOIP service has been delivered, you must immediately cancel 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
+++ b/docs/pl/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
@@ -103,4 +103,4 @@ Jeśli domena odpowiada poprawnie na poziomie Twojej usługi WWW, zmodyfikuj kod
  
 ## Sprawdź również
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/)
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
+++ b/docs/pl/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
@@ -41,4 +41,4 @@ Poniżej znajdziesz listę adresów IP:
 
 ## Sprawdź również <a name="go-further"></a>
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
+++ b/docs/pl/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
@@ -61,4 +61,4 @@ Po aktywacji certyfikatu wyświetli się komunikat:
 
 [Pierwsza konfiguracja domeny](/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration)
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/network/content-delivery-network-infrastructure/quota.mdx
+++ b/docs/pl/guides/network/content-delivery-network-infrastructure/quota.mdx
@@ -48,4 +48,4 @@ Niezależnie od tego, czy pliki umieszczone są w pamięci cache czy wywoływane
 
 ## Sprawdź również
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/network/load-balancer/case-http2.mdx
+++ b/docs/pl/guides/network/load-balancer/case-http2.mdx
@@ -159,4 +159,4 @@ HTTP/2 200
 
 Jeśli chcesz uzyskać więcej informacji na temat protokołu HTTP/2, odwiedź stronę [https://http2.github.io/](https://http2.github.io/).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/network/load-balancer/create-proxyprotocol.mdx
+++ b/docs/pl/guides/network/load-balancer/create-proxyprotocol.mdx
@@ -268,4 +268,4 @@ service haproxy reload
 
 ## Go Further
 
-Discuss with our [user community](/links/community).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/network/load-balancer/overview.mdx
+++ b/docs/pl/guides/network/load-balancer/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz roadmapę i changelog"
       link: https://www.ovhcloud.com/pl-pl/roadmap-changelog/
     - title: "Dołącz do Discorda"

--- a/docs/pl/guides/network/load-balancer/use-api-details.mdx
+++ b/docs/pl/guides/network/load-balancer/use-api-details.mdx
@@ -2689,4 +2689,4 @@ Table of farm identifiers that you wish to attach to this private network. The V
 
 ## Go further
 
-Interact with our user community on [https://community.ovh.com](https://community.ovh.com).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/network/load-balancer/use-lb.mdx
+++ b/docs/pl/guides/network/load-balancer/use-lb.mdx
@@ -131,4 +131,4 @@ Jeśli masz już swój certyfikat SSL, masz możliwość dodania go bezpośredni
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/network/load-balancer/use-presentation.mdx
+++ b/docs/pl/guides/network/load-balancer/use-presentation.mdx
@@ -105,4 +105,4 @@ Balance your databases, and make them redundant.
 - [HAProxy official site](http://www.haproxy.org/#desc)
 - [Nginx documentation](https://nginx.org/en/docs/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/network/load-balancer/zones.mdx
+++ b/docs/pl/guides/network/load-balancer/zones.mdx
@@ -124,4 +124,4 @@ Don't forget to deploy the configuration. To do this, click <code className="act
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/network/network-tools.mdx
+++ b/docs/pl/guides/network/network-tools.mdx
@@ -91,4 +91,4 @@ For more information and tutorials, please see our other [Networking and Securit
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/network/ovhcloud-connect/overview.mdx
+++ b/docs/pl/guides/network/ovhcloud-connect/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: /links/community
+      link: https://community.ovhcloud.com/
     - title: "Zobacz roadmapę i changelog"
       link: https://www.ovhcloud.com/pl-pl/roadmap-changelog/
     - title: "Dołącz do Discorda"

--- a/docs/pl/guides/network/vrack-services/global.mdx
+++ b/docs/pl/guides/network/vrack-services/global.mdx
@@ -502,4 +502,4 @@ Please note that creating vRack Services, Subnets, or Service Endpoints on a pro
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/network/vrack/overview.mdx
+++ b/docs/pl/guides/network/vrack/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz roadmapę i changelog"
       link: https://www.ovhcloud.com/pl-pl/roadmap-changelog/
     - title: "Dołącz do Discorda"

--- a/docs/pl/guides/network/whois-ip.mdx
+++ b/docs/pl/guides/network/whois-ip.mdx
@@ -48,4 +48,4 @@ W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, itp.) skontaktuj
 
 Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](https://www.ovhcloud.com/pl/support-levels/).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pt/guides/network/additional-ip/additional-ip-cancellation.mdx
+++ b/docs/pt/guides/network/additional-ip/additional-ip-cancellation.mdx
@@ -47,4 +47,4 @@ You will then receive an email asking you to confirm the cancellation. After con
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/network/additional-ip/blocklist-ip-delist.mdx
+++ b/docs/pt/guides/network/additional-ip/blocklist-ip-delist.mdx
@@ -171,4 +171,4 @@ Para [remover um IP do MIPSpace](https://www.mipspace.com/removal.php), aceda em
 
 Para serviços especializados (referenciamento, desenvolvimento, etc), contacte os [parceiros OVHcloud](https://partner.ovhcloud.com/pt/directory/).
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/network/additional-ip/overview.mdx
+++ b/docs/pt/guides/network/additional-ip/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: "Visite a comunidade OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte a roadmap & changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Junte-se ao Discord"

--- a/docs/pt/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
+++ b/docs/pt/guides/network/bring-your-own-ip/bring-your-own-ip.mdx
@@ -311,4 +311,4 @@ Yes, but once the BYOIP service has been delivered, you must immediately cancel 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
+++ b/docs/pt/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration.mdx
@@ -103,4 +103,4 @@ Se o domínio responde corretamente no seu serviço web, só terá de editar o c
  
 ## Quer saber mais?
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/)
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
+++ b/docs/pt/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ip-range.mdx
@@ -41,4 +41,4 @@ Encontre aqui a lista dos endereços IP:
 
 ## Quer saber mais? <a name="go-further"></a>
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
+++ b/docs/pt/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-ssl-certificate.mdx
@@ -61,4 +61,4 @@ Uma vez ativado o certificado, irá obter o seguinte resultado:
 
 [Primeira configuração de um domínio](/guides/network/content-delivery-network-infrastructure/cdn-infrastructure-first-domain-configuration) (versão em inglês)
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/)
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/network/content-delivery-network-infrastructure/quota.mdx
+++ b/docs/pt/guides/network/content-delivery-network-infrastructure/quota.mdx
@@ -48,4 +48,4 @@ Em ambos os casos, quer os ficheiros estejam guardados na cache ou enviados para
 
 ## Quer saber mais?
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/)
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/network/load-balancer/case-http2.mdx
+++ b/docs/pt/guides/network/load-balancer/case-http2.mdx
@@ -159,4 +159,4 @@ HTTP/2 200
 
 Se desejar obter mais informações sobre o protocolo HTTP/2, aceda a [https://http2.github.io/](https://http2.github.io/).
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/network/load-balancer/create-proxyprotocol.mdx
+++ b/docs/pt/guides/network/load-balancer/create-proxyprotocol.mdx
@@ -268,4 +268,4 @@ service haproxy reload
 
 ## Go Further
 
-Discuss with our [user community](/links/community).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/network/load-balancer/overview.mdx
+++ b/docs/pt/guides/network/load-balancer/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visite a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulte a roadmap & changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Junte-se ao Discord"

--- a/docs/pt/guides/network/load-balancer/use-api-details.mdx
+++ b/docs/pt/guides/network/load-balancer/use-api-details.mdx
@@ -2689,4 +2689,4 @@ Table of farm identifiers that you wish to attach to this private network. The V
 
 ## Go further
 
-Interact with our user community on [https://community.ovh.com](https://community.ovh.com).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/network/load-balancer/use-lb.mdx
+++ b/docs/pt/guides/network/load-balancer/use-lb.mdx
@@ -131,4 +131,4 @@ Se já tem um certificado SSL, este pode ser associado ao serviço:
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/network/load-balancer/use-presentation.mdx
+++ b/docs/pt/guides/network/load-balancer/use-presentation.mdx
@@ -105,4 +105,4 @@ Balance your databases, and make them redundant.
 - [HAProxy official site](http://www.haproxy.org/#desc)
 - [Nginx documentation](https://nginx.org/en/docs/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/network/load-balancer/zones.mdx
+++ b/docs/pt/guides/network/load-balancer/zones.mdx
@@ -124,4 +124,4 @@ Don't forget to deploy the configuration. To do this, click <code className="act
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/network/network-tools.mdx
+++ b/docs/pt/guides/network/network-tools.mdx
@@ -91,4 +91,4 @@ For more information and tutorials, please see our other [Networking and Securit
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/network/ovhcloud-connect/overview.mdx
+++ b/docs/pt/guides/network/ovhcloud-connect/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: Visite a comunidade OVHcloud
-      link: /links/community
+      link: https://community.ovhcloud.com/
     - title: "Consulte a roadmap & changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: Junte-se ao Discord

--- a/docs/pt/guides/network/vrack-services/global.mdx
+++ b/docs/pt/guides/network/vrack-services/global.mdx
@@ -502,4 +502,4 @@ Please note that creating vRack Services, Subnets, or Service Endpoints on a pro
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/network/vrack/overview.mdx
+++ b/docs/pt/guides/network/vrack/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: "Visite a comunidade OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte a roadmap & changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Junte-se ao Discord"

--- a/docs/pt/guides/network/whois-ip.mdx
+++ b/docs/pt/guides/network/whois-ip.mdx
@@ -48,4 +48,4 @@ Para serviços especializados (referenciamento, desenvolvimento, etc.), contacte
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).


### PR DESCRIPTION
### Scope: Network

- Replace (dead) links to legacy community page with proper keys
- Fix hard URL in Overview pages to the correct one