### PR TITLE
fix(build): strip trailing slash client-side to remove 404 flash

### DIFF
--- a/rspress.config.build.ts
+++ b/rspress.config.build.ts
@@ -49,6 +49,24 @@ export default defineConfig({
       // injection from useEffect guarantees React has hydrated first.
       tags: [
         {
+          // Trailing-slash normalization (runs before paint, no flash).
+          // Rspress cleanUrls emits flat files (foo.html), so the static
+          // server returns 404.html for `/<locale>/.../foo/`; the SPA router
+          // then renders the real content but leaves the slash in the URL,
+          // producing a visible "404 flash". Strip the slash synchronously in
+          // <head> and replace() to the canonical no-slash URL before React
+          // mounts. Excludes `/` and bare locale roots (`/fr/`, `/en/`, …).
+          tag: 'script',
+          head: true,
+          append: false,
+          children: [
+            '(function(){var p=location.pathname;',
+            "if(/^\\/(fr|en|de|es|it|pl|pt)\\/.+\\/$/.test(p)){",
+            'location.replace(p.replace(/\\/+$/,"")+location.search+location.hash);',
+            '}})();',
+          ].join(''),
+        },
+        {
           tag: 'script',
           head: true,
           append: true,

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -83,6 +83,21 @@ export default defineConfig({
       // components/Analytics) to guarantee React hydration completes first.
       tags: [
         {
+          // Trailing-slash normalization — mirrors rspress.config.build.ts.
+          // Strips a trailing slash from locale-prefixed paths and replace()s
+          // to the canonical no-slash URL before React mounts (no 404 flash).
+          // Excludes `/` and bare locale roots (`/fr/`, `/en/`, …).
+          tag: 'script',
+          head: true,
+          append: false,
+          children: [
+            '(function(){var p=location.pathname;',
+            "if(/^\\/(fr|en|de|es|it|pl|pt)\\/.+\\/$/.test(p)){",
+            'location.replace(p.replace(/\\/+$/,"")+location.search+location.hash);',
+            '}})();',
+          ].join(''),
+        },
+        {
           tag: 'script',
           head: true,
           append: true,


### PR DESCRIPTION
Rspress cleanUrls emits flat files (foo.html, not foo/index.html), so the
deploy platform's static server returns 404.html for /<locale>/.../foo/.
The SPA router then renders the real content but leaves the slash in the
URL — a visible "404 flash".

This injects a synchronous <head> script (before React mounts) that strips
a trailing slash from locale-prefixed paths and replace()s to the canonical
no-slash URL. Query string and hash preserved; bare locale roots (/fr/, …)
and / excluded. Added to both rspress.config.build.ts (prod) and
rspress.config.ts (dev).

Verified with Playwright against a static server emulating the deploy
platform: slashed URL lands directly on the no-slash page, no flash;
normal pages and locale roots unaffected.

Not addressed here: root-level typos like /test still return the platform
nginx default 404. That serving layer is owned by the dtci platform (not
this repo, not puppet — confirmed), so it needs a platform-config change.
