### PR TITLE
[SK-2630] docs: surface migration steps 3.1/3.2 in TOC + fix anchors (new-docs port)

### DIFF
--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -108,7 +108,9 @@ Die E-Mail-Technologie Ihrer MX Plan-Angebot kann je nach Aktivierungsdatum Ihre
 :::
 
 
-#### 3.1 Manuelle Migration eines MX Plan-Angebots zu Exchange, E-Mail Pro oder Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Manuelle Migration eines MX Plan-Angebots zu Exchange, E-Mail Pro oder Zimbra
 
 :::warning
 Dieser Abschnitt betrifft alle MX Plan-Dienste, die die Webmail-Technologie Roundcube, Zimbra oder OWA nutzen.
@@ -176,7 +178,9 @@ Wenn Sie ihn löschen möchten, gehen Sie in den Tab <code className="action">E-
 
 <Region zones={['eu']}>
 
-#### 3.2 Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder E-Mail Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder E-Mail Pro
 
 :::warning
 Dieser Abschnitt betrifft ausschließlich MX Plan-Dienste, die die Webmail-Technologie Roundcube nutzen.
@@ -211,13 +215,13 @@ Auch wenn Sie nicht mehr auf Ihre aktuelle E-Mail-Adresse zugreifen können, geh
 :::
 
 
-##### **Migration mit Exchange Konfigurationsassistent**
+#### **Migration mit Exchange Konfigurationsassistent**
 
 Der Assistent sollte erscheinen, um Ihnen bei der Konfiguration Ihres neuen Exchange Dienstes zu helfen. Während dieses Vorgangs können Sie die zu migrierenden MX Plan E-Mail-Accounts auswählen.
 
 Wenn der Konfigurationsassistent nicht startet, werden stattdessen die allgemeinen Informationen zum Exchange Dienst angezeigt. In diesem Fall müssen Sie Ihre Accounts über das MX Plan Interface migrieren.
 
-##### **Migration über das MX Plan Interface**
+#### **Migration über das MX Plan Interface**
 
 Um die Migration über dieses Interface durchzuführen, wählen Sie im Bereich <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> Ihres OVHcloud Kundencenters die betreffende Domain aus. Klicken Sie im Tab <code className="action">E-Mails</code> auf <code className="action">...</code> in der Zeile des betreffenden E-Mail-Accounts (auch als Quell-Account bezeichnet) und dann auf <code className="action">Account überführen</code>.
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -109,7 +109,9 @@ The email technology of your MX Plan offer may vary depending on the date of act
 :::
 
 
-#### 3.1 Manual migration of an MX Plan offer to Exchange, Email Pro or Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Manual migration of an MX Plan offer to Exchange, Email Pro or Zimbra
 
 :::warning
 This section concerns all MX Plan services using the Roundcube, Zimbra or OWA webmail technology.
@@ -177,7 +179,9 @@ If you want to delete it, go to the <code className="action">Email accounts</cod
 
 <Region zones={['eu']}>
 
-#### 3.2 Automatic migration of an MX Plan Roundcube offer to Exchange or Email Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Automatic migration of an MX Plan Roundcube offer to Exchange or Email Pro
 
 :::warning
 This section concerns only MX Plan services using the Roundcube webmail technology.
@@ -212,13 +216,13 @@ Even if you can no longer access your current email account, existing and newly 
 :::
 
 
-##### **Migration with the Exchange configuration assistant**
+#### **Migration with the Exchange configuration assistant**
 
 A wizard will guide you through configuring your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
 
 If the configuration wizard does not appear, the general information for the Exchange service will appear instead. In this case, you will need to migrate your accounts via the MX Plan interface.
 
-##### **Migration from the MX Plan interface**
+#### **Migration from the MX Plan interface**
 
 To migrate from this interface, go to the <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> section of your OVHcloud Control Panel and select the relevant domain. In the <code className="action">Emails</code> tab, click on <code className="action">...</code> on the line of the relevant email account (also called the source account), then on <code className="action">Migrate account</code>.
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -108,7 +108,9 @@ La tecnología de correo de su oferta MX Plan puede variar según la fecha de ac
 :::
 
 
