### PR TITLE
fix(email/exchange): zone Exchange server hostname (ex.mail.ovh.ca) for CA in config guides

### DIFF
--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
@@ -96,15 +96,34 @@ Dieser Fehler zeigt an, dass E-Mails nicht empfangen werden können, und steht i
 
 Je nach Verwendung Ihres Exchange Dienstes sind die folgenden MX Server gültig:
 
+<Region zones={['eu']}>
+
 - Nur Exchange: mx0.mail.ovh.net, mx1.mail.ovh.net, mx2.mail.ovh.net, mx3.mail.ovh.net & mx4.mail.ovh.net
 - Exchange und bei OVHcloud gehostete POP/IMAP-E-Mails: mx0.mail.ovh.net, mx1.mail.ovh.net, mx2.mail.ovh.net, mx3.mail.ovh.net & mx4.mail.ovh.net
 - Exchange und nicht bei OVHcloud gehostete POP/IMAP-E-Mails: ex<b>?</b>.mail.ovh.net
+
+</Region>
+
+<Region zones={['ca']}>
+
+- Nur Exchange: mx0.mail.ovh.ca, mx1.mail.ovh.ca, mx2.mail.ovh.ca, mx3.mail.ovh.ca & mx4.mail.ovh.ca
+- Exchange und bei OVHcloud gehostete POP/IMAP-E-Mails: mx0.mail.ovh.ca, mx1.mail.ovh.ca, mx2.mail.ovh.ca, mx3.mail.ovh.ca & mx4.mail.ovh.ca
+- Exchange und nicht bei OVHcloud gehostete POP/IMAP-E-Mails: ex.mail.ovh.ca
+
+</Region>
+
 <a name="hostname"></a>
 
 :::warning
+<Region zones={['eu']}>
 In unseren Anleitungen verwenden wir als Servernamen: ex<b>?</b>.mail.ovh.net. Ersetzen Sie das "?" durch die dem Server Ihres Exchange Dienstes entsprechende Nummer.
 
 Diese Informationen finden Sie im OVHcloud Kundencenter im Bereich <code className="action">Web Cloud</code>: Öffnen Sie <code className="action">Exchange</code> und wählen Sie Ihre Dienstleistung aus. Der Servername wird im Bereich **Verbindung** im Tab <code className="action">Allgemeine Informationen</code> angezeigt.
