### PR TITLE
fix(docs): normalize community links batch 5: Storage & Backup (2/2)

### DIFF
--- a/docs/de/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
+++ b/docs/de/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
@@ -87,4 +87,4 @@ Wenn Sie einen Bare Metal Server in **Beauharnois (BHS)** mit einer europäische
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/backup-agent/backup-restore.mdx
+++ b/docs/de/guides/storage-and-backup/backup-agent/backup-restore.mdx
@@ -230,4 +230,4 @@ Sie müssen den Server und die Anmeldeinformationen an die von uns bereitgestell
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/backup-agent/billing.mdx
+++ b/docs/de/guides/storage-and-backup/backup-agent/billing.mdx
@@ -29,4 +29,4 @@ Sie können das Dashboard <code className="action">Abrechnung</code> in Ihrem <M
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/backup-agent/deletion.mdx
+++ b/docs/de/guides/storage-and-backup/backup-agent/deletion.mdx
@@ -78,4 +78,4 @@ Bestätigen Sie die Löschung im erscheinenden Fenster.
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/backup-agent/first-configuration.mdx
+++ b/docs/de/guides/storage-and-backup/backup-agent/first-configuration.mdx
@@ -149,4 +149,4 @@ Sobald die Installationsdatei auf Ihrem Server ist, navigieren Sie zum Ordner, i
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
+++ b/docs/de/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
@@ -277,4 +277,4 @@ Sobald Ihre Agents laufen, konfigurieren Sie Ihre Backups über die Veeam Agent 
 - [Backups und Wiederherstellungen verwalten](/guides/storage-and-backup/backup-agent/backup-restore)
 - [Anleitung zur Fehlerbehebung](/guides/storage-and-backup/backup-agent/troubleshooting)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/backup-agent/overview.mdx
