### PR TITLE
AI Endpoints - Detail reasoning_effort param

### DIFF
--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints-responses-api.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints-responses-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: AI Endpoints - Responses API
 description: Learn how to use OVHcloud AI Endpoints with the Responses API
-lastUpdated: 2026-02-24
+lastUpdated: 2026-06-22
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -919,7 +919,7 @@ Refer to the [Catalog](https://www.ovhcloud.com/en-gb/public-cloud/ai-endpoints/
 ### Reasoning models (`reasoning`)
 
 Some models expose reasoning-related controls.
-When supported, a `reasoning` object can be used to tune the reasoning effort and/or retrieve reasoning metadata.
+When supported, the `reasoning` object can be used to adjust the reasoning effort and/or retrieve reasoning metadata. Depending on the model, `reasoning_effort` may support the values `low`, `medium`, or `high`, and some models also allow reasoning to be disabled by setting `reasoning_effort` to `None`.
 
 :::info
 Reasoning parameters are model-specific. If you get validation errors, either remove `reasoning` or switch to a reasoning-capable model.


### PR DESCRIPTION
i will re-update this PR as `reasoning_effort` is only usable from v1/chat/completions endpoint, not v1/responses one 