-#### 3.1 Migración manual de una oferta MX Plan a Exchange, Email Pro o Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Migración manual de una oferta MX Plan a Exchange, Email Pro o Zimbra
 
 :::warning
 Esta sección se aplica a todos los servicios MX Plan que utilizan la tecnología de webmail Roundcube, Zimbra u OWA.
@@ -174,7 +176,9 @@ Si quiere eliminarlo, abra la pestaña <code className="action">Cuentas de corre
 
 <Region zones={['eu']}>
 
-#### 3.2 Migración automática de una oferta MX Plan Roundcube a Exchange o Email Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Migración automática de una oferta MX Plan Roundcube a Exchange o Email Pro
 
 :::warning
 Esta sección se aplica únicamente a los servicios MX Plan que utilizan la tecnología de webmail Roundcube.
@@ -209,13 +213,13 @@ Aunque ya no podrá acceder a su dirección de correo electrónico actual, tanto
 :::
 
 
-##### **Migración desde el asistente de configuración de Exchange**
+#### **Migración desde el asistente de configuración de Exchange**
 
 El asistente aparecerá para ayudarle a configurar su nuevo servicio Exchange. Durante este proceso, podrá seleccionar las cuentas MX Plan que quiera migrar.
 
 Si no aparece el asistente de configuración, la información general del servicio Exchange se mostrará en su lugar. En ese caso, deberá realizar la migración de sus cuentas a través de la interfaz MX Plan.
 
-##### **Migración desde la interfaz MX Plan**
+#### **Migración desde la interfaz MX Plan**
 
 Para realizar la migración desde esta interfaz, acceda a la sección <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> de su área de cliente de OVHcloud y seleccione el dominio correspondiente. En la pestaña <code className="action">Correo electrónico</code>, haga clic en <code className="action">...</code> en la línea de la cuenta de correo correspondiente (también llamada cuenta de origen) y seleccione <code className="action">Migrar la cuenta</code>.
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -110,7 +110,9 @@ La technologie e-mail de votre offre MX Plan peut varier selon la date d’activ
 :::
 
 
-#### 3.1 Migration manuelle d'une offre MX Plan vers Exchange, Email Pro ou Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Migration manuelle d'une offre MX Plan vers Exchange, Email Pro ou Zimbra
 
 :::warning
 Cette partie concerne l'ensemble des services MX Plan utilisant la technologie webmail Roundcube, Zimbra ou OWA.
@@ -178,7 +180,9 @@ Si vous souhaitez le supprimer, dirigez-vous dans l'onglet <code className="acti
 
 <Region zones={['eu']}>
 
-#### 3.2 Migration automatique d'une offre MX Plan Roundcube vers Exchange ou Email Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Migration automatique d'une offre MX Plan Roundcube vers Exchange ou Email Pro
 
 :::warning
 Cette partie concerne uniquement les services MX Plan utilisant la technologie webmail Roundcube.
@@ -213,13 +217,13 @@ Même si vous ne pourrez plus accéder à votre adresse e-mail actuelle, les mes
 :::
 
 
-##### **Migration depuis l'assistant de configuration Exchange**
+#### **Migration depuis l'assistant de configuration Exchange**
 
 L'assistant s'affiche pour vous aider à configurer votre nouveau service Exchange. Durant ce processus, vous pouvez sélectionner les comptes e-mail MX Plan à migrer.
 
 Si l'assistant de configuration ne s'affiche pas, les informations générales du service Exchange apparaîtront à la place. Dans ce cas, vous devrez réaliser la migration de vos comptes via l'interface MX Plan.
 
