### PR TITLE
fix(docs): normalize community links batch 10: Public Cloud (3/4)

### DIFF
--- a/docs/de/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
+++ b/docs/de/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
+++ b/docs/de/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
+++ b/docs/de/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
+++ b/docs/de/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
+++ b/docs/de/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/ai-machine-learning/overview.mdx
+++ b/docs/de/guides/public-cloud/ai-machine-learning/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Weiterführende Informationen"
   items:
     - title: "OVHcloud Community besuchen"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog ansehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: "Discord beitreten"

--- a/docs/de/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
+++ b/docs/de/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
@@ -198,4 +198,4 @@ slmgr.vbs -dli
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/apps-first-steps.mdx
+++ b/docs/de/guides/public-cloud/compute/apps-first-steps.mdx
@@ -238,4 +238,4 @@ Es ist kein weiterer Schritt erforderlich, um die erste Konfiguration dieser Anw
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/change-project-contacts.mdx
+++ b/docs/de/guides/public-cloud/compute/change-project-contacts.mdx
@@ -62,4 +62,4 @@ Genauere Informationen zur Vorgehensweise finden Sie in unserer Anleitung "[Die 
 
 [Projekte delegieren](/guides/public-cloud/cross-functional/delegate-projects)
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -98,4 +98,4 @@ sudo cat /etc/hosts
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
+++ b/docs/de/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
@@ -162,4 +162,4 @@ Weitere Informationen zur Verwendung von SSH-Schlüsseln mit Public Cloud-Instan
 
 [So ersetzen Sie ein SSH-Schlüsselpaar auf einer Public Cloud-Instanz durch den Rescue-Modus](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/de/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -170,5 +170,5 @@ openstack image list | grep 'My Custom Image'
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/de/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/de/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -185,4 +185,4 @@ Achtung, diese Optionen sind für die Erstellung einer Instanz nicht zwingend er
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
+++ b/docs/de/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
@@ -206,4 +206,4 @@ Tragen Sie die Werte für folgende Parameter ein:
 
 [Backup einer Instanz erstellen](/guides/public-cloud/compute/save-an-instance)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/creating-ssh-keys.mdx
+++ b/docs/de/guides/public-cloud/compute/creating-ssh-keys.mdx
@@ -456,4 +456,4 @@ Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.
 
 Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
+++ b/docs/de/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
@@ -77,4 +77,4 @@ In der Spalte **Actions** können Sie:
 
 ## Weiterführende Informationen
  
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
+++ b/docs/de/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
@@ -47,4 +47,4 @@ Bei einer monatlichen Vertragslaufzeit wird jeder Monat, den Sie starten, vollst
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -185,4 +185,4 @@ Weitere Informationen zu den notwendigen Schritten finden Sie in unserer Anleitu
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/forensics.mdx
+++ b/docs/de/guides/public-cloud/compute/forensics.mdx
@@ -202,4 +202,4 @@ Note that the output `raw` file size of this command will be the actual size of 
 
 The _QEMU_ convertion tool supports many output file formats as explained in this documentation: [https://docs.openstack.org/image-guide/convert-images.html](https://docs.openstack.org/image-guide/convert-images.html)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/de/guides/public-cloud/compute/image-life-cycle.mdx
@@ -112,4 +112,4 @@ Please note that:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/de/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -258,4 +258,4 @@ Nachdem dies abgeschlossen ist, trennen Sie das Volume von der Instanz und häng
 
 [Typ des Block Storage-Volumes ändern](/guides/public-cloud/compute/switch-volume-type)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -77,4 +77,4 @@ Sie möchten Ihre Lizenz ändern, etwa um einen Testschlüssel zu ersetzen oder 
 
 [Offizielle Plesk Dokumentation](https://docs.plesk.com/de-DE/obsidian/)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -251,4 +251,4 @@ scrape_configs:
 
 [Erstellen und Konfigurieren einer Sicherheitsgruppe in Horizon](/guides/public-cloud/compute/setup-security-group)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/de/guides/public-cloud/compute/install-wordpress.mdx
@@ -279,4 +279,4 @@ Certbot verlängert die Zertifikate automatisch; es sind keine weiteren Schritte
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/key-concepts.mdx
+++ b/docs/de/guides/public-cloud/compute/key-concepts.mdx
@@ -144,4 +144,4 @@ Nachdem Sie mit den grundlegenden Konzepten von OVHcloud Public Cloud Compute ve
 - [Erste Schritte mit vorinstallierten Anwendungen](/guides/public-cloud/compute/apps-first-steps)
 - [Cloud-Guthaben hinzufügen](/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
+++ b/docs/de/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
@@ -158,4 +158,4 @@ Please send us your questions, feedback and suggestions to improve the service:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/compute/managing-instances-horizon.mdx
+++ b/docs/de/guides/public-cloud/compute/managing-instances-horizon.mdx
@@ -177,4 +177,4 @@ Wenn Sie die Instanz gelöscht haben, werden Ihnen keine Kosten mehr berechnet u
 
 ##  Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
+++ b/docs/de/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
@@ -88,4 +88,4 @@ Klicken Sie anschließend auf den Dropdown-Pfeil neben dem zu löschenden Snapsh
 
 ## Weiterführende Informationen
  
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/migration-between-regions.mdx
+++ b/docs/de/guides/public-cloud/compute/migration-between-regions.mdx
@@ -90,4 +90,4 @@ Alle detaillierten Informationen finden Sie im Abschnitt **Eine Instanz aus eine
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/overview.mdx
+++ b/docs/de/guides/public-cloud/compute/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Roadmap & Changelog einsehen
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
+++ b/docs/de/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
@@ -118,4 +118,4 @@ nova unrescue INSTANCE_ID
 
 [SSH-Schlüsselpaar einer Instanz ersetzen](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
+++ b/docs/de/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
@@ -63,4 +63,4 @@ Sie können die Instanz nun aus dem Rescue-Modus entfernen (siehe Anleitung zum 
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/de/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -94,4 +94,4 @@ Sie haben jetzt mit Ihrem neuen SSH-Schlüsselpaar wieder Zugriff auf die Instan
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
@@ -71,4 +71,4 @@ $ openstack server unrescue SERVERID
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/compute/resize-freebsd-file-system-after-install.mdx
+++ b/docs/de/guides/public-cloud/compute/resize-freebsd-file-system-after-install.mdx
@@ -80,4 +80,4 @@ Sie werden feststellen, dass in diesem Beispiel `zroot` nun 50 GB groß ist. ZFS
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/resize-instance-manager.mdx
+++ b/docs/de/guides/public-cloud/compute/resize-instance-manager.mdx
@@ -90,4 +90,4 @@ Klicken Sie abschließend auf <code className="action">Finish</code>, um die Än
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/resize-instance-openstack.mdx
+++ b/docs/de/guides/public-cloud/compute/resize-instance-openstack.mdx
@@ -139,4 +139,4 @@ Wenn Sie Ihre Instanz verkleinern möchten, können Sie dies tun, indem Sie die 
 
 [Größe einer Public Cloud Instanz über Horizon ändern](/guides/public-cloud/compute/resize-of-an-instance)
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/resize-of-an-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/resize-of-an-instance.mdx
@@ -96,4 +96,4 @@ Klicken Sie abschließend auf <code className="action">Finish</code>, um die Än
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/revert-a-flex-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/revert-a-flex-instance.mdx
@@ -76,4 +76,4 @@ Alternativ können Sie auch im OVHcloud Kundencenter [die Konfiguration der Inst
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/save-an-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/save-an-instance.mdx
@@ -258,4 +258,4 @@ Erfahren Sie in [dieser Anleitung](/guides/public-cloud/compute/create-restore-a
 
 [Verwenden von Backups zum Erzeugen oder Wiederherstellen von Instanzen](/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup)
 
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/setup-instance-reverse.mdx
+++ b/docs/de/guides/public-cloud/compute/setup-instance-reverse.mdx
@@ -58,4 +58,4 @@ Wenn die Domain von OVHcloud als Registrar verwaltet wird und OVHcloud DNS-Serve
 
 [Bearbeiten der OVHcloud DNS-Zone](/guides/web-cloud/domains/dns-zone-edit)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/de/guides/public-cloud/compute/setup-security-group.mdx
@@ -112,4 +112,4 @@ Um eine Sicherheitsgruppe zu löschen, setzen Sie links den Haken und klicken Si
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
+++ b/docs/de/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
@@ -113,4 +113,4 @@ Fortgeschrittene Benutzer können temporäre Adressen auch ohne das Skript **swi
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/share-images-between-projects.mdx
+++ b/docs/de/guides/public-cloud/compute/share-images-between-projects.mdx
@@ -157,4 +157,4 @@ $ openstack image remove project `<image>` <UUID_Project_To_Delete>
 
 [Backup einer Instanz von einer Region in eine andere übertragen](/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
+++ b/docs/de/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
@@ -258,4 +258,4 @@ Für die aktuelle Version von OpenStack mit einem bootfähigen Volume ist die OV
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
+++ b/docs/de/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
@@ -195,4 +195,4 @@ admin@server-1:~$ openstack volume delete f75d60b3-4179-4ca9-8bc7-8e5f7a1682f8
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/de/guides/public-cloud/compute/starting-with-nova.mdx
@@ -199,4 +199,4 @@ admin@server-1:~$ openstack server delete InstanceTest
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/de/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -76,4 +76,4 @@ Sobald der Vorgang abgeschlossen ist, können Sie für die nächsten Schritte un
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
+++ b/docs/de/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
@@ -77,4 +77,4 @@ Klicken Sie auf den Button <code className="action">...</code> um einen Snapshot
 
 [Die Größe einer zusätzlichen Disk erweitern](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/test-disk-speed.mdx
+++ b/docs/de/guides/public-cloud/compute/test-disk-speed.mdx
@@ -217,4 +217,4 @@ Greifen Sie dann über Powershell auf das zusätzliche Laufwerk zu und führen S
 
 [Zusätzliches Volume auf einer Instanz erstellen und konfigurieren](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
  
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
+++ b/docs/de/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
@@ -146,4 +146,4 @@ $ openstack server create --key-name SSHKEY --flavor 98c1e679-5f2c-4069-b4da-4a4
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/upgrading-operating-system.mdx
+++ b/docs/de/guides/public-cloud/compute/upgrading-operating-system.mdx
@@ -180,4 +180,4 @@ Bei Schwierigkeiten finden Sie möglicherweise Antworten auf Ihre Fragen in der 
 
 ## Weiterführende Informationen
  
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/upload-own-image.mdx
+++ b/docs/de/guides/public-cloud/compute/upload-own-image.mdx
@@ -106,4 +106,4 @@ Sobald Ihr Image importbereit ist, folgen Sie den diesen Schritten, um es über 
 
 ## Weiterführende Informationen
  
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/de/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -147,4 +147,4 @@ Now you can code your Pulumi program and after running the `pulumi up` command, 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
+++ b/docs/de/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
@@ -173,4 +173,4 @@ Now you can define your Terraform configuration files and providers and after ru
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/compute/volume-backup.mdx
+++ b/docs/de/guides/public-cloud/compute/volume-backup.mdx
@@ -109,4 +109,4 @@ Weitere Informationen zu diesem Thema finden Sie in unserer [Anleitung zur Erste
 
 [Die Größe einer zusätzlichen Disk erweitern](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/ai-machine-learning/overview.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Go further"
   items:
     - title: "Visit the OVHcloud community"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: "Join Discord"

--- a/docs/en/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
+++ b/docs/en/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
@@ -192,4 +192,4 @@ slmgr.vbs -dli
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/apps-first-steps.mdx
+++ b/docs/en/guides/public-cloud/compute/apps-first-steps.mdx
@@ -229,4 +229,4 @@ No further steps are necessary to complete the first configuration of this appli
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/change-project-contacts.mdx
+++ b/docs/en/guides/public-cloud/compute/change-project-contacts.mdx
@@ -57,4 +57,4 @@ For a more detailed explanation of this process, please consult our guide [Manag
 
 [Delegating projects](/guides/public-cloud/cross-functional/delegate-projects)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -98,4 +98,4 @@ sudo cat /etc/hosts
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
+++ b/docs/en/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
@@ -158,4 +158,4 @@ Consult the [SSH key guide](/guides/public-cloud/compute/creating-ssh-keys) to l
 
 [How to replace an SSH key pair on a Public Cloud instance with rescue mode](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/en/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -170,5 +170,5 @@ openstack image list | grep 'My Custom Image'
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/en/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -179,4 +179,4 @@ Please note that these options are not mandatory for the creation of a basic ins
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
+++ b/docs/en/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
@@ -200,4 +200,4 @@ Fill in the variables:
 
 [Creating instance backups](/guides/public-cloud/compute/save-an-instance)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/create-server-group-horizon-cli.mdx
+++ b/docs/en/guides/public-cloud/compute/create-server-group-horizon-cli.mdx
@@ -224,4 +224,4 @@ openstack quota show <project> |grep -i server-group
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/creating-ssh-keys.mdx
+++ b/docs/en/guides/public-cloud/compute/creating-ssh-keys.mdx
@@ -456,4 +456,4 @@ For specialized services (SEO, development, etc.), contact [OVHcloud partners](h
 
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-gb/support-levels/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
+++ b/docs/en/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
@@ -70,4 +70,4 @@ In the **Actions** column, you can:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
+++ b/docs/en/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
@@ -38,4 +38,4 @@ With a monthly commitment, any month you start is payable in full. But this inst
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -185,4 +185,4 @@ Consult our [Getting started guide](/guides/public-cloud/compute/getting-started
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/forensics.mdx
+++ b/docs/en/guides/public-cloud/compute/forensics.mdx
@@ -202,4 +202,4 @@ Note that the output `raw` file size of this command will be the actual size of 
 
 The _QEMU_ convertion tool supports many output file formats as explained in this documentation: [https://docs.openstack.org/image-guide/convert-images.html](https://docs.openstack.org/image-guide/convert-images.html)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/en/guides/public-cloud/compute/image-life-cycle.mdx
@@ -112,4 +112,4 @@ Please note that:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/en/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -256,4 +256,4 @@ Once this is completed, detach the volume from the instance and reattach it to e
 
 [Change your Block Storage volume type](/guides/public-cloud/compute/switch-volume-type)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/install-owncloud-on-a-public-cloud-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/install-owncloud-on-a-public-cloud-instance.mdx
@@ -361,4 +361,4 @@ service apache2 start
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -76,4 +76,4 @@ Want to change your licence, to replace a test key or change your solution, for 
 
 [Official Plesk documentation](https://docs.plesk.com/en-US/obsidian/).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -251,4 +251,4 @@ scrape_configs:
 
 [Creating and configuring a security group in Horizon](/guides/public-cloud/compute/setup-security-group)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/en/guides/public-cloud/compute/install-wordpress.mdx
@@ -279,4 +279,4 @@ Certbot will automatically renew the certificates. There are no further steps re
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/key-concepts.mdx
+++ b/docs/en/guides/public-cloud/compute/key-concepts.mdx
@@ -144,4 +144,4 @@ Once you are familiar with the core concepts of OVHcloud Public Cloud Compute, y
 - [First steps with preinstalled applications](/guides/public-cloud/compute/apps-first-steps)
 - [Adding cloud credit](/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -108,4 +108,4 @@ root@instance1:/home/ovh#
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
+++ b/docs/en/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
@@ -158,4 +158,4 @@ Please send us your questions, feedback and suggestions to improve the service:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/managing-instances-horizon.mdx
+++ b/docs/en/guides/public-cloud/compute/managing-instances-horizon.mdx
@@ -170,4 +170,4 @@ Once deleted, you will no longer be charged for your instance, and you will not 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
+++ b/docs/en/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
@@ -82,4 +82,4 @@ Next, click the drop-down arrow next to the snapshot you want to delete and clic
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume.mdx
+++ b/docs/en/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume.mdx
@@ -128,4 +128,4 @@ Ensure the mount point `/mnt/data` exists before boot or the system may fail to 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/migration-between-regions.mdx
+++ b/docs/en/guides/public-cloud/compute/migration-between-regions.mdx
@@ -90,4 +90,4 @@ Find all the detailed information in the **Creating an instance from a backup** 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/overview.mdx
+++ b/docs/en/guides/public-cloud/compute/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: View the roadmap & changelog
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
+++ b/docs/en/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
@@ -118,4 +118,4 @@ nova unrescue INSTANCE_ID
 
 [How to replace an SSH key pair on an instance](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
+++ b/docs/en/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
@@ -63,4 +63,4 @@ You can now leave the rescue mode and boot normally (see [How to activate rescue
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/en/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -89,4 +89,4 @@ You have now access to the instance with your new SSH key pair.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
@@ -71,4 +71,4 @@ $ openstack server unrescue SERVERID
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/resize-freebsd-file-system-after-install.mdx
+++ b/docs/en/guides/public-cloud/compute/resize-freebsd-file-system-after-install.mdx
@@ -75,4 +75,4 @@ In the example output above, `zroot` now has a size of 50 GB. ZFS is therefore w
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/resize-instance-manager.mdx
+++ b/docs/en/guides/public-cloud/compute/resize-instance-manager.mdx
@@ -90,4 +90,4 @@ Once done, click on <code className="action">Finish</code> to confirm your choic
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/resize-instance-openstack.mdx
+++ b/docs/en/guides/public-cloud/compute/resize-instance-openstack.mdx
@@ -135,4 +135,4 @@ In case you wish to scale down your instance, you can do this by performing the 
 
 [Resize a Public Cloud instance via Horizon](/guides/public-cloud/compute/resize-of-an-instance)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/resize-of-an-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/resize-of-an-instance.mdx
@@ -91,4 +91,4 @@ Once done, click on <code className="action">Finish</code> to confirm your choic
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/revert-a-flex-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/revert-a-flex-instance.mdx
@@ -69,4 +69,4 @@ Alternatively, you can [edit the configuration of the instance](/guides/public-c
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/save-an-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/save-an-instance.mdx
@@ -259,4 +259,4 @@ Find out how to use backups to clone or restore instances in [this guide](/guide
 
 [Using instance backups to create or restore an instance](/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/setup-instance-reverse.mdx
+++ b/docs/en/guides/public-cloud/compute/setup-instance-reverse.mdx
@@ -58,4 +58,4 @@ If the domain name is managed by OVHcloud as its registrar **and** it uses OVHcl
 
 [How to edit an OVHcloud DNS zone](/guides/web-cloud/domains/dns-zone-edit)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/en/guides/public-cloud/compute/setup-security-group.mdx
@@ -109,4 +109,4 @@ To delete a security group, select it by ticking the corresponding box on the le
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
+++ b/docs/en/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
@@ -112,4 +112,4 @@ More advanced users who want to generate temporary addresses without the **swift
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/share-images-between-projects.mdx
+++ b/docs/en/guides/public-cloud/compute/share-images-between-projects.mdx
@@ -162,4 +162,4 @@ $ openstack image remove project `<image>` <UUID_Project_To_Delete>
 
 [Transfer an instance backup from one datacentre to another](/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
+++ b/docs/en/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
@@ -259,4 +259,4 @@ With the current version of OpenStack, rescue-pro mode is not available on an in
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
+++ b/docs/en/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
@@ -190,4 +190,4 @@ admin@server-1:~$ openstack volume delete f75d60b3-4179-4ca9-8bc7-8e5f7a1682f8
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/en/guides/public-cloud/compute/starting-with-nova.mdx
@@ -193,4 +193,4 @@ admin@server-1:~$ openstack server delete InstanceTest
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/storage-classic-multi-attach-3az.mdx
+++ b/docs/en/guides/public-cloud/compute/storage-classic-multi-attach-3az.mdx
@@ -50,4 +50,4 @@ Classic Multi-Attach volumes come with specific limitations that should be consi
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/en/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -73,4 +73,4 @@ Once the attachment is complete, you can follow these steps on how to configure 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
+++ b/docs/en/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
@@ -74,4 +74,4 @@ Click on the button <code className="action">...</code> to <code className="acti
 
 [Increasing the size of an additional disk](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/test-disk-speed.mdx
+++ b/docs/en/guides/public-cloud/compute/test-disk-speed.mdx
@@ -216,4 +216,4 @@ Next, access the disk via powershell and run the same command as above.
 
 [Create and configure an additional disk on an Instance](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
+++ b/docs/en/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
@@ -138,4 +138,4 @@ If you wish to recreate your instance from this backup, follow our guide "[Using
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/upgrading-operating-system.mdx
+++ b/docs/en/guides/public-cloud/compute/upgrading-operating-system.mdx
@@ -171,4 +171,4 @@ If you encounter any issues, you may find answers to your questions on the [Fedo
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/upload-own-image.mdx
+++ b/docs/en/guides/public-cloud/compute/upload-own-image.mdx
@@ -106,4 +106,4 @@ Once your image is ready to upload, you can use the following steps to upload it
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/en/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -147,4 +147,4 @@ Now you can code your Pulumi program and after running the `pulumi up` command, 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
+++ b/docs/en/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
@@ -173,4 +173,4 @@ Now you can define your Terraform configuration files and providers and after ru
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/volume-backup.mdx
+++ b/docs/en/guides/public-cloud/compute/volume-backup.mdx
@@ -100,4 +100,4 @@ You can find further information in [this guide](/guides/public-cloud/compute/st
 
 [Increasing the size of an additional disk](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
+++ b/docs/es/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
+++ b/docs/es/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
+++ b/docs/es/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
+++ b/docs/es/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
+++ b/docs/es/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/ai-machine-learning/overview.mdx
+++ b/docs/es/guides/public-cloud/ai-machine-learning/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Más información"
   items:
     - title: "Visitar la comunidad OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Ver la hoja de ruta y el changelog"
       link: https://www.ovhcloud.com/es-es/roadmap-changelog/
     - title: "Unirse a Discord"

--- a/docs/es/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
+++ b/docs/es/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
@@ -198,4 +198,4 @@ slmgr.vbs -dli
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/apps-first-steps.mdx
+++ b/docs/es/guides/public-cloud/compute/apps-first-steps.mdx
@@ -238,4 +238,4 @@ No es necesario realizar ningún otro paso para finalizar la primera configuraci
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/change-project-contacts.mdx
+++ b/docs/es/guides/public-cloud/compute/change-project-contacts.mdx
@@ -62,4 +62,4 @@ Para más información, consulte nuestra guía [Gestionar los contactos de los s
 
 [Delegar proyectos](/guides/public-cloud/cross-functional/delegate-projects)
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -98,4 +98,4 @@ sudo cat /etc/hosts
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
+++ b/docs/es/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
@@ -165,4 +165,4 @@ Consulte la [guía sobre las claves SSH](/guides/public-cloud/compute/creating-s
 
 [Cómo sustituir un par de claves SSH en una instancia Public Cloud por el modo de rescate](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/es/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -170,5 +170,5 @@ openstack image list | grep 'My Custom Image'
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/es/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/es/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -186,4 +186,4 @@ Atención: Estas opciones no son obligatorias para la creación de una instancia
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
+++ b/docs/es/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
@@ -206,4 +206,4 @@ Rellene las variables:
 
 [Guardar una copia de seguridad de una instancia](/guides/public-cloud/compute/save-an-instance)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/creating-ssh-keys.mdx
+++ b/docs/es/guides/public-cloud/compute/creating-ssh-keys.mdx
@@ -457,4 +457,4 @@ Para servicios especializados (posicionamiento web, desarrollo...), póngase en 
 
 Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
+++ b/docs/es/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
@@ -76,4 +76,4 @@ Utilizando el menú desplegable de la columna **Actions** es posible:
 
 ## Más información
   
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
+++ b/docs/es/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
@@ -38,4 +38,4 @@ Así pues, con un compromiso mensual, cada mes comenzado deberá abonarse en su 
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -187,4 +187,4 @@ Consulte nuestra guía [Crear una primera instancia de Public Cloud y conectarse
 
 Si necesita formación o asistencia técnica para implementar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/forensics.mdx
+++ b/docs/es/guides/public-cloud/compute/forensics.mdx
@@ -202,4 +202,4 @@ Note that the output `raw` file size of this command will be the actual size of 
 
 The _QEMU_ convertion tool supports many output file formats as explained in this documentation: [https://docs.openstack.org/image-guide/convert-images.html](https://docs.openstack.org/image-guide/convert-images.html)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/es/guides/public-cloud/compute/image-life-cycle.mdx
@@ -112,4 +112,4 @@ Please note that:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/es/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -258,4 +258,4 @@ Una vez finalizada esta operación, desmonte el volumen de la instancia y vuelva
 
 [Cambie el tipo de volumen en su Block Storage](/guides/public-cloud/compute/switch-volume-type)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -77,4 +77,4 @@ OVHcloud no comercializa licencias de Plesk para la solución Public Cloud. No o
 
 [Documentación oficial de Plesk](https://docs.plesk.com/es-ES/obsidian/)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -251,4 +251,4 @@ scrape_configs:
 
 [Crear y configurar un grupo de seguridad en Horizon](/guides/public-cloud/compute/setup-security-group)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/es/guides/public-cloud/compute/install-wordpress.mdx
@@ -287,4 +287,4 @@ Certbot renovará automáticamente los certificados. No es necesario realizar ni
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/key-concepts.mdx
+++ b/docs/es/guides/public-cloud/compute/key-concepts.mdx
@@ -144,4 +144,4 @@ Una vez que domine los conceptos fundamentales de Public Cloud Compute de OVHclo
 - [Primeros pasos con aplicaciones preinstaladas](/guides/public-cloud/compute/apps-first-steps)
 - [Añadir créditos de nube](/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project)
 
-Únete a nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
+++ b/docs/es/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
@@ -158,4 +158,4 @@ Please send us your questions, feedback and suggestions to improve the service:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/compute/managing-instances-horizon.mdx
+++ b/docs/es/guides/public-cloud/compute/managing-instances-horizon.mdx
@@ -177,4 +177,4 @@ Una vez eliminada, la instancia dejará de facturarse y no podrá recuperarla.
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
+++ b/docs/es/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
@@ -89,6 +89,6 @@ Haga clic en la flecha desplegable situada junto al snapshot que desea eliminar 
 
 ## Más información
   
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).
 	
 

--- a/docs/es/guides/public-cloud/compute/migration-between-regions.mdx
+++ b/docs/es/guides/public-cloud/compute/migration-between-regions.mdx
@@ -90,4 +90,4 @@ Encuentre toda la información detallada en la sección **Crear o restaurar un s
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/overview.mdx
+++ b/docs/es/guides/public-cloud/compute/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
+++ b/docs/es/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
@@ -123,4 +123,4 @@ nova unrescue INSTANCE_ID
 
 [Cómo sustituir un par de claves SSH en una instancia](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
+++ b/docs/es/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
@@ -69,4 +69,4 @@ Ya puede sacar la instancia del modo de rescate. (Ver la guía [Convertir una in
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/es/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -95,4 +95,4 @@ Ya puede acceder a la instancia con su nuevo par de claves SSH.
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
@@ -71,4 +71,4 @@ $ openstack server unrescue SERVERID
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/compute/resize-freebsd-file-system-after-install.mdx
+++ b/docs/es/guides/public-cloud/compute/resize-freebsd-file-system-after-install.mdx
@@ -80,4 +80,4 @@ Notarán que en este ejemplo, `zroot` ahora tiene `50 GB`. ZFS es, por lo tanto,
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/resize-instance-manager.mdx
+++ b/docs/es/guides/public-cloud/compute/resize-instance-manager.mdx
@@ -90,4 +90,4 @@ Haga clic en <code className="action">Finish</code> para confirmar su elección.
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/resize-instance-openstack.mdx
+++ b/docs/es/guides/public-cloud/compute/resize-instance-openstack.mdx
@@ -139,4 +139,4 @@ Si desea reducir su instancia, puede hacerlo siguiendo los mismos pasos menciona
 
 [Redimensionar una instancia de Public Cloud a través de Horizon](/guides/public-cloud/compute/resize-of-an-instance)
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/resize-of-an-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/resize-of-an-instance.mdx
@@ -96,4 +96,4 @@ Haga clic en <code className="action">Finish</code> para aceptar la opción que 
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/revert-a-flex-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/revert-a-flex-instance.mdx
@@ -74,4 +74,4 @@ También puede [editar la configuración de una instancia](/guides/public-cloud/
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/save-an-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/save-an-instance.mdx
@@ -260,4 +260,4 @@ Esta guía explica cómo utilizar las copias de seguridad para clonar o restaura
 
 [Crear o restaurar un servidor virtual a partir de un snapshot](/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup)
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/setup-instance-reverse.mdx
+++ b/docs/es/guides/public-cloud/compute/setup-instance-reverse.mdx
@@ -54,4 +54,4 @@ Si la modificación no funciona como se esperaba, compruebe que el registro `A` 
 
 [Crear una primera instancia de Public Cloud y conectarse a ella](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/es/guides/public-cloud/compute/setup-security-group.mdx
@@ -112,4 +112,4 @@ Para eliminar un grupo de seguridad, selecciónelo marcando la casilla correspon
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
+++ b/docs/es/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
@@ -111,4 +111,4 @@ Los usuarios más avanzados que quieran generar direcciones temporales sin el sc
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/share-images-between-projects.mdx
+++ b/docs/es/guides/public-cloud/compute/share-images-between-projects.mdx
@@ -162,4 +162,4 @@ $ openstack image remove project `<image>` <UUID_Project_To_Delete>
 
 [Transferir el backup de una instancia entre datacenters](/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
+++ b/docs/es/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
@@ -260,4 +260,4 @@ Con la versión actual de OpenStack, el modo rescue-pro no está disponible en u
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
+++ b/docs/es/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
@@ -195,4 +195,4 @@ admin@server-1:~$ openstack volume delete f75d60b3-4179-4ca9-8bc7-8e5f7a1682f8
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/es/guides/public-cloud/compute/starting-with-nova.mdx
@@ -196,4 +196,4 @@ admin@server-1:~$ openstack server delete InstanceTest
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/es/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -76,4 +76,4 @@ Una vez realizado el apego, puede seguir los siguientes pasos [en Linux](/guides
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
+++ b/docs/es/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
@@ -77,4 +77,4 @@ Haga clic en el botón <code className="action">...</code> para eliminar o <code
 
 [Aumentar el tamaño de un disco adicional](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/test-disk-speed.mdx
+++ b/docs/es/guides/public-cloud/compute/test-disk-speed.mdx
@@ -218,4 +218,4 @@ A continuación, acceda al disco adicional mediante powershell y ejecute el mism
 
 [Crear y configurar un disco adicional en una instancia](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
+++ b/docs/es/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
@@ -146,4 +146,4 @@ $ openstack server create --key-name SSHKEY --flavor 98c1e679-5f2c-4069-b4da-4a4
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/upgrading-operating-system.mdx
+++ b/docs/es/guides/public-cloud/compute/upgrading-operating-system.mdx
@@ -177,4 +177,4 @@ Si necesita ayuda, encontrará respuestas en el sitio web [Fedora Docs](https://
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/upload-own-image.mdx
+++ b/docs/es/guides/public-cloud/compute/upload-own-image.mdx
@@ -106,4 +106,4 @@ Una vez que la imagen esté lista para ser importada, siga los pasos que se indi
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/es/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -147,4 +147,4 @@ Now you can code your Pulumi program and after running the `pulumi up` command, 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
+++ b/docs/es/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
@@ -173,4 +173,4 @@ Now you can define your Terraform configuration files and providers and after ru
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/compute/volume-backup.mdx
+++ b/docs/es/guides/public-cloud/compute/volume-backup.mdx
@@ -109,4 +109,4 @@ Para más información, consulte [nuestra guía sobre la creación de un volumen
 
 [Aumentar el tamaño de un disco adicional](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/ai-machine-learning/overview.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Aller plus loin"
   items:
     - title: "Rejoindre la communauté OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Voir la roadmap & changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: "Rejoindre Discord"

--- a/docs/fr/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
+++ b/docs/fr/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
@@ -192,4 +192,4 @@ slmgr.vbs -dli
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/apps-first-steps.mdx
+++ b/docs/fr/guides/public-cloud/compute/apps-first-steps.mdx
@@ -232,4 +232,4 @@ Aucune autre étape n'est nécessaire pour terminer la première configuration d
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/change-project-contacts.mdx
+++ b/docs/fr/guides/public-cloud/compute/change-project-contacts.mdx
@@ -59,4 +59,4 @@ Pour une explication plus détaillée de cette procédure, nous vous invitons à
 
 [Déléguer des projets](/guides/public-cloud/cross-functional/delegate-projects)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -98,4 +98,4 @@ sudo cat /etc/hosts
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
+++ b/docs/fr/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
@@ -158,4 +158,4 @@ Consultez le [guide sur les clés SSH](/guides/public-cloud/compute/creating-ssh
 
 [Comment remplacer une paire de clés SSH sur une instance Public Cloud par le mode rescue](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/fr/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -178,4 +178,4 @@ openstack image list | grep 'My Custom Image'
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/fr/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -179,4 +179,4 @@ Attention, ces options ne sont pas obligatoires pour la création d'une instance
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
+++ b/docs/fr/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
@@ -200,4 +200,4 @@ Renseignez les variables :
 
 [Sauvegarder une instance](/guides/public-cloud/compute/save-an-instance)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/create-server-group-horizon-cli.mdx
+++ b/docs/fr/guides/public-cloud/compute/create-server-group-horizon-cli.mdx
@@ -224,4 +224,4 @@ openstack quota show <project> |grep -i server-group
 
 ## Aller plus loin
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/creating-ssh-keys.mdx
+++ b/docs/fr/guides/public-cloud/compute/creating-ssh-keys.mdx
@@ -457,4 +457,4 @@ Pour des prestations spécialisées (référencement, développement, etc), cont
 
 Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr/support-levels/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
+++ b/docs/fr/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
@@ -68,4 +68,4 @@ Dans la colonne  **Actions**  il est possible :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
+++ b/docs/fr/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
@@ -42,4 +42,4 @@ Avec un engagement mensuel, chaque mois que vous commencez est payable en intég
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -187,4 +187,4 @@ Consultez notre guide « [Créer une première instance Public Cloud et s'y conn
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/forensics.mdx
+++ b/docs/fr/guides/public-cloud/compute/forensics.mdx
@@ -200,4 +200,4 @@ A noter que le fichier `raw` produit aura strictement la taille du disque de l'i
 
 Le convertisseur de _QEMU_ supporte un grand nombre de formats de fichier en sortie, comme expliqué dans la documentation suivante : [https://docs.openstack.org/image-guide/convert-images.html](https://docs.openstack.org/image-guide/convert-images.html)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/fr/guides/public-cloud/compute/image-life-cycle.mdx
@@ -113,4 +113,4 @@ Veuillez noter au préalable que :
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/fr/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -262,4 +262,4 @@ Une fois cette opération terminée, détachez le volume de l'instance et rattac
 
 [Modifier un Volume Block Storage](/guides/public-cloud/compute/switch-volume-type)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/install-owncloud-on-a-public-cloud-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/install-owncloud-on-a-public-cloud-instance.mdx
@@ -323,4 +323,4 @@ service apache2 start
 ```
 
 ## Aller plus loin
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -76,4 +76,4 @@ Vous souhaitez modifier votre licence, par exemple pour remplacer une clé de te
 
 [Documentation officielle de Plesk](https://docs.plesk.com/en-US/obsidian/).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -251,4 +251,4 @@ scrape_configs:
 
 [Créer et configurer un groupe de sécurité dans Horizon](/guides/public-cloud/compute/setup-security-group)
 
-Échangez avec notre [communauté d’utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/fr/guides/public-cloud/compute/install-wordpress.mdx
@@ -273,4 +273,4 @@ Certbot renouvelle automatiquement les certificats. Aucune autre étape n'est re
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/key-concepts.mdx
+++ b/docs/fr/guides/public-cloud/compute/key-concepts.mdx
@@ -144,4 +144,4 @@ Une fois que vous maîtrisez les concepts fondamentaux du Public Cloud Compute d
 - [Premiers pas avec des applications préinstallées](/guides/public-cloud/compute/apps-first-steps)
 - [Ajouter des crédits cloud](/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project)
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -108,4 +108,4 @@ root@instance1:/home/ovh#
 
 ## Aller plus loin
   
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
+++ b/docs/fr/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
@@ -158,4 +158,4 @@ N’hésitez pas à nous faire part de vos questions, retours et suggestions pou
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/managing-instances-horizon.mdx
+++ b/docs/fr/guides/public-cloud/compute/managing-instances-horizon.mdx
@@ -172,4 +172,4 @@ Une fois supprimée, votre instance ne vous sera plus facturée et vous ne serez
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
+++ b/docs/fr/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
@@ -82,4 +82,4 @@ Cliquez ensuite sur la flèche déroulante à côté du snapshot à supprimer et
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume.mdx
+++ b/docs/fr/guides/public-cloud/compute/migrating-non-encrypted-to-encrypted-volume.mdx
@@ -128,4 +128,4 @@ Assurez-vous que le point de montage `/mnt/data` existe avant le démarrage, sin
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/migration-between-regions.mdx
+++ b/docs/fr/guides/public-cloud/compute/migration-between-regions.mdx
@@ -90,4 +90,4 @@ Retrouvez toutes les informations détaillées dans la partie **Créer une insta
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/overview.mdx
+++ b/docs/fr/guides/public-cloud/compute/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulter la roadmap & le changelog
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
+++ b/docs/fr/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
@@ -118,4 +118,4 @@ nova unrescue INSTANCE_ID
 
 [Comment remplacer une paire de clés SSH sur une instance](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
+++ b/docs/fr/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
@@ -79,4 +79,4 @@ Vous pouvez maintenant sortir l'instance du mode rescue. (Voir le guide [Comment
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/fr/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -88,4 +88,4 @@ Vous avez maintenant accès à l'instance avec votre nouvelle paire de clés SSH
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
@@ -71,4 +71,4 @@ $ openstack server unrescue SERVERID
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/resize-freebsd-file-system-after-install.mdx
+++ b/docs/fr/guides/public-cloud/compute/resize-freebsd-file-system-after-install.mdx
@@ -75,4 +75,4 @@ Vous remarquerez que, dans cet exemple, `zroot` fait maintenant `50 GB`. ZFS est
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/resize-instance-manager.mdx
+++ b/docs/fr/guides/public-cloud/compute/resize-instance-manager.mdx
@@ -90,4 +90,4 @@ Cliquez ensuite sur <code className="action">Terminer</code> pour valider votre 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/resize-instance-openstack.mdx
+++ b/docs/fr/guides/public-cloud/compute/resize-instance-openstack.mdx
@@ -134,4 +134,4 @@ Si vous souhaitez réduire votre instance, vous pouvez le faire en suivant les m
 
 [Redimensionner une instance Public Cloud via Horizon](/guides/public-cloud/compute/resize-of-an-instance)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/resize-of-an-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/resize-of-an-instance.mdx
@@ -91,4 +91,4 @@ Cliquez ensuite sur <code className="action">Terminer</code> pour valider votre 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/revert-a-flex-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/revert-a-flex-instance.mdx
@@ -69,4 +69,4 @@ Vous pouvez également [modifier la configuration de l'instance](/guides/public-
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/save-an-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/save-an-instance.mdx
@@ -259,4 +259,4 @@ Découvrez comment utiliser les sauvegardes pour cloner ou restaurer des instanc
 
 [Créer / restaurer un serveur virtuel a partir d’une sauvegarde](/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/setup-instance-reverse.mdx
+++ b/docs/fr/guides/public-cloud/compute/setup-instance-reverse.mdx
@@ -54,4 +54,4 @@ Si la modification ne fonctionne pas comme prévu, vérifiez que le champ `A` es
 
 [Créer une première instance Public Cloud et s’y connecter](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/fr/guides/public-cloud/compute/setup-security-group.mdx
@@ -109,4 +109,4 @@ Pour supprimer un groupe de sécurité, sélectionnez-le en cochant la case corr
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
+++ b/docs/fr/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
@@ -113,4 +113,4 @@ Pour les utilisateurs les plus avancés, qui veulent générer des adresses temp
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/share-images-between-projects.mdx
+++ b/docs/fr/guides/public-cloud/compute/share-images-between-projects.mdx
@@ -162,4 +162,4 @@ $ openstack image remove project `<image>` <UUID_Projet_A_Supprimer>
 
 [Transférer la sauvegarde d'une instance d'un datacenter à un autre](/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
+++ b/docs/fr/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
@@ -260,4 +260,4 @@ Avec la version actuelle d'OpenStack, le mode rescue-pro n'est pas disponible su
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
+++ b/docs/fr/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
@@ -190,4 +190,4 @@ admin@serveur-1:~$ openstack volume delete f75d60b3-4179-4ca9-8bc7-8e5f7a1682f8
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/fr/guides/public-cloud/compute/starting-with-nova.mdx
@@ -194,4 +194,4 @@ admin@serveur-1:~$ openstack server delete InstanceTest
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/storage-classic-multi-attach-3az.mdx
+++ b/docs/fr/guides/public-cloud/compute/storage-classic-multi-attach-3az.mdx
@@ -50,4 +50,4 @@ Les volumes Classic Multi-attach sont assortis de limitations spécifiques qu'il
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/fr/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -73,4 +73,4 @@ Une fois l'attachement effectué, vous pouvez suivre les étapes suivantes pour 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
+++ b/docs/fr/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
@@ -77,4 +77,4 @@ Cliquez sur le bouton <code className="action">...</code> pour <code className="
 
 [Augmenter la taille d’un disque supplémentaire](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/test-disk-speed.mdx
+++ b/docs/fr/guides/public-cloud/compute/test-disk-speed.mdx
@@ -214,4 +214,4 @@ Accédez ensuite au disque supplémentaire via powershell et exécutez la même 
 
 [Créer et configurer un disque supplémentaire sur une instance](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
+++ b/docs/fr/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
@@ -138,4 +138,4 @@ Si vous souhaitez recréer votre instance à partir de cette sauvegarde, suivez 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/upgrading-operating-system.mdx
+++ b/docs/fr/guides/public-cloud/compute/upgrading-operating-system.mdx
@@ -172,4 +172,4 @@ Si vous rencontrez des difficultés, vous trouverez des réponses à vos questio
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/upload-own-image.mdx
+++ b/docs/fr/guides/public-cloud/compute/upload-own-image.mdx
@@ -106,4 +106,4 @@ Une fois que votre image est prête à être importée, suivez les étapes ci-de
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/fr/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -147,4 +147,4 @@ Now you can code your Pulumi program and after running the `pulumi up` command, 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
+++ b/docs/fr/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
@@ -173,4 +173,4 @@ Il est maintenant possible de définir vos fichiers de configuration et provider
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/volume-backup.mdx
+++ b/docs/fr/guides/public-cloud/compute/volume-backup.mdx
@@ -109,4 +109,4 @@ Retrouvez plus d’informations à ce sujet dans [notre guide sur la création d
 
 [Augmenter la taille d’un disque supplémentaire](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/it/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
+++ b/docs/it/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
+++ b/docs/it/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
+++ b/docs/it/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
+++ b/docs/it/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
+++ b/docs/it/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/ai-machine-learning/overview.mdx
+++ b/docs/it/guides/public-cloud/ai-machine-learning/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Per saperne di più"
   items:
     - title: "Visita la community OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Visualizza la roadmap e il changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: "Unisciti a Discord"

--- a/docs/it/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
+++ b/docs/it/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
@@ -198,4 +198,4 @@ slmgr.vbs -dli
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/apps-first-steps.mdx
+++ b/docs/it/guides/public-cloud/compute/apps-first-steps.mdx
@@ -239,4 +239,4 @@ Per completare la prima configurazione dell'applicazione non sono necessari ulte
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/change-project-contacts.mdx
+++ b/docs/it/guides/public-cloud/compute/change-project-contacts.mdx
@@ -62,4 +62,4 @@ Per maggiori informazioni sulla procedura da seguire, consulta la guida [Gestire
 
 [Delega progetti](/guides/public-cloud/cross-functional/delegate-projects)
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -103,4 +103,4 @@ sudo cat /etc/hosts
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
+++ b/docs/it/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
@@ -163,4 +163,4 @@ Per saperne di più sull'utilizzo delle chiavi SSH con le istanze Public Cloud, 
 
 [Come sostituire una coppia di chiavi SSH su un’istanza Public Cloud con la modalità Rescue](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/it/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -170,5 +170,5 @@ openstack image list | grep 'My Custom Image'
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/it/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/it/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -182,4 +182,4 @@ Attenzione: queste opzioni non sono obbligatorie per la creazione di un’istanz
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
+++ b/docs/it/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
@@ -206,4 +206,4 @@ Compila le variabili:
 
 [Effettuare lo Snapshot di un'istanza](/guides/public-cloud/compute/save-an-instance)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/creating-ssh-keys.mdx
+++ b/docs/it/guides/public-cloud/compute/creating-ssh-keys.mdx
@@ -452,4 +452,4 @@ Per prestazioni specializzate (referenziamento, sviluppo, ecc...), contatta i [p
 
 Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre soluzioni [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
+++ b/docs/it/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
@@ -80,4 +80,4 @@ Dalla colonna **Actions** è possibile:
 
 ## Per saperne di più
   
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
+++ b/docs/it/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
@@ -47,4 +47,4 @@ Con un impegno mensile, ogni mese a partire dall’orario di inizio del servizio
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all'indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -187,4 +187,4 @@ Consulta la nostra guida [Creare e connettersi a un'istanza Public Cloud](/guide
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/forensics.mdx
+++ b/docs/it/guides/public-cloud/compute/forensics.mdx
@@ -202,4 +202,4 @@ Note that the output `raw` file size of this command will be the actual size of 
 
 The _QEMU_ convertion tool supports many output file formats as explained in this documentation: [https://docs.openstack.org/image-guide/convert-images.html](https://docs.openstack.org/image-guide/convert-images.html)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/it/guides/public-cloud/compute/image-life-cycle.mdx
@@ -112,4 +112,4 @@ Please note that:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/it/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -258,4 +258,4 @@ Una volta completata questa operazione, scollegate il volume dall'istanza e rico
 
 [Modifica il tipo di volume di Block Storage](/guides/public-cloud/compute/switch-volume-type)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -77,4 +77,4 @@ Vuoi modificare la tua licenza, ad esempio per sostituire una chiave di test o c
 
 [Documentazione ufficiale Plesk](https://docs.plesk.com/it-IT/obsidian/)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -251,4 +251,4 @@ scrape_configs:
 
 [Creare e configurare un gruppo di sicurezza in Horizon](/guides/public-cloud/compute/setup-security-group)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/it/guides/public-cloud/compute/install-wordpress.mdx
@@ -286,4 +286,4 @@ Certbot rinnova automaticamente i certificati. Non sono necessarie ulteriori fas
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/key-concepts.mdx
+++ b/docs/it/guides/public-cloud/compute/key-concepts.mdx
@@ -144,4 +144,4 @@ Una volta che hai padroneggiato i concetti fondamentali del Public Cloud Compute
 - [Primi passi con applicazioni preinstallate](/guides/public-cloud/compute/apps-first-steps)
 - [Aggiungi crediti cloud](/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -106,4 +106,4 @@ root@instance1:/home/ovh#
 
 ## Per saperne di più
   
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
+++ b/docs/it/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
@@ -158,4 +158,4 @@ Please send us your questions, feedback and suggestions to improve the service:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/compute/managing-instances-horizon.mdx
+++ b/docs/it/guides/public-cloud/compute/managing-instances-horizon.mdx
@@ -179,4 +179,4 @@ Una volta eliminata, l'istanza non sarà più fatturata e non sarà più in grad
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
+++ b/docs/it/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
@@ -89,4 +89,4 @@ Clicca sulla freccia a tendina accanto allo Snapshot da eliminare e clicca su <c
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/migration-between-regions.mdx
+++ b/docs/it/guides/public-cloud/compute/migration-between-regions.mdx
@@ -90,4 +90,4 @@ Trovate tutte le informazioni dettagliate nella sezione **Crea un’istanza a pa
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/overview.mdx
+++ b/docs/it/guides/public-cloud/compute/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
+++ b/docs/it/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
@@ -116,4 +116,4 @@ nova unrescue INSTANCE_ID
 
 [Come sostituire una coppia di chiavi SSH su un’istanza](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
+++ b/docs/it/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
@@ -69,4 +69,4 @@ A questo punto, è possibile rimuovere l'istanza dal Rescue mode. (Consulta la g
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/it/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -94,4 +94,4 @@ A questo punto, avrai accesso all’istanza con la tua nuova coppia di chiavi SS
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
@@ -71,4 +71,4 @@ $ openstack server unrescue SERVERID
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/compute/resize-freebsd-file-system-after-install.mdx
+++ b/docs/it/guides/public-cloud/compute/resize-freebsd-file-system-after-install.mdx
@@ -80,4 +80,4 @@ Noterete che, in questo esempio, `zroot` fa ora `50 GB`. ZFS è quindi ben estes
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/resize-instance-manager.mdx
+++ b/docs/it/guides/public-cloud/compute/resize-instance-manager.mdx
@@ -90,4 +90,4 @@ Clicca su <code className="action">Finish</code> per confermare la tua scelta.
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/resize-instance-openstack.mdx
+++ b/docs/it/guides/public-cloud/compute/resize-instance-openstack.mdx
@@ -139,4 +139,4 @@ Se si desidera ridurre un'istanza, è possibile farlo seguendo gli stessi passag
 
 [Ridimensionare un’istanza Public Cloud con Horizon](/guides/public-cloud/compute/resize-of-an-instance)
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/resize-of-an-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/resize-of-an-instance.mdx
@@ -96,4 +96,4 @@ Clicca su <code className="action">Finish</code> per confermare la tua scelta.
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/revert-a-flex-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/revert-a-flex-instance.mdx
@@ -74,4 +74,4 @@ Se vuoi passare a un modello *flex*, puoi farlo eseguendo gli stessi passaggi me
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/save-an-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/save-an-instance.mdx
@@ -259,4 +259,4 @@ Questa guida ti mostra come utilizzare i backup per clonare o ripristinare le is
 
 [Crea/ripristina il tuo server virtuale da un backup](/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup)
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/setup-instance-reverse.mdx
+++ b/docs/it/guides/public-cloud/compute/setup-instance-reverse.mdx
@@ -54,4 +54,4 @@ Se la modifica non funziona come previsto, verifica che il record `A` sia config
 
 [Creare una prima istanza Public Cloud e connettersi](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/it/guides/public-cloud/compute/setup-security-group.mdx
@@ -112,4 +112,4 @@ Per eliminare un gruppo di sicurezza, selezionalo selezionando la casella corris
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
+++ b/docs/it/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
@@ -113,4 +113,4 @@ Gli utenti avanzati che intendono generare un Temp URL senza utilizzare lo scrip
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/share-images-between-projects.mdx
+++ b/docs/it/guides/public-cloud/compute/share-images-between-projects.mdx
@@ -162,4 +162,4 @@ $ openstack image remove project `<image>` <UUID_Project_To_Delete>
 
 [Trasferire il backup di un’istanza tra datacenter](/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another).
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
+++ b/docs/it/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
@@ -259,4 +259,4 @@ Con la versione attuale di OpenStack, la modalità rescue-pro non è disponibile
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
+++ b/docs/it/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
@@ -195,4 +195,4 @@ admin@server-1:~$ openstack volume delete f75d60b3-4179-4ca9-8bc7-8e5f7a1682f8
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/it/guides/public-cloud/compute/starting-with-nova.mdx
@@ -196,4 +196,4 @@ admin@server-1:~$ openstack server delete InstanceTest
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/it/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -76,4 +76,4 @@ Una volta effettuato l'associazione, puoi seguire gli step successivi [con Linux
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
+++ b/docs/it/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
@@ -77,4 +77,4 @@ Clicca sul pulsante <code className="action">...</code> per eliminare uno Snapsh
 
 [Aumenta lo spazio del tuo disco aggiuntivo](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/test-disk-speed.mdx
+++ b/docs/it/guides/public-cloud/compute/test-disk-speed.mdx
@@ -218,4 +218,4 @@ A questo punto accedi al disco aggiuntivo tramite powershell ed esegui lo stesso
 
 [Crea e configura un disco aggiuntivo sulla tua istanza](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
   
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
+++ b/docs/it/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
@@ -145,4 +145,4 @@ $ openstack server create --key-name SSHKEY --flavor 98c1e679-5f2c-4069-b4da-4a4
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/upgrading-operating-system.mdx
+++ b/docs/it/guides/public-cloud/compute/upgrading-operating-system.mdx
@@ -177,4 +177,4 @@ In caso di difficoltà o dubbi, consulta il sito [Fedora Doc](https://docs.fedor
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/upload-own-image.mdx
+++ b/docs/it/guides/public-cloud/compute/upload-own-image.mdx
@@ -112,4 +112,4 @@ Una volta che l'immagine è pronta, segui gli step qui sotto per importarla dall
 
 ## Per saperne di più <a name="go-further"></a>
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/it/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -147,4 +147,4 @@ Now you can code your Pulumi program and after running the `pulumi up` command, 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
+++ b/docs/it/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
@@ -173,4 +173,4 @@ Now you can define your Terraform configuration files and providers and after ru
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/compute/volume-backup.mdx
+++ b/docs/it/guides/public-cloud/compute/volume-backup.mdx
@@ -109,4 +109,4 @@ Per maggiori informazioni, consulta la [nostra guida sulla creazione di un volum
 
 [Aumenta la dimensione di un disco aggiuntivo](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/pl/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
+++ b/docs/pl/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
+++ b/docs/pl/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
+++ b/docs/pl/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
+++ b/docs/pl/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
+++ b/docs/pl/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/ai-machine-learning/overview.mdx
+++ b/docs/pl/guides/public-cloud/ai-machine-learning/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz harmonogram i dziennik zmian"
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: "Dołącz do Discorda"

--- a/docs/pl/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
+++ b/docs/pl/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
@@ -198,4 +198,4 @@ slmgr.vbs -dli
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/apps-first-steps.mdx
+++ b/docs/pl/guides/public-cloud/compute/apps-first-steps.mdx
@@ -239,4 +239,4 @@ Nie musisz wykonywać żadnych innych kroków, aby zakończyć pierwszą konfigu
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie[https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/change-project-contacts.mdx
+++ b/docs/pl/guides/public-cloud/compute/change-project-contacts.mdx
@@ -62,4 +62,4 @@ Aby uzyskać szczegółowe informacje na temat tej procedury, zapoznaj się z na
 
 [Delegowanie projektów](/guides/public-cloud/cross-functional/delegate-projects)
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -106,4 +106,4 @@ sudo cat /etc/hosts
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
+++ b/docs/pl/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
@@ -165,4 +165,4 @@ Więcej informacji na temat używania kluczy SSH z instancjami Public Cloud znaj
 
 [Jak zastąpić parę kluczy SSH w instancji Public Cloud trybem rescue](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/pl/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -170,5 +170,5 @@ openstack image list | grep 'My Custom Image'
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pl/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/pl/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -184,4 +184,4 @@ Uwaga: te opcje nie są wymagane do utworzenia podstawowej instancji. Jeśli chc
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
+++ b/docs/pl/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
@@ -206,4 +206,4 @@ Uzupełnij zmienne:
 
 [Tworzenie kopii zapasowej instancji](/guides/public-cloud/compute/save-an-instance)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/creating-ssh-keys.mdx
+++ b/docs/pl/guides/public-cloud/compute/creating-ssh-keys.mdx
@@ -457,4 +457,4 @@ W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj
 
 Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](https://www.ovhcloud.com/pl/support-levels/).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
+++ b/docs/pl/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
@@ -77,4 +77,4 @@ W kolumnie **Actions** można:
 
 ## Sprawdź również
  
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
+++ b/docs/pl/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
@@ -38,4 +38,4 @@ W przypadku zawarcia umowy miesięcznej, cały rozpoczęty miesiąc jest płatny
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -185,4 +185,4 @@ Więcej informacji o wymaganych krokach znajdziesz w naszym przewodniku [Tworzen
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/forensics.mdx
+++ b/docs/pl/guides/public-cloud/compute/forensics.mdx
@@ -202,4 +202,4 @@ Note that the output `raw` file size of this command will be the actual size of 
 
 The _QEMU_ convertion tool supports many output file formats as explained in this documentation: [https://docs.openstack.org/image-guide/convert-images.html](https://docs.openstack.org/image-guide/convert-images.html)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/pl/guides/public-cloud/compute/image-life-cycle.mdx
@@ -112,4 +112,4 @@ Please note that:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/pl/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -258,4 +258,4 @@ Po wykonaniu tych czynności odłącz wolumin od instancji i ponownie dołącz g
 
 [Zmień typ wolumenu Block Storage](/guides/public-cloud/compute/switch-volume-type)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -78,4 +78,4 @@ Jeśli chcesz zmienić licencję (wymiana klucza testowego, zmiana oferty), moż
 
 [Oficjalna dokumentacja Plesk](https://docs.plesk.com/en-US/onyx/)
 
-Przyłącz się do [społeczności użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -251,4 +251,4 @@ scrape_configs:
 
 [Tworzenie i konfigurowanie grupy bezpieczeństwa w Horizon](/guides/public-cloud/compute/setup-security-group)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/pl/guides/public-cloud/compute/install-wordpress.mdx
@@ -285,4 +285,4 @@ Certbot automatycznie odnawia certyfikaty. Nie jest wymagany żaden inny etap. A
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/key-concepts.mdx
+++ b/docs/pl/guides/public-cloud/compute/key-concepts.mdx
@@ -144,4 +144,4 @@ Po zapoznaniu się z podstawowymi pojęciami Public Cloud Compute OVHcloud może
 - [Pierwsze kroki z wstępnie zainstalowanymi aplikacjami](/guides/public-cloud/compute/apps-first-steps)
 - [Dodawanie kredytu chmurowego](/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -115,5 +115,5 @@ root@instance1:/home/ovh#
 
 ## Sprawdź również
  
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).
 

--- a/docs/pl/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
+++ b/docs/pl/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
@@ -158,4 +158,4 @@ Please send us your questions, feedback and suggestions to improve the service:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/compute/managing-instances-horizon.mdx
+++ b/docs/pl/guides/public-cloud/compute/managing-instances-horizon.mdx
@@ -177,4 +177,4 @@ Po usunięciu instancji nie będzie już fakturowana i nie będziesz mógł jej 
 
 ## Sprawdź również
  
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
+++ b/docs/pl/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
@@ -89,5 +89,5 @@ Następnie kliknij rozwijaną strzałkę obok snapshota, który chcesz usunąć 
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).
 

--- a/docs/pl/guides/public-cloud/compute/migration-between-regions.mdx
+++ b/docs/pl/guides/public-cloud/compute/migration-between-regions.mdx
@@ -90,4 +90,4 @@ Znajdź wszystkie szczegółowe informacje w sekcji **Tworzenie instancji na pod
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/overview.mdx
+++ b/docs/pl/guides/public-cloud/compute/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
+++ b/docs/pl/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
@@ -123,4 +123,4 @@ nova unrescue INSTANCE_ID
 
 [Jak zastąpić parę kluczy SSH na instancji](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
+++ b/docs/pl/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
@@ -69,4 +69,4 @@ Możesz teraz wyjąć instancję z trybu Rescue. (Sprawdź przewodnik [Zmień in
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/pl/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -94,4 +94,4 @@ Teraz masz dostęp do instancji za pomocą nowej pary kluczy SSH.
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
@@ -71,4 +71,4 @@ $ openstack server unrescue SERVERID
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/compute/resize-instance-manager.mdx
+++ b/docs/pl/guides/public-cloud/compute/resize-instance-manager.mdx
@@ -90,4 +90,4 @@ Kliknij <code className="action">Finish</code>, aby potwierdzić wybór.
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/resize-instance-openstack.mdx
+++ b/docs/pl/guides/public-cloud/compute/resize-instance-openstack.mdx
@@ -139,4 +139,4 @@ Jeśli chcesz zmniejszyć swoją instancję, możesz to zrobić, wykonując te s
 
 [Skaluj instancję Public Cloud za pomocą interfejsu Horizon](/guides/public-cloud/compute/resize-of-an-instance)
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/resize-of-an-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/resize-of-an-instance.mdx
@@ -96,4 +96,4 @@ Następnie kliknij <code className="action">Finish</code>, aby zatwierdzić wyb�
 
 ## Sprawdź również
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/revert-a-flex-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/revert-a-flex-instance.mdx
@@ -76,4 +76,4 @@ Można również [zmodyfikować konfigurację instancji](/guides/public-cloud/co
 
 ## Sprawdź również
  
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/save-an-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/save-an-instance.mdx
@@ -260,4 +260,4 @@ Dowiedz się, jak w [tym przewodniku](/guides/public-cloud/compute/create-restor
 
 [Tworzenie/ przywracanie serwera wirtualnego na podstawie kopii zapasowej](/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup)
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/setup-instance-reverse.mdx
+++ b/docs/pl/guides/public-cloud/compute/setup-instance-reverse.mdx
@@ -56,4 +56,4 @@ Jeśli modyfikacja nie działa zgodnie z oczekiwaniami, sprawdź, czy pole `A` j
 
 [Modyfikacja strefy DNS](/guides/web-cloud/domains/dns-zone-edit)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/pl/guides/public-cloud/compute/setup-security-group.mdx
@@ -112,4 +112,4 @@ Aby usunąć grupę zabezpieczeń, zaznacz ją w odpowiednim polu po lewej stron
 
 ## Sprawdź również
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
+++ b/docs/pl/guides/public-cloud/compute/share-an-object-via-a-temporary-url.mdx
@@ -113,4 +113,4 @@ Zaawansowani użytkownicy, którzy chcą generować tymczasowe adresy bez skrypt
 
 ## Sprawdź również
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/share-images-between-projects.mdx
+++ b/docs/pl/guides/public-cloud/compute/share-images-between-projects.mdx
@@ -162,4 +162,4 @@ $ openstack image remove project `<image>` <UUID_Project_To_Delete>
 
 [Przeniesienie kopii zapasowej instancji do innego centrum danych](/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
+++ b/docs/pl/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
@@ -260,4 +260,4 @@ W aktualnej wersji OpenStack tryb rescue-pro nie jest dostępny na instancji uru
 
 ## Sprawdź również
 
-Przyłącz się do [społeczności użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
+++ b/docs/pl/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
@@ -195,4 +195,4 @@ admin@server-1:~$ openstack volume delete f75d60b3-4179-4ca9-8bc7-8e5f7a1682f8
 
 ## Sprawdź również
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/pl/guides/public-cloud/compute/starting-with-nova.mdx
@@ -196,5 +196,5 @@ admin@server-1:~$ openstack server delete InstanceTest
 
 ## Sprawdź również
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).
 

--- a/docs/pl/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/pl/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -76,4 +76,4 @@ Po podłączeniu możesz przejść do kolejnych etapów [w systemie Linux](/guid
 
 ## Sprawdź również
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
+++ b/docs/pl/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
@@ -77,4 +77,4 @@ Kliknij przycisk <code className="action">...</code>, aby usunąć snapshot lub 
 
 [Zwiększenie rozmiaru dodatkowego dysku](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/test-disk-speed.mdx
+++ b/docs/pl/guides/public-cloud/compute/test-disk-speed.mdx
@@ -217,4 +217,4 @@ Następnie przejdź do dodatkowego dysku za pomocą programu PowerShell i wykona
 
 [Zarządzanie wolumenem instancji Public Cloud](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
  
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
+++ b/docs/pl/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
@@ -148,5 +148,5 @@ $ openstack server create --key-name SSHKEY --flavor 98c1e679-5f2c-4069-b4da-4a4
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).
 

--- a/docs/pl/guides/public-cloud/compute/upgrading-operating-system.mdx
+++ b/docs/pl/guides/public-cloud/compute/upgrading-operating-system.mdx
@@ -177,4 +177,4 @@ Jeśli napotkasz trudności, możesz znaleźć odpowiedzi na Twoje pytania na st
 
 ## Sprawdź również
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/upload-own-image.mdx
+++ b/docs/pl/guides/public-cloud/compute/upload-own-image.mdx
@@ -106,4 +106,4 @@ Kiedy Twój obraz jest gotowy do importu, wykonaj poniższe kroki, aby zaimporto
 
 ## Sprawdź również <a name="go-further"></a>
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/pl/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -147,4 +147,4 @@ Now you can code your Pulumi program and after running the `pulumi up` command, 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
+++ b/docs/pl/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
@@ -173,4 +173,4 @@ Now you can define your Terraform configuration files and providers and after ru
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/compute/volume-backup.mdx
+++ b/docs/pl/guides/public-cloud/compute/volume-backup.mdx
@@ -109,4 +109,4 @@ Więcej informacji na ten temat znajdziesz w [naszym przewodniku dotyczącym two
 
 [Zwiększ rozmiar dodatkowego dysku](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pt/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
+++ b/docs/pt/guides/public-cloud/ai-machine-learning/ai-deploy/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
+++ b/docs/pt/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
+++ b/docs/pt/guides/public-cloud/ai-machine-learning/ai-endpoints/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
+++ b/docs/pt/guides/public-cloud/ai-machine-learning/ai-notebooks/overview.mdx
@@ -13,7 +13,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
+++ b/docs/pt/guides/public-cloud/ai-machine-learning/ai-training/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/public-cloud/ai-machine-learning/overview.mdx
+++ b/docs/pt/guides/public-cloud/ai-machine-learning/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: "Visite a comunidade OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulte o roadmap e o changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Junte-se ao Discord"

--- a/docs/pt/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
+++ b/docs/pt/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
@@ -198,4 +198,4 @@ slmgr.vbs -dli
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/apps-first-steps.mdx
+++ b/docs/pt/guides/public-cloud/compute/apps-first-steps.mdx
@@ -238,4 +238,4 @@ Não é necessário mais nenhuma etapa para terminar a primeira configuração d
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
  
-Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/change-project-contacts.mdx
+++ b/docs/pt/guides/public-cloud/compute/change-project-contacts.mdx
@@ -62,4 +62,4 @@ Para uma explicação mais detalhada deste procedimento, consulte o nosso guia "
 
 [Delegar projetos](/guides/public-cloud/cross-functional/delegate-projects)
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -101,4 +101,4 @@ sudo cat /etc/hosts
 
 ## Quer saber mais?
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
+++ b/docs/pt/guides/public-cloud/compute/configuring-additional-ssh-keys.mdx
@@ -163,4 +163,4 @@ Consulte [manual sobre as chaves SSH](/guides/public-cloud/compute/creating-ssh-
 
 [Como substituir um par de chaves SSH numa instância Public Cloud pelo modo rescue](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/pt/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -170,5 +170,5 @@ openstack image list | grep 'My Custom Image'
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pt/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/pt/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -183,4 +183,4 @@ Atenção: estas opções não são obrigatórias para a criação de uma instâ
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
+++ b/docs/pt/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup.mdx
@@ -206,4 +206,4 @@ Preencha as variáveis:
 
 [Efetuar um backup de uma instância](/guides/public-cloud/compute/save-an-instance)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/creating-ssh-keys.mdx
+++ b/docs/pt/guides/public-cloud/compute/creating-ssh-keys.mdx
@@ -457,4 +457,4 @@ Para serviços especializados (referenciamento, desenvolvimento, etc), contacte 
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
+++ b/docs/pt/guides/public-cloud/compute/creation-launch-deletion-of-images-in-horizon.mdx
@@ -79,4 +79,4 @@ Na coluna Ações será possível:
 
 ## Quer saber mais?
  
-Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
+++ b/docs/pt/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
@@ -38,4 +38,4 @@ Com um compromisso mensal, todos os meses iniciados são devidos na íntegra. No
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -187,4 +187,4 @@ Consulte o nosso guia [Criação e conexão a uma primeira instância Public Clo
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projeto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/forensics.mdx
+++ b/docs/pt/guides/public-cloud/compute/forensics.mdx
@@ -202,4 +202,4 @@ Note that the output `raw` file size of this command will be the actual size of 
 
 The _QEMU_ convertion tool supports many output file formats as explained in this documentation: [https://docs.openstack.org/image-guide/convert-images.html](https://docs.openstack.org/image-guide/convert-images.html)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/pt/guides/public-cloud/compute/image-life-cycle.mdx
@@ -112,4 +112,4 @@ Please note that:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/pt/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -258,4 +258,4 @@ Assim que esta operação estiver concluída, desligue o volume da instância e 
 
 [Alterar o tipo de volume do seu Block Storage](/guides/public-cloud/compute/switch-volume-type)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -76,4 +76,4 @@ Pretende alterar a sua licença para substituir uma chave de teste ou para alter
 
 [Documentação oficial do Plesk.](https://docs.plesk.com/en-US/obsidian/)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -251,4 +251,4 @@ scrape_configs:
 
 [Criar e configurar um grupo de segurança no Horizon](/guides/public-cloud/compute/setup-security-group)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/pt/guides/public-cloud/compute/install-wordpress.mdx
@@ -285,4 +285,4 @@ Certbot renova automaticamente os certificados. Não é necessária outra etapa.
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/key-concepts.mdx
+++ b/docs/pt/guides/public-cloud/compute/key-concepts.mdx
@@ -144,4 +144,4 @@ Assim que dominar os conceitos fundamentais do Public Cloud Compute da OVHcloud,
 - [Primeiros passos com aplicações pré-instaladas](/guides/public-cloud/compute/apps-first-steps)
 - [Adicionar créditos cloud](/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
+++ b/docs/pt/guides/public-cloud/compute/local-zones-vpn-tailscale-integration.mdx
@@ -158,4 +158,4 @@ Please send us your questions, feedback and suggestions to improve the service:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/compute/managing-instances-horizon.mdx
+++ b/docs/pt/guides/public-cloud/compute/managing-instances-horizon.mdx
@@ -177,4 +177,4 @@ Uma vez eliminada, a sua instância não lhe será faturada e não poderá recup
 
 ## Quer saber mais?
 
-Fale com a nossa comunidade de utilizadores [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
+++ b/docs/pt/guides/public-cloud/compute/managing-snapshots-in-horizon.mdx
@@ -89,4 +89,4 @@ A seguir, clique na seta pendente junto da snapshot a eliminar e clique em <code
 
 ## Saiba mais
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/migration-between-regions.mdx
+++ b/docs/pt/guides/public-cloud/compute/migration-between-regions.mdx
@@ -90,4 +90,4 @@ Encontre todas as informações detalhadas na seção **Criar uma instância a p
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/overview.mdx
+++ b/docs/pt/guides/public-cloud/compute/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: Juntar-se ao Discord

--- a/docs/pt/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
+++ b/docs/pt/guides/public-cloud/compute/put-an-instance-in-rescue-mode.mdx
@@ -123,4 +123,4 @@ nova unrescue INSTANCE_ID
 
 [Como substituir um par de chaves SSH numa instância](/guides/public-cloud/compute/replacing-lost-ssh-key-pair)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
+++ b/docs/pt/guides/public-cloud/compute/repairing-the-grub-bootloader.mdx
@@ -69,4 +69,4 @@ Agora pode retirar a instância do modo rescue. (Ver o guia [Passar uma instânc
 
 ## Saiba mais
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/pt/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -94,4 +94,4 @@ Já tem acesso à instância com o seu novo par de chaves SSH.
 
 ## Quer saber mais?
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
@@ -71,4 +71,4 @@ $ openstack server unrescue SERVERID
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/compute/resize-freebsd-file-system-after-install.mdx
+++ b/docs/pt/guides/public-cloud/compute/resize-freebsd-file-system-after-install.mdx
@@ -80,4 +80,4 @@ Reparem que, neste exemplo, o `zroot` agora tem `50 GB`. Portanto, o ZFS é bem 
 
 ## Quer saber mais?
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/resize-instance-manager.mdx
+++ b/docs/pt/guides/public-cloud/compute/resize-instance-manager.mdx
@@ -90,4 +90,4 @@ Clique em <code className="action">Finish</code> para confirmar a sua escolha.
 
 ## Quer saber mais?
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/resize-instance-openstack.mdx
+++ b/docs/pt/guides/public-cloud/compute/resize-instance-openstack.mdx
@@ -139,4 +139,4 @@ Se quiser reduzir a sua instância, pode fazê-lo seguindo os mesmos passos menc
 
 [Redimensionar uma instância Public Cloud através do Horizon](/guides/public-cloud/compute/resize-of-an-instance)
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/resize-of-an-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/resize-of-an-instance.mdx
@@ -97,5 +97,5 @@ A seguir, clique em <code className="action">Finish</code> para validar a sua es
 
 ## Quer saber mais?
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).
 

--- a/docs/pt/guides/public-cloud/compute/revert-a-flex-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/revert-a-flex-instance.mdx
@@ -74,4 +74,4 @@ Também pode [editar a configuração da instância](/guides/public-cloud/comput
 
 ## Quer saber mais?
 
-Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/save-an-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/save-an-instance.mdx
@@ -260,4 +260,4 @@ Saiba como utilizar os backups para clonar ou restaurar instâncias neste [guia]
 
 [Criar/restaurar um servidor virtual a partir de um backup](/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup)
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/setup-instance-reverse.mdx
+++ b/docs/pt/guides/public-cloud/compute/setup-instance-reverse.mdx
@@ -54,4 +54,4 @@ Se a alteração não funcionar como previsto, verifique se o campo `A` está co
 
 [Criar uma primeira instância Public Cloud e ligar-se a ela](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/pt/guides/public-cloud/compute/setup-security-group.mdx
@@ -112,4 +112,4 @@ Para eliminar um grupo de segurança, selecione-o clicando no quadrado correspon
 
 ## Saiba mais
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/share-images-between-projects.mdx
+++ b/docs/pt/guides/public-cloud/compute/share-images-between-projects.mdx
@@ -162,4 +162,4 @@ $ openstack image remove project `<image>` <UUID_Project_To_Delete>
 
 [Transferir a cópia de segurança de uma instância de um datacenter para outro](/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another).
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
+++ b/docs/pt/guides/public-cloud/compute/start-instance-on-attached-volume.mdx
@@ -259,4 +259,4 @@ Com a versão atual do OpenStack, o modo rescue-pro não está disponível numa 
 
 ## Quer saber mais?
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
+++ b/docs/pt/guides/public-cloud/compute/starting-with-managing-volumes-openstack-api.mdx
@@ -195,4 +195,4 @@ admin@server-1:~$ openstack volume delete f75d60b3-4179-4ca9-8bc7-8e5f7a1682f8
 
 ## Saiba mais
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/pt/guides/public-cloud/compute/starting-with-nova.mdx
@@ -197,4 +197,4 @@ admin@server-1:~$ openstack server delete InstanceTest
 
 ## Saiba mais
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
+++ b/docs/pt/guides/public-cloud/compute/storage-create-volume-from-backup.mdx
@@ -76,4 +76,4 @@ Uma vez efetuada a associação, pode seguir os passos indicados [em Linux](/gui
 
 ## Saiba mais
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
+++ b/docs/pt/guides/public-cloud/compute/storage-create-volume-snapshot.mdx
@@ -77,4 +77,4 @@ Clique no botão <code className="action">...</code> para eliminar uma snapshot 
 
 [Aumentar o tamanho de um disco suplementar](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/test-disk-speed.mdx
+++ b/docs/pt/guides/public-cloud/compute/test-disk-speed.mdx
@@ -216,4 +216,4 @@ A seguir, aceda ao disco suplementar através do powershell e execute o mesmo co
 
 [Criar e configurar um disco suplementar numa instância](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
  
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
+++ b/docs/pt/guides/public-cloud/compute/transfer-instance-backup-from-one-datacentre-to-another.mdx
@@ -147,4 +147,4 @@ $ openstack server create --key-name SSHKEY --flavor 98c1e679-5f2c-4069-b4da-4a4
 
 ## Quer saber mais?
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/upgrading-operating-system.mdx
+++ b/docs/pt/guides/public-cloud/compute/upgrading-operating-system.mdx
@@ -177,4 +177,4 @@ Se encontrar dificuldades, encontrará respostas às suas questões no website [
 
 ## Quer saber mais?
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/upload-own-image.mdx
+++ b/docs/pt/guides/public-cloud/compute/upload-own-image.mdx
@@ -106,4 +106,4 @@ Quando a sua imagem estiver pronta para ser importada, siga os passos abaixo par
 
 ## Quer saber mais? <a name="go-further"></a>
  
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/pt/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -147,4 +147,4 @@ Now you can code your Pulumi program and after running the `pulumi up` command, 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
+++ b/docs/pt/guides/public-cloud/compute/use-object-storage-terraform-backend-state.mdx
@@ -173,4 +173,4 @@ Now you can define your Terraform configuration files and providers and after ru
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/compute/volume-backup.mdx
+++ b/docs/pt/guides/public-cloud/compute/volume-backup.mdx
@@ -109,4 +109,4 @@ Para mais informações, consulte o [nosso manual sobre a criação de um volume
 
 [Aumentar o tamanho de um disco adicional](/guides/public-cloud/compute/increase-the-size-of-an-additional-disk)
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).


### PR DESCRIPTION
### Scope: Public Cloud - Compute

- Replace (dead) links to legacy community page with proper keys
- Fix hard URL in Overview pages to the correct one