### PR TITLE
fix(docs): normalize community links batch 4: Storage & Backup (1/2)

### DIFF
--- a/docs/de/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
@@ -300,6 +300,6 @@ On Cold Archive v1 (legacy offering), it corresponds to the availability SLA of 
 
 Discover our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide comments, and interact directly with the team that designs our storage and backup services.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
@@ -315,6 +315,6 @@ Check out our dedicated Discord channel: [https://discord.gg/ovhcloud](https://d
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
@@ -185,6 +185,6 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
@@ -133,4 +133,4 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
@@ -80,4 +80,4 @@ To set this new policy to your S3 user, please follow the different steps shared
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/overview.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/overview.mdx
@@ -25,7 +25,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Roadmap & Changelog einsehen
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/storage-and-backup/object-storage/pca-acl.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pca-acl.mdx
@@ -799,4 +799,4 @@ swift download <container> <largeobject>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
@@ -268,4 +268,4 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pca-create-container.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pca-create-container.mdx
@@ -78,4 +78,4 @@ Ihr Container wurde erstellt:
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
@@ -310,4 +310,4 @@ curl "${OS_STORAGE_URL}/<container>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
@@ -73,4 +73,4 @@ Bei Verbindungsschwierigkeiten können Sie das Cyberduck Verbindungsprofil für 
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/object-storage/pca-rsync.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pca-rsync.mdx
@@ -90,4 +90,4 @@ Darüber hinaus ist auf Clientseite nur ein Teil der Optionen erlaubt:
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/object-storage/pca-sftp.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pca-sftp.mdx
@@ -80,4 +80,4 @@ Das Abrufen von Daten unterliegt der vorherigen Freigabe des Objekts. Für das b
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
@@ -423,4 +423,4 @@ swift capabilities
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pca-unlock.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pca-unlock.mdx
@@ -193,4 +193,4 @@ swift download <pca_container> <object> | at now + ${RETRIEVAL_DELAY} minutes
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com](https://community.ovh.com).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-acl.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-acl.mdx
@@ -687,4 +687,4 @@ swift post dlo --read-acl ".rlistings"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
@@ -260,4 +260,4 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
@@ -49,4 +49,4 @@ The file will therefore be deleted on the 19th November 2022.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
@@ -112,4 +112,4 @@ Once you've entered all the information and checked that it is correct, the red 
  
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-cors.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-cors.mdx
@@ -265,4 +265,4 @@ swift stat <container>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-create-container.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-create-container.mdx
@@ -126,4 +126,4 @@ You can also see it in your OVHcloud Control Panel.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
@@ -301,4 +301,4 @@ curl "${OS_STORAGE_URL}/<container>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
@@ -196,4 +196,4 @@ Damit werden auch alle im Container enthaltenen Dateien gelöscht.
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
@@ -203,4 +203,4 @@ user@host:~$ aws s3 rb s3://bucket
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
@@ -119,4 +119,4 @@ Folgende Zeichen dürfen Sie im Containernamen nicht verwenden:
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
@@ -78,4 +78,4 @@ Bei Verbindungsschwierigkeiten können Sie das Cyberduck Verbindungsprofil für 
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
@@ -48,6 +48,6 @@ This guide lists the main features of Amazon S3 **\*** that are supported.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
@@ -38,4 +38,4 @@ Die Upload-Geschwindigkeit können Sie übrigens mithilfe von Programmen wie ift
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
@@ -72,4 +72,4 @@ Alle diese Informationen finden Sie in der OpenRC-Datei, die Sie im vorherigen S
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
@@ -435,4 +435,4 @@ Consider using the --segment-size option to chunk the object
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
@@ -173,4 +173,4 @@ You can also use this guide for migrating RunAbove objects to the OVHcloud Publi
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
@@ -58,4 +58,4 @@ You can find more detailed instructions on how to synchronise your object storag
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
@@ -97,4 +97,4 @@ Außerdem ist von einer Persistence-Konfiguration über die /etc/fstab-Datei abz
  
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
@@ -673,6 +673,6 @@ You can access the details of the Offsite Replication pricing on the global Obje
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -303,4 +303,4 @@ ACLs and policies can be combined. However the principle of least privilege will
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
@@ -882,6 +882,6 @@ Delete operations resulting from application of lifecycle rules are not replicat
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovh.com/).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
@@ -171,6 +171,6 @@ The list of all API endpoints can be found [here](/guides/storage-and-backup/obj
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
@@ -104,4 +104,4 @@ You will be guided through the entire process, from selecting the Storage Server
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
@@ -67,6 +67,6 @@ The following table provides an overview of the compatibility of our OVHcloud Ob
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>*</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
@@ -456,4 +456,4 @@ The OVHcloud Key Management Service (KMS) is a testament to our commitment to se
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -241,6 +241,6 @@ With Object Storage in a 3-AZ region, we have introduced a new option called **O
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
@@ -351,6 +351,6 @@ No additional permissions are required beyond the standard read permissions.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
@@ -675,6 +675,6 @@ A bucket can only be deleted if it is empty.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
@@ -329,5 +329,5 @@ The following policy to attempt to deny read access to objects to specific IPs b
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-limitations.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-limitations.mdx
@@ -61,4 +61,4 @@ Read our guide on [Object Storage - Compatibility](/guides/storage-and-backup/ob
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
@@ -63,4 +63,4 @@ The OVHcloud development team is working on implementing this API.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/s3-location.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-location.mdx
@@ -381,6 +381,6 @@ The mapping for **READ(GET/LIST/HEAD)** operations on the **perf** endpoint is t
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 _<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc._

--- a/docs/de/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
@@ -349,4 +349,4 @@ This command will fail if the object is protected by Object Lock in Compliance o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -147,6 +147,6 @@ rclone size ovhcloud:ovh-bucket-name/
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -193,4 +193,4 @@ rclone size ovhcloud:ovh-bucket-name/
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -182,6 +182,6 @@ Edit your `config/config.php` file and add:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
@@ -138,6 +138,6 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
@@ -53,5 +53,5 @@ aws configure set default.s3.max_concurrent_requests 20
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -85,4 +85,4 @@ The result should be similar to this:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
@@ -322,4 +322,4 @@ When applicable, we recommend that you increase the object/part size as much as 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
@@ -79,6 +79,6 @@ The list of all OVHcloud Object Storage endpoints can be found [here](/guides/st
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -93,4 +93,4 @@ You will find on the official Rclone website a detailed documentation of the pos
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
@@ -120,4 +120,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Visit our [Discord channel](https://discord.gg/ovhcloud).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
@@ -74,6 +74,6 @@ You can restore an object in the Cold Archive storage class by using the <Manage
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
@@ -535,6 +535,6 @@ This guide lists the features supported by OVHcloud Object Storage.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -133,7 +133,7 @@ You will find a detailed documentation of the possible actions on the [official 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
@@ -252,7 +252,7 @@ aws --profile `<profile_name>` s3api put-bucket-logging --bucket `<bucket_name>`
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
@@ -104,5 +104,5 @@ The Object Storage server will expose the `Access-Control-Allow-Origin` header i
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
@@ -96,5 +96,5 @@ OVHcloud Object Storage offers three main ways to share objects externally. Choo
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-terraform.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-terraform.mdx
@@ -116,6 +116,6 @@ This process may fail if the bucket contains locked objects. In this case, you'l
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
@@ -1249,6 +1249,6 @@ Object Storage lifecycle rules are evaluated once per day. There may be a delay 
 - [Object Storage - Getting started with Object Storage](/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage)
 - [Object Storage - Endpoints and geoavailability](/guides/storage-and-backup/object-storage/s3-location)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -96,6 +96,6 @@ At the **Summary** step of the wizard, complete the object storage repository co
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/object-storage/s3-website-https.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-website-https.mdx
@@ -204,4 +204,4 @@ Check that the website and the redirect work properly. Open a private browser to
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/object-storage/s3-website.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-website.mdx
@@ -113,5 +113,5 @@ Find more information on OVHcloud domain name offers on the [OVHcloud website](h
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/de/guides/storage-and-backup/object-storage/swift/overview.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/swift/overview.mdx
@@ -24,7 +24,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Roadmap & Changelog einsehen
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/en/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
@@ -300,6 +300,6 @@ On Cold Archive v1 (legacy offering), it corresponds to the availability SLA of 
 
 Discover our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide comments, and interact directly with the team that designs our storage and backup services.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
@@ -315,6 +315,6 @@ Check out our dedicated Discord channel: [https://discord.gg/ovhcloud](https://d
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
@@ -185,6 +185,6 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
@@ -133,4 +133,4 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
@@ -80,4 +80,4 @@ To set this new policy to your S3 user, please follow the different steps shared
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/overview.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/overview.mdx
@@ -25,7 +25,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: View the roadmap & changelog
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/storage-and-backup/object-storage/pca-acl.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-acl.mdx
@@ -799,4 +799,4 @@ swift download <container> <largeobject>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
@@ -268,4 +268,4 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pca-create-container.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-create-container.mdx
@@ -70,4 +70,4 @@ Your container is now created:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
@@ -310,4 +310,4 @@ curl "${OS_STORAGE_URL}/<container>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
@@ -69,4 +69,4 @@ In case of connection difficulties, you can download the Cyberduck connection pr
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pca-rsync.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-rsync.mdx
@@ -85,4 +85,4 @@ Additionally, only a subset of options are allowed on the client side:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pca-sftp.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-sftp.mdx
@@ -68,4 +68,4 @@ Data recovery requires that the object be unlocked first. A GET request must be 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
@@ -423,4 +423,4 @@ swift capabilities
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pca-unlock.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-unlock.mdx
@@ -189,4 +189,4 @@ swift download <pca_container> <object> | at now + ${RETRIEVAL_DELAY} minutes
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-acl.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-acl.mdx
@@ -687,4 +687,4 @@ swift post dlo --read-acl ".rlistings"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
@@ -260,4 +260,4 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
@@ -49,5 +49,5 @@ The file will therefore be deleted on the 19th November 2022.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
  

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
@@ -111,4 +111,4 @@ Once you've entered all the information and checked that it is correct, the red 
  
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-cors.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-cors.mdx
@@ -265,4 +265,4 @@ swift stat <container>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-create-container.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-create-container.mdx
@@ -126,4 +126,4 @@ You can also see it in your OVHcloud Control Panel.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
@@ -301,4 +301,4 @@ curl "${OS_STORAGE_URL}/<container>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
@@ -191,4 +191,4 @@ This will delete all the files in the container.
  
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
@@ -203,4 +203,4 @@ user@host:~$ aws s3 rb s3://bucket
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
@@ -114,4 +114,4 @@ You cannot use the following characters in your container name:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
@@ -67,4 +67,4 @@ In case of connection difficulties, you can download the Cyberduck connection pr
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
@@ -48,6 +48,6 @@ This guide lists the main features of Amazon S3 **\*** that are supported.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
@@ -39,5 +39,5 @@ You can measure the upload speed using iftop.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
  

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
@@ -65,4 +65,4 @@ You can find this information in the OpenRC file which you downloaded in the pre
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
@@ -429,4 +429,4 @@ Consider using the --segment-size option to chunk the object
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
@@ -173,4 +173,4 @@ You can also use this guide for migrating RunAbove objects to the OVHcloud Publi
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
@@ -58,4 +58,4 @@ You can find more detailed instructions on how to synchronise your object storag
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
@@ -94,4 +94,4 @@ You cannot use S3QL in offline mode, you should not configure persistance via th
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
@@ -673,6 +673,6 @@ You can access the details of the Offsite Replication pricing on the global Obje
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -303,4 +303,4 @@ ACLs and policies can be combined. However the principle of least privilege will
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
@@ -882,6 +882,6 @@ Delete operations resulting from application of lifecycle rules are not replicat
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovh.com/).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
@@ -171,6 +171,6 @@ The list of all API endpoints can be found [here](/guides/storage-and-backup/obj
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
@@ -102,4 +102,4 @@ You will be guided through the entire process, from selecting the Storage Server
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
@@ -67,6 +67,6 @@ The following table provides an overview of the compatibility of our OVHcloud Ob
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
@@ -456,4 +456,4 @@ The OVHcloud Key Management Service (KMS) is a testament to our commitment to se
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -241,6 +241,6 @@ With Object Storage in a 3-AZ region, we have introduced a new option called **O
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
@@ -351,6 +351,6 @@ No additional permissions are required beyond the standard read permissions.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
@@ -675,6 +675,6 @@ A bucket can only be deleted if it is empty.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
@@ -329,5 +329,5 @@ The following policy to attempt to deny read access to objects to specific IPs b
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-limitations.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-limitations.mdx
@@ -61,4 +61,4 @@ Read our guide on [Object Storage - Compatibility](/guides/storage-and-backup/ob
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
@@ -63,4 +63,4 @@ The OVHcloud development team is working on implementing this API.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-location.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-location.mdx
@@ -381,6 +381,6 @@ The mapping for **READ(GET/LIST/HEAD)** operations on the **perf** endpoint is t
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 _<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc._

--- a/docs/en/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
@@ -349,4 +349,4 @@ This command will fail if the object is protected by Object Lock in Compliance o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -145,6 +145,6 @@ rclone size ovhcloud-s3:<destination_bucket_name>/
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -200,6 +200,6 @@ rclone size ovhcloud:<destination_bucket_name>/
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -182,6 +182,6 @@ Edit your `config/config.php` file and add:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
@@ -138,6 +138,6 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
@@ -53,5 +53,5 @@ aws configure set default.s3.max_concurrent_requests 20
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -85,4 +85,4 @@ The result should be similar to this:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
@@ -322,4 +322,4 @@ When applicable, we recommend that you increase the object/part size as much as 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
@@ -89,6 +89,6 @@ The list of all OVHcloud Object Storage endpoints can be found [here](/guides/st
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -93,4 +93,4 @@ You will find on the official Rclone website a detailed documentation of the pos
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
@@ -120,4 +120,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Visit our [Discord channel](https://discord.gg/ovhcloud).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
@@ -83,6 +83,6 @@ You can restore an object in the Cold Archive storage class by using the <Manage
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
@@ -535,6 +535,6 @@ This guide lists the features supported by OVHcloud Object Storage.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -133,7 +133,7 @@ You will find a detailed documentation of the possible actions on the [official 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
@@ -252,7 +252,7 @@ aws --profile `<profile_name>` s3api put-bucket-logging --bucket `<bucket_name>`
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
@@ -104,5 +104,5 @@ The Object Storage server will expose the `Access-Control-Allow-Origin` header i
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
@@ -95,7 +95,7 @@ OVHcloud Object Storage offers three main ways to share objects externally. Choo
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-terraform.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-terraform.mdx
@@ -116,6 +116,6 @@ This process may fail if the bucket contains locked objects. In this case, you'l
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
@@ -1249,6 +1249,6 @@ Object Storage lifecycle rules are evaluated once per day. There may be a delay 
 - [Object Storage - Getting started with Object Storage](/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage)
 - [Object Storage - Endpoints and geoavailability](/guides/storage-and-backup/object-storage/s3-location)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -96,6 +96,6 @@ At the **Summary** step of the wizard, complete the object storage repository co
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-versioning.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-versioning.mdx
@@ -248,4 +248,4 @@ To permanently delete a specific version, click the object, then go to the <code
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-website-https.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-website-https.mdx
@@ -204,4 +204,4 @@ Check that the website and the redirect work properly. Open a private browser to
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-website.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-website.mdx
@@ -113,5 +113,5 @@ Find more information on OVHcloud domain name offers on the [OVHcloud website](h
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-winscp.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-winscp.mdx
@@ -68,7 +68,7 @@ The `Create directory` command in the root folder creates a new bucket.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/en/guides/storage-and-backup/object-storage/swift/overview.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/swift/overview.mdx
@@ -24,7 +24,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: View the roadmap & changelog
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/es/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
@@ -300,6 +300,6 @@ On Cold Archive v1 (legacy offering), it corresponds to the availability SLA of 
 
 Discover our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide comments, and interact directly with the team that designs our storage and backup services.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
@@ -315,6 +315,6 @@ Check out our dedicated Discord channel: [https://discord.gg/ovhcloud](https://d
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
@@ -185,6 +185,6 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
@@ -133,4 +133,4 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
@@ -80,4 +80,4 @@ To set this new policy to your S3 user, please follow the different steps shared
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/overview.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/overview.mdx
@@ -25,7 +25,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/storage-and-backup/object-storage/pca-acl.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pca-acl.mdx
@@ -799,4 +799,4 @@ swift download <container> <largeobject>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
@@ -268,4 +268,4 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pca-create-container.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pca-create-container.mdx
@@ -77,4 +77,4 @@ Su contenedor está creado:
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
@@ -310,4 +310,4 @@ curl "${OS_STORAGE_URL}/<container>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
@@ -75,4 +75,4 @@ Si tiene problemas de conexión, puede descargar el perfil de conexión Cyberduc
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pca-rsync.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pca-rsync.mdx
@@ -90,4 +90,4 @@ Además, solo está permitido un subconjunto de opciones en el lado del cliente:
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pca-sftp.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pca-sftp.mdx
@@ -79,4 +79,4 @@ La recuperación de datos está sujeta a la deslocalización previa del objeto. 
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
@@ -423,4 +423,4 @@ swift capabilities
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pca-unlock.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pca-unlock.mdx
@@ -193,4 +193,4 @@ swift download <pca_container> <object> | at now + ${RETRIEVAL_DELAY} minutes
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-acl.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-acl.mdx
@@ -687,4 +687,4 @@ swift post dlo --read-acl ".rlistings"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
@@ -260,4 +260,4 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
@@ -50,4 +50,4 @@ En este ejemplo, el archivo test.txt se eliminará el 19/11/2022.
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
   
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
@@ -113,5 +113,5 @@ Once you've entered all the information and checked that it is correct, the red 
  
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-cors.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-cors.mdx
@@ -265,4 +265,4 @@ swift stat <container>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-create-container.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-create-container.mdx
@@ -126,4 +126,4 @@ You can also see it in your OVHcloud Control Panel.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
@@ -301,4 +301,4 @@ curl "${OS_STORAGE_URL}/<container>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
@@ -196,4 +196,4 @@ Esta operación eliminará todos los archivos del contenedor.
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
@@ -203,4 +203,4 @@ user@host:~$ aws s3 rb s3://bucket
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
@@ -113,5 +113,5 @@ Además, es necesario sustituir «auth-ProjectID» por «auth_ProjectID».
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).
 

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
@@ -75,4 +75,4 @@ Si tiene problemas de conexión, puede descargar el perfil de conexión Cyberduc
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
@@ -48,6 +48,6 @@ This guide lists the main features of Amazon S3 **\*** that are supported.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
@@ -35,4 +35,4 @@ Es posible medir la velocidad de envío utilizando programas como iftop.
   
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
@@ -72,4 +72,4 @@ Todos estos datos se pueden encontrar en el archivo OpenRC que obtuvo en el paso
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
@@ -429,4 +429,4 @@ Consider using the --segment-size option to chunk the object
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
@@ -173,4 +173,4 @@ You can also use this guide for migrating RunAbove objects to the OVHcloud Publi
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
@@ -58,4 +58,4 @@ You can find more detailed instructions on how to synchronise your object storag
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
@@ -94,4 +94,4 @@ Atención: Ya no será posible utilizar S3QL en modo «offline». Por otra parte
   
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
@@ -673,6 +673,6 @@ You can access the details of the Offsite Replication pricing on the global Obje
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -303,4 +303,4 @@ ACLs and policies can be combined. However the principle of least privilege will
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
@@ -882,6 +882,6 @@ Delete operations resulting from application of lifecycle rules are not replicat
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovh.com/).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
@@ -171,6 +171,6 @@ The list of all API endpoints can be found [here](/guides/storage-and-backup/obj
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
@@ -104,4 +104,4 @@ You will be guided through the entire process, from selecting the Storage Server
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
@@ -67,6 +67,6 @@ The following table provides an overview of the compatibility of our OVHcloud Ob
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>*</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
@@ -456,4 +456,4 @@ The OVHcloud Key Management Service (KMS) is a testament to our commitment to se
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -241,6 +241,6 @@ With Object Storage in a 3-AZ region, we have introduced a new option called **O
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
@@ -351,6 +351,6 @@ No additional permissions are required beyond the standard read permissions.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
@@ -675,6 +675,6 @@ A bucket can only be deleted if it is empty.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
@@ -329,5 +329,5 @@ The following policy to attempt to deny read access to objects to specific IPs b
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-limitations.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-limitations.mdx
@@ -61,4 +61,4 @@ Read our guide on [Object Storage - Compatibility](/guides/storage-and-backup/ob
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
@@ -63,4 +63,4 @@ The OVHcloud development team is working on implementing this API.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/s3-location.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-location.mdx
@@ -381,6 +381,6 @@ The mapping for **READ(GET/LIST/HEAD)** operations on the **perf** endpoint is t
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 _<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc._

--- a/docs/es/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
@@ -349,4 +349,4 @@ This command will fail if the object is protected by Object Lock in Compliance o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -147,6 +147,6 @@ rclone size ovhcloud:ovh-bucket-name/
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -193,4 +193,4 @@ rclone size ovhcloud:ovh-bucket-name/
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -182,6 +182,6 @@ Edit your `config/config.php` file and add:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
@@ -138,6 +138,6 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
@@ -53,5 +53,5 @@ aws configure set default.s3.max_concurrent_requests 20
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -85,4 +85,4 @@ The result should be similar to this:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
@@ -322,4 +322,4 @@ When applicable, we recommend that you increase the object/part size as much as 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
@@ -79,6 +79,6 @@ The list of all OVHcloud Object Storage endpoints can be found [here](/guides/st
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -93,4 +93,4 @@ You will find on the official Rclone website a detailed documentation of the pos
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
@@ -120,4 +120,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Visit our [Discord channel](https://discord.gg/ovhcloud).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
@@ -74,6 +74,6 @@ You can restore an object in the Cold Archive storage class by using the <Manage
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
@@ -535,6 +535,6 @@ This guide lists the features supported by OVHcloud Object Storage.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -133,7 +133,7 @@ You will find a detailed documentation of the possible actions on the [official 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
@@ -252,7 +252,7 @@ aws --profile `<profile_name>` s3api put-bucket-logging --bucket `<bucket_name>`
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
@@ -104,5 +104,5 @@ The Object Storage server will expose the `Access-Control-Allow-Origin` header i
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
@@ -96,5 +96,5 @@ OVHcloud Object Storage offers three main ways to share objects externally. Choo
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-terraform.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-terraform.mdx
@@ -116,6 +116,6 @@ This process may fail if the bucket contains locked objects. In this case, you'l
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
@@ -1249,6 +1249,6 @@ Object Storage lifecycle rules are evaluated once per day. There may be a delay 
 - [Object Storage - Getting started with Object Storage](/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage)
 - [Object Storage - Endpoints and geoavailability](/guides/storage-and-backup/object-storage/s3-location)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -96,6 +96,6 @@ At the **Summary** step of the wizard, complete the object storage repository co
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-website-https.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-website-https.mdx
@@ -206,4 +206,4 @@ Check that the website and the redirect work properly. Open a private browser to
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/object-storage/s3-website.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-website.mdx
@@ -113,5 +113,5 @@ Find more information on OVHcloud domain name offers on the [OVHcloud website](h
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/es/guides/storage-and-backup/object-storage/swift/overview.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/swift/overview.mdx
@@ -24,7 +24,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/fr/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
@@ -291,6 +291,6 @@ Sur Cold Archive v1, il correspond au SLA de disponibilité du service Object St
 
 Découvrez notre chaîne dédiée Discord : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites vos commentaires et interagissez directement avec l’équipe qui conçoit nos services de stockage et de sauvegarde.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
@@ -314,6 +314,6 @@ Découvrez notre chaîne dédiée Discord : [https://discord.gg/ovhcloud](https:
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
@@ -186,6 +186,6 @@ Rendez-vous sur notre chaîne Discord dédiée : [https://discord.gg/ovhcloud](h
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
@@ -133,4 +133,4 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
@@ -82,4 +82,4 @@ Pour appliquer cette nouvelle politique à votre utilisateur S3, veuillez suivre
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/overview.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/overview.mdx
@@ -25,7 +25,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulter la roadmap & le changelog
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/storage-and-backup/object-storage/pca-acl.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pca-acl.mdx
@@ -799,4 +799,4 @@ swift download <conteneur> <largeobject>
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
@@ -266,4 +266,4 @@ La version actuelle de keystone est la 3, la v2 étant obsolète depuis plusieur
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pca-create-container.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pca-create-container.mdx
@@ -72,4 +72,4 @@ Votre conteneur est créé :
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
@@ -310,4 +310,4 @@ curl "${OS_STORAGE_URL}/<conteneur>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
@@ -67,4 +67,4 @@ En cas de difficulté de connexion, vous pouvez télécharger le profil de conne
 
 [Débuter avec l'API Swift](/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pca-rsync.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pca-rsync.mdx
@@ -85,4 +85,4 @@ En outre, seul un sous-ensemble d'options est autorisé côté client:
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pca-sftp.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pca-sftp.mdx
@@ -72,4 +72,4 @@ La récupération de données est soumise à un déblocage préalable de l'objet
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
@@ -423,4 +423,4 @@ swift capabilities
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pca-unlock.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pca-unlock.mdx
@@ -193,4 +193,4 @@ swift download <conteneur_pca> <objet> | at now + ${RETRIEVAL_DELAY} minutes
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-acl.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-acl.mdx
@@ -685,4 +685,4 @@ swift post dlo --read-acl ".rlistings"
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
@@ -260,4 +260,4 @@ La version actuelle de keystone est la 3, la v2 étant obsolète depuis plusieur
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
@@ -49,4 +49,4 @@ Le fichier sera donc supprimé le 19/11/2022.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
@@ -111,4 +111,4 @@ La "clé d'API" et le "Temps d'attente maximum" sont optionnels.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-cors.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-cors.mdx
@@ -265,4 +265,4 @@ swift stat `<conteneur>`
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-create-container.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-create-container.mdx
@@ -124,4 +124,4 @@ Vous pouvez également le voir dans votre espace client OVHcloud :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
@@ -301,4 +301,4 @@ curl "${OS_STORAGE_URL}/<conteneur>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
@@ -189,4 +189,4 @@ Cette opération supprimera tous les fichiers du conteneur.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
@@ -199,4 +199,4 @@ user@host:~$ aws s3 rb s3://bucket
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
@@ -67,4 +67,4 @@ En cas de difficulté de connexion, vous pouvez télécharger le profil de conne
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
@@ -48,6 +48,6 @@ Ce guide énumère les fonctionnalités principales d'Amazon S3 **\*** supporté
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
@@ -38,4 +38,4 @@ Vous pouvez mesurer la vitesse de téléchargement en utilisant iftop.
  
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
@@ -67,4 +67,4 @@ Toutes ces informations sont trouvables dans le fichier OpenRC que vous avez ré
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
@@ -423,4 +423,4 @@ Consider using the --segment-size option to chunk the object
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
@@ -174,4 +174,4 @@ Public Cloud.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
@@ -57,4 +57,4 @@ Vous trouverez sur le site officiel de rClone une documentation précise des act
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
@@ -96,4 +96,4 @@ Vous ne pouvez pas utiliser S3QL en mode hors ligne. Vous ne devez pas configure
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
@@ -671,6 +671,6 @@ Vous pouvez consulter les détails de tarification de l'option Offsite Replicati
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d’utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -305,5 +305,5 @@ Les ACLs et les politiques peuvent être combinées mais le principe du moindre 
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
@@ -882,6 +882,6 @@ Les opérations de suppression résultant de l'application des règles de cycle 
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovh.com/).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
@@ -168,6 +168,6 @@ La liste de tous les points de terminaison API est disponible [ici](/guides/stor
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
@@ -103,4 +103,4 @@ Vous serez guidé tout au long de la procédure, depuis la sélection du Storage
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
@@ -68,6 +68,6 @@ Le tableau suivant fournit une vue d'ensemble de la compatibilité de notre serv
 
 ## Aller plus loin
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
@@ -461,6 +461,6 @@ L'OVHcloud Key Management Service (KMS) témoigne de notre engagement dans la s�
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -238,6 +238,6 @@ Cette fonctionnalité n'est disponible que pour les régions 3-AZ et repose sur 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
@@ -351,6 +351,6 @@ Aucune permission supplémentaire n'est requise au-delà des permissions de lect
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
@@ -669,6 +669,6 @@ Un bucket ne peut être supprimé que s'il est vide.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
@@ -330,4 +330,4 @@ La politique suivante visant à refuser l'accès en lecture à des objets à des
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-limitations.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-limitations.mdx
@@ -60,5 +60,5 @@ Consultez notre guide [Object Storage - Compatibilité](/guides/storage-and-back
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
@@ -65,4 +65,4 @@ Des améliorations sur la gestion des stratégies utilisateur sont envisagées p
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-location.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-location.mdx
@@ -379,6 +379,6 @@ Le mapping des opérations **READ(GET/LIST/HEAD)** sur le point de terminaison *
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 _<sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit._

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
@@ -350,4 +350,4 @@ Cette commande échouera si l’objet est protégé par Object Lock en mode Comp
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -144,6 +144,6 @@ rclone size ovhcloud-s3:<destination_bucket_name>/
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -199,6 +199,6 @@ rclone size ovhcloud:<destination_bucket_name>/
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -182,6 +182,6 @@ Editez votre fichier `config/config.php` et ajoutez :
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 **\*** : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
@@ -138,6 +138,6 @@ Le RACI ci-dessous détaille le partage des responsabilités entre OVHcloud et l
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
@@ -53,4 +53,4 @@ aws configure set default.s3.max_concurrent_requests 20
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -85,4 +85,4 @@ Voici le résultat que vous devez obtenir :
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
@@ -326,4 +326,4 @@ Le cas échéant, nous vous recommandons d'augmenter autant que possible la tail
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
@@ -89,6 +89,6 @@ La liste de tous les endooints OVHcloud Object Storage se trouve [ici](/guides/s
 
 ## Aller plus loin
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -93,4 +93,4 @@ Vous trouverez sur le site officiel de Rclone une documentation précise des act
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
@@ -122,4 +122,4 @@ Pour des détails supplémentaires et de l’assistance sur les modes de déploi
 
 Visitez notre canal [Discord](https://discord.gg/ovhcloud).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
@@ -84,6 +84,6 @@ Vous pouvez restaurer un objet dans la classe de stockage Cold Archive en utilis
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
  
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
@@ -535,6 +535,6 @@ Ce guide a pour objectif d'énumérer les fonctionnalités supportées par l'Obj
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -134,6 +134,6 @@ Vous trouverez sur le site officiel de S3cmd une documentation détaillée des a
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
@@ -252,6 +252,6 @@ aws --profile `<profile_name>` s3api put-bucket-logging --bucket `<bucket_name>`
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
@@ -105,4 +105,4 @@ Le serveur Object Storage va exposer l'entête `Access-Control-Allow-Origin` dan
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
@@ -95,6 +95,6 @@ L'Object Storage OVHcloud propose trois méthodes principales pour partager des 
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-terraform.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-terraform.mdx
@@ -116,6 +116,6 @@ Ce processus peut échouer si le bucket contient des objets verrouillés. Dans c
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
@@ -1249,6 +1249,6 @@ Les règles de lifecycle de l'Object Storage sont évaluées une fois par jour. 
 - [Object Storage - Premiers pas avec l'Object Storage](/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage)
 - [Object Storage - Endpoints et disponibilité géographique](/guides/storage-and-backup/object-storage/s3-location)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -98,6 +98,6 @@ Pour définir une limite souple qui peut être dépassée temporairement pour vo
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 **\*** : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-versioning.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-versioning.mdx
@@ -251,4 +251,4 @@ Cette protection permet de restaurer un objet supprimé par erreur.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-website-https.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-website-https.mdx
@@ -201,4 +201,4 @@ Vérifiez que le site web et la redirection fonctionnent correctement. Ouvrez vo
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-website.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-website.mdx
@@ -113,4 +113,4 @@ Retrouvez plus d’informations sur les offres de noms de domaine OVHcloud sur [
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-winscp.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-winscp.mdx
@@ -70,6 +70,6 @@ La commande `Create directory` dans le dossier racine crée un nouveau bucket.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d’utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/object-storage/swift/overview.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/swift/overview.mdx
@@ -24,7 +24,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulter la roadmap & le changelog
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/it/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
@@ -300,6 +300,6 @@ On Cold Archive v1 (legacy offering), it corresponds to the availability SLA of 
 
 Discover our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide comments, and interact directly with the team that designs our storage and backup services.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
@@ -315,6 +315,6 @@ Check out our dedicated Discord channel: [https://discord.gg/ovhcloud](https://d
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
@@ -185,6 +185,6 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
@@ -133,4 +133,4 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
@@ -80,4 +80,4 @@ To set this new policy to your S3 user, please follow the different steps shared
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/overview.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/overview.mdx
@@ -25,7 +25,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/storage-and-backup/object-storage/pca-acl.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pca-acl.mdx
@@ -799,4 +799,4 @@ swift download <container> <largeobject>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
@@ -268,4 +268,4 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pca-create-container.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pca-create-container.mdx
@@ -77,4 +77,4 @@ Il tuo container è stato creato:
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
@@ -310,4 +310,4 @@ curl "${OS_STORAGE_URL}/<container>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
@@ -71,4 +71,4 @@ In caso di difficoltà di connessione, è possibile scaricare il profilo di conn
 
 [Come utilizzare l'API Swift](/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api)
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pca-rsync.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pca-rsync.mdx
@@ -90,4 +90,4 @@ Inoltre, è consentito solo un sottoinsieme di opzioni sul lato cliente:
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pca-sftp.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pca-sftp.mdx
@@ -65,4 +65,4 @@ Per recuperare i dati, per prima cosa è necessario sbloccare l’oggetto effett
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
@@ -423,4 +423,4 @@ swift capabilities
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pca-unlock.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pca-unlock.mdx
@@ -193,4 +193,4 @@ swift download <pca_container> <object> | at now + ${RETRIEVAL_DELAY} minutes
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-acl.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-acl.mdx
@@ -687,4 +687,4 @@ swift post dlo --read-acl ".rlistings"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
@@ -260,4 +260,4 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
@@ -49,4 +49,4 @@ Nel nostro esempio, il file test.txt sarà eliminato il 19/11/2021.
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
   
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
@@ -113,4 +113,4 @@ Once you've entered all the information and checked that it is correct, the red 
  
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-cors.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-cors.mdx
@@ -265,4 +265,4 @@ swift stat <container>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-create-container.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-create-container.mdx
@@ -126,4 +126,4 @@ You can also see it in your OVHcloud Control Panel.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
@@ -301,4 +301,4 @@ curl "${OS_STORAGE_URL}/<container>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
@@ -196,4 +196,4 @@ Questa operazione comporta la cancellazione di tutti i file del container.
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
@@ -203,4 +203,4 @@ user@host:~$ aws s3 rb s3://bucket
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
@@ -114,4 +114,4 @@ Il nome del tuo container non può contenere questi caratteri:
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
@@ -73,4 +73,4 @@ In caso di difficoltà di connessione, è possibile scaricare il profilo di conn
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
@@ -48,6 +48,6 @@ This guide lists the main features of Amazon S3 **\*** that are supported.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
@@ -39,4 +39,4 @@ Per verificare la velocità di invio, utilizza programmi come iftop.
   
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
@@ -72,4 +72,4 @@ Tutte queste informazioni sono disponibili nel file OpenRC recuperato nel preced
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
@@ -429,4 +429,4 @@ Consider using the --segment-size option to chunk the object
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
@@ -173,4 +173,4 @@ You can also use this guide for migrating RunAbove objects to the OVHcloud Publi
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
@@ -58,4 +58,4 @@ You can find more detailed instructions on how to synchronise your object storag
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
@@ -95,4 +95,4 @@ You cannot use S3QL in offline mode, you should not configure persistance via th
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
@@ -673,6 +673,6 @@ You can access the details of the Offsite Replication pricing on the global Obje
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -303,4 +303,4 @@ ACLs and policies can be combined. However the principle of least privilege will
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
@@ -882,6 +882,6 @@ Delete operations resulting from application of lifecycle rules are not replicat
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovh.com/).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
@@ -171,6 +171,6 @@ The list of all API endpoints can be found [here](/guides/storage-and-backup/obj
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
@@ -104,4 +104,4 @@ You will be guided through the entire process, from selecting the Storage Server
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
@@ -67,6 +67,6 @@ The following table provides an overview of the compatibility of our OVHcloud Ob
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>*</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
@@ -456,4 +456,4 @@ The OVHcloud Key Management Service (KMS) is a testament to our commitment to se
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -241,6 +241,6 @@ With Object Storage in a 3-AZ region, we have introduced a new option called **O
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
@@ -351,6 +351,6 @@ No additional permissions are required beyond the standard read permissions.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
@@ -675,6 +675,6 @@ A bucket can only be deleted if it is empty.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
@@ -329,5 +329,5 @@ The following policy to attempt to deny read access to objects to specific IPs b
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-limitations.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-limitations.mdx
@@ -61,4 +61,4 @@ Read our guide on [Object Storage - Compatibility](/guides/storage-and-backup/ob
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
@@ -63,4 +63,4 @@ The OVHcloud development team is working on implementing this API.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/s3-location.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-location.mdx
@@ -381,6 +381,6 @@ The mapping for **READ(GET/LIST/HEAD)** operations on the **perf** endpoint is t
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 _<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc._

--- a/docs/it/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
@@ -349,4 +349,4 @@ This command will fail if the object is protected by Object Lock in Compliance o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -147,6 +147,6 @@ rclone size ovhcloud:ovh-bucket-name/
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -193,4 +193,4 @@ rclone size ovhcloud:ovh-bucket-name/
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -182,6 +182,6 @@ Edit your `config/config.php` file and add:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
@@ -138,6 +138,6 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
@@ -53,5 +53,5 @@ aws configure set default.s3.max_concurrent_requests 20
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -85,4 +85,4 @@ The result should be similar to this:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
@@ -322,4 +322,4 @@ When applicable, we recommend that you increase the object/part size as much as 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
@@ -79,6 +79,6 @@ The list of all OVHcloud Object Storage endpoints can be found [here](/guides/st
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -93,4 +93,4 @@ You will find on the official Rclone website a detailed documentation of the pos
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
@@ -120,4 +120,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Visit our [Discord channel](https://discord.gg/ovhcloud).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
@@ -74,6 +74,6 @@ You can restore an object in the Cold Archive storage class by using the <Manage
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
@@ -535,6 +535,6 @@ This guide lists the features supported by OVHcloud Object Storage.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -133,7 +133,7 @@ You will find a detailed documentation of the possible actions on the [official 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
@@ -252,7 +252,7 @@ aws --profile `<profile_name>` s3api put-bucket-logging --bucket `<bucket_name>`
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
@@ -104,5 +104,5 @@ The Object Storage server will expose the `Access-Control-Allow-Origin` header i
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
@@ -96,5 +96,5 @@ OVHcloud Object Storage offers three main ways to share objects externally. Choo
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-terraform.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-terraform.mdx
@@ -116,6 +116,6 @@ This process may fail if the bucket contains locked objects. In this case, you'l
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
@@ -1249,6 +1249,6 @@ Object Storage lifecycle rules are evaluated once per day. There may be a delay 
 - [Object Storage - Getting started with Object Storage](/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage)
 - [Object Storage - Endpoints and geoavailability](/guides/storage-and-backup/object-storage/s3-location)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -96,6 +96,6 @@ At the **Summary** step of the wizard, complete the object storage repository co
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/object-storage/s3-website-https.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-website-https.mdx
@@ -206,4 +206,4 @@ Check that the website and the redirect work properly. Open a private browser to
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/object-storage/s3-website.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-website.mdx
@@ -113,5 +113,5 @@ Find more information on OVHcloud domain name offers on the [OVHcloud website](h
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/it/guides/storage-and-backup/object-storage/swift/overview.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/swift/overview.mdx
@@ -25,7 +25,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/pl/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
@@ -300,6 +300,6 @@ On Cold Archive v1 (legacy offering), it corresponds to the availability SLA of 
 
 Discover our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide comments, and interact directly with the team that designs our storage and backup services.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
@@ -315,6 +315,6 @@ Check out our dedicated Discord channel: [https://discord.gg/ovhcloud](https://d
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
@@ -185,6 +185,6 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
@@ -133,4 +133,4 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
@@ -80,4 +80,4 @@ To set this new policy to your S3 user, please follow the different steps shared
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/overview.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/overview.mdx
@@ -25,7 +25,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/storage-and-backup/object-storage/pca-acl.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pca-acl.mdx
@@ -799,4 +799,4 @@ swift download <container> <largeobject>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
@@ -268,4 +268,4 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pca-create-container.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pca-create-container.mdx
@@ -77,4 +77,4 @@ Kontener został utworzony:
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
@@ -310,4 +310,4 @@ curl "${OS_STORAGE_URL}/<container>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
@@ -73,4 +73,4 @@ W przypadku problemów z logowaniem możesz pobrać profil połączenia Cyberduc
 
 [Pierwsze kroki z API Swift](/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api)
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pca-rsync.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pca-rsync.mdx
@@ -90,4 +90,4 @@ Ponadto tylko jedna podgrupa opcji jest dostępna dla klienta:
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pca-sftp.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pca-sftp.mdx
@@ -68,4 +68,4 @@ Odyskiwanie danych wymaga odblokowania obiektu. Dla wybranego obiektu należy wy
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
@@ -423,4 +423,4 @@ swift capabilities
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pca-unlock.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pca-unlock.mdx
@@ -193,4 +193,4 @@ swift download <pca_container> <object> | at now + ${RETRIEVAL_DELAY} minutes
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-acl.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-acl.mdx
@@ -687,4 +687,4 @@ swift post dlo --read-acl ".rlistings"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
@@ -260,4 +260,4 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
@@ -49,4 +49,4 @@ Plik test.txt zostanie usunięty 19/11/2022 roku.
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
  
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
@@ -113,4 +113,4 @@ Once you've entered all the information and checked that it is correct, the red 
  
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-cors.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-cors.mdx
@@ -265,4 +265,4 @@ swift stat <container>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-create-container.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-create-container.mdx
@@ -126,4 +126,4 @@ You can also see it in your OVHcloud Control Panel.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
@@ -301,4 +301,4 @@ curl "${OS_STORAGE_URL}/<container>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
@@ -196,4 +196,4 @@ Operacja ta spowoduje usunięcie wszystkich plików z kontenera.
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
@@ -203,4 +203,4 @@ user@host:~$ aws s3 rb s3://bucket
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
@@ -114,4 +114,4 @@ W nazwie kontenera nie można używać poniższych znaków:
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
@@ -76,4 +76,4 @@ W przypadku problemów z logowaniem możesz pobrać profil połączenia Cyberduc
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
@@ -48,6 +48,6 @@ This guide lists the main features of Amazon S3 **\*** that are supported.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
@@ -39,4 +39,4 @@ Można zmierzyć prędkość wysyłki wykorzystując programy takie jak iftop.
  
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
@@ -72,4 +72,4 @@ Wszystkie te informacje można znaleźć w pliku OpenRC, który pobrałeś podcz
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
@@ -429,4 +429,4 @@ Consider using the --segment-size option to chunk the object
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
@@ -173,4 +173,4 @@ You can also use this guide for migrating RunAbove objects to the OVHcloud Publi
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
@@ -58,4 +58,4 @@ You can find more detailed instructions on how to synchronise your object storag
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
@@ -95,4 +95,4 @@ You cannot use S3QL in offline mode, you should not configure persistance via th
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
@@ -673,6 +673,6 @@ You can access the details of the Offsite Replication pricing on the global Obje
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -303,4 +303,4 @@ ACLs and policies can be combined. However the principle of least privilege will
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
@@ -882,6 +882,6 @@ Delete operations resulting from application of lifecycle rules are not replicat
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovh.com/).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
@@ -171,6 +171,6 @@ The list of all API endpoints can be found [here](/guides/storage-and-backup/obj
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
@@ -104,4 +104,4 @@ You will be guided through the entire process, from selecting the Storage Server
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
@@ -67,6 +67,6 @@ The following table provides an overview of the compatibility of our OVHcloud Ob
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>*</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
@@ -456,4 +456,4 @@ The OVHcloud Key Management Service (KMS) is a testament to our commitment to se
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -241,6 +241,6 @@ With Object Storage in a 3-AZ region, we have introduced a new option called **O
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
@@ -351,6 +351,6 @@ No additional permissions are required beyond the standard read permissions.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
@@ -675,6 +675,6 @@ A bucket can only be deleted if it is empty.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
@@ -329,5 +329,5 @@ The following policy to attempt to deny read access to objects to specific IPs b
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-limitations.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-limitations.mdx
@@ -61,4 +61,4 @@ Read our guide on [Object Storage - Compatibility](/guides/storage-and-backup/ob
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
@@ -63,4 +63,4 @@ The OVHcloud development team is working on implementing this API.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-location.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-location.mdx
@@ -381,6 +381,6 @@ The mapping for **READ(GET/LIST/HEAD)** operations on the **perf** endpoint is t
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 _<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc._

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
@@ -349,4 +349,4 @@ This command will fail if the object is protected by Object Lock in Compliance o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -147,6 +147,6 @@ rclone size ovhcloud:ovh-bucket-name/
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -193,4 +193,4 @@ rclone size ovhcloud:ovh-bucket-name/
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -182,6 +182,6 @@ Edit your `config/config.php` file and add:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
@@ -138,6 +138,6 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
@@ -53,5 +53,5 @@ aws configure set default.s3.max_concurrent_requests 20
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -85,4 +85,4 @@ The result should be similar to this:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
@@ -322,4 +322,4 @@ When applicable, we recommend that you increase the object/part size as much as 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
@@ -79,6 +79,6 @@ The list of all OVHcloud Object Storage endpoints can be found [here](/guides/st
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -93,4 +93,4 @@ You will find on the official Rclone website a detailed documentation of the pos
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
@@ -120,4 +120,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Visit our [Discord channel](https://discord.gg/ovhcloud).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
@@ -74,6 +74,6 @@ You can restore an object in the Cold Archive storage class by using the <Manage
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
@@ -535,6 +535,6 @@ This guide lists the features supported by OVHcloud Object Storage.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -133,7 +133,7 @@ You will find a detailed documentation of the possible actions on the [official 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
@@ -252,7 +252,7 @@ aws --profile `<profile_name>` s3api put-bucket-logging --bucket `<bucket_name>`
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
@@ -104,5 +104,5 @@ The Object Storage server will expose the `Access-Control-Allow-Origin` header i
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
@@ -96,5 +96,5 @@ OVHcloud Object Storage offers three main ways to share objects externally. Choo
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-terraform.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-terraform.mdx
@@ -116,6 +116,6 @@ This process may fail if the bucket contains locked objects. In this case, you'l
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
@@ -1249,6 +1249,6 @@ Object Storage lifecycle rules are evaluated once per day. There may be a delay 
 - [Object Storage - Getting started with Object Storage](/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage)
 - [Object Storage - Endpoints and geoavailability](/guides/storage-and-backup/object-storage/s3-location)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -96,6 +96,6 @@ At the **Summary** step of the wizard, complete the object storage repository co
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-website-https.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-website-https.mdx
@@ -206,4 +206,4 @@ Check that the website and the redirect work properly. Open a private browser to
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-website.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-website.mdx
@@ -113,5 +113,5 @@ Find more information on OVHcloud domain name offers on the [OVHcloud website](h
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pl/guides/storage-and-backup/object-storage/swift/overview.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/swift/overview.mdx
@@ -25,7 +25,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pt/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/cold-archive-faq.mdx
@@ -300,6 +300,6 @@ On Cold Archive v1 (legacy offering), it corresponds to the availability SLA of 
 
 Discover our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide comments, and interact directly with the team that designs our storage and backup services.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
@@ -315,6 +315,6 @@ Check out our dedicated Discord channel: [https://discord.gg/ovhcloud](https://d
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
@@ -185,6 +185,6 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
@@ -133,4 +133,4 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
@@ -80,4 +80,4 @@ To set this new policy to your S3 user, please follow the different steps shared
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/overview.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/overview.mdx
@@ -25,7 +25,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: Juntar-se ao Discord

--- a/docs/pt/guides/storage-and-backup/object-storage/pca-acl.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pca-acl.mdx
@@ -799,4 +799,4 @@ swift download <container> <largeobject>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
@@ -268,4 +268,4 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pca-create-container.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pca-create-container.mdx
@@ -78,4 +78,4 @@ O seu container é criado:
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pca-curl-commands-memo.mdx
@@ -310,4 +310,4 @@ curl "${OS_STORAGE_URL}/<container>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
@@ -73,4 +73,4 @@ Em caso de dificuldade de ligação, pode descarregar o perfil de ligação Cybe
 
 [Primeiros passos com a API Swift](/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api)
 
-Fale com a nossa comunidade de utilizadores [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pca-rsync.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pca-rsync.mdx
@@ -90,4 +90,4 @@ Além disso, apenas é permitido um subconjunto de opções no lado do cliente:
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pca-sftp.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pca-sftp.mdx
@@ -79,4 +79,4 @@ A recuperação de dados está sujeita a um desbloqueio prévio do objeto. É ne
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pca-swift-commands-memo.mdx
@@ -423,4 +423,4 @@ swift capabilities
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pca-unlock.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pca-unlock.mdx
@@ -193,4 +193,4 @@ swift download <pca_container> <object> | at now + ${RETRIEVAL_DELAY} minutes
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-acl.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-acl.mdx
@@ -687,4 +687,4 @@ swift post dlo --read-acl ".rlistings"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
@@ -260,4 +260,4 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
@@ -50,4 +50,4 @@ O ficheiro test.txt será eliminado a 19/11/2022.
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
  
-Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
@@ -111,4 +111,4 @@ Once you've entered all the information and checked that it is correct, the red 
  
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-cors.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-cors.mdx
@@ -265,4 +265,4 @@ swift stat <container>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-create-container.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-create-container.mdx
@@ -126,4 +126,4 @@ You can also see it in your OVHcloud Control Panel.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-curl-commands-memo.mdx
@@ -301,4 +301,4 @@ curl "${OS_STORAGE_URL}/<container>" -X POST -H "X-Auth-Token: ${OS_AUTH_TOKEN}"
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-api.mdx
@@ -196,4 +196,4 @@ Esta operação eliminará todos os ficheiros do container.
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-getting-started-with-the-swift-s3-api.mdx
@@ -203,4 +203,4 @@ user@host:~$ aws s3 rb s3://bucket
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
@@ -112,4 +112,4 @@ Não pode utilizar os seguintes caracteres no seu nome de container:
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
@@ -73,4 +73,4 @@ Em caso de dificuldade de ligação, pode descarregar o perfil de ligação Cybe
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa comunidade de utilizadores [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-object-storage-standard-s3-and-swift-rest-api-compatibility.mdx
@@ -48,6 +48,6 @@ This guide lists the main features of Amazon S3 **\*** that are supported.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
@@ -40,4 +40,4 @@ container_name 10Gio.dat
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
@@ -72,4 +72,4 @@ Todas estas informações podem ser encontradas no ficheiro OpenRC que recuperou
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-swift-commands-memo.mdx
@@ -429,4 +429,4 @@ Consider using the --segment-size option to chunk the object
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
@@ -173,4 +173,4 @@ You can also use this guide for migrating RunAbove objects to the OVHcloud Publi
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
@@ -58,4 +58,4 @@ You can find more detailed instructions on how to synchronise your object storag
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
@@ -95,4 +95,4 @@ You cannot use S3QL in offline mode, you should not configure persistance via th
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
@@ -673,6 +673,6 @@ You can access the details of the Offsite Replication pricing on the global Obje
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -303,4 +303,4 @@ ACLs and policies can be combined. However the principle of least privilege will
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-bucket-lifecycle.mdx
@@ -882,6 +882,6 @@ Delete operations resulting from application of lifecycle rules are not replicat
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovh.com/).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
@@ -171,6 +171,6 @@ The list of all API endpoints can be found [here](/guides/storage-and-backup/obj
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
@@ -104,4 +104,4 @@ You will be guided through the entire process, from selecting the Storage Server
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-ecosystem.mdx
@@ -67,6 +67,6 @@ The following table provides an overview of the compatibility of our OVHcloud Ob
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>*</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c.mdx
@@ -456,4 +456,4 @@ The OVHcloud Key Management Service (KMS) is a testament to our commitment to se
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-faq.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-faq.mdx
@@ -241,6 +241,6 @@ With Object Storage in a 3-AZ region, we have introduced a new option called **O
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-get-object-attributes.mdx
@@ -351,6 +351,6 @@ No additional permissions are required beyond the standard read permissions.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
@@ -675,6 +675,6 @@ A bucket can only be deleted if it is empty.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
@@ -329,5 +329,5 @@ The following policy to attempt to deny read access to objects to specific IPs b
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-limitations.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-limitations.mdx
@@ -61,4 +61,4 @@ Read our guide on [Object Storage - Compatibility](/guides/storage-and-backup/ob
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
@@ -63,4 +63,4 @@ The OVHcloud development team is working on implementing this API.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-location.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-location.mdx
@@ -381,6 +381,6 @@ The mapping for **READ(GET/LIST/HEAD)** operations on the **perf** endpoint is t
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 _<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc._

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
@@ -349,4 +349,4 @@ This command will fail if the object is protected by Object Lock in Compliance o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -147,6 +147,6 @@ rclone size ovhcloud:ovh-bucket-name/
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -193,4 +193,4 @@ rclone size ovhcloud:ovh-bucket-name/
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -182,6 +182,6 @@ Edit your `config/config.php` file and add:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
@@ -138,6 +138,6 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
@@ -53,5 +53,5 @@ aws configure set default.s3.max_concurrent_requests 20
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -85,4 +85,4 @@ The result should be similar to this:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
@@ -322,4 +322,4 @@ When applicable, we recommend that you increase the object/part size as much as 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade.mdx
@@ -79,6 +79,6 @@ The list of all OVHcloud Object Storage endpoints can be found [here](/guides/st
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -93,4 +93,4 @@ You will find on the official Rclone website a detailed documentation of the pos
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
@@ -120,4 +120,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Visit our [Discord channel](https://discord.gg/ovhcloud).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
@@ -74,6 +74,6 @@ You can restore an object in the Cold Archive storage class by using the <Manage
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
@@ -535,6 +535,6 @@ This guide lists the features supported by OVHcloud Object Storage.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -133,7 +133,7 @@ You will find a detailed documentation of the possible actions on the [official 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
@@ -252,7 +252,7 @@ aws --profile `<profile_name>` s3api put-bucket-logging --bucket `<bucket_name>`
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
@@ -104,5 +104,5 @@ The Object Storage server will expose the `Access-Control-Allow-Origin` header i
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
@@ -96,5 +96,5 @@ OVHcloud Object Storage offers three main ways to share objects externally. Choo
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-terraform.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-terraform.mdx
@@ -116,6 +116,6 @@ This process may fail if the bucket contains locked objects. In this case, you'l
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication.mdx
@@ -1249,6 +1249,6 @@ Object Storage lifecycle rules are evaluated once per day. There may be a delay 
 - [Object Storage - Getting started with Object Storage](/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage)
 - [Object Storage - Endpoints and geoavailability](/guides/storage-and-backup/object-storage/s3-location)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -96,6 +96,6 @@ At the **Summary** step of the wizard, complete the object storage repository co
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 **\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-website-https.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-website-https.mdx
@@ -206,4 +206,4 @@ Check that the website and the redirect work properly. Open a private browser to
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-website.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-website.mdx
@@ -113,5 +113,5 @@ Find more information on OVHcloud domain name offers on the [OVHcloud website](h
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pt/guides/storage-and-backup/object-storage/swift/overview.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/swift/overview.mdx
@@ -25,7 +25,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: Juntar-se ao Discord


### PR DESCRIPTION
### Scope: Storage and Backup

- Replace (dead) links to legacy community page with proper keys
- Fix hard URL in Overview pages to the correct one