### PR TITLE
fix(docs): normalize community links batch 9: Public Cloud (2/4)

### DIFF
--- a/docs/de/guides/public-cloud/databases/capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/capabilities.mdx
@@ -87,6 +87,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/faq.mdx
+++ b/docs/de/guides/public-cloud/databases/faq.mdx
@@ -424,6 +424,6 @@ If your data is corrupted, you have 2 options:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
+++ b/docs/de/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
@@ -83,4 +83,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
+++ b/docs/de/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
+++ b/docs/de/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
+++ b/docs/de/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
@@ -59,4 +59,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/lifecycle-policy.mdx
+++ b/docs/de/guides/public-cloud/databases/lifecycle-policy.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/mongodb-analytics.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-analytics.mdx
@@ -82,7 +82,7 @@ You can either use the delete node endpoint to remove the Analytics node, or tur
 
 [MongoDB capabilities](/guides/public-cloud/databases/mongodb-concept-capabilities)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/de/guides/public-cloud/databases/mongodb-benchmark.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-benchmark.mdx
@@ -206,6 +206,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/mongodb-bi-connector.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-bi-connector.mdx
@@ -59,6 +59,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
@@ -220,6 +220,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -149,6 +149,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/mongodb-connect-cli.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-connect-cli.mdx
@@ -117,4 +117,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/mongodb-connect-compass.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-connect-compass.mdx
@@ -117,7 +117,7 @@ Explore the [documentation](https://docs.mongodb.com/compass/current/) to view a
 
 Visit the [Github examples repository](https://github.com/ovh/public-cloud-databases-examples/tree/main/databases/mongodb) to find how to connect to your database with several languages.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/de/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -175,4 +175,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -169,4 +169,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
@@ -300,6 +300,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/de/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
@@ -75,6 +75,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/mongodb-developer-tools.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-developer-tools.mdx
@@ -85,6 +85,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/mongodb-getting-started.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-getting-started.mdx
@@ -76,4 +76,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
@@ -72,6 +72,6 @@ Again, depending on the volume of data and your network connection, this operati
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/mongodb-kafka-connector.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-kafka-connector.mdx
@@ -70,6 +70,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
@@ -118,4 +118,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
@@ -113,6 +113,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/mongodb-monitoring.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-monitoring.mdx
@@ -127,6 +127,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/de/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
@@ -124,6 +124,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
@@ -90,6 +90,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/mongodb-relational-migrator.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-relational-migrator.mdx
@@ -43,6 +43,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/mongodb-why-mongodb.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-why-mongodb.mdx
@@ -178,6 +178,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/de/guides/public-cloud/databases/mongodb/overview.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
+++ b/docs/de/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
@@ -74,4 +74,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/mysql-connect-php.mdx
+++ b/docs/de/guides/public-cloud/databases/mysql-connect-php.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/de/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -113,4 +113,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/mysql-connect-workbench.mdx
+++ b/docs/de/guides/public-cloud/databases/mysql-connect-workbench.mdx
@@ -73,4 +73,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/mysql-external-database-migration.mdx
+++ b/docs/de/guides/public-cloud/databases/mysql-external-database-migration.mdx
@@ -88,4 +88,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
+++ b/docs/de/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
@@ -112,4 +112,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/mysql/overview.mdx
+++ b/docs/de/guides/public-cloud/databases/mysql/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
+++ b/docs/de/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
@@ -234,4 +234,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/overview.mdx
+++ b/docs/de/guides/public-cloud/databases/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: "Weiterführende Informationen"
   items:
     - title: "OVHcloud Community besuchen"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog ansehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: "Discord beitreten"

--- a/docs/de/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
@@ -108,4 +108,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
@@ -77,4 +77,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/postgresql-connect-php.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-connect-php.mdx
@@ -133,4 +133,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/postgresql-connect-python.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-connect-python.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/postgresql-pool.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-pool.mdx
@@ -142,4 +142,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
@@ -102,4 +102,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/postgresql-terminate-queries.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-terminate-queries.mdx
@@ -107,4 +107,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/postgresql/overview.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql/overview.mdx
@@ -26,7 +26,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
+++ b/docs/de/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/de/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
+++ b/docs/de/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
@@ -132,4 +132,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/de/guides/public-cloud/databases/redis-connect-php.mdx
@@ -94,4 +94,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/redis-connect-python.mdx
+++ b/docs/de/guides/public-cloud/databases/redis-connect-python.mdx
@@ -81,4 +81,4 @@ Join our Discord: Visit our dedicated [Discord channel](https://discord.gg/ovhcl
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/redis-connect-redisinsight.mdx
+++ b/docs/de/guides/public-cloud/databases/redis-connect-redisinsight.mdx
@@ -80,4 +80,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
+++ b/docs/de/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
@@ -102,4 +102,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/de/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -187,7 +187,7 @@ As seen, using a Valkey service you will see a performance gain for your CMS. It
 - [How to connect to a Valkey service with PHP](/guides/public-cloud/databases/redis-connect-php)
 - [Valkey Roadmap](https://github.com/orgs/ovh/projects/16/views/5?card_filter_query=label%3Aredis)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/de/guides/public-cloud/databases/restore-backup.mdx
+++ b/docs/de/guides/public-cloud/databases/restore-backup.mdx
@@ -146,4 +146,4 @@ The newly created service does not duplicate IP restrictions nor users which wer
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/databases/valkey/overview.mdx
+++ b/docs/de/guides/public-cloud/databases/valkey/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/en/guides/public-cloud/databases/capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/capabilities.mdx
@@ -87,6 +87,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/faq.mdx
+++ b/docs/en/guides/public-cloud/databases/faq.mdx
@@ -424,6 +424,6 @@ If your data is corrupted, you have 2 options:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
@@ -83,4 +83,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
+++ b/docs/en/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/kafka-dev-python-basics.mdx
+++ b/docs/en/guides/public-cloud/databases/kafka-dev-python-basics.mdx
@@ -159,4 +159,4 @@ The publishing action is in fact done in two steps:
 
 [Confluent Kafka Python library](https://github.com/confluentinc/confluent-kafka-python)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
@@ -59,4 +59,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/lifecycle-policy.mdx
+++ b/docs/en/guides/public-cloud/databases/lifecycle-policy.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mongodb-analytics.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-analytics.mdx
@@ -82,7 +82,7 @@ You can either use the delete node endpoint to remove the Analytics node, or tur
 
 [MongoDB capabilities](/guides/public-cloud/databases/mongodb-concept-capabilities)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/en/guides/public-cloud/databases/mongodb-benchmark.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-benchmark.mdx
@@ -206,6 +206,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-bi-connector.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-bi-connector.mdx
@@ -59,6 +59,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
@@ -220,6 +220,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -149,6 +149,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-connect-cli.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-connect-cli.mdx
@@ -117,4 +117,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mongodb-connect-compass.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-connect-compass.mdx
@@ -117,7 +117,7 @@ Explore the [documentation](https://docs.mongodb.com/compass/current/) to view a
 
 Visit the [Github examples repository](https://github.com/ovh/public-cloud-databases-examples/tree/main/databases/mongodb) to find how to connect to your database with several languages.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/en/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -175,4 +175,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -169,4 +169,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
@@ -300,6 +300,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/en/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
@@ -75,6 +75,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-developer-tools.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-developer-tools.mdx
@@ -85,6 +85,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-getting-started.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-getting-started.mdx
@@ -76,4 +76,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
@@ -72,6 +72,6 @@ Again, depending on the volume of data and your network connection, this operati
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-kafka-connector.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-kafka-connector.mdx
@@ -70,6 +70,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
@@ -118,4 +118,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
@@ -113,6 +113,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-monitoring.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-monitoring.mdx
@@ -127,6 +127,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/en/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
@@ -124,6 +124,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
@@ -90,6 +90,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-relational-migrator.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-relational-migrator.mdx
@@ -43,6 +43,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-why-mongodb.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-why-mongodb.mdx
@@ -178,6 +178,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb/overview.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
@@ -74,4 +74,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mysql-connect-php.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-connect-php.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -113,4 +113,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mysql-connect-workbench.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-connect-workbench.mdx
@@ -73,4 +73,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mysql-external-database-migration.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-external-database-migration.mdx
@@ -88,4 +88,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
@@ -111,4 +111,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mysql/overview.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
@@ -234,4 +234,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/overview.mdx
+++ b/docs/en/guides/public-cloud/databases/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: "Go further"
   items:
     - title: "Visit the OVHcloud community"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: "Join Discord"

--- a/docs/en/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
@@ -108,4 +108,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
@@ -77,4 +77,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-connect-php.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-connect-php.mdx
@@ -133,4 +133,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-connect-python.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-connect-python.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-pool.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-pool.mdx
@@ -143,4 +143,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
@@ -102,4 +102,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-terminate-queries.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-terminate-queries.mdx
@@ -107,4 +107,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql/overview.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql/overview.mdx
@@ -26,7 +26,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
+++ b/docs/en/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/en/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
@@ -132,4 +132,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-connect-php.mdx
@@ -94,4 +94,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/redis-connect-python.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-connect-python.mdx
@@ -81,4 +81,4 @@ Join our Discord: Visit our dedicated [Discord channel](https://discord.gg/ovhcl
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/redis-connect-redisinsight.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-connect-redisinsight.mdx
@@ -80,4 +80,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
@@ -102,5 +102,5 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -187,7 +187,7 @@ As seen, using a Valkey service you will see a performance gain for your CMS. It
 - [How to connect to a Valkey service with PHP](/guides/public-cloud/databases/redis-connect-php)
 - [Valkey Roadmap](https://github.com/orgs/ovh/projects/16/views/5?card_filter_query=label%3Aredis)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/en/guides/public-cloud/databases/responsibility-model.mdx
+++ b/docs/en/guides/public-cloud/databases/responsibility-model.mdx
@@ -161,4 +161,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/restore-backup.mdx
+++ b/docs/en/guides/public-cloud/databases/restore-backup.mdx
@@ -146,4 +146,4 @@ The newly created service does not duplicate IP restrictions nor users which wer
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/valkey/overview.mdx
+++ b/docs/en/guides/public-cloud/databases/valkey/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/es/guides/public-cloud/databases/capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/capabilities.mdx
@@ -87,6 +87,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/faq.mdx
+++ b/docs/es/guides/public-cloud/databases/faq.mdx
@@ -424,6 +424,6 @@ If your data is corrupted, you have 2 options:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
+++ b/docs/es/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
@@ -83,4 +83,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
+++ b/docs/es/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
+++ b/docs/es/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
+++ b/docs/es/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
@@ -59,4 +59,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/lifecycle-policy.mdx
+++ b/docs/es/guides/public-cloud/databases/lifecycle-policy.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/mongodb-analytics.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-analytics.mdx
@@ -82,7 +82,7 @@ You can either use the delete node endpoint to remove the Analytics node, or tur
 
 [MongoDB capabilities](/guides/public-cloud/databases/mongodb-concept-capabilities)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/es/guides/public-cloud/databases/mongodb-benchmark.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-benchmark.mdx
@@ -206,6 +206,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/mongodb-bi-connector.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-bi-connector.mdx
@@ -59,6 +59,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
@@ -220,6 +220,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -149,6 +149,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/mongodb-connect-cli.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-connect-cli.mdx
@@ -117,4 +117,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/mongodb-connect-compass.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-connect-compass.mdx
@@ -117,7 +117,7 @@ Explore the [documentation](https://docs.mongodb.com/compass/current/) to view a
 
 Visit the [Github examples repository](https://github.com/ovh/public-cloud-databases-examples/tree/main/databases/mongodb) to find how to connect to your database with several languages.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/es/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -175,4 +175,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -169,4 +169,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
@@ -300,6 +300,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/es/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
@@ -75,6 +75,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/mongodb-developer-tools.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-developer-tools.mdx
@@ -85,6 +85,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/mongodb-getting-started.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-getting-started.mdx
@@ -76,4 +76,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
@@ -72,6 +72,6 @@ Again, depending on the volume of data and your network connection, this operati
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/mongodb-kafka-connector.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-kafka-connector.mdx
@@ -70,6 +70,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
@@ -118,4 +118,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
@@ -113,6 +113,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/mongodb-monitoring.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-monitoring.mdx
@@ -127,6 +127,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/es/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
@@ -124,6 +124,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
@@ -90,6 +90,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/mongodb-relational-migrator.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-relational-migrator.mdx
@@ -43,6 +43,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/mongodb-why-mongodb.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-why-mongodb.mdx
@@ -178,6 +178,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/es/guides/public-cloud/databases/mongodb/overview.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
+++ b/docs/es/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
@@ -74,4 +74,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/mysql-connect-php.mdx
+++ b/docs/es/guides/public-cloud/databases/mysql-connect-php.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/es/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -113,4 +113,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/mysql-connect-workbench.mdx
+++ b/docs/es/guides/public-cloud/databases/mysql-connect-workbench.mdx
@@ -73,4 +73,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/mysql-external-database-migration.mdx
+++ b/docs/es/guides/public-cloud/databases/mysql-external-database-migration.mdx
@@ -88,4 +88,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
+++ b/docs/es/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
@@ -112,4 +112,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/mysql/overview.mdx
+++ b/docs/es/guides/public-cloud/databases/mysql/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
+++ b/docs/es/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
@@ -234,4 +234,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/overview.mdx
+++ b/docs/es/guides/public-cloud/databases/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: "Más información"
   items:
     - title: "Visitar la comunidad OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Ver la hoja de ruta y el changelog"
       link: https://www.ovhcloud.com/es-es/roadmap-changelog/
     - title: "Unirse a Discord"

--- a/docs/es/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
@@ -108,4 +108,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
@@ -77,4 +77,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/postgresql-connect-php.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-connect-php.mdx
@@ -133,4 +133,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/postgresql-connect-python.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-connect-python.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/postgresql-pool.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-pool.mdx
@@ -143,4 +143,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
@@ -102,4 +102,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/postgresql-terminate-queries.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-terminate-queries.mdx
@@ -107,4 +107,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/postgresql/overview.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql/overview.mdx
@@ -26,7 +26,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
+++ b/docs/es/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/es/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
+++ b/docs/es/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
@@ -132,4 +132,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/es/guides/public-cloud/databases/redis-connect-php.mdx
@@ -94,4 +94,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/redis-connect-python.mdx
+++ b/docs/es/guides/public-cloud/databases/redis-connect-python.mdx
@@ -81,4 +81,4 @@ Join our Discord: Visit our dedicated [Discord channel](https://discord.gg/ovhcl
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/redis-connect-redisinsight.mdx
+++ b/docs/es/guides/public-cloud/databases/redis-connect-redisinsight.mdx
@@ -80,4 +80,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
+++ b/docs/es/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
@@ -102,4 +102,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/es/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -187,7 +187,7 @@ As seen, using a Valkey service you will see a performance gain for your CMS. It
 - [How to connect to a Valkey service with PHP](/guides/public-cloud/databases/redis-connect-php)
 - [Valkey Roadmap](https://github.com/orgs/ovh/projects/16/views/5?card_filter_query=label%3Aredis)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/es/guides/public-cloud/databases/restore-backup.mdx
+++ b/docs/es/guides/public-cloud/databases/restore-backup.mdx
@@ -146,4 +146,4 @@ The newly created service does not duplicate IP restrictions nor users which wer
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/databases/valkey/overview.mdx
+++ b/docs/es/guides/public-cloud/databases/valkey/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/fr/guides/public-cloud/databases/capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/capabilities.mdx
@@ -87,6 +87,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/faq.mdx
+++ b/docs/fr/guides/public-cloud/databases/faq.mdx
@@ -424,6 +424,6 @@ If your data is corrupted, you have 2 options:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
+++ b/docs/fr/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
@@ -83,4 +83,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
+++ b/docs/fr/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
+++ b/docs/fr/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/kafka-dev-python-basics.mdx
+++ b/docs/fr/guides/public-cloud/databases/kafka-dev-python-basics.mdx
@@ -159,4 +159,4 @@ The publishing action is in fact done in two steps:
 
 [Confluent Kafka Python library](https://github.com/confluentinc/confluent-kafka-python)
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
+++ b/docs/fr/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
@@ -59,4 +59,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/lifecycle-policy.mdx
+++ b/docs/fr/guides/public-cloud/databases/lifecycle-policy.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/mongodb-analytics.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-analytics.mdx
@@ -82,7 +82,7 @@ You can either use the delete node endpoint to remove the Analytics node, or tur
 
 [MongoDB capabilities](/guides/public-cloud/databases/mongodb-concept-capabilities)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/fr/guides/public-cloud/databases/mongodb-benchmark.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-benchmark.mdx
@@ -206,6 +206,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/mongodb-bi-connector.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-bi-connector.mdx
@@ -59,6 +59,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
@@ -220,6 +220,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -149,6 +149,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/mongodb-connect-cli.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-connect-cli.mdx
@@ -117,4 +117,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/mongodb-connect-compass.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-connect-compass.mdx
@@ -117,7 +117,7 @@ Explore the [documentation](https://docs.mongodb.com/compass/current/) to view a
 
 Visit the [Github examples repository](https://github.com/ovh/public-cloud-databases-examples/tree/main/databases/mongodb) to find how to connect to your database with several languages.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/fr/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -175,4 +175,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -169,4 +169,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
@@ -300,6 +300,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/fr/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
@@ -75,6 +75,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/mongodb-developer-tools.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-developer-tools.mdx
@@ -85,6 +85,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/mongodb-getting-started.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-getting-started.mdx
@@ -76,4 +76,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
@@ -72,6 +72,6 @@ Again, depending on the volume of data and your network connection, this operati
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/mongodb-kafka-connector.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-kafka-connector.mdx
@@ -70,6 +70,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
@@ -118,4 +118,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
@@ -113,6 +113,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/mongodb-monitoring.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-monitoring.mdx
@@ -127,6 +127,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/fr/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
@@ -124,6 +124,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
@@ -90,6 +90,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/mongodb-relational-migrator.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-relational-migrator.mdx
@@ -43,6 +43,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/mongodb-why-mongodb.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-why-mongodb.mdx
@@ -178,6 +178,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/fr/guides/public-cloud/databases/mongodb/overview.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
+++ b/docs/fr/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
@@ -74,4 +74,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/mysql-connect-php.mdx
+++ b/docs/fr/guides/public-cloud/databases/mysql-connect-php.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/fr/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -113,4 +113,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/mysql-connect-workbench.mdx
+++ b/docs/fr/guides/public-cloud/databases/mysql-connect-workbench.mdx
@@ -73,4 +73,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/mysql-external-database-migration.mdx
+++ b/docs/fr/guides/public-cloud/databases/mysql-external-database-migration.mdx
@@ -88,4 +88,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
+++ b/docs/fr/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
@@ -112,4 +112,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/mysql/overview.mdx
+++ b/docs/fr/guides/public-cloud/databases/mysql/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
+++ b/docs/fr/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
@@ -234,4 +234,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/overview.mdx
+++ b/docs/fr/guides/public-cloud/databases/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: "Aller plus loin"
   items:
     - title: "Rejoindre la communauté OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Voir la roadmap & changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: "Rejoindre Discord"

--- a/docs/fr/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
@@ -108,4 +108,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
@@ -77,4 +77,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/postgresql-connect-php.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-connect-php.mdx
@@ -133,4 +133,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/postgresql-connect-python.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-connect-python.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/postgresql-pool.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-pool.mdx
@@ -143,4 +143,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
@@ -102,4 +102,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/postgresql-terminate-queries.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-terminate-queries.mdx
@@ -107,4 +107,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/postgresql/overview.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql/overview.mdx
@@ -26,7 +26,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
+++ b/docs/fr/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/fr/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
+++ b/docs/fr/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
@@ -132,4 +132,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/fr/guides/public-cloud/databases/redis-connect-php.mdx
@@ -94,4 +94,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/redis-connect-python.mdx
+++ b/docs/fr/guides/public-cloud/databases/redis-connect-python.mdx
@@ -81,4 +81,4 @@ Join our Discord: Visit our dedicated [Discord channel](https://discord.gg/ovhcl
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/redis-connect-redisinsight.mdx
+++ b/docs/fr/guides/public-cloud/databases/redis-connect-redisinsight.mdx
@@ -80,4 +80,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
+++ b/docs/fr/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
@@ -102,4 +102,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/fr/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -187,7 +187,7 @@ As seen, using a Valkey service you will see a performance gain for your CMS. It
 - [How to connect to a Valkey service with PHP](/guides/public-cloud/databases/redis-connect-php)
 - [Valkey Roadmap](https://github.com/orgs/ovh/projects/16/views/5?card_filter_query=label%3Aredis)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/fr/guides/public-cloud/databases/responsibility-model.mdx
+++ b/docs/fr/guides/public-cloud/databases/responsibility-model.mdx
@@ -161,4 +161,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/restore-backup.mdx
+++ b/docs/fr/guides/public-cloud/databases/restore-backup.mdx
@@ -146,4 +146,4 @@ The newly created service does not duplicate IP restrictions nor users which wer
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/databases/valkey/overview.mdx
+++ b/docs/fr/guides/public-cloud/databases/valkey/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/it/guides/public-cloud/databases/capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/capabilities.mdx
@@ -87,6 +87,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/faq.mdx
+++ b/docs/it/guides/public-cloud/databases/faq.mdx
@@ -424,6 +424,6 @@ If your data is corrupted, you have 2 options:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
+++ b/docs/it/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
@@ -83,4 +83,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
+++ b/docs/it/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
+++ b/docs/it/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
+++ b/docs/it/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
@@ -59,4 +59,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/lifecycle-policy.mdx
+++ b/docs/it/guides/public-cloud/databases/lifecycle-policy.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/mongodb-analytics.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-analytics.mdx
@@ -82,7 +82,7 @@ You can either use the delete node endpoint to remove the Analytics node, or tur
 
 [MongoDB capabilities](/guides/public-cloud/databases/mongodb-concept-capabilities)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/it/guides/public-cloud/databases/mongodb-benchmark.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-benchmark.mdx
@@ -206,6 +206,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/mongodb-bi-connector.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-bi-connector.mdx
@@ -59,6 +59,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
@@ -220,6 +220,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -149,6 +149,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/mongodb-connect-cli.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-connect-cli.mdx
@@ -117,4 +117,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/mongodb-connect-compass.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-connect-compass.mdx
@@ -117,7 +117,7 @@ Explore the [documentation](https://docs.mongodb.com/compass/current/) to view a
 
 Visit the [Github examples repository](https://github.com/ovh/public-cloud-databases-examples/tree/main/databases/mongodb) to find how to connect to your database with several languages.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/it/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -175,4 +175,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -169,4 +169,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
@@ -300,6 +300,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/it/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
@@ -75,6 +75,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/mongodb-developer-tools.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-developer-tools.mdx
@@ -85,6 +85,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/mongodb-getting-started.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-getting-started.mdx
@@ -76,4 +76,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
@@ -72,6 +72,6 @@ Again, depending on the volume of data and your network connection, this operati
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/mongodb-kafka-connector.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-kafka-connector.mdx
@@ -70,6 +70,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
@@ -118,4 +118,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
@@ -113,6 +113,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/mongodb-monitoring.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-monitoring.mdx
@@ -127,6 +127,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/it/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
@@ -124,6 +124,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
@@ -90,6 +90,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/mongodb-relational-migrator.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-relational-migrator.mdx
@@ -43,6 +43,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/mongodb-why-mongodb.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-why-mongodb.mdx
@@ -178,6 +178,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/it/guides/public-cloud/databases/mongodb/overview.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
+++ b/docs/it/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
@@ -74,4 +74,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/mysql-connect-php.mdx
+++ b/docs/it/guides/public-cloud/databases/mysql-connect-php.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/it/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -113,4 +113,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/mysql-connect-workbench.mdx
+++ b/docs/it/guides/public-cloud/databases/mysql-connect-workbench.mdx
@@ -73,4 +73,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/mysql-external-database-migration.mdx
+++ b/docs/it/guides/public-cloud/databases/mysql-external-database-migration.mdx
@@ -88,4 +88,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
+++ b/docs/it/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
@@ -112,4 +112,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/mysql/overview.mdx
+++ b/docs/it/guides/public-cloud/databases/mysql/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
+++ b/docs/it/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
@@ -234,4 +234,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/overview.mdx
+++ b/docs/it/guides/public-cloud/databases/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: "Per saperne di più"
   items:
     - title: "Visita la community OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Visualizza la roadmap e il changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: "Unisciti a Discord"

--- a/docs/it/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
@@ -108,4 +108,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
@@ -77,4 +77,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/postgresql-connect-php.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-connect-php.mdx
@@ -133,4 +133,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/postgresql-connect-python.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-connect-python.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/postgresql-pool.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-pool.mdx
@@ -143,4 +143,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
@@ -102,4 +102,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/postgresql-terminate-queries.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-terminate-queries.mdx
@@ -107,4 +107,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/postgresql/overview.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql/overview.mdx
@@ -26,7 +26,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
+++ b/docs/it/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/it/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
+++ b/docs/it/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
@@ -132,4 +132,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/it/guides/public-cloud/databases/redis-connect-php.mdx
@@ -94,4 +94,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/redis-connect-python.mdx
+++ b/docs/it/guides/public-cloud/databases/redis-connect-python.mdx
@@ -81,4 +81,4 @@ Join our Discord: Visit our dedicated [Discord channel](https://discord.gg/ovhcl
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/redis-connect-redisinsight.mdx
+++ b/docs/it/guides/public-cloud/databases/redis-connect-redisinsight.mdx
@@ -80,4 +80,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
+++ b/docs/it/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
@@ -102,4 +102,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/it/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -187,7 +187,7 @@ As seen, using a Valkey service you will see a performance gain for your CMS. It
 - [How to connect to a Valkey service with PHP](/guides/public-cloud/databases/redis-connect-php)
 - [Valkey Roadmap](https://github.com/orgs/ovh/projects/16/views/5?card_filter_query=label%3Aredis)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/it/guides/public-cloud/databases/restore-backup.mdx
+++ b/docs/it/guides/public-cloud/databases/restore-backup.mdx
@@ -146,4 +146,4 @@ The newly created service does not duplicate IP restrictions nor users which wer
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/databases/valkey/overview.mdx
+++ b/docs/it/guides/public-cloud/databases/valkey/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/pl/guides/public-cloud/databases/capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/capabilities.mdx
@@ -87,6 +87,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/faq.mdx
+++ b/docs/pl/guides/public-cloud/databases/faq.mdx
@@ -424,6 +424,6 @@ If your data is corrupted, you have 2 options:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
+++ b/docs/pl/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
@@ -83,4 +83,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
+++ b/docs/pl/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
+++ b/docs/pl/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
+++ b/docs/pl/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
@@ -59,4 +59,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/lifecycle-policy.mdx
+++ b/docs/pl/guides/public-cloud/databases/lifecycle-policy.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/mongodb-analytics.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-analytics.mdx
@@ -82,7 +82,7 @@ You can either use the delete node endpoint to remove the Analytics node, or tur
 
 [MongoDB capabilities](/guides/public-cloud/databases/mongodb-concept-capabilities)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/pl/guides/public-cloud/databases/mongodb-benchmark.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-benchmark.mdx
@@ -206,6 +206,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/mongodb-bi-connector.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-bi-connector.mdx
@@ -59,6 +59,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
@@ -220,6 +220,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -149,6 +149,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/mongodb-connect-cli.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-connect-cli.mdx
@@ -117,4 +117,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/mongodb-connect-compass.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-connect-compass.mdx
@@ -117,7 +117,7 @@ Explore the [documentation](https://docs.mongodb.com/compass/current/) to view a
 
 Visit the [Github examples repository](https://github.com/ovh/public-cloud-databases-examples/tree/main/databases/mongodb) to find how to connect to your database with several languages.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/pl/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -175,4 +175,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -169,4 +169,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
@@ -300,6 +300,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/pl/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
@@ -75,6 +75,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/mongodb-developer-tools.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-developer-tools.mdx
@@ -85,6 +85,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/mongodb-getting-started.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-getting-started.mdx
@@ -76,4 +76,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
@@ -72,6 +72,6 @@ Again, depending on the volume of data and your network connection, this operati
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/mongodb-kafka-connector.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-kafka-connector.mdx
@@ -70,6 +70,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
@@ -118,4 +118,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
@@ -113,6 +113,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/mongodb-monitoring.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-monitoring.mdx
@@ -127,6 +127,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/pl/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
@@ -124,6 +124,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
@@ -90,6 +90,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/mongodb-relational-migrator.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-relational-migrator.mdx
@@ -43,6 +43,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/mongodb-why-mongodb.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-why-mongodb.mdx
@@ -178,6 +178,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pl/guides/public-cloud/databases/mongodb/overview.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
+++ b/docs/pl/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
@@ -74,4 +74,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/mysql-connect-php.mdx
+++ b/docs/pl/guides/public-cloud/databases/mysql-connect-php.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/pl/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -113,4 +113,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/mysql-connect-workbench.mdx
+++ b/docs/pl/guides/public-cloud/databases/mysql-connect-workbench.mdx
@@ -73,4 +73,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/mysql-external-database-migration.mdx
+++ b/docs/pl/guides/public-cloud/databases/mysql-external-database-migration.mdx
@@ -88,4 +88,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
+++ b/docs/pl/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
@@ -112,4 +112,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/mysql/overview.mdx
+++ b/docs/pl/guides/public-cloud/databases/mysql/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
+++ b/docs/pl/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
@@ -234,4 +234,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/overview.mdx
+++ b/docs/pl/guides/public-cloud/databases/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz harmonogram i dziennik zmian"
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: "Dołącz do Discorda"

--- a/docs/pl/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
@@ -108,4 +108,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
@@ -77,4 +77,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/postgresql-connect-php.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-connect-php.mdx
@@ -133,4 +133,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/postgresql-connect-python.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-connect-python.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/postgresql-pool.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-pool.mdx
@@ -143,4 +143,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
@@ -102,4 +102,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/postgresql-terminate-queries.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-terminate-queries.mdx
@@ -107,4 +107,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/postgresql/overview.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql/overview.mdx
@@ -26,7 +26,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
+++ b/docs/pl/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/pl/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
+++ b/docs/pl/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
@@ -132,4 +132,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/pl/guides/public-cloud/databases/redis-connect-php.mdx
@@ -94,4 +94,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/redis-connect-python.mdx
+++ b/docs/pl/guides/public-cloud/databases/redis-connect-python.mdx
@@ -81,4 +81,4 @@ Join our Discord: Visit our dedicated [Discord channel](https://discord.gg/ovhcl
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/redis-connect-redisinsight.mdx
+++ b/docs/pl/guides/public-cloud/databases/redis-connect-redisinsight.mdx
@@ -80,4 +80,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
+++ b/docs/pl/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
@@ -102,4 +102,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/pl/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -187,7 +187,7 @@ As seen, using a Valkey service you will see a performance gain for your CMS. It
 - [How to connect to a Valkey service with PHP](/guides/public-cloud/databases/redis-connect-php)
 - [Valkey Roadmap](https://github.com/orgs/ovh/projects/16/views/5?card_filter_query=label%3Aredis)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/pl/guides/public-cloud/databases/restore-backup.mdx
+++ b/docs/pl/guides/public-cloud/databases/restore-backup.mdx
@@ -146,4 +146,4 @@ The newly created service does not duplicate IP restrictions nor users which wer
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/databases/valkey/overview.mdx
+++ b/docs/pl/guides/public-cloud/databases/valkey/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pt/guides/public-cloud/databases/capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/capabilities.mdx
@@ -87,6 +87,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/faq.mdx
+++ b/docs/pt/guides/public-cloud/databases/faq.mdx
@@ -424,6 +424,6 @@ If your data is corrupted, you have 2 options:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
+++ b/docs/pt/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
@@ -83,4 +83,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
+++ b/docs/pt/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
+++ b/docs/pt/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
@@ -91,4 +91,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
+++ b/docs/pt/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
@@ -59,4 +59,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/lifecycle-policy.mdx
+++ b/docs/pt/guides/public-cloud/databases/lifecycle-policy.mdx
@@ -87,4 +87,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/mongodb-analytics.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-analytics.mdx
@@ -82,7 +82,7 @@ You can either use the delete node endpoint to remove the Analytics node, or tur
 
 [MongoDB capabilities](/guides/public-cloud/databases/mongodb-concept-capabilities)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/pt/guides/public-cloud/databases/mongodb-benchmark.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-benchmark.mdx
@@ -206,6 +206,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/mongodb-bi-connector.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-bi-connector.mdx
@@ -59,6 +59,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
@@ -220,6 +220,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -149,6 +149,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/mongodb-connect-cli.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-connect-cli.mdx
@@ -117,4 +117,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/mongodb-connect-compass.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-connect-compass.mdx
@@ -117,7 +117,7 @@ Explore the [documentation](https://docs.mongodb.com/compass/current/) to view a
 
 Visit the [Github examples repository](https://github.com/ovh/public-cloud-databases-examples/tree/main/databases/mongodb) to find how to connect to your database with several languages.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/pt/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -175,4 +175,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -169,4 +169,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
@@ -300,6 +300,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/pt/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
@@ -75,6 +75,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/mongodb-developer-tools.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-developer-tools.mdx
@@ -85,6 +85,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/mongodb-getting-started.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-getting-started.mdx
@@ -76,4 +76,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
@@ -72,6 +72,6 @@ Again, depending on the volume of data and your network connection, this operati
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/mongodb-kafka-connector.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-kafka-connector.mdx
@@ -70,6 +70,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
@@ -118,4 +118,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
@@ -113,6 +113,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/mongodb-monitoring.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-monitoring.mdx
@@ -127,6 +127,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/pt/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
@@ -124,6 +124,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
@@ -90,6 +90,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/mongodb-relational-migrator.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-relational-migrator.mdx
@@ -43,6 +43,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/mongodb-why-mongodb.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-why-mongodb.mdx
@@ -178,6 +178,6 @@ We would love to help answer questions and appreciate any feedback you may have.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/pt/guides/public-cloud/databases/mongodb/overview.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
+++ b/docs/pt/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
@@ -74,4 +74,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/mysql-connect-php.mdx
+++ b/docs/pt/guides/public-cloud/databases/mysql-connect-php.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/pt/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -113,4 +113,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/mysql-connect-workbench.mdx
+++ b/docs/pt/guides/public-cloud/databases/mysql-connect-workbench.mdx
@@ -73,4 +73,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/mysql-external-database-migration.mdx
+++ b/docs/pt/guides/public-cloud/databases/mysql-external-database-migration.mdx
@@ -88,4 +88,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
+++ b/docs/pt/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
@@ -112,4 +112,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/mysql/overview.mdx
+++ b/docs/pt/guides/public-cloud/databases/mysql/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
+++ b/docs/pt/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
@@ -234,4 +234,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/overview.mdx
+++ b/docs/pt/guides/public-cloud/databases/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: "Visite a comunidade OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte o roadmap e o changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Junte-se ao Discord"

--- a/docs/pt/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
@@ -108,4 +108,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
@@ -77,4 +77,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/postgresql-connect-php.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-connect-php.mdx
@@ -133,4 +133,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/postgresql-connect-python.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-connect-python.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/postgresql-pool.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-pool.mdx
@@ -143,4 +143,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
@@ -102,4 +102,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/postgresql-terminate-queries.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-terminate-queries.mdx
@@ -107,4 +107,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
@@ -147,4 +147,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/postgresql/overview.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql/overview.mdx
@@ -26,7 +26,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
+++ b/docs/pt/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/pt/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
+++ b/docs/pt/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
@@ -132,4 +132,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/pt/guides/public-cloud/databases/redis-connect-php.mdx
@@ -94,4 +94,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/redis-connect-python.mdx
+++ b/docs/pt/guides/public-cloud/databases/redis-connect-python.mdx
@@ -81,4 +81,4 @@ Join our Discord: Visit our dedicated [Discord channel](https://discord.gg/ovhcl
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/redis-connect-redisinsight.mdx
+++ b/docs/pt/guides/public-cloud/databases/redis-connect-redisinsight.mdx
@@ -80,4 +80,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
+++ b/docs/pt/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
@@ -102,4 +102,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/pt/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -187,7 +187,7 @@ As seen, using a Valkey service you will see a performance gain for your CMS. It
 - [How to connect to a Valkey service with PHP](/guides/public-cloud/databases/redis-connect-php)
 - [Valkey Roadmap](https://github.com/orgs/ovh/projects/16/views/5?card_filter_query=label%3Aredis)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/pt/guides/public-cloud/databases/restore-backup.mdx
+++ b/docs/pt/guides/public-cloud/databases/restore-backup.mdx
@@ -146,4 +146,4 @@ The newly created service does not duplicate IP restrictions nor users which wer
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/databases/valkey/overview.mdx
+++ b/docs/pt/guides/public-cloud/databases/valkey/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"


### PR DESCRIPTION
### Scope: Public Cloud - Databases

- Replace (dead) links to legacy community page with proper keys
- Fix hard URL in Overview pages to the correct one