-##### **Migration depuis l'interface MX Plan**
+#### **Migration depuis l'interface MX Plan**
 
 Pour réaliser la migration depuis cette interface, rendez-vous dans la section <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> de votre espace client OVHcloud et sélectionnez le domaine concerné. Dans l'onglet <code className="action">Emails</code>, cliquez sur <code className="action">...</code> sur la ligne du compte e-mail concerné (également appelé compte source), puis sur <code className="action">Migrer le compte</code>.
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -108,7 +108,9 @@ La tecnologia e-mail della vostra offerta MX Plan può variare in base alla data
 :::
 
 
-#### 3.1 Migrazione manuale di un'offerta MX Plan verso Exchange, Email Pro o Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Migrazione manuale di un'offerta MX Plan verso Exchange, Email Pro o Zimbra
 
 :::warning
 Questa parte riguarda tutti i servizi MX Plan che utilizzano la tecnologia webmail Roundcube, Zimbra o OWA.
@@ -176,7 +178,9 @@ Per eliminarlo, seleziona la scheda <code className="action">Account email</code
 
 <Region zones={['eu']}>
 
-#### 3.2 Migrazione automatica di un'offerta MX Plan Roundcube verso Exchange o Email Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Migrazione automatica di un'offerta MX Plan Roundcube verso Exchange o Email Pro
 
 :::warning
 Questa parte riguarda esclusivamente i servizi MX Plan che utilizzano la tecnologia webmail Roundcube.
@@ -211,13 +215,13 @@ Anche se non sarà più possibile accedere al tuo indirizzo email corrente, i me
 :::
 
 
-##### **Migrazione dall'assistente di configurazione Exchange**
+#### **Migrazione dall'assistente di configurazione Exchange**
 
 L'assistente dovrebbe apparire per aiutarti a configurare il tuo nuovo servizio Exchange. Durante questo processo, è possibile selezionare gli account email MX Plan da migrare.
 
 Se l'assistente di configurazione non compare, visualizzi le informazioni generali del servizio Exchange. In questo caso, sarà necessario effettuare la migrazione dei tuoi account tramite l'interfaccia MX Plan.
 
-##### **Migrazione dall'interfaccia MX Plan**
+#### **Migrazione dall'interfaccia MX Plan**
 
 Per effettuare la migrazione da questa interfaccia, accedi alla sezione <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> del tuo Spazio Cliente OVHcloud e seleziona il dominio interessato. Nella scheda <code className="action">Email</code>, clicca su <code className="action">...</code> sulla riga dell'account email interessato (chiamato anche account sorgente) e poi su <code className="action">Migra l'account</code>.
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -108,7 +108,9 @@ Technologia e-maila oferty MX Plan może się różnić w zależności od daty a
 :::
 
 
-#### 3.1 Ręczna migracja oferty MX Plan do Exchange, E-mail Pro lub Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Ręczna migracja oferty MX Plan do Exchange, E-mail Pro lub Zimbra
 
 :::warning
 Ta sekcja dotyczy wszystkich usług MX Plan korzystających z technologii webmaila Roundcube, Zimbra lub OWA.
@@ -176,7 +178,9 @@ Jeśli chcesz go usunąć, przejdź do zakładki <code className="action">Konta 
 
 <Region zones={['eu']}>
 
-#### 3.2 Automatyczna migracja oferty MX Plan Roundcube do Exchange lub E-mail Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Automatyczna migracja oferty MX Plan Roundcube do Exchange lub E-mail Pro
 
 :::warning
 Ta sekcja dotyczy wyłącznie usług MX Plan korzystających z technologii webmaila Roundcube.
@@ -211,13 +215,13 @@ Nawet jeśli nie będziesz miał dostępu do Twojego aktualnego adresu e-mail, j
 :::
 
 
-##### **Migracja z poziomu asystenta konfiguracji Exchange**
+#### **Migracja z poziomu asystenta konfiguracji Exchange**
 
 Asystent powinien pojawić się, aby pomóc Ci w skonfigurowaniu nowej usługi Exchange. Podczas tego procesu będziesz mógł wybrać konta e-mail MX Plan, które chcesz przenieść.
 
 Jeśli asystent konfiguracji nie wyświetla się, wyświetlą się ogólne informacje o usłudze Exchange. W takim przypadku będziesz musiał przeprowadzić migrację Twoich kont za pomocą interfejsu MX Plan.
 
