### PR TITLE
fix(docs): normalize community links batch 11: Public Cloud (4/4)

### DIFF
--- a/docs/de/guides/public-cloud/cross-functional/activate-hds-certification.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/activate-hds-certification.mdx
@@ -57,4 +57,4 @@ Review the information and check the box for accepting the contracts. Finally, c
 
 [Public Cloud documentation](/guides/public-cloud/compute/overview)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/cross-functional/analyze-billing.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/analyze-billing.mdx
@@ -194,4 +194,4 @@ Für die Klassen Infrequent Access, Active Archive und Cold Archive gelten eine 
 
 <sup>1</sup>: S3 ist eine Marke von Amazon Technologies, Inc. Der OVHcloud Dienst wird nicht von Amazon Technologies, Inc. gesponsert, unterstützt oder ist anderweitig mit dieser verbunden.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/cross-functional/api-rate-limits.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/api-rate-limits.mdx
@@ -106,4 +106,4 @@ Im Folgenden finden Sie Beispiele für etablierte Bibliotheken zur Implementieru
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com](https://community.ovh.com).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/cross-functional/compute-essential-information.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/compute-essential-information.mdx
@@ -156,4 +156,4 @@ Einer der großen Vorteile der Verwendung von Standard- und Open-Source-Technolo
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
@@ -49,4 +49,4 @@ Fügen Sie eine Sicherheitsgruppe mit dem Button <code className="action">Create
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -190,4 +190,4 @@ You can create your Savings Plan for the type of resource you want by following 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
@@ -170,4 +170,4 @@ openstack --help
 
 [OpenStack Umgebungsvariablen einrichten](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
@@ -84,4 +84,4 @@ set OS_PASSWORD="Ihr Benutzerpasswort"
 
 [OpenStack Dokumentation](https://docs.openstack.org/)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
@@ -107,4 +107,4 @@ Die Löschung eines Benutzers ist endgültig und führt zur Ungültigkeit aller 
 
 [Einführung in das Horizon Interface](/guides/public-cloud/cross-functional/introducing-horizon)
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/cross-functional/delegate-projects.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/delegate-projects.mdx
@@ -72,4 +72,4 @@ Um einen Zugang zu widerrufen, klicken Sie auf den Button <code className="actio
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
@@ -257,4 +257,4 @@ Architecture:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/de/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
@@ -175,4 +175,4 @@ Thanks to dynamic service transfer between availability zones, the application r
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/de/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -274,4 +274,4 @@ Der Grund dafür ist, dass dies bei einigen Betriebssystemen Instabilität verur
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
@@ -642,4 +642,4 @@ terraform destroy
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/cross-functional/introducing-horizon.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/introducing-horizon.mdx
@@ -125,4 +125,4 @@ Oben rechts im Horizon Interface haben Sie folgende Optionen im Benutzermenü:
 
 [Einführung in das Public Cloud Interface](/guides/public-cloud/cross-functional/public-cloud-interface-walk-me)
  
-Für den Austausch mit unserer Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/cross-functional/managing-tokens.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/managing-tokens.mdx
@@ -182,4 +182,4 @@ Sie erhalten nur eine Ausgabe, wenn es einen Fehler gibt.
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/cross-functional/metrics-informations.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/metrics-informations.mdx
@@ -107,4 +107,4 @@ The table below shows the availability status of metrics and the planned release
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/cross-functional/overview.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -267,4 +267,4 @@ The vCPUs of control-plane nodes are not billed.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/cross-functional/security-group-private-network.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/security-group-private-network.mdx
@@ -170,4 +170,4 @@ openstack port set --security-group private 5be009d9-fc2e-4bf5-a152-dab52614b02d
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
@@ -156,4 +156,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
@@ -171,4 +171,4 @@ openstack --os-auth-type token token revoke $OS_TOKEN
 
 ## Weiterführende Informationen
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -140,4 +140,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -186,4 +186,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -104,7 +104,7 @@ ClickHouse service capabilities
 
 [Configuring vRack for Public Cloud](/guides/public-cloud/network-services/vrack)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -90,4 +90,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -44,4 +44,4 @@ Visit our Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhc
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or our [Professional Services experts](https://www.ovhcloud.com/de/professional-services/) for a quote and custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -69,4 +69,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -110,7 +110,7 @@ ClickHouse service capabilities
 
 [Official Aiven documentation to integrate Kafka](https://aiven.io/docs/products/clickhouse/howto/integrate-kafka)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/de/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -146,4 +146,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -84,4 +84,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -70,4 +70,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
@@ -161,4 +161,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -136,4 +136,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -58,4 +58,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -62,4 +62,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/data-analytics/clickhouse/overview.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/clickhouse/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/data-analytics/grafana/overview.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/grafana/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/data-analytics/kafka/overview.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/kafka/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
+++ b/docs/de/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
@@ -69,4 +69,4 @@ The pricing methods depend on the use of the IP you choose. Additional IP usage 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/buy-additional-ip.mdx
+++ b/docs/de/guides/public-cloud/network-services/buy-additional-ip.mdx
@@ -108,4 +108,4 @@ Im nächsten Schritt muss die IP-Adresse in Ihrem Betriebssystem konfiguriert we
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/network-services/change-instance-dns-servers.mdx
+++ b/docs/de/guides/public-cloud/network-services/change-instance-dns-servers.mdx
@@ -174,4 +174,4 @@ In PowerShell kann mit dem Befehl `nslookup` überprüft werden, welche DNS-Serv
 
 [Hostname einer Public Cloud Instanz ändern](/guides/public-cloud/compute/changing-the-hostname-of-an-instance)
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/network-services/concepts.mdx
+++ b/docs/de/guides/public-cloud/network-services/concepts.mdx
@@ -150,4 +150,4 @@ Find out more about Additional IP and Floating IP on the dedicated [Concepts pag
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
+++ b/docs/de/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
@@ -125,4 +125,4 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/configure-additional-ip.mdx
+++ b/docs/de/guides/public-cloud/network-services/configure-additional-ip.mdx
@@ -398,4 +398,4 @@ Um die Verbindung zu testen, senden Sie einfach von außerhalb einen Ping an Ihr
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/network-services/create-private-network-gateway.mdx
+++ b/docs/de/guides/public-cloud/network-services/create-private-network-gateway.mdx
@@ -272,4 +272,4 @@ Learn more about Gateway and its scenarios on our [dedicated page](https://www.o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
+++ b/docs/de/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
@@ -510,4 +510,4 @@ The Public Cloud project and Bare Metal server must be added to the same vRack:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/faq.mdx
+++ b/docs/de/guides/public-cloud/network-services/faq.mdx
@@ -239,4 +239,4 @@ Yes, the [OHVcloud Anti-DDoS infrastructure](https://www.ovhcloud.com/de/securit
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/import-additional-ip.mdx
+++ b/docs/de/guides/public-cloud/network-services/import-additional-ip.mdx
@@ -88,4 +88,4 @@ Im nächsten Schritt muss die IP-Adresse in Ihrem Betriebssystem konfiguriert we
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/network-services/ipv6-configuration.mdx
+++ b/docs/de/guides/public-cloud/network-services/ipv6-configuration.mdx
@@ -372,4 +372,4 @@ Zögern Sie jedenfalls nicht, sich mit Testergebnissen zu den oben erwähnten An
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
+++ b/docs/de/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
@@ -151,4 +151,4 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/load-balancer-concepts.mdx
+++ b/docs/de/guides/public-cloud/network-services/load-balancer-concepts.mdx
@@ -153,4 +153,4 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
+++ b/docs/de/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
@@ -118,4 +118,4 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
+++ b/docs/de/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
@@ -224,4 +224,4 @@ You can now access your Load Balancer securely. However, you will need to renew 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
+++ b/docs/de/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
@@ -201,4 +201,4 @@ Each method offers specific advantages depending on your familiarity with the to
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
+++ b/docs/de/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
@@ -372,4 +372,4 @@ resource "openstack_lb_l7rule_v2" "l7rule_1" {
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
+++ b/docs/de/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
@@ -195,4 +195,4 @@ To delete your subscription you can use the following API call:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
+++ b/docs/de/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
@@ -349,4 +349,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/migrate-additional-ip.mdx
+++ b/docs/de/guides/public-cloud/network-services/migrate-additional-ip.mdx
@@ -84,4 +84,4 @@ Die Additional IP kann vor oder nach der Migration auf dem Zielserver konfigurie
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
+++ b/docs/de/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
@@ -328,6 +328,6 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 Join our [Discord](https://discord.gg/ovhcloud) to discuss with the OVHcloud team and other users.

--- a/docs/de/guides/public-cloud/network-services/overview.mdx
+++ b/docs/de/guides/public-cloud/network-services/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Weiterführende Informationen
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Roadmap & Changelog einsehen
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/public-cloud/network-services/stormshield-vrack.mdx
+++ b/docs/de/guides/public-cloud/network-services/stormshield-vrack.mdx
@@ -612,4 +612,4 @@ PING <ip_address> (<ip_address>) 56(84) bytes of data.
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/network-services/ubika-vrack.mdx
+++ b/docs/de/guides/public-cloud/network-services/ubika-vrack.mdx
@@ -426,4 +426,4 @@ ubika-test-webserver-1
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/en) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/de/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -172,4 +172,4 @@ You can check that the subnet has been updated:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/activate-hds-certification.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/activate-hds-certification.mdx
@@ -57,4 +57,4 @@ Review the information and check the box for accepting the contracts. Finally, c
 
 [Public Cloud documentation](/guides/public-cloud/compute/overview)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/analyze-billing.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/analyze-billing.mdx
@@ -199,4 +199,4 @@ For Infrequent Access, Active Archive and Cold Archive classes, a minimum storag
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/api-rate-limits.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/api-rate-limits.mdx
@@ -100,4 +100,4 @@ Some examples of well-known libraries to implement retry backoff in Python are:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/compute-essential-information.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/compute-essential-information.mdx
@@ -151,4 +151,4 @@ One of the big advantages of using standard and open technologies, like OpenStac
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
@@ -49,4 +49,4 @@ Add a security group by clicking on <code className="action">Create Security Gro
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -196,4 +196,4 @@ You can create your Savings Plan for the type of resource you want by following 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
@@ -164,4 +164,4 @@ openstack --help
 
 [Setting OpenStack environment variables](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
@@ -83,4 +83,4 @@ set OS_PASSWORD="Your Horizon user password"
 
 To learn how to use OpenStack: [OpenStack documentation](https://docs.openstack.org/)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
@@ -106,4 +106,4 @@ Deleting a user is permanent and will invalidate all associated tokens, even tho
 
 [Introducing Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/delegate-projects.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/delegate-projects.mdx
@@ -66,4 +66,4 @@ To revoke an access, click on the <code className="action">...</code> button and
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/delete-a-project.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/delete-a-project.mdx
@@ -57,4 +57,4 @@ Please note that when a project is marked for deletion, it remains in suspend st
 
 [Getting started with Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
@@ -257,4 +257,4 @@ Architecture:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/en/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
@@ -175,4 +175,4 @@ Thanks to dynamic service transfer between availability zones, the application r
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/en/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -273,4 +273,4 @@ We can not provide this flag because it may bring some instabilities on some ope
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/getting-started-ovhcloudshell.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/getting-started-ovhcloudshell.mdx
@@ -182,4 +182,4 @@ ovhcloud cloud instance list --cloud-project fbbc9b79-****-****-****-***********
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
@@ -642,4 +642,4 @@ terraform destroy
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -190,4 +190,4 @@ Explore our guide "[How do Savings Plans work?](/guides/public-cloud/cross-funct
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/en/guides/public-cloud/cross-functional/introducing-horizon.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/introducing-horizon.mdx
@@ -119,4 +119,4 @@ In the top right-hand corner of the Horizon interface, a user menu allows you to
 
 [How to use the Public Cloud interface](/guides/public-cloud/cross-functional/public-cloud-interface-walk-me)
  
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/landing-zone-migration.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/landing-zone-migration.mdx
@@ -189,6 +189,6 @@ Use tagging, IAM roles, and alerts to link costs to teams, environments, or serv
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).
 
 _<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc._

--- a/docs/en/guides/public-cloud/cross-functional/managing-tokens.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/managing-tokens.mdx
@@ -183,4 +183,4 @@ If there’s no error then the response is empty.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/metrics-informations.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/metrics-informations.mdx
@@ -104,4 +104,4 @@ The table below shows the availability status of metrics and the planned release
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/overview.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -267,4 +267,4 @@ The vCPUs of control-plane nodes are not billed.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/security-group-private-network.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/security-group-private-network.mdx
@@ -160,4 +160,4 @@ openstack port set --security-group private 5be009d9-fc2e-4bf5-a152-dab52614b02d
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
@@ -156,4 +156,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
@@ -171,4 +171,4 @@ openstack --os-auth-type token token revoke $OS_TOKEN
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/whats-is-landing-zone.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/whats-is-landing-zone.mdx
@@ -203,4 +203,4 @@ Think of your landing zone as a product: iterate, document, and optimise it over
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/advanced-configuration.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/advanced-configuration.mdx
@@ -193,4 +193,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/backups.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/backups.mdx
@@ -90,4 +90,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/capabilities.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/capabilities.mdx
@@ -74,4 +74,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -140,4 +140,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -190,4 +190,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -104,7 +104,7 @@ ClickHouse service capabilities
 
 [Configuring vRack for Public Cloud](/guides/public-cloud/network-services/vrack)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -92,4 +92,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -44,4 +44,4 @@ Visit our Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhc
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or our [Professional Services experts](https://www.ovhcloud.com/en-gb/professional-services/) for a quote and custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -71,4 +71,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -110,7 +110,7 @@ ClickHouse service capabilities
 
 [Official Aiven documentation to integrate Kafka](https://aiven.io/docs/products/clickhouse/howto/integrate-kafka)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -146,4 +146,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/handling-disk-full.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/handling-disk-full.mdx
@@ -56,4 +56,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/lifecycle-policy.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/lifecycle-policy.mdx
@@ -83,4 +83,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -90,4 +90,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/maintenance.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/maintenance.mdx
@@ -66,4 +66,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -74,4 +74,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
@@ -161,4 +161,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -146,4 +146,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/service-metrics-with-prometheus.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/service-metrics-with-prometheus.mdx
@@ -81,4 +81,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -60,4 +60,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -64,4 +64,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/clickhouse/overview.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/clickhouse/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/data-analytics/grafana/overview.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/grafana/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/data-analytics/kafka/overview.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/kafka/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
+++ b/docs/en/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
@@ -69,4 +69,4 @@ The pricing methods depend on the use of the IP you choose. Additional IP usage 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/buy-additional-ip.mdx
+++ b/docs/en/guides/public-cloud/network-services/buy-additional-ip.mdx
@@ -98,4 +98,4 @@ The next step will be the IP configuration in your OS; please refer to our [guid
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/change-instance-dns-servers.mdx
+++ b/docs/en/guides/public-cloud/network-services/change-instance-dns-servers.mdx
@@ -168,4 +168,4 @@ In PowerShell, you can use the command `nslookup` to check which DNS server is u
 
 [Changing the hostname of a Public Cloud instance](/guides/public-cloud/compute/changing-the-hostname-of-an-instance)
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/concepts.mdx
+++ b/docs/en/guides/public-cloud/network-services/concepts.mdx
@@ -150,4 +150,4 @@ Find out more about Additional IP and Floating IP on the dedicated [Concepts pag
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
+++ b/docs/en/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
@@ -125,4 +125,4 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/configure-additional-ip.mdx
+++ b/docs/en/guides/public-cloud/network-services/configure-additional-ip.mdx
@@ -389,4 +389,4 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assistance with your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/create-private-network-gateway.mdx
+++ b/docs/en/guides/public-cloud/network-services/create-private-network-gateway.mdx
@@ -272,4 +272,4 @@ Learn more about Gateway and its scenarios on our [dedicated page](https://www.o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/create-share-private-network.mdx
+++ b/docs/en/guides/public-cloud/network-services/create-share-private-network.mdx
@@ -226,4 +226,4 @@ rtt min/avg/max/mdev = 0.292/0.292/0.292/0.000 ms
  
 ## Go further
  
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
+++ b/docs/en/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
@@ -498,4 +498,4 @@ The Public Cloud project and Bare Metal server must be added to the same vRack:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/faq.mdx
+++ b/docs/en/guides/public-cloud/network-services/faq.mdx
@@ -239,4 +239,4 @@ Yes, the [OHVcloud Anti-DDoS infrastructure](https://www.ovhcloud.com/en-gb/secu
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/import-additional-ip.mdx
+++ b/docs/en/guides/public-cloud/network-services/import-additional-ip.mdx
@@ -89,4 +89,4 @@ The next step will be the IP configuration in your OS; please refer to our [guid
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/ipv6-configuration.mdx
+++ b/docs/en/guides/public-cloud/network-services/ipv6-configuration.mdx
@@ -358,4 +358,4 @@ In any case, please feel free to reach out to our [support team](https://help.ov
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts to assist you with your use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
+++ b/docs/en/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
@@ -151,4 +151,4 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/load-balancer-concepts.mdx
+++ b/docs/en/guides/public-cloud/network-services/load-balancer-concepts.mdx
@@ -153,4 +153,4 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
+++ b/docs/en/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
@@ -118,4 +118,4 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
+++ b/docs/en/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
@@ -223,4 +223,4 @@ You can now access your Load Balancer securely. However, you will need to renew 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
+++ b/docs/en/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
@@ -201,4 +201,4 @@ Each method offers specific advantages depending on your familiarity with the to
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
+++ b/docs/en/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
@@ -372,4 +372,4 @@ resource "openstack_lb_l7rule_v2" "l7rule_1" {
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
+++ b/docs/en/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
@@ -195,4 +195,4 @@ To delete your subscription you can use the following API call:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
+++ b/docs/en/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
@@ -349,4 +349,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/loadbalancer-update-size.mdx
+++ b/docs/en/guides/public-cloud/network-services/loadbalancer-update-size.mdx
@@ -70,4 +70,4 @@ Once the new flavor is selected, click <code className="action">Apply</code> or 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/migrate-additional-ip.mdx
+++ b/docs/en/guides/public-cloud/network-services/migrate-additional-ip.mdx
@@ -76,4 +76,4 @@ The Additional IP can be configured on the destination server before or after ca
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
+++ b/docs/en/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
@@ -328,6 +328,6 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 Join our [Discord](https://discord.gg/ovhcloud) to discuss with the OVHcloud team and other users.

--- a/docs/en/guides/public-cloud/network-services/overview.mdx
+++ b/docs/en/guides/public-cloud/network-services/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/public-cloud/network-services/stormshield-vrack.mdx
+++ b/docs/en/guides/public-cloud/network-services/stormshield-vrack.mdx
@@ -588,4 +588,4 @@ PING <ip_address> (<ip_address>) 56(84) bytes of data.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/ubika-vrack.mdx
+++ b/docs/en/guides/public-cloud/network-services/ubika-vrack.mdx
@@ -412,4 +412,4 @@ ubika-test-webserver-1
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/en/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -172,4 +172,4 @@ You can check that the subnet has been updated:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/weight-load-balancer-member.mdx
+++ b/docs/en/guides/public-cloud/network-services/weight-load-balancer-member.mdx
@@ -374,4 +374,4 @@ You should see alternating responses from the two members:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/activate-hds-certification.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/activate-hds-certification.mdx
@@ -57,4 +57,4 @@ Review the information and check the box for accepting the contracts. Finally, c
 
 [Public Cloud documentation](/guides/public-cloud/compute/overview)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/analyze-billing.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/analyze-billing.mdx
@@ -200,4 +200,4 @@ Para las clases Infrequent Access, Active Archive y Cold Archive, se aplican una
 
 <sup>1</sup>: S3 es una marca de Amazon Technologies, Inc. El servicio de OVHcloud no está patrocinado, respaldado ni afiliado de ninguna manera a Amazon Technologies, Inc.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/api-rate-limits.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/api-rate-limits.mdx
@@ -106,4 +106,4 @@ Estos son algunos ejemplos de librerías conocidas por implementar la función *
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/compute-essential-information.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/compute-essential-information.mdx
@@ -157,4 +157,4 @@ Una de las grandes ventajas de utilizar tecnologías estándares y abiertas, com
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
@@ -56,4 +56,4 @@ Añada un grupo de seguridad haciendo clic en <code className="action">Create Se
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -190,4 +190,4 @@ You can create your Savings Plan for the type of resource you want by following 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
@@ -165,4 +165,4 @@ nova help
 
 [Cargar las variables de entorno necesarias para OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables).
 
-Únase a nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
@@ -89,4 +89,4 @@ set OS_PASSWORD="Contraseña del usuario de Horizon"
 
 Para aprender a utilizar OpenStack: [Documentación de OpenStack](https://docs.openstack.org/)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
@@ -107,4 +107,4 @@ La eliminación de un usuario es definitiva e invalidará todos los tokens asoci
 
 [Presentación de Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/delegate-projects.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/delegate-projects.mdx
@@ -72,4 +72,4 @@ Para desbloquear un acceso, haga clic en el botón <code className="action">...<
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/delete-a-project.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/delete-a-project.mdx
@@ -70,4 +70,4 @@ Tenga en cuenta que cuando un proyecto entra en esta fase de eliminación, perma
 
 [Crear una primera instancia de Public Cloud y conectarse a ella](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
@@ -257,4 +257,4 @@ Architecture:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/es/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
@@ -175,4 +175,4 @@ Thanks to dynamic service transfer between availability zones, the application r
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/es/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -269,4 +269,4 @@ La *flag CPU SSBD* no está disponible para su instancia, ya que puede provocar 
 
 ## Más información
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
@@ -642,4 +642,4 @@ terraform destroy
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/introducing-horizon.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/introducing-horizon.mdx
@@ -125,4 +125,4 @@ En la esquina superior derecha de la interfaz de Horizon, un menú de usuario pe
 
 [Conocer la interfaz de Public Cloud](/guides/public-cloud/cross-functional/public-cloud-interface-walk-me)
  
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/managing-tokens.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/managing-tokens.mdx
@@ -182,4 +182,4 @@ Si no hay errores, se obtiene una respuesta vacía.
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/metrics-informations.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/metrics-informations.mdx
@@ -107,4 +107,4 @@ The table below shows the availability status of metrics and the planned release
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/overview.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -267,4 +267,4 @@ The vCPUs of control-plane nodes are not billed.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/security-group-private-network.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/security-group-private-network.mdx
@@ -170,4 +170,4 @@ openstack port set --security-group private 5be009d9-fc2e-4bf5-a152-dab52614b02d
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
@@ -156,4 +156,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
@@ -171,4 +171,4 @@ openstack --os-auth-type token token revoke $OS_TOKEN
 
 ## Más información
 
-Únase a nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -140,4 +140,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -186,4 +186,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -104,7 +104,7 @@ ClickHouse service capabilities
 
 [Configuring vRack for Public Cloud](/guides/public-cloud/network-services/vrack)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -90,4 +90,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -44,4 +44,4 @@ Visit our Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhc
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or our [Professional Services experts](https://www.ovhcloud.com/es/professional-services/) for a quote and custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -69,4 +69,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -110,7 +110,7 @@ ClickHouse service capabilities
 
 [Official Aiven documentation to integrate Kafka](https://aiven.io/docs/products/clickhouse/howto/integrate-kafka)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/es/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -146,4 +146,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -84,4 +84,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -70,4 +70,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
@@ -161,4 +161,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -136,4 +136,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -58,4 +58,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -62,4 +62,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/data-analytics/clickhouse/overview.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/clickhouse/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/data-analytics/grafana/overview.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/grafana/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/data-analytics/kafka/overview.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/kafka/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
+++ b/docs/es/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
@@ -69,4 +69,4 @@ The pricing methods depend on the use of the IP you choose. Additional IP usage 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/buy-additional-ip.mdx
+++ b/docs/es/guides/public-cloud/network-services/buy-additional-ip.mdx
@@ -110,4 +110,4 @@ El siguiente paso es configurar la IP en el sistema operativo. Consulte [nuestra
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/network-services/change-instance-dns-servers.mdx
+++ b/docs/es/guides/public-cloud/network-services/change-instance-dns-servers.mdx
@@ -174,4 +174,4 @@ En un PowerShell, el comando `nslookup` permite comprobar cuál es el servidor D
 
 [Cambiar el hostname de una instancia de Public Cloud](/guides/public-cloud/compute/changing-the-hostname-of-an-instance)
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/network-services/concepts.mdx
+++ b/docs/es/guides/public-cloud/network-services/concepts.mdx
@@ -150,4 +150,4 @@ Find out more about Additional IP and Floating IP on the dedicated [Concepts pag
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
+++ b/docs/es/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
@@ -125,4 +125,4 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/configure-additional-ip.mdx
+++ b/docs/es/guides/public-cloud/network-services/configure-additional-ip.mdx
@@ -397,4 +397,4 @@ Para probar la conexión, solo tiene que enviar un ping a su dirección Addition
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/network-services/create-private-network-gateway.mdx
+++ b/docs/es/guides/public-cloud/network-services/create-private-network-gateway.mdx
@@ -272,4 +272,4 @@ Learn more about Gateway and its scenarios on our [dedicated page](https://www.o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
+++ b/docs/es/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
@@ -510,4 +510,4 @@ The Public Cloud project and Bare Metal server must be added to the same vRack:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/faq.mdx
+++ b/docs/es/guides/public-cloud/network-services/faq.mdx
@@ -239,4 +239,4 @@ Yes, the [OHVcloud Anti-DDoS infrastructure](https://www.ovhcloud.com/es-es/secu
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/import-additional-ip.mdx
+++ b/docs/es/guides/public-cloud/network-services/import-additional-ip.mdx
@@ -88,4 +88,4 @@ El siguiente paso es configurar la IP en el sistema operativo. Consulte [nuestra
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/network-services/ipv6-configuration.mdx
+++ b/docs/es/guides/public-cloud/network-services/ipv6-configuration.mdx
@@ -369,4 +369,4 @@ Si el problema persiste, puede ponerse en contacto con [nuestro equipo de soport
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
+++ b/docs/es/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
@@ -151,4 +151,4 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/load-balancer-concepts.mdx
+++ b/docs/es/guides/public-cloud/network-services/load-balancer-concepts.mdx
@@ -153,4 +153,4 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
+++ b/docs/es/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
@@ -118,4 +118,4 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
+++ b/docs/es/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
@@ -224,4 +224,4 @@ You can now access your Load Balancer securely. However, you will need to renew 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
+++ b/docs/es/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
@@ -201,4 +201,4 @@ Each method offers specific advantages depending on your familiarity with the to
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
+++ b/docs/es/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
@@ -372,4 +372,4 @@ resource "openstack_lb_l7rule_v2" "l7rule_1" {
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
+++ b/docs/es/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
@@ -195,4 +195,4 @@ To delete your subscription you can use the following API call:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
+++ b/docs/es/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
@@ -349,4 +349,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/migrate-additional-ip.mdx
+++ b/docs/es/guides/public-cloud/network-services/migrate-additional-ip.mdx
@@ -82,4 +82,4 @@ La Additional IP puede configurarse en el servidor de destino antes o después d
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
+++ b/docs/es/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
@@ -328,6 +328,6 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 Join our [Discord](https://discord.gg/ovhcloud) to discuss with the OVHcloud team and other users.

--- a/docs/es/guides/public-cloud/network-services/overview.mdx
+++ b/docs/es/guides/public-cloud/network-services/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Más información
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar la hoja de ruta y el registro de cambios
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/public-cloud/network-services/stormshield-vrack.mdx
+++ b/docs/es/guides/public-cloud/network-services/stormshield-vrack.mdx
@@ -587,4 +587,4 @@ PING <ip_address> (<ip_address>) 56(84) bytes of data.
  
 Si necesita formación o asistencia técnica para implementar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener una cotización y solicite a nuestros expertos de Professional Services que le ayuden en su caso de uso específico de su proyecto.
  
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/network-services/ubika-vrack.mdx
+++ b/docs/es/guides/public-cloud/network-services/ubika-vrack.mdx
@@ -413,4 +413,4 @@ ubika-test-webserver-1
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/es/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -172,4 +172,4 @@ You can check that the subnet has been updated:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/activate-hds-certification.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/activate-hds-certification.mdx
@@ -57,4 +57,4 @@ Prenez connaissance de ces dernières et cochez la case d'acceptation des contra
 
 [Documentation Public Cloud](/guides/public-cloud/compute/overview)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/analyze-billing.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/analyze-billing.mdx
@@ -197,4 +197,4 @@ Pour les classes Infrequent Access, Active Archive et Cold Archive, une durée m
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/api-rate-limits.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/api-rate-limits.mdx
@@ -101,4 +101,4 @@ Voici quelques exemples de librairies bien connues pour implémenter la fonction
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/compute-essential-information.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/compute-essential-information.mdx
@@ -152,4 +152,4 @@ Un des gros avantages d'utiliser des technologies standards et ouvertes, comme O
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
@@ -51,4 +51,4 @@ Ajoutez un groupe de sécurité en cliquant sur <code className="action">Create 
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -197,4 +197,4 @@ Vous pouvez créer votre Savings Plan pour le type de ressource voulue en suivan
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
@@ -164,4 +164,4 @@ openstack --help
 
 [Charger les variables d’environnement OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
@@ -83,4 +83,4 @@ set OS_PASSWORD="Mot de passe de l'utilisateur Horizon"
 
 Pour apprendre à utiliser OpenStack : [Documentation OpenStack](https://docs.openstack.org/)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
@@ -107,4 +107,4 @@ La suppression d'un utilisateur est définitive et invalidera tous les tokens as
 
 [Présentation de Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/delegate-projects.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/delegate-projects.mdx
@@ -66,4 +66,4 @@ Pour révoquer un accès, cliquez sur le bouton <code className="action">...</co
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/delete-a-project.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/delete-a-project.mdx
@@ -64,4 +64,4 @@ Veuillez noter que lorsqu'un projet entre dans cette phase de suppression, il re
 
 [Créer une première instance Public Cloud et s’y connecter](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
@@ -257,4 +257,4 @@ Architecture:
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et une analyse personnalisée de votre projet.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr) et notre communauté sur [Discord](https://discord.gg/ovhcloud).
+Échangez avec notre [communauté d’utilisateurs](/links/community) et notre communauté sur [Discord](https://discord.gg/ovhcloud).

--- a/docs/fr/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
@@ -175,4 +175,4 @@ Grâce au transfert dynamique des services entre les Availability Zones, l'appli
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et une analyse personnalisée de votre projet.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr) et notre communauté sur [Discord](https://discord.gg/ovhcloud).
+Échangez avec notre [communauté d’utilisateurs](/links/community) et notre communauté sur [Discord](https://discord.gg/ovhcloud).

--- a/docs/fr/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -270,4 +270,4 @@ En effet, le *flag CPU SSBD* n'est pas disponible pour votre instance car il peu
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/getting-started-ovhcloudshell.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/getting-started-ovhcloudshell.mdx
@@ -182,4 +182,4 @@ ovhcloud cloud instance list --cloud-project fbbc9b79-****-****-****-***********
 
 ## Aller plus loin
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
@@ -643,4 +643,4 @@ terraform destroy
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -190,4 +190,4 @@ Consultez notre guide « [Comment fonctionnent les Savings Plans ?](/guides/publ
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et une analyse personnalisée de votre projet.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr) et notre communauté sur [Discord](https://discord.gg/ovhcloud).
+Échangez avec notre [communauté d’utilisateurs](/links/community) et notre communauté sur [Discord](https://discord.gg/ovhcloud).

--- a/docs/fr/guides/public-cloud/cross-functional/introducing-horizon.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/introducing-horizon.mdx
@@ -119,4 +119,4 @@ En haut à droite de l'interface Horizon, un menu utilisateur vous permet notamm
 
 [Se familiariser avec l’interface Public Cloud](/guides/public-cloud/cross-functional/public-cloud-interface-walk-me)
  
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/introduction-about-instances.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/introduction-about-instances.mdx
@@ -91,4 +91,4 @@ Une application *Cloud Native* est une application entièrement automatisée dan
 
 [FAQ Public Cloud](/guides/public-cloud/cross-functional/faq-pci)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/landing-zone-migration.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/landing-zone-migration.mdx
@@ -189,6 +189,6 @@ Utilisez les tags, les rôles IAM et les alertes pour associer les coûts aux é
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr) et visitez notre [canal Discord](https://discord.gg/ovhcloud).
+Rejoignez notre [communauté d’utilisateurs](/links/community) et visitez notre [canal Discord](https://discord.gg/ovhcloud).
 
 _<sup>1</sup>: S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit._

--- a/docs/fr/guides/public-cloud/cross-functional/managing-tokens.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/managing-tokens.mdx
@@ -181,4 +181,4 @@ S'il n'y a pas d'erreur, on obtient une réponse vide.
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/metrics-informations.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/metrics-informations.mdx
@@ -104,4 +104,4 @@ Le tableau ci-dessous présente l’état de disponibilité des métriques ainsi
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/overview.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -265,4 +265,4 @@ Le minimum de consommation pour Managed Rancher Service est de 20 vCPU par Ranch
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/security-group-private-network.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/security-group-private-network.mdx
@@ -165,4 +165,4 @@ openstack port set --security-group private 5be009d9-fc2e-4bf5-a152-dab52614b02d
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
@@ -153,4 +153,4 @@ Si vous avez besoin d'une formation ou d'une assistance technique pour la mise e
 
 Êtes-vous sur Discord ? Connectez-vous à notre chaîne sur [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) et interagissez directement avec l'équipe qui construit nos services !
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
@@ -171,4 +171,4 @@ openstack --os-auth-type token token revoke $OS_TOKEN
 
 ## Aller plus loin
 
-Rejoignez notre communauté d'utilisateurs sur [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/cross-functional/whats-is-landing-zone.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/whats-is-landing-zone.mdx
@@ -203,4 +203,4 @@ Considérez votre Landing Zone comme un produit : itérez, documentez et optimis
 
 ## Aller plus loin
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/advanced-configuration.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/advanced-configuration.mdx
@@ -191,4 +191,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/backups.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/backups.mdx
@@ -90,4 +90,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/capabilities.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/capabilities.mdx
@@ -74,4 +74,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -140,4 +140,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -186,4 +186,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -104,7 +104,7 @@ ClickHouse service capabilities
 
 [Configuring vRack for Public Cloud](/guides/public-cloud/network-services/vrack)
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -90,4 +90,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -44,4 +44,4 @@ Visit our Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhc
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or our [Professional Services experts](https://www.ovhcloud.com/fr/professional-services/) for a quote and custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -69,4 +69,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -110,7 +110,7 @@ ClickHouse service capabilities
 
 [Official Aiven documentation to integrate Kafka](https://aiven.io/docs/products/clickhouse/howto/integrate-kafka)
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -146,4 +146,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/handling-disk-full.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/handling-disk-full.mdx
@@ -56,4 +56,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/lifecycle-policy.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/lifecycle-policy.mdx
@@ -83,4 +83,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -84,4 +84,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/maintenance.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/maintenance.mdx
@@ -66,4 +66,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -70,4 +70,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
@@ -161,4 +161,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -136,4 +136,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/service-metrics-with-prometheus.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/service-metrics-with-prometheus.mdx
@@ -81,4 +81,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -58,4 +58,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -62,4 +62,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/data-analytics/clickhouse/overview.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/clickhouse/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/data-analytics/grafana/overview.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/grafana/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/data-analytics/kafka/overview.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/kafka/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
+++ b/docs/fr/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
@@ -69,4 +69,4 @@ Les modes de tarification dépendent de l'utilisation de l'IP que vous choisisse
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/buy-additional-ip.mdx
+++ b/docs/fr/guides/public-cloud/network-services/buy-additional-ip.mdx
@@ -103,4 +103,4 @@ La prochaine étape consiste à configurer l’IP dans votre système d'exploita
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/change-instance-dns-servers.mdx
+++ b/docs/fr/guides/public-cloud/network-services/change-instance-dns-servers.mdx
@@ -168,4 +168,4 @@ Dans un PowerShell, la commande `nslookup` permet de vérifier quel est le serve
 
 [Modifier le hostname d’une instance Public Cloud](/guides/public-cloud/compute/changing-the-hostname-of-an-instance)
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/concepts.mdx
+++ b/docs/fr/guides/public-cloud/network-services/concepts.mdx
@@ -150,4 +150,4 @@ Apprenez-en plus sur les Additional IP et Floating IP sur la [page concept dédi
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
+++ b/docs/fr/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
@@ -125,4 +125,4 @@ A la suite de la mise à jour de la valeur MTU sur un réseau sur lequel des ins
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/configure-additional-ip.mdx
+++ b/docs/fr/guides/public-cloud/network-services/configure-additional-ip.mdx
@@ -391,4 +391,4 @@ Pour tester la connexion, il vous suffit d'envoyer un ping à votre adresse Addi
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/create-private-network-gateway.mdx
+++ b/docs/fr/guides/public-cloud/network-services/create-private-network-gateway.mdx
@@ -273,4 +273,4 @@ Pour en savoir plus sur Gateway et ses cas d'usage, consultez notre [page dédi�
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/create-share-private-network.mdx
+++ b/docs/fr/guides/public-cloud/network-services/create-share-private-network.mdx
@@ -230,4 +230,4 @@ Exemple de résultat :
 
 ## Aller plus loin
  
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
+++ b/docs/fr/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
@@ -498,4 +498,4 @@ Le projet Public Cloud et le serveur Bare Metal doivent être ajoutés au même 
 
 ## Aller plus loin
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/faq.mdx
+++ b/docs/fr/guides/public-cloud/network-services/faq.mdx
@@ -238,4 +238,4 @@ Oui, l’[infrastructure anti-DDoS d’OVHcloud](https://www.ovhcloud.com/fr/sec
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/import-additional-ip.mdx
+++ b/docs/fr/guides/public-cloud/network-services/import-additional-ip.mdx
@@ -88,4 +88,4 @@ La prochaine étape consiste à configurer l’IP dans votre système d'exploita
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/ipv6-configuration.mdx
+++ b/docs/fr/guides/public-cloud/network-services/ipv6-configuration.mdx
@@ -356,4 +356,4 @@ Dans tous les cas, n'hésitez pas à effectuer une [demande au support](https://
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
+++ b/docs/fr/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
@@ -147,4 +147,4 @@ La VM **vmpriv** a un accès externe à Internet tout en étant connectée à un
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/load-balancer-concepts.mdx
+++ b/docs/fr/guides/public-cloud/network-services/load-balancer-concepts.mdx
@@ -158,4 +158,4 @@ La formulation est légèrement différente entre OpenStack et OVHcloud. Le tabl
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
+++ b/docs/fr/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
@@ -118,4 +118,4 @@ Vous pouvez maintenant accéder à votre Load Balancer de manière sécurisée a
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
+++ b/docs/fr/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
@@ -225,4 +225,4 @@ Vous pouvez maintenant accéder à votre Load Balancer de manière sécurisée. 
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
+++ b/docs/fr/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
@@ -201,4 +201,4 @@ Chaque méthode offre des avantages spécifiques selon votre familiarité avec l
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
+++ b/docs/fr/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
@@ -374,4 +374,4 @@ resource "openstack_lb_l7rule_v2" "l7rule_1" {
 
 ## Aller plus Loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
+++ b/docs/fr/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
@@ -194,4 +194,4 @@ Pour supprimer votre abonnement, vous pouvez utiliser l'appel API suivant :
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
+++ b/docs/fr/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
@@ -349,4 +349,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/loadbalancer-update-size.mdx
+++ b/docs/fr/guides/public-cloud/network-services/loadbalancer-update-size.mdx
@@ -70,4 +70,4 @@ Après avoir choisi la nouvelle *flavor*, cliquez sur <code className="action">A
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/migrate-additional-ip.mdx
+++ b/docs/fr/guides/public-cloud/network-services/migrate-additional-ip.mdx
@@ -75,4 +75,4 @@ L’Additional IP peut être configurée sur le serveur de destination avant ou 
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
+++ b/docs/fr/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
@@ -323,6 +323,6 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 Rejoignez notre [Discord](https://discord.gg/ovhcloud) pour discuter avec les membres de l'équipe OVHcloud et d'autre utilisateurs.

--- a/docs/fr/guides/public-cloud/network-services/overview.mdx
+++ b/docs/fr/guides/public-cloud/network-services/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: Consulter la communauté OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulter la roadmap & le changelog
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/public-cloud/network-services/stormshield-vrack.mdx
+++ b/docs/fr/guides/public-cloud/network-services/stormshield-vrack.mdx
@@ -588,4 +588,4 @@ PING <adresse_ip> (<adresse_ip>) 56(84) bytes of data.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l'équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/ubika-vrack.mdx
+++ b/docs/fr/guides/public-cloud/network-services/ubika-vrack.mdx
@@ -412,4 +412,4 @@ ubika-test-webserver-1
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l'équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/fr/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -172,4 +172,4 @@ You can check that the subnet has been updated:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/weight-load-balancer-member.mdx
+++ b/docs/fr/guides/public-cloud/network-services/weight-load-balancer-member.mdx
@@ -374,4 +374,4 @@ Vous devriez voir des réponses alternées provenant des deux membres :
 
 ## Aller plus loin
 
-Rejoignez notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/activate-hds-certification.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/activate-hds-certification.mdx
@@ -57,4 +57,4 @@ Review the information and check the box for accepting the contracts. Finally, c
 
 [Public Cloud documentation](/guides/public-cloud/compute/overview)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/analyze-billing.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/analyze-billing.mdx
@@ -192,4 +192,4 @@ Per le classi Infrequent Access, Active Archive e Cold Archive si applicano una 
 
 <sup>1</sup>: S3 è un marchio di Amazon Technologies, Inc. Il servizio OVHcloud non è sponsorizzato, approvato o altrimenti affiliato con Amazon Technologies, Inc.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/api-rate-limits.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/api-rate-limits.mdx
@@ -106,4 +106,4 @@ Ecco alcuni esempi di librerie ben note per applicare la funzione *retry backoff
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all'indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/compute-essential-information.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/compute-essential-information.mdx
@@ -156,4 +156,4 @@ Uno dei principali vantaggi dell'utilizzo di tecnologie standard e aperte, come 
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
@@ -56,4 +56,4 @@ Per aggiungere un gruppo di sicurezza, clicca su <code className="action">Create
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -190,4 +190,4 @@ You can create your Savings Plan for the type of resource you want by following 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
@@ -162,4 +162,4 @@ openstack --help
 
 [Impostare le variabili d’ambiente OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables).
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
@@ -83,4 +83,4 @@ export OS_PASSWORD="Password dell’utente Horizon"
 
 OpenStack, istruzioni per l'uso: [Documentation OpenStack](https://docs.openstack.org/)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
@@ -106,4 +106,4 @@ L'eliminazione di un utente è definitiva e invaliderà tutti i token associati,
 
 [Introduzione a Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/delegate-projects.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/delegate-projects.mdx
@@ -72,4 +72,4 @@ Per rimuovere un accesso, clicca sul pulsante <code className="action">...</code
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/delete-a-project.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/delete-a-project.mdx
@@ -70,4 +70,4 @@ Ti ricordiamo che, quando un progetto entra in questa fase di cancellazione, rim
 
 [Creare una prima istanza Public Cloud e connettersi](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
@@ -257,4 +257,4 @@ Architecture:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/it/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
@@ -175,4 +175,4 @@ Thanks to dynamic service transfer between availability zones, the application r
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/it/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -270,4 +270,4 @@ Infatti, il *flag CPU SSBD* non è disponibile per la tua istanza perché può c
 
 ## Per saperne di più
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
@@ -642,4 +642,4 @@ terraform destroy
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/introducing-horizon.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/introducing-horizon.mdx
@@ -125,4 +125,4 @@ In alto a destra dell'interfaccia Horizon, un menu utente ti permette in partico
 
 [Scopri l'interfaccia Public Cloud](/guides/public-cloud/cross-functional/public-cloud-interface-walk-me)
  
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/managing-tokens.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/managing-tokens.mdx
@@ -183,4 +183,4 @@ Se non ci sono errori, si ottiene una risposta vuota.
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/metrics-informations.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/metrics-informations.mdx
@@ -107,4 +107,4 @@ The table below shows the availability status of metrics and the planned release
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/overview.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -267,4 +267,4 @@ The vCPUs of control-plane nodes are not billed.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/security-group-private-network.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/security-group-private-network.mdx
@@ -170,4 +170,4 @@ openstack port set --security-group private 5be009d9-fc2e-4bf5-a152-dab52614b02d
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
@@ -156,4 +156,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
@@ -171,4 +171,4 @@ openstack --os-auth-type token token revoke $OS_TOKEN
 
 ## Per saperne di più
 
-Unisciti alla nostra Community di utenti [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -140,4 +140,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -186,4 +186,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -104,7 +104,7 @@ ClickHouse service capabilities
 
 [Configuring vRack for Public Cloud](/guides/public-cloud/network-services/vrack)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -90,4 +90,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -44,4 +44,4 @@ Visit our Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhc
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or our [Professional Services experts](https://www.ovhcloud.com/it/professional-services/) for a quote and custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -69,4 +69,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -110,7 +110,7 @@ ClickHouse service capabilities
 
 [Official Aiven documentation to integrate Kafka](https://aiven.io/docs/products/clickhouse/howto/integrate-kafka)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/it/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -146,4 +146,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -84,4 +84,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -70,4 +70,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
@@ -161,4 +161,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -136,4 +136,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -58,4 +58,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -62,4 +62,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/data-analytics/clickhouse/overview.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/clickhouse/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/data-analytics/grafana/overview.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/grafana/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/data-analytics/kafka/overview.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/kafka/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
+++ b/docs/it/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
@@ -69,4 +69,4 @@ The pricing methods depend on the use of the IP you choose. Additional IP usage 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/buy-additional-ip.mdx
+++ b/docs/it/guides/public-cloud/network-services/buy-additional-ip.mdx
@@ -110,4 +110,4 @@ Il prossimo step consiste nel configurare l'IP nel tuo sistema operativo. Consul
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/network-services/change-instance-dns-servers.mdx
+++ b/docs/it/guides/public-cloud/network-services/change-instance-dns-servers.mdx
@@ -174,4 +174,4 @@ In un PowerShell, il comando `nslookup` permette di verificare quale server DNS 
 
 [Modificare l’hostname di un’istanza Public Cloud](/guides/public-cloud/compute/changing-the-hostname-of-an-instance)
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/network-services/concepts.mdx
+++ b/docs/it/guides/public-cloud/network-services/concepts.mdx
@@ -150,4 +150,4 @@ Find out more about Additional IP and Floating IP on the dedicated [Concepts pag
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
+++ b/docs/it/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
@@ -125,4 +125,4 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/configure-additional-ip.mdx
+++ b/docs/it/guides/public-cloud/network-services/configure-additional-ip.mdx
@@ -398,4 +398,4 @@ Per testare la connessione, ti basta inviare un ping al tuo indirizzo Additional
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/network-services/create-private-network-gateway.mdx
+++ b/docs/it/guides/public-cloud/network-services/create-private-network-gateway.mdx
@@ -272,4 +272,4 @@ Learn more about Gateway and its scenarios on our [dedicated page](https://www.o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
+++ b/docs/it/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
@@ -510,4 +510,4 @@ The Public Cloud project and Bare Metal server must be added to the same vRack:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/faq.mdx
+++ b/docs/it/guides/public-cloud/network-services/faq.mdx
@@ -239,4 +239,4 @@ Yes, the [OHVcloud Anti-DDoS infrastructure](https://www.ovhcloud.com/it/securit
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/import-additional-ip.mdx
+++ b/docs/it/guides/public-cloud/network-services/import-additional-ip.mdx
@@ -88,4 +88,4 @@ Il prossimo step consiste nel configurare l'IP nel tuo sistema operativo. Consul
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/network-services/ipv6-configuration.mdx
+++ b/docs/it/guides/public-cloud/network-services/ipv6-configuration.mdx
@@ -371,4 +371,4 @@ In ogni caso, se necessario, invia una [richiesta di assistenza](https://help.ov
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
+++ b/docs/it/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
@@ -151,4 +151,4 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/load-balancer-concepts.mdx
+++ b/docs/it/guides/public-cloud/network-services/load-balancer-concepts.mdx
@@ -153,4 +153,4 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
+++ b/docs/it/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
@@ -118,4 +118,4 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
+++ b/docs/it/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
@@ -224,4 +224,4 @@ You can now access your Load Balancer securely. However, you will need to renew 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
+++ b/docs/it/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
@@ -201,4 +201,4 @@ Each method offers specific advantages depending on your familiarity with the to
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
+++ b/docs/it/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
@@ -372,4 +372,4 @@ resource "openstack_lb_l7rule_v2" "l7rule_1" {
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
+++ b/docs/it/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
@@ -195,4 +195,4 @@ To delete your subscription you can use the following API call:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
+++ b/docs/it/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
@@ -349,4 +349,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/migrate-additional-ip.mdx
+++ b/docs/it/guides/public-cloud/network-services/migrate-additional-ip.mdx
@@ -82,4 +82,4 @@ L'Additional IP può essere configurato sul server di destinazione prima o dopo 
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
+++ b/docs/it/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
@@ -328,6 +328,6 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 Join our [Discord](https://discord.gg/ovhcloud) to discuss with the OVHcloud team and other users.

--- a/docs/it/guides/public-cloud/network-services/overview.mdx
+++ b/docs/it/guides/public-cloud/network-services/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/public-cloud/network-services/stormshield-vrack.mdx
+++ b/docs/it/guides/public-cloud/network-services/stormshield-vrack.mdx
@@ -589,4 +589,4 @@ PING <ip_address> (<ip_address>) 56(84) bytes of data.
 
 Se hai bisogno di formazione o assistenza tecnica per implementare le nostre soluzioni, contatta il tuo rappresentante commerciale o clicca su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del tuo progetto ai nostri esperti del team Professional Services.
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/en).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/network-services/ubika-vrack.mdx
+++ b/docs/it/guides/public-cloud/network-services/ubika-vrack.mdx
@@ -413,4 +413,4 @@ ubika-test-webserver-1
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/it/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -172,4 +172,4 @@ You can check that the subnet has been updated:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/activate-hds-certification.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/activate-hds-certification.mdx
@@ -57,4 +57,4 @@ Review the information and check the box for accepting the contracts. Finally, c
 
 [Public Cloud documentation](/guides/public-cloud/compute/overview)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/analyze-billing.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/analyze-billing.mdx
@@ -197,4 +197,4 @@ Dla klas Infrequent Access, Active Archive i Cold Archive obowiązuje minimalny 
 
 <sup>1</sup>: S3 jest znakiem towarowym Amazon Technologies, Inc. Usługa OVHcloud nie jest sponsorowana, popierana ani w żaden sposób powiązana z Amazon Technologies, Inc.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/api-rate-limits.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/api-rate-limits.mdx
@@ -106,4 +106,4 @@ Oto przykłady znanych bibliotek implementujących funkcję *retry backoff* w py
 
 ## Sprawdź również
 
-Przyłącz się do społeczności naszych użytkowników na [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/compute-essential-information.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/compute-essential-information.mdx
@@ -153,4 +153,4 @@ Jedną z największych zalet korzystania ze standardowych i otwartych technologi
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
@@ -56,4 +56,4 @@ Dodaj grupę zabezpieczeń, klikając <code className="action">Create Security G
 
 ## Sprawdź również
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -190,4 +190,4 @@ You can create your Savings Plan for the type of resource you want by following 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
@@ -169,5 +169,5 @@ openstack --help
 
 [Zmienne środowiskowe OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables).
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).
 

--- a/docs/pl/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
@@ -89,4 +89,4 @@ set OS_PASSWORD="Hasło użytkownika Horizon"
 
 Informacje na temat korzystania z OpenStack: [Dokumentacja OpenStack](https://docs.openstack.org/)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
@@ -107,4 +107,4 @@ Usunięcie użytkownika jest definitywne i spowoduje unieważnienie wszystkich p
 
 [Prezentacja Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/delegate-projects.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/delegate-projects.mdx
@@ -72,4 +72,4 @@ Aby cofnąć dostęp, kliknij przycisk <code className="action">...</code> i wyb
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/delete-a-project.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/delete-a-project.mdx
@@ -70,4 +70,4 @@ Pamiętaj, że w momencie, gdy projekt wchodzi w etap usuwania, status zawieszen
 
 [Utwórz pierwszą instancję Public Cloud i połącz się z nią](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
@@ -257,4 +257,4 @@ Architecture:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/pl/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
@@ -175,4 +175,4 @@ Thanks to dynamic service transfer between availability zones, the application r
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/pl/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -269,4 +269,4 @@ Nawet jeśli wynik jest `Vulnerable`, Twoja instancja jest jednocześnie chronio
 
 ## Sprawdź również
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
@@ -642,4 +642,4 @@ terraform destroy
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/introducing-horizon.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/introducing-horizon.mdx
@@ -125,4 +125,4 @@ W prawym górnym rogu interfejsu Horizon menu użytkownika umożliwia:
 
 [Poznaj interfejs Public Cloud](/guides/public-cloud/cross-functional/public-cloud-interface-walk-me)
  
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/managing-tokens.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/managing-tokens.mdx
@@ -183,4 +183,4 @@ Jeśli nie wystąpią żadne błędy, otrzymasz pustą odpowiedź.
 
 ## Sprawdź również
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/metrics-informations.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/metrics-informations.mdx
@@ -107,4 +107,4 @@ The table below shows the availability status of metrics and the planned release
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/overview.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -267,4 +267,4 @@ The vCPUs of control-plane nodes are not billed.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/security-group-private-network.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/security-group-private-network.mdx
@@ -170,4 +170,4 @@ openstack port set --security-group private 5be009d9-fc2e-4bf5-a152-dab52614b02d
 
 ## Sprawdź również
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
@@ -156,4 +156,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
@@ -171,4 +171,4 @@ openstack --os-auth-type token token revoke $OS_TOKEN
 
 ## Sprawdź również
 
-Dołącz do społeczności naszych użytkowników na [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -140,4 +140,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -186,4 +186,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -104,7 +104,7 @@ ClickHouse service capabilities
 
 [Configuring vRack for Public Cloud](/guides/public-cloud/network-services/vrack)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -90,4 +90,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -44,4 +44,4 @@ Visit our Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhc
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or our [Professional Services experts](https://www.ovhcloud.com/pl/professional-services/) for a quote and custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -69,4 +69,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -110,7 +110,7 @@ ClickHouse service capabilities
 
 [Official Aiven documentation to integrate Kafka](https://aiven.io/docs/products/clickhouse/howto/integrate-kafka)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -146,4 +146,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -84,4 +84,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -70,4 +70,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
@@ -161,4 +161,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -136,4 +136,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -58,4 +58,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -62,4 +62,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/data-analytics/clickhouse/overview.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/clickhouse/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/data-analytics/grafana/overview.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/grafana/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/data-analytics/kafka/overview.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/kafka/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
+++ b/docs/pl/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
@@ -69,4 +69,4 @@ The pricing methods depend on the use of the IP you choose. Additional IP usage 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/buy-additional-ip.mdx
+++ b/docs/pl/guides/public-cloud/network-services/buy-additional-ip.mdx
@@ -110,5 +110,5 @@ Następnym krokiem jest konfiguracja IP w systemie operacyjnym. Zapoznaj się [z
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).
 

--- a/docs/pl/guides/public-cloud/network-services/change-instance-dns-servers.mdx
+++ b/docs/pl/guides/public-cloud/network-services/change-instance-dns-servers.mdx
@@ -174,4 +174,4 @@ Polecenie `nslookup` pozwala na sprawdzenie, który serwer DNS jest używany dom
 
 [Zmiana hostname instancji Public Cloud](/guides/public-cloud/compute/changing-the-hostname-of-an-instance)
 
-Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/concepts.mdx
+++ b/docs/pl/guides/public-cloud/network-services/concepts.mdx
@@ -150,4 +150,4 @@ Find out more about Additional IP and Floating IP on the dedicated [Concepts pag
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
+++ b/docs/pl/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
@@ -125,4 +125,4 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/configure-additional-ip.mdx
+++ b/docs/pl/guides/public-cloud/network-services/configure-additional-ip.mdx
@@ -398,4 +398,4 @@ Aby przetestować połączenie, wystarczy wysłać ping na adres Additional IP z
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/create-private-network-gateway.mdx
+++ b/docs/pl/guides/public-cloud/network-services/create-private-network-gateway.mdx
@@ -272,4 +272,4 @@ Learn more about Gateway and its scenarios on our [dedicated page](https://www.o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
+++ b/docs/pl/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
@@ -510,4 +510,4 @@ The Public Cloud project and Bare Metal server must be added to the same vRack:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/faq.mdx
+++ b/docs/pl/guides/public-cloud/network-services/faq.mdx
@@ -239,4 +239,4 @@ Yes, the [OHVcloud Anti-DDoS infrastructure](https://www.ovhcloud.com/pl/securit
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/import-additional-ip.mdx
+++ b/docs/pl/guides/public-cloud/network-services/import-additional-ip.mdx
@@ -88,4 +88,4 @@ Następnym krokiem jest konfiguracja IP w systemie operacyjnym. Zapoznaj się [z
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/ipv6-configuration.mdx
+++ b/docs/pl/guides/public-cloud/network-services/ipv6-configuration.mdx
@@ -371,4 +371,4 @@ W każdym przypadku warto skontaktować się z działem [pomocy technicznej](htt
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
+++ b/docs/pl/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
@@ -151,4 +151,4 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/load-balancer-concepts.mdx
+++ b/docs/pl/guides/public-cloud/network-services/load-balancer-concepts.mdx
@@ -153,4 +153,4 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
+++ b/docs/pl/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
@@ -118,4 +118,4 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
+++ b/docs/pl/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
@@ -224,4 +224,4 @@ You can now access your Load Balancer securely. However, you will need to renew 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
+++ b/docs/pl/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
@@ -201,4 +201,4 @@ Each method offers specific advantages depending on your familiarity with the to
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
+++ b/docs/pl/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
@@ -372,4 +372,4 @@ resource "openstack_lb_l7rule_v2" "l7rule_1" {
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
+++ b/docs/pl/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
@@ -195,4 +195,4 @@ To delete your subscription you can use the following API call:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
+++ b/docs/pl/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
@@ -349,4 +349,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/migrate-additional-ip.mdx
+++ b/docs/pl/guides/public-cloud/network-services/migrate-additional-ip.mdx
@@ -83,5 +83,5 @@ Additional IP może być skonfigurowany na serwerze docelowym przed lub po migra
  
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Dołącz do [grona naszych użytkowników](/links/community).
 

--- a/docs/pl/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
+++ b/docs/pl/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
@@ -328,6 +328,6 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 Join our [Discord](https://discord.gg/ovhcloud) to discuss with the OVHcloud team and other users.

--- a/docs/pl/guides/public-cloud/network-services/overview.mdx
+++ b/docs/pl/guides/public-cloud/network-services/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Sprawdź również
   items:
     - title: Odwiedź społeczność OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Zobacz roadmapę i changelog
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: Dołącz do Discord

--- a/docs/pl/guides/public-cloud/network-services/stormshield-vrack.mdx
+++ b/docs/pl/guides/public-cloud/network-services/stormshield-vrack.mdx
@@ -589,4 +589,4 @@ PING <ip_address> (<ip_address>) 56(84) bytes of data.
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/en).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/ubika-vrack.mdx
+++ b/docs/pl/guides/public-cloud/network-services/ubika-vrack.mdx
@@ -413,4 +413,4 @@ ubika-test-webserver-1
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/pl/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -172,4 +172,4 @@ You can check that the subnet has been updated:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/activate-hds-certification.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/activate-hds-certification.mdx
@@ -57,4 +57,4 @@ Review the information and check the box for accepting the contracts. Finally, c
 
 [Public Cloud documentation](/guides/public-cloud/compute/overview)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/analyze-billing.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/analyze-billing.mdx
@@ -200,4 +200,4 @@ Para as classes Infrequent Access, Active Archive e Cold Archive, aplicam-se uma
 
 <sup>1</sup>: S3 é uma marca registada da Amazon Technologies, Inc. O serviço OVHcloud não é patrocinado, endossado ou de outra forma afiliado à Amazon Technologies, Inc.
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/api-rate-limits.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/api-rate-limits.mdx
@@ -106,4 +106,4 @@ Aqui estão alguns exemplos de livrarias bem conhecidas para implementar a funç
 
 ### Quer saber mais?
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/compute-essential-information.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/compute-essential-information.mdx
@@ -154,4 +154,4 @@ Uma das grandes vantagens de utilizar tecnologias standard e abertas, como OpenS
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/compute-horizon-access-security.mdx
@@ -56,4 +56,4 @@ Adicione um grupo de segurança ao clicar no <code className="action">Create Sec
 
 ## Saiba mais
 
-Fale com a nossa comunidade de utilizadores [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/compute-managing-savings-plan.mdx
@@ -190,4 +190,4 @@ You can create your Savings Plan for the type of resource you want by following 
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment.mdx
@@ -169,4 +169,4 @@ openstack --help
 
 [Carregar as variáveis de ambiente OpenStack](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables).
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables.mdx
@@ -89,4 +89,4 @@ set OS_PASSWORD="Palavra-passe do utilizador Horizon"
 
 Para aprender a utilizar o OpenStack: [Documentação OpenStack](https://docs.openstack.org/)
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/create-and-delete-a-user.mdx
@@ -107,4 +107,4 @@ A eliminação de um utilizador é definitiva e invalidará todos os tokens asso
 
 [Apresentação do Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/delegate-projects.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/delegate-projects.mdx
@@ -72,4 +72,4 @@ Para anular um acesso, clique no botão <code className="action">...</code> e se
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/delete-a-project.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/delete-a-project.mdx
@@ -70,4 +70,4 @@ Tenha em conta que, quando um projeto entra nesta fase de eliminação, fica sus
 
 [Criar uma primeira instância Public Cloud e ligar-se a ela](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
 
-Fale com a nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/deployment-modes-comparison-resilience-details.mdx
@@ -257,4 +257,4 @@ Architecture:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/pt/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/deployments-modes-reference-architecture.mdx
@@ -175,4 +175,4 @@ Thanks to dynamic service transfer between availability zones, the application r
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/pt/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -269,4 +269,4 @@ A *flag CPU SSBD* não está disponível para a sua instância, pois pode causar
 
 ## Quer saber mais?
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/how-to-use-terraform.mdx
@@ -642,4 +642,4 @@ terraform destroy
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/introducing-horizon.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/introducing-horizon.mdx
@@ -131,4 +131,4 @@ No canto superior direito da interface Horizon, um menu de utilizador permite-lh
 
 [Familiarizar-se com a interface Public Cloud](/guides/public-cloud/cross-functional/public-cloud-interface-walk-me)
  
-Fale com a nossa comunidade de utilizadores [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/managing-tokens.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/managing-tokens.mdx
@@ -183,4 +183,4 @@ Se não houver erros, obtém-se uma resposta vazia.
 
 ## Saiba mais
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/metrics-informations.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/metrics-informations.mdx
@@ -107,4 +107,4 @@ The table below shows the availability status of metrics and the planned release
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/overview.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/overview.mdx
@@ -19,7 +19,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/public-cloud/cross-functional/savings-plans.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/savings-plans.mdx
@@ -267,4 +267,4 @@ The vCPUs of control-plane nodes are not billed.
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/security-group-private-network.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/security-group-private-network.mdx
@@ -170,4 +170,4 @@ openstack port set --security-group private 5be009d9-fc2e-4bf5-a152-dab52614b02d
 
 ## Quer saber mais?
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/security-structure-best-practices.mdx
@@ -156,4 +156,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/using-openstack-tokens-for-multiple-calls.mdx
@@ -172,4 +172,4 @@ openstack --os-auth-type token token revoke $OS_TOKEN
 
 ## Saiba mais
 
-Junte-se à nossa comunidade de utilizadores [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -54,4 +54,4 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
-Join our [community of users](https://community.ovhcloud.com/community/en) and visit our [Discord channel](https://discord.gg/ovhcloud).
+Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -140,4 +140,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -186,4 +186,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -104,7 +104,7 @@ ClickHouse service capabilities
 
 [Configuring vRack for Public Cloud](/guides/public-cloud/network-services/vrack)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -90,4 +90,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -44,4 +44,4 @@ Visit our Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhc
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or our [Professional Services experts](https://www.ovhcloud.com/pt/professional-services/) for a quote and custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -69,4 +69,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -110,7 +110,7 @@ ClickHouse service capabilities
 
 [Official Aiven documentation to integrate Kafka](https://aiven.io/docs/products/clickhouse/howto/integrate-kafka)
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 ## We want your feedback!
 

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -146,4 +146,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -84,4 +84,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -70,4 +70,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
@@ -161,4 +161,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -136,4 +136,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
@@ -89,4 +89,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -58,4 +58,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -62,4 +62,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/data-analytics/clickhouse/overview.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/clickhouse/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/public-cloud/data-analytics/grafana/overview.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/grafana/overview.mdx
@@ -18,7 +18,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/public-cloud/data-analytics/kafka/overview.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/kafka/overview.mdx
@@ -22,7 +22,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
+++ b/docs/pt/guides/public-cloud/network-services/additional-ip-vs-floating-ip.mdx
@@ -69,4 +69,4 @@ The pricing methods depend on the use of the IP you choose. Additional IP usage 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/buy-additional-ip.mdx
+++ b/docs/pt/guides/public-cloud/network-services/buy-additional-ip.mdx
@@ -110,4 +110,4 @@ O próximo passo consiste em configurar o IP no seu sistema operativo. Consulte 
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/change-instance-dns-servers.mdx
+++ b/docs/pt/guides/public-cloud/network-services/change-instance-dns-servers.mdx
@@ -174,4 +174,4 @@ Num PowerShell, o comando `nslookup` permite verificar qual o servidor DNS utili
 
 [Modificar o hostname de uma instância Public Cloud](/guides/public-cloud/compute/changing-the-hostname-of-an-instance)
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/concepts.mdx
+++ b/docs/pt/guides/public-cloud/network-services/concepts.mdx
@@ -150,4 +150,4 @@ Find out more about Additional IP and Floating IP on the dedicated [Concepts pag
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
+++ b/docs/pt/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
@@ -125,4 +125,4 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/configure-additional-ip.mdx
+++ b/docs/pt/guides/public-cloud/network-services/configure-additional-ip.mdx
@@ -398,4 +398,4 @@ Para testar a ligação, basta enviar um ping ao seu endereço Additional IP a p
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/create-private-network-gateway.mdx
+++ b/docs/pt/guides/public-cloud/network-services/create-private-network-gateway.mdx
@@ -272,4 +272,4 @@ Learn more about Gateway and its scenarios on our [dedicated page](https://www.o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
+++ b/docs/pt/guides/public-cloud/network-services/extend-private-network-multi-regions.mdx
@@ -510,4 +510,4 @@ The Public Cloud project and Bare Metal server must be added to the same vRack:
 
 ## Go further
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/faq.mdx
+++ b/docs/pt/guides/public-cloud/network-services/faq.mdx
@@ -239,4 +239,4 @@ Yes, the [OHVcloud Anti-DDoS infrastructure](https://www.ovhcloud.com/pt/securit
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/import-additional-ip.mdx
+++ b/docs/pt/guides/public-cloud/network-services/import-additional-ip.mdx
@@ -88,4 +88,4 @@ O próximo passo consiste em configurar o IP no seu sistema operativo. Consulte 
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/ipv6-configuration.mdx
+++ b/docs/pt/guides/public-cloud/network-services/ipv6-configuration.mdx
@@ -370,4 +370,4 @@ De qualquer forma, não hesite em contactar o suporte com os elementos testados 
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projeto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
+++ b/docs/pt/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
@@ -151,4 +151,4 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/load-balancer-concepts.mdx
+++ b/docs/pt/guides/public-cloud/network-services/load-balancer-concepts.mdx
@@ -153,4 +153,4 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
+++ b/docs/pt/guides/public-cloud/network-services/load-balancer-letsencrypt.mdx
@@ -118,4 +118,4 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
+++ b/docs/pt/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
@@ -224,4 +224,4 @@ You can now access your Load Balancer securely. However, you will need to renew 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
+++ b/docs/pt/guides/public-cloud/network-services/loadbalancer-create-health-monitor.mdx
@@ -201,4 +201,4 @@ Each method offers specific advantages depending on your familiarity with the to
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
+++ b/docs/pt/guides/public-cloud/network-services/loadbalancer-create-l7-policies.mdx
@@ -372,4 +372,4 @@ resource "openstack_lb_l7rule_v2" "l7rule_1" {
 
 ## Go further
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
+++ b/docs/pt/guides/public-cloud/network-services/loadbalancer-logs-forward.mdx
@@ -195,4 +195,4 @@ To delete your subscription you can use the following API call:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
+++ b/docs/pt/guides/public-cloud/network-services/loadbalancer-monitoring-prometheus.mdx
@@ -349,4 +349,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/migrate-additional-ip.mdx
+++ b/docs/pt/guides/public-cloud/network-services/migrate-additional-ip.mdx
@@ -82,4 +82,4 @@ O Additional IP pode ser configurado no servidor de destino antes ou depois da m
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
-Fale com nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
+++ b/docs/pt/guides/public-cloud/network-services/octavia-use-lbaas-openstack.mdx
@@ -328,6 +328,6 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 Join our [Discord](https://discord.gg/ovhcloud) to discuss with the OVHcloud team and other users.

--- a/docs/pt/guides/public-cloud/network-services/overview.mdx
+++ b/docs/pt/guides/public-cloud/network-services/overview.mdx
@@ -31,7 +31,7 @@ goFurther:
   title: Saiba mais
   items:
     - title: Visitar a comunidade OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: Consultar o roadmap e o changelog
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: Juntar-se ao Discord

--- a/docs/pt/guides/public-cloud/network-services/stormshield-vrack.mdx
+++ b/docs/pt/guides/public-cloud/network-services/stormshield-vrack.mdx
@@ -593,4 +593,4 @@ PING <ip_address> (<ip_address>) 56(84) bytes of data.
 
 Se necessitar de formação ou de assistência técnica para a implementação das nossas soluções, contacte o seu representante de vendas ou clique em [este link](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projeto aos nossos peritos da equipa Professional Services.
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/ubika-vrack.mdx
+++ b/docs/pt/guides/public-cloud/network-services/ubika-vrack.mdx
@@ -413,4 +413,4 @@ ubika-test-webserver-1
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/pt/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -172,4 +172,4 @@ You can check that the subnet has been updated:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).


### PR DESCRIPTION
### Scope: Public Cloud - Network, Cross, Analytics

- Replace (dead) links to legacy community page with proper keys
- Fix hard URL in Overview pages to the correct one