### PR TITLE
fix(components): make <Api> region picker usable in tabs and after zone selection

### DIFF
--- a/components/Api/index.css
+++ b/components/Api/index.css
@@ -80,6 +80,13 @@
   box-shadow: var(--rp-shadow-4);
 }
 
+/* Portaled to <body> and positioned via inline top/left, so it escapes the
+   `contain: content` paint clipping Rspress applies to `.rp-tabs`. */
+.ovh-api-dropdown__menu--portal {
+  position: fixed;
+  z-index: 9999;
+}
+
 .ovh-api-dropdown__title {
   margin: 0 0 6px;
   padding: 4px 8px;

--- a/components/Api/index.tsx
+++ b/components/Api/index.tsx
@@ -1,8 +1,14 @@
 import { useI18n } from '@rspress/core/runtime';
-import { useZone } from '@components/Zone';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useRegion } from './RegionContext';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { regionsForPath } from './productRegions';
+import { useRegion } from './RegionContext';
 import './index.css';
 
 const REGIONS = {
@@ -28,7 +34,6 @@ export default function Api({
   regions: regionsProp,
 }: ApiProps) {
   const { region: globalRegion, setRegion } = useRegion();
-  const { isSet: zoneChosen } = useZone();
   // Default the offered regions to the product's commercial-zone availability
   // (derived from the route, then the section); an explicit `regions` prop
   // overrides it. Falls back to both regions when no zoned product matches.
@@ -44,17 +49,49 @@ export default function Api({
 
   const [open, setOpen] = useState(false);
   const [focusIndex, setFocusIndex] = useState(-1);
-  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [coords, setCoords] = useState<{ top: number; left: number } | null>(
+    null,
+  );
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
-  // Close on outside click
+  // Position the menu relative to the trigger (viewport coords for `fixed`).
+  // The menu is portaled to <body> so it escapes the `contain: content` paint
+  // clipping that Rspress applies to `.rp-tabs` — without this, an <Api> block
+  // near the bottom of a tab would render its dropdown into the clipped area.
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    setCoords({ top: rect.bottom + 6, left: rect.left });
+  }, [open]);
+
+  // Close on outside click (menu is portaled, so it's not inside the wrapper)
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
-      if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+      const target = e.target as Node;
+      if (
+        !triggerRef.current?.contains(target) &&
+        !menuRef.current?.contains(target)
+      ) {
+        setOpen(false);
+      }
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  // Close on scroll/resize — simpler than tracking the trigger's position
+  useEffect(() => {
+    if (!open) return;
+    const close = () => setOpen(false);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
   }, [open]);
 
   // Keyboard navigation
@@ -109,12 +146,66 @@ export default function Api({
     setOpen(false);
   };
 
+  const menu = open && coords && (
+    <div
+      ref={menuRef}
+      className="ovh-api-dropdown__menu ovh-api-dropdown__menu--portal"
+      role="listbox"
+      aria-label={t('api.regionTooltipTitle')}
+      style={{ top: coords.top, left: coords.left }}
+    >
+      <p className="ovh-api-dropdown__title">{t('api.regionTooltipTitle')}</p>
+      {regions.map((r, i) => {
+        const isSelected = r === region;
+        const descKey = `api.regionTooltip${r.toUpperCase()}` as const;
+        const desc = t(descKey);
+
+        return (
+          <button
+            key={r}
+            ref={(el) => {
+              optionRefs.current[i] = el;
+            }}
+            type="button"
+            role="option"
+            aria-selected={isSelected}
+            className={`ovh-api-dropdown__option${isSelected ? ' ovh-api-dropdown__option--selected' : ''}`}
+            onClick={() => selectRegion(r)}
+            onKeyDown={handleKeyDown}
+            tabIndex={-1}
+          >
+            <span className="ovh-api-dropdown__option-header">
+              <span className="ovh-api-dropdown__option-flag">
+                {REGIONS[r].flag}
+              </span>
+              <span className="ovh-api-dropdown__option-label">
+                {REGIONS[r].label}
+              </span>
+              {isSelected && (
+                <span className="ovh-api-dropdown__check" aria-hidden="true">
+                  ✓
+                </span>
+              )}
+            </span>
+            {desc && desc !== descKey && (
+              <span className="ovh-api-dropdown__option-desc">{desc}</span>
+            )}
+            <span className="ovh-api-dropdown__option-url">
+              {REGIONS[r].base.replace('https://', '').replace('/console/', '')}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+
   return (
     <div className="ovh-api-main">
-      {regions.length > 1 && !zoneChosen && (
-        <div className="ovh-api-dropdown" ref={wrapperRef}>
+      {regions.length > 1 && (
+        <div className="ovh-api-dropdown">
           <button
             type="button"
+            ref={triggerRef}
             className="ovh-api-dropdown__trigger"
             onClick={() => setOpen(!open)}
             onKeyDown={handleKeyDown}
@@ -135,70 +226,11 @@ export default function Api({
               ▾
             </span>
           </button>
-
-          {open && (
-            <div
-              className="ovh-api-dropdown__menu"
-              role="listbox"
-              aria-label={t('api.regionTooltipTitle')}
-            >
-              <p className="ovh-api-dropdown__title">
-                {t('api.regionTooltipTitle')}
-              </p>
-              {regions.map((r, i) => {
-                const isSelected = r === region;
-                const descKey = `api.regionTooltip${r.toUpperCase()}` as const;
-                const desc = t(descKey);
-
-                return (
-                  <button
-                    key={r}
-                    ref={(el) => {
-                      optionRefs.current[i] = el;
-                    }}
-                    type="button"
-                    role="option"
-                    aria-selected={isSelected}
-                    className={`ovh-api-dropdown__option${isSelected ? ' ovh-api-dropdown__option--selected' : ''}`}
-                    onClick={() => selectRegion(r)}
-                    onKeyDown={handleKeyDown}
-                    tabIndex={-1}
-                  >
-                    <span className="ovh-api-dropdown__option-header">
-                      <span className="ovh-api-dropdown__option-flag">
-                        {REGIONS[r].flag}
-                      </span>
-                      <span className="ovh-api-dropdown__option-label">
-                        {REGIONS[r].label}
-                      </span>
-                      {isSelected && (
-                        <span
-                          className="ovh-api-dropdown__check"
-                          aria-hidden="true"
-                        >
-                          ✓
-                        </span>
-                      )}
-                    </span>
-                    {desc && desc !== descKey && (
-                      <span className="ovh-api-dropdown__option-desc">
-                        {desc}
-                      </span>
-                    )}
-                    <span className="ovh-api-dropdown__option-url">
-                      {REGIONS[r].base
-                        .replace('https://', '')
-                        .replace('/console/', '')}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          )}
+          {menu && createPortal(menu, document.body)}
         </div>
       )}
       <a target="_blank" href={href} rel="noopener noreferrer">
-        {(regions.length === 1 || zoneChosen) && (
+        {regions.length === 1 && (
           <span className="ovh-api-flag">{REGIONS[region].flag}</span>
         )}
         <span className={`ovh-api-verb ovh-api-verb-${method}`}>{method}</span>


### PR DESCRIPTION
Portal the EU/CA dropdown to <body> so it escapes the `contain: content`
paint clipping Rspress applies to .rp-tabs (the menu was clipped when an
<Api> call sat near the bottom of a tab), and always render the picker when
multiple regions apply instead of suppressing it once a commercial zone is
stored — the zone still sets the default region, but readers can override it
per call without clearing localStorage / using private browsing.