+</Region>
+
+<Region zones={['ca']}>
+In unseren Anleitungen verwenden wir als Servernamen: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -117,6 +136,8 @@ Sie können diese Einstellungen in der [DNS Zone Ihrer Domain überprüfen](/gui
 
 Die folgende Tabelle enthält die Werte für einen Exchange Dienst:
 
+<Region zones={['eu']}>
+
 Feld | Wert
 ------------ | -------------
 Subdomain | _autodiscover._tcp
@@ -124,6 +145,20 @@ Priorität | 0
 Gewichtung | 0
 Port | 443
 Ziel | [ex<b>?</b>.mail.ovh.net](#hostname) (ersetzen Sie "?" durch die entsprechende Nummer Ihres Exchange Servers)
+
+</Region>
+
+<Region zones={['ca']}>
+
+Feld | Wert
+------------ | -------------
+Subdomain | _autodiscover._tcp
+Priorität | 0
+Gewichtung | 0
+Port | 443
+Ziel | [ex.mail.ovh.ca](#hostname)
+
+</Region>
 
 ### Die Test-E-Mail konnte nicht über den Account versendet werden
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
@@ -59,9 +59,15 @@ Die Anweisungen in dieser Anleitung basieren auf einem Gerät mit Android Versio
 ### E-Mail-Account hinzufügen <a name="addaccount"></a>
 
 :::info
+<Region zones={['eu']}>
 In dieser Anleitung verwenden wir den Servernamen: ex?.mail.ovh.net. Das "?" muss mit der jeweils passenden Nummer Ihres zuständigen Servers für den einzurichtenden Exchange Dienst ersetzt werden.
 
 Klicken Sie auf <ManagerLink to="/#/web/exchange">diesen Link</ManagerLink>, um auf den Bereich <code className="action">Exchange</code> zuzugreifen. Der Servername wird im Bereich **Verbindung** des Tabs <code className="action">Allgemeine Informationen</code> angezeigt.
+</Region>
+
+<Region zones={['ca']}>
+In dieser Anleitung verwenden wir den Servernamen: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -102,7 +108,13 @@ Folgen Sie den in den Tabs aufgeführten Schritten:
     <img className="thumbnail" alt="Exchange Android" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-03.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 4">
+    <Region zones={['eu']}>
     Vervollständigen Sie die Seite "**Adresskonfiguration**"<br/><br/>- **E-Mail**: Ihre vollständige E-Mail-Adresse<br/>- **Passwort**: Passwort des E-Mail-Accounts<br/>- **Zertifikat**: "Keines"<br/>- **Domain\Benutzername**: Ihre vollständige E-Mail-Adresse<br/>- **Server**: **ex?.mail.ovh.net** (ersetzen Sie **?** mit der [Nummer Ihres Exchange Servers](#addaccount))<br/>- **Port**: 443<br/>- **Sicherheitstyp**: SSL/TLS<br/><br/>Tippen Sie auf <code className="action">Weiter</code>, um die Konfiguration zu bestätigen.<br/><br/>
+    </Region>
+
+    <Region zones={['ca']}>
+    Vervollständigen Sie die Seite "**Adresskonfiguration**"<br/><br/>- **E-Mail**: Ihre vollständige E-Mail-Adresse<br/>- **Passwort**: Passwort des E-Mail-Accounts<br/>- **Zertifikat**: "Keines"<br/>- **Domain\Benutzername**: Ihre vollständige E-Mail-Adresse<br/>- **Server**: **ex.mail.ovh.ca**<br/>- **Port**: 443<br/>- **Sicherheitstyp**: SSL/TLS<br/><br/>Tippen Sie auf <code className="action">Weiter</code>, um die Konfiguration zu bestätigen.<br/><br/>
+    </Region>
     <img className="thumbnail" alt="Exchange Android" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-04.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 5">

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
@@ -48,9 +48,15 @@ Diese Anleitung soll Sie bei allgemeinen Aufgaben so weit wie möglich unterstü
 ### Account hinzufügen <a name="addaccount"></a>
 
 :::info
+<Region zones={['eu']}>
 In dieser Anleitung verwenden wir den Servernamen: ex?.mail.ovh.net. Das "?" muss mit der jeweils passenden Nummer Ihres zuständigen Servers für den einzurichtenden Exchange Dienst ersetzt werden.
 
 Klicken Sie auf <ManagerLink to="/#/web/exchange">diesen Link</ManagerLink>, um auf den Bereich <code className="action">Exchange</code> zuzugreifen. Der Servername wird im Bereich **Verbindung** des Tabs <code className="action">Allgemeine Informationen</code> angezeigt.
+</Region>
+
+<Region zones={['ca']}>
+In dieser Anleitung verwenden wir den Servernamen: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -62,12 +68,27 @@ Klicken Sie vom Homescreen des Geräts aus auf <code className="action">Einstell
 
 - **Für die Versionen iOS 14 und höher**: Folgen Sie den Anweisungen in der nachfolgenden Tabelle.
 
+<Region zones={['eu']}>
+
 | | |
 |---|---|
 |<video className="thumbnail" autoPlay loop muted playsInline aria-label="iPhone" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. In `Einstellungen` gehen Sie auf `Mail`. <br/><br/> 2. Tippen Sie auf `Accounts`.<br/><br/> 3. Tippen Sie auf `Account hinzufügen`.<br/><br/> 4. Wählen Sie `Microsoft Exchange`.|
 |5. Geben Sie Ihre **E-Mail-Adresse** und eine **Beschreibung** Ihres Accounts ein und tippen Sie auf `Weiter`.<br/><br/>6. Wählen Sie `Manuelle Konfiguration` aus.<br/><br/>|<img className="thumbnail" alt="iPhone" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
 |<img className="thumbnail" alt="iPhone" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Geben Sie an: <br/>- Server **ex?.mail.ovh.net** (ersetzen Sie **?** mit der [Nummer Ihres Exchange Servers](#addaccount))<br/>- Ihre vollständige **E-Mail-Adresse** als Benutzername <br/>- das Passwort Ihrer E-Mail-Adresse|
 |8. Stellen Sie sicher, dass Sie <code className="action">Mail</code> aktiviert lassen, damit die Anwendung diesen Account verwenden kann. Die anderen Apps (wie *Kalender* und *Notizen*) können einige der kollaborativen Funktionen von Exchange ebenfalls nutzen.<br/><br/>9. Tippen Sie auf `Speichern`, um das Hinzufügen Ihres Exchange Accounts abzuschließen.|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
+
+<Region zones={['ca']}>
+
+| | |
+|---|---|
+|<video className="thumbnail" autoPlay loop muted playsInline aria-label="iPhone" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. In `Einstellungen` gehen Sie auf `Mail`. <br/><br/> 2. Tippen Sie auf `Accounts`.<br/><br/> 3. Tippen Sie auf `Account hinzufügen`.<br/><br/> 4. Wählen Sie `Microsoft Exchange`.|
+|5. Geben Sie Ihre **E-Mail-Adresse** und eine **Beschreibung** Ihres Accounts ein und tippen Sie auf `Weiter`.<br/><br/>6. Wählen Sie `Manuelle Konfiguration` aus.<br/><br/>|<img className="thumbnail" alt="iPhone" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
+|<img className="thumbnail" alt="iPhone" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Geben Sie an: <br/>- Server **ex.mail.ovh.ca**<br/>- Ihre vollständige **E-Mail-Adresse** als Benutzername <br/>- das Passwort Ihrer E-Mail-Adresse|
+|8. Stellen Sie sicher, dass Sie <code className="action">Mail</code> aktiviert lassen, damit die Anwendung diesen Account verwenden kann. Die anderen Apps (wie *Kalender* und *Notizen*) können einige der kollaborativen Funktionen von Exchange ebenfalls nutzen.<br/><br/>9. Tippen Sie auf `Speichern`, um das Hinzufügen Ihres Exchange Accounts abzuschließen.|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
 
 Sie können eine Test-E-Mail versenden, um zu überprüfen, ob der Account korrekt eingerichtet ist.
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
@@ -54,9 +54,15 @@ Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. De
 ### Hinzufügen des E-Mail-Accounts <a name="addaccount"></a>
 
 :::info
+<Region zones={['eu']}>
 In dieser Anleitung verwenden wir den Servernamen: ex?.mail.ovh.net. Das "?" muss mit der jeweils passenden Nummer Ihres zuständigen Servers für den einzurichtenden Exchange Dienst ersetzt werden.
 
 Klicken Sie auf <ManagerLink to="/#/web/exchange">diesen Link</ManagerLink>, um auf den Bereich <code className="action">Exchange</code> zuzugreifen. Der Servername wird im Bereich **Verbindung** des Tabs <code className="action">Allgemeine Informationen</code> angezeigt.
+</Region>
+
+<Region zones={['ca']}>
+In dieser Anleitung verwenden wir den Servernamen: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -79,7 +85,13 @@ Klicken Sie auf <ManagerLink to="/#/web/exchange">diesen Link</ManagerLink>, um 
     <img className="thumbnail" alt="mailmac" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos/mail-mac-exchange03.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 4">
+    <Region zones={['eu']}>
     Geben Sie ein: <br/><br/>- E-Mail-Adresse: Geben Sie Ihre vollständige E-Mail-Adresse ein.<br/>- Benutzername: Geben Sie Ihre vollständige E-Mail-Adresse ein. <br/>- Passwort: Geben Sie Ihr **Passwort** ein.<br/> - Interne URL: **ex?.mail.ovh.net** (ersetzen Sie **?** durch [Ihre Exchange-Servernummer](#addaccount).)<br/>- Externe URL: **ex?.mail.ovh.net** (ersetzen Sie **?** durch [Ihre Exchange-Servernummer](#addaccount).)<br/><br/>
+    </Region>
+
+    <Region zones={['ca']}>
+    Geben Sie ein: <br/><br/>- E-Mail-Adresse: Geben Sie Ihre vollständige E-Mail-Adresse ein.<br/>- Benutzername: Geben Sie Ihre vollständige E-Mail-Adresse ein. <br/>- Passwort: Geben Sie Ihr **Passwort** ein.<br/> - Interne URL: **ex.mail.ovh.ca**<br/>- Externe URL: **ex.mail.ovh.ca**<br/><br/>
+    </Region>
     
     :::warning
     Die Fehlermeldung "**Kontoname oder Kennwort kann nicht überprüft werden**" erscheint, wenn das Fenster das erste Mal angezeigt wird. Wenn diese Meldung jedoch nach der Validierung weiterhin angezeigt wird, sind die eingegebenen Informationen fehlerhaft.<br/><br/>

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
@@ -56,9 +56,15 @@ Weitere Informationen finden Sie am [Ende dieser Anleitung](#gofurther).
 ## In der praktischen Anwendung
 
 :::info
+<Region zones={['eu']}>
 In dieser Anleitung verwenden wir den Servernamen: ex?.mail.ovh.net. Das "?" muss mit der jeweils passenden Nummer Ihres zuständigen Servers für den einzurichtenden Exchange Dienst ersetzt werden.
 
 Klicken Sie auf <ManagerLink to="/#/web/exchange">diesen Link</ManagerLink>, um auf den Bereich <code className="action">Exchange</code> zuzugreifen. Der Servername wird im Bereich **Verbindung** des Tabs <code className="action">Allgemeine Informationen</code> angezeigt.
+</Region>
+
+<Region zones={['ca']}>
+In dieser Anleitung verwenden wir den Servernamen: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -94,6 +100,8 @@ Folgen Sie den Konfigurationsschritten, indem Sie nacheinander auf die folgenden
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 3">
+    <Region zones={['eu']}>
+
     Empfangsservereinstellungen:
     
      - **Protokoll**: IMAP
@@ -102,10 +110,27 @@ Folgen Sie den Konfigurationsschritten, indem Sie nacheinander auf die folgenden
      - **Verbindungssicherheit**: SSL/TLS
      - **Authentifizierungsart**: Normales Passwort
      - **Benutzername**: Ihre vollständige E-Mail-Adresse
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Empfangsservereinstellungen:
     
+     - **Protokoll**: IMAP
+     - **Hostname**: ex.mail.ovh.ca
+     - **Port**: 993
+     - **Verbindungssicherheit**: SSL/TLS
+     - **Authentifizierungsart**: Normales Passwort
+     - **Benutzername**: Ihre vollständige E-Mail-Adresse
+
+    </Region>
+
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 4">
+    <Region zones={['eu']}>
+
     Einstellungen des Sendeservers:
     
      - **Protokoll**: SMTP 
@@ -114,7 +139,22 @@ Folgen Sie den Konfigurationsschritten, indem Sie nacheinander auf die folgenden
      - **Verbindungssicherheit**: STARTTLS
      - **Authentifizierungsart**: Normales Passwort
      - **Benutzername**: Ihre vollständige E-Mail-Adresse
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Einstellungen des Sendeservers:
     
+     - **Protokoll**: SMTP 
+     - **Hostname**: ex.mail.ovh.ca
+     - **Port**: 587
+     - **Verbindungssicherheit**: STARTTLS
+     - **Authentifizierungsart**: Normales Passwort
+     - **Benutzername**: Ihre vollständige E-Mail-Adresse
+
+    </Region>
+
     1\. Klicken Sie auf <code className="action">Testen</code>, um die eingegebenen Einstellungen zu überprüfen.
     2\. Klicken Sie auf <code className="action">Weiter</code>, um diese Einstellungen zu bestätigen.
     
@@ -133,6 +173,8 @@ Folgen Sie den Konfigurationsschritten, indem Sie nacheinander auf die folgenden
 
 Wenn Sie eine POP-Konfiguration für Ihre E-Mail-Adresse wünschen, ersetzen Sie die Einstellungen des **Schritts 3** durch folgende:
 
+<Region zones={['eu']}>
+
 Empfangsservereinstellungen:
 
 - **Protokoll**: POP3
@@ -142,21 +184,22 @@ Empfangsservereinstellungen:
 - **Authentifizierungsart**: Normales Passwort
 - **Benutzername**: Ihre vollständige E-Mail-Adresse
 
-:::
+</Region>
 
-**POP-Konfiguration**
-
-Wenn Sie eine POP-Konfiguration für Ihre E-Mail-Adresse wünschen, ersetzen Sie die Einstellungen des Schritts 3 durch folgende:
+<Region zones={['ca']}>
 
 Empfangsservereinstellungen:
 
-- Protokoll: POP3
-- Hostname: ex?.mail.ovh.net (ersetzen Sie das '?' durch die Nummer Ihres Servers)
-- Port: 995
-- Verbindungssicherheit: SSL/TLS
-- Authentifizierungsart: Normales Passwort
-- Benutzername: Ihre vollständige E-Mail-Adresse
+- **Protokoll**: POP3
+- **Hostname**: ex.mail.ovh.ca
+- **Port**: 995
+- **Verbindungssicherheit**: SSL/TLS
+- **Authentifizierungsart**: Normales Passwort
+- **Benutzername**: Ihre vollständige E-Mail-Adresse
 
+</Region>
+
+:::
 
 ### E-Mail-Adresse nutzen
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
@@ -56,9 +56,15 @@ Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
 ## In der praktischen Anwendung
 
 :::info
+<Region zones={['eu']}>
 In dieser Anleitung verwenden wir den Servernamen: ex?.mail.ovh.net. Das "?" muss mit der jeweils passenden Nummer Ihres zuständigen Servers für den einzurichtenden Exchange Dienst ersetzt werden.
 
 Klicken Sie auf <ManagerLink to="/#/web/exchange">diesen Link</ManagerLink>, um auf den Bereich <code className="action">Exchange</code> zuzugreifen. Der Servername wird im Bereich **Verbindung** des Tabs <code className="action">Allgemeine Informationen</code> angezeigt.
+</Region>
+
+<Region zones={['ca']}>
+In dieser Anleitung verwenden wir den Servernamen: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -94,6 +100,8 @@ Folgen Sie den Konfigurationsschritten, indem Sie nacheinander auf die folgenden
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 3">
+    <Region zones={['eu']}>
+
     Empfangsservereinstellungen:
     
      - **Protokoll**: IMAP
@@ -102,10 +110,27 @@ Folgen Sie den Konfigurationsschritten, indem Sie nacheinander auf die folgenden
      - **Verbindungssicherheit**: SSL/TLS
      - **Authentifizierungsart**: Normales Passwort
      - **Benutzername**: Ihre vollständige E-Mail-Adresse
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Empfangsservereinstellungen:
     
+     - **Protokoll**: IMAP
+     - **Hostname**: ex.mail.ovh.ca
+     - **Port**: 993
+     - **Verbindungssicherheit**: SSL/TLS
+     - **Authentifizierungsart**: Normales Passwort
+     - **Benutzername**: Ihre vollständige E-Mail-Adresse
+
+    </Region>
+
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 4">
+    <Region zones={['eu']}>
+
     Einstellungen des Sendeservers:
     
      - **Protokoll**: SMTP 
@@ -114,7 +139,22 @@ Folgen Sie den Konfigurationsschritten, indem Sie nacheinander auf die folgenden
      - **Verbindungssicherheit**: STARTTLS
      - **Authentifizierungsart**: Normales Passwort
      - **Benutzername**: Ihre vollständige E-Mail-Adresse
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Einstellungen des Sendeservers:
     
+     - **Protokoll**: SMTP 
+     - **Hostname**: ex.mail.ovh.ca
+     - **Port**: 587
+     - **Verbindungssicherheit**: STARTTLS
+     - **Authentifizierungsart**: Normales Passwort
+     - **Benutzername**: Ihre vollständige E-Mail-Adresse
+
+    </Region>
+
     1\. Klicken Sie auf <code className="action">Testen</code>, um die eingegebenen Einstellungen zu überprüfen.
     2\. Klicken Sie auf <code className="action">Weiter</code>, um diese Einstellungen zu bestätigen.
     
@@ -133,6 +173,8 @@ Folgen Sie den Konfigurationsschritten, indem Sie nacheinander auf die folgenden
 
 Wenn Sie eine POP-Konfiguration für Ihre E-Mail-Adresse wünschen, ersetzen Sie die Einstellungen des **Schritts 3** durch folgende:
 
+<Region zones={['eu']}>
+
 Empfangsservereinstellungen:
 
 - **Protokoll**: POP3
@@ -141,6 +183,21 @@ Empfangsservereinstellungen:
 - **Verbindungssicherheit**: SSL/TLS
 - **Authentifizierungsart**: Normales Passwort
 - **Benutzername**: Ihre vollständige E-Mail-Adresse
+
+</Region>
+
+<Region zones={['ca']}>
+
+Empfangsservereinstellungen:
+
+- **Protokoll**: POP3
+- **Hostname**: ex.mail.ovh.ca
+- **Port**: 995
+- **Verbindungssicherheit**: SSL/TLS
+- **Authentifizierungsart**: Normales Passwort
+- **Benutzername**: Ihre vollständige E-Mail-Adresse
+
+</Region>
 
 :::
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
@@ -92,15 +92,34 @@ This error indicates that emails cannot be received and it is also linked to the
 
 Depending on your Exchange service usage, the following MX servers are valid:
 
+<Region zones={['eu']}>
+
 - Exchange only: mx0.mail.ovh.net, mx1.mail.ovh.net, mx2.mail.ovh.net, mx3.mail.ovh.net & mx4.mail.ovh.net
 - Exchange & POP/IMAP email hosted by OVHcloud: mx0.mail.ovh.net, mx1.mail.ovh.net mx2.mail.ovh.net, mx3.mail.ovh.net & mx4.mail.ovh.net
 - Exchange & POP/IMAP email not hosted by OVHcloud: ex<b>?</b>.mail.ovh.net
+
+</Region>
+
+<Region zones={['ca']}>
+
+- Exchange only: mx0.mail.ovh.ca, mx1.mail.ovh.ca, mx2.mail.ovh.ca, mx3.mail.ovh.ca & mx4.mail.ovh.ca
+- Exchange & POP/IMAP email hosted by OVHcloud: mx0.mail.ovh.ca, mx1.mail.ovh.ca mx2.mail.ovh.ca, mx3.mail.ovh.ca & mx4.mail.ovh.ca
+- Exchange & POP/IMAP email not hosted by OVHcloud: ex.mail.ovh.ca
+
+</Region>
+
 <a name="hostname"></a>
 
 :::warning
+<Region zones={['eu']}>
 In our guides, we use as the server name: ex<b>?</b>.mail.ovh.net. You will need to replace the "?" with the actual number indicating the appropriate server  for your Exchange service.
 
 You can find this information in the OVHcloud Control Panel, in the <code className="action">Web Cloud</code> section. Open <code className="action">Exchange</code> and select your service. The server name is displayed in the **Connection** section of the <code className="action">General information</code> tab.
+</Region>
+
+<Region zones={['ca']}>
+In our guides, we use as the server name: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -113,6 +132,8 @@ You can verify these settings in your [domain's DNS zone](/guides/web-cloud/doma
 
 Here are the mandatory values for an Exchange service:
 
+<Region zones={['eu']}>
+
 Field        | Value
 ------------ | -------------
 Sub-domain   | _autodiscover._tcp
@@ -120,6 +141,20 @@ Priority     | 0
 Weight       | 0
 Port         | 443
 Target       | [Your hostname](#hostname) (ex<b>?</b>.mail.ovh.net)
+
+</Region>
+
+<Region zones={['ca']}>
+
+Field        | Value
+------------ | -------------
+Sub-domain   | _autodiscover._tcp
+Priority     | 0
+Weight       | 0
+Port         | 443
+Target       | [Your hostname](#hostname) (ex.mail.ovh.ca)
+
+</Region>
 
 ### The test email could not be sent from this account 
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
@@ -59,9 +59,15 @@ The instructions in this guide are based on a device that uses Android version 1
 ### How to add your email account <a name="addaccount"></a>
 
 :::info
-In this guide, we use as the hostname: ex?.mail.ovh.net. You will need to replace the "?" with the actual number indicating the appropriate server for your Email Pro service.
+<Region zones={['eu']}>
+In this guide, we use as the hostname: ex?.mail.ovh.net. You will need to replace the "?" with the actual number indicating the appropriate server for your Exchange service.
 
 Click <ManagerLink to="/#/web/exchange">this link</ManagerLink> to access the <code className="action">Exchange</code> section. The server name is displayed in the **Connection** section of the <code className="action">General information</code> tab.
+</Region>
+
+<Region zones={['ca']}>
+In this guide, we use as the hostname: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -102,7 +108,13 @@ Follow the next steps in the configuration process by clicking on the tabs below
     <img className="thumbnail" alt="Android Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-03.png" loading="lazy" />
   </Tab>
   <Tab label="Step 4">
+    <Region zones={['eu']}>
     Complete the "**Address configuration**" page.<br/><br/>- **Email**: Your full email address<br/>- **Password**: Your email password<br/>- **Certificate**: Leave "None"<br/>- **Domain\Username**: Your full email address<br/>- **Server**: **ex?.mail.ovh.net** (replace the **?** by [your Exchange server number](#addaccount))<br/>- **Port**: 443<br/>- **Security type**: SSL/TLS<br/><br/>Press <code className="action">Next</code> to confirm the configuration.<br/><br/>
+    </Region>
+
+    <Region zones={['ca']}>
+    Complete the "**Address configuration**" page.<br/><br/>- **Email**: Your full email address<br/>- **Password**: Your email password<br/>- **Certificate**: Leave "None"<br/>- **Domain\Username**: Your full email address<br/>- **Server**: **ex.mail.ovh.ca**<br/>- **Port**: 443<br/>- **Security type**: SSL/TLS<br/><br/>Press <code className="action">Next</code> to confirm the configuration.<br/><br/>
+    </Region>
     <img className="thumbnail" alt="Android Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-04.png" loading="lazy" />
   </Tab>
   <Tab label="Step 5">

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
@@ -48,9 +48,15 @@ This guide is designed to assist you in common tasks as much as possible. If you
 ### Adding an account <a name="addaccount"></a>
 
 :::info
-In this guide, we use as the hostname: ex?.mail.ovh.net. You will need to replace the "?" with the actual number indicating the appropriate server for your Email Pro service.
+<Region zones={['eu']}>
+In this guide, we use as the hostname: ex?.mail.ovh.net. You will need to replace the "?" with the actual number indicating the appropriate server for your Exchange service.
 
 Click <ManagerLink to="/#/web/exchange">this link</ManagerLink> to access the <code className="action">Exchange</code> section. The server name is displayed in the **Connection** section of the <code className="action">General information</code> tab.
+</Region>
+
+<Region zones={['ca']}>
+In this guide, we use as the hostname: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -63,12 +69,27 @@ On your device’s home screen, go to <code className="action">Settings</code> (
 
 - **For iOS versions 14 and above**: Follow the instructions in the table below.
 
+<Region zones={['eu']}>
+
 | | |
 |---|---|
 |<video className="thumbnail" autoPlay loop muted playsInline aria-label="iPhone" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. In `Settings`, go to `Mail`. <br/><br/> 2. Tap `Accounts`.<br/><br/> 3. Tap `Add Account`.<br/><br/> 4. Choose `Microsoft Exchange`.|
 |5. Enter your email **address** and email account **description**, tap `Next`.<br/><br/>6. Select `Configure Manually`.<br/><br/>|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
 |<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Enter: <br/>- the server **ex?.mail.ovh.net** (replace the **?** by [your Exchange server number](#addaccount))<br/>-your **full email address** as username <br/>- your account password|
 |8. Please ensure that you leave <code className="action">Mail</code> activated, so that the application can use this account. Other applications (e.g. *Calendars* and *Notes*) can use some of Exchange’s collaborative features.<br/><br/>9. Tap `Save` to finish adding your Exchange account.|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
+
+<Region zones={['ca']}>
+
+| | |
+|---|---|
+|<video className="thumbnail" autoPlay loop muted playsInline aria-label="iPhone" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. In `Settings`, go to `Mail`. <br/><br/> 2. Tap `Accounts`.<br/><br/> 3. Tap `Add Account`.<br/><br/> 4. Choose `Microsoft Exchange`.|
+|5. Enter your email **address** and email account **description**, tap `Next`.<br/><br/>6. Select `Configure Manually`.<br/><br/>|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
+|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Enter: <br/>- the server **ex.mail.ovh.ca**<br/>-your **full email address** as username <br/>- your account password|
+|8. Please ensure that you leave <code className="action">Mail</code> activated, so that the application can use this account. Other applications (e.g. *Calendars* and *Notes*) can use some of Exchange’s collaborative features.<br/><br/>9. Tap `Save` to finish adding your Exchange account.|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
 
 To check that the account has been correctly configured, you can send a test email.
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
@@ -53,9 +53,15 @@ This guide is designed to help you with common tasks. Nevertheless, we recommend
 ### How to add your account <a name="addaccount"></a>
 
 :::info
-In this guide, we use as the hostname: ex?.mail.ovh.net. You will need to replace the "?" with the actual number indicating the appropriate server for your Email Pro service.
+<Region zones={['eu']}>
+In this guide, we use as the hostname: ex?.mail.ovh.net. You will need to replace the "?" with the actual number indicating the appropriate server for your Exchange service.
 
 Click <ManagerLink to="/#/web/exchange">this link</ManagerLink> to access the <code className="action">Exchange</code> section. The server name is displayed in the **Connection** section of the <code className="action">General information</code> tab.
+</Region>
+
+<Region zones={['ca']}>
+In this guide, we use as the hostname: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -78,7 +84,13 @@ Click <ManagerLink to="/#/web/exchange">this link</ManagerLink> to access the <c
     <img className="thumbnail" alt="mailmac" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos/mail-mac-exchange03.png" loading="lazy" />
   </Tab>
   <Tab label="Step 4">
+    <Region zones={['eu']}>
     Type: <br/><br/>- Email address: Leave your full email address.<br/>- User name: Leave your full email address. <br/>- Password: Leave your **Password**.<br/> - Internal URL: **ex?.mail.ovh.net** (replace **?** with [your Exchange server number](#addaccount))<br/>- External URL: **ex?.mail.ovh.net** (replace **?** with [your Exchange server number](#addaccount))<br/><br/>
+    </Region>
+
+    <Region zones={['ca']}>
+    Type: <br/><br/>- Email address: Leave your full email address.<br/>- User name: Leave your full email address. <br/>- Password: Leave your **Password**.<br/> - Internal URL: **ex.mail.ovh.ca**<br/>- External URL: **ex.mail.ovh.ca**<br/><br/>
+    </Region>
     
     :::warning
     It is normal that an error message of the type “**Unable to verify account name or password**” occurs when the window appears for the first time. However, if this message persists after validation, the information entered is incorrect.<br/><br/>

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
@@ -55,9 +55,15 @@ If you experience any difficulties carrying out these operations, we recommend t
 ## Instructions
 
 :::info
+<Region zones={['eu']}>
 In our example, we use the server reference: ex?.mail.ovh.net. The "?" must be replaced with the number corresponding to your Exchange service's server.
 
 Click <ManagerLink to="/#/web/exchange">this link</ManagerLink> to access the <code className="action">Exchange</code> section. The server name is displayed in the **Connection** section of the <code className="action">General information</code> tab.
+</Region>
+
+<Region zones={['ca']}>
+In our example, we use the server reference: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -93,27 +99,61 @@ Follow the configuration steps by clicking successively on the **5** tabs below:
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Step 3">
+    <Region zones={['eu']}>
+
     Incoming server settings:
-    
+
      - **Protocol**: IMAP
      - **Hostname**: ex?.mail.ovh.net (replace the "?" with your server number)
      - **Port**: 993
      - **Connection security**: SSL/TLS
      - **Authentication method**: Normal password
      - **Username**: Your full email address
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Incoming server settings:
+
+     - **Protocol**: IMAP
+     - **Hostname**: ex.mail.ovh.ca
+     - **Port**: 993
+     - **Connection security**: SSL/TLS
+     - **Authentication method**: Normal password
+     - **Username**: Your full email address
+
+    </Region>
+
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Step 4">
+    <Region zones={['eu']}>
+
     Outgoing server settings:
-    
+
      - **Protocol**: SMTP 
      - **Hostname**: ex?.mail.ovh.net (replace the "?" with your server number)
      - **Port**: 587
      - **Connection security**: STARTTLS
      - **Authentication method**: Normal password
      - **Username**: Your full email address
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Outgoing server settings:
+
+     - **Protocol**: SMTP 
+     - **Hostname**: ex.mail.ovh.ca
+     - **Port**: 587
+     - **Connection security**: STARTTLS
+     - **Authentication method**: Normal password
+     - **Username**: Your full email address
+
+    </Region>
+
     1\. Click on <code className="action">Test</code> to verify the entered settings.
     2\. Click on <code className="action">Continue</code> to validate these settings.
     
@@ -132,6 +172,8 @@ Follow the configuration steps by clicking successively on the **5** tabs below:
 
 If you want a POP configuration for your email address, replace the settings in **Step 3** with the following:
 
+<Region zones={['eu']}>
+
 Incoming server settings:
 
 - **Protocol**: POP3
@@ -141,21 +183,22 @@ Incoming server settings:
 - **Authentication method**: Normal password
 - **Username**: Your full email address
 
-:::
+</Region>
 
-**POP configuration**
-
-If you want a POP configuration for your email address, replace the settings in Step 3 with the following:
+<Region zones={['ca']}>
 
 Incoming server settings:
 
-- Protocol: POP3
-- Hostname: ex?.mail.ovh.net (replace the '?' with your server number)
-- Port: 995
-- Connection security: SSL/TLS
-- Authentication method: Normal password
-- Username: Your full email address
+- **Protocol**: POP3
+- **Hostname**: ex.mail.ovh.ca
+- **Port**: 995
+- **Connection security**: SSL/TLS
+- **Authentication method**: Normal password
+- **Username**: Your full email address
 
+</Region>
+
+:::
 
 ### Use the email address
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
@@ -55,9 +55,15 @@ If you experience any difficulties carrying out these operations, we recommend t
 ## Instructions
 
 :::info
+<Region zones={['eu']}>
 In our example, we use the server reference: ex?.mail.ovh.net. The "?" must be replaced with the number corresponding to your Exchange service's server.
 
 Click <ManagerLink to="/#/web/exchange">this link</ManagerLink> to access the <code className="action">Exchange</code> section. The server name is displayed in the **Connection** section of the <code className="action">General information</code> tab.
+</Region>
+
+<Region zones={['ca']}>
+In our example, we use the server reference: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -93,27 +99,61 @@ Follow the configuration steps by clicking successively on the **5** tabs below:
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Step 3">
+    <Region zones={['eu']}>
+
     Incoming server settings:
-    
+
      - **Protocol**: IMAP
      - **Hostname**: ex?.mail.ovh.net (replace the "?" with your server number)
      - **Port**: 993
      - **Connection security**: SSL/TLS
      - **Authentication method**: Normal password
      - **Username**: Your full email address
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Incoming server settings:
+
+     - **Protocol**: IMAP
+     - **Hostname**: ex.mail.ovh.ca
+     - **Port**: 993
+     - **Connection security**: SSL/TLS
+     - **Authentication method**: Normal password
+     - **Username**: Your full email address
+
+    </Region>
+
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Step 4">
+    <Region zones={['eu']}>
+
     Outgoing server settings:
-    
+
      - **Protocol**: SMTP 
      - **Hostname**: ex?.mail.ovh.net (replace the "?" with your server number)
      - **Port**: 587
      - **Connection security**: STARTTLS
      - **Authentication method**: Normal password
      - **Username**: Your full email address
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Outgoing server settings:
+
+     - **Protocol**: SMTP 
+     - **Hostname**: ex.mail.ovh.ca
+     - **Port**: 587
+     - **Connection security**: STARTTLS
+     - **Authentication method**: Normal password
+     - **Username**: Your full email address
+
+    </Region>
+
     1\. Click on <code className="action">Test</code> to verify the entered settings.
     2\. Click on <code className="action">Continue</code> to validate these settings.
     
@@ -132,6 +172,8 @@ Follow the configuration steps by clicking successively on the **5** tabs below:
 
 If you want a POP configuration for your email address, replace the settings in **Step 3** with the following:
 
+<Region zones={['eu']}>
+
 Incoming server settings:
 
 - **Protocol**: POP3
@@ -140,6 +182,21 @@ Incoming server settings:
 - **Connection security**: SSL/TLS
 - **Authentication method**: Normal password
 - **Username**: Your full email address
+
+</Region>
+
+<Region zones={['ca']}>
+
+Incoming server settings:
+
+- **Protocol**: POP3
+- **Hostname**: ex.mail.ovh.ca
+- **Port**: 995
+- **Connection security**: SSL/TLS
+- **Authentication method**: Normal password
+- **Username**: Your full email address
+
+</Region>
 
 :::
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
@@ -94,15 +94,33 @@ Este error indica que los mensajes de correo no pueden ser recibidos y que tambi
 
 En función del uso de su servicio Exchange, son válidos los siguientes servidores MX:
 
+<Region zones={['eu']}>
+
 - Solo Exchange: mx0.mail.ovh.net, mx1.mail.ovh.net mx2.mail.ovh.net, mx3.mail.ovh.net & mx4.mail.ovh.net
 - Exchange + Correo POP/IMAP alojado en OVHcloud: mx0.mail.ovh.net, mx1.mail.ovh.net mx2.mail.ovh.net, mx3.mail.ovh.net & mx4.mail.ovh.net
 - Exchange + Correo POP/IMAP no alojado en OVHcloud: ex\*\*?**.mail.ovh.net
 
+</Region>
+
+<Region zones={['ca']}>
+
+- Solo Exchange: mx0.mail.ovh.ca, mx1.mail.ovh.ca mx2.mail.ovh.ca, mx3.mail.ovh.ca & mx4.mail.ovh.ca
+- Exchange + Correo POP/IMAP alojado en OVHcloud: mx0.mail.ovh.ca, mx1.mail.ovh.ca mx2.mail.ovh.ca, mx3.mail.ovh.ca & mx4.mail.ovh.ca
+- Exchange + Correo POP/IMAP no alojado en OVHcloud: ex.mail.ovh.ca
+
+</Region>
+
 <a name="hostname"></a>
 
 :::warning
+<Region zones={['eu']}>
 En nuestras guías utilizamos como nombre de servidor: ex<b>?</b>.mail.ovh.net. Debe reemplazar el "?" por el número correspondiente al servidor de su servicio Exchange.<br/>
 Puede consultar esta información en el área de cliente de OVHcloud, en la sección <code className="action">Web Cloud</code>. Abra <code className="action">Exchange</code> y seleccione su servicio. El nombre del servidor aparece en la pestaña **Conexión** de la <code className="action">Información general</code>.
+</Region>
+
+<Region zones={['ca']}>
+En nuestras guías utilizamos como nombre de servidor: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -121,6 +139,8 @@ Puede comprobar estos parámetros en la [zona DNS del dominio](/guides/web-cloud
 
 Estos son los valores para un servicio Exchange:
 
+<Region zones={['eu']}>
+
 Campo | Valor
 ------------ | -------------
 Subdominio | _autodiscover._tcp
@@ -128,6 +148,20 @@ Prioridad | 0
 Peso | 0
 Puerto | 443
 Destino | [ex<b>?</b>.mail.ovh.net](#hostname) (sustituya "?" por el número correspondiente al servidor de su servicio Exchange)
+
+</Region>
+
+<Region zones={['ca']}>
+
+Campo | Valor
+------------ | -------------
+Subdominio | _autodiscover._tcp
+Prioridad | 0
+Peso | 0
+Puerto | 443
+Destino | [ex.mail.ovh.ca](#hostname)
+
+</Region>
 
 ### El mensaje de correo de prueba no se ha podido enviar desde la cuenta
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
@@ -65,9 +65,15 @@ Esta documentación se ha realizado desde un dispositivo que utiliza la versión
 ### Cómo añadir una cuenta de correo <a name="addaccount"></a>
 
 :::warning
+<Region zones={['eu']}>
 En nuestro ejemplo, utilizamos el nombre del servidor: ex?.mail.ovh.net. Debe reemplazar el "?" por el número que designa el servidor del servicio Exchange.
 
 Haga clic en <ManagerLink to="/#/web/exchange">este enlace</ManagerLink> para acceder a la sección <code className="action">Exchange</code>. El nombre del servidor aparece en la zona **Conexión** de la pestaña <code className="action">Información general</code>.
+</Region>
+
+<Region zones={['ca']}>
+En nuestro ejemplo, utilizamos el nombre del servidor: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -108,7 +114,13 @@ Siga los siguientes pasos de configuración en las fichas siguientes:
     <img className="thumbnail" alt="Exchange Android" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-03.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 4">
+    <Region zones={['eu']}>
     Rellene la página "**Configuración de la dirección**"<br/><br/>- **Correo** electrónico: su dirección de correo electrónico completa<br/>- **Contraseña**: la contraseña de su dirección de correo<br/>- **Certificado**: Deje "Ninguno"<br/>- **Dominio\Nombre de usuario**: su dirección de correo electrónico completa<br/>- **Servidor**: **ex?.mail.ovh.net** (sustituir el **?** por [el número de su servidor Exchange](#addaccount))<br/>- **Puerto**: 443<br/>- **Tipo de seguridad**: SSL/TLS<br/><br/>Pulse <code className="action">Siguiente</code> para validar la configuración.<br/><br/>
+    </Region>
+
+    <Region zones={['ca']}>
+    Rellene la página "**Configuración de la dirección**"<br/><br/>- **Correo** electrónico: su dirección de correo electrónico completa<br/>- **Contraseña**: la contraseña de su dirección de correo<br/>- **Certificado**: Deje "Ninguno"<br/>- **Dominio\Nombre de usuario**: su dirección de correo electrónico completa<br/>- **Servidor**: **ex.mail.ovh.ca**<br/>- **Puerto**: 443<br/>- **Tipo de seguridad**: SSL/TLS<br/><br/>Pulse <code className="action">Siguiente</code> para validar la configuración.<br/><br/>
+    </Region>
     <img className="thumbnail" alt="Exchange Android" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-04.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 5">

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
@@ -49,9 +49,15 @@ Esta guía le ayudará a realizar las tareas más habituales. No obstante, si ti
 ### Añadir la cuenta <a name="addaccount"></a>
 
 :::warning
+<Region zones={['eu']}>
 En nuestro ejemplo, utilizamos el nombre del servidor: ex?.mail.ovh.net. Debe reemplazar el "?" por el número que designa el servidor del servicio Exchange.
 
 Haga clic en <ManagerLink to="/#/web/exchange">este enlace</ManagerLink> para acceder a la sección <code className="action">Exchange</code>. El nombre del servidor aparece en la zona **Conexión** de la pestaña <code className="action">Información general</code>.
+</Region>
+
+<Region zones={['ca']}>
+En nuestro ejemplo, utilizamos el nombre del servidor: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -64,12 +70,27 @@ En la pantalla de bienvenida de su dispositivo, acceda a <code className="action
 
 - **Para versiones de iOS 14 y superiores**: siga las instrucciones de la tabla siguiente.
 
+<Region zones={['eu']}>
+
 | | |
 |---|---|
 |<video className="thumbnail" autoPlay loop muted playsInline aria-label="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. En `Ajustes`, vaya a `Mail`. <br/><br/> 2. Pulse `Cuentas`.<br/><br/> 3. Pulse `Añadir cuenta`.<br/><br/> 3.4. Seleccione `Microsoft Exchange`.|
 |5. Introduzca su **dirección de correo electrónico** y una **descripción** de su cuenta de correo, y pulse `Siguiente`.<br/><br/>6. Seleccione `Configuración manual`.<br/><br/>|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
 |<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Introduzca: <br/>- el servidor **ex?.mail.ovh.net** (sustituir el **?** por [el número de su servidor Exchange](#addaccount))<br/>- su dirección de **correo electrónico completa** en nombre de usuario <br/>- la contraseña de su dirección de correo electrónico|
 |8. Asegúrese de dejar al menos <code className="action">Mail</code> marcado para que la aplicación pueda utilizar la cuenta. Las demás aplicaciones (como el *Calendario* o las *Notas*) pueden utilizar otras funciones colaborativas inherentes a Exchange.<br/><br/>9. Pulse `Guardar` para terminar de añadir su cuenta Exchange.|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
+
+<Region zones={['ca']}>
+
+| | |
+|---|---|
+|<video className="thumbnail" autoPlay loop muted playsInline aria-label="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. En `Ajustes`, vaya a `Mail`. <br/><br/> 2. Pulse `Cuentas`.<br/><br/> 3. Pulse `Añadir cuenta`.<br/><br/> 3.4. Seleccione `Microsoft Exchange`.|
+|5. Introduzca su **dirección de correo electrónico** y una **descripción** de su cuenta de correo, y pulse `Siguiente`.<br/><br/>6. Seleccione `Configuración manual`.<br/><br/>|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
+|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Introduzca: <br/>- el servidor **ex.mail.ovh.ca**<br/>- su dirección de **correo electrónico completa** en nombre de usuario <br/>- la contraseña de su dirección de correo electrónico|
+|8. Asegúrese de dejar al menos <code className="action">Mail</code> marcado para que la aplicación pueda utilizar la cuenta. Las demás aplicaciones (como el *Calendario* o las *Notas*) pueden utilizar otras funciones colaborativas inherentes a Exchange.<br/><br/>9. Pulse `Guardar` para terminar de añadir su cuenta Exchange.|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
 
 Si lo desea, puede realizar una prueba de envío para comprobar que la cuenta esté bien configurada.
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
@@ -53,9 +53,15 @@ Esta guía le ayudará a realizar las tareas más habituales. No obstante, si ne
 ### Añadir la cuenta <a name="addaccount"></a>
 
 :::warning
+<Region zones={['eu']}>
 En nuestro ejemplo, utilizamos el nombre del servidor: ex?.mail.ovh.net. Debe reemplazar el "?" por el número que designa el servidor del servicio Exchange.
 
 Haga clic en <ManagerLink to="/#/web/exchange">este enlace</ManagerLink> para acceder a la sección <code className="action">Exchange</code>. El nombre del servidor aparece en la zona **Conexión** de la pestaña <code className="action">Información general</code>.
+</Region>
+
+<Region zones={['ca']}>
+En nuestro ejemplo, utilizamos el nombre del servidor: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -78,7 +84,13 @@ Haga clic en <ManagerLink to="/#/web/exchange">este enlace</ManagerLink> para ac
     <img className="thumbnail" alt="mailmac" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos/mail-mac-exchange03.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 4">
+    <Region zones={['eu']}>
     Escriba: <br/><br/>- Dirección de correo electrónico: deje su dirección de correo electrónico completa<br/>- Nombre de usuario: deje su dirección de correo electrónico completa <br/>- Contraseña: deje su **contraseña**<br/> - URL interna: **ex?.mail.ovh.net** (sustituya el **?** por [el número de su servidor Exchange](#addaccount))<br/>- URL externa: **ex?.mail.ovh.net** (sustituya el **?** por [el número de su servidor Exchange](#addaccount))<br/><br/>
+    </Region>
+
+    <Region zones={['ca']}>
+    Escriba: <br/><br/>- Dirección de correo electrónico: deje su dirección de correo electrónico completa<br/>- Nombre de usuario: deje su dirección de correo electrónico completa <br/>- Contraseña: deje su **contraseña**<br/> - URL interna: **ex.mail.ovh.ca**<br/>- URL externa: **ex.mail.ovh.ca**<br/><br/>
+    </Region>
     
     :::warning
     Es normal que aparezca el mensaje en rojo «**No se puede comprobar el nombre o la contraseña de la cuenta**» la primera vez que aparece la ventana. Sin embargo, si este mensaje persiste después de la validación, significa que la información introducida es incorrecta.<br/><br/>

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
@@ -55,9 +55,15 @@ Le ofrecemos este guía para acompañarle en tareas cotidianas. Sin embargo, le 
 ## Procedimiento
 
 :::info
+<Region zones={['eu']}>
 En nuestro ejemplo, utilizamos la referencia del servidor: ex?.mail.ovh.net. Deberá reemplazar el "?" por el número que identifica su servidor de Exchange.
 
 Haga clic en <ManagerLink to="/#/web/exchange">este enlace</ManagerLink> para acceder a la sección <code className="action">Exchange</code>. El nombre del servidor aparece en la zona **Conexión** de la pestaña <code className="action">Información general</code>.
+</Region>
+
+<Region zones={['ca']}>
+En nuestro ejemplo, utilizamos la referencia del servidor: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -93,27 +99,61 @@ Siga los pasos de configuración haciendo clic sucesivamente en los **5** siguie
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 3">
+    <Region zones={['eu']}>
+
     Configuración del servidor de recepción:
-    
+
      - **Protocolo**: IMAP
      - **Nombre de host**: ex?.mail.ovh.net (reemplace el "?" por el número de su servidor)
      - **Puerto**: 993
      - **Seguridad de la conexión**: SSL/TLS
      - **Método de autenticación**: Contraseña normal
      - **Nombre de usuario**: Su dirección de correo electrónico completa
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Configuración del servidor de recepción:
+
+     - **Protocolo**: IMAP
+     - **Nombre de host**: ex.mail.ovh.ca
+     - **Puerto**: 993
+     - **Seguridad de la conexión**: SSL/TLS
+     - **Método de autenticación**: Contraseña normal
+     - **Nombre de usuario**: Su dirección de correo electrónico completa
+
+    </Region>
+
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 4">
+    <Region zones={['eu']}>
+
     Configuración del servidor de envío:
-    
+
      - **Protocolo**: SMTP 
      - **Nombre de host**: ex?.mail.ovh.net (reemplace el "?" por el número de su servidor)
      - **Puerto**: 587
      - **Seguridad de la conexión**: STARTTLS
      - **Método de autenticación**: Contraseña normal
      - **Nombre de usuario**: Su dirección de correo electrónico completa
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Configuración del servidor de envío:
+
+     - **Protocolo**: SMTP 
+     - **Nombre de host**: ex.mail.ovh.ca
+     - **Puerto**: 587
+     - **Seguridad de la conexión**: STARTTLS
+     - **Método de autenticación**: Contraseña normal
+     - **Nombre de usuario**: Su dirección de correo electrónico completa
+
+    </Region>
+
     1. Haga clic en <code className="action">Probar</code> para verificar los parámetros introducidos.
     2. Haga clic en <code className="action">Continuar</code> para validar estos parámetros.
     
@@ -132,6 +172,8 @@ Siga los pasos de configuración haciendo clic sucesivamente en los **5** siguie
 
 Si desea una configuración POP para su dirección de correo electrónico, reemplace los parámetros del **paso 3** por los siguientes:
 
+<Region zones={['eu']}>
+
 Configuración del servidor de recepción:
 
 - **Protocolo**: POP3
@@ -141,23 +183,22 @@ Configuración del servidor de recepción:
 - **Método de autenticación**: Contraseña normal
 - **Nombre de usuario**: Su dirección de correo electrónico completa
 
-:::
+</Region>
 
-**Configuración POP**
-
-Si desea una configuración POP para su dirección de correo electrónico, reemplace los parámetros del paso 3 por los siguientes:
+<Region zones={['ca']}>
 
 Configuración del servidor de recepción:
 
-- Protocolo: POP3
-- Nombre de host: ex?.mail.ovh.net (reemplace el '?' por el número de su servidor)
-- Puerto: 995
-- Seguridad de la conexión: SSL/TLS
-- Método de autenticación: Contraseña normal
+- **Protocolo**: POP3
+- **Nombre de host**: ex.mail.ovh.ca
+- **Puerto**: 995
+- **Seguridad de la conexión**: SSL/TLS
+- **Método de autenticación**: Contraseña normal
+- **Nombre de usuario**: Su dirección de correo electrónico completa
 
-Nombre de usuario: Su dirección de correo electrónico completa
+</Region>
 
-
+:::
 
 ### Utilizar la dirección de correo electrónico
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
@@ -55,9 +55,15 @@ Le ofrecemos este guía para acompañarle en tareas cotidianas. Sin embargo, le 
 ## Procedimiento
 
 :::info
+<Region zones={['eu']}>
 En nuestro ejemplo, utilizamos la referencia del servidor: ex?.mail.ovh.net. Deberá reemplazar el "?" por el número que identifica su servidor de Exchange.
 
 Haga clic en <ManagerLink to="/#/web/exchange">este enlace</ManagerLink> para acceder a la sección <code className="action">Exchange</code>. El nombre del servidor aparece en la zona **Conexión** de la pestaña <code className="action">Información general</code>.
+</Region>
+
+<Region zones={['ca']}>
+En nuestro ejemplo, utilizamos la referencia del servidor: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -93,27 +99,61 @@ Siga los pasos de configuración haciendo clic sucesivamente en los **5** siguie
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 3">
+    <Region zones={['eu']}>
+
     Configuración del servidor de recepción:
-    
+
      - **Protocolo**: IMAP
      - **Nombre de host**: ex?.mail.ovh.net (reemplace el "?" por el número de su servidor)
      - **Puerto**: 993
      - **Seguridad de la conexión**: SSL/TLS
      - **Método de autenticación**: Contraseña normal
      - **Nombre de usuario**: Su dirección de correo electrónico completa
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Configuración del servidor de recepción:
+
+     - **Protocolo**: IMAP
+     - **Nombre de host**: ex.mail.ovh.ca
+     - **Puerto**: 993
+     - **Seguridad de la conexión**: SSL/TLS
+     - **Método de autenticación**: Contraseña normal
+     - **Nombre de usuario**: Su dirección de correo electrónico completa
+
+    </Region>
+
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 4">
+    <Region zones={['eu']}>
+
     Configuración del servidor de envío:
-    
+
      - **Protocolo**: SMTP 
      - **Nombre de host**: ex?.mail.ovh.net (reemplace el "?" por el número de su servidor)
      - **Puerto**: 587
      - **Seguridad de la conexión**: STARTTLS
      - **Método de autenticación**: Contraseña normal
      - **Nombre de usuario**: Su dirección de correo electrónico completa
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Configuración del servidor de envío:
+
+     - **Protocolo**: SMTP 
+     - **Nombre de host**: ex.mail.ovh.ca
+     - **Puerto**: 587
+     - **Seguridad de la conexión**: STARTTLS
+     - **Método de autenticación**: Contraseña normal
+     - **Nombre de usuario**: Su dirección de correo electrónico completa
+
+    </Region>
+
     1. Haga clic en <code className="action">Probar</code> para verificar los parámetros introducidos.
     2. Haga clic en <code className="action">Continuar</code> para validar estos parámetros.
     
@@ -132,6 +172,8 @@ Siga los pasos de configuración haciendo clic sucesivamente en los **5** siguie
 
 Si desea una configuración POP para su dirección de correo electrónico, reemplace los parámetros del **paso 3** por los siguientes:
 
+<Region zones={['eu']}>
+
 Configuración del servidor de recepción:
 
 - **Protocolo**: POP3
@@ -140,6 +182,21 @@ Configuración del servidor de recepción:
 - **Seguridad de la conexión**: SSL/TLS
 - **Método de autenticación**: Contraseña normal
 - **Nombre de usuario**: Su dirección de correo electrónico completa
+
+</Region>
+
+<Region zones={['ca']}>
+
+Configuración del servidor de recepción:
+
+- **Protocolo**: POP3
+- **Nombre de host**: ex.mail.ovh.ca
+- **Puerto**: 995
+- **Seguridad de la conexión**: SSL/TLS
+- **Método de autenticación**: Contraseña normal
+- **Nombre de usuario**: Su dirección de correo electrónico completa
+
+</Region>
 
 :::
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
@@ -92,15 +92,33 @@ Cette erreur indique que les e-mails ne peuvent pas être reçus et sera égalem
 
 En fonction de l'utilisation de votre service Exchange, les serveurs MX suivants sont valides :
 
+<Region zones={['eu']}>
+
 - Exchange seul : mx0.mail.ovh.net, mx1.mail.ovh.net, mx2.mail.ovh.net, mx3.mail.ovh.net et mx4.mail.ovh.net
 - Exchange + E-mail POP/IMAP hébergé par OVHcloud: mx0.mail.ovh.net, mx1.mail.ovh.net, mx2.mail.ovh.net, mx3.mail.ovh.net et mx4.mail.ovh.net
 - Exchange + E-mail POP/IMAP non hébergé par OVHcloud: ex?.mail.ovh.net
 
+</Region>
+
+<Region zones={['ca']}>
+
+- Exchange seul : mx0.mail.ovh.ca, mx1.mail.ovh.ca, mx2.mail.ovh.ca, mx3.mail.ovh.ca et mx4.mail.ovh.ca
+- Exchange + E-mail POP/IMAP hébergé par OVHcloud: mx0.mail.ovh.ca, mx1.mail.ovh.ca, mx2.mail.ovh.ca, mx3.mail.ovh.ca et mx4.mail.ovh.ca
+- Exchange + E-mail POP/IMAP non hébergé par OVHcloud: ex.mail.ovh.ca
+
+</Region>
+
 <a name="hostname"></a>
 
 :::warning
+<Region zones={['eu']}>
 Dans nos guides, nous utilisons comme nom de serveur: ex<b>?</b>.mail.ovh.net. Vous devrez remplacer le « ? » par le numéro correspondant au serveur de votre service Exchange.<br/>
 Vous trouverez ces informations dans l'espace client OVHcloud, dans la section <code className="action">Web Cloud</code>. Ouvrez <code className="action">Exchange</code> et sélectionnez votre service. Le nom du serveur s'affiche dans la zone **Connexion** de l'onglet <code className="action">Informations générales</code>.
+</Region>
+
+<Region zones={['ca']}>
+Dans nos guides, nous utilisons comme nom de serveur: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -119,6 +137,8 @@ Vous pouvez vérifier ces paramètres dans la [zone DNS de votre domaine](/guide
 
 Voici les valeurs pour un service Exchange:
 
+<Region zones={['eu']}>
+
 Champ | Valeur
 ------------ | -------------
 Sous domaine | _autodiscover._tcp
@@ -126,6 +146,20 @@ Priorité | 0
 Poids | 0
 Port | 443
 Cible | [ex?.mail.ovh.net ](#hostname) (remplacez le « ? » par le numéro correspondant au serveur de votre service Exchange)
+
+</Region>
+
+<Region zones={['ca']}>
+
+Champ | Valeur
+------------ | -------------
+Sous domaine | _autodiscover._tcp
+Priorité | 0
+Poids | 0
+Port | 443
+Cible | [ex.mail.ovh.ca](#hostname)
+
+</Region>
 
 ### L'email de test n'a pas pu être envoyé à partir du compte
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
@@ -59,9 +59,15 @@ Cette documentation a été réalisée depuis un appareil utilisant la version 1
 ### Comment ajouter votre compte e-mail <a name="addaccount"></a>
 
 :::warning
+<Region zones={['eu']}>
 Dans notre exemple, nous utilisons la mention serveur : ex?.mail.ovh.net. Vous devrez remplacer le « ? » par le chiffre désignant le serveur de votre service Exchange.
 
 Cliquez sur <ManagerLink to="/#/web/exchange">ce lien</ManagerLink> pour accéder à la section <code className="action">Exchange</code>. Le nom du serveur s'affiche dans la zone **Connexion** de l'onglet <code className="action">Informations générales</code>.
+</Region>
+
+<Region zones={['ca']}>
+Dans notre exemple, nous utilisons la mention serveur : ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -102,7 +108,13 @@ Suivez les étapes successives de configuration en parcourant les onglets ci-des
     <img className="thumbnail" alt="exchange android" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-03.png" loading="lazy" />
   </Tab>
   <Tab label="Etape 4">
+    <Region zones={['eu']}>
     Complétez la page « **Configuration de l'adresse** »<br/><br/>- **E-mail** : votre adresse e-mail complète<br/>- **Mot de passe** : le mot de passe de votre adresse e-mail<br/>- **Certificat** : laissez « Aucun »<br/>- **Domaine\Nom d'utilisateur** : votre adresse e-mail complète<br/>- **Serveur** : ex?.mail.ovh.net ( remplacez le **?** par [le numéro de votre serveur Exchange](#addaccount))<br/>- **Port** : 443<br/>- **Type de sécurité** : SSL/TLS<br/><br/>Appuyez sur <code className="action">Suivant</code> pour valider la configuration.<br/><br/>
+    </Region>
+
+    <Region zones={['ca']}>
+    Complétez la page « **Configuration de l'adresse** »<br/><br/>- **E-mail** : votre adresse e-mail complète<br/>- **Mot de passe** : le mot de passe de votre adresse e-mail<br/>- **Certificat** : laissez « Aucun »<br/>- **Domaine\Nom d'utilisateur** : votre adresse e-mail complète<br/>- **Serveur** : ex.mail.ovh.ca<br/>- **Port** : 443<br/>- **Type de sécurité** : SSL/TLS<br/><br/>Appuyez sur <code className="action">Suivant</code> pour valider la configuration.<br/><br/>
+    </Region>
     <img className="thumbnail" alt="exchange android" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-04.png" loading="lazy" />
   </Tab>
   <Tab label="Etape 5">

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
@@ -48,9 +48,15 @@ Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur
 ### Ajouter le compte <a name="addaccount"></a>
 
 :::warning
+<Region zones={['eu']}>
 Dans notre exemple, nous utilisons la mention serveur : ex?.mail.ovh.net. Vous devrez remplacer le « ? » par le chiffre désignant le serveur de votre service Exchange.
 
 Cliquez sur <ManagerLink to="/#/web/exchange">ce lien</ManagerLink> pour accéder à la section <code className="action">Exchange</code>. Le nom du serveur s'affiche dans la zone **Connexion** de l'onglet <code className="action">Informations générales</code>.
+</Region>
+
+<Region zones={['ca']}>
+Dans notre exemple, nous utilisons la mention serveur : ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -63,12 +69,27 @@ Sur l'écran d'accueil de votre appareil, rendez-vous sur <code className="actio
 
 - **Pour les versions iOS 14 et supérieure** : suivez les instructions du tableau suivant.
 
+<Region zones={['eu']}>
+
 | | |
 |---|---|
 |<video className="thumbnail" autoPlay loop muted playsInline aria-label="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. Dans  `Réglages`, allez sur `Mail`. <br/><br/> 2. Appuyez sur `Comptes`.<br/><br/> 3. Appuyez sur `Ajouter un compte`.<br/><br/> 4. Choisissez `Microsoft Exchange`.|
 |5. Saisissez votre **adresse e-mail** et une **description** de votre compte e-mail, appuyez sur `Suivant`.<br/><br/>6. Sélectionnez `Configuration manuelle`.<br/><br/>|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
 |<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Saisissez: <br/>- le serveur **ex?.mail.ovh.net** ( remplacez le **?** par [le numéro de votre serveur Exchange](#addaccount)) <br/>- votre **adresse e-mail complète** dans nom d'utilisateur <br/>- le mot de passe de votre adresse e-mail|
 |8. Assurez-vous de bien laisser au minimum <code className="action">Mail</code> coché afin que l'application puisse utiliser ce compte. Les autres applications (comme *Calendrier* et *Notes*) peuvent utiliser certaines des fonctions collaboratives inhérentes à Exchange.<br/><br/>9. Appuyez sur `Enregistrer` pour finaliser l'ajout de votre compte exchange.|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
+
+<Region zones={['ca']}>
+
+| | |
+|---|---|
+|<video className="thumbnail" autoPlay loop muted playsInline aria-label="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. Dans  `Réglages`, allez sur `Mail`. <br/><br/> 2. Appuyez sur `Comptes`.<br/><br/> 3. Appuyez sur `Ajouter un compte`.<br/><br/> 4. Choisissez `Microsoft Exchange`.|
+|5. Saisissez votre **adresse e-mail** et une **description** de votre compte e-mail, appuyez sur `Suivant`.<br/><br/>6. Sélectionnez `Configuration manuelle`.<br/><br/>|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
+|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Saisissez: <br/>- le serveur **ex.mail.ovh.ca** <br/>- votre **adresse e-mail complète** dans nom d'utilisateur <br/>- le mot de passe de votre adresse e-mail|
+|8. Assurez-vous de bien laisser au minimum <code className="action">Mail</code> coché afin que l'application puisse utiliser ce compte. Les autres applications (comme *Calendrier* et *Notes*) peuvent utiliser certaines des fonctions collaboratives inhérentes à Exchange.<br/><br/>9. Appuyez sur `Enregistrer` pour finaliser l'ajout de votre compte exchange.|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
 
 Vous pouvez effectuer un test d'envoi pour vérifier que le compte est correctement paramétré.
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
@@ -53,9 +53,15 @@ Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur
 ### Ajouter le compte <a name="addaccount"></a>
 
 :::warning
+<Region zones={['eu']}>
 Dans notre exemple, nous utilisons la mention serveur : ex?.mail.ovh.net. Vous devrez remplacer le « ? » par le chiffre désignant le serveur de votre service Exchange.
 
 Cliquez sur <ManagerLink to="/#/web/exchange">ce lien</ManagerLink> pour accéder à la section <code className="action">Exchange</code>. Le nom du serveur s'affiche dans la zone **Connexion** de l'onglet <code className="action">Informations générales</code>.
+</Region>
+
+<Region zones={['ca']}>
+Dans notre exemple, nous utilisons la mention serveur : ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -78,7 +84,13 @@ Cliquez sur <ManagerLink to="/#/web/exchange">ce lien</ManagerLink> pour accéde
     <img className="thumbnail" alt="mailmac" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos/mail-mac-exchange03.png" loading="lazy" />
   </Tab>
   <Tab label="Etape 4">
+    <Region zones={['eu']}>
     Saisissez: <br/><br/>- Adresse e-mail : laissez votre adresse e-mail complète<br/>- Nom d'utilisateur : laissez votre adresse e-mail complète <br/>- Mot de passe : laissez votre **mot de passe**<br/> - URL interne : **ex?.mail.ovh.net** (remplacez le **?** par [le numéro de votre serveur Exchange](#addaccount))<br/>- URL externe : **ex?.mail.ovh.net** (remplacez le **?** par [le numéro de votre serveur Exchange](#addaccount))<br/><br/>
+    </Region>
+
+    <Region zones={['ca']}>
+    Saisissez: <br/><br/>- Adresse e-mail : laissez votre adresse e-mail complète<br/>- Nom d'utilisateur : laissez votre adresse e-mail complète <br/>- Mot de passe : laissez votre **mot de passe**<br/> - URL interne : **ex.mail.ovh.ca**<br/>- URL externe : **ex.mail.ovh.ca**<br/><br/>
+    </Region>
     
     :::warning
     Il est normal de voir apparaître le message en rouge « **Impossible de vérfier le nom ou le mot de passe du compte** » lorsque la fenêtre apparaît la première fois. Néanmoins, si ce message persiste après validation, cela signifie que les informations saisies sont erronées.<br/><br/>

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
@@ -55,9 +55,15 @@ Si vous éprouvez des difficultés à effectuer ces opérations, nous vous recom
 ## En pratique
 
 :::info
+<Region zones={['eu']}>
 Dans notre exemple, nous utilisons la mention serveur : ex?.mail.ovh.net. Vous devrez remplacer le « ? » par le chiffre désignant le serveur de votre service Exchange.
 
 Cliquez sur <ManagerLink to="/#/web/exchange">ce lien</ManagerLink> pour accéder à la section <code className="action">Exchange</code>. Le nom du serveur s’affiche dans la zone **Connexion** de l’onglet <code className="action">Informations générales</code>.
+</Region>
+
+<Region zones={['ca']}>
+Dans notre exemple, nous utilisons la mention serveur : ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -93,6 +99,8 @@ Suivez les étapes de configuration en cliquant successivement sur les **5** ong
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 3">
+    <Region zones={['eu']}>
+
     Paramètres du serveur de réception :
     
      - **Protocole** : IMAP
@@ -101,10 +109,27 @@ Suivez les étapes de configuration en cliquant successivement sur les **5** ong
      - **Sécurité de la connexion** : SSL/TLS
      - **Méthode d'authentification** : Mot de passe normal
      - **Nom d'utilisateur** : Votre adresse e-mail complète
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Paramètres du serveur de réception :
+    
+     - **Protocole** : IMAP
+     - **Nom d'hôte** : ex.mail.ovh.ca
+     - **Port** : 993
+     - **Sécurité de la connexion** : SSL/TLS
+     - **Méthode d'authentification** : Mot de passe normal
+     - **Nom d'utilisateur** : Votre adresse e-mail complète
+
+    </Region>
     
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 4">
+    <Region zones={['eu']}>
+
     Paramètres du serveur d'envoi :
     
      - **Protocole** : SMTP 
@@ -113,6 +138,21 @@ Suivez les étapes de configuration en cliquant successivement sur les **5** ong
      - **Sécurité de la connexion** : STARTTLS
      - **Méthode d'authentification** : Mot de passe normal
      - **Nom d'utilisateur** : Votre adresse e-mail complète
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Paramètres du serveur d'envoi :
+    
+     - **Protocole** : SMTP 
+     - **Nom d'hôte** : ex.mail.ovh.ca
+     - **Port** : 587
+     - **Sécurité de la connexion** : STARTTLS
+     - **Méthode d'authentification** : Mot de passe normal
+     - **Nom d'utilisateur** : Votre adresse e-mail complète
+
+    </Region>
     
     1\. Cliquez sur <code className="action">Tester</code> pour vérifier les paramètres saisis.
     2\. Cliquez sur <code className="action">Continuer</code> pour valider ces paramètres.
@@ -132,6 +172,8 @@ Suivez les étapes de configuration en cliquant successivement sur les **5** ong
 
 Si vous souhaitez une configuration POP pour votre adresse e-mail, remplacez les paramètres de **l'étape 3** par les suivants :
 
+<Region zones={['eu']}>
+
 Paramètres du serveur de réception :
 
 - **Protocole** : POP3
@@ -141,21 +183,22 @@ Paramètres du serveur de réception :
 - **Méthode d'authentification** : Mot de passe normal
 - **Nom d'utilisateur** : Votre adresse e-mail complète
 
-:::
+</Region>
 
-**Configuration POP**
-
-Si vous souhaitez une configuration POP pour votre adresse e-mail, remplacez les paramètres de l'étape 3 par les suivants :
+<Region zones={['ca']}>
 
 Paramètres du serveur de réception :
 
-- Protocole : POP3
-- Nom d'hôte : ex?.mail.ovh.net (remplacez le « ? » par le numéro de votre serveur)
-- Port : 995
-- Sécurité de la connexion : SSL/TLS
-- Méthode d'authentification : Mot de passe normal
-- Nom d'utilisateur : Votre adresse e-mail complète
+- **Protocole** : POP3
+- **Nom d'hôte** : ex.mail.ovh.ca
+- **Port** : 995
+- **Sécurité de la connexion** : SSL/TLS
+- **Méthode d'authentification** : Mot de passe normal
+- **Nom d'utilisateur** : Votre adresse e-mail complète
 
+</Region>
+
+:::
 
 ### Utiliser l'adresse e-mail
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
@@ -55,9 +55,15 @@ Si vous éprouvez des difficultés à effectuer ces opérations, nous vous recom
 ## En pratique
 
 :::info
+<Region zones={['eu']}>
 Dans notre exemple, nous utilisons la mention serveur : ex?.mail.ovh.net. Vous devrez remplacer le « ? » par le chiffre désignant le serveur de votre service Exchange.
 
 Cliquez sur <ManagerLink to="/#/web/exchange">ce lien</ManagerLink> pour accéder à la section <code className="action">Exchange</code>. Le nom du serveur s’affiche dans la zone **Connexion** de l’onglet <code className="action">Informations générales</code>.
+</Region>
+
+<Region zones={['ca']}>
+Dans notre exemple, nous utilisons la mention serveur : ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -93,6 +99,8 @@ Suivez les étapes de configuration en cliquant successivement sur les **5** ong
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 3">
+    <Region zones={['eu']}>
+
     Paramètres du serveur de réception :
     
      - **Protocole** : IMAP
@@ -101,10 +109,27 @@ Suivez les étapes de configuration en cliquant successivement sur les **5** ong
      - **Sécurité de la connexion** : SSL/TLS
      - **Méthode d'authentification** : Mot de passe normal
      - **Nom d'utilisateur** : Votre adresse e-mail complète
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Paramètres du serveur de réception :
+    
+     - **Protocole** : IMAP
+     - **Nom d'hôte** : ex.mail.ovh.ca
+     - **Port** : 993
+     - **Sécurité de la connexion** : SSL/TLS
+     - **Méthode d'authentification** : Mot de passe normal
+     - **Nom d'utilisateur** : Votre adresse e-mail complète
+
+    </Region>
     
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 4">
+    <Region zones={['eu']}>
+
     Paramètres du serveur d'envoi :
     
      - **Protocole** : SMTP 
@@ -113,6 +138,21 @@ Suivez les étapes de configuration en cliquant successivement sur les **5** ong
      - **Sécurité de la connexion** : STARTTLS
      - **Méthode d'authentification** : Mot de passe normal
      - **Nom d'utilisateur** : Votre adresse e-mail complète
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Paramètres du serveur d'envoi :
+    
+     - **Protocole** : SMTP 
+     - **Nom d'hôte** : ex.mail.ovh.ca
+     - **Port** : 587
+     - **Sécurité de la connexion** : STARTTLS
+     - **Méthode d'authentification** : Mot de passe normal
+     - **Nom d'utilisateur** : Votre adresse e-mail complète
+
+    </Region>
     
     1\. Cliquez sur <code className="action">Tester</code> pour vérifier les paramètres saisis.
     2\. Cliquez sur <code className="action">Continuer</code> pour valider ces paramètres.
@@ -132,6 +172,8 @@ Suivez les étapes de configuration en cliquant successivement sur les **5** ong
 
 Si vous souhaitez une configuration POP pour votre adresse e-mail, remplacez les paramètres de **l'étape 3** par les suivants :
 
+<Region zones={['eu']}>
+
 Paramètres du serveur de réception :
 
 - **Protocole** : POP3
@@ -140,6 +182,21 @@ Paramètres du serveur de réception :
 - **Sécurité de la connexion** : SSL/TLS
 - **Méthode d'authentification** : Mot de passe normal
 - **Nom d'utilisateur** : Votre adresse e-mail complète
+
+</Region>
+
+<Region zones={['ca']}>
+
+Paramètres du serveur de réception :
+
+- **Protocole** : POP3
+- **Nom d'hôte** : ex.mail.ovh.ca
+- **Port** : 995
+- **Sécurité de la connexion** : SSL/TLS
+- **Méthode d'authentification** : Mot de passe normal
+- **Nom d'utilisateur** : Votre adresse e-mail complète
+
+</Region>
 
 :::
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
@@ -94,15 +94,33 @@ Questo errore indica che le email non possono essere ricevute e sarà associato 
 
 In base all'utilizzo del tuo servizio Exchange, i server MX seguenti sono validi:
 
+<Region zones={['eu']}>
+
 - Exchange: mx0.mail.ovh.net, mx1.mail.ovh.net mx2.mail.ovh.net, mx3.mail.ovh.net & mx4.mail.ovh.net
 - Exchange + E-mail POP/IMAP ospitati da OVHcloud: mx0.mail.ovh.net, mx1.mail.ovh.net mx2.mail.ovh.net, mx3.mail.ovh.net & mx4.mail.ovh.net
 - Exchange + E-mail POP/IMAP non ospitati da OVHcloud: ex<b>?</b>.mail.ovh.net
 
+</Region>
+
+<Region zones={['ca']}>
+
+- Exchange: mx0.mail.ovh.ca, mx1.mail.ovh.ca mx2.mail.ovh.ca, mx3.mail.ovh.ca & mx4.mail.ovh.ca
+- Exchange + E-mail POP/IMAP ospitati da OVHcloud: mx0.mail.ovh.ca, mx1.mail.ovh.ca mx2.mail.ovh.ca, mx3.mail.ovh.ca & mx4.mail.ovh.ca
+- Exchange + E-mail POP/IMAP non ospitati da OVHcloud: ex.mail.ovh.ca
+
+</Region>
+
 <a name="hostname"></a>
 
 :::warning
+<Region zones={['eu']}>
 Nelle nostre guide, utilizziamo come nome server: ex<b>?</b>.mail.ovh.net. Dovrai sostituire il ""? " dal numero corrispondente al server del tuo servizio Exchange.<br/>
 Queste informazioni sono disponibili nello Spazio Cliente OVHcloud, sezione <code className="action">Web Cloud</code>. Apri <code className="action">Exchange</code> e seleziona il tuo servizio. Il nome del server compare nella sezione **Connessione** della scheda <code className="action">Informazioni generali</code>.
+</Region>
+
+<Region zones={['ca']}>
+Nelle nostre guide, utilizziamo come nome server: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -121,6 +139,8 @@ Puoi verificare queste impostazioni nella [zona DNS del tuo dominio](/guides/web
 
 Ecco i valori per un servizio Exchange:
 
+<Region zones={['eu']}>
+
 Campo | Valore
 ------------ | -------------
 sottodominio | _autodiscover._tcp
@@ -128,6 +148,20 @@ Priorità | 0
 Peso | 0
 Porta | 443
 Destinazione | [ex<b>?</b>.mail.ovh.net](#hostname)(sostituisci il "?" dal numero corrispondente al server del tuo servizio Exchange)
+
+</Region>
+
+<Region zones={['ca']}>
+
+Campo | Valore
+------------ | -------------
+sottodominio | _autodiscover._tcp
+Priorità | 0
+Peso | 0
+Porta | 443
+Destinazione | [ex.mail.ovh.ca](#hostname)
+
+</Region>
 
 ### Impossibile inviare l'email di test da questo account
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
@@ -59,9 +59,15 @@ Questa guida è stata realizzata da un dispositivo che utilizza la versione 13 d
 ### Come aggiungere un account email
 
 :::warning
+<Region zones={['eu']}>
 Nel nostro esempio, usiamo il nome del server: ex?.mail.ovh.net. Dovrai sostituire il "?" dalla cifra che indica il server del tuo servizio Exchange.
 
 Clicca su <ManagerLink to="/#/web/exchange">questo link</ManagerLink> per accedere alla sezione <code className="action">Exchange</code>. Il nome del server viene visualizzato nella zona **Connessione** della scheda <code className="action">Informazioni generali</code>.
+</Region>
+
+<Region zones={['ca']}>
+Nel nostro esempio, usiamo il nome del server: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -102,7 +108,13 @@ Segui i passaggi successivi di configurazione scorrendo le schede seguenti:
     <img className="thumbnail" alt="exchange android" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-03.png" loading="lazy" />
   </Tab>
   <Tab label="Step 4">
+    <Region zones={['eu']}>
     Completa la pagina "**Configurazione dell’indirizzo**"<br/><br/>- **Email**: l’indirizzo email completo<br/>- **Password**: la password del tuo indirizzo email<br/>- **Certificato**: lascia "Nessuno"<br/>- **Dominio\Nome utente**: l’indirizzo email completo<br/>- **Server**: **ex?.mail.ovh.net** (sostituisci il server **?** per [numero del tuo server Exchange](#addaccount))<br/>- **Porta**: 443<br/>- **Tipo di sicurezza**: SSL/TLS<br/><br/>Clicca su <code className="action">Seguente</code> per confermare la configurazione.<br/><br/>
+    </Region>
+
+    <Region zones={['ca']}>
+    Completa la pagina "**Configurazione dell’indirizzo**"<br/><br/>- **Email**: l’indirizzo email completo<br/>- **Password**: la password del tuo indirizzo email<br/>- **Certificato**: lascia "Nessuno"<br/>- **Dominio\Nome utente**: l’indirizzo email completo<br/>- **Server**: **ex.mail.ovh.ca**<br/>- **Porta**: 443<br/>- **Tipo di sicurezza**: SSL/TLS<br/><br/>Clicca su <code className="action">Seguente</code> per confermare la configurazione.<br/><br/>
+    </Region>
     <img className="thumbnail" alt="exchange android" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-04.png" loading="lazy" />
   </Tab>
   <Tab label="Step 5">

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
@@ -48,9 +48,15 @@ Questa guida ti aiuta a eseguire le operazioni necessarie sul tuo sito. Tuttavia
 ### Aggiungi l’account <a name="addaccount"></a>
 
 :::warning
+<Region zones={['eu']}>
 Nel nostro esempio, usiamo il nome del server: ex?.mail.ovh.net. Dovrai sostituire il "?" dalla cifra che indica il server del tuo servizio Exchange.
 
 Clicca su <ManagerLink to="/#/web/exchange">questo link</ManagerLink> per accedere alla sezione <code className="action">Exchange</code>. Il nome del server viene visualizzato nella zona **Connessione** della scheda <code className="action">Informazioni generali</code>.
+</Region>
+
+<Region zones={['ca']}>
+Nel nostro esempio, usiamo il nome del server: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -63,12 +69,27 @@ Sulla schermata Home del tuo dispositivo clicca su <code className="action">Impo
 
 - **Per le versioni iOS 14 e successive**: seguire le istruzioni riportate nella tabella seguente.
 
+<Region zones={['eu']}>
+
 | | |
 |---|---|
 |<video className="thumbnail" autoPlay loop muted playsInline aria-label="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. Nelle `Impostazioni`, vai su `Mail`. <br/><br/> 2. Premi su `Account`.<br/><br/> 3. Clicca su `Aggiungi account`.<br/><br/> 4. Scegli `Microsoft Exchange`.|
 |5. Inserisci il tuo **indirizzo email** e una **descrizione** del tuo account email, clicca su `Avanti`.<br/><br/>6. Seleziona `Configurazione manuale`.<br/><br/>|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
 |<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Inserisci: <br/>- il server **ex?.mail.ovh.net** (sostituisci il server **?** per [numero del tuo server Exchange](#addaccount))<br/>- il tuo **indirizzo email completo** nel nome utente <br/>- la password del tuo indirizzo email|
 |8. Assicurati di lasciare almeno <code className="action">Selezionata Mail</code> affinché l'applicazione possa utilizzare questo account. Le altre applicazioni, come *Calendario* e *Note*, possono utilizzare alcune delle funzionalità collaborative legate ad Exchange.<br/><br/>9. Clicca su `Salva` per completare l'aggiunta del tuo account Exchange.|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
+
+<Region zones={['ca']}>
+
+| | |
+|---|---|
+|<video className="thumbnail" autoPlay loop muted playsInline aria-label="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. Nelle `Impostazioni`, vai su `Mail`. <br/><br/> 2. Premi su `Account`.<br/><br/> 3. Clicca su `Aggiungi account`.<br/><br/> 4. Scegli `Microsoft Exchange`.|
+|5. Inserisci il tuo **indirizzo email** e una **descrizione** del tuo account email, clicca su `Avanti`.<br/><br/>6. Seleziona `Configurazione manuale`.<br/><br/>|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
+|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Inserisci: <br/>- il server **ex.mail.ovh.ca**<br/>- il tuo **indirizzo email completo** nel nome utente <br/>- la password del tuo indirizzo email|
+|8. Assicurati di lasciare almeno <code className="action">Selezionata Mail</code> affinché l'applicazione possa utilizzare questo account. Le altre applicazioni, come *Calendario* e *Note*, possono utilizzare alcune delle funzionalità collaborative legate ad Exchange.<br/><br/>9. Clicca su `Salva` per completare l'aggiunta del tuo account Exchange.|<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
 
 Per verificare la corretta configurazione dell’account esegui un test di invio.
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
@@ -53,9 +53,15 @@ Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione de
 ### Aggiungi l’account <a name="addaccount"></a>
 
 :::warning
+<Region zones={['eu']}>
 Nel nostro esempio, usiamo il nome del server: ex?.mail.ovh.net. Dovrai sostituire il "?" dalla cifra che indica il server del tuo servizio Exchange.
 
 Clicca su <ManagerLink to="/#/web/exchange">questo link</ManagerLink> per accedere alla sezione <code className="action">Exchange</code>. Il nome del server viene visualizzato nella zona **Connessione** della scheda <code className="action">Informazioni generali</code>.
+</Region>
+
+<Region zones={['ca']}>
+Nel nostro esempio, usiamo il nome del server: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -78,7 +84,13 @@ Clicca su <ManagerLink to="/#/web/exchange">questo link</ManagerLink> per accede
     <img className="thumbnail" alt="mailmac" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos/mail-mac-exchange03.png" loading="lazy" />
   </Tab>
   <Tab label="Step 4">
+    <Region zones={['eu']}>
     Inserisci: <br/><br/>- Indirizzo email: lascia l’indirizzo email completo<br/>- Nome utente: lascia l’indirizzo email completo <br/>- Password: lascia la tua **password**<br/> - URL interno: **ex?.mail.ovh.net** (sostituisci il **?** con [il numero del tuo server Exchange](#addaccount))<br/>- URL esterno: **ex?.mail.ovh.net** (sostituisci il **?** con il numero del [tuo server Exchange](#addaccount))<br/><br/>
+    </Region>
+
+    <Region zones={['ca']}>
+    Inserisci: <br/><br/>- Indirizzo email: lascia l’indirizzo email completo<br/>- Nome utente: lascia l’indirizzo email completo <br/>- Password: lascia la tua **password**<br/> - URL interno: **ex.mail.ovh.ca**<br/>- URL esterno: **ex.mail.ovh.ca**<br/><br/>
+    </Region>
     
     :::warning
     È normale vedere apparire il messaggio in rosso "**Impossibile controllare il nome o la password dell'account**" quando viene visualizzata la prima finestra. Tuttavia, se il messaggio persiste dopo la convalida, significa che le informazioni immesse sono errate.<br/><br/>

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
@@ -55,9 +55,15 @@ Se riscontri difficoltà nell'esecuzione di queste operazioni, ti consigliamo di
 ## Procedura
 
 :::info
+<Region zones={['eu']}>
 Nel nostro esempio, utilizziamo il nome del server: ex?.mail.ovh.net. Dovrai sostituire il "?" con il numero che identifica il server del tuo servizio Exchange.
 
 Clicca su <ManagerLink to="/#/web/exchange">questo link</ManagerLink> per accedere alla sezione <code className="action">Exchange</code>. Il nome del server viene visualizzato nella zona **Connessione** della scheda <code className="action">Informazioni generali</code>.
+</Region>
+
+<Region zones={['ca']}>
+Nel nostro esempio, utilizziamo il nome del server: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -93,27 +99,61 @@ Segui le fasi di configurazione cliccando successivamente sui **5** tab sottosta
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Passagio 3">
+    <Region zones={['eu']}>
+
     Impostazioni del server di ricezione:
-    
+
      - **Protocollo** : IMAP
      - **Nome host** : ex?.mail.ovh.net (sostituisci il "?" con il numero del tuo server)
      - **Porta** : 993
      - **Sicurezza della connessione** : SSL/TLS
      - **Metodo di autenticazione** : Password normale
      - **Nome utente** : Il tuo indirizzo e-mail completo
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Impostazioni del server di ricezione:
+
+     - **Protocollo** : IMAP
+     - **Nome host** : ex.mail.ovh.ca
+     - **Porta** : 993
+     - **Sicurezza della connessione** : SSL/TLS
+     - **Metodo di autenticazione** : Password normale
+     - **Nome utente** : Il tuo indirizzo e-mail completo
+
+    </Region>
+
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Passagio 4">
+    <Region zones={['eu']}>
+
     Impostazioni del server di invio:
-    
+
      - **Protocollo** : SMTP 
      - **Nome host** : ex?.mail.ovh.net (sostituisci il "?" con il numero del tuo server)
      - **Porta** : 587
      - **Sicurezza della connessione** : STARTTLS
      - **Metodo di autenticazione** : Password normale
      - **Nome utente** : Il tuo indirizzo e-mail completo
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Impostazioni del server di invio:
+
+     - **Protocollo** : SMTP 
+     - **Nome host** : ex.mail.ovh.ca
+     - **Porta** : 587
+     - **Sicurezza della connessione** : STARTTLS
+     - **Metodo di autenticazione** : Password normale
+     - **Nome utente** : Il tuo indirizzo e-mail completo
+
+    </Region>
+
     1. Clicca su <code className="action">Testa</code> per verificare le impostazioni inserite.
     2. Clicca su <code className="action">Continua</code> per confermare queste impostazioni.
     
@@ -132,6 +172,8 @@ Segui le fasi di configurazione cliccando successivamente sui **5** tab sottosta
 
 Se desideri una configurazione POP per il tuo indirizzo e-mail, sostituisci le impostazioni del **passagio 3** con le seguenti:
 
+<Region zones={['eu']}>
+
 Impostazioni del server di ricezione:
 
 - **Protocollo** : POP3
@@ -141,19 +183,22 @@ Impostazioni del server di ricezione:
 - **Metodo di autenticazione** : Password normale
 - **Nome utente** : Il tuo indirizzo e-mail completo
 
+</Region>
+
+<Region zones={['ca']}>
+
+Impostazioni del server di ricezione:
+
+- **Protocollo** : POP3
+- **Nome host** : ex.mail.ovh.ca
+- **Porta** : 995
+- **Sicurezza della connessione** : SSL/TLS
+- **Metodo di autenticazione** : Password normale
+- **Nome utente** : Il tuo indirizzo e-mail completo
+
+</Region>
+
 :::
-
-**Configurazione POP**
-
-- Se desideri una configurazione POP per il tuo indirizzo e-mail, sostituisci le impostazioni del passagio 3 con le seguenti:
-- Impostazioni del server di ricezione:
-- Protocollo : POP3
-- Nome host : ex?.mail.ovh.net (sostituisci il '?' con il numero del tuo server)
-- Porta : 995
-- Sicurezza della connessione : SSL/TLS
-- Metodo di autenticazione : Password normale
-- Nome utente : Il tuo indirizzo e-mail completo
-
 
 ### Utilizzare l'indirizzo e-mail
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
@@ -55,9 +55,15 @@ Se riscontri difficoltà nell'esecuzione di queste operazioni, ti consigliamo di
 ## Procedura
 
 :::info
+<Region zones={['eu']}>
 Nel nostro esempio, utilizziamo il nome del server: ex?.mail.ovh.net. Dovrai sostituire il "?" con il numero che identifica il server del tuo servizio Exchange.
 
 Clicca su <ManagerLink to="/#/web/exchange">questo link</ManagerLink> per accedere alla sezione <code className="action">Exchange</code>. Il nome del server viene visualizzato nella zona **Connessione** della scheda <code className="action">Informazioni generali</code>.
+</Region>
+
+<Region zones={['ca']}>
+Nel nostro esempio, utilizziamo il nome del server: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -93,27 +99,61 @@ Segui le fasi di configurazione cliccando successivamente sui **5** tab sottosta
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Passagio 3">
+    <Region zones={['eu']}>
+
     Impostazioni del server di ricezione:
-    
+
      - **Protocollo** : IMAP
      - **Nome host** : ex?.mail.ovh.net (sostituisci il "?" con il numero del tuo server)
      - **Porta** : 993
      - **Sicurezza della connessione** : SSL/TLS
      - **Metodo di autenticazione** : Password normale
      - **Nome utente** : Il tuo indirizzo e-mail completo
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Impostazioni del server di ricezione:
+
+     - **Protocollo** : IMAP
+     - **Nome host** : ex.mail.ovh.ca
+     - **Porta** : 993
+     - **Sicurezza della connessione** : SSL/TLS
+     - **Metodo di autenticazione** : Password normale
+     - **Nome utente** : Il tuo indirizzo e-mail completo
+
+    </Region>
+
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Passagio 4">
+    <Region zones={['eu']}>
+
     Impostazioni del server di invio:
-    
+
      - **Protocollo** : SMTP 
      - **Nome host** : ex?.mail.ovh.net (sostituisci il "?" con il numero del tuo server)
      - **Porta** : 587
      - **Sicurezza della connessione** : STARTTLS
      - **Metodo di autenticazione** : Password normale
      - **Nome utente** : Il tuo indirizzo e-mail completo
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Impostazioni del server di invio:
+
+     - **Protocollo** : SMTP 
+     - **Nome host** : ex.mail.ovh.ca
+     - **Porta** : 587
+     - **Sicurezza della connessione** : STARTTLS
+     - **Metodo di autenticazione** : Password normale
+     - **Nome utente** : Il tuo indirizzo e-mail completo
+
+    </Region>
+
     1. Clicca su <code className="action">Testa</code> per verificare le impostazioni inserite.
     2. Clicca su <code className="action">Continua</code> per confermare queste impostazioni.
     
@@ -132,6 +172,8 @@ Segui le fasi di configurazione cliccando successivamente sui **5** tab sottosta
 
 Se desideri una configurazione POP per il tuo indirizzo e-mail, sostituisci le impostazioni del **passagio 3** con le seguenti:
 
+<Region zones={['eu']}>
+
 Impostazioni del server di ricezione:
 
 - **Protocollo** : POP3
@@ -140,6 +182,21 @@ Impostazioni del server di ricezione:
 - **Sicurezza della connessione** : SSL/TLS
 - **Metodo di autenticazione** : Password normale
 - **Nome utente** : Il tuo indirizzo e-mail completo
+
+</Region>
+
+<Region zones={['ca']}>
+
+Impostazioni del server di ricezione:
+
+- **Protocollo** : POP3
+- **Nome host** : ex.mail.ovh.ca
+- **Porta** : 995
+- **Sicurezza della connessione** : SSL/TLS
+- **Metodo di autenticazione** : Password normale
+- **Nome utente** : Il tuo indirizzo e-mail completo
+
+</Region>
 
 :::
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
@@ -94,15 +94,33 @@ Ten błąd wskazuje, że e-maile nie mogą zostać odebrane i będzie również 
 
 Następujące serwery MX są ważne w zależności od korzystania z usługi Exchange:
 
+<Region zones={['eu']}>
+
 - Tylko Exchange: mx0.mail.ovh.net, mx1.mail.ovh.net mx2.mail.ovh.net, mx3.mail.ovh.net & mx4.mail.ovh.net
 - Exchange + E-mail POP/IMAP hostowany przez OVHcloud: mx0.mail.ovh.net, mx1.mail.ovh.net mx2.mail.ovh.net, mx3.mail.ovh.net & mx4.mail.ovh.net
 - Exchange + E-mail POP/IMAP nie obsługiwany przez OVHcloud: ex<b>?</b>.mail.ovh.net
 
+</Region>
+
+<Region zones={['ca']}>
+
+- Tylko Exchange: mx0.mail.ovh.ca, mx1.mail.ovh.ca mx2.mail.ovh.ca, mx3.mail.ovh.ca & mx4.mail.ovh.ca
+- Exchange + E-mail POP/IMAP hostowany przez OVHcloud: mx0.mail.ovh.ca, mx1.mail.ovh.ca mx2.mail.ovh.ca, mx3.mail.ovh.ca & mx4.mail.ovh.ca
+- Exchange + E-mail POP/IMAP nie obsługiwany przez OVHcloud: ex.mail.ovh.ca
+
+</Region>
+
 <a name="hostname"></a>
 
 :::warning
+<Region zones={['eu']}>
 W przewodnikach wykorzystujemy jako nazwę serwera: na przykład ex<b>?</b>.mail.ovh.net. Chcesz zastąpić "?" przez numer odpowiadający serwerowi usługi Exchange.<br/>
 Informacje te znajdziesz w Panelu klienta OVHcloud, w sekcji <code className="action">Web Cloud</code>.  Otwórz <code className="action">Exchange</code> i wybierz Twoją usługę. Nazwa serwera wyświetla się w strefie **Logowanie** w zakładce <code className="action">Informacje ogólne</code>.
+</Region>
+
+<Region zones={['ca']}>
+W przewodnikach wykorzystujemy jako nazwę serwera: na przykład ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -121,6 +139,8 @@ Możesz sprawdzić te parametry w [strefie DNS Twojej domeny](/guides/web-cloud/
 
 Oto wartości dla usługi Exchange:
 
+<Region zones={['eu']}>
+
 Pole | Wartość
 ------------ | -------------
 Subdomena | _autodiscover._tcp
@@ -128,6 +148,20 @@ Priorytet | 0
 Waga | 0
 Port | 443
 Adres docelowy | [ex<b>?</b>.mail.ovh.net](#hostname)(zastąp "?" za numer odpowiadający serwerowi usługi Exchange)
+
+</Region>
+
+<Region zones={['ca']}>
+
+Pole | Wartość
+------------ | -------------
+Subdomena | _autodiscover._tcp
+Priorytet | 0
+Waga | 0
+Port | 443
+Adres docelowy | [ex.mail.ovh.ca](#hostname)
+
+</Region>
 
 ### E-mail testowy nie mógł zostać wysłany z konta
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
@@ -60,9 +60,15 @@ Niniejszy przewodnik został stworzony na urządzeniu korzystającym z wersji 13
 ### Jak dodać konto e-mail
 
 :::warning
+<Region zones={['eu']}>
 Poniżej stosujemy przykładową nazwę serwera: ex?.mail.ovh.net. Chcesz zastąpić "?" cyfrą wskazującą serwer Twojej usługi Exchange.
 
 Kliknij <ManagerLink to="/#/web/exchange">ten link</ManagerLink>, aby uzyskać dostęp do sekcji <code className="action">Exchange</code>. Nazwa serwera wyświetla się w strefie **Połączenie** w zakładce <code className="action">Informacje ogólne</code>.
+</Region>
+
+<Region zones={['ca']}>
+Poniżej stosujemy przykładową nazwę serwera: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -103,7 +109,13 @@ Postępuj zgodnie z kolejnymi instrukcjami, przechodząc przez poniższe karty:
     <img className="thumbnail" alt="Exchange Android" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-03.png" loading="lazy" />
   </Tab>
   <Tab label="Etap 4">
+    <Region zones={['eu']}>
     Uzupełnij stronę "**Konfiguracja adresu**"<br/><br/>- **E-mail**: Twój kompletny adres e-mail<br/>- **Hasło**: hasło do Twojego konta e-mail<br/>- **Certyfikat**: zostaw "Brak"<br/>- **Domena\Nazwa użytkownika**: Twój kompletny adres e-mail<br/>- **Serwer** : **ex?.mail.ovh.net** ( zastąp **?** przez [numer serwera Exchange](#addaccount))<br/>- **Port**: 443<br/>- **Rodzaj zabezpieczenia**: SSL/TLS<br/><br/>Kliknij <code className="action">Dalej</code>, aby zatwierdzić konfigurację.<br/><br/>
+    </Region>
+
+    <Region zones={['ca']}>
+    Uzupełnij stronę "**Konfiguracja adresu**"<br/><br/>- **E-mail**: Twój kompletny adres e-mail<br/>- **Hasło**: hasło do Twojego konta e-mail<br/>- **Certyfikat**: zostaw "Brak"<br/>- **Domena\Nazwa użytkownika**: Twój kompletny adres e-mail<br/>- **Serwer** : **ex.mail.ovh.ca**<br/>- **Port**: 443<br/>- **Rodzaj zabezpieczenia**: SSL/TLS<br/><br/>Kliknij <code className="action">Dalej</code>, aby zatwierdzić konfigurację.<br/><br/>
+    </Region>
     <img className="thumbnail" alt="Exchange Android" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-04.png" loading="lazy" />
   </Tab>
   <Tab label="Etap 5">

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
@@ -49,9 +49,15 @@ Niniejszy przewodnik ułatwi Ci realizację bieżących zadań. W przypadku trud
 ### Dodaj konto <a name="addaccount"></a>
 
 :::warning
+<Region zones={['eu']}>
 Poniżej stosujemy przykładową nazwę serwera: ex?.mail.ovh.net. Chcesz zastąpić "?" cyfrą wskazującą serwer Twojej usługi Exchange.
 
 Kliknij <ManagerLink to="/#/web/exchange">ten link</ManagerLink>, aby uzyskać dostęp do sekcji <code className="action">Exchange</code>. Nazwa serwera wyświetla się w strefie **Połączenie** w zakładce <code className="action">Informacje ogólne</code>.
+</Region>
+
+<Region zones={['ca']}>
+Poniżej stosujemy przykładową nazwę serwera: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -64,12 +70,27 @@ Na ekranie Twojego urządzenia wybierz <code className="action">Ustawienia</code
 
 - **Dla wersji iOS 14 i nowszych** wersji: postępuj zgodnie z instrukcjami z poniższej tabeli.
 
+<Region zones={['eu']}>
+
 | | |
 |---|---|
 |<video className="thumbnail" autoPlay loop muted playsInline aria-label="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. W `Ustawieniach` przejdź do `Mail`. <br/><br/> 2. Kliknij `Konta`.<br/><br/> 3. Kliknij `Dodaj konto`.<br/><br/> 4. Wybierz `Microsoft Exchange`.|
 |5. Wpisz swój **adres e-mail** i **opis** konta e-mail, naciśnij przycisk `Dalej`.<br/><br/>6. Wybierz `Konfigurację ręczną`.<br/><br/>|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
 |<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Wpisz: <br/>- serwer **ex?.mail.ovh.net** ( zastąp **?** przez [numer serwera Exchange](#addaccount)) <br/>- Twój **kompletny adres e-mail** w nazwie użytkownika <br/>- hasło do Twojego konta e-mail|
 |8. Upewnij się, czy zaznaczyłeś co najmniej <code className="action">Mail</code>, aby aplikacja mogła korzystać z tego konta. Pozostałe aplikacje (jak *Kalendarz* czy *Notatki*) mogą używać niektórych funkcji do pracy zespołowej dostępnych w programie Exchange.<br/><br/>9. Kliknij `Zapisz`, aby dokończyć dodawanie konta exchange.|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
+
+<Region zones={['ca']}>
+
+| | |
+|---|---|
+|<video className="thumbnail" autoPlay loop muted playsInline aria-label="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. W `Ustawieniach` przejdź do `Mail`. <br/><br/> 2. Kliknij `Konta`.<br/><br/> 3. Kliknij `Dodaj konto`.<br/><br/> 4. Wybierz `Microsoft Exchange`.|
+|5. Wpisz swój **adres e-mail** i **opis** konta e-mail, naciśnij przycisk `Dalej`.<br/><br/>6. Wybierz `Konfigurację ręczną`.<br/><br/>|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
+|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Wpisz: <br/>- serwer **ex.mail.ovh.ca** <br/>- Twój **kompletny adres e-mail** w nazwie użytkownika <br/>- hasło do Twojego konta e-mail|
+|8. Upewnij się, czy zaznaczyłeś co najmniej <code className="action">Mail</code>, aby aplikacja mogła korzystać z tego konta. Pozostałe aplikacje (jak *Kalendarz* czy *Notatki*) mogą używać niektórych funkcji do pracy zespołowej dostępnych w programie Exchange.<br/><br/>9. Kliknij `Zapisz`, aby dokończyć dodawanie konta exchange.|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
 
 Wykonaj test wysyłki e-maili, aby sprawdzić, czy konto zostało poprawnie skonfigurowane.
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
@@ -53,9 +53,15 @@ Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonyw
 ### Dodaj konto <a name="addaccount"></a>
 
 :::warning
+<Region zones={['eu']}>
 Poniżej stosujemy przykładową nazwę serwera: ex?.mail.ovh.net. Chcesz zastąpić "?" cyfrą wskazującą serwer Twojej usługi Exchange.
 
 Kliknij <ManagerLink to="/#/web/exchange">ten link</ManagerLink>, aby uzyskać dostęp do sekcji <code className="action">Exchange</code>. Nazwa serwera wyświetla się w strefie **Połączenie** w zakładce <code className="action">Informacje ogólne</code>.
+</Region>
+
+<Region zones={['ca']}>
+Poniżej stosujemy przykładową nazwę serwera: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -78,8 +84,14 @@ Kliknij <ManagerLink to="/#/web/exchange">ten link</ManagerLink>, aby uzyskać d
     <img className="thumbnail" alt="MailMac" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos/mail-mac-exchange03.png" loading="lazy" />
   </Tab>
   <Tab label="Etap 4">
+    <Region zones={['eu']}>
     Wpisz: <br/><br/>- Adres e-mail: pozostaw pełny adres e-mail<br/>- Nazwa użytkownika: pozostaw pełny adres e-mail <br/>- Hasło: zostaw swoje **hasło**<br/> - Wewnętrzny adres URL: **ex?.mail.ovh.net** (zmień **?** na [numer serwera Exchange](#addaccount))<br/>- Zewnętrzny adres URL: **ex?.mail.ovh.net** (zmień **?** na [numer serwera Exchange](#addaccount))<br/><br/>
-    
+    </Region>
+
+    <Region zones={['ca']}>
+    Wpisz: <br/><br/>- Adres e-mail: pozostaw pełny adres e-mail<br/>- Nazwa użytkownika: pozostaw pełny adres e-mail <br/>- Hasło: zostaw swoje **hasło**<br/> - Wewnętrzny adres URL: **ex.mail.ovh.ca**<br/>- Zewnętrzny adres URL: **ex.mail.ovh.ca**<br/><br/>
+    </Region>
+
     :::warning
     Wiadomość jest wyświetlana na czerwono "**Nie można sprawdzić nazwy lub hasła konta**", gdy po raz pierwszy zostanie wyświetlone okno. Jeśli jednak ten komunikat będzie się powtarzać po zatwierdzeniu, wprowadzone informacje będą błędne.<br/><br/>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
@@ -55,9 +55,15 @@ Jeśli napotkasz trudności w wykonaniu tych czynności, zalecamy kontakt z [spe
 ## W praktyce
 
 :::info
+<Region zones={['eu']}>
 W naszym przykładzie używamy nazwy serwera: ex?.mail.ovh.net. Musisz zastąpić znak "?" numerem serwera swojej usługi Exchange.
 
 Kliknij <ManagerLink to="/#/web/exchange">ten link</ManagerLink>, aby uzyskać dostęp do sekcji <code className="action">Exchange</code>. Nazwa serwera wyświetla się w strefie **Połączenie** w zakładce <code className="action">Informacje ogólne</code>.
+</Region>
+
+<Region zones={['ca']}>
+W naszym przykładzie używamy nazwy serwera: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -93,27 +99,61 @@ Postępuj zgodnie z krokami konfiguracji, klikając kolejno poniższe **5** kart
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Krok 3">
+    <Region zones={['eu']}>
+
     Ustawienia serwera odbioru:
-    
+
      - **Protokół** : IMAP
      - **Nazwa hosta** : ex?.mail.ovh.net (zastąp znak "?" numerem swojego serwera)
      - **Port** : 993
      - **Zabezpieczenia połączenia** : SSL/TLS
      - **Metoda uwierzytelniania** : Normalne hasło
      - **Nazwa użytkownika** : Pełny adres e-mail
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Ustawienia serwera odbioru:
+
+     - **Protokół** : IMAP
+     - **Nazwa hosta** : ex.mail.ovh.ca
+     - **Port** : 993
+     - **Zabezpieczenia połączenia** : SSL/TLS
+     - **Metoda uwierzytelniania** : Normalne hasło
+     - **Nazwa użytkownika** : Pełny adres e-mail
+
+    </Region>
+
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Krok 4">
+    <Region zones={['eu']}>
+
     Ustawienia serwera wysyłania:
-    
+
      - **Protokół** : SMTP 
      - **Nazwa hosta** : ex?.mail.ovh.net (zastąp znak "?" numerem swojego serwera)
      - **Port** : 587
      - **Zabezpieczenia połączenia** : STARTTLS
      - **Metoda uwierzytelniania** : Normalne hasło
      - **Nazwa użytkownika** : Pełny adres e-mail
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Ustawienia serwera wysyłania:
+
+     - **Protokół** : SMTP 
+     - **Nazwa hosta** : ex.mail.ovh.ca
+     - **Port** : 587
+     - **Zabezpieczenia połączenia** : STARTTLS
+     - **Metoda uwierzytelniania** : Normalne hasło
+     - **Nazwa użytkownika** : Pełny adres e-mail
+
+    </Region>
+
     1. Kliknij <code className="action">Testuj</code>, aby zweryfikować wprowadzone ustawienia.
     2. Kliknij <code className="action">Dalej</code>, aby potwierdzić te ustawienia.
     
@@ -132,6 +172,8 @@ Postępuj zgodnie z krokami konfiguracji, klikając kolejno poniższe **5** kart
 
 Jeśli chcesz skonfigurować POP dla swojego adresu e-mail, zastąp ustawienia **kroku 3** następującymi:
 
+<Region zones={['eu']}>
+
 Ustawienia serwera odbioru:
 
 - **Protokół** : POP3
@@ -141,21 +183,22 @@ Ustawienia serwera odbioru:
 - **Metoda uwierzytelniania** : Normalne hasło
 - **Nazwa użytkownika** : Pełny adres e-mail
 
-:::
+</Region>
 
-**Konfiguracja POP**
-
-Jeśli chcesz skonfigurować POP dla swojego adresu e-mail, zastąp ustawienia kroku 3 następującymi:
+<Region zones={['ca']}>
 
 Ustawienia serwera odbioru:
 
-- Protokół : POP3
-- Nazwa hosta : ex?.mail.ovh.net (zastąp znak '?' numerem swojego serwera)
-- Port : 995
-- Zabezpieczenia połączenia : SSL/TLS
-- Metoda uwierzytelniania : Normalne hasło
-- Nazwa użytkownika : Pełny adres e-mail
+- **Protokół** : POP3
+- **Nazwa hosta** : ex.mail.ovh.ca
+- **Port** : 995
+- **Zabezpieczenia połączenia** : SSL/TLS
+- **Metoda uwierzytelniania** : Normalne hasło
+- **Nazwa użytkownika** : Pełny adres e-mail
 
+</Region>
+
+:::
 
 ### Używanie adresu e-mail
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
@@ -55,9 +55,15 @@ Jeśli napotkasz trudności w wykonaniu tych czynności, zalecamy kontakt z [spe
 ## W praktyce
 
 :::info
+<Region zones={['eu']}>
 W naszym przykładzie używamy nazwy serwera: ex?.mail.ovh.net. Musisz zastąpić znak "?" numerem serwera swojej usługi Exchange.
 
 Kliknij <ManagerLink to="/#/web/exchange">ten link</ManagerLink>, aby uzyskać dostęp do sekcji <code className="action">Exchange</code>. Nazwa serwera wyświetla się w strefie **Połączenie** w zakładce <code className="action">Informacje ogólne</code>.
+</Region>
+
+<Region zones={['ca']}>
+W naszym przykładzie używamy nazwy serwera: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -93,27 +99,61 @@ Postępuj zgodnie z krokami konfiguracji, klikając kolejno poniższe **5** kart
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Krok 3">
+    <Region zones={['eu']}>
+
     Ustawienia serwera odbioru:
-    
+
      - **Protokół** : IMAP
      - **Nazwa hosta** : ex?.mail.ovh.net (zastąp znak "?" numerem swojego serwera)
      - **Port** : 993
      - **Zabezpieczenia połączenia** : SSL/TLS
      - **Metoda uwierzytelniania** : Normalne hasło
      - **Nazwa użytkownika** : Pełny adres e-mail
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Ustawienia serwera odbioru:
+
+     - **Protokół** : IMAP
+     - **Nazwa hosta** : ex.mail.ovh.ca
+     - **Port** : 993
+     - **Zabezpieczenia połączenia** : SSL/TLS
+     - **Metoda uwierzytelniania** : Normalne hasło
+     - **Nazwa użytkownika** : Pełny adres e-mail
+
+    </Region>
+
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Krok 4">
+    <Region zones={['eu']}>
+
     Ustawienia serwera wysyłania:
-    
+
      - **Protokół** : SMTP 
      - **Nazwa hosta** : ex?.mail.ovh.net (zastąp znak "?" numerem swojego serwera)
      - **Port** : 587
      - **Zabezpieczenia połączenia** : STARTTLS
      - **Metoda uwierzytelniania** : Normalne hasło
      - **Nazwa użytkownika** : Pełny adres e-mail
-    
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Ustawienia serwera wysyłania:
+
+     - **Protokół** : SMTP 
+     - **Nazwa hosta** : ex.mail.ovh.ca
+     - **Port** : 587
+     - **Zabezpieczenia połączenia** : STARTTLS
+     - **Metoda uwierzytelniania** : Normalne hasło
+     - **Nazwa użytkownika** : Pełny adres e-mail
+
+    </Region>
+
     1. Kliknij <code className="action">Testuj</code>, aby zweryfikować wprowadzone ustawienia.
     2. Kliknij <code className="action">Dalej</code>, aby potwierdzić te ustawienia.
     
@@ -132,6 +172,8 @@ Postępuj zgodnie z krokami konfiguracji, klikając kolejno poniższe **5** kart
 
 Jeśli chcesz skonfigurować POP dla swojego adresu e-mail, zastąp ustawienia **kroku 3** następującymi:
 
+<Region zones={['eu']}>
+
 Ustawienia serwera odbioru:
 
 - **Protokół** : POP3
@@ -140,6 +182,21 @@ Ustawienia serwera odbioru:
 - **Zabezpieczenia połączenia** : SSL/TLS
 - **Metoda uwierzytelniania** : Normalne hasło
 - **Nazwa użytkownika** : Pełny adres e-mail
+
+</Region>
+
+<Region zones={['ca']}>
+
+Ustawienia serwera odbioru:
+
+- **Protokół** : POP3
+- **Nazwa hosta** : ex.mail.ovh.ca
+- **Port** : 995
+- **Zabezpieczenia połączenia** : SSL/TLS
+- **Metoda uwierzytelniania** : Normalne hasło
+- **Nazwa użytkownika** : Pełny adres e-mail
+
+</Region>
 
 :::
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced.mdx
@@ -94,15 +94,33 @@ Este erro indica que os e-mails não podem ser recebidos e estará também assoc
 
 Em função da utilização do seu serviço Exchange, os seguintes servidores MX são válidos:
 
+<Region zones={['eu']}>
+
 - Exchange sozinho: mx0.mail.ovh.net, mx1.mail.ovh.net mx2.mail.ovh.net, mx3.mail.ovh.net & mx4.mail.ovh.net
 - Exchange + E-mail POP/IMAP alojado pela OVHcloud: mx0.mail.ovh.net, mx1.mail.ovh.net mx2.mail.ovh.net, mx3.mail.ovh.net & mx4.mail.ovh.net
 - Exchange + E-mail POP/IMAP não alojado pela OVHcloud: ex<b>?</b>.mail.ovh.net
 
+</Region>
+
+<Region zones={['ca']}>
+
+- Exchange sozinho: mx0.mail.ovh.ca, mx1.mail.ovh.ca mx2.mail.ovh.ca, mx3.mail.ovh.ca & mx4.mail.ovh.ca
+- Exchange + E-mail POP/IMAP alojado pela OVHcloud: mx0.mail.ovh.ca, mx1.mail.ovh.ca mx2.mail.ovh.ca, mx3.mail.ovh.ca & mx4.mail.ovh.ca
+- Exchange + E-mail POP/IMAP não alojado pela OVHcloud: ex.mail.ovh.ca
+
+</Region>
+
 <a name="hostname"></a>
 
 :::warning
+<Region zones={['eu']}>
 Nos nossos guias, utilizamos como nome de servidor: ex<b>?</b>.mail.ovh.net. Deverá substituir o "? " pelo número correspondente ao servidor do seu serviço Exchange.<br/>
 Encontrará estas informações na Área de Cliente OVHcloud, na secção <code className="action">Web Cloud</code>. Abra <code className="action">Exchange</code> e selecione o seu serviço. O nome do servidor aparece na zona **Ligação** do separador <code className="action">Informações gerais</code>.
+</Region>
+
+<Region zones={['ca']}>
+Nos nossos guias, utilizamos como nome de servidor: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -121,6 +139,8 @@ Pode verificar estes parâmetros na [zona DNS do seu domínio](/guides/web-cloud
 
 Eis os valores para um serviço Exchange:
 
+<Region zones={['eu']}>
+
 Campo | Valor
 ------------ | -------------
 Subdomínio | _autodiscover._tcp
@@ -128,6 +148,20 @@ Prioridade | 0
 Peso | 0
 Porta | 443
 Destino | [ex<b>?</b>.mail.ovh.net](#hostname)(substituir o "?" pelo número correspondente ao servidor do seu serviço Exchange)
+
+</Region>
+
+<Region zones={['ca']}>
+
+Campo | Valor
+------------ | -------------
+Subdomínio | _autodiscover._tcp
+Prioridade | 0
+Peso | 0
+Porta | 443
+Destino | [ex.mail.ovh.ca](#hostname)
+
+</Region>
 
 ### O e-mail de teste não pôde ser enviado a partir da conta
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
@@ -59,9 +59,15 @@ Esta documentação foi feita a partir de um dispositivo que utiliza a versão 1
 ### Como adicionar a sua conta de e-mail
 
 :::warning
+<Region zones={['eu']}>
 No nosso exemplo, utilizamos a menção servidor: ex?.mail.ovh.net. Deverá substituir o "?" pelo número que designa o servidor do seu serviço Exchange.
 
 Clique <ManagerLink to="/#/web/exchange">neste link</ManagerLink> para aceder à secção <code className="action">Exchange</code>. O nome do servidor é apresentado na zona **Ligação** do separador <code className="action">Informações gerais</code>.
+</Region>
+
+<Region zones={['ca']}>
+No nosso exemplo, utilizamos a menção servidor: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -102,7 +108,13 @@ Siga as etapas sucessivas de configuração, navegando nos separadores abaixo:
     <img className="thumbnail" alt="Exchange Android" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-03.png" loading="lazy" />
   </Tab>
   <Tab label="Etapa 4">
+    <Region zones={['eu']}>
     Preencha a página « **Configuração do Endereço** de »<br/><br/>- **E-mail**: o seu endereço de e-mail completo<br/>- **Palavra-passe**: a palavra-passe do seu e-mail<br/>- **Certificado**: « Nenhum »<br/>- **Domínio\Nome de utilizador**: o seu endereço de e-mail completo<br/>- **Servidor**: **ex?.mail.ovh.net** ( substitua o **?** por [o número do seu servidor Exchange](#addaccount))<br/>- **Porta**: 443<br/>- **Tipo de segurança**: SSL/TLS<br/><br/>Prima <code className="action">Seguinte</code> para validar a configuração.<br/><br/>
+    </Region>
+
+    <Region zones={['ca']}>
+    Preencha a página « **Configuração do Endereço** de »<br/><br/>- **E-mail**: o seu endereço de e-mail completo<br/>- **Palavra-passe**: a palavra-passe do seu e-mail<br/>- **Certificado**: « Nenhum »<br/>- **Domínio\Nome de utilizador**: o seu endereço de e-mail completo<br/>- **Servidor**: **ex.mail.ovh.ca**<br/>- **Porta**: 443<br/>- **Tipo de segurança**: SSL/TLS<br/><br/>Prima <code className="action">Seguinte</code> para validar a configuração.<br/><br/>
+    </Region>
     <img className="thumbnail" alt="Exchange Android" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android/exchange-android-04.png" loading="lazy" />
   </Tab>
   <Tab label="Etapa 5">

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios.mdx
@@ -48,9 +48,15 @@ Este guia explica como implementar algumas medidas para otimizar a performance e
 ### Adicionar a conta <a name="addaccount"></a>
 
 :::warning
+<Region zones={['eu']}>
 No nosso exemplo, utilizamos a menção servidor: ex?.mail.ovh.net. Deverá substituir o "?" pelo número que designa o servidor do seu serviço Exchange.
 
 Clique <ManagerLink to="/#/web/exchange">neste link</ManagerLink> para aceder à secção <code className="action">Exchange</code>. O nome do servidor é apresentado na zona **Ligação** do separador <code className="action">Informações gerais</code>.
+</Region>
+
+<Region zones={['ca']}>
+No nosso exemplo, utilizamos a menção servidor: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -63,12 +69,27 @@ No ecrã principal do seu dispositivo, aceda a <code className="action">Regulaç
 
 - **Para iOS versões 14 e superiore**: siga as instruções da tabela abaixo.
 
+<Region zones={['eu']}>
+
 | | |
 |---|---|
 |<video className="thumbnail" autoPlay loop muted playsInline aria-label="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. Em `Regulações`, aceda ao `Mail`. <br/><br/> 2. Carregue em `Contas`.<br/><br/> 3. Carregue em `Adicionar uma conta`.<br/><br/> 4. Escolha a `Microsoft Exchange`.|
 |5. Introduza o seu **endereço de e-mail** e uma **descrição** da sua conta de e-mail, aceda a `Seguinte`.<br/><br/>6. Selecione `Configuração manual`.<br/><br/>|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
 |<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Introduza: <br/>- o servidor **ex?.mail.ovh.net** ( substitua o **?** por [o número do seu servidor Exchange](#addaccount)) <br/>- o seu **endereço de e-mail completo** no nome de utilizador <br/>- a palavra-passe do seu endereço de e-mail|
 |8. Certifique-se de que tem um <code className="action">Mail</code> selecionado para que a aplicação possa utilizar esta conta. As outras aplicações (como *Calendar* e *Notes*) podem usar algumas das funções colaborativas inerentes ao Exchange.<br/><br/>9. Carregue em `Guardar` para finalizar a adição da sua conta exchange.|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
+
+<Region zones={['ca']}>
+
+| | |
+|---|---|
+|<video className="thumbnail" autoPlay loop muted playsInline aria-label="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step01.mp4" />|1. Em `Regulações`, aceda ao `Mail`. <br/><br/> 2. Carregue em `Contas`.<br/><br/> 3. Carregue em `Adicionar uma conta`.<br/><br/> 4. Escolha a `Microsoft Exchange`.|
+|5. Introduza o seu **endereço de e-mail** e uma **descrição** da sua conta de e-mail, aceda a `Seguinte`.<br/><br/>6. Selecione `Configuração manual`.<br/><br/>|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step02.png" loading="lazy" />|
+|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step03.png" loading="lazy" />|7. Introduza: <br/>- o servidor **ex.mail.ovh.ca** <br/>- o seu **endereço de e-mail completo** no nome de utilizador <br/>- a palavra-passe do seu endereço de e-mail|
+|8. Certifique-se de que tem um <code className="action">Mail</code> selecionado para que a aplicação possa utilizar esta conta. As outras aplicações (como *Calendar* e *Notes*) podem usar algumas das funções colaborativas inerentes ao Exchange.<br/><br/>9. Carregue em `Guardar` para finalizar a adição da sua conta exchange.|<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-ios/configuration-mailex-ios-step04.png" loading="lazy" />|
+
+</Region>
 
 Se quiser, pode efetuar um teste de envio para verificar se a conta está corretamente configurada.
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos.mdx
@@ -53,9 +53,15 @@ Este manual fornece as instruções necessárias para realizar as operações ma
 ### Adicionar a conta
 
 :::warning
+<Region zones={['eu']}>
 No nosso exemplo, utilizamos a menção servidor: ex?.mail.ovh.net. Deverá substituir o "?" pelo número que designa o servidor do seu serviço Exchange.
 
 Clique <ManagerLink to="/#/web/exchange">neste link</ManagerLink> para aceder à secção <code className="action">Exchange</code>. O nome do servidor é apresentado na zona **Ligação** do separador <code className="action">Informações gerais</code>.
+</Region>
+
+<Region zones={['ca']}>
+No nosso exemplo, utilizamos a menção servidor: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -78,7 +84,13 @@ Clique <ManagerLink to="/#/web/exchange">neste link</ManagerLink> para aceder à
     <img className="thumbnail" alt="mailmac" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-mail-macos/mail-mac-exchange03.png" loading="lazy" />
   </Tab>
   <Tab label="Etapa 4">
+    <Region zones={['eu']}>
     Introduza: <br/><br/>- Endereço de e-mail: Deixe o seu endereço de e-mail completo<br/>- Nome de utilizador: deixe o seu endereço de e-mail completo <br/>- Palavra-passe: deixe o seu **palavra-passe**<br/> - URL interno: **ex?.mail.ovh.net** (substitua o **?** por [número do seu servidor Exchange](#addaccount))<br/>- URL externo: **ex?.mail.ovh.net** (substitua o **?** por [número do seu servidor Exchange](#addaccount))<br/>
+    </Region>
+
+    <Region zones={['ca']}>
+    Introduza: <br/><br/>- Endereço de e-mail: Deixe o seu endereço de e-mail completo<br/>- Nome de utilizador: deixe o seu endereço de e-mail completo <br/>- Palavra-passe: deixe o seu **palavra-passe**<br/> - URL interno: **ex.mail.ovh.ca**<br/>- URL externo: **ex.mail.ovh.ca**<br/>
+    </Region>
     
     :::warning
     É normal que a mensagem seja apresentada a vermelho « **Não é possível verificar o nome de conta ou a palavra-passe** » quando a janela é apresentada pela primeira vez. No entanto, se esta mensagem persistir após a validação, as informações introduzidas estão incorretas.<br/><br/>

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
@@ -55,9 +55,15 @@ Se você tiver dificuldades ao executar estas operações, recomendamos que entr
 ## Instruções
 
 :::info
+<Region zones={['eu']}>
 No nosso exemplo, usamos o nome do servidor: ex?.mail.ovh.net. Você deverá substituir o "?" pelo número que identifica o servidor do seu serviço Exchange.
 
 Clique <ManagerLink to="/#/web/exchange">neste link</ManagerLink> para aceder à secção <code className="action">Exchange</code>. O nome do servidor é apresentado na zona **Ligação** do separador <code className="action">Informações gerais</code>.
+</Region>
+
+<Region zones={['ca']}>
+No nosso exemplo, usamos o nome do servidor: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -93,6 +99,8 @@ Siga as etapas de configuração clicando sucessivamente nos **5** abas abaixo:
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Etapa 3">
+    <Region zones={['eu']}>
+
     Configurações do servidor de recepção:
     
      - **Protocolo** : IMAP
@@ -101,10 +109,27 @@ Siga as etapas de configuração clicando sucessivamente nos **5** abas abaixo:
      - **Segurança da conexão** : SSL/TLS
      - **Método de autenticação** : Senha normal
      - **Nome de usuário** : Seu endereço de e-mail completo
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Configurações do servidor de recepção:
     
+     - **Protocolo** : IMAP
+     - **Nome do host** : ex.mail.ovh.ca
+     - **Porta** : 993
+     - **Segurança da conexão** : SSL/TLS
+     - **Método de autenticação** : Senha normal
+     - **Nome de usuário** : Seu endereço de e-mail completo
+
+    </Region>
+
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Etapa 4">
+    <Region zones={['eu']}>
+
     Configurações do servidor de envio:
     
      - **Protocolo** : SMTP 
@@ -113,7 +138,22 @@ Siga as etapas de configuração clicando sucessivamente nos **5** abas abaixo:
      - **Segurança da conexão** : STARTTLS
      - **Método de autenticação** : Senha normal
      - **Nome de usuário** : Seu endereço de e-mail completo
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Configurações do servidor de envio:
     
+     - **Protocolo** : SMTP 
+     - **Nome do host** : ex.mail.ovh.ca
+     - **Porta** : 587
+     - **Segurança da conexão** : STARTTLS
+     - **Método de autenticação** : Senha normal
+     - **Nome de usuário** : Seu endereço de e-mail completo
+
+    </Region>
+
     1. Clique em <code className="action">Testar</code> para verificar as configurações inseridas.
     2. Clique em <code className="action">Continuar</code> para confirmar estas configurações.
     
@@ -132,6 +172,8 @@ Siga as etapas de configuração clicando sucessivamente nos **5** abas abaixo:
 
 Se desejar uma configuração POP para seu endereço de e-mail, substitua as configurações do **etapa 3** pelas seguintes:
 
+<Region zones={['eu']}>
+
 Configurações do servidor de recepção:
 
 - **Protocolo** : POP3
@@ -141,19 +183,22 @@ Configurações do servidor de recepção:
 - **Método de autenticação** : Senha normal
 - **Nome de usuário** : Seu endereço de e-mail completo
 
+</Region>
+
+<Region zones={['ca']}>
+
+Configurações do servidor de recepção:
+
+- **Protocolo** : POP3
+- **Nome do host** : ex.mail.ovh.ca
+- **Porta** : 995
+- **Segurança da conexão** : SSL/TLS
+- **Método de autenticação** : Senha normal
+- **Nome de usuário** : Seu endereço de e-mail completo
+
+</Region>
+
 :::
-
-**Configuração POP**
-
-- Se desejar uma configuração POP para seu endereço de e-mail, substitua as configurações do etapa 3 pelas seguintes:
-- Configurações do servidor de recepção:
-- Protocolo : POP3
-- Nome do host : ex?.mail.ovh.net (substitua o '?' pelo número do seu servidor)
-- Porta : 995
-- Segurança da conexão : SSL/TLS
-- Método de autenticação : Senha normal
-- Nome de usuário : Seu endereço de e-mail completo
-
 
 ### Usar o endereço de e-mail
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/thunderbird-windows-configuration.mdx
@@ -55,9 +55,15 @@ Se você tiver dificuldades ao executar estas operações, recomendamos que entr
 ## Instruções
 
 :::info
+<Region zones={['eu']}>
 No nosso exemplo, usamos o nome do servidor: ex?.mail.ovh.net. Você deverá substituir o "?" pelo número que identifica o servidor do seu serviço Exchange.
 
 Clique <ManagerLink to="/#/web/exchange">neste link</ManagerLink> para aceder à secção <code className="action">Exchange</code>. O nome do servidor é apresentado na zona **Ligação** do separador <code className="action">Informações gerais</code>.
+</Region>
+
+<Region zones={['ca']}>
+No nosso exemplo, usamos o nome do servidor: ex.mail.ovh.ca.
+</Region>
 
 :::
 
@@ -93,6 +99,8 @@ Siga as etapas de configuração clicando sucessivamente nos **5** abas abaixo:
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-ssl0-03.png" loading="lazy" />
   </Tab>
   <Tab label="Etapa 3">
+    <Region zones={['eu']}>
+
     Configurações do servidor de recepção:
     
      - **Protocolo** : IMAP
@@ -101,10 +109,27 @@ Siga as etapas de configuração clicando sucessivamente nos **5** abas abaixo:
      - **Segurança da conexão** : SSL/TLS
      - **Método de autenticação** : Senha normal
      - **Nome de usuário** : Seu endereço de e-mail completo
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Configurações do servidor de recepção:
     
+     - **Protocolo** : IMAP
+     - **Nome do host** : ex.mail.ovh.ca
+     - **Porta** : 993
+     - **Segurança da conexão** : SSL/TLS
+     - **Método de autenticação** : Senha normal
+     - **Nome de usuário** : Seu endereço de e-mail completo
+
+    </Region>
+
     <img className="thumbnail" alt="thunderbird" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird/configuration-thunderbird-exchange-04.png" loading="lazy" />
   </Tab>
   <Tab label="Etapa 4">
+    <Region zones={['eu']}>
+
     Configurações do servidor de envio:
     
      - **Protocolo** : SMTP 
@@ -113,7 +138,22 @@ Siga as etapas de configuração clicando sucessivamente nos **5** abas abaixo:
      - **Segurança da conexão** : STARTTLS
      - **Método de autenticação** : Senha normal
      - **Nome de usuário** : Seu endereço de e-mail completo
+
+    </Region>
+
+    <Region zones={['ca']}>
+
+    Configurações do servidor de envio:
     
+     - **Protocolo** : SMTP 
+     - **Nome do host** : ex.mail.ovh.ca
+     - **Porta** : 587
+     - **Segurança da conexão** : STARTTLS
+     - **Método de autenticação** : Senha normal
+     - **Nome de usuário** : Seu endereço de e-mail completo
+
+    </Region>
+
     1. Clique em <code className="action">Testar</code> para verificar as configurações inseridas.
     2. Clique em <code className="action">Continuar</code> para confirmar estas configurações.
     
@@ -132,6 +172,8 @@ Siga as etapas de configuração clicando sucessivamente nos **5** abas abaixo:
 
 Se desejar uma configuração POP para seu endereço de e-mail, substitua as configurações do **etapa 3** pelas seguintes:
 
+<Region zones={['eu']}>
+
 Configurações do servidor de recepção:
 
 - **Protocolo** : POP3
@@ -140,6 +182,21 @@ Configurações do servidor de recepção:
 - **Segurança da conexão** : SSL/TLS
 - **Método de autenticação** : Senha normal
 - **Nome de usuário** : Seu endereço de e-mail completo
+
+</Region>
+
+<Region zones={['ca']}>
+
+Configurações do servidor de recepção:
+
+- **Protocolo** : POP3
+- **Nome do host** : ex.mail.ovh.ca
+- **Porta** : 995
+- **Segurança da conexão** : SSL/TLS
+- **Método de autenticação** : Senha normal
+- **Nome de usuário** : Seu endereço de e-mail completo
+
+</Region>
 
 :::
 


### PR DESCRIPTION
## What & why
The Hosted Microsoft Exchange server hostname is zone-specific:
- **EU**: `ex?.mail.ovh.net` (the `?` is the customer's server number)
- **CA**: `ex.mail.ovh.ca` (fixed hostname, no server number)

The new-docs migration exposed only the EU form to every zone, so CA readers
were shown the wrong server name. This PR gates each hostname reference per
zone with `<Region>`.

## Changes — 6 guides × 7 languages (42 files)
`how-to-configure-{ios,mail-macos,thunderbird-mac,android}`,
`thunderbird-windows-configuration`, `diagnostic-advanced`.

For each hostname reference:
- `<Region zones={['eu']}>` keeps `ex?.mail.ovh.net` + the "replace ?" note
- `<Region zones={['ca']}>` shows `ex.mail.ovh.ca` (note dropped — CA has no number)

Also in `diagnostic-advanced`: MX-record list zoned (`mx0-4.mail.ovh.net` → `.ca`
in the CA block). Removed a duplicated POP-config block in
`how-to-configure-thunderbird-mac` (pre-existing editing artifact).

## Source of truth
Legacy docs (`ovh/docs`) CA locales (`en-ca`/`fr-ca`/`en-us`/`es-us`) use `ex.mail.ovh.ca`.

## Validation
- All 42 files compile (MDX 3 + GFM).
- 0 `.net` hostname leaks outside an `eu` Region (region-state scan).

The landing-pages counterpart shipped in #220.