-##### **Migracja z poziomu interfejsu MX Plan**
+#### **Migracja z poziomu interfejsu MX Plan**
 
 Aby przeprowadzić migrację w tym interfejsie, przejdź do sekcji <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> Panelu klienta OVHcloud i wybierz odpowiednią domenę. W karcie <code className="action">E-maile</code> kliknij logo w kształcie koła zębatego na linii odpowiedniego konta e-mail (zwane również kontem źródłowym), a następnie kliknij <code className="action">Przeprowadź migrację konta</code>.
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -108,7 +108,9 @@ A tecnologia de e-mail da sua oferta MX Plan pode variar consoante a data de ati
 :::
 
 
-#### 3.1 Migração manual de uma oferta MX Plan para Exchange, E-mail Pro ou Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Migração manual de uma oferta MX Plan para Exchange, E-mail Pro ou Zimbra
 
 :::warning
 Esta secção aplica-se a todos os serviços MX Plan que utilizam a tecnologia webmail Roundcube, Zimbra ou OWA.
@@ -176,7 +178,9 @@ Se pretender eliminá-lo, aceda ao separador <code className="action">Contas de 
 
 <Region zones={['eu']}>
 
-#### 3.2 Migração automática de uma oferta MX Plan Roundcube para Exchange ou E-mail Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Migração automática de uma oferta MX Plan Roundcube para Exchange ou E-mail Pro
 
 :::warning
 Esta secção aplica-se apenas aos serviços MX Plan que utilizam a tecnologia webmail Roundcube.
@@ -211,13 +215,13 @@ Mesmo que já não possa aceder ao seu endereço de e-mail atual, as mensagens j
 :::
 
 
-##### **Migração a partir do assistente de configuração Exchange**
+#### **Migração a partir do assistente de configuração Exchange**
 
 O assistente deverá aparecer para o ajudar a configurar o seu novo serviço Exchange. Durante este processo, poderá selecionar as contas de e-mail MX Plan a migrar.
 
 Se o assistente de configuração não for apresentado, aparecerão as informações gerais do serviço Exchange. Neste caso, deverá realizar a migração das suas contas através da interface MX Plan.
 
-##### **Migração a partir da interface MX Plan**
+#### **Migração a partir da interface MX Plan**
 
 Para realizar a migração a partir desta interface, aceda à secção <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> da sua Área de Cliente OVHcloud e selecione o domínio em causa. No separador <code className="action">E-mails</code>, clique no ícone em forma de engrenagem na linha da conta de e-mail em causa (também designada conta de origem) e, a seguir, em <code className="action">Migrar conta</code>.
 


### PR DESCRIPTION
Port of legacy PR ovh/docs#9409 to new-docs.

## Context
Support feedback (SK-2630) on the MX Plan → Exchange / Email Pro migration guide.
Two issues, same root cause: sub-parts 3.1 and 3.2 were level-4 headings (`####`).

1. **TOC** — the OVHcloud TOC only goes down to `###`, so 3.1/3.2 never appeared and couldn't be anchored to send a customer the "3.2 Automatic migration" section (they landed on Step 3 and could miss the Roundcube alert callout).
2. **Off-by-one anchors** — `<a name>` anchors sat inline at the end of the heading line, so internal links (`#roundcube-mxplan`) landed one line below the heading.

## Changes
- Promote 3.1 / 3.2 from `####` to `###` → visible in the TOC and anchorable.
- Move `<a name>` anchors onto their own line, before the heading → links land on the heading.
- Demote the two "Migration from…" sub-headings `#####` → `####` for hierarchy.

Anchor names unchanged → existing internal links keep working. Purely structural; no images, no syntax conversion needed.

## Scope
7 locales (en, fr, de, es, it, pl, pt) — all real files, no symlinks. New-docs content matched the legacy base exactly → clean port, no divergence.