### PR TITLE
fix(docs): normalize community links batch 3: Account & Service

### DIFF
--- a/docs/de/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
+++ b/docs/de/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
@@ -94,4 +94,4 @@ Using the API, you can set up a policy according to the following example:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/account-and-service-management/account-information/iam-permission-groups.mdx
+++ b/docs/de/guides/account-and-service-management/account-information/iam-permission-groups.mdx
@@ -5424,4 +5424,4 @@ This permission group does not cover the administration of a Public Cloud projec
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/account-and-service-management/account-information/iam-policies-api.mdx
+++ b/docs/de/guides/account-and-service-management/account-information/iam-policies-api.mdx
@@ -733,4 +733,4 @@ Here is a part of the output:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/account-and-service-management/account-information/iam-policy-ui.mdx
+++ b/docs/de/guides/account-and-service-management/account-information/iam-policy-ui.mdx
@@ -227,4 +227,4 @@ In einem Popup-Fenster werden Sie aufgefordert, den Löschvorgang zu bestätigen
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/account-and-service-management/account-information/overview.mdx
+++ b/docs/de/guides/account-and-service-management/account-information/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Weiterführende Informationen"
   items:
     - title: "OVHcloud Community besuchen"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog ansehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: "Discord beitreten"

--- a/docs/de/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
+++ b/docs/de/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
@@ -124,4 +124,4 @@ Beachten Sie dazu unsere Anleitung zur [Verwaltung der IAM-Richtlinien](/guides/
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/account-and-service-management/account-information/use-plik.mdx
+++ b/docs/de/guides/account-and-service-management/account-information/use-plik.mdx
@@ -93,4 +93,4 @@ Klicken Sie auf Ihre Kundenkennung oben rechts, um auf die Account-Optionen zuzu
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
+++ b/docs/de/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
@@ -160,4 +160,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/account-and-service-management/startup-program/overview.mdx
+++ b/docs/de/guides/account-and-service-management/startup-program/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Weiterführende Informationen"
   items:
     - title: "OVHcloud Community besuchen"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog ansehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: "Discord beitreten"

--- a/docs/en/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
+++ b/docs/en/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
@@ -94,4 +94,4 @@ Using the API, you can set up a policy according to the following example:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/account-and-service-management/account-information/iam-permission-groups.mdx
+++ b/docs/en/guides/account-and-service-management/account-information/iam-permission-groups.mdx
@@ -5424,4 +5424,4 @@ This permission group does not cover the administration of a Public Cloud projec
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/account-and-service-management/account-information/iam-policies-api.mdx
+++ b/docs/en/guides/account-and-service-management/account-information/iam-policies-api.mdx
@@ -733,4 +733,4 @@ Here is a part of the output:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/account-and-service-management/account-information/iam-policy-ui.mdx
+++ b/docs/en/guides/account-and-service-management/account-information/iam-policy-ui.mdx
@@ -224,4 +224,4 @@ A popup window will ask you to confirm the deletion.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/account-and-service-management/account-information/overview.mdx
+++ b/docs/en/guides/account-and-service-management/account-information/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Go further"
   items:
     - title: "Visit the OVHcloud community"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: "Join Discord"

--- a/docs/en/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
+++ b/docs/en/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
@@ -123,4 +123,4 @@ OVHcloud IAM policies management is covered by the [dedicated guide](/guides/acc
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/account-and-service-management/account-information/use-plik.mdx
+++ b/docs/en/guides/account-and-service-management/account-information/use-plik.mdx
@@ -93,4 +93,4 @@ Using this menu, you can log out, generate tokens to use the Plik tool in the co
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
+++ b/docs/en/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
@@ -160,4 +160,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/account-and-service-management/startup-program/overview.mdx
+++ b/docs/en/guides/account-and-service-management/startup-program/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Go further"
   items:
     - title: "Visit the OVHcloud community"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: "Join Discord"

--- a/docs/es/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
+++ b/docs/es/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
@@ -94,4 +94,4 @@ Using the API, you can set up a policy according to the following example:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/account-and-service-management/account-information/iam-permission-groups.mdx
+++ b/docs/es/guides/account-and-service-management/account-information/iam-permission-groups.mdx
@@ -5424,4 +5424,4 @@ This permission group does not cover the administration of a Public Cloud projec
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/account-and-service-management/account-information/iam-policies-api.mdx
+++ b/docs/es/guides/account-and-service-management/account-information/iam-policies-api.mdx
@@ -733,4 +733,4 @@ Here is a part of the output:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/account-and-service-management/account-information/iam-policy-ui.mdx
+++ b/docs/es/guides/account-and-service-management/account-information/iam-policy-ui.mdx
@@ -227,4 +227,4 @@ Aparecerá una ventana emergente en la que deberá confirmar la eliminación.
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/account-and-service-management/account-information/overview.mdx
+++ b/docs/es/guides/account-and-service-management/account-information/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Más información"
   items:
     - title: "Visitar la comunidad OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Ver la hoja de ruta y el changelog"
       link: https://www.ovhcloud.com/es-es/roadmap-changelog/
     - title: "Unirse a Discord"

--- a/docs/es/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
+++ b/docs/es/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
@@ -124,4 +124,4 @@ Consulte nuestra guía sobre [la gestión de las políticas IAM de OVHcloud](/gu
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/account-and-service-management/account-information/use-plik.mdx
+++ b/docs/es/guides/account-and-service-management/account-information/use-plik.mdx
@@ -93,4 +93,4 @@ Desde este menú podrá desconectarse, generar tokens para utilizar la herramien
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
+++ b/docs/es/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
@@ -160,4 +160,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/account-and-service-management/startup-program/overview.mdx
+++ b/docs/es/guides/account-and-service-management/startup-program/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Más información"
   items:
     - title: "Visitar la comunidad OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Ver la hoja de ruta y el changelog"
       link: https://www.ovhcloud.com/es-es/roadmap-changelog/
     - title: "Unirse a Discord"

--- a/docs/fr/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
@@ -94,4 +94,4 @@ L'API vous permet de mettre en place une policy selon l'exemple suivant :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/account-information/iam-permission-groups.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/iam-permission-groups.mdx
@@ -5421,4 +5421,4 @@ Ce groupe de permissions ne couvre pas l'administration d'un projet public cloud
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/account-information/iam-policies-api.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/iam-policies-api.mdx
@@ -735,4 +735,4 @@ Voici une partie du résultat:
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/account-information/iam-policy-ui.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/iam-policy-ui.mdx
@@ -225,4 +225,4 @@ Une fenêtre contextuelle vous demandera de confirmer la suppression.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/account-information/overview.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Aller plus loin"
   items:
     - title: "Rejoindre la communauté OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Voir la roadmap & changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: "Rejoindre Discord"

--- a/docs/fr/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
@@ -124,4 +124,4 @@ Consultez notre guide sur [la gestion des politiques IAM OVHcloud](/guides/accou
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/account-information/use-plik.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/use-plik.mdx
@@ -93,4 +93,4 @@ Via ce menu, vous pouvez vous déconnecter, générer des tokens pour utiliser l
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
+++ b/docs/fr/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
@@ -160,4 +160,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/account-and-service-management/startup-program/overview.mdx
+++ b/docs/fr/guides/account-and-service-management/startup-program/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Aller plus loin"
   items:
     - title: "Rejoindre la communauté OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Voir la roadmap & changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: "Rejoindre Discord"

--- a/docs/it/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
+++ b/docs/it/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
@@ -94,4 +94,4 @@ Using the API, you can set up a policy according to the following example:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/account-and-service-management/account-information/iam-permission-groups.mdx
+++ b/docs/it/guides/account-and-service-management/account-information/iam-permission-groups.mdx
@@ -5424,4 +5424,4 @@ This permission group does not cover the administration of a Public Cloud projec
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/account-and-service-management/account-information/iam-policies-api.mdx
+++ b/docs/it/guides/account-and-service-management/account-information/iam-policies-api.mdx
@@ -733,4 +733,4 @@ Here is a part of the output:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/account-and-service-management/account-information/iam-policy-ui.mdx
+++ b/docs/it/guides/account-and-service-management/account-information/iam-policy-ui.mdx
@@ -227,4 +227,4 @@ Una finestra contestuale ti chiederà di confermare l'eliminazione.
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/account-and-service-management/account-information/overview.mdx
+++ b/docs/it/guides/account-and-service-management/account-information/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Per saperne di più"
   items:
     - title: "Visita la community OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Visualizza la roadmap e il changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: "Unisciti a Discord"

--- a/docs/it/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
+++ b/docs/it/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
@@ -124,4 +124,4 @@ Consulta la nostra guida su [la gestione delle politiche IAM OVHcloud](/guides/a
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/account-and-service-management/account-information/use-plik.mdx
+++ b/docs/it/guides/account-and-service-management/account-information/use-plik.mdx
@@ -93,4 +93,4 @@ Tramite questo menu, potete disconnettervi, generare token per utilizzare il too
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
+++ b/docs/it/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
@@ -160,4 +160,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/account-and-service-management/startup-program/overview.mdx
+++ b/docs/it/guides/account-and-service-management/startup-program/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Per saperne di più"
   items:
     - title: "Visita la community OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Visualizza la roadmap e il changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: "Unisciti a Discord"

--- a/docs/pl/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
+++ b/docs/pl/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
@@ -94,4 +94,4 @@ Using the API, you can set up a policy according to the following example:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/account-and-service-management/account-information/iam-permission-groups.mdx
+++ b/docs/pl/guides/account-and-service-management/account-information/iam-permission-groups.mdx
@@ -5424,4 +5424,4 @@ This permission group does not cover the administration of a Public Cloud projec
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/account-and-service-management/account-information/iam-policies-api.mdx
+++ b/docs/pl/guides/account-and-service-management/account-information/iam-policies-api.mdx
@@ -733,4 +733,4 @@ Here is a part of the output:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/account-and-service-management/account-information/iam-policy-ui.mdx
+++ b/docs/pl/guides/account-and-service-management/account-information/iam-policy-ui.mdx
@@ -227,4 +227,4 @@ W oknie podręcznym zostanie wyświetlona prośba o potwierdzenie usunięcia hos
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/account-and-service-management/account-information/overview.mdx
+++ b/docs/pl/guides/account-and-service-management/account-information/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz harmonogram i dziennik zmian"
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: "Dołącz do Discorda"

--- a/docs/pl/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
+++ b/docs/pl/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
@@ -124,4 +124,4 @@ Zapoznaj się z naszym przewodnikiem dotyczącym [zarządzania polityką IAM OVH
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/account-and-service-management/account-information/use-plik.mdx
+++ b/docs/pl/guides/account-and-service-management/account-information/use-plik.mdx
@@ -93,4 +93,4 @@ Za pomocą tego menu możesz się wylogować, wygenerować tokeny, aby używać 
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
+++ b/docs/pl/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
@@ -160,4 +160,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/account-and-service-management/startup-program/overview.mdx
+++ b/docs/pl/guides/account-and-service-management/startup-program/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz harmonogram i dziennik zmian"
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: "Dołącz do Discorda"

--- a/docs/pt/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
+++ b/docs/pt/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
@@ -94,4 +94,4 @@ Using the API, you can set up a policy according to the following example:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/account-and-service-management/account-information/iam-permission-groups.mdx
+++ b/docs/pt/guides/account-and-service-management/account-information/iam-permission-groups.mdx
@@ -5424,4 +5424,4 @@ This permission group does not cover the administration of a Public Cloud projec
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/account-and-service-management/account-information/iam-policies-api.mdx
+++ b/docs/pt/guides/account-and-service-management/account-information/iam-policies-api.mdx
@@ -733,4 +733,4 @@ Here is a part of the output:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/account-and-service-management/account-information/iam-policy-ui.mdx
+++ b/docs/pt/guides/account-and-service-management/account-information/iam-policy-ui.mdx
@@ -227,4 +227,4 @@ Uma janela contextual irá pedir-lhe que confirme a eliminação.
 
 ## Quer saber mais?
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/account-and-service-management/account-information/overview.mdx
+++ b/docs/pt/guides/account-and-service-management/account-information/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: "Visite a comunidade OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte o roadmap e o changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Junte-se ao Discord"

--- a/docs/pt/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
+++ b/docs/pt/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
@@ -124,4 +124,4 @@ Consulte o nosso guia sobre [gestão das políticas IAM da OVHcloud](/guides/acc
 
 ## Quer saber mais?
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/account-and-service-management/account-information/use-plik.mdx
+++ b/docs/pt/guides/account-and-service-management/account-information/use-plik.mdx
@@ -93,4 +93,4 @@ Através deste menu, pode desligar-se, gerar tokens para utilizar a ferramenta P
 
 ## Saiba mais
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
+++ b/docs/pt/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
@@ -160,4 +160,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/account-and-service-management/startup-program/overview.mdx
+++ b/docs/pt/guides/account-and-service-management/startup-program/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: "Visite a comunidade OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte o roadmap e o changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Junte-se ao Discord"


### PR DESCRIPTION
### Scope: Account & Service Management

- Replace (dead) links to legacy community page with proper keys
- Fix hard URL in Overview pages to the correct one