+++ b/docs/de/guides/storage-and-backup/backup-agent/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Roadmap & Changelog einsehen
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/storage-and-backup/backup-agent/product-presentation.mdx
+++ b/docs/de/guides/storage-and-backup/backup-agent/product-presentation.mdx
@@ -87,4 +87,4 @@ Zuordnung der Backup-Regionen:
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/backup-agent/restrictions.mdx
+++ b/docs/de/guides/storage-and-backup/backup-agent/restrictions.mdx
@@ -45,4 +45,4 @@ Dieser Anwendungsfall kann jedoch nicht als unterstützt betrachtet werden. Es k
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/backup-agent/troubleshooting.mdx
+++ b/docs/de/guides/storage-and-backup/backup-agent/troubleshooting.mdx
@@ -247,4 +247,4 @@ Um Probleme mit dem Backup Agent zu beheben, ist es oft notwendig, die Protokoll
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/backup-agent/update.mdx
+++ b/docs/de/guides/storage-and-backup/backup-agent/update.mdx
@@ -28,4 +28,4 @@ Wenn Sie spezielle Anfragen haben, zögern Sie nicht, den [OVHcloud Support](htt
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
+++ b/docs/de/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
@@ -81,4 +81,4 @@ Sie können die neuesten Alarme zu Ihren Agents und Sicherungen im Bereich <code
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
+++ b/docs/de/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Weiterführende Informationen"
   items:
     - title: "OVHcloud Community besuchen"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog ansehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: "Discord beitreten"

--- a/docs/de/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
+++ b/docs/de/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
@@ -135,4 +135,4 @@ The duration of the restore process depends on the size of your backup and your 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
+++ b/docs/de/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Roadmap & Changelog einsehen
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
+++ b/docs/de/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
@@ -278,4 +278,4 @@ You can now disable the user that you have created to create the registration.
 
 If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](https://www.ovhcloud.com/de/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
@@ -110,4 +110,4 @@ Die richtige Auswahl der Bereitstellungsvariante gewährleistet eine optimale Le
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder an unser [Professional Services Team](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
@@ -128,4 +128,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
@@ -241,4 +241,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
@@ -53,4 +53,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
@@ -97,4 +97,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
@@ -93,4 +93,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
@@ -96,4 +96,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
@@ -61,4 +61,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
@@ -208,4 +208,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
@@ -106,4 +106,4 @@ Besuchen Sie unseren speziellen Discord-Kanal: [https://discord.gg/ovhcloud](htt
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer Benutzergemeinschaft auf [https://community.ovh.com/en/](https://community.ovh.com/en/) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
@@ -112,4 +112,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
@@ -172,4 +172,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Roadmap & Changelog einsehen
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/storage-and-backup/block-storage/overview.mdx
+++ b/docs/de/guides/storage-and-backup/block-storage/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
@@ -117,4 +117,4 @@ Je nach Größe des verwendeten Snapshots kann die Erstellung des Volumes einige
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts.mdx
@@ -141,4 +141,4 @@ Was ist der Unterschied zwischen Terabyte (TB) und Tebibyte (TiB)?
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
@@ -233,4 +233,4 @@ Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unser
 
 Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
@@ -140,4 +140,4 @@ Enterprise File Storage ist ein Dienst, der monatlich nach Volumen abgerechnet w
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
@@ -62,4 +62,4 @@ Beachten Sie die neue `id`, wenn Sie weitere Operationen mit dem Snapshot durchf
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
@@ -118,4 +118,4 @@ You can now follow the guides below to create and manage your volumes, snapshots
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
@@ -58,4 +58,4 @@ Wenn Sie jedoch während bestimmter Schreibvorgänge Fehler wie "invalid device 
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
@@ -251,4 +251,4 @@ If no errors occur, the EFS volume will now automatically mount on boot.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
@@ -155,4 +155,4 @@ Sie können Ihr Volume mit folgender Route löschen:
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
@@ -152,4 +152,4 @@ Das Volume wird jetzt auf den ausgewählten Snapshot zurückgesetzt.
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
@@ -107,4 +107,4 @@ So löschen Sie eine Snapshot-Policy:
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
@@ -865,4 +865,4 @@ Destroy complete! Resources: 2 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
@@ -626,4 +626,4 @@ Der Snapshot wird im Enterprise File Storage-Dienst erstellt und kann für Siche
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
@@ -102,4 +102,4 @@ Sie erhalten `aclRuleId` bei Erstellung der ACL oder indem Sie bestehende ACLs I
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
@@ -111,4 +111,4 @@ Ersetzen Sie `serviceName` mit der ID Ihres Dienstes, `shareId` mit der Volume-I
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
@@ -130,4 +130,4 @@ Ersetzen Sie `serviceName` mit der ID Ihres Dienstes und `shareId` mit der ID de
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Roadmap & Changelog einsehen
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
@@ -86,4 +86,4 @@ Deletion is irreversible. Ensure the snapshot is no longer required.
 - [File Storage Service – Getting Started](/guides/storage-and-backup/file-storage/file-storage-service/getting-started)
 - [Preparing an environment for using the OpenStack API](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
@@ -93,6 +93,6 @@ You remain responsible for:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
@@ -88,4 +88,4 @@ mount: /mnt/FolderMount: mount(2) system call failed: No route to host.
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
@@ -386,4 +386,4 @@ Die angebotenen Nutzungsperioden sind 1, 12, 24 und 36 Monate. Am Ende Ihrer Ver
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
@@ -130,4 +130,4 @@ Um eine Partition zu löschen, klicken Sie auf den <code className="action">...<
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
@@ -108,4 +108,4 @@ Um eine IP-Adresse oder einen Adressbereich aus der ACL zu löschen, verwenden S
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
@@ -45,4 +45,4 @@ Achtung, wenn Sie weitere Optionen zu `rsync` hinzufügen, sind diese möglicher
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -337,4 +337,4 @@ Einige Linux Kernel verwenden standardmäßig einen Wert von 128 KB `read_ahead_
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
@@ -158,4 +158,4 @@ Verwenden Sie die folgende Route, um eine Partition zu löschen:
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
@@ -124,4 +124,4 @@ Verwenden Sie die folgende Route, um eine Partition zu löschen:
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -175,4 +175,4 @@ Zusätzliche Hilfe finden Sie unter "[Weiterführende Informationen](#gofurther)
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Roadmap & Changelog einsehen
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/storage-and-backup/file-storage/overview.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/overview.mdx
@@ -11,7 +11,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/en/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
+++ b/docs/en/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
@@ -87,4 +87,4 @@ If you have a Bare Metal server in **Beauharnois (BHS)** with a European network
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/backup-agent/backup-restore.mdx
+++ b/docs/en/guides/storage-and-backup/backup-agent/backup-restore.mdx
@@ -230,4 +230,4 @@ You will need to adapt the server and credentials to match the ones we have prov
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/backup-agent/billing.mdx
+++ b/docs/en/guides/storage-and-backup/backup-agent/billing.mdx
@@ -29,4 +29,4 @@ You can use the <code className="action">Billing</code> dashboard in your <Manag
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/backup-agent/deletion.mdx
+++ b/docs/en/guides/storage-and-backup/backup-agent/deletion.mdx
@@ -78,4 +78,4 @@ Confirm the deletion in the window that appears.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/backup-agent/first-configuration.mdx
+++ b/docs/en/guides/storage-and-backup/backup-agent/first-configuration.mdx
@@ -150,4 +150,4 @@ Once the installation file is on your server, go to the folder containing it and
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
+++ b/docs/en/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
@@ -277,4 +277,4 @@ Once your agents are up and running, configure your backups through the Veeam Ag
 - [Manage your backups and restores](/guides/storage-and-backup/backup-agent/backup-restore)
 - [Troubleshooting guide](/guides/storage-and-backup/backup-agent/troubleshooting)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/backup-agent/overview.mdx
+++ b/docs/en/guides/storage-and-backup/backup-agent/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: View the roadmap & changelog
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/storage-and-backup/backup-agent/product-presentation.mdx
+++ b/docs/en/guides/storage-and-backup/backup-agent/product-presentation.mdx
@@ -87,4 +87,4 @@ Mapping of backup areas:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/backup-agent/restrictions.mdx
+++ b/docs/en/guides/storage-and-backup/backup-agent/restrictions.mdx
@@ -45,5 +45,5 @@ However, this use case cannot be considered as supported. Too many specific case
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/backup-agent/troubleshooting.mdx
+++ b/docs/en/guides/storage-and-backup/backup-agent/troubleshooting.mdx
@@ -247,4 +247,4 @@ To troubleshoot issues with Backup Agent, it is often necessary to view and expo
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/backup-agent/update.mdx
+++ b/docs/en/guides/storage-and-backup/backup-agent/update.mdx
@@ -28,4 +28,4 @@ If you have any specific requests, please feel free to [contact OVHcloud support
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
+++ b/docs/en/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
@@ -81,5 +81,5 @@ You can view the latest alarms on your agents and backups in the <code className
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
+++ b/docs/en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Go further"
   items:
     - title: "Visit the OVHcloud community"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: "Join Discord"

--- a/docs/en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
+++ b/docs/en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
@@ -583,6 +583,6 @@ You can also run the Plakar UI locally on your own computer by installing Plakar
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
+++ b/docs/en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
@@ -135,4 +135,4 @@ The duration of the restore process depends on the size of your backup and your 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
+++ b/docs/en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: View the roadmap & changelog
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
+++ b/docs/en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
@@ -278,4 +278,4 @@ You can now disable the user that you have created to create the registration.
 
 If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
@@ -110,4 +110,4 @@ Choosing the right deployment option ensures optimal performance, redundancy, an
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or reach out to our [Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a personalised analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
@@ -128,4 +128,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
@@ -241,4 +241,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
@@ -53,4 +53,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
@@ -97,4 +97,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
@@ -93,4 +93,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
@@ -96,4 +96,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
@@ -61,4 +61,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
@@ -207,4 +207,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
@@ -106,4 +106,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
@@ -112,4 +112,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
@@ -172,4 +172,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: View the roadmap & changelog
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/storage-and-backup/block-storage/overview.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
@@ -123,4 +123,4 @@ Depending on the snapshot size, the volume creation may take some time.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
@@ -237,4 +237,4 @@ If you are new to using Enterprise File Storage, you can follow this sequence of
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
@@ -134,4 +134,4 @@ Enterprise File Storage is a service that is billed monthly by volume (from 1 TB
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
@@ -61,4 +61,4 @@ Please take note of the new `id` if you want to perform further operations with 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
@@ -118,4 +118,4 @@ You can now follow the guides below to create and manage your volumes, snapshots
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
@@ -58,4 +58,4 @@ However, if you get "invalid device error" errors during certain write operation
 
 If you require training or technical support to implement our solutions, please contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
@@ -259,4 +259,4 @@ If no errors occur, the EFS volume will now automatically mount on boot.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
@@ -150,4 +150,4 @@ You can remove your volume using the following route:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
@@ -147,4 +147,4 @@ The volume is now restored to the selected snapshot.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
@@ -101,4 +101,4 @@ To delete a snapshot policy:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
@@ -1167,4 +1167,4 @@ Destroy complete! Resources: 2 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
@@ -626,4 +626,4 @@ The snapshot is created on the Enterprise File Storage service and can be used f
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
@@ -97,4 +97,4 @@ You can get the `aclRuleId` either from the ACL creation body response or by lis
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
@@ -106,4 +106,4 @@ Replace `serviceName` with the ID of your service, `shareId` with your volume ID
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
@@ -124,4 +124,4 @@ Replace `serviceName` with the ID of your service and `shareId` with your volume
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: View the roadmap & changelog
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
@@ -86,4 +86,4 @@ Deletion is irreversible. Ensure the snapshot is no longer required.
 - [File Storage Service – Getting Started](/guides/storage-and-backup/file-storage/file-storage-service/getting-started)
 - [Preparing an environment for using the OpenStack API](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
@@ -93,6 +93,6 @@ You remain responsible for:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
@@ -89,4 +89,4 @@ mount: /mnt/FolderMount: mount(2) system call failed: No route to host.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
@@ -386,4 +386,4 @@ The subscription periods offered are 1 month, 12 months, 24 months and 36 months
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
@@ -125,4 +125,4 @@ To delete a partition, click on the <code className="action">...</code> button t
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
@@ -103,4 +103,4 @@ To delete an IP address or address range from the ACL, use the following route:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
@@ -40,4 +40,4 @@ Warning: if you add other options to `rsync`, these may not be compatible with t
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -337,4 +337,4 @@ Some Linux kernels use a default `read_ahead_kb` value of 128 KB. We recommend t
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
@@ -153,4 +153,4 @@ Use the following route to delete a partition:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
@@ -119,4 +119,4 @@ Use the following route to delete a partition:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -170,4 +170,4 @@ You can find more information in the [Go further](#gofurther) section of this gu
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: View the roadmap & changelog
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/storage-and-backup/file-storage/overview.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/overview.mdx
@@ -11,7 +11,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/es/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
+++ b/docs/es/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
@@ -87,4 +87,4 @@ Si tiene un servidor Bare Metal en **Beauharnois (BHS)** con una interfaz de red
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/backup-agent/backup-restore.mdx
+++ b/docs/es/guides/storage-and-backup/backup-agent/backup-restore.mdx
@@ -230,4 +230,4 @@ Tendrás que adaptar el servidor y las credenciales con las que te hayamos propo
 
 ## Más información
 
-Interactúa con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/backup-agent/billing.mdx
+++ b/docs/es/guides/storage-and-backup/backup-agent/billing.mdx
@@ -29,4 +29,4 @@ Tiene a su disposición un tableau de bord `Facturación` en su <ManagerLink to=
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/backup-agent/deletion.mdx
+++ b/docs/es/guides/storage-and-backup/backup-agent/deletion.mdx
@@ -78,4 +78,4 @@ Confirme la eliminación en la ventana que aparece.
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/backup-agent/first-configuration.mdx
+++ b/docs/es/guides/storage-and-backup/backup-agent/first-configuration.mdx
@@ -149,4 +149,4 @@ Una vez que el archivo de instalación esté en su servidor, vaya al directorio 
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
+++ b/docs/es/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
@@ -277,4 +277,4 @@ Una vez que sus agentes estén operativos, configure sus backups a través de la
 - [Gestionar sus backups y restauraciones](/guides/storage-and-backup/backup-agent/backup-restore)
 - [Diagnóstico y resolución de problemas](/guides/storage-and-backup/backup-agent/troubleshooting)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/backup-agent/overview.mdx
+++ b/docs/es/guides/storage-and-backup/backup-agent/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/storage-and-backup/backup-agent/product-presentation.mdx
+++ b/docs/es/guides/storage-and-backup/backup-agent/product-presentation.mdx
@@ -87,4 +87,4 @@ Mapeo de zonas de copia de seguridad:
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/backup-agent/restrictions.mdx
+++ b/docs/es/guides/storage-and-backup/backup-agent/restrictions.mdx
@@ -44,4 +44,4 @@ lastUpdated: 2026-02-03
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/backup-agent/troubleshooting.mdx
+++ b/docs/es/guides/storage-and-backup/backup-agent/troubleshooting.mdx
@@ -247,4 +247,4 @@ Para resolver problemas con Backup Agent, a menudo es necesario consultar y expo
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/backup-agent/update.mdx
+++ b/docs/es/guides/storage-and-backup/backup-agent/update.mdx
@@ -28,4 +28,4 @@ Si tiene alguna solicitud específica, no dude en [contactar con el soporte de O
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
+++ b/docs/es/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
@@ -81,4 +81,4 @@ Puede ver las últimas alarmas sobre sus agentes y copias de seguridad en la sec
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
+++ b/docs/es/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Más información"
   items:
     - title: "Visitar la comunidad OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Ver la hoja de ruta y el changelog"
       link: https://www.ovhcloud.com/es-es/roadmap-changelog/
     - title: "Unirse a Discord"

--- a/docs/es/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
+++ b/docs/es/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
@@ -135,4 +135,4 @@ The duration of the restore process depends on the size of your backup and your 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
+++ b/docs/es/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
+++ b/docs/es/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
@@ -278,4 +278,4 @@ You can now disable the user that you have created to create the registration.
 
 If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
@@ -112,4 +112,4 @@ Elegir la opción adecuada de despliegue garantiza un rendimiento óptimo, una r
 
 Si necesita formación o asistencia técnica para la implementación de nuestras soluciones, contacte a su representante comercial o diríjase a nuestro [equipo de Professional Services](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
@@ -128,4 +128,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
@@ -241,4 +241,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
@@ -53,4 +53,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
@@ -97,4 +97,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
@@ -93,4 +93,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
@@ -96,4 +96,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
@@ -61,4 +61,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
@@ -208,4 +208,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
@@ -108,4 +108,4 @@ Visite nuestro canal dedicado de Discord: [https://discord.gg/ovhcloud](https://
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Únase a nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
@@ -112,4 +112,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
@@ -172,4 +172,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/storage-and-backup/block-storage/overview.mdx
+++ b/docs/es/guides/storage-and-backup/block-storage/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
@@ -119,4 +119,4 @@ Dependiendo del tamaño del snapshot utilizado, la operación de creación del v
 
 Si necesita formación o asistencia técnica para implementar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Professional Services.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts.mdx
@@ -141,4 +141,4 @@ Para más información, consulte la guía [Gestionar los snapshots de un volumen
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
@@ -233,4 +233,4 @@ Si necesita formación o asistencia técnica para implantar nuestras soluciones,
 
 Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
@@ -140,4 +140,4 @@ Enterprise File Storage es un servicio con facturación mensual por volumen (de 
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
@@ -59,4 +59,4 @@ Tome nota del nuevo `id` si desea continuar realizando operaciones en el snapsho
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
@@ -118,4 +118,4 @@ You can now follow the guides below to create and manage your volumes, snapshots
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
@@ -58,4 +58,4 @@ No obstante, si se producen errores de tipo "invalid device error" durante deter
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
@@ -251,4 +251,4 @@ If no errors occur, the EFS volume will now automatically mount on boot.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
@@ -155,4 +155,4 @@ Puede eliminar el volumen utilizando la siguiente ruta de la API:
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
@@ -152,4 +152,4 @@ El volumen se restaurará en el snapshot seleccionado.
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
@@ -108,4 +108,4 @@ Para eliminar una política de snapshots:
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
@@ -865,4 +865,4 @@ Destroy complete! Resources: 2 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
@@ -626,4 +626,4 @@ El snapshot se crea en el servicio Enterprise File Storage y puede utilizarse pa
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
@@ -102,4 +102,4 @@ Puede obtener el `aclRuleId` a partir de la respuesta obtenida al crear el ACL o
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Únase a nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
@@ -111,4 +111,4 @@ Sustituya el `serviceName` por el ID del servicio, `shareId` por el ID del volum
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
@@ -130,4 +130,4 @@ Sustituya el `serviceName` por el ID de su servicio y `shareId` por el ID del vo
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
@@ -86,4 +86,4 @@ Deletion is irreversible. Ensure the snapshot is no longer required.
 - [File Storage Service – Getting Started](/guides/storage-and-backup/file-storage/file-storage-service/getting-started)
 - [Preparing an environment for using the OpenStack API](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
@@ -93,6 +93,6 @@ You remain responsible for:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
@@ -88,4 +88,4 @@ mount: /mnt/FolderMount: mount(2) system call failed: No route to host.
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
@@ -386,5 +386,5 @@ Los períodos ofrecidos son de 1, 3, 6 y 12 meses. Al finalizar el período cont
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).
 

--- a/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
@@ -130,4 +130,4 @@ Para eliminar una partición, haga clic en el botón <code className="action">(.
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
@@ -108,4 +108,4 @@ Para eliminar una dirección IP o un rango de direcciones de la ACL, utilice la 
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
@@ -47,4 +47,4 @@ Atención: Si añade más opciones a rsync, estas opciones podrían no ser compa
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -337,4 +337,4 @@ Algunos kernels Linux utilizan un valor por defecto de 128 KB de `read_ahead_kb`
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
@@ -158,4 +158,4 @@ Utilice la siguiente ruta para eliminar una partición:
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
@@ -124,4 +124,4 @@ Utilice la siguiente ruta para eliminar una partition:
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -175,4 +175,4 @@ Para más información, consulte el apartado [Más información](#gofurther) de 
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/storage-and-backup/file-storage/overview.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/overview.mdx
@@ -11,7 +11,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/fr/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
@@ -87,5 +87,5 @@ Si vous avez un serveur Bare Metal à **Beauharnois (BHS)** avec une interface r
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 

--- a/docs/fr/guides/storage-and-backup/backup-agent/backup-restore.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-agent/backup-restore.mdx
@@ -230,4 +230,4 @@ Vous devrez adapter le serveur et les identifiants avec ceux que nous vous auron
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/backup-agent/billing.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-agent/billing.mdx
@@ -29,4 +29,4 @@ Vous avez à votre disposition un teableau de bord `Facturation` dans votre <Man
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/backup-agent/deletion.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-agent/deletion.mdx
@@ -78,5 +78,5 @@ Confirmez la suppression dans la fenêtre qui s'affiche.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 

--- a/docs/fr/guides/storage-and-backup/backup-agent/first-configuration.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-agent/first-configuration.mdx
@@ -149,4 +149,4 @@ Une fois le fichier d'installation sur votre serveur, accédez au dossier le con
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
@@ -277,4 +277,4 @@ Une fois vos agents opérationnels, configurez vos sauvegardes via l'interface V
 - [Gérer vos sauvegardes et restaurations](/guides/storage-and-backup/backup-agent/backup-restore)
 - [Diagnostic et dépannage](/guides/storage-and-backup/backup-agent/troubleshooting)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/backup-agent/overview.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-agent/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulter la roadmap & le changelog
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/storage-and-backup/backup-agent/product-presentation.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-agent/product-presentation.mdx
@@ -87,4 +87,4 @@ Mapping des zones de sauvegarde :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/backup-agent/restrictions.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-agent/restrictions.mdx
@@ -45,5 +45,5 @@ Cependant, ce cas d'usage ne peut pas être considéré comme supporté. Trop de
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 

--- a/docs/fr/guides/storage-and-backup/backup-agent/troubleshooting.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-agent/troubleshooting.mdx
@@ -248,4 +248,4 @@ Pour résoudre les problèmes avec Backup Agent, il est souvent nécessaire de c
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/backup-agent/update.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-agent/update.mdx
@@ -28,4 +28,4 @@ Si vous avez des demandes spécifiques, n'hésitez pas à [contacter le support 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
@@ -81,5 +81,5 @@ Vous pouvez voir les dernières alarmes sur vos agents et sauvegardes dans la pa
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 

--- a/docs/fr/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Aller plus loin"
   items:
     - title: "Rejoindre la communauté OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Voir la roadmap & changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: "Rejoindre Discord"

--- a/docs/fr/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
@@ -583,6 +583,6 @@ Vous pouvez également exécuter l'interface utilisateur localement sur votre pr
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
@@ -135,4 +135,4 @@ La durée du processus de restauration dépend de la taille de votre sauvegarde 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d’utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulter la roadmap & le changelog
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
+++ b/docs/fr/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
@@ -278,4 +278,4 @@ Vous pouvez maintenant désactiver l'utilisateur que vous avez créé pour crée
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre Technical Account Manager ou rendez-vous sur [cette page](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr), ou sur le channel dédié [Discord](https://discord.gg/ovhcloud).
+Échangez avec notre [communauté d’utilisateurs](/links/community), ou sur le channel dédié [Discord](https://discord.gg/ovhcloud).

--- a/docs/fr/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
@@ -112,4 +112,4 @@ Choisir la bonne option de déploiement garantit des performances optimales, une
 
 Si vous avez besoin d’une formation ou d’une assistance technique pour la mise en œuvre de nos solutions, contactez votre représentant commercial ou adressez-vous à notre [équipe Professional Services](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
@@ -128,4 +128,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
@@ -241,4 +241,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
@@ -53,4 +53,4 @@ Rendez-vous sur notre chaîne Discord dédiée : [https://discord.gg/ovhcloud](h
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
@@ -97,4 +97,4 @@ Rendez-vous sur notre chaîne Discord dédiée : [https://discord.gg/ovhcloud](h
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
@@ -93,4 +93,4 @@ Rendez-vous sur notre chaîne Discord dédiée : [https://discord.gg/ovhcloud](h
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
@@ -96,5 +96,5 @@ Rendez-vous sur notre chaîne Discord dédiée : [https://discord.gg/ovhcloud](h
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
@@ -61,4 +61,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
@@ -205,4 +205,4 @@ Rendez-vous sur notre chaîne Discord dédiée : [https://discord.gg/ovhcloud](h
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
@@ -110,4 +110,4 @@ Rendez-vous sur notre chaîne Discord dédiée : [https://discord.gg/ovhcloud](h
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
@@ -112,4 +112,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
@@ -172,4 +172,4 @@ Rendez-vous sur notre chaîne Discord dédiée : [https://discord.gg/ovhcloud](h
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulter la roadmap & le changelog
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/storage-and-backup/block-storage/overview.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
@@ -119,4 +119,4 @@ Suivant la taille du snapshot utilisé, l'opération de création du volume pour
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
@@ -233,4 +233,4 @@ Si vous n'êtes pas familier avec l'utilisation de la solution Enterprise File S
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
@@ -134,4 +134,4 @@ Enterprise File Storage est un service facturé mensuellement au volume (de 1 à
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
@@ -61,4 +61,4 @@ Prenez note du nouvel `id` si vous souhaitez continuer à effectuer des opérati
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
@@ -120,4 +120,4 @@ Vous pouvez à présent suivre les guides ci-dessous pour créer et gérer vos v
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
@@ -58,4 +58,4 @@ Cependant, si vous obtenez des erreurs de type « erreur périphérique invalide
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
@@ -259,4 +259,4 @@ Si aucune erreur ne se produit, le volume EFS sera désormais monté automatique
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
@@ -150,4 +150,4 @@ Vous pouvez supprimer votre volume à l'aide de la route API suivante :
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
@@ -147,4 +147,4 @@ Le volume est maintenant restauré au snapshot sélectionné.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
@@ -102,4 +102,4 @@ Pour supprimer une politique de snapshot :
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
@@ -1164,4 +1164,4 @@ Destroy complete! Resources: 2 destroyed.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
@@ -628,4 +628,4 @@ Le snapshot est créé sur le service Enterprise File Storage et peut être util
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l'équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
@@ -97,4 +97,4 @@ Vous pouvez obtenir le `aclRuleId` à partir de la réponse obtenue lors de cré
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
@@ -106,4 +106,4 @@ Remplacez `serviceName` par l'ID de votre service, `shareId` par l'ID du volume 
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
@@ -125,4 +125,4 @@ Remplacez `serviceName` par l'ID de votre service et `shareId` par l'ID du volum
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulter la roadmap & le changelog
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
@@ -86,4 +86,4 @@ La suppression est irréversible. Assurez-vous que le snapshot n'est plus néces
 - [File Storage Service – Premiers pas](/guides/storage-and-backup/file-storage/file-storage-service/getting-started)
 - [Préparation d'un environnement pour utiliser l'API OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
@@ -93,6 +93,6 @@ Vous restez responsable de :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
@@ -89,4 +89,4 @@ mount: /mnt/FolderMount: mount(2) system call failed: No route to host.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
@@ -384,4 +384,4 @@ Les périodes proposées sont de 1, 12, 24 et 36 mois. À la fin de votre pério
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
@@ -125,4 +125,4 @@ Pour supprimer une partition, cliquez sur le bouton <code className="action">(..
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
@@ -103,4 +103,4 @@ Pour supprimer une adresse IP ou une plage d'adresses de l'ACL, utilisez la rout
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
@@ -42,4 +42,4 @@ Attention si vous ajoutez d'autres options à rsync, celles-ci pourraient ne pas
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -339,4 +339,4 @@ Certains noyaux Linux utilisent une valeur `read_ahead_kb` par défaut de 128 Ko
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
@@ -153,4 +153,4 @@ Utilisez la route suivante pour supprimer une partition :
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
@@ -119,4 +119,4 @@ Utilisez la route suivante pour supprimer une partition :
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -170,4 +170,4 @@ Plus d’informations dans la section [Aller plus loin](#gofurther) de ce guide.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulter la roadmap & le changelog
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/storage-and-backup/file-storage/overview.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/overview.mdx
@@ -11,7 +11,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/it/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
+++ b/docs/it/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
@@ -87,4 +87,4 @@ Se hai un server Bare Metal a **Beauharnois (BHS)** con una interfaccia di rete 
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/backup-agent/backup-restore.mdx
+++ b/docs/it/guides/storage-and-backup/backup-agent/backup-restore.mdx
@@ -230,4 +230,4 @@ Dovrai adattare il server e le credenziali a quelle che ti abbiamo fornito.
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/backup-agent/billing.mdx
+++ b/docs/it/guides/storage-and-backup/backup-agent/billing.mdx
@@ -29,4 +29,4 @@ A vostra disposizione c'è un pannello `Fatturazione` nel vostro <ManagerLink to
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/backup-agent/deletion.mdx
+++ b/docs/it/guides/storage-and-backup/backup-agent/deletion.mdx
@@ -78,4 +78,4 @@ Conferma l'eliminazione nella finestra che appare.
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/backup-agent/first-configuration.mdx
+++ b/docs/it/guides/storage-and-backup/backup-agent/first-configuration.mdx
@@ -149,4 +149,4 @@ Una volta che il file di installazione è sul tuo server, vai nella directory ch
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
+++ b/docs/it/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
@@ -277,4 +277,4 @@ Una volta che i tuoi agenti sono operativi, configura i tuoi backup tramite l'in
 - [Gestire backup e ripristini](/guides/storage-and-backup/backup-agent/backup-restore)
 - [Diagnostica e risoluzione dei problemi](/guides/storage-and-backup/backup-agent/troubleshooting)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/backup-agent/overview.mdx
+++ b/docs/it/guides/storage-and-backup/backup-agent/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/storage-and-backup/backup-agent/product-presentation.mdx
+++ b/docs/it/guides/storage-and-backup/backup-agent/product-presentation.mdx
@@ -87,4 +87,4 @@ Mapping delle zone di backup:
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/backup-agent/restrictions.mdx
+++ b/docs/it/guides/storage-and-backup/backup-agent/restrictions.mdx
@@ -44,4 +44,4 @@ lastUpdated: 2026-02-03
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/backup-agent/troubleshooting.mdx
+++ b/docs/it/guides/storage-and-backup/backup-agent/troubleshooting.mdx
@@ -246,4 +246,4 @@ Per risolvere i problemi con Backup Agent, è spesso necessario consultare ed es
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/backup-agent/update.mdx
+++ b/docs/it/guides/storage-and-backup/backup-agent/update.mdx
@@ -28,4 +28,4 @@ Se avete richieste specifiche, non esitate a [contattare l'assistenza OVHcloud](
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
+++ b/docs/it/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
@@ -81,4 +81,4 @@ Puoi visualizzare le ultime allerte sui tuoi agenti e copie di backup nella sezi
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
+++ b/docs/it/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Per saperne di più"
   items:
     - title: "Visita la community OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Visualizza la roadmap e il changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: "Unisciti a Discord"

--- a/docs/it/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
+++ b/docs/it/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
@@ -135,4 +135,4 @@ The duration of the restore process depends on the size of your backup and your 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
+++ b/docs/it/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
+++ b/docs/it/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
@@ -278,4 +278,4 @@ You can now disable the user that you have created to create the registration.
 
 If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](https://www.ovhcloud.com/it/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
@@ -112,4 +112,4 @@ Scegliere l'opzione di distribuzione corretta garantisce prestazioni ottimali, u
 
 Se hai bisogno di formazione o di supporto tecnico per l'implementazione delle nostre soluzioni, contatta il tuo rappresentante commerciale o rivolgiti al nostro [team Professional Services](https://www.ovhcloud.com/it/professional-services/) per richiedere un preventivo e un'analisi personalizzata del tuo progetto.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
@@ -128,4 +128,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
@@ -241,4 +241,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
@@ -53,4 +53,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
@@ -97,4 +97,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
@@ -93,4 +93,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
@@ -96,4 +96,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
@@ -61,4 +61,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
@@ -208,4 +208,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
@@ -108,4 +108,4 @@ Visita il nostro canale Discord dedicato: [https://discord.gg/ovhcloud](https://
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Unisciti alla nostra community di utenti su [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
@@ -112,4 +112,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
@@ -172,4 +172,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/storage-and-backup/block-storage/overview.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
@@ -119,4 +119,4 @@ In base alla dimensione dello Snapshot utilizzato, l’operazione di creazione d
 
 Se hai bisogno di formazione o assistenza tecnica per implementare le nostre soluzioni, contatta il tuo rappresentante commerciale o clicca su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del tuo progetto ai nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts.mdx
@@ -141,4 +141,4 @@ Qual è la differenza tra Terabyte (TB) e Tebibyte (TiB)?
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
@@ -233,4 +233,4 @@ Se avete bisogno di formazione o di assistenza tecnica per implementare le nostr
 
 Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre soluzioni [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
@@ -140,4 +140,4 @@ Enterprise File Storage è un servizio fatturato mensilmente al volume (da 1 a 5
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
@@ -61,4 +61,4 @@ Prendi nota del nuovo `id` se vuoi continuare a eseguire operazioni sullo Snapsh
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
@@ -118,4 +118,4 @@ You can now follow the guides below to create and manage your volumes, snapshots
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
@@ -58,4 +58,4 @@ Tuttavia, se si verificano errori di tipo "invalid device error" durante alcune 
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
@@ -251,4 +251,4 @@ If no errors occur, the EFS volume will now automatically mount on boot.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
@@ -155,4 +155,4 @@ Puoi eliminare il tuo volume utilizzando la strada API seguente:
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
@@ -152,4 +152,4 @@ A questo punto il volume verrà ripristinato allo Snapshot selezionato.
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all'indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
@@ -108,4 +108,4 @@ Per eliminare una politica di Snapshot:
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all'indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
@@ -865,4 +865,4 @@ Destroy complete! Resources: 2 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
@@ -626,4 +626,4 @@ Lo snapshot viene creato sul servizio Enterprise File Storage e può essere util
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
@@ -102,4 +102,4 @@ Puoi ottenere il `aclRuleId` a partire dalla risposta ottenuta durante la creazi
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
@@ -111,4 +111,4 @@ Sostituisci `serviceName` con l'ID del tuo servizio, `shareId` con l'ID del volu
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
@@ -130,4 +130,4 @@ Sostituisci `serviceName` con l'ID del tuo servizio e `shareId` con l'ID del vol
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
@@ -86,4 +86,4 @@ Deletion is irreversible. Ensure the snapshot is no longer required.
 - [File Storage Service – Getting Started](/guides/storage-and-backup/file-storage/file-storage-service/getting-started)
 - [Preparing an environment for using the OpenStack API](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
@@ -93,6 +93,6 @@ You remain responsible for:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
@@ -87,4 +87,4 @@ mount: /mnt/FolderMount: mount(2) system call failed: No route to host.
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
@@ -387,4 +387,4 @@ I periodi proposti sono di 1, 12, 24 e 36 mesi. Alla fine del periodo contrattua
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
@@ -130,4 +130,4 @@ Per eliminare una partizione, clicca sul pulsante <code className="action">(...)
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
@@ -108,4 +108,4 @@ Per eliminare un indirizzo IP o una gamma di indirizzi dell'ACL, utilizza questa
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
@@ -47,4 +47,4 @@ Attenzione: se aggiungi altre opzioni a rsync, queste potrebbero non essere comp
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -337,4 +337,4 @@ Alcuni kernel Linux utilizzano un valore `read_ahead_kb` di default di 128 KB. Ã
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
@@ -158,4 +158,4 @@ Per eliminare una partizione, utilizza questa pagina:
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
@@ -124,4 +124,4 @@ Per eliminare una partizione, utilizza questa pagina:
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -175,4 +175,4 @@ Per maggiori informazioni consulta la sezione [Per saperne di più](#gofurther) 
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/storage-and-backup/file-storage/overview.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/overview.mdx
@@ -11,7 +11,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/pl/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
@@ -87,4 +87,4 @@ Jeśli masz serwer Bare Metal w **Beauharnois (BHS)** z europejskim interfejsem 
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/backup-agent/backup-restore.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-agent/backup-restore.mdx
@@ -230,4 +230,4 @@ Będziesz musiał dostosować serwer i poświadczenia, aby dopasować je do tych
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/backup-agent/billing.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-agent/billing.mdx
@@ -29,4 +29,4 @@ Możesz użyć pulpitu <code className="action">Billing</code> w Twoim <ManagerL
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/backup-agent/deletion.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-agent/deletion.mdx
@@ -78,4 +78,4 @@ Potwierdź usunięcie w oknie, które się pojawi.
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/backup-agent/first-configuration.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-agent/first-configuration.mdx
@@ -149,4 +149,4 @@ Po tym, jak plik instalacyjny znajdzie się na Twoim serwerze, przejdź do folde
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
@@ -277,4 +277,4 @@ Po uruchomieniu agentów skonfiguruj kopie zapasowe za pomocą interfejsu Veeam 
 - [Zarządzanie kopiami zapasowymi i przywracaniem](/guides/storage-and-backup/backup-agent/backup-restore)
 - [Przewodnik rozwiązywania problemów](/guides/storage-and-backup/backup-agent/troubleshooting)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/backup-agent/overview.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-agent/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/storage-and-backup/backup-agent/product-presentation.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-agent/product-presentation.mdx
@@ -87,4 +87,4 @@ Mapowanie obszarów kopii zapasowych:
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/backup-agent/restrictions.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-agent/restrictions.mdx
@@ -45,4 +45,4 @@ Tego przypadku zastosowania nie można jednak uznać za wspierany. Może pojawi�
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/backup-agent/troubleshooting.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-agent/troubleshooting.mdx
@@ -247,4 +247,4 @@ Aby rozwiązać problemy z Aplikacją Backup, często konieczne jest przeglądan
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/backup-agent/update.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-agent/update.mdx
@@ -28,4 +28,4 @@ Jeśli masz jakiekolwiek specjalne żądania, skontaktuj się proszę z [wsparci
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
@@ -81,4 +81,4 @@ Możesz wyświetlić najnowsze alerty dotyczące swoich agentów i kopii zapasow
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz harmonogram i dziennik zmian"
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: "Dołącz do Discorda"

--- a/docs/pl/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
@@ -135,4 +135,4 @@ The duration of the restore process depends on the size of your backup and your 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
@@ -278,4 +278,4 @@ You can now disable the user that you have created to create the registration.
 
 If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](https://www.ovhcloud.com/pl/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
@@ -110,4 +110,4 @@ Wybór odpowiedniej opcji wdrażania zapewnia optymalną wydajność, nadmiarowo
 
 Jeśli potrzebujesz szkoleń lub pomocy technicznej w wdrożeniu naszych rozwiązań, skontaktuj się ze swoim przedstawicielem handlowym lub zwróć się do naszego [zespołu Professional Services](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o indywidualną analizę Twojego projektu.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
@@ -128,4 +128,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
@@ -241,4 +241,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
@@ -53,4 +53,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
@@ -97,4 +97,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
@@ -93,4 +93,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
@@ -96,4 +96,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
@@ -61,4 +61,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
@@ -208,4 +208,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
@@ -105,7 +105,7 @@ Aby zmierzyć wydajność Cloud Disk Array, prowadzimy przez kilka godzin testy 
 
 ## Sprawdź również
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).
 
 ## Sprawdź również
 
@@ -113,4 +113,4 @@ Odwiedź nasz dedykowany kanał na Discordzie: [https://discord.gg/ovhcloud](htt
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do naszej społeczności użytkowników na [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
@@ -112,4 +112,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
@@ -172,4 +172,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/storage-and-backup/block-storage/overview.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
@@ -119,4 +119,4 @@ W zależności od użytego rozmiaru snapshota operacja tworzenia wolumenu może 
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w zakresie wdrażania naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij na [link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić naszych ekspertów z zespołu Professional Services o indywidualną analizę Twojego projektu.
 
-Przyłącz się do [społeczności użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts.mdx
@@ -141,4 +141,4 @@ Jaka jest różnica między Terabyte (TB) i Tebibyte (TiB)?
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
@@ -233,4 +233,4 @@ Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych r
 
 Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](https://www.ovhcloud.com/pl/support-levels/).
  
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
@@ -140,4 +140,4 @@ Enterprise File Storage to usługa płatna co miesiąc za wolumen (od 1 do 58 TB
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie[https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
@@ -61,4 +61,4 @@ Zapisz informacje o nowym `id`, jeśli chcesz kontynuować wykonywanie operacji 
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
@@ -118,4 +118,4 @@ You can now follow the guides below to create and manage your volumes, snapshots
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
@@ -58,4 +58,4 @@ Jeśli jednak podczas niektórych operacji zapisu wystąpią błędy typu "inval
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Przyłącz się do [społeczności użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
@@ -251,4 +251,4 @@ If no errors occur, the EFS volume will now automatically mount on boot.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
@@ -155,4 +155,4 @@ Możesz usunąć wolumen za pomocą następującej drogi API:
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
@@ -152,4 +152,4 @@ Wolumen jest teraz przywracany do wybranego snapshota.
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
@@ -108,4 +108,4 @@ Aby usunąć politykę wykonywania snapshotów:
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
@@ -865,4 +865,4 @@ Destroy complete! Resources: 2 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
@@ -626,4 +626,4 @@ Migawka jest tworzona na usłudze Enterprise File Storage i może być używana 
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
@@ -102,4 +102,4 @@ Możesz uzyskać `aclRuleId` na podstawie odpowiedzi uzyskanej podczas tworzenia
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
@@ -111,4 +111,4 @@ Zastąp `serviceName` ID Twojej usługi, `shareId` ID wolumenu i `snapshotId` ID
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
@@ -130,4 +130,4 @@ Zamień `serviceName` na ID usługi i `shareId` na ID wolumenu do usunięcia.
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
@@ -86,4 +86,4 @@ Deletion is irreversible. Ensure the snapshot is no longer required.
 - [File Storage Service – Getting Started](/guides/storage-and-backup/file-storage/file-storage-service/getting-started)
 - [Preparing an environment for using the OpenStack API](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
@@ -93,6 +93,6 @@ You remain responsible for:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
@@ -87,4 +87,4 @@ mount: /mnt/FolderMount: mount(2) system call failed: No route to host.
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
@@ -387,4 +387,4 @@ Proponowane okresy to 1, 12, 24 i 36 miesięcy. Pod koniec okresu abonamentu zos
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
@@ -130,4 +130,4 @@ Aby usunąć partycję, kliknij przycisk <code className="action">(...)</code> z
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
@@ -108,4 +108,4 @@ Aby usunąć adres IP lub zakres adresów ACL, użyj następującej drogi:
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
@@ -47,4 +47,4 @@ Uwaga: jeśli dodajesz inne opcje do rsync, mogą one nie być kompatybilne z sy
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [ https://community.ovh.com/en/](https://community.ovh.com/en/)
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -337,4 +337,4 @@ Niektóre jądra systemu Linux używają domyślnej wartości `read_ahead_kb` wy
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
@@ -158,4 +158,4 @@ Użyj następującej drogi, aby usunąć partycję:
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
@@ -124,4 +124,4 @@ Użyj następującej drogi, aby usunąć partycję:
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -175,4 +175,4 @@ Więcej informacji znajduje się w sekcji [Sprawdź również](#gofurther) ten p
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/storage-and-backup/file-storage/overview.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/overview.mdx
@@ -11,7 +11,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pt/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-agent/backup-agent-vault.mdx
@@ -87,4 +87,4 @@ Se tiver um servidor Bare Metal em **Beauharnois (BHS)** com uma interface de re
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/backup-agent/backup-restore.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-agent/backup-restore.mdx
@@ -232,4 +232,4 @@ Terá de adaptar o servidor e as credenciais com as que lhe fornecermos.
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/backup-agent/billing.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-agent/billing.mdx
@@ -29,4 +29,4 @@ Tem à sua disposição um painel de `Faturação` no seu <ManagerLink to="/">Á
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/backup-agent/deletion.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-agent/deletion.mdx
@@ -78,4 +78,4 @@ Confirme a eliminação na janela que aparece.
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/backup-agent/first-configuration.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-agent/first-configuration.mdx
@@ -149,4 +149,4 @@ Uma vez o ficheiro de instalação no seu servidor, aceda à pasta que o contém
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-agent/linux-cli-assistant.mdx
@@ -277,4 +277,4 @@ Depois de os seus agentes estarem operacionais, configure as suas cópias de seg
 - [Gerir as suas cópias de segurança e restauros](/guides/storage-and-backup/backup-agent/backup-restore)
 - [Diagnóstico e resolução de problemas](/guides/storage-and-backup/backup-agent/troubleshooting)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/backup-agent/overview.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-agent/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: Juntar-se ao Discord

--- a/docs/pt/guides/storage-and-backup/backup-agent/product-presentation.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-agent/product-presentation.mdx
@@ -87,4 +87,4 @@ Mapeamento das zonas de cópia de segurança:
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/backup-agent/restrictions.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-agent/restrictions.mdx
@@ -44,4 +44,4 @@ lastUpdated: 2026-02-03
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/backup-agent/troubleshooting.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-agent/troubleshooting.mdx
@@ -247,4 +247,4 @@ Para resolver problemas com o Backup Agent, é frequentemente necessário consul
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/backup-agent/update.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-agent/update.mdx
@@ -28,4 +28,4 @@ Se tiver solicitações específicas, não hesite em [contactar o suporte da OVH
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-agent/vspc-presentation.mdx
@@ -81,4 +81,4 @@ Pode ver os últimos alarmes nos seus agentes e cópias de segurança na secçã
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-and-disaster-recovery-solutions/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: "Visite a comunidade OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte o roadmap e o changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Junte-se ao Discord"

--- a/docs/pt/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/agent-bare-metal-recovery.mdx
@@ -135,4 +135,4 @@ The duration of the restore process depends on the size of your backup and your 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: Juntar-se ao Discord

--- a/docs/pt/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
@@ -278,4 +278,4 @@ You can now disable the user that you have created to create the registration.
 
 If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](https://www.ovhcloud.com/pt/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
@@ -112,4 +112,4 @@ Escolher a opção correta de implantação garante desempenho otimizado, redund
 
 Se precisar de formação ou de assistência técnica para a implementação das nossas soluções, contacte o seu representante comercial ou dirija-se à nossa [equipa de Professional Services](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projeto.
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
@@ -128,4 +128,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
@@ -241,4 +241,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
@@ -53,4 +53,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool.mdx
@@ -97,4 +97,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
@@ -93,4 +93,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
@@ -96,4 +96,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
@@ -61,4 +61,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
@@ -208,4 +208,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
@@ -108,4 +108,4 @@ Visite nosso canal Discord dedicado: [https://discord.gg/ovhcloud](https://disco
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
@@ -112,4 +112,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
@@ -172,4 +172,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: Juntar-se ao Discord

--- a/docs/pt/guides/storage-and-backup/block-storage/overview.mdx
+++ b/docs/pt/guides/storage-and-backup/block-storage/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
@@ -119,4 +119,4 @@ A criação do volume pode levar algum tempo, dependendo do tamanho da snapshot 
 
 Se necessitar de formação ou de assistência técnica para a implementação das nossas soluções, contacte o seu representante de vendas ou clique [neste link](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projeto aos nossos peritos da equipa Professional Services.
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts.mdx
@@ -141,4 +141,4 @@ Qual é a diferença entre Terabyte (TB) e Tebibyte (TiB)?
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
@@ -233,4 +233,4 @@ Se precisar de formação ou de assistência técnica para implementar as nossas
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
@@ -140,4 +140,4 @@ Enterprise File Storage é um serviço faturado mensalmente ao volume (de 1 a 58
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
@@ -61,4 +61,4 @@ Tome nota do novo `id` se deseja continuar a efetuar operações na snapshot.
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
@@ -118,4 +118,4 @@ You can now follow the guides below to create and manage your volumes, snapshots
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
@@ -58,4 +58,4 @@ No entanto, se receber erros do tipo "invalid device error" durante certas opera
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
@@ -251,4 +251,4 @@ If no errors occur, the EFS volume will now automatically mount on boot.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
@@ -155,4 +155,4 @@ Pode eliminar o seu volume através da seguinte rota API:
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
@@ -152,4 +152,4 @@ O volume será restaurado para a snapshot selecionada.
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
@@ -108,4 +108,4 @@ Para eliminar uma política de snapshots:
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
@@ -865,4 +865,4 @@ Destroy complete! Resources: 2 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
@@ -626,4 +626,4 @@ O snapshot é criado no serviço Enterprise File Storage e pode ser utilizado pa
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projeto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
@@ -102,4 +102,4 @@ Pode obter o `aclRuleId` a partir da resposta obtida aquando da criação do ACL
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
@@ -111,4 +111,4 @@ Substitua o `serviceName` pelo ID do seu serviço, `shareId` pelo ID do volume e
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
@@ -130,4 +130,4 @@ Substitua o `serviceName` pelo ID do seu serviço e `shareId` pelo ID do volume 
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/enterprise-file-storage/overview.mdx
@@ -15,7 +15,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: Juntar-se ao Discord

--- a/docs/pt/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/file-storage-service/create-snapshot.mdx
@@ -86,4 +86,4 @@ Deletion is irreversible. Ensure the snapshot is no longer required.
 - [File Storage Service – Getting Started](/guides/storage-and-backup/file-storage/file-storage-service/getting-started)
 - [Preparing an environment for using the OpenStack API](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/file-storage-service/key-concepts.mdx
@@ -93,6 +93,6 @@ You remain responsible for:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
@@ -88,4 +88,4 @@ mount: /mnt/FolderMount: mount(2) system call failed: No route to host.
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
@@ -384,4 +384,4 @@ Les périodes proposées sont de 1, 12, 24 et 36 mois. À la fin de votre pério
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
@@ -130,4 +130,4 @@ Para eliminar uma partição, clique no botão <code className="action">(...)</c
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
@@ -108,4 +108,4 @@ Para eliminar um endereço IP ou um intervalo de endereços do ACL, utilize a se
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
@@ -47,4 +47,4 @@ Atenção: se adicionar outras opções ao rsync, estas poderão não ser compat
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -337,4 +337,4 @@ Alguns kernels Linux utilizam um valor predefinido de 128 KB `read_ahead_kb`. Re
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
@@ -158,4 +158,4 @@ Utilize a seguinte rota para eliminar uma partição:
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
@@ -124,4 +124,4 @@ Utilize a seguinte rota para eliminar uma partição:
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -175,4 +175,4 @@ Para mais informações, aceda à secção [Quer saber mais](#gofurther).
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/ha-nas/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: Juntar-se ao Discord

--- a/docs/pt/guides/storage-and-backup/file-storage/overview.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/overview.mdx
@@ -11,7 +11,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"


### PR DESCRIPTION
### Scope: Storage and Backup

- Replace (dead) links to legacy community page with proper keys
- Fix hard URL in Overview pages to the correct one
