### PR TITLE
fix(components): hide zone switcher while AI assistant drawer is open

### DIFF
--- a/components/Zone/ZoneSwitcher.tsx
+++ b/components/Zone/ZoneSwitcher.tsx
@@ -1,5 +1,6 @@
 import { useFrontmatter, useI18n } from '@rspress/core/runtime';
 import { useEffect, useRef, useState } from 'react';
+import { useAIChatbotDrawer } from 'theme/components/AIChatbotDrawer/context';
 import { useZone, ZONES, type Zone } from './ZoneContext';
 import './ZoneSwitcher.css';
 
@@ -24,6 +25,7 @@ const ZONE_DESC_KEY: Record<Zone, string> = {
 export function ZoneSwitcher() {
   const { zone, setZone, isSet } = useZone();
   const { frontmatter } = useFrontmatter();
+  const { isOpen: aiDrawerOpen } = useAIChatbotDrawer();
   const t = useI18n();
   const availableIn = (frontmatter as Record<string, unknown>)?.availableIn;
   const [open, setOpen] = useState(false);
@@ -40,6 +42,10 @@ export function ZoneSwitcher() {
 
   if (!isSet) return null;
   if (!Array.isArray(availableIn) || availableIn.length === 0) return null;
+  // Hide the sticky zone button while the AI assistant drawer is open — both
+  // are pinned bottom-right, and the switcher (z-index 90) would otherwise
+  // float over the conversation panel (z-index 81).
+  if (aiDrawerOpen) return null;
 
   const current = zone === 'unset' ? 'eu' : zone;
 


### PR DESCRIPTION
The sticky zone switcher (z-index 90) is pinned to the bottom-right corner, the same anchor as the AI assistant chat drawer (z-index 81). With both visible the switcher floated over the conversation panel, covering its lower-right corner.

ZoneSwitcher already renders inside AIChatbotDrawerProvider, so it now reads the drawer's open state via useAIChatbotDrawer() and returns null while the chat is open. It reappears as soon as the drawer closes.