### PR TITLE
fix(docs): normalize community links batch 7: Bare Metal (2/2)

### DIFF
--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
@@ -114,4 +114,4 @@ Danach wird die neue Regel in der Übersicht angezeigt und Sie können die Einst
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
@@ -94,4 +94,4 @@ Konsultieren Sie die entsprechenden Anleitungen und sonstige externe Wissensress
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/apps-first-steps.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/apps-first-steps.mdx
@@ -184,4 +184,4 @@ IMPORTANT NOTES:
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
@@ -188,4 +188,4 @@ Wenn Sie die Änderungen vorgenommen haben, starten Sie Ihren VPS in Ihrem <Mana
 
 [Rescue-Modus für einen VPS aktivieren](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
@@ -172,4 +172,4 @@ ntfsfix /dev/sdb2
 
 [Rescue-Modus für einen VPS aktivieren](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
@@ -312,4 +312,4 @@ Im Tab <code className="action">Start</code> finden Sie im Bereich **Ihre Konfig
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
@@ -561,4 +561,4 @@ Um die automatische Netzwerkverwaltung mit Cloud-init wieder zu aktivieren, lös
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
@@ -523,4 +523,4 @@ Um die Verbindung zu testen senden Sie einfach von außerhalb einen Ping an Ihre
 
 Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
 
-Für den Austausch mit unserer [User Community](https://community.ovhcloud.com/community/en).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
@@ -71,4 +71,4 @@ Falls der Domänenname von OVHcloud als Registrar verwaltet wird **und OVHcloud 
 
 [DNS-Server von Domainnamen bei OVHcloud ändern](/guides/web-cloud/domains/dns-server-edit)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
@@ -77,4 +77,4 @@ Beachten Sie, dass diese Methode von cPanel nicht empfohlen wird. Ihre Verwendun
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
@@ -122,4 +122,4 @@ Wir empfehlen Ihnen außerdem unsere Anleitung [zum Sichern eines VPS](/guides/b
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
@@ -355,4 +355,4 @@ By following this guide, you have set up an automatic deployment pipeline from y
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/de/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
@@ -228,4 +228,4 @@ By following this guide, you have set up an automatic deployment pipeline betwee
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/de/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
@@ -112,4 +112,4 @@ Um die Terminierung von End-of-Life und End-of-Support für Images und Betriebss
 
 Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](https://partner.ovhcloud.com/de/directory/).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
@@ -222,4 +222,4 @@ Zögern Sie nicht, zu experimentieren, denn Sie können nicht mehr benötigte Re
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
@@ -229,4 +229,4 @@ Das erweiterte Volume beinhaltet nun den zusätzlichen Speicherplatz.
 
 Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
@@ -135,4 +135,4 @@ You can now use Docker to:
 
 [Secure an OVHcloud VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -238,4 +238,4 @@ For advanced or multi-service use, this guide is recommended.
 
 [Secure an OVHcloud VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -153,4 +153,4 @@ To deepen certain aspects or strengthen the security and reliability of your ins
 
 [Official Nextcloud documentation](https://docs.nextcloud.com)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -118,4 +118,4 @@ The rest takes place in the **Overview** menu: enter your **Gateway Token** to l
 
 [Official OpenClaw documentation](https://docs.openclaw.ai/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
@@ -276,4 +276,4 @@ sudo systemctl list-timers | grep certbot
  
 Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](https://partner.ovhcloud.com/de/directory/).
  
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
@@ -388,4 +388,4 @@ For a full list of security best practices, please refer to our guides "[Securin
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/de/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
@@ -197,4 +197,4 @@ Beachten Sie, dass diese Installationsanleitung auch für einen [OVHcloud Dedica
 
 Zu Add-ons, Mods und um die Konfiguration Ihres Minecraft-Servers zu individualisieren, finden Sie hier die offizielle Dokumentation: [https://help.mojang.com/](https://help.mojang.com/).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
@@ -100,4 +100,4 @@ For a list of available commands, see the "Basic Usage" section of [LinuxGSM](ht
 
 [OVHcloud VPS FAQ](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
@@ -174,4 +174,4 @@ Wenn beim Neustart eines VPS ein Fehler auftritt, folgen Sie diesen Schritten:
 
 [Dateisystem auf einem VPS überprüfen](/guides/bare-metal-cloud/virtual-private-servers/check-filesystem)
 
-Für den Austausch mit unserer User Community besuchen Sie [unsere Community](https://community.ovhcloud.com/community/en).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
@@ -146,4 +146,4 @@ Sie können sich nun als "Administrator" mit diesem neuen Passwort anmelden.
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf unsere [Community-Seite](https://community.ovhcloud.com/community/en).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
@@ -356,4 +356,4 @@ Alle Informationen zu den für Ihren Dienst verfügbaren Backup-Lösungen finden
 
 [Network Firewall](/guides/bare-metal-cloud/dedicated-servers/firewall-network)
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/)
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
@@ -178,4 +178,4 @@ Dazu empfehlen wir Ihnen, folgende Aktionen auszuführen:
 
 [So rufen Sie den Server wieder auf, wenn das Benutzerpasswort verloren gegangen ist](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
@@ -233,4 +233,4 @@ Der Neuinstallationsvorgang kann einige Minuten dauern.
 
 [So rufen Sie den Serverzugriff bei verlorenem Benutzerpasswort wiederherstellen](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
@@ -145,4 +145,4 @@ Das Upgrade wird sofort wirksam und bewahrt alle Ihre Daten. Durch das Upgrade w
 
 [VPS FAQ](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
@@ -298,4 +298,4 @@ Geben Sie die gewünschte Größe des Volumes ein und klicken Sie auf <code clas
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
@@ -302,4 +302,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [Snapshots auf einem VPS verwenden](/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
@@ -127,4 +127,4 @@ Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.
 
 Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
@@ -202,4 +202,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [Automatische Backups auf einem VPS verwenden](/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
@@ -135,4 +135,4 @@ Ihr VPS kann automatisch auf die aktuelle Reihe migriert werden. Entdecken Sie d
 
 [Erste Schritte mit einem VPS](/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps)
 
-Werden Sie Mitglied unserer User Community auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -64,4 +64,4 @@ Um die Protokolldatei im Rettungsmodus zu öffnen, folgen Sie den Anweisungen im
 
 [So rufen Sie den Server wieder auf, wenn Sie das Benutzerpasswort verloren haben](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
@@ -108,4 +108,4 @@ You can then make changes to the settings of the new rule you have created.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
@@ -86,4 +86,4 @@ Please refer to the corresponding manuals and external knowledge resources if yo
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/apps-first-steps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/apps-first-steps.mdx
@@ -183,4 +183,4 @@ IMPORTANT NOTES:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
@@ -180,4 +180,4 @@ Once you have done the modifications, reboot your VPS in 'normal' mode in your <
 
 [Activating rescue mode on a VPS](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
@@ -163,4 +163,4 @@ ntfsfix /dev/sdb2
 
 [Activating Rescue Mode on VPS](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
@@ -314,4 +314,4 @@ In the <code className="action">Home</code> tab, in the **Your configuration** s
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
@@ -557,4 +557,4 @@ To re-enable automatic network management by Cloud-init, delete the newly create
 
 ## Go further <a name="go-further"></a>
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
@@ -525,4 +525,4 @@ To test the connection, ping your Additional IP from the outside. If it responds
 
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-gb/support-levels/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
@@ -71,4 +71,4 @@ If the domain name is managed by OVHcloud as its registrar **and it uses OVHclou
 
 [How to modify the DNS servers of an OVHcloud domain name](/guides/web-cloud/domains/dns-server-edit)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
@@ -79,4 +79,4 @@ Please note this is not recommended by cPanel and at your own risk. Should you w
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
@@ -122,4 +122,4 @@ We also recommend reading our guide to [securing a VPS](/guides/bare-metal-cloud
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
@@ -355,4 +355,4 @@ By following this guide, you have set up an automatic deployment pipeline from y
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
@@ -228,4 +228,4 @@ By following this guide, you have set up an automatic deployment pipeline betwee
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
@@ -112,4 +112,4 @@ To find out the end-of-life and end-of-support dates for images and operating sy
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
@@ -222,4 +222,4 @@ Feel free to experiment because you can always delete the rules you don't need, 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/import-export-n8n.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/import-export-n8n.mdx
@@ -285,4 +285,4 @@ For more information, please refer to the [official n8n documentation](https://d
 
 [How to install n8n on an OVHcloud VPS](/guides/bare-metal-cloud/virtual-private-servers/install-n8n-on-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/import-lovable-website-on-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/import-lovable-website-on-vps.mdx
@@ -221,4 +221,4 @@ In just a few minutes, you built your website with Lovable, then put it online o
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
@@ -227,4 +227,4 @@ The resized volume now includes the additional disk space.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-cloudpanel.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-cloudpanel.mdx
@@ -193,4 +193,4 @@ On the first launch, CloudPanel asks you to create the administrator account by 
 
 For specialized services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
@@ -133,4 +133,4 @@ You can now use Docker to:
 
 [Secure an OVHcloud VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-env-web-dev-on-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-env-web-dev-on-vps.mdx
@@ -157,4 +157,4 @@ For some general tips on securing a GNU/Linux-based server, see our guides:
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-ia-agent-on-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-ia-agent-on-vps.mdx
@@ -143,4 +143,4 @@ With this guide, you have installed an AI agent on your OVHcloud VPS, capable of
 
 For specialized services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-ispmanager.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-ispmanager.mdx
@@ -217,4 +217,4 @@ Accept the license agreement that appears to continue. Installation is complete,
 
 For specialized services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-n8n-on-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-n8n-on-vps.mdx
@@ -281,4 +281,4 @@ You now have a secure, operational n8n instance on your OVHcloud VPS, with autom
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -238,4 +238,4 @@ For advanced or multi-service use, this guide is recommended.
 
 [Secure an OVHcloud VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -153,4 +153,4 @@ To deepen certain aspects or strengthen the security and reliability of your ins
 
 [Official Nextcloud documentation](https://docs.nextcloud.com)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -361,4 +361,4 @@ docker exec -it openclaw node dist/index.js devices approve `<ID>`
 
 [Official OpenClaw documentation](https://docs.openclaw.ai/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
@@ -276,4 +276,4 @@ sudo systemctl list-timers | grep certbot
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -274,4 +274,4 @@ For some general tips on securing a GNU/Linux-based server, see our guides:
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-site-on-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-site-on-vps.mdx
@@ -267,4 +267,4 @@ You have just installed WordPress on your OVHcloud VPS or dedicated server with 
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
@@ -388,4 +388,4 @@ For a full list of security best practices, please refer to our guides "[Securin
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
@@ -193,4 +193,4 @@ Please note that this installation guide should also work on an OVHcloud [dedica
 
 For add-ons, mods and to personalise your Minecraft experience, please consult this official documentation: [https://help.mojang.com/](https://help.mojang.com/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
@@ -100,4 +100,4 @@ For a list of available commands, see the "Basic Usage" section of [LinuxGSM](ht
 
 [OVHcloud VPS FAQ](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
@@ -173,4 +173,4 @@ If you encounter errors when rebooting a VPS, use the following procedure:
 
 [Checking the file system on a VPS](/guides/bare-metal-cloud/virtual-private-servers/check-filesystem)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
@@ -143,4 +143,4 @@ You can now log in as "Administrator" with this new password.
 ## Go further
 
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
@@ -354,4 +354,4 @@ You can find all information on the available backup solutions for your service 
 
 [Network Firewall guide](/guides/bare-metal-cloud/dedicated-servers/firewall-network)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
@@ -178,4 +178,4 @@ For this, we recommend performing the following actions:
 
 [How to recover access to the server in case of lost user password](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
@@ -233,4 +233,4 @@ The reinstallation process can take a few minutes.
 
 [How to recover access to the server in case of lost user password](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
@@ -145,4 +145,4 @@ The upgrade will be effective immediately, keeping all of your data. Upgrading w
 
 [VPS FAQ](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
@@ -287,4 +287,4 @@ Enter your desired size and click <code className="action">OK</code>. Your volum
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
@@ -316,4 +316,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [How to use snapshots on a VPS](/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
@@ -127,4 +127,4 @@ For specialized services (SEO, development, etc.), contact [OVHcloud partners](h
 
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-gb/support-levels/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
@@ -206,4 +206,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [How to use automated backups on a VPS](/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
@@ -125,4 +125,4 @@ Your VPS can be migrated to the current range automatically. Find out the benefi
 
 [Getting started with a VPS](/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -62,4 +62,4 @@ To access the log file in rescue mode, follow the instructions in the guide "[En
 
 [How to recover access to the server if you lose the user password](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
@@ -114,4 +114,4 @@ A continuación, podrá realizar cambios en la seguridad de la nueva regla cread
 
 ## Más información <a name="go-further"></a>
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
@@ -94,4 +94,4 @@ Si necesita más información sobre estas tareas administrativas, consulte la do
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
@@ -186,4 +186,4 @@ Una vez realizados los cambios, reinicie su VPS en modo "normal" desde el <Manag
 
 [Activar el modo de rescate en un VPS](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
@@ -171,4 +171,4 @@ ntfsfix /dev/sdb2
 
 [Activar el modo de rescate en un VPS](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
@@ -314,4 +314,4 @@ En la pestaña <code className="action">Inicio</code>, en la sección **Su confi
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
@@ -564,4 +564,4 @@ Para que cloud-init vuelva a gestionar la red automáticamente, elimine dicho ar
 
 ## Más información <a name="go-further"></a>
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
@@ -524,4 +524,4 @@ Para probar la conexión, solo tiene que enviar un ping a su dirección Addition
 
 Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
  
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
@@ -71,4 +71,4 @@ Si el nombre de dominio está gestionado por OVHcloud como registrador **y utili
 
 [Modificar los servidores DNS de un dominio de OVHcloud](/guides/web-cloud/domains/dns-server-edit)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
@@ -78,4 +78,4 @@ Tenga en cuenta que cPanel no recomienda este método. Su uso está a tu riesgo 
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
@@ -124,4 +124,4 @@ Asimismo, le recomendamos que consulte nuestra guía para [proteger un VPS](/gui
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
@@ -355,4 +355,4 @@ By following this guide, you have set up an automatic deployment pipeline from y
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/es-es/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
@@ -228,4 +228,4 @@ By following this guide, you have set up an automatic deployment pipeline betwee
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/es-es/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
@@ -112,4 +112,4 @@ Para conocer las fechas de fin de vida y de fin de soporte de las imágenes y lo
 
 Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con [partners de OVHcloud](https://partner.ovhcloud.com/es-es/directory/).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
@@ -222,4 +222,4 @@ No dude en experimentar, ya que siempre puede borrar las reglas que no necesita,
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
@@ -227,4 +227,4 @@ El volumen redimensionado incluye ahora el espacio en disco adicional.
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
@@ -135,4 +135,4 @@ You can now use Docker to:
 
 [Secure an OVHcloud VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -238,4 +238,4 @@ For advanced or multi-service use, this guide is recommended.
 
 [Secure an OVHcloud VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -153,4 +153,4 @@ To deepen certain aspects or strengthen the security and reliability of your ins
 
 [Official Nextcloud documentation](https://docs.nextcloud.com)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -118,4 +118,4 @@ The rest takes place in the **Overview** menu: enter your **Gateway Token** to l
 
 [Official OpenClaw documentation](https://docs.openclaw.ai/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
@@ -275,4 +275,4 @@ sudo systemctl list-timers | grep certbot
  
 Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con [partners de OVHcloud](https://partner.ovhcloud.com/es-es/directory/).
  
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
@@ -388,4 +388,4 @@ For a full list of security best practices, please refer to our guides "[Securin
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/es-es/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
@@ -196,4 +196,4 @@ Esta guía de instalación también es válida para un [servidor dedicado de OVH
 
 Para añadir add-ons, mods y configurar más finamente su servidor Minecraft, consulte la siguiente documentación oficial: [https://help.mojang.com/](https://help.mojang.com/).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: "Más información"
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consultar la hoja de ruta y el registro de cambios"
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
@@ -100,4 +100,4 @@ For a list of available commands, see the "Basic Usage" section of [LinuxGSM](ht
 
 [OVHcloud VPS FAQ](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
@@ -175,4 +175,4 @@ Si se produce un error al reiniciar un VPS, siga estos pasos:
 
 [Comprobar el sistema de archivos en un VPS](/guides/bare-metal-cloud/virtual-private-servers/check-filesystem)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
@@ -146,4 +146,4 @@ Ahora puede iniciar sesión como «Administrator» con la nueva contraseña.
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
@@ -359,4 +359,4 @@ En la [página de producto](https://www.ovhcloud.com/es-es/vps/options/) y en la
 
 [Configurar el firewall de red](/guides/bare-metal-cloud/dedicated-servers/firewall-network)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
@@ -178,4 +178,4 @@ Para ello, le recomendamos realizar las siguientes acciones:
 
 [¿Cómo recuperar el acceso al servidor en caso de pérdida de la contraseña del usuario?](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
@@ -233,4 +233,4 @@ El proceso de reinstalación puede durar unos minutos.
 
 [Cómo recuperar el acceso al servidor en caso de pérdida de la contraseña del usuario](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
@@ -145,4 +145,4 @@ La actualización será efectiva inmediatamente, conservando todos sus datos. La
 
 [FAQ VPS](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
@@ -290,4 +290,4 @@ Escriba el tamaño deseado y haga clic en <code className="action">Aceptar</code
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
@@ -315,4 +315,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [Usar instantáneas en un servidor virtual privado (VPS)](/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
@@ -126,4 +126,4 @@ Para servicios especializados (posicionamiento web, desarrollo...), póngase en 
 
 Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas [ofertas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
@@ -202,4 +202,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [Usar copias de seguridad automatizadas en un servidor virtual privado (VPS)](/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
@@ -134,4 +134,4 @@ Su VPS puede migrarse automáticamente a la gama actual. Descubra las ventajas d
 
 [Primeros pasos con un VPS](/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps)
 
-Únase a nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -64,4 +64,4 @@ Para acceder al archivo de registro en modo rescue, siga las instrucciones del t
 
 [¿Cómo recuperar el acceso al servidor en caso de pérdida de la contraseña del usuario?](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
@@ -109,4 +109,4 @@ Par la suite, vous pouvez apporter des modifications au niveau de la sécurité 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
@@ -88,4 +88,4 @@ Reportez-vous aux documentations externes si vous avez besoin d'informations sup
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/apps-first-steps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/apps-first-steps.mdx
@@ -183,4 +183,4 @@ IMPORTANT NOTES:
 
 ## Allez plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
@@ -180,4 +180,4 @@ Une fois les modifications effectuées, redémarrez votre VPS en mode « normal 
 
 [Activer le mode rescue sur un VPS](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
@@ -163,4 +163,4 @@ ntfsfix /dev/sdb2
 
 [Activer le mode rescue sur un VPS](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
@@ -314,4 +314,4 @@ Depuis l'onglet <code className="action">Accueil</code>, dans la section **Votre
 
 ## Allez plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
@@ -562,4 +562,4 @@ Pour revenir à une gestion automatique de votre réseau par Cloud-init, supprim
 
 ## Aller plus loin <a name="go-further"></a>
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
@@ -526,4 +526,4 @@ Pour tester la connexion, envoyez un ping à votre adresse Additional IP depuis 
 
 Pour bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, consultez nos [offres de support](https://www.ovhcloud.com/fr/support-levels/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
@@ -71,4 +71,4 @@ Si le nom de domaine est géré par OVHcloud en tant que bureau d’enregistreme
 
 [Modifier les serveurs DNS d'un nom de domaine OVHcloud](/guides/web-cloud/domains/dns-server-edit)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
@@ -73,4 +73,4 @@ Veuillez noter que cette méthode n'est pas recommandée par cPanel. Son utilisa
 
 ## Allez plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
@@ -124,4 +124,4 @@ Nous vous recommandons également de consulter notre guide pour [sécuriser un V
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
@@ -355,4 +355,4 @@ En suivant ce guide, vous avez mis en place un pipeline de déploiement automati
 
 Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
@@ -228,4 +228,4 @@ En suivant ce guide, vous avez mis en place un pipeline de déploiement automati
 
 Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
@@ -112,4 +112,4 @@ Pour connaître les dates de fin de vie et de fin de support des images et des O
 
 Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
@@ -220,4 +220,4 @@ N'hésitez pas à expérimenter car vous pouvez toujours supprimer les règles d
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/import-export-n8n.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/import-export-n8n.mdx
@@ -285,4 +285,4 @@ Pour plus d’informations, référez-vous à la [documentation officielle n8n](
 
 [Comment installer n8n sur un VPS OVHcloud](/guides/bare-metal-cloud/virtual-private-servers/install-n8n-on-vps)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/import-lovable-website-on-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/import-lovable-website-on-vps.mdx
@@ -221,4 +221,4 @@ En quelques minutes, vous avez créé votre site web avec Lovable, puis l’avez
 
 Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
@@ -227,4 +227,4 @@ Le volume redimensionné inclut désormais l'espace disque additionnel.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-cloudpanel.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-cloudpanel.mdx
@@ -193,4 +193,4 @@ Au premier lancement, CloudPanel vous demande de créer le compte administrateur
 
 Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/)
 
-Échangez avec notre [communauté d’utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
@@ -133,4 +133,4 @@ Vous pouvez maintenant utiliser Docker pour :
 
 [Sécuriser un VPS OVHcloud](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-env-web-dev-on-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-env-web-dev-on-vps.mdx
@@ -157,4 +157,4 @@ Pour obtenir quelques conseils généraux pour sécuriser un serveur basé sur G
 
 Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-ia-agent-on-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-ia-agent-on-vps.mdx
@@ -143,4 +143,4 @@ Grâce à ce guide, vous avez installé un agent IA sur votre VPS OVHcloud, capa
 
 Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-ispmanager.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-ispmanager.mdx
@@ -217,4 +217,4 @@ Acceptez le contrat de licence qui s’affiche pour continuer. L’installation 
 
 Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/)
 
-Échangez avec notre [communauté d’utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-n8n-on-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-n8n-on-vps.mdx
@@ -281,4 +281,4 @@ Vous disposez désormais d’une instance n8n opérationnelle et sécurisée sur
 
 Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -238,4 +238,4 @@ Pour un usage avancé ou multi-services, ce guide est recommandé.
 
 [Sécuriser un VPS OVHcloud](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -153,4 +153,4 @@ Pour approfondir certains aspects ou renforcer la sécurité et la fiabilité de
 
 [Documentation officielle Nextcloud](https://docs.nextcloud.com)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -361,4 +361,4 @@ docker exec -it openclaw node dist/index.js devices approve `<ID>`
 
 [Documentation officielle OpenClaw](https://docs.openclaw.ai/)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
@@ -275,4 +275,4 @@ sudo systemctl list-timers | grep certbot
 
 Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -274,4 +274,4 @@ Pour obtenir quelques conseils généraux pour sécuriser un serveur basé sur G
 
 Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-site-on-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-site-on-vps.mdx
@@ -264,4 +264,4 @@ Vous venez d'installer WordPress sur votre VPS OVHcloud ou votre Serveur Dédié
 
 Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
@@ -388,4 +388,4 @@ Pour une liste complète des bonnes pratiques de sécurité, consultez nos guide
 
 Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
@@ -196,4 +196,4 @@ Notez que ce guide d'installation est également valable pour un [serveur dédi�
 
 Pour ajouter des add-ons, des mods et configurer plus finement votre serveur Minecraft, veuillez consulter la documentation officielle suivante: [https://help.mojang.com/](https://help.mojang.com/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
@@ -99,4 +99,4 @@ Pour connaître la liste des commandes disponibles, consultez la partie « Basic
 
 [FAQ VPS OVHcloud](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
@@ -176,4 +176,4 @@ En cas d'erreur lors du redémarrage d'un VPS, suivez ces étapes :
 
 [Vérifier le système de fichiers sur un VPS](/guides/bare-metal-cloud/virtual-private-servers/check-filesystem)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
@@ -141,4 +141,4 @@ Vous pouvez maintenant vous connecter en tant qu'« Administrator » avec ce nou
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
@@ -360,4 +360,4 @@ Vous trouverez toutes les informations sur les solutions de sauvegarde disponibl
 
 [Configurer le Network Firewall](/guides/bare-metal-cloud/dedicated-servers/firewall-network)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
@@ -178,4 +178,4 @@ Pour cela, nous vous conseillons d'effectuer les actions suivantes :
 
 [Comment récupérer l'accès au serveur en cas de perte du mot de passe de l'utilisateur](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
@@ -233,4 +233,4 @@ Le processus de réinstallation peut prendre quelques minutes.
 
 [Comment récupérer l'accès au serveur en cas de perte du mot de passe de l'utilisateur](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
@@ -145,4 +145,4 @@ La mise à niveau sera effective immédiatement, en conservant toutes vos donné
 
 [FAQ VPS](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
@@ -287,4 +287,4 @@ Entrez la taille souhaitée et cliquez sur <code className="action">OK</code>. V
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
@@ -318,4 +318,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [Utiliser les snapshots sur un VPS](/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
@@ -126,4 +126,4 @@ Pour des prestations spécialisées (référencement, développement, etc), cont
 
 Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, consultez nos différentes [offres de support](https://www.ovhcloud.com/fr/support-levels/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
@@ -209,4 +209,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [Utiliser la sauvegarde automatique sur un VPS](/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
@@ -129,4 +129,4 @@ Votre VPS peut être migré automatiquement vers la gamme actuelle. Découvrez l
 
 [Débuter avec un VPS](/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -62,4 +62,4 @@ Pour accéder au fichier journal en mode rescue, suivez les instructions du guid
 
 [Comment récupérer l'accès au serveur en cas de perte du mot de passe de l'utilisateur](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
@@ -114,4 +114,4 @@ Successivamente, è possibile apportare modifiche al livello di sicurezza della 
 
 ## Per saperne di più <a name="go-further"></a>
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
@@ -94,4 +94,4 @@ Se hai bisogno di informazioni aggiuntive per eseguire queste operazioni, fai ri
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
@@ -186,4 +186,4 @@ Una volta effettuate le modifiche, riavvia il tuo VPS in modalità normale dal t
 
 [Attiva la modalità Rescue su un VPS](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
@@ -173,4 +173,4 @@ ntfsfix /dev/sdb2
 
 [Attiva la modalità Rescue su un VPS](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
@@ -314,4 +314,4 @@ Nella scheda <code className="action">Home page</code>, nella sezione **La tua c
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
@@ -564,4 +564,4 @@ Per ripristinare la gestione automatica del server tramite cloud-Init, rimuovi i
 
 ## Per saperne di più <a name="go-further"></a>
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
@@ -524,4 +524,4 @@ Per testare la connessione, ti basta inviare un ping al tuo indirizzo Additional
 
 Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre soluzioni [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
  
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
@@ -70,4 +70,4 @@ Se il nome di dominio è gestito da OVHcloud come registro **e utilizza i server
 
 [Modificare i server DNS di un dominio OVHcloud](/guides/web-cloud/domains/dns-server-edit)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
@@ -78,4 +78,4 @@ Ti ricordiamo che questo metodo non è consigliato da cPanel. Il suo utilizzo è
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
@@ -124,4 +124,4 @@ Per [proteggere un VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
@@ -355,4 +355,4 @@ By following this guide, you have set up an automatic deployment pipeline from y
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/it/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
@@ -228,4 +228,4 @@ By following this guide, you have set up an automatic deployment pipeline betwee
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/it/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
@@ -112,4 +112,4 @@ Per conoscere le date di fine vita e di fine supporto delle immagini e dei siste
 
 Per prestazioni specializzate (referenziamento, sviluppo, ecc.), contatta i [partner OVHcloud](https://partner.ovhcloud.com/it/directory/).
  
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
@@ -222,4 +222,4 @@ Non esitare a sperimentare perché puoi sempre eliminare le regole di cui non ha
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
@@ -227,4 +227,4 @@ Il volume ridimensionato include lo spazio disco aggiuntivo.
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
@@ -135,4 +135,4 @@ You can now use Docker to:
 
 [Secure an OVHcloud VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -238,4 +238,4 @@ For advanced or multi-service use, this guide is recommended.
 
 [Secure an OVHcloud VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -153,4 +153,4 @@ To deepen certain aspects or strengthen the security and reliability of your ins
 
 [Official Nextcloud documentation](https://docs.nextcloud.com)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -118,4 +118,4 @@ The rest takes place in the **Overview** menu: enter your **Gateway Token** to l
 
 [Official OpenClaw documentation](https://docs.openclaw.ai/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
@@ -275,4 +275,4 @@ sudo systemctl list-timers | grep certbot
  
 Per prestazioni specializzate (referenziamento, sviluppo, ecc...), contatta i [partner OVHcloud](https://partner.ovhcloud.com/it/directory/).
  
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
@@ -388,4 +388,4 @@ For a full list of security best practices, please refer to our guides "[Securin
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/it/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
@@ -201,4 +201,4 @@ Questa guida è valida anche per un [server dedicato OVHcloud](https://www.ovhcl
 
 Per aggiungere add-ons, mods e configurare più finemente il tuo server Minecraft, consulta la documentazione ufficiale: [https://help.mojang.com/](https://help.mojang.com/).
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulta la roadmap e il changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
@@ -100,4 +100,4 @@ For a list of available commands, see the "Basic Usage" section of [LinuxGSM](ht
 
 [OVHcloud VPS FAQ](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
@@ -174,4 +174,4 @@ In caso di errore durante il riavvio di un VPS, segui questi step:
 
 [Controllare il file system su un VPS](/guides/bare-metal-cloud/virtual-private-servers/check-filesystem)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
@@ -146,4 +146,4 @@ A questo punto puoi accedere come "Administrator" con la nuova password.
 
 ## Per saperne di più
 
-Contatta la nostra [comunità di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
@@ -357,4 +357,4 @@ Tutte le informazioni sulle soluzioni di backup disponibili per il tuo servizio 
 
 [Configurare il Network Firewall](/guides/bare-metal-cloud/dedicated-servers/firewall-network)
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
@@ -178,4 +178,4 @@ A tale scopo, ti consigliamo di effettuare le seguenti azioni:
 
 [Come recuperare l'accesso al server in caso di perdita della password utente](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
@@ -233,4 +233,4 @@ Il processo di reinstallazione può richiedere alcuni minuti.
 
 [Come recuperare l'accesso al server in caso di perdita della password dell'utente](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
@@ -144,4 +144,4 @@ L'aggiornamento sarà effettivo immediatamente, conservando tutti i dati. L’ag
 
 [FAQ VPS](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
@@ -291,4 +291,4 @@ Inserisci la dimensione desiderata e clicca su <code className="action">OK</code
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
@@ -316,4 +316,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [Usare snapshot su un VPS](/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
@@ -126,4 +126,4 @@ Per prestazioni specializzate (referenziamento, sviluppo, ecc...), contatta i [p
 
 Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
@@ -191,4 +191,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [Usare backup automatizzati su un VPS](/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
@@ -135,4 +135,4 @@ Il VPS può essere migrato automaticamente verso la gamma attuale. Scopri i vant
 
 [Iniziare a utilizzare un VPS](/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps)
 
-Unisciti alla nostra Community di utenti all'indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -64,4 +64,4 @@ Per accedere al file di log in modalità rescue, segui le istruzioni del manuale
 
 [Come recuperare l'accesso al server in caso di perdita della password dell'utente](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
@@ -114,4 +114,4 @@ Następnie możesz wprowadzić zmiany w zakresie bezpieczeństwa nowej reguły u
 
 ## Sprawdź również <a name="go-further"></a>
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
@@ -94,4 +94,4 @@ Jeśli potrzebujesz dodatkowych informacji do realizacji tych zadań administrac
 
 ## Sprawdź również
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
@@ -186,4 +186,4 @@ Po przeprowadzeniu modyfikacji uruchom ponownie Twój VPS w trybie "normalnym" w
 
 [Włącz tryb Rescue na serwerze VPS](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
@@ -171,4 +171,4 @@ ntfsfix /dev/sdb2
 
 [Włącz tryb Rescue na serwerze VPS](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
@@ -314,4 +314,4 @@ W zakładce <code className="action">Strona główna</code>, w sekcji **Twoja ko
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
@@ -563,4 +563,4 @@ Aby powrócić do automatycznego zarządzania siecią za pomocą cloud-init, usu
 
 ## Sprawdź również <a name="go-further"></a>
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
@@ -526,4 +526,4 @@ Aby przetestować połączenie, wystarczy wysłać ping na adres Additional IP z
 
 Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](https://www.ovhcloud.com/pl/support-levels/).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
@@ -70,4 +70,4 @@ Jeśli domena jest zarządzana przez OVHcloud jako operator **i korzysta z serwe
 
 [Zmień serwery DNS domeny OVHcloud](/guides/web-cloud/domains/dns-server-edit)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
@@ -78,4 +78,4 @@ Nie zaleca się stosowania tej metody przez cPanel. Korzystanie z niego jest na 
 
 ## Sprawdź również
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
@@ -124,4 +124,4 @@ Zalecamy również zapoznanie się z naszym przewodnikiem dotyczącym [zabezpiec
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
@@ -355,4 +355,4 @@ By following this guide, you have set up an automatic deployment pipeline from y
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/pl/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
@@ -228,4 +228,4 @@ By following this guide, you have set up an automatic deployment pipeline betwee
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/pl/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
@@ -112,4 +112,4 @@ Aby poznać daty końca życia i końca wsparcia dla obrazów i systemów operac
 
 W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, itp.) skontaktuj się z [partnerami OVHcloud](https://partner.ovhcloud.com/pl/directory/).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
@@ -222,4 +222,4 @@ Nie wahaj się doświadczyć, ponieważ zawsze możesz usunąć reguły, któryc
 
 ## Sprawdź również
 
-Dołącz do społeczności naszych użytkowników na stronie  [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
@@ -227,4 +227,4 @@ Zmieniony rozmiar przestrzeni dyskowej zawiera teraz dodatkową przestrzeń dysk
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
@@ -135,4 +135,4 @@ You can now use Docker to:
 
 [Secure an OVHcloud VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -238,4 +238,4 @@ For advanced or multi-service use, this guide is recommended.
 
 [Secure an OVHcloud VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -153,4 +153,4 @@ To deepen certain aspects or strengthen the security and reliability of your ins
 
 [Official Nextcloud documentation](https://docs.nextcloud.com)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -118,4 +118,4 @@ The rest takes place in the **Overview** menu: enter your **Gateway Token** to l
 
 [Official OpenClaw documentation](https://docs.openclaw.ai/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
@@ -274,4 +274,4 @@ sudo systemctl list-timers | grep certbot
  
 W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj się z [partnerami OVHcloud](https://partner.ovhcloud.com/pl/directory/).
  
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
@@ -388,4 +388,4 @@ For a full list of security best practices, please refer to our guides "[Securin
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/pl/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
@@ -196,4 +196,4 @@ Niniejszy przewodnik instalacyjny dotyczy również [serwera dedykowanego OVHclo
 
 Aby dodać dodatki, mody i sprawniej skonfigurować serwer Minecraft, zapoznaj się z oficjalną dokumentacją: [https://help.mojang.com/](https://help.mojang.com/).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz roadmapę i changelog"
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: "Dołącz do Discord"

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
@@ -100,4 +100,4 @@ For a list of available commands, see the "Basic Usage" section of [LinuxGSM](ht
 
 [OVHcloud VPS FAQ](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
@@ -174,4 +174,4 @@ Jeśli podczas restartu serwera VPS wystąpi błąd, wykonaj następujące kroki
 
 [Sprawdź system plików na serwerze VPS](/guides/bare-metal-cloud/virtual-private-servers/check-filesystem)
 
-Przyłącz się do [społeczności naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
@@ -146,4 +146,4 @@ Możesz teraz zalogować się jako "Administrator" przy użyciu nowego hasła.
 
 ## Sprawdź również
 
-Przyłącz się do [społeczności naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
@@ -359,4 +359,4 @@ Wszystkie informacje na temat rozwiązań kopii zapasowych dostępnych dla Twoje
 
 [Konfiguracja rozwiązania Network Firewall](/guides/bare-metal-cloud/dedicated-servers/firewall-network)
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
@@ -178,4 +178,4 @@ Do tego zalecamy wykonanie poniższych działań:
 
 [Jak odzyskać dostęp do serwera w przypadku utraty hasła użytkownika](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
@@ -233,4 +233,4 @@ Proces reinstalacji może zająć kilka minut.
 
 [Jak odzyskać dostęp do serwera w przypadku utraty hasła użytkownika](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
@@ -144,4 +144,4 @@ Aktualizacja zostanie wykonana natychmiast, z zachowaniem wszystkich danych. Akt
 
 [VPS FAQ](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
@@ -290,4 +290,4 @@ Wprowadź żądany rozmiar i kliknij <code className="action">OK</code>. Wolumen
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
@@ -316,4 +316,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [Korzystanie z migawek na prywatnym serwerze wirtualnym](/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
@@ -126,4 +126,4 @@ W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj
 
 Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](https://www.ovhcloud.com/pl/support-levels/).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
@@ -191,4 +191,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [Korzystanie z automatycznych kopii zapasowych na prywatnym serwerze wirtualnym](/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
@@ -135,4 +135,4 @@ Możesz automatycznie przenieść VPS do aktualnej gamy. Sprawdź zalety tej ofe
 
 [Pierwsze kroki z serwerem VPS](/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps)
 
-Dołącz do społeczności naszych użytkowników na [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -64,4 +64,4 @@ Aby uzyskać dostęp do pliku logu w trybie ratunkowym, postępuj zgodnie z inst
 
 [Jak odzyskać dostęp do serwera, jeśli straciłeś hasło użytkownika](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win.mdx
@@ -114,4 +114,4 @@ De seguida, poderá efetuar alterações ao nível de segurança da nova regra c
 
 ## Quer saber mais? <a name="go-further"></a>
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/adding-secondary-dns-on-vps.mdx
@@ -94,4 +94,4 @@ Recorra à documentação externa caso necessite de informações suplementares 
 
 ## Quer saber mais?
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/apps-first-steps.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/apps-first-steps.mdx
@@ -184,4 +184,4 @@ IMPORTANT NOTES:
 
 ## Quer saber mais?
 
-Fale com a nossa comunidade de utilizadores em [community.ovh.com](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/bootlog-display-kvm.mdx
@@ -186,4 +186,4 @@ Depois de efetuar as modificações, reinicie o seu VPS em modo "normal" a parti
 
 [Ativar o modo rescue num VPS](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/check-filesystem.mdx
@@ -171,4 +171,4 @@ ntfsfix /dev/sdb2
 
 [Ativar o modo rescue num VPS](/guides/bare-metal-cloud/virtual-private-servers/rescue)
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/config-additional-disk.mdx
@@ -314,4 +314,4 @@ No separador <code className="action">Página Inicial</code>, na secção **A su
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6.mdx
@@ -563,4 +563,4 @@ Para que o cloud-init volte a gerir a rede de forma automática, elimine o fiche
 
 ## Quer saber mais? <a name="go-further"></a>
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
@@ -522,4 +522,4 @@ Para testar a ligação, basta enviar um ping ao seu endereço Additional IP a p
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/configuring-reverse-dns.mdx
@@ -70,4 +70,4 @@ Se o nome de domínio for gerido pela OVHcloud como um registo **e utilizar os s
 
 [Alterar os servidores DNS de um domínio OVHcloud](/guides/web-cloud/domains/dns-server-edit)
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/cpanel-snapshot.mdx
@@ -78,4 +78,4 @@ Tenha em conta que este método não é recomendado pelo cPanel. A sua utilizaç
 
 ## Saiba mais
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/cpanel.mdx
@@ -124,4 +124,4 @@ Além disso, recomendamos que consulte o nosso manual para [proteger um VPS](/gu
 
 ## Quer saber mais?
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/deploy-website-github-actions.mdx
@@ -355,4 +355,4 @@ By following this guide, you have set up an automatic deployment pipeline from y
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/pt/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/deploy-website-gitlab-ci-cd.mdx
@@ -228,4 +228,4 @@ By following this guide, you have set up an automatic deployment pipeline betwee
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/pt/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/eos-cpanel-plesk.mdx
@@ -112,4 +112,4 @@ Para conhecer as datas de fim de vida e de fim de suporte das imagens e dos sist
 
 Para serviços especializados (referenciamento, desenvolvimento, etc.), contacte os [parceiros OVHcloud](https://partner.ovhcloud.com/pt/directory/).
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable.mdx
@@ -221,4 +221,4 @@ Não hesite em experimentar, pois pode sempre eliminar as regras de que não pre
 
 ## Saiba mais
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/increase-additional-disk.mdx
@@ -227,4 +227,4 @@ O volume redimensionado inclui agora o espaço de disco adicional.
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-docker-on-vps.mdx
@@ -135,4 +135,4 @@ You can now use Docker to:
 
 [Secure an OVHcloud VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx
@@ -238,4 +238,4 @@ For advanced or multi-service use, this guide is recommended.
 
 [Secure an OVHcloud VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -153,4 +153,4 @@ To deepen certain aspects or strengthen the security and reliability of your ins
 
 [Official Nextcloud documentation](https://docs.nextcloud.com)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -118,4 +118,4 @@ The rest takes place in the **Overview** menu: enter your **Gateway Token** to l
 
 [Official OpenClaw documentation](https://docs.openclaw.ai/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-ssl-certificate.mdx
@@ -275,4 +275,4 @@ sudo systemctl list-timers | grep certbot
  
 Para serviços especializados (referenciamento, desenvolvimento, etc), contacte os [parceiros OVHcloud](https://partner.ovhcloud.com/pt/directory/).
  
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/migrate-to-pci-or-dedicated-server.mdx
@@ -388,4 +388,4 @@ For a full list of security best practices, please refer to our guides "[Securin
 
 For specialized services (SEO, development, etc.), contact the [OVHcloud partners](https://partner.ovhcloud.com/pt/directory/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/minecraft-server-on-vps.mdx
@@ -196,4 +196,4 @@ Tenha em conta que este guia de instalação é igualmente válido para um [serv
 
 Para adicionar add-ons, mods e configurar mais detalhadamente o seu servidor Minecraft, queira consultar a seguinte documentação oficial: [https://help.mojang.com/](https://help.mojang.com/).
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consultar o roadmap e o changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: Juntar-se ao Discord

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/palworld-server-on-vps.mdx
@@ -100,4 +100,4 @@ For a list of available commands, see the "Basic Usage" section of [LinuxGSM](ht
 
 [OVHcloud VPS FAQ](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/rescue.mdx
@@ -173,4 +173,4 @@ Se ocorrer um erro ao reiniciar um VPS, efetue estes passos:
 
 [Verificar o sistema de ficheiros num VPS](/guides/bare-metal-cloud/virtual-private-servers/check-filesystem)
 
-Junte-se à nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/resetting-a-windows-password.mdx
@@ -146,4 +146,4 @@ Já se pode iniciar sessão como "Administrator" com esta nova palavra-passe.
 
 ## Saiba mais
 
-Junte-se à nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
@@ -360,4 +360,4 @@ Na [página do produto](https://www.ovhcloud.com/pt/vps/options/) e nos respetiv
 
 [Configurar a Network Firewall](/guides/bare-metal-cloud/dedicated-servers/firewall-network)
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps.mdx
@@ -178,4 +178,4 @@ Para isso, recomendamos que execute as seguintes ações:
 
 [Como recuperar o acesso ao servidor em caso de perda da palavra-passe do utilizador](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
@@ -233,4 +233,4 @@ O processo de reinstalação pode demorar alguns minutos.
 
 [Como recuperar o acesso ao servidor em caso de perda da palavra-passe do utilizador](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/upgrade-resources.mdx
@@ -144,4 +144,4 @@ A atualização ficará efetiva imediatamente, mantendo todos os seus dados. A a
 
 [VPS FAQ](/guides/bare-metal-cloud/virtual-private-servers/vps-faq)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/upsize-vps-partition.mdx
@@ -290,4 +290,4 @@ Introduza o tamanho pretendido e clique em <code className="action">OK</code>. O
 
 ## Quer saber mais?
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps.mdx
@@ -315,4 +315,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [Utilizar snapshots num alojamento VPS](/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps.mdx
@@ -126,4 +126,4 @@ Para serviços especializados (referenciamento, desenvolvimento, etc), contacte 
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps.mdx
@@ -191,4 +191,4 @@ Running  QEMU-GA            QEMU Guest Agent
 
 [Utilizar backups automáticos num alojamento VPS](/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/vps-legacy-control-panel.mdx
@@ -135,4 +135,4 @@ O seu VPS pode ser migrado automaticamente para a gama atual. Descubra as vantag
 
 [VPS: primeira utilização](/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps)
 
-Junte-se à nossa comunidade de utilizadores no [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -64,4 +64,4 @@ Para aceder ao ficheiro de registo em modo rescue, siga as instruções do guia 
 
 [Como recuperar o acesso ao servidor em caso de perda da palavra-passe do utilizador](/guides/bare-metal-cloud/dedicated-servers/replacing-user-password)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).


### PR DESCRIPTION
### Scope:  Bare Metal (VPS)

- Replace (dead) links to legacy community page with proper keys
- Fix hard URL in Overview pages to the correct one
