### PR TITLE
[SK-1992] docs: unify webmail-tech identification and zone-adapt MX Plan email 1/2

### DIFF
--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -78,16 +78,27 @@ Sie möchten:
 
 <a name="whichmxplan"></a>
 
-:::info
-**Identifizierung der E-Mail-Technologie Ihres MX Plan Angebots.**
+**Identifizierung der E-Mail-Technologie Ihres MX Plan Angebots**
 
-Je nach Aktivierungsdatum Ihres MX Plan Angebots oder nach einer kürzlich erfolgten Migration kann die zugehörige E-Mail-Technologie abweichen. Diese Technologie zeichnet sich durch die Oberfläche ihres Webmails aus. Um sie zu identifizieren:
+<Region zones={['eu']}>
 
-- Notieren Sie sich im Tab <code className="action">Allgemeine Informationen</code> die verwendete Technologie unter der Angabe **Webmail** im Rahmen <code className="action">Abo</code>.
+Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/technology-email.png" loading="lazy" />
+- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
+- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
+- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
 
-:::
+Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
+
+<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Rufen Sie Ihre E-Mails online und ohne Installation über das Webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) ab.
+
+</Region>
 
 
 ## In der praktischen Anwendung <a name="instructions"></a>
@@ -107,7 +118,7 @@ OVHcloud bietet 4 E-Mail-Lösungen an. Das Konzept der Löschung von Accounts va
 Wählen Sie den Tab für Ihren E-Mail-Dienst aus:
 
 <ZoneTabs>
-  <Tab label="MX Plan Roundcube">
+  <Tab label="MX Plan Roundcube" availableIn={['eu']}>
     Um die E-Mail-Technologie Ihres MX Plan Dienstes zu identifizieren, lesen Sie den Abschnitt "[Identifizierung der E-Mail-Technologie Ihres MX Plan Angebots](#whichmxplan)" in dieser Anleitung.
     
     1. Wechseln Sie zum Tab <code className="action">E-Mails</code>. Im daraufhin angezeigten Fenster werden die vorhandenen E-Mail-Accounts angezeigt.
@@ -115,7 +126,7 @@ Wählen Sie den Tab für Ihren E-Mail-Dienst aus:
     
     <img className="thumbnail" alt="E-Mail" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/email-mxplan-legacy-reset.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan Zimbra/OWA">
+  <Tab label="MX Plan">
     Um die E-Mail-Technologie Ihres MX Plan Dienstes zu identifizieren, lesen Sie den Abschnitt "[Identifizierung der E-Mail-Technologie Ihres MX Plan Angebots](#whichmxplan)" in dieser Anleitung.
     
     1. Wechseln Sie zum Tab <code className="action">E-Mails</code>. Im daraufhin angezeigten Fenster werden die vorhandenen E-Mail-Accounts angezeigt.

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -91,15 +91,27 @@ Aus Sicherheitsgründen empfehlen wir, Passwörter nicht mehrfach zu verwenden, 
 
 <a name="whichmxplan"></a>
 
-:::info
-**E-Mail-Technologie Ihres MX Plan Angebots identifizieren.**
+**E-Mail-Technologie Ihres MX Plan Angebots identifizieren**
 
-Abhängig vom Aktivierungsdatum Ihres MX Plan Angebots oder einer kürzlich durchgeführten Migration kann die zugehörige E-Mail-Technologie variieren. Diese Version ist durch das Webmail-Interface gekennzeichnet.
+<Region zones={['eu']}>
 
-- Gehen Sie in den Tab <code className="action">Allgemeine Informationen</code> und wählen Sie die Technologie aus, die unter **Webmail** in der Randleiste <code className="action">Abonnement</code> oder <code className="action">Webmail</code> verwendet wird.
+Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
 
-<img className="thumbnail" alt="mx plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/technology-email.png" loading="lazy" />
-:::
+- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
+- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
+- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+
+Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
+
+<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Rufen Sie Ihre E-Mails online und ohne Installation über das Webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) ab.
+
+</Region>
 
 Folgen Sie den passenden Anweisungen für Ihren E-Mail-Dienst:
 
@@ -145,16 +157,37 @@ Klicken Sie auf den Button <code className="action">...</code> und dann auf <cod
 
 Die Änderung eines Passworts über Webmail ist für die OVHcloud E-Mail-Angebote unter Verwendung von **OWA** (**O**utlook **W**eb **A**pp) verfügbar:
 
+<Region zones={['eu']}>
+
 - MX Plan OWA
 - E-Mail Pro
 - Exchange
 - MX Plan Zimbra
 - Zimbra Starter et Pro
 
+</Region>
+
+<Region zones={['ca']}>
+
+- MX Plan OWA
+- Exchange
+
+</Region>
+
+<Region zones={['apac']}>
+
+- MX Plan OWA
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 Beim Angebot **MX Plan Roundcube** erfolgt die Passwortänderung ausschließlich [über das Kundencenter](#controlpanel).
 
 :::
+
+</Region>
 
 
 #### OWA
@@ -183,6 +216,8 @@ Geben Sie das neue Passwort auch in allen für diesen Account verwendeten E-Mail
 
 <img className="thumbnail" alt="E-Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/mxplan-password-new-step5.png" loading="lazy" />
 
+<Region zones={['eu']}>
+
 ### Zimbra
 
 Gehen Sie auf die Seite [Webmail](https://www.ovhcloud.com/de/mail/). Geben Sie Ihre E-Mail-Adresse und das Passwort ein und klicken Sie auf <code className="action">Anmelden</code>.
@@ -190,6 +225,8 @@ Gehen Sie auf die Seite [Webmail](https://www.ovhcloud.com/de/mail/). Geben Sie 
 Klicken Sie rechts oben in Ihrem Interface auf den Namen Ihres E-Mail-Accounts. In diesem Menü können Sie das <code className="action">Passwort ändern</code>.
 
 <img className="thumbnail" alt="Zimbra - Voreinstellungen" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/zimbra-password.png" loading="lazy" />
+
+</Region>
 
 ### Passwort abrufen
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -54,16 +54,27 @@ Sie haben gerade eine MX Plan E-Mail-Lösung erworben. Diese bietet Ihnen E-Mail
 
 **Fahren Sie mit der von Ihrem MX Plan Dienst verwendeten E-Mail Technologie fort**.
 
-:::info
-**E-Mail-Technologie Ihres MX Plan Angebots identifizieren.**
+**E-Mail-Technologie Ihres MX Plan Angebots identifizieren**
 
-Abhängig vom Aktivierungsdatum Ihres MX Plan Angebots oder einer kürzlich durchgeführten Migration kann die zugehörige E-Mail-Technologie variieren. Diese Version ist durch das Webmail-Interface gekennzeichnet. Um es zu identifizieren:
+<Region zones={['eu']}>
 
-- Gehen Sie in den Tab <code className="action">Allgemeine Informationen</code> und beachten Sie die Technologie unter **Webmail** in der Randleiste <code className="action">Abonnement</code> unter <code className="action">Webmail</code>.
+Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation/technology-email.png" loading="lazy" />
+- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
+- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
+- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
 
-:::
+Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
+
+<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Rufen Sie Ihre E-Mails online und ohne Installation über das Webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) ab.
+
+</Region>
 
 
 ### OWA und Zimbra
@@ -295,7 +306,14 @@ Für den Versand von E-Mails verwenden Sie die folgenden **SMTP** Einstellungen:
 **Sie benötigen mehr E-Mail-Adressen?**
 
 - Fragen in [unseren E-Mail FAQ](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails).
-- Sehen Sie sich alle unsere E-Mail-Angebote [Zimbra](https://www.ovhcloud.com/de/emails/zimbra-emails/) oder [Exchange](https://www.ovhcloud.com/de/emails-exchange/) an, um Ihr MX Plan Angebot für dieselbe Domain zu vervollständigen.
+
+<Region zones={['eu']}>
+Sehen Sie sich alle unsere E-Mail-Angebote [Zimbra](https://www.ovhcloud.com/de/emails/zimbra-emails/) oder [Exchange](https://www.ovhcloud.com/de/emails-exchange/) an, um Ihr MX Plan Angebot für dieselbe Domain zu vervollständigen.
+</Region>
+
+<Region zones={['ca']}>
+Entdecken Sie unser E-Mail-Angebot [Exchange](https://www.ovhcloud.com/de/emails-exchange/), um Ihr MX Plan Angebot für dieselbe Domain zu vervollständigen.
+</Region>
 
 ## Weiterführende Informationen <a name="go-further"></a>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -44,15 +44,27 @@ Mit der MX Plan Lösung verfügen Sie über E-Mail-Adressen, mit denen Sie Nachr
 
 **Fahren Sie mit der von Ihrem MX Plan Dienst verwendeten E-Mail Technologie fort.**
 
-:::info
-**E-Mail-Technologie Ihres MX Plan Angebots identifizieren.**
+**E-Mail-Technologie Ihres MX Plan Angebots identifizieren**
 
-Abhängig vom Aktivierungsdatum Ihres MX Plan Angebots oder einer kürzlich durchgeführten Migration kann die zugehörige E-Mail-Technologie variieren. Diese Version ist durch das Webmail-Interface gekennzeichnet.
+<Region zones={['eu']}>
 
-- Gehen Sie in den Tab <code className="action">Allgemeine Informationen</code> und wählen Sie die Technologie aus, die unter **Webmail** in der Randleiste <code className="action">Abonnement</code> oder <code className="action">Webmail</code> verwendet wird.
+Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
 
-<img className="thumbnail" alt="mx plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities/technology-email.png" loading="lazy" />
-:::
+- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
+- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
+- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+
+Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
+
+<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Rufen Sie Ihre E-Mails online und ohne Installation über das Webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) ab.
+
+</Region>
 
 **Inhalt**
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -4,6 +4,8 @@ lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
+import { Region } from '@components/Zone';
+
 ## Ziel
 
 Mit der OVHcloud MX Plan Lösung können Sie E-Mails über eine Drittanbieter-Software oder über Webmail versenden und empfangen. OVHcloud bietet einen Online-E-Mail-Dienst namens Roundcube, mit dem Sie über einen Webbrowser auf einen E-Mail-Account zugreifen können.
@@ -16,19 +18,27 @@ Mit der OVHcloud MX Plan Lösung können Sie E-Mails über eine Drittanbieter-So
 - Sie verfügen über die Logindaten der MX Plan E-Mail-Adresse, die Sie verwenden möchten. Weitere Informationen finden Sie in unserer Anleitung [Erste Schritte mit der MX Plan Lösung](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Ihre OVHcloud E-Mail-Lösung **MX Plan** muss die Webmail-Technologie **Roundcube** verwenden. Folgen Sie den nachstehenden Anweisungen, um dies zu identifizieren.
 
-:::info
-**Wie identifiziere ich die in meiner MX Plan Lösung verwendete Technologie?**
+**Die E-Mail-Technologie Ihres MX Plan-Angebots ermitteln**
 
-Die für Ihre MX Plan Lösung verwendete E-Mail-Technologie ist anhand des Webmail-Interface erkennbar. Um dies in Ihrem Kundencenter zu identifizieren, folgen Sie diesem Pfad:
+<Region zones={['eu']}>
 
-1. Loggen Sie sich in Ihr <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> ein.
-1. Gehen Sie in den Bereich <code className="action">Web Cloud</code>.
-1. Klicken Sie auf <code className="action">MX Plan</code>.
-1. Wählen Sie die betreffende Domain aus.
-1. Im Tab <code className="action">Allgemeine Informationen</code> (standardmäßig ausgewählt) prüfen Sie die unter dem Eintrag **Webmail** verwendete Technologie.
+Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube/technology-email.png" loading="lazy" />
-:::
+- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
+- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
+- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+
+Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
+
+<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Rufen Sie Ihre E-Mails online und ohne Installation über das Webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) ab.
+
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 ---

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -72,7 +72,15 @@ OVHcloud bietet derzeit 4 E-Mail-Angebote an. Um mehr über die Eigenschaften zu
     
     1. Das älteste E-Mail-Angebot von OVHcloud, das die wesentlichen Funktionen eines E-Mail-Dienstes mit 5 GB Speicherplatz pro E-Mail-Account enthält.
     2. Es ist in den Webhosting-Angeboten inklusive und kann über das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> bestellt werden.
-    3. Dieses Angebot ist mit 3 verschiedenen E-Mail-Technologien verfügbar. **RoundCube**, **OWA** (Outlook Web App) und **Zimbra**.
+    3. Dieses Angebot ist mit folgenden Webmail-Technologien verfügbar:
+
+       <Region zones={['eu']}>
+       **RoundCube**, **OWA** (Outlook Web App) und **Zimbra**.
+       </Region>
+
+       <Region zones={['ca', 'apac']}>
+       **OWA** (Outlook Web App).
+       </Region>
   </Tab>
   <Tab label="Zimbra Mail" availableIn={['eu']}>
     <img className="thumbnail" alt="Zimbra Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/zimbra01.png" loading="lazy" />
@@ -133,12 +141,25 @@ Im Folgenden finden Sie eine Tabelle mit einer Zusammenfassung der wichtigsten E
 <summary>Wie kann ich die bei meinem **MX Plan** verwendete Technologie identifizieren?</summary>
 
 
-Die für Ihr MX Plan Angebot verwendete E-Mail-Technologie ist durch das Webmail-Interface gekennzeichnet. Um ihn über Ihr Kundencenter zu identifizieren, folgen Sie dem folgenden Pfad:
+<Region zones={['eu']}>
 
-1. Wählen Sie in <code className="action">Allgemeine Informationen</code> die Option „Standard“.
-1. Notieren Sie die unter **Webmail** verwendete Technologie.
+Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
 
-<img className="thumbnail" alt="MX PLAN" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/technology-email.png" loading="lazy" />
+- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
+- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
+- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+
+Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
+
+<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Rufen Sie Ihre E-Mails online und ohne Installation über das Webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) ab.
+
+</Region>
 
 </details>
 
@@ -385,7 +406,18 @@ Wenn Sie [eines der E-Mail-Angebote von OVHcloud](https://www.ovhcloud.com/de/em
 
 Sie möchten zu einem anderen [E-Mail-Angebot](https://www.ovhcloud.com/de/emails/) wechseln, um mehr Speicherplatz und Funktionen nutzen zu können, möchten aber den Inhalt Ihres bestehenden Accounts beibehalten.  Folgen Sie hierzu der passenden Migrationsanleitung:
 
-- [MX Plan E-Mail-Account auf E-Mail Pro oder Exchange Account migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+<Region zones={['eu']}>
+
+[MX Plan E-Mail-Account auf E-Mail Pro oder Exchange Account migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+
+</Region>
+
+<Region zones={['ca']}>
+
+[MX Plan E-Mail-Account auf Exchange Account migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+
+</Region>
+
 - [E-Mail-Accounts von einer OVHcloud-E-Mail-Plattform auf eine andere migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
 - [E-Mail-Accounts manuell migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)
 - [E-Mail-Accounts über OVHcloud Mail Migrator migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud)

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -75,15 +75,27 @@ Jeder OVHcloud E-Mail-Account verfügt über einen dedizierten Speicherplatz. Ei
 :::
 
 
-:::info
-**E-Mail-Technologie Ihres MX Plan Angebots identifizieren.**
+**E-Mail-Technologie Ihres MX Plan Angebots identifizieren**
 
-Abhängig vom Aktivierungsdatum Ihres MX Plan Angebots oder einer kürzlich durchgeführten Migration kann die zugehörige E-Mail-Technologie variieren. Diese Version ist durch das Webmail-Interface gekennzeichnet.
+<Region zones={['eu']}>
 
-- Gehen Sie in den Tab <code className="action">Allgemeine Informationen</code> und wählen Sie die Technologie aus, die unter **Webmail** in der Randleiste <code className="action">Abonnement</code> oder <code className="action">Webmail</code> verwendet wird.
+Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
 
-<img className="thumbnail" alt="mx plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/technology-email.png" loading="lazy" />
-:::
+- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
+- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
+- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+
+Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
+
+<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Rufen Sie Ihre E-Mails online und ohne Installation über das Webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) ab.
+
+</Region>
 
 ## In der praktischen Anwendung <a name="instructions"></a>
 
@@ -132,11 +144,11 @@ Um sich im Webmail einzuloggen, gehen Sie auf die Seite [Webmail](https://www.ov
     Klicken Sie auf das Zahnrad oben rechts und klicken Sie auf <code className="action">Optionen</code>. Klicken Sie unter <code className="action">Allgemein</code> auf <code className="action">Mein Konto</code> in der linken Spalte. Sie können die aktuelle Speicherbelegung Ihres Accounts auf unten auf der Seite einsehen.<br/><br/>
     <img className="thumbnail" alt="E-Mail" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail01.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Roundcube: MX Plan">
+  <Tab label="Roundcube: MX Plan" availableIn={['eu']}>
     Wenn Sie im Roundcube Webmail eingeloggt sind, sehen Sie unten links das Quota in einem Kreisdiagramm und den prozentualen Verbrauch.<br/><br/>
     <img className="thumbnail" alt="E-Mail" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail02.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Zimbra: MX Plan / Zimbra Starter / Zimbra Pro">
+  <Tab label="Zimbra: MX Plan / Zimbra Starter / Zimbra Pro" availableIn={['eu']}>
     Wenn Sie im Zimbra Webmail eingeloggt sind, klicken Sie auf das Zahnrad ( &#9881;) oben rechts in Ihrem Interface und dann auf <code className="action">Einstellungen</code>. Im Tab <code className="action">Allgemein</code> wird das verwendete Quota unter dem Vermerk "Stauraum" angezeigt.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail03.png" loading="lazy" /><br/>
   </Tab>
@@ -227,7 +239,7 @@ Nachfolgend finden Sie eine nicht erschöpfende Liste der Konfigurationsanleitun
 </Region>
 
 <ZoneTabs>
-  <Tab label="MX Plan und Zimbra Starter">
+  <Tab label="MX Plan und Zimbra Starter" availableIn={['eu']}>
     Konfiguration eines MX Plan Accounts auf **Windows**:<br/><br/>
     - [Windows 10 Mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10) (bei Windows inklusive)<br/>
     - [Outlook mit MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016)
@@ -293,7 +305,15 @@ Folgen Sie der passenden Dokumentation für Ihren E-Mail-Dienst:
 
 <ZoneTabs>
   <Tab label="MX Plan">
-    Wenn die Kapazität Ihres E-Mail-Accounts bereits bei 5 GB beträgt, können Sie sich für eine Migration auf [**E-Mail Pro** mit 10 GB](https://www.ovhcloud.com/de/emails/email-pro/) oder [**Hosted Exchange** mit 50 GB](https://www.ovhcloud.com/de/emails/hosted-exchange/) entscheiden. Bestellen Sie hierzu das gewünschte Angebot und folgen Sie unserer Anleitung "[E-Mail-Accounts von MX Plan zu E-Mail Pro oder Exchange migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)". 
+    <Region zones={['eu']}>
+    Wenn die Kapazität Ihres E-Mail-Accounts bereits bei 5 GB beträgt, können Sie sich für eine Migration auf [**E-Mail Pro** mit 10 GB](https://www.ovhcloud.com/de/emails/email-pro/) oder [**Hosted Exchange** mit 50 GB](https://www.ovhcloud.com/de/emails/hosted-exchange/) entscheiden. Bestellen Sie hierzu das gewünschte Angebot und folgen Sie unserer Anleitung "[E-Mail-Accounts von MX Plan zu E-Mail Pro oder Exchange migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)".
+    </Region>
+    <Region zones={['ca']}>
+    Wenn die Kapazität Ihres E-Mail-Accounts bereits bei 5 GB beträgt, können Sie sich für eine Migration auf [**Hosted Exchange** mit 50 GB](https://www.ovhcloud.com/de/emails/hosted-exchange/) entscheiden. Bestellen Sie hierzu das gewünschte Angebot und folgen Sie unserer Anleitung "[E-Mail-Accounts von MX Plan zu Exchange migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)".
+    </Region>
+    <Region zones={['apac']}>
+    Um Ihre Speicherkapazität zu erhöhen, entdecken Sie unsere [E-Mail-Lösungen](https://www.ovhcloud.com/de/emails/).
+    </Region>
   </Tab>
   <Tab label="E-Mail Pro" availableIn={['eu']}>
     Das Angebot E-Mail Pro verfügt über eine feste Account-Kapazität von 10 GB. Sie können auf [**Hosted Exchange** mit 50 GB](https://www.ovhcloud.com/de/emails/hosted-exchange/) wechseln. Bestellen Sie hierzu Hosted Exchange und folgen Sie unserer Anleitung "[E-Mail-Accounts von einer OVHcloud E-Mail-Plattform auf eine andere migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform)".
@@ -314,7 +334,13 @@ Klicken Sie im Tab <code className="action">E-Mail-Accounts</code> Ihres Exchang
 
 ## Weiterführende Informationen
 
+<Region zones={['eu']}>
 [E-Mail-Accounts von MX Plan zu E-Mail Pro oder Exchange migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
+
+<Region zones={['ca']}>
+[E-Mail-Accounts von MX Plan zu Exchange migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
 
 [Ihre E-Mail-Account manuell migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -8,6 +8,7 @@ availableIn: [eu, ca, apac]
 import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
+import { Region } from '@components/Zone';
 
 
 ## Ziel
@@ -59,20 +60,27 @@ Wenn Ihre E-Mail-Adresse wegen Spamversands gesperrt ist, bedeutet dies, dass be
 
 Bevor Sie fortfahren: Falls die Sperrung eine MX Plan E-Mail-Adresse betrifft, identifizieren Sie zunächst die von Ihrer Lösung verwendete E-Mail-Technologie, um den richtigen Entsperrvorgang zu befolgen. Für die Lösungen **Zimbra Starter** und **Zimbra Pro** wechseln Sie direkt zum Tab **Zimbra** in Schritt 2, ohne dabei die Prüfungen aus Schritt 1 zu überspringen.
 
-:::info
-**Identifizieren Sie die E-Mail-Technologie Ihrer MX Plan Lösung.**
+**Identifizieren Sie die E-Mail-Technologie Ihrer MX Plan Lösung**
 
-Je nach Aktivierungsdatum Ihrer MX Plan Lösung oder nach einer kürzlich erfolgten Migration kann sich die zugehörige E-Mail-Technologie unterscheiden. Diese Version erkennen Sie an ihrer Webmail-Oberfläche. So identifizieren Sie sie:
+<Region zones={['eu']}>
 
-- Prüfen Sie im Tab <code className="action">Allgemeine Informationen</code> die im Bereich <code className="action">Abonnement</code> unter dem Label **Webmail** angegebene Technologie.
+Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
 
-<img className="thumbnail" alt="Identifizierung der E-Mail-Technologie im Kundencenter des MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
+- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
+- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
+- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
 
-- Wird **Roundcube** angezeigt, folgen Sie den Anweisungen im Tab **MX Plan - Roundcube**.
-- Wird **OWA** (Outlook Web App) angezeigt, folgen Sie den Anweisungen im Tab **MX Plan - OWA**.
-- Wird **Zimbra** angezeigt, folgen Sie den Anweisungen im Tab **Zimbra** (das Verfahren ist für MX Plan - Zimbra, Zimbra Starter und Zimbra Pro identisch).
+Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
 
-:::
+<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Rufen Sie Ihre E-Mails online und ohne Installation über das Webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) ab.
+
+</Region>
 
 
 ### Schritt 1: Die Ursache der Sperrung verstehen und beheben <a name="step1"></a>
@@ -149,7 +157,7 @@ Wählen Sie in den folgenden Tabs die betroffene E-Mail-Lösung aus:
 
     <img className="thumbnail" alt="Spalte Status auf Spam im Tab E-Mail-Accounts für MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra">
+  <Tab label="Zimbra" availableIn={['eu']}>
     Dieser Tab gilt für alle Adressen, die die Technologie **Zimbra** verwenden: **MX Plan - Zimbra**, **Zimbra Starter** und **Zimbra Pro**. Der Entsperrvorgang ist für diese drei Lösungen identisch.
 
     Wenn die Sperrung greift, wird **kein Support-Ticket automatisch erzeugt**, und die Adresse ist nicht mehr zugänglich (sowohl das Zimbra-Webmail als auch der E-Mail-Versand sind deaktiviert).
@@ -165,7 +173,7 @@ Wählen Sie in den folgenden Tabs die betroffene E-Mail-Lösung aus:
 
     Sobald das Ticket vom Support bearbeitet wurde, wird die Adresse entsperrt. [Schritt 3](#step3) ist in diesem Fall nicht anwendbar.
   </Tab>
-  <Tab label="MX Plan - Roundcube">
+  <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     Wenn die Sperrung eine MX Plan E-Mail-Adresse mit dem Webmail **Roundcube** betrifft, wird kein Support-Ticket erzeugt.
 
     Bevor Sie Maßnahmen ergreifen, ist es **unerlässlich, die Ursache der Sperrung zu identifizieren**, indem Sie die Prüfungen aus [Schritt 1](#step1) durchführen (möglicherweise infizierte Geräte, Drittanbieter-Software, Weiterleitungen, Filter, Abwesenheitsbenachrichtigungen).

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -78,16 +78,27 @@ You want to:
 
 <a name="whichmxplan"></a>
 
-:::info
-**Identifying the email technology of your MX Plan solution.**
+**Identifying the email technology of your MX Plan solution**
 
-Depending on when your MX Plan solution was activated or on a recent migration, the associated email technology may differ. This technology is characterised by the interface of its webmail. To identify it:
+<Region zones={['eu']}>
 
-- From the <code className="action">General information</code> tab, note the technology used under the **Webmail** heading in the <code className="action">Subscription</code> box.
+Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/technology-email.png" loading="lazy" />
+- **Roundcube**: the original webmail, lightweight and easy to use.
+- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
+- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
 
-:::
+To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
+
+<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Access your email online, without installation, via the [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) webmail.
+
+</Region>
 
 
 ## Instructions <a name="instructions"></a>
@@ -107,7 +118,7 @@ OVHcloud offers 4 email solutions, and the concept of account deletion differs d
 Select the tab corresponding to your email solution:
 
 <ZoneTabs>
-  <Tab label="MX Plan Roundcube">
+  <Tab label="MX Plan Roundcube" availableIn={['eu']}>
     To identify the email technology associated with your MX Plan service, please refer to the "[Identifying the email technology of your MX Plan solution](#whichmxplan)" section of this guide.
     
     1. Go to the <code className="action">Email accounts</code> tab. The window that appears will display the existing email accounts.
@@ -115,7 +126,7 @@ Select the tab corresponding to your email solution:
     
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/email-mxplan-legacy-reset.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan Zimbra/OWA">
+  <Tab label="MX Plan">
     To identify the email technology associated with your MX Plan service, please refer to the "[Identifying the email technology of your MX Plan solution](#whichmxplan)" section of this guide.
     
     1. Go to the <code className="action">Email accounts</code> tab. The window that appears will display the existing email accounts.

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -92,16 +92,27 @@ For security reasons, we recommend not using the same password twice, and choosi
 
 <a name="whichmxplan"></a>
 
-:::info
-**Identify the email technology for your MX Plan solution.**
+**Identify the email technology for your MX Plan solution**
 
-Depending on the activation date of your MX Plan solution, or on a recent migration, the email technology associated with it may differ. This version is characterized by its webmail interface. To identify it:
+<Region zones={['eu']}>
 
-- In the <code className="action">General information</code> tab, note the technology used under the **Webmail** comment in the <code className="action">Subscription</code> or <code className="action">Connection</code> box.
+Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
 
-<img className="thumbnail" alt="mx plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/technology-email.png" loading="lazy" />Webmail
+- **Roundcube**: the original webmail, lightweight and easy to use.
+- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
+- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
 
-:::
+To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
+
+<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Access your email online, without installation, via the [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) webmail.
+
+</Region>
 
 
 Follow the instructions for your solution:
@@ -148,16 +159,37 @@ Click the <code className="action">...</code> button, then <code className="acti
 
 Changing your password via webmail is available for OVHcloud email offers using **OWA** (**O**utlook **W**eb **A**pp):
 
+<Region zones={['eu']}>
+
 - MX Plan OWA
 - Email Pro
 - Exchange
 - MX Plan Zimbra
 - Zimbra Starter / Pro
 
+</Region>
+
+<Region zones={['ca']}>
+
+- MX Plan OWA
+- Exchange
+
+</Region>
+
+<Region zones={['apac']}>
+
+- MX Plan OWA
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 For the **MX Plan Roundcube** solution, you can only change your password [via the OVHcloud Control Panel](#controlpanel).
 
 :::
+
+</Region>
 
 
 #### OWA
@@ -186,6 +218,8 @@ You will need to enter the new password in all email clients that access this ac
 
 <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/mxplan-password-new-step5.png" loading="lazy" />
 
+<Region zones={['eu']}>
+
 #### Zimbra
 
 Go to the [Webmail](https://www.ovhcloud.com/en-gb/mail/). Enter your email address and password, then click <code className="action">Login</code>.
@@ -193,6 +227,8 @@ Go to the [Webmail](https://www.ovhcloud.com/en-gb/mail/). Enter your email addr
 Click on the name of your email account in the top right-hand corner of your interface. From this menu, you can <code className="action">Change the password</code>.
 
 <img className="thumbnail" alt="Zimbra - preferences" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/zimbra-password.png" loading="lazy" />
+
+</Region>
 
 ### Retrieve a password
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -54,16 +54,27 @@ You have just purchased an MX Plan email solution. It allows you to benefit from
 
 **Continue with the email technology used by your MX Plan service**.
 
-:::info
-**Identify the email technology for your MX Plan solution.**
+**Identify the email technology for your MX Plan solution**
 
-Depending on the activation date of your MX Plan solution, or on a recent migration, the email technology associated with it may differ. This version is characterized by its webmail interface. To identify it:
+<Region zones={['eu']}>
 
-- In the <code className="action">General information</code> tab, note the technology used under the **Webmail** comment in the <code className="action">Subscription</code> box under <code className="action">Webmail</code>.
+Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation/technology-email.png" loading="lazy" />
+- **Roundcube**: the original webmail, lightweight and easy to use.
+- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
+- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
 
-:::
+To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
+
+<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Access your email online, without installation, via the [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) webmail.
+
+</Region>
 
 
 ### OWA and Zimbra
@@ -295,7 +306,14 @@ Below are the **SMTP** settings to use when sending emails:
 **Have you used all of the email addresses included in your solution?**
 
 - Refer to [our email FAQ](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails).
-- See all of our email solutions, [Zimbra](https://www.ovhcloud.com/en-gb/emails/zimbra-emails/) or [Exchange](https://www.ovhcloud.com/en-gb/emails-exchange/) to complete your MX Plan solution on the same domain name.
+
+<Region zones={['eu']}>
+See all of our email solutions, [Zimbra](https://www.ovhcloud.com/en-gb/emails/zimbra-emails/) or [Exchange](https://www.ovhcloud.com/en-gb/emails-exchange/), to complete your MX Plan solution on the same domain name.
+</Region>
+
+<Region zones={['ca']}>
+Discover our [Exchange](https://www.ovhcloud.com/en-gb/emails-exchange/) email solution to complete your MX Plan solution on the same domain name.
+</Region>
 
 ## Go further <a name="go-further"></a>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -44,16 +44,27 @@ If you have just purchased an MX Plan solution, this means you have email addres
 
 **Continue with the email technology used by your MX Plan service**.
 
-:::info
-**Identify the email technology for your MX Plan solution.**
+**Identify the email technology for your MX Plan solution**
 
-Depending on the activation date of your MX Plan solution, or on a recent migration, the email technology associated with it may differ. This version is characterized by its webmail interface. To identify it:
+<Region zones={['eu']}>
 
-- In the <code className="action">General information</code> tab, note the technology used under the **Webmail** mention in the <code className="action">Subscription</code> or <code className="action">Connection</code> box.
+Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
 
-<img className="thumbnail" alt="mx plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities/technology-email.png" loading="lazy" />
+- **Roundcube**: the original webmail, lightweight and easy to use.
+- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
+- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
 
-:::
+To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
+
+<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Access your email online, without installation, via the [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) webmail.
+
+</Region>
 
 
 **Contents**

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -19,19 +19,27 @@ With the OVHcloud MX Plan solution, you can send and receive emails from third-p
 - Access to the login details for the MX Plan email address you want to consult. For more information, see our guide [Getting started with the MX Plan solution](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Your OVHcloud **MX Plan** email solution must use the **Roundcube** webmail technology. To identify it, follow the instructions below.
 
-:::info
-**How do I identify the technology used on my MX Plan solution?**
+**Identify the email technology of your MX Plan offer**
 
-The email technology used for your MX Plan solution is identified by its webmail interface. To identify it from your Control Panel, follow this path:
+<Region zones={['eu']}>
 
-1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-1. Go to the <code className="action">Web Cloud</code> section.
-1. Click <code className="action">MX Plan</code>.
-1. Select the relevant domain.
-1. From the <code className="action">General information</code> tab (selected by default), check the technology used under the **Webmail** entry.
+Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube/technology-email.png" loading="lazy" />
-:::
+- **Roundcube**: the original webmail, lightweight and easy to use.
+- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
+- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
+
+To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
+
+<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Access your email online, without installation, via the [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) webmail.
+
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 ---

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -73,7 +73,15 @@ OVHcloud currently offers 4 email solutions. To understand their specifics, navi
     
     1. OVHcloud's oldest email solution, which includes the essential features of an email service with 5GB of storage space per email account.
     2. Included with web hosting plans and can be ordered via the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-    3. This offer is available in 3 different email technologies. **Roundcube**, **OWA** (Outlook Web App) and **Zimbra**.
+    3. This offer is available in the following webmail technologies:
+
+       <Region zones={['eu']}>
+       **Roundcube**, **OWA** (Outlook Web App) and **Zimbra**.
+       </Region>
+
+       <Region zones={['ca', 'apac']}>
+       **OWA** (Outlook Web App).
+       </Region>
   </Tab>
   <Tab label="Zimbra Mail" availableIn={['eu']}>
     <img className="thumbnail" alt="Zimbra Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/zimbra01.png" loading="lazy" />
@@ -134,12 +142,25 @@ Below is a summary table of key email features, sorted by technology and configu
 <summary>How do I identify the technology used on my **MX Plan** solution?</summary>
 
 
-The email technology used for your MX Plan solution is characterized by its webmail interface. To identify it via the OVHcloud Control Panel:
+<Region zones={['eu']}>
 
-1. From the <code className="action">General Information</code> tab, select by default.
-1. Note the technology used as **Webmail**.
+Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
 
-<img className="thumbnail" alt="MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/technology-email.png" loading="lazy" />
+- **Roundcube**: the original webmail, lightweight and easy to use.
+- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
+- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
+
+To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
+
+<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Access your email online, without installation, via the [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) webmail.
+
+</Region>
 
 </details>
 
@@ -390,7 +411,18 @@ If you have signed up to [one of our OVHcloud email solutions](https://www.ovhcl
 
 Want to change your [email solution](https://www.ovhcloud.com/en-gb/emails/) to get more space and features, but want to keep the content of your existing email account? To do this, please follow the migration guide that corresponds to your needs:
 
-- [Migrate an MX Plan email address to an Email Pro or Exchange account](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+<Region zones={['eu']}>
+
+[Migrate an MX Plan email address to an Email Pro or Exchange account](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+
+</Region>
+
+<Region zones={['ca']}>
+
+[Migrate an MX Plan email address to an Exchange account](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+
+</Region>
+
 - [Migrate your email addresses from one OVHcloud email platform to another](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
 - [Migrate your email address manually](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)
 - [Migrate email accounts via the OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud)

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -75,16 +75,27 @@ Every OVHcloud email account has a dedicated storage space. By managing your sto
 :::
 
 
-:::info
-**Identify the email technology for your MX Plan solution.**
+**Identify the email technology for your MX Plan solution**
 
-Depending on the activation date of your MX Plan solution, or on a recent migration, the email technology associated with it may differ. This version is characterized by its webmail interface. To identify it:
+<Region zones={['eu']}>
 
-- In the <code className="action">General information</code> tab, note the technology used under the **Webmail** comment in the <code className="action">Subscription</code> or <code className="action">Connection</code> box.
+Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
 
-<img className="thumbnail" alt="mx plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/technology-email.png" loading="lazy" />
+- **Roundcube**: the original webmail, lightweight and easy to use.
+- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
+- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
 
-:::
+To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
+
+<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Access your email online, without installation, via the [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) webmail.
+
+</Region>
 
 
 ## Instructions <a name="instructions"></a>
@@ -134,11 +145,11 @@ Go to the page [Webmail](https://www.ovhcloud.com/en-gb/mail/) and enter the log
     Click the gear icon on the top right and select <code className="action">Options</code>. Click <code className="action">My account</code> in the <code className="action">General</code> section in the left-hand column. You can view your account’s current quota in the lower right-hand corner of the form.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail01.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Roundcube: MX Plan">
+  <Tab label="Roundcube: MX Plan" availableIn={['eu']}>
     When you are logged in to the Roundcube webmail, the quota is visible on the lower left-hand side, represented by a circular diagram and the percentage used.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail02.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Zimbra: MX Plan / Zimbra Starter / Zimbra Pro">
+  <Tab label="Zimbra: MX Plan / Zimbra Starter / Zimbra Pro" availableIn={['eu']}>
     When you are logged in to the Zimbra webmail, click on the cogwheel (&#9881;) in the top right-hand corner of your interface, then click <code className="action">Settings</code>. In the <code className="action">General</code> tab, you can view the quota used under the heading “Storage space”.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail03.png" loading="lazy" />
   </Tab>
@@ -230,7 +241,7 @@ Below is a nonexhaustive list of configuration guides for email clients on compu
 </Region>
 
 <ZoneTabs>
-  <Tab label="MX Plan and Zimbra Starter">
+  <Tab label="MX Plan and Zimbra Starter" availableIn={['eu']}>
     Configuring an MX Plan account on **Windows**:<br/><br/>
     - [Windows 10 Mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10) (included with Windows)<br/>
     - [Outlook for MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016)
@@ -299,7 +310,15 @@ Select the current solution for your email account from the menu below:
 
 <ZoneTabs>
   <Tab label="MX Plan">
+    <Region zones={['eu']}>
     If your email account already has a maximum capacity of 5 GB, you can opt for a migration to a [10 GB **Email Pro** solution](https://www.ovhcloud.com/en-gb/emails/email-pro/) or a 50 GB [**Hosted Exchange** offer](https://www.ovhcloud.com/en-gb/emails/hosted-exchange/). To do this, please order the solution that suits your needs, and follow our guide on [Migrating an MX Plan email account to Email Pro or Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+    </Region>
+    <Region zones={['ca']}>
+    If your email account already has a maximum capacity of 5 GB, you can opt for a migration to a 50 GB [**Hosted Exchange** offer](https://www.ovhcloud.com/en-gb/emails/hosted-exchange/). To do this, please order the solution that suits your needs, and follow our guide on [Migrating an MX Plan email account to Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+    </Region>
+    <Region zones={['apac']}>
+    To increase your storage capacity, discover our [email solutions](https://www.ovhcloud.com/asia/emails/).
+    </Region>
   </Tab>
   <Tab label="Email Pro" availableIn={['eu']}>
     The Email Pro offer has a unique capacity of 10GB. You can choose to migrate to a [50 GB **Hosted Exchange** solution](https://www.ovhcloud.com/en-gb/emails/hosted-exchange/). To do this, order Hosted Exchange and follow our guide on [Migrating your email account from one OVHcloud email platform to another](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform).
@@ -320,7 +339,13 @@ In the <code className="action">Email accounts</code> tab on your Exchange platf
 
 ## Go further
 
+<Region zones={['eu']}>
 [Migrating an MX Plan email account to Email Pro or Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
+
+<Region zones={['ca']}>
+[Migrating an MX Plan email account to Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
 
 [Manually migrate your email account](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -8,6 +8,7 @@ availableIn: [eu, ca, apac]
 import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
+import { Region } from '@components/Zone';
 
 
 ## Objective
@@ -59,20 +60,27 @@ When your email address is blocked for spam, this means that suspicious activity
 
 Before continuing, if the block concerns an MX Plan email address, identify the email technology used by your solution in order to follow the correct unblocking process. For **Zimbra Starter** and **Zimbra Pro** solutions, go directly to the **Zimbra** tab in step 2, without skipping the checks in step 1.
 
-:::info
-**Identify the email technology of your MX Plan solution.**
+**Identify the email technology of your MX Plan solution**
 
-Depending on the activation date of your MX Plan solution or following a recent migration, the associated email technology may differ. This version is characterised by its webmail interface. To identify it:
+<Region zones={['eu']}>
 
-- From the <code className="action">General information</code> tab, check the technology used under the **Webmail** label in the <code className="action">Subscription</code> section.
+Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
 
-<img className="thumbnail" alt="Identifying the email technology in the MX Plan Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
+- **Roundcube**: the original webmail, lightweight and easy to use.
+- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
+- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
 
-- If the technology displayed is **Roundcube**, follow the instructions in the **MX Plan - Roundcube** tab.
-- If the technology displayed is **OWA** (Outlook Web App), follow the instructions in the **MX Plan - OWA** tab.
-- If the technology displayed is **Zimbra**, follow the instructions in the **Zimbra** tab (the procedure is common to MX Plan - Zimbra, Zimbra Starter and Zimbra Pro).
+To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
 
-:::
+<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Access your email online, without installation, via the [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) webmail.
+
+</Region>
 
 
 ### Step 1: Understand and address the cause of the block <a name="step1"></a>
@@ -149,7 +157,7 @@ Select the email solution concerned in the following tabs:
     
     <img className="thumbnail" alt="Status column Spam in the Email accounts tab for MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra">
+  <Tab label="Zimbra" availableIn={['eu']}>
     This tab applies to all addresses using the **Zimbra** technology: **MX Plan - Zimbra**, **Zimbra Starter** and **Zimbra Pro**. The unblocking process is identical for these three solutions.
 
     When the block is applied, **no support ticket is generated automatically** and the address is no longer accessible (Zimbra webmail and email sending are both disabled).
@@ -165,7 +173,7 @@ Select the email solution concerned in the following tabs:
 
     Once the ticket has been processed by support, the address is unblocked. [Step 3](#step3) does not apply in this case.
   </Tab>
-  <Tab label="MX Plan - Roundcube">
+  <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     If the block concerns an MX Plan email address with **Roundcube** webmail, no support ticket is generated.
 
     Before taking any action, it is **essential to identify the cause of the block** by carrying out the checks in [step 1](#step1) (potentially infected devices, third-party software, redirections, filters, auto-replies).

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -78,16 +78,27 @@ Quiere:
 
 <a name="whichmxplan"></a>
 
-:::info
-**Identificar la tecnología de correo de su solución MX Plan.**
+**Identificar la tecnología de correo de su solución MX Plan**
 
-En función de la fecha de activación de su solución MX Plan o de una migración reciente, la tecnología de correo electrónico asociada puede diferir. Esta tecnología se caracteriza por la interfaz de su webmail. Para identificarla:
+<Region zones={['eu']}>
 
-- Desde la pestaña <code className="action">Información general</code>, indique la tecnología utilizada en la mención **Webmail** presente en el recuadro <code className="action">Suscripción</code>.
+Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/technology-email.png" loading="lazy" />
+- **Roundcube**: el webmail original, ligero y fácil de usar.
+- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
+- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
 
-:::
+Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
+
+<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte su correo en línea, sin instalación, mediante el webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ## Procedimiento <a name="instructions"></a>
@@ -107,7 +118,7 @@ OVHcloud ofrece 4 soluciones de correo electrónico. El concepto de eliminación
 Seleccione la pestaña correspondiente a su servicio de correo:
 
 <ZoneTabs>
-  <Tab label="MX Plan Roundcube">
+  <Tab label="MX Plan Roundcube" availableIn={['eu']}>
     Para identificar la tecnología de correo electrónico asociada a su servicio MX Plan, consulte la sección "[Identificar la tecnología de correo de su solución MX Plan](#whichmxplan)" de esta guía.
     
     1. Abra la pestaña <code className="action">Cuentas de correo</code>. Se abrirá una ventana en la que se mostrarán las cuentas de correo existentes.
@@ -115,7 +126,7 @@ Seleccione la pestaña correspondiente a su servicio de correo:
     
     <img className="thumbnail" alt="Correo electrónico" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/email-mxplan-legacy-reset.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan Zimbra/OWA">
+  <Tab label="MX Plan">
     Para identificar la tecnología de correo electrónico asociada a su servicio MX Plan, consulte la sección "[Identificar la tecnología de correo de su solución MX Plan](#whichmxplan)" de esta guía.
     
     1. Abra la pestaña <code className="action">Cuentas de correo</code>. Se abrirá una ventana en la que se mostrarán las cuentas de correo existentes.

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -91,16 +91,27 @@ Por motivos de seguridad, le recomendamos que no utilice dos veces la misma cont
 
 <a name="whichmxplan"></a>
 
-:::info
-**Identificar la tecnología de correo electrónico de su solución MX Plan.**
+**Identificar la tecnología de correo electrónico de su solución MX Plan**
 
-En función de la fecha de activación de su MX Plan o de una migración reciente, la tecnología de correo asociada puede diferir. Esta versión se caracteriza por la interfaz de su webmail. Para identificarlo:
+<Region zones={['eu']}>
 
-- En la pestaña <code className="action">Información general</code>, consulte la tecnología utilizada bajo la mención **Webmail** que aparece en el recuadro <code className="action">Suscripción</code> o <code className="action">Webmail</code>.
+Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/technology-email.png" loading="lazy" />
+- **Roundcube**: el webmail original, ligero y fácil de usar.
+- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
+- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
 
-:::
+Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
+
+<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte su correo en línea, sin instalación, mediante el webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 Siga las indicaciones de su solución:
@@ -147,16 +158,37 @@ Haga clic en el botón <code className="action">...</code> y luego en <code clas
 
 La modificación de su contraseña a través del webmail está disponible para los servicios de correo electrónico de OVHcloud que utilizan **OWA** (**O**utlook **W**eb **A**pp):
 
+<Region zones={['eu']}>
+
 - MX Plan OWA
 - Email Pro
 - Exchange
 - MX Plan Zimbra
 - Zimbra Starter / Pro
 
+</Region>
+
+<Region zones={['ca']}>
+
+- MX Plan OWA
+- Exchange
+
+</Region>
+
+<Region zones={['apac']}>
+
+- MX Plan OWA
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 Para la solución **MX Plan Roundcube**, el cambio de contraseña solo se realiza [desde el área de cliente](#controlpanel).
 
 :::
+
+</Region>
 
 
 #### OWA
@@ -185,6 +217,8 @@ Recuerde que deberá introducir la nueva contraseña en todos los dispositivos e
 
 <img className="thumbnail" alt="Correo electrónico" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/mxplan-password-new-step5.png" loading="lazy" />
 
+<Region zones={['eu']}>
+
 #### Zimbra
 
 Acceda a la página [Webmail](https://www.ovhcloud.com/es-es/mail/). Introduzca su dirección de correo electrónico y la contraseña y haga clic en <code className="action">Conectar</code>.
@@ -192,6 +226,8 @@ Acceda a la página [Webmail](https://www.ovhcloud.com/es-es/mail/). Introduzca 
 Haga clic en el nombre de su cuenta de correo en la parte superior derecha de su interfaz. Desde este menú, podrá <code className="action">Cambiar la contraseña</code>.
 
 <img className="thumbnail" alt="Zimbra - preferencias" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/zimbra-password.png" loading="lazy" />
+
+</Region>
 
 ### Recupera una password
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -54,15 +54,27 @@ La solución MX Plan le permite disfrutar de direcciones de correo asociadas a u
 
 **Prosiga con la tecnología de correo electrónico que utiliza su servicio MX Plan**.
 
-:::info
-**Identificar la tecnología de correo electrónico de su solución MX Plan.**
+**Identificar la tecnología de correo electrónico de su solución MX Plan**
 
-En función de la fecha de activación de su MX Plan o de una migración reciente, la tecnología de correo asociada puede diferir. Esta versión se caracteriza por la interfaz de su webmail. Para identificarlo:
+<Region zones={['eu']}>
 
-- En la pestaña <code className="action">Información general</code>, consulte la tecnología utilizada bajo la mención **Webmail** que aparece en el recuadro <code className="action">Suscripción</code> en <code className="action">Webmail</code>.
+Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation/technology-email.png" loading="lazy" />
-:::
+- **Roundcube**: el webmail original, ligero y fácil de usar.
+- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
+- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
+
+Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
+
+<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte su correo en línea, sin instalación, mediante el webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 ### OWA y Zimbra
 
@@ -293,7 +305,14 @@ Para el envío de mensajes de correo, consulte a continuación los parámetros *
 **Ha utilizado todas las direcciones incluidas en su plan?**
 
 - Consulte las preguntas de [nuestras FAQ de correo](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails).
-- Consulte todos nuestros productos de correo electrónico [Zimbra](https://www.ovhcloud.com/es-es/emails/zimbra-emails/) o [Exchange](https://www.ovhcloud.com/es-es/emails-exchange/) para completar su MX Plan con el mismo dominio.
+
+<Region zones={['eu']}>
+Consulte todos nuestros productos de correo electrónico [Zimbra](https://www.ovhcloud.com/es-es/emails/zimbra-emails/) o [Exchange](https://www.ovhcloud.com/es-es/emails-exchange/) para completar su MX Plan con el mismo dominio.
+</Region>
+
+<Region zones={['ca']}>
+Descubra nuestro producto de correo electrónico [Exchange](https://www.ovhcloud.com/es-es/emails-exchange/) para completar su MX Plan con el mismo dominio.
+</Region>
 
 ## Más información <a name="go-further"></a>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -44,16 +44,27 @@ Usted acaba de adquirir una solución MX Plan que permite disfrutar de direccion
 
 **Prosiga con la tecnología de correo electrónico que utiliza su servicio MX Plan**.
 
-:::info
-**Identificar la tecnología de correo electrónico de su solución MX Plan.**
+**Identificar la tecnología de correo electrónico de su solución MX Plan**
 
-En función de la fecha de activación de su MX Plan o de una migración reciente, la tecnología de correo asociada puede diferir. Esta versión se caracteriza por la interfaz de su webmail. Para identificarlo:
+<Region zones={['eu']}>
 
-- En la pestaña <code className="action">Información general</code>, consulte la tecnología utilizada bajo la mención **Webmail** que aparece en el recuadro <code className="action">Suscripción</code> o <code className="action">Webmail</code>.
+Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities/technology-email.png" loading="lazy" />
+- **Roundcube**: el webmail original, ligero y fácil de usar.
+- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
+- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
 
-:::
+Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
+
+<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte su correo en línea, sin instalación, mediante el webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 **Contenido**

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -4,6 +4,8 @@ lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
+import { Region } from '@components/Zone';
+
 ## Objetivo
 
 Con la solución MX Plan de OVHcloud, puede enviar y recibir correos electrónicos desde un programa de terceros o a través de un webmail. OVHcloud ofrece un servicio de mensajería en línea llamado Roundcube que permite, mediante un navegador web, acceder a una cuenta de correo electrónico.
@@ -16,19 +18,27 @@ Con la solución MX Plan de OVHcloud, puede enviar y recibir correos electrónic
 - Disponer de los datos de conexión a la dirección de correo electrónico MX Plan que desea consultar. Para más información, consulte nuestra guía [Primeros pasos con la solución MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Su solución de correo electrónico **MX Plan** de OVHcloud debe utilizar la tecnología de webmail **Roundcube**. Para identificarla, siga las siguientes instrucciones.
 
-:::info
-**¿Cómo identificar la tecnología utilizada en mi solución MX Plan?**
+**Identificar la tecnología de correo electrónico de su solución MX Plan**
 
-La tecnología de correo electrónico utilizada para su solución MX Plan se caracteriza por la interfaz de su webmail. Para identificarla desde su área de cliente, siga la siguiente ruta:
+<Region zones={['eu']}>
 
-1. Conéctese a su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>.
-1. Acceda al apartado <code className="action">Web Cloud</code>.
-1. Haga clic en <code className="action">MX Plan</code>.
-1. Seleccione el dominio correspondiente.
-1. En la pestaña <code className="action">Información general</code> (seleccionada por defecto), revise la tecnología utilizada bajo la indicación **Webmail**.
+Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube/technology-email.png" loading="lazy" />
-:::
+- **Roundcube**: el webmail original, ligero y fácil de usar.
+- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
+- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
+
+Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
+
+<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte su correo en línea, sin instalación, mediante el webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 ---

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -73,7 +73,15 @@ OVHcloud ofrece actualmente 4 soluciones de correo. Para entender sus especifica
     
     1. La solución de correo electrónico más antigua de OVHcloud, que incluye las funciones esenciales de un servicio de correo con 5 GB de espacio de almacenamiento por cuenta de correo.
     2. Incluido con los planes de hosting, puede contratarlo desde el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>.
-    3. Esta oferta está disponible en tres tecnologías de correo diferentes. **Roundcube**, **OWA** (Outlook Web Access) y **Zimbra**.
+    3. Esta oferta está disponible en las siguientes tecnologías de webmail:
+
+       <Region zones={['eu']}>
+       **Roundcube**, **OWA** (Outlook Web Access) y **Zimbra**.
+       </Region>
+
+       <Region zones={['ca', 'apac']}>
+       **OWA** (Outlook Web Access).
+       </Region>
   </Tab>
   <Tab label="Zimbra Mail" availableIn={['eu']}>
     <img className="thumbnail" alt="Zimbra Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/zimbra01.png" loading="lazy" />
@@ -134,12 +142,25 @@ A continuación, se ofrece un resumen de las principales funcionalidades de corr
 <summary>¿Cómo identificar la tecnología utilizada en mi solución **MX Plan**?</summary>
 
 
-La tecnología de correo utilizada en su solución MX Plan se caracteriza por la interfaz de su webmail. Para identificarlo desde el área de cliente, acceda a la siguiente ruta:
+<Region zones={['eu']}>
 
-1. En la pestaña <code className="action">Información general</code>, seleccionada por defecto.
-1. Revise la tecnología utilizada en la etiqueta **Webmail**.
+Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/technology-email.png" loading="lazy" />
+- **Roundcube**: el webmail original, ligero y fácil de usar.
+- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
+- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
+
+Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
+
+<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte su correo en línea, sin instalación, mediante el webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 </details>
 
@@ -386,7 +407,18 @@ Si ha contratado [una de nuestras soluciones de correo de OVHcloud](https://www.
 
 ¿Quiere cambiar de [producto de correo](https://www.ovhcloud.com/es-es/emails/) para disfrutar de más espacio y funcionalidades, pero quiere conservar el contenido de su dirección existente? Para ello, puede consultar la guía de migración correspondiente a sus necesidades:
 
-- [Migrar una dirección de correo MX Plan a una cuenta Email Pro o Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+<Region zones={['eu']}>
+
+[Migrar una dirección de correo MX Plan a una cuenta Email Pro o Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+
+</Region>
+
+<Region zones={['ca']}>
+
+[Migrar una dirección de correo MX Plan a una cuenta Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+
+</Region>
+
 - [Migrar las direcciones de correo electrónico de una plataforma de correo de OVHcloud a otra](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
 - [Migrar manualmente una dirección de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration).
 - [Migrar cuentas de correo electrónico mediante OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -75,16 +75,27 @@ Cada cuenta de correo de OVHcloud dispone de un espacio de almacenamiento dedica
 :::
 
 
-:::info
-**Identificar la tecnología de correo electrónico de su solución MX Plan.**
+**Identificar la tecnología de correo electrónico de su solución MX Plan**
 
-En función de la fecha de activación de su MX Plan o de una migración reciente, la tecnología de correo asociada puede diferir. Esta versión se caracteriza por la interfaz de su webmail. Para identificarlo:
+<Region zones={['eu']}>
 
-- En la pestaña <code className="action">Información general</code>, consulte la tecnología utilizada bajo la mención **Webmail** que aparece en el recuadro <code className="action">Suscripción</code> o <code className="action">Webmail</code>.
+Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/technology-email.png" loading="lazy" />
+- **Roundcube**: el webmail original, ligero y fácil de usar.
+- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
+- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
 
-:::
+Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
+
+<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte su correo en línea, sin instalación, mediante el webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ## Procedimiento  <a name="instructions"></a>
@@ -134,11 +145,11 @@ Para conectarse al webmail, acceda a la página [Webmail](https://www.ovhcloud.c
     Haga clic en el botón <i className="icons-gear-concept icons-masterbrand-blue"></i> situado en la parte superior derecha de la pantalla y seleccione <code className="action">Opciones</code>. Haga clic en <code className="action">Mi cuenta</code> en la sección <code className="action">General</code> de la columna izquierda. Puede ver el límite actual de su cuenta en la parte inferior derecha del formulario.<br/><br/>
     <img className="thumbnail" alt="Correo electrónico" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail01.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Roundcube: MX Plan">
+  <Tab label="Roundcube: MX Plan" availableIn={['eu']}>
     Cuando se conecta al webmail Roundcube, la cuota se muestra en la parte inferior izquierda, materializada en un diagrama circular y el porcentaje consumido.<br/><br/>
     <img className="thumbnail" alt="Correo electrónico" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail02.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Zimbra: MX Plan / Zimbra Starter / Zimbra Pro">
+  <Tab label="Zimbra: MX Plan / Zimbra Starter / Zimbra Pro" availableIn={['eu']}>
     Cuando se conecte al webmail Zimbra, haga clic en la rueda dentada ( &#9881;) en la parte superior derecha de su interfaz y, a continuación, haga clic en <code className="action">Parámetros</code>. En la pestaña <code className="action">General</code> de la columna izquierda, haga clic en  para consultar el "Almacenamiento".<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail03.png" loading="lazy" /><br/>
   </Tab>
@@ -230,7 +241,7 @@ A continuación ofrecemos una lista no exhaustiva de las guías de configuració
 </Region>
 
 <ZoneTabs>
-  <Tab label="MX Plan y Zimbra Starter">
+  <Tab label="MX Plan y Zimbra Starter" availableIn={['eu']}>
     Configuración de una cuenta MX Plan en **Windows**:<br/><br/>
     - [Correo en Windows 10](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10) (incluido con Windows)<br/>
     - [Outlook para MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016)
@@ -297,7 +308,15 @@ En el siguiente menú, seleccione la solución actual de su cuenta de correo:
 
 <ZoneTabs>
   <Tab label="MX Plan">
+    <Region zones={['eu']}>
+    Si su cuenta de correo ya tiene una capacidad máxima de 5 GB, puede optar por migrar a una solución [**Email Pro** de 10 GB](https://www.ovhcloud.com/es-es/emails/email-pro/) o [**Hosted Exchange** de 50 GB](https://www.ovhcloud.com/es-es/emails/hosted-exchange/). Para ello, puede contratar el servicio más adecuado y consultar nuestra guía [Migrar una dirección de correo MX Plan a una cuenta Email Pro o Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+    </Region>
+    <Region zones={['ca']}>
     Si su cuenta de correo ya tiene una capacidad máxima de 5 GB, puede optar por migrar a una solución [**Hosted Exchange** de 50 GB](https://www.ovhcloud.com/es-es/emails/hosted-exchange/). Para ello, puede contratar el servicio más adecuado y consultar nuestra guía [Migrar una dirección de correo MX Plan a una cuenta Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+    </Region>
+    <Region zones={['apac']}>
+    Para aumentar su capacidad de almacenamiento, descubra nuestras [soluciones de correo electrónico](https://www.ovhcloud.com/es-es/emails/).
+    </Region>
   </Tab>
   <Tab label="Email Pro" availableIn={['eu']}>
     El producto Email Pro dispone de una capacidad única de 10 GB. Puede migrar a un servicio [**Hosted Exchange** de 50 GB](https://www.ovhcloud.com/es-es/emails/hosted-exchange/) o [**Zimbra** de 50 GB](https://www.ovhcloud.com/es-es/emails/zimbra-emails/). Para ello, le invitamos a contratar el servicio que mejor se adapta a sus necesidades y a seguir nuestra guía «[Migrar sus direcciones de correo electrónico de una plataforma de correo de OVHcloud a otra](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform) ».
@@ -318,7 +337,13 @@ En la pestaña <code className="action">Cuentas de correo</code> de su plataform
 
 ## Más información
 
-[Migrar una cuenta MX Plan a una cuenta o Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+<Region zones={['eu']}>
+[Migrar una cuenta MX Plan a una cuenta Email Pro o Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
+
+<Region zones={['ca']}>
+[Migrar una cuenta MX Plan a una cuenta Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
 
 [Migrar manualmente una dirección de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -8,6 +8,7 @@ availableIn: [eu, ca, apac]
 import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
+import { Region } from '@components/Zone';
 
 
 ## Objetivo
@@ -59,20 +60,27 @@ Cuando su dirección de correo electrónico está bloqueada por spam, significa 
 
 Antes de continuar, y si el bloqueo afecta a una dirección de correo electrónico de tipo MX Plan, identifique la tecnología de correo electrónico utilizada por su plan para seguir el proceso de desbloqueo adecuado. Para los planes **Zimbra Starter** y **Zimbra Pro**, vaya directamente a la pestaña **Zimbra** de la etapa 2, sin omitir las comprobaciones de la etapa 1.
 
-:::info
 **Identificar la tecnología de correo electrónico de su plan MX Plan.**
 
-En función de la fecha de activación de su plan MX Plan o de una migración reciente, la tecnología de correo electrónico asociada puede variar. Esta versión se caracteriza por la interfaz de su webmail. Para identificarla:
+<Region zones={['eu']}>
 
-- Desde la pestaña <code className="action">Información general</code>, consulte la tecnología utilizada bajo la mención **Webmail** presente en el recuadro <code className="action">Suscripción</code>.
+Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
 
-<img className="thumbnail" alt="Identificar la tecnología de correo electrónico en el área de cliente MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
+- **Roundcube**: el webmail original, ligero y fácil de usar.
+- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
+- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
 
-- Si la tecnología que se muestra es **Roundcube**, siga las instrucciones de la pestaña **MX Plan - Roundcube**.
-- Si la tecnología que se muestra es **OWA** (Outlook Web App), siga las instrucciones de la pestaña **MX Plan - OWA**.
-- Si la tecnología que se muestra es **Zimbra**, siga las instrucciones de la pestaña **Zimbra** (procedimiento común a MX Plan - Zimbra, Zimbra Starter y Zimbra Pro).
+Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
 
-:::
+<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte su correo en línea, sin instalación, mediante el webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ### Etapa 1: comprender y tratar la causa del bloqueo <a name="step1"></a>
@@ -149,7 +157,7 @@ Seleccione el plan de correo electrónico correspondiente en las siguientes pest
     
     <img className="thumbnail" alt="Columna estado Spam en la pestaña Cuentas de correo MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra">
+  <Tab label="Zimbra" availableIn={['eu']}>
     Esta pestaña se aplica a todas las direcciones que utilizan la tecnología **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** y **Zimbra Pro**. El proceso de desbloqueo es idéntico para estos tres planes.
 
     En el momento del bloqueo, **no se genera ningún tique de asistencia automáticamente** y la dirección deja de ser accesible (webmail Zimbra y envío desactivados).
@@ -165,7 +173,7 @@ Seleccione el plan de correo electrónico correspondiente en las siguientes pest
 
     Una vez que el soporte tramite el tique, la dirección se desbloqueará. La [etapa 3](#step3) no se aplica en este caso.
   </Tab>
-  <Tab label="MX Plan - Roundcube">
+  <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     Si el bloqueo afecta a una dirección de correo electrónico MX Plan con el webmail **Roundcube**, no se genera ningún tique de asistencia.
 
     Antes de cualquier acción, es **imprescindible identificar la causa del bloqueo** realizando las comprobaciones de la [etapa 1](#step1) (equipos potencialmente infectados, programas de terceros, redirecciones, filtros, respuestas automáticas).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -78,16 +78,27 @@ Vous souhaitez :
 
 <a name="whichmxplan"></a>
 
-:::info
-**Identifier la technologie e-mail de votre offre MX Plan.**
+**Identifier la technologie e-mail de votre offre MX Plan**
 
-En fonction de la date d’activation de votre offre MX Plan ou d’une migration récente, la technologie e-mail associée peut différer. Cette technologie est caractérisée par l'interface de son webmail. Pour l'identifier :
+<Region zones={['eu']}>
 
-- Depuis l'onglet <code className="action">Informations générales</code>, relevez la technologie utilisée sous la mention **Webmail** présente dans l'encadré <code className="action">Abonnement</code>.
+Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/technology-email.png" loading="lazy" />
+- **Roundcube** : le webmail historique, léger et simple d'utilisation.
+- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
+- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
 
-:::
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+
+<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultez votre messagerie en ligne, sans installation, via le webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ## En pratique <a name="instructions"></a>
@@ -107,7 +118,7 @@ OVHcloud propose 4 solutions e-mail, la notion de suppression de compte est diff
 Sélectionnez l'onglet correspondant à votre offre e-mail :
 
 <ZoneTabs>
-  <Tab label="MX Plan Roundcube">
+  <Tab label="MX Plan Roundcube" availableIn={['eu']}>
     Pour identifier la technologie e-mail associée à votre service MX Plan, référez-vous à la partie « [Identifier la technologie e-mail de votre offre MX Plan](#whichmxplan) » de ce guide.
     
     1. Positionnez-vous sur l'onglet <code className="action">Comptes e-mail</code>. La fenêtre qui apparaît affiche les comptes e-mail existants.
@@ -115,7 +126,7 @@ Sélectionnez l'onglet correspondant à votre offre e-mail :
     
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/email-mxplan-legacy-reset.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan Zimbra/OWA">
+  <Tab label="MX Plan">
     Pour identifier la technologie e-mail associée à votre service MX Plan, référez-vous à la partie « [Identifier la technologie e-mail de votre offre MX Plan](#whichmxplan) » de ce guide.
     
     1. Positionnez-vous sur l'onglet <code className="action">Comptes e-mail</code>. La fenêtre qui apparaît affiche les comptes e-mail existants.

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -92,16 +92,27 @@ Pour des raisons de sécurité, nous vous recommandons de ne pas utiliser deux f
 
 <a name="whichmxplan"></a>
 
-:::info
-**Identifier la technologie e-mail de votre offre MX Plan.**
+**Identifier la technologie e-mail de votre offre MX Plan**
 
-En fonction de la date d’activation de votre offre MX Plan ou d’une migration récente, la technologie e-mail associée peut différer. Celle-ci est caractérisée par l'interface de son webmail. Pour l'identifier :
+<Region zones={['eu']}>
 
-- Depuis l'onglet <code className="action">Informations Générales</code>, relevez la technologie utilisée sous la mention **Webmail** présente dans l'encadré <code className="action">Abonnement</code> sous <code className="action">Webmail</code>.
+Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/technology-email.png" loading="lazy" />
+- **Roundcube** : le webmail historique, léger et simple d'utilisation.
+- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
+- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
 
-:::
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+
+<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultez votre messagerie en ligne, sans installation, via le webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 Suivez les instructions selon votre offre :
@@ -148,16 +159,37 @@ Cliquez sur le bouton <code className="action">...</code> puis sur <code classNa
 
 La modification de votre mot de passe via le webmail est disponible pour les offres email OVHcloud utilisant **OWA** (**O**utlook **W**eb **A**pp) et Zimbra :
 
+<Region zones={['eu']}>
+
 - MX Plan OWA
 - Email Pro
 - Exchange
 - MX Plan Zimbra
 - Zimbra Starter / Pro
 
+</Region>
+
+<Region zones={['ca']}>
+
+- MX Plan OWA
+- Exchange
+
+</Region>
+
+<Region zones={['apac']}>
+
+- MX Plan OWA
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 Pour l'offre **MX Plan Roundcube** le changement de mot de passe se fait uniquement [via l'espace client](#controlpanel).
 
 :::
+
+</Region>
 
 
 #### OWA
@@ -186,6 +218,8 @@ Vous devrez renseigner le nouveau mot de passe sur tous les appareils où l’ad
 
 <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/mxplan-password-new-step5.png" loading="lazy" />
 
+<Region zones={['eu']}>
+
 #### Zimbra
 
 Rendez-vous sur la page [Webmail](https://www.ovhcloud.com/fr/mail/). Saisissez votre adresse e-mail et le mot de passe puis cliquez sur <code className="action">Connexion</code>.
@@ -193,6 +227,8 @@ Rendez-vous sur la page [Webmail](https://www.ovhcloud.com/fr/mail/). Saisissez 
 Cliquez sur le nom de votre compte e-mail dans la partie supérieure droite de votre interface. Depuis ce menu, vous pourrez <code className="action">Changer le mot de passe</code>.
 
 <img className="thumbnail" alt="Zimbra - préférences" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/zimbra-password.png" loading="lazy" />
+
+</Region>
 
 ### Récupérer un mot de passe
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -54,16 +54,27 @@ Vous venez d'acquérir une solution e-mail MX Plan. Celle-ci vous permet de bén
 
 **Poursuivez selon la technologie e-mail utilisée par votre service MX Plan**.
 
-:::info
-**Identifier la technologie e-mail de votre offre MX Plan.**
+**Identifier la technologie e-mail de votre offre MX Plan**
 
-En fonction de la date d’activation de votre offre MX Plan ou d’une migration récente, la technologie e-mail associée peut différer. Cette version est caractérisée par l'interface de son webmail. Pour l'identifier :
+<Region zones={['eu']}>
 
-- Depuis l'onglet <code className="action">Informations Générales</code>, relevez la technologie utilisée sous la mention **Webmail** présente dans l'encadré <code className="action">Abonnement</code> sous <code className="action">Webmail</code>.
+Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation/technology-email.png" loading="lazy" />
+- **Roundcube** : le webmail historique, léger et simple d'utilisation.
+- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
+- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
 
-:::
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+
+<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultez votre messagerie en ligne, sans installation, via le webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ### OWA et Zimbra
@@ -295,7 +306,14 @@ Pour l'envoi des e-mails, retrouvez ci-dessous les paramètres **SMTP** à utili
 **Vous avez utilisé toutes les adresses comprises dans votre offre ?**
 
 - Consultez les questions de [notre FAQ e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails).
-- Consultez l'ensemble de nos offres e-mail [Zimbra](https://www.ovhcloud.com/fr/emails/zimbra-emails/) ou [Exchange](https://www.ovhcloud.com/fr/emails-exchange/) pour compléter votre offre MX Plan sur le même nom de domaine.
+
+<Region zones={['eu']}>
+Consultez l'ensemble de nos offres e-mail [Zimbra](https://www.ovhcloud.com/fr/emails/zimbra-emails/) ou [Exchange](https://www.ovhcloud.com/fr/emails-exchange/) pour compléter votre offre MX Plan sur le même nom de domaine.
+</Region>
+
+<Region zones={['ca']}>
+Découvrez notre offre e-mail [Exchange](https://www.ovhcloud.com/fr/emails-exchange/) pour compléter votre offre MX Plan sur le même nom de domaine.
+</Region>
 
 ## Aller plus loin <a name="go-further"></a>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -44,16 +44,27 @@ Vous venez d'acquérir une solution MX Plan. Celle-ci vous permet de bénéficie
 
 **Poursuivez selon la technologie e-mail utilisée par votre service MX Plan**.
 
-:::info
-**Identifier la technologie e-mail de votre offre MX Plan.**
+**Identifier la technologie e-mail de votre offre MX Plan**
 
-En fonction de la date d’activation de votre offre MX Plan ou d’une migration récente, la technologie e-mail associée peut différer. Cette version est caractérisée par l'interface de son webmail. Pour l'identifier :
+<Region zones={['eu']}>
 
-- Depuis l'onglet <code className="action">Informations Générales</code>, relevez la technologie utilisée sous la mention **Webmail** présente dans l'encadré <code className="action">Abonnement</code> sous <code className="action">Webmail</code>.
+Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities/technology-email.png" loading="lazy" />
+- **Roundcube** : le webmail historique, léger et simple d'utilisation.
+- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
+- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
 
-:::
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+
+<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultez votre messagerie en ligne, sans installation, via le webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 **Sommaire**

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -4,6 +4,8 @@ lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
+import { Region } from '@components/Zone';
+
 ## Objectif
 
 Avec l'offre MX Plan OVHcloud, vous pouvez envoyer et recevoir des e-mails depuis un logiciel tiers ou via un webmail. OVHcloud fournit un service de messagerie en ligne appelé Roundcube qui permet, via un navigateur web, d'accéder à un compte e-mail.
@@ -16,19 +18,27 @@ Avec l'offre MX Plan OVHcloud, vous pouvez envoyer et recevoir des e-mails depui
 - Disposer des informations de connexion à l'adresse e-mail MX Plan que vous souhaitez consulter. Pour plus d'informations, consultez notre guide [Premiers pas avec l'offre MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Votre solution e-mail OVHcloud **MX Plan** doit utiliser la technologie webmail **Roundcube**. Pour l'identifier, suivez les instructions ci-dessous.
 
-:::info
-**Comment identifier la technologie utilisée sur mon offre MX Plan ?**
+**Identifier la technologie e-mail de votre offre MX Plan**
 
-La technologie e-mail utilisée pour votre offre MX Plan est caractérisée par l'interface de son webmail. Pour l'identifier depuis votre espace client suivez le chemin suivant :
+<Region zones={['eu']}>
 
-1. Connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
-1. Rendez-vous dans la partie <code className="action">Web Cloud</code>.
-1. Cliquez sur <code className="action">MX Plan</code>.
-1. Sélectionnez le domaine concerné.
-1. Depuis l'onglet <code className="action">Informations générales</code> (sélectionné par défaut), relevez la technologie utilisée sous la mention **Webmail**.
+Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube/technology-email.png" loading="lazy" />
-:::
+- **Roundcube** : le webmail historique, léger et simple d'utilisation.
+- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
+- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
+
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+
+<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultez votre messagerie en ligne, sans installation, via le webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 ---

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -73,7 +73,15 @@ OVHcloud propose actuellement 4 offres e-mail. Pour comprendre leurs spécificit
     
     1. L'offre e-mail la plus ancienne d'OVHcloud, qui comprend les fonctions essentielles d'un service e-mail avec 5 Go d'espace de stockage par compte e-mail.
     2. Incluse avec les offres d'hébergement web et peut être commandée via l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>.
-    3. Cette offre existe sous 3 technologies e-mail différentes. **Roundcube**, **OWA** (Outlook Web Access) et **Zimbra**.
+    3. Cette offre est disponible dans les technologies de webmail suivantes :
+
+       <Region zones={['eu']}>
+       **Roundcube**, **OWA** (Outlook Web Access) et **Zimbra**.
+       </Region>
+
+       <Region zones={['ca', 'apac']}>
+       **OWA** (Outlook Web Access).
+       </Region>
   </Tab>
   <Tab label="Zimbra Mail" availableIn={['eu']}>
     <img className="thumbnail" alt="Zimbra Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/zimbra01_fr.png" loading="lazy" />
@@ -134,12 +142,25 @@ Ci-dessous, vous trouverez un tableau récapitulatif des principales fonctionnal
 <summary>Comment identifier la technologie utilisée sur mon offre **MX Plan** ?</summary>
 
 
-La technologie e-mail utilisée pour votre offre MX Plan est caractérisée par l'interface de son webmail. Pour l'identifier depuis votre espace client :
+<Region zones={['eu']}>
 
-1. Depuis l'onglet <code className="action">Informations Générales</code>, sélectionné par défaut.
-1. Relevez la technologie utilisée sous la mention **Webmail**.
+Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/technology-email.png" loading="lazy" />
+- **Roundcube** : le webmail historique, léger et simple d'utilisation.
+- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
+- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
+
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+
+<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultez votre messagerie en ligne, sans installation, via le webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 </details>
 
@@ -390,7 +411,18 @@ Si vous avez souscrit à l'une de nos [offres e-mail OVHcloud](https://www.ovhcl
 
 Vous souhaitez changer d'[offre e-mail](https://www.ovhcloud.com/fr/emails/) pour bénéficier de plus d'espace et de fonctionnalités, mais vous souhaitez conserver le contenu de votre adresse existante ? Pour cela nous vous invitons à suivre le guide de migration correspondant à votre besoin :
 
-- [Migrer une adresse e-mail MX Plan vers un compte Email Pro ou Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+<Region zones={['eu']}>
+
+[Migrer une adresse e-mail MX Plan vers un compte Email Pro ou Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+
+</Region>
+
+<Region zones={['ca']}>
+
+[Migrer une adresse e-mail MX Plan vers un compte Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+
+</Region>
+
 - [Migrer vos adresses e-mail d'une plateforme e-mail OVHcloud vers une autre](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
 - [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration).
 - [Migrer des comptes e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -75,16 +75,27 @@ Chaque compte e-mail OVHcloud dispose d'un espace de stockage dédié. Bien gér
 :::
 
 
-:::info
-**Identifier la technologie e-mail de votre offre MX Plan.**
+**Identifier la technologie e-mail de votre offre MX Plan**
 
-En fonction de la date d’activation de votre offre MX Plan ou d’une migration récente, la technologie e-mail associée peut différer. Celle-ci est caractérisée par l'interface de son webmail. Pour l'identifier :
+<Region zones={['eu']}>
 
-- Depuis l'onglet <code className="action">Informations Générales</code>, relevez la technologie utilisée sous la mention **Webmail** présente dans l'encadré <code className="action">Abonnement</code> sous <code className="action">Webmail</code>.
+Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/technology-email.png" loading="lazy" />
+- **Roundcube** : le webmail historique, léger et simple d'utilisation.
+- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
+- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
 
-:::
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+
+<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultez votre messagerie en ligne, sans installation, via le webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ## En pratique <a name="instructions"></a>
@@ -134,11 +145,11 @@ Pour vous connecter au webmail, rendez-vous sur la page [Webmail](https://www.ov
     Cliquez sur le bouton <i className="icons-gear-concept icons-masterbrand-blue"></i> en haut à droite de votre écran, cliquez sur <code className="action">Options</code>. Cliquez sur <code className="action">Mon compte</code> dans la section <code className="action">Général</code> dans la colonne de gauche. Vous pouvez visualiser le quota actuel de votre compte dans la partie inférieure droite du formulaire.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail01.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Roundcube : MX Plan">
+  <Tab label="Roundcube : MX Plan" availableIn={['eu']}>
     Lorsque vous êtes connecté au webmail Roundcube, le quota est visible dans la partie inférieure gauche, matérialisé par un diagramme circulaire et le pourcentage consommé.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail02.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Zimbra : MX Plan / Zimbra Starter / Zimbra Pro">
+  <Tab label="Zimbra : MX Plan / Zimbra Starter / Zimbra Pro" availableIn={['eu']}>
     Lorsque vous êtes connecté au webmail Zimbra, cliquez sur la roue crantée &#9881; en haut à droite de votre interface, puis cliquez sur <code className="action">Paramètres</code>. Dans l'onglet <code className="action">Général</code>, le quota utilisé est visible sous la mention « Espace de rangement ».<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail03.png" loading="lazy" /><br/>
   </Tab>
@@ -230,7 +241,7 @@ Vous trouverez ci-dessous une liste non-exhaustive des guides de configuration p
 </Region>
 
 <ZoneTabs>
-  <Tab label="MX Plan et Zimbra Starter">
+  <Tab label="MX Plan et Zimbra Starter" availableIn={['eu']}>
     Configuration d'un compte MX Plan sur **Windows** :<br/><br/>
     - [Courrier sur Windows 10](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10) (inclus avec Windows)<br/>
     - [Outlook pour MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016)
@@ -299,7 +310,15 @@ Sélectionnez, dans le menu ci-dessous, l'offre actuelle de votre compte e-mail 
 
 <ZoneTabs>
   <Tab label="MX Plan">
+    <Region zones={['eu']}>
     Si la capacité de votre compte e-mail est déjà à son maximum de 5 Go, vous pouvez opter pour une migration vers une offre [**Email Pro** de 10 Go](https://www.ovhcloud.com/fr/emails/email-pro/), [**Hosted Exchange** de 50 Go](https://www.ovhcloud.com/fr/emails/hosted-exchange/) ou [**Zimbra** de 15 Go ou 50 Go](https://www.ovhcloud.com/fr/emails/zimbra-emails/). Pour cela, nous vous invitons à commander l'offre qui vous convient et suivre notre documentation « [Migrer une adresse e-mail MX Plan vers un compte Email Pro ou Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel) ».
+    </Region>
+    <Region zones={['ca']}>
+    Si la capacité de votre compte e-mail est déjà à son maximum de 5 Go, vous pouvez opter pour une migration vers une offre [**Hosted Exchange** de 50 Go](https://www.ovhcloud.com/fr/emails/hosted-exchange/). Pour cela, nous vous invitons à commander l'offre qui vous convient et suivre notre documentation « [Migrer une adresse e-mail MX Plan vers un compte Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel) ».
+    </Region>
+    <Region zones={['apac']}>
+    Pour augmenter votre capacité de stockage, découvrez nos [solutions e-mail](https://www.ovhcloud.com/fr/emails/).
+    </Region>
   </Tab>
   <Tab label="Email Pro" availableIn={['eu']}>
     L'offre Email Pro dispose d'une capacité unique de 10Go. Vous pouvez opter pour une migration vers une offre [**Hosted Exchange** de 50 Go](https://www.ovhcloud.com/fr/emails/hosted-exchange/) ou [**Zimbra** de 50 Go](https://www.ovhcloud.com/fr/emails/zimbra-emails/). Pour cela, nous vous invitons à commander l'offre qui vous convient et suivre notre documentation « [Migrer vos adresses e-mail d’une plateforme e-mail OVHcloud vers une autre](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform) ».
@@ -320,7 +339,13 @@ Depuis l'onglet <code className="action">Comptes e-mail</code> de votre platefor
 
 ## Aller plus loin
 
+<Region zones={['eu']}>
 [Migrer une adresse e-mail MX Plan vers un compte Email Pro ou Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
+
+<Region zones={['ca']}>
+[Migrer une adresse e-mail MX Plan vers un compte Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
 
 [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -8,6 +8,7 @@ availableIn: [eu, ca, apac]
 import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
+import { Region } from '@components/Zone';
 
 
 ## Objectif
@@ -59,20 +60,27 @@ Lorsque votre adresse e-mail est bloquée pour spam, cela signifie qu'une activi
 
 Avant de poursuivre et si le blocage concerne une adresse e-mail de type MX Plan, identifiez la technologie e-mail utilisée par votre offre pour suivre le bon processus de déblocage. Pour les offres **Zimbra Starter** et **Zimbra Pro**, rendez-vous directement à l'onglet **Zimbra** de l'étape 2, sans omettre les vérifications de l'étape 1.
 
-:::info
-**Identifier la technologie e-mail de votre offre MX Plan.**
+**Identifier la technologie e-mail de votre offre MX Plan**
 
-En fonction de la date d'activation de votre offre MX Plan ou d'une migration récente, la technologie e-mail associée peut différer. Cette version est caractérisée par l'interface de son webmail. Pour l'identifier :
+<Region zones={['eu']}>
 
-- Depuis l'onglet <code className="action">Informations générales</code>, relevez la technologie utilisée sous la mention **Webmail** présente dans l'encadré <code className="action">Abonnement</code>.
+Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
 
-<img className="thumbnail" alt="Identifier la technologie e-mail dans l'espace client MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
+- **Roundcube** : le webmail historique, léger et simple d'utilisation.
+- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
+- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
 
-- Si la technologie affichée est **Roundcube**, suivez les instructions de l'onglet **MX Plan - Roundcube**.
-- Si la technologie affichée est **OWA** (Outlook Web App), suivez les instructions de l'onglet **MX Plan - OWA**.
-- Si la technologie affichée est **Zimbra**, suivez les instructions de l'onglet **Zimbra** (procédure commune à MX Plan - Zimbra, Zimbra Starter et Zimbra Pro).
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
-:::
+<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultez votre messagerie en ligne, sans installation, via le webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ### Étape 1 : comprendre et traiter la cause du blocage <a name="step1"></a>
@@ -149,7 +157,7 @@ Sélectionnez l'offre e-mail concernée dans les onglets suivants :
     
     <img className="thumbnail" alt="Colonne statut Spam dans l'onglet Comptes e-mail MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra">
+  <Tab label="Zimbra" availableIn={['eu']}>
     Cet onglet s'applique à toutes les adresses utilisant la technologie **Zimbra** : **MX Plan - Zimbra**, **Zimbra Starter** et **Zimbra Pro**. Le processus de déblocage est identique pour ces trois offres.
 
     Lors du blocage, **aucun ticket d'assistance n'est généré automatiquement** et l'adresse n'est plus accessible (webmail Zimbra et envoi désactivés).
@@ -165,7 +173,7 @@ Sélectionnez l'offre e-mail concernée dans les onglets suivants :
 
     Une fois le ticket traité par le support, l'adresse est débloquée. L'[étape 3](#step3) ne s'applique pas dans ce cas.
   </Tab>
-  <Tab label="MX Plan - Roundcube">
+  <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     Si le blocage concerne une adresse e-mail MX Plan avec le webmail **Roundcube**, aucun ticket d'assistance n'est généré.
 
     Avant toute action, il est **indispensable d'identifier la cause du blocage** en réalisant les vérifications de [l'étape 1](#step1) (postes potentiellement infectés, logiciels tiers, redirections, filtres, réponses automatiques).

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -78,16 +78,27 @@ Vuoi:
 
 <a name="whichmxplan"></a>
 
-:::info
-**Identificare la tecnologia email della tua offerta MX Plan.**
+**Identificare la tecnologia email della tua offerta MX Plan**
 
-In base alla data di attivazione della tua offerta MX Plan o a una migrazione recente, la tecnologia email associata può differire. Questa tecnologia è caratterizzata dall'interfaccia del suo webmail. Per identificarla:
+<Region zones={['eu']}>
 
-- Dalla scheda <code className="action">Informazioni generali</code>, rileva la tecnologia utilizzata sotto la dicitura **Webmail** presente nel riquadro <code className="action">Abbonamento</code>.
+In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/technology-email.png" loading="lazy" />
+- **Roundcube**: la webmail storica, leggera e semplice da usare.
+- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
+- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
 
-:::
+Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
+
+<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultate la posta elettronica online, senza installazione, tramite la webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ## Procedura <a name="instructions"></a>
@@ -107,7 +118,7 @@ OVHcloud propone 4 soluzioni email, la nozione di eliminazione di un account è 
 Seleziona la scheda corrispondente al tuo servizio di posta:
 
 <ZoneTabs>
-  <Tab label="MX Plan Roundcube">
+  <Tab label="MX Plan Roundcube" availableIn={['eu']}>
     Per identificare la tecnologia email associata al tuo servizio MX Plan, fai riferimento alla sezione "[Identificare la tecnologia email della tua offerta MX Plan](#whichmxplan)" di questa guida.
     
     1. Clicca sulla scheda <code className="action">Account email</code>. Visualizzi una finestra con tutti gli account email esistenti.
@@ -115,7 +126,7 @@ Seleziona la scheda corrispondente al tuo servizio di posta:
     
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/email-mxplan-legacy-reset.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan Zimbra/OWA">
+  <Tab label="MX Plan">
     Per identificare la tecnologia email associata al tuo servizio MX Plan, fai riferimento alla sezione "[Identificare la tecnologia email della tua offerta MX Plan](#whichmxplan)" di questa guida.
     
     1. Clicca sulla scheda <code className="action">Account email</code>. Visualizzi una finestra con tutti gli account email esistenti.

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -91,16 +91,27 @@ Per motivi di sicurezza, ti consigliamo di non utilizzare due volte la stessa pa
 
 <a name="whichmxplan"></a>
 
-:::info
-**Identificare la tecnologia di posta elettronica della soluzione MX Plan.**
+**Identificare la tecnologia di posta elettronica della soluzione MX Plan**
 
-In base alla data di attivazione del servizio MX Plan o a una migrazione recente, la tecnologia di posta associata potrebbe variare. Questa versione è caratterizzata dall'interfaccia della sua Webmail. Per identificarlo:
+<Region zones={['eu']}>
 
-- Nella scheda <code className="action">Informazioni generali</code>, rileggi la tecnologia utilizzata sotto la dicitura **Webmail** presente nel riquadro <code className="action">Abbonamento</code> o <code className="action">Webmail</code>.
+In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/technology-email.png" loading="lazy" />
+- **Roundcube**: la webmail storica, leggera e semplice da usare.
+- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
+- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
 
-:::
+Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
+
+<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultate la posta elettronica online, senza installazione, tramite la webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 Segui le indicazioni fornite:
@@ -147,16 +158,37 @@ Clicca sul pulsante <code className="action">...</code> e poi su <code className
 
 La modifica della password tramite la Webmail è disponibile per le soluzioni email OVHcloud che utilizzano **OWA** (**O**utlook **W**eb **A**pp):
 
+<Region zones={['eu']}>
+
 - MX Plan OWA
 - Email Pro
 - Exchange
 - MX Plan Zimbra
 - Zimbra Starter / Pro
 
+</Region>
+
+<Region zones={['ca']}>
+
+- MX Plan OWA
+- Exchange
+
+</Region>
+
+<Region zones={['apac']}>
+
+- MX Plan OWA
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 Per l'offerta **MX Plan Roundcube**, la modifica della password avviene esclusivamente [dallo Spazio Cliente](#controlpanel).
 
 :::
+
+</Region>
 
 
 #### OWA
@@ -185,6 +217,8 @@ Se imposti una nuova password per il tuo account, sarà necessario apportare la 
 
 <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/mxplan-password-new-step5.png" loading="lazy" />
 
+<Region zones={['eu']}>
+
 #### Zimbra
 
 Accedi alla pagina [Webmail](https://www.ovhcloud.com/it/mail/). Inserisci il tuo indirizzo e-mail e la password, poi clicca su <code className="action">Connessione</code>.
@@ -192,6 +226,8 @@ Accedi alla pagina [Webmail](https://www.ovhcloud.com/it/mail/). Inserisci il tu
 Clicca sul nome del tuo account email nell’angolo in alto a destra. Da questo menu è possibile <code className="action">Modificare la password</code>.
 
 <img className="thumbnail" alt="Zimbra - preferenze" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/zimbra-password.png" loading="lazy" />
+
+</Region>
 
 ### Recupera una password
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -54,15 +54,27 @@ Una soluzione email MX Plan è stata appena creata per usufruire di indirizzi em
 
 **Prosegui nella lettura di questa guida in base alla tecnologia utilizzata dal tuo servizio MX Plan**.
 
-:::info
-**Identificare la tecnologia di posta elettronica della soluzione MX Plan.**
+**Identificare la tecnologia di posta elettronica della soluzione MX Plan**
 
-In base alla data di attivazione del servizio MX Plan o a una migrazione recente, la tecnologia di posta associata potrebbe variare. Questa versione è caratterizzata dall'interfaccia della sua Webmail. Per identificarlo:
+<Region zones={['eu']}>
 
-- Nella scheda <code className="action">Informazioni generali</code>, indica la tecnologia utilizzata sotto la voce **Webmail** presente nel riquadro <code className="action">Abbonamento</code> sotto <code className="action">Webmail</code>.
+In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation/technology-email.png" loading="lazy" />
-:::
+- **Roundcube**: la webmail storica, leggera e semplice da usare.
+- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
+- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
+
+Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
+
+<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultate la posta elettronica online, senza installazione, tramite la webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 ### OWA e Zimbra
 
@@ -293,7 +305,14 @@ Di seguito sono riportati i parametri **SMTP** da utilizzare per l’invio delle
 **Hai utilizzato tutti gli indirizzi inclusi nella tua offerta?**
 
 - Consulta le domande della [nostra FAQ e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails).
-- Consulta tutte le nostre soluzioni email [Zimbra](https://www.ovhcloud.com/it/emails/zimbra-emails/) o [Exchange](https://www.ovhcloud.com/it/emails-exchange/) per completare la soluzione MX Plan sullo stesso dominio.
+
+<Region zones={['eu']}>
+Consulta tutte le nostre soluzioni email [Zimbra](https://www.ovhcloud.com/it/emails/zimbra-emails/) o [Exchange](https://www.ovhcloud.com/it/emails-exchange/) per completare la soluzione MX Plan sullo stesso dominio.
+</Region>
+
+<Region zones={['ca']}>
+Scopri la nostra soluzione email [Exchange](https://www.ovhcloud.com/it/emails-exchange/) per completare la soluzione MX Plan sullo stesso dominio.
+</Region>
 
 ## Per saperne di più <a name="go-further"></a>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -44,16 +44,27 @@ La soluzione MX Plan di OVHcloud con cui potrai inviare e ricevere messaggi dal 
 
 **Prosegui nella lettura di questa guida in base alla tecnologia utilizzata dal tuo servizio MX Plan**.
 
-:::info
-**Identificare la tecnologia di posta elettronica della soluzione MX Plan.**
+**Identificare la tecnologia di posta elettronica della soluzione MX Plan**
 
-In base alla data di attivazione del servizio MX Plan o a una migrazione recente, la tecnologia di posta associata potrebbe variare. Questa versione è caratterizzata dall'interfaccia della sua Webmail. Per identificarlo:
+<Region zones={['eu']}>
 
-- Nella scheda <code className="action">Informazioni generali</code>, rileggi la tecnologia utilizzata sotto la dicitura **Webmail** presente nel riquadro <code className="action">Abbonamento</code> o <code className="action">Webmail</code>.
+In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities/technology-email.png" loading="lazy" />
+- **Roundcube**: la webmail storica, leggera e semplice da usare.
+- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
+- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
 
-:::
+Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
+
+<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultate la posta elettronica online, senza installazione, tramite la webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 **Riepilogo**

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -4,6 +4,8 @@ lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
+import { Region } from '@components/Zone';
+
 ## Obiettivo
 
 Con la soluzione MX Plan OVHcloud, puoi inviare e ricevere e-mail da un software di terze parti o tramite una webmail. OVHcloud fornisce un servizio di messaggistica online chiamato Roundcube che permette, tramite un browser web, di accedere a un account e-mail.
@@ -16,19 +18,27 @@ Con la soluzione MX Plan OVHcloud, puoi inviare e ricevere e-mail da un software
 - Disporre delle informazioni di connessione all'indirizzo e-mail MX Plan che desideri consultare. Per maggiori informazioni, consulta la nostra guida [Iniziare a utilizzare la soluzione MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - La tua soluzione e-mail OVHcloud **MX Plan** deve utilizzare la tecnologia webmail **Roundcube**. Per identificarla, segui le istruzioni riportate di seguito.
 
-:::info
-**Come identificare la tecnologia utilizzata sulla mia offerta MX Plan?**
+**Identificare la tecnologia email della vostra offerta MX Plan**
 
-La tecnologia e-mail utilizzata per la tua offerta MX Plan è caratterizzata dall'interfaccia della sua webmail. Per identificarla dal tuo Spazio Cliente, segui questo percorso:
+<Region zones={['eu']}>
 
-1. Accedi al tuo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>.
-1. Accedi alla sezione <code className="action">Web Cloud</code>.
-1. Clicca su <code className="action">MX Plan</code>.
-1. Seleziona il dominio interessato.
-1. Dalla scheda <code className="action">Informazioni generali</code> (selezionata di default), individua la tecnologia utilizzata sotto la voce **Webmail**.
+In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube/technology-email.png" loading="lazy" />
-:::
+- **Roundcube**: la webmail storica, leggera e semplice da usare.
+- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
+- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
+
+Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
+
+<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultate la posta elettronica online, senza installazione, tramite la webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 ---

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -73,7 +73,15 @@ OVHcloud propone attualmente 4 offerte email. Per comprenderne le specificità, 
     
     1. Il servizio email più datato di OVHcloud, che include le funzioni essenziali di un servizio di posta con 5 GB di spazio di storage per ogni account email.
     2. Incluso nelle offerte di hosting Web e può essere ordinato dallo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>.
-    3. Questa soluzione è disponibile con 3 diverse tecnologie di posta. **Roundcube**, **OWA** (Outlook Web Access) e **Zimbra**.
+    3. Questa soluzione è disponibile con le seguenti tecnologie di Webmail:
+
+       <Region zones={['eu']}>
+       **Roundcube**, **OWA** (Outlook Web Access) e **Zimbra**.
+       </Region>
+
+       <Region zones={['ca', 'apac']}>
+       **OWA** (Outlook Web Access).
+       </Region>
   </Tab>
   <Tab label="Zimbra Mail" availableIn={['eu']}>
     <img className="thumbnail" alt="Zimbra Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/zimbra01.png" loading="lazy" />
@@ -134,12 +142,25 @@ Di seguito trovi una tabella riassuntiva delle principali funzionalità email, o
 <summary>Come identificare la tecnologia utilizzata sulla tua offerta **MX Plan**?</summary>
 
 
-La tecnologia di posta utilizzata per il servizio MX Plan è caratterizzata dall’interfaccia della sua Webmail. Per identificarlo dallo Spazio Cliente, segui questo percorso:
+<Region zones={['eu']}>
 
-1. Nella scheda <code className="action">Informazioni generali</code>, selezionata di default.
-1. Aumenta la tecnologia utilizzata sotto la voce **Webmail**.
+In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/technology-email.png" loading="lazy" />
+- **Roundcube**: la webmail storica, leggera e semplice da usare.
+- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
+- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
+
+Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
+
+<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultate la posta elettronica online, senza installazione, tramite la webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 </details>
 
@@ -386,7 +407,18 @@ Se hai attivato una delle nostre [soluzioni email OVHcloud](https://www.ovhcloud
 
 Per modificare il tuo [servizio di posta](https://www.ovhcloud.com/it/emails/) e usufruire di più spazio e funzionalità, conserva il contenuto del tuo indirizzo esistente. Per effettuare questa operazione, consulta le nostre guide alla migrazione:
 
-- [Migrare un indirizzo email MX Plan verso un account Email Pro o Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+<Region zones={['eu']}>
+
+[Migrare un indirizzo email MX Plan verso un account Email Pro o Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+
+</Region>
+
+<Region zones={['ca']}>
+
+[Migrare un indirizzo email MX Plan verso un account Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+
+</Region>
+
 - [Migrare gli indirizzi email da una piattaforma di posta elettronica OVHcloud a un’altra](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
 - [Migrare manualmente l’indirizzo email](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration).
 - [Migrare account email tramite OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -75,16 +75,27 @@ Ogni account email OVHcloud dispone di uno spazio di storage dedicato. Gestire c
 :::
 
 
-:::info
-**Identificare la tecnologia di posta elettronica della soluzione MX Plan.**
+**Identificare la tecnologia di posta elettronica della soluzione MX Plan**
 
-In base alla data di attivazione del servizio MX Plan o a una migrazione recente, la tecnologia di posta associata potrebbe variare. Questa versione è caratterizzata dall'interfaccia della sua Webmail. Per identificarlo:
+<Region zones={['eu']}>
 
-- Nella scheda <code className="action">Informazioni generali</code>, rileggi la tecnologia utilizzata sotto la dicitura **Webmail** presente nel riquadro <code className="action">Abbonamento</code> o <code className="action">Webmail</code>.
+In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/technology-email.png" loading="lazy" />
+- **Roundcube**: la webmail storica, leggera e semplice da usare.
+- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
+- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
 
-:::
+Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
+
+<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultate la posta elettronica online, senza installazione, tramite la webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ## Procedura <a name="instructions"></a>
@@ -134,11 +145,11 @@ Accedi alla Webmail, clicca sulla pagina [Webmail](https://www.ovhcloud.com/it/m
     Clicca sul pulsante <i className="icons-gear-concept icons-masterbrand-blue"></i>in alto a destra dello schermo e poi su <code className="action">Opzioni</code>. Clicca sul <code className="action">tuo account</code> nella sezione <code className="action">Generale</code> nella colonna di sinistra. Visualizza la quota attuale del tuo account nella parte inferiore destra del form.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail01.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Roundcube: MX Plan">
+  <Tab label="Roundcube: MX Plan" availableIn={['eu']}>
     Quando sei connesso alla Webmail Roundcube, la quota è visibile nella parte inferiore sinistra, materializzata da un camembert e la percentuale consumata.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail02.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Zimbra: MX Plan / Zimbra Starter / Zimbra Pro">
+  <Tab label="Zimbra: MX Plan / Zimbra Starter / Zimbra Pro" availableIn={['eu']}>
     Una volta connesso alla Webmail Zimbra, clicca sull’icona a forma di ingranaggio ( &#9881;) in alto a destra e poi clicca su <code className="action">Impostazioni</code>. Dalla scheda <code className="action">Generale</code> la quota utilizzata è visibile sotto la voce "Spazio di archiviazione".<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail03.png" loading="lazy" /><br/>
   </Tab>
@@ -230,7 +241,7 @@ Di seguito trovi una lista non esaustiva delle guide di configurazione per i cli
 </Region>
 
 <ZoneTabs>
-  <Tab label="MX Plan e Zimbra Starter">
+  <Tab label="MX Plan e Zimbra Starter" availableIn={['eu']}>
     Configurazione di un account MX Plan su **Windows**:<br/><br/>
     - [Posta su Windows 10](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10) (incluso con Windows)<br/>
     - [Outlook per MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016)
@@ -299,7 +310,15 @@ Seleziona l'offerta corrente del tuo account email nel menu qui sotto:
 
 <ZoneTabs>
   <Tab label="MX Plan">
-    Se la capacità del tuo account email è già al massimo di 5 GB, puoi optare per una migrazione verso un'offerta [**Email Pro** da 10 GB](https://www.ovhcloud.com/it/emails/email-pro/) o [**Hosted Exchange** da 50 GB](https://www.ovhcloud.com/it/emails/hosted-exchange/). Per effettuare questa operazione, puoi scegliere la soluzione più adatta alle tue esigenze e consultare la nostra guida [Migrare un indirizzo email MX Plan verso un account Email Pro o Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel). 
+    <Region zones={['eu']}>
+    Se la capacità del tuo account email è già al massimo di 5 GB, puoi optare per una migrazione verso un'offerta [**Email Pro** da 10 GB](https://www.ovhcloud.com/it/emails/email-pro/) o [**Hosted Exchange** da 50 GB](https://www.ovhcloud.com/it/emails/hosted-exchange/). Per effettuare questa operazione, puoi scegliere la soluzione più adatta alle tue esigenze e consultare la nostra guida [Migrare un indirizzo email MX Plan verso un account Email Pro o Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+    </Region>
+    <Region zones={['ca']}>
+    Se la capacità del tuo account email è già al massimo di 5 GB, puoi optare per una migrazione verso un'offerta [**Hosted Exchange** da 50 GB](https://www.ovhcloud.com/it/emails/hosted-exchange/). Per effettuare questa operazione, puoi scegliere la soluzione più adatta alle tue esigenze e consultare la nostra guida [Migrare un indirizzo email MX Plan verso un account Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+    </Region>
+    <Region zones={['apac']}>
+    Per aumentare la tua capacità di archiviazione, scopri le nostre [soluzioni email](https://www.ovhcloud.com/it/emails/).
+    </Region>
   </Tab>
   <Tab label="Email Pro" availableIn={['eu']}>
     L'offerta Email Pro dispone di una capacità unica di 10GB. È possibile optare per una migrazione verso un'offerta [**Hosted Exchange** da 50 GB](https://www.ovhcloud.com/it/emails/hosted-exchange/). Per effettuare questa operazione, puoi scegliere la soluzione più adatta alle tue esigenze e consultare la guida [Migrare i tuoi indirizzi email da una piattaforma OVHcloud verso un'altra](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform).
@@ -320,7 +339,13 @@ Nella scheda <code className="action">Account email</code> della piattaforma Exc
 
 ## Per saperne di più
 
+<Region zones={['eu']}>
 [Migrare un indirizzo email MX Plan verso un account Email Pro o Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
+
+<Region zones={['ca']}>
+[Migrare un indirizzo email MX Plan verso un account Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
 
 [Migra manualmente il tuo indirizzo email](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -8,6 +8,7 @@ availableIn: [eu, ca, apac]
 import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
+import { Region } from '@components/Zone';
 
 
 ## Obiettivo
@@ -59,20 +60,27 @@ Quando il tuo indirizzo e-mail viene bloccato per spam, significa che è stata r
 
 Prima di proseguire, se il blocco riguarda un indirizzo e-mail di tipo MX Plan, individua la tecnologia e-mail utilizzata dalla tua offerta per seguire la procedura di sblocco corretta. Per le offerte **Zimbra Starter** e **Zimbra Pro**, vai direttamente alla scheda **Zimbra** della fase 2, senza tralasciare le verifiche della fase 1.
 
-:::info
-**Individuare la tecnologia e-mail della tua offerta MX Plan.**
+**Individuare la tecnologia e-mail della tua offerta MX Plan**
 
-In base alla data di attivazione della tua offerta MX Plan o a una migrazione recente, la tecnologia e-mail associata può variare. Questa versione è caratterizzata dall'interfaccia del suo webmail. Per identificarla:
+<Region zones={['eu']}>
 
-- Dalla scheda <code className="action">Informazioni generali</code>, controlla la tecnologia utilizzata sotto la voce **Webmail** presente nel riquadro <code className="action">Abbonamento</code>.
+In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
 
-<img className="thumbnail" alt="Individuare la tecnologia e-mail nello Spazio Cliente MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
+- **Roundcube**: la webmail storica, leggera e semplice da usare.
+- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
+- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
 
-- Se la tecnologia visualizzata è **Roundcube**, segui le istruzioni della scheda **MX Plan - Roundcube**.
-- Se la tecnologia visualizzata è **OWA** (Outlook Web App), segui le istruzioni della scheda **MX Plan - OWA**.
-- Se la tecnologia visualizzata è **Zimbra**, segui le istruzioni della scheda **Zimbra** (procedura comune a MX Plan - Zimbra, Zimbra Starter e Zimbra Pro).
+Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
 
-:::
+<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consultate la posta elettronica online, senza installazione, tramite la webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ### Fase 1: comprendere e risolvere la causa del blocco <a name="step1"></a>
@@ -149,7 +157,7 @@ Seleziona l'offerta e-mail interessata nelle seguenti schede:
     
     <img className="thumbnail" alt="Colonna stato Spam nella scheda Account email MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra">
+  <Tab label="Zimbra" availableIn={['eu']}>
     Questa scheda si applica a tutti gli indirizzi che utilizzano la tecnologia **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** e **Zimbra Pro**. La procedura di sblocco è identica per queste tre offerte.
 
     Al momento del blocco, **non viene generato automaticamente alcun ticket di assistenza** e l'indirizzo non è più accessibile (webmail Zimbra e invio disattivati).
@@ -165,7 +173,7 @@ Seleziona l'offerta e-mail interessata nelle seguenti schede:
 
     Una volta elaborato il ticket dal supporto, l'indirizzo viene sbloccato. La [fase 3](#step3) non si applica in questo caso.
   </Tab>
-  <Tab label="MX Plan - Roundcube">
+  <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     Se il blocco riguarda un indirizzo e-mail MX Plan con il webmail **Roundcube**, non viene generato alcun ticket di assistenza.
 
     Prima di qualsiasi azione, è **indispensabile individuare la causa del blocco** eseguendo le verifiche della [fase 1](#step1) (postazioni potenzialmente infette, software di terze parti, reindirizzamenti, filtri, risposte automatiche).

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -78,16 +78,27 @@ Chcesz:
 
 <a name="whichmxplan"></a>
 
-:::info
-**Identyfikacja technologii e-mail Twojej oferty MX Plan.**
+**Identyfikacja technologii e-mail Twojej oferty MX Plan**
 
-W zależności od daty aktywacji Twojej oferty MX Plan lub niedawnej migracji, powiązana technologia e-mail może się różnić. Technologia ta charakteryzuje się interfejsem webmail. Aby ją zidentyfikować:
+<Region zones={['eu']}>
 
-- W zakładce <code className="action">Informacje ogólne</code> zanotuj używaną technologię pod wzmianką **Webmail** w ramce <code className="action">Abonament</code>.
+W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/technology-email.png" loading="lazy" />
+- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
+- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
+- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
 
-:::
+Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
+
+<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Sprawdzaj pocztę online, bez instalacji, przez webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ## W praktyce <a name="instructions"></a>
@@ -107,7 +118,7 @@ OVHcloud oferuje 4 rozwiązania poczty elektronicznej. Pojęcie usunięcia konta
 Wybierz kartę odpowiadającą Twojej usłudze e-mail:
 
 <ZoneTabs>
-  <Tab label="MX Plan Roundcube">
+  <Tab label="MX Plan Roundcube" availableIn={['eu']}>
     Aby zidentyfikować technologię e-mail związaną z Twoją usługą MX Plan, zapoznaj się z częścią "[Identyfikacja technologii e-mail Twojej oferty MX Plan](#whichmxplan)" tego przewodnika.
     
     1. Przejdź do zakładki <code className="action">Konta e-mail</code>. Pojawi się okno, w którym widoczne są istniejące konta e-mail.
@@ -115,7 +126,7 @@ Wybierz kartę odpowiadającą Twojej usłudze e-mail:
     
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/email-mxplan-legacy-reset.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan Zimbra/OWA">
+  <Tab label="MX Plan">
     Aby zidentyfikować technologię e-mail związaną z Twoją usługą MX Plan, zapoznaj się z częścią "[Identyfikacja technologii e-mail Twojej oferty MX Plan](#whichmxplan)" tego przewodnika.
     
     1. Przejdź do zakładki <code className="action">Konta e-mail</code>. Pojawi się okno, w którym widoczne są istniejące konta e-mail.

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -91,16 +91,27 @@ Ze względów bezpieczeństwa zalecamy nie używać dwa razy tego samego hasła.
 
 <a name="whichmxplan"></a>
 
-:::info
-**Sprawdzenie konfiguracji usługi MX Plan:**
+**Sprawdzenie konfiguracji usługi MX Plan**
 
-W zależności od daty aktywacji oferty MX Plan lub niedawnej migracji, przypisana technologia e-mail może się różnić. Wersja ta charakteryzuje się interfejsem webmaila. Aby ją zidentyfikować:
+<Region zones={['eu']}>
 
-- W zakładce <code className="action">Informacje ogólne</code> sprawdź technologię oznaczoną **Webmail** w ramce <code className="action">Subskrypcja</code> lub <code className="action">Logowanie</code>.
+W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/technology-email.png" loading="lazy" />
+- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
+- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
+- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
 
-:::
+Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
+
+<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Sprawdzaj pocztę online, bez instalacji, przez webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 Postępuj zgodnie z instrukcjami zawartymi w Twojej ofercie:
@@ -147,16 +158,37 @@ Kliknij przycisk <code className="action">...</code> następnie <code className=
 
 Zmiana hasła za pomocą interfejsu webmail jest dostępna w przypadku ofert e-mail OVHcloud wykorzystujących **OWA** (**O**utlook **W**eb **A**pp):
 
+<Region zones={['eu']}>
+
 - MX Plan OWA
 - E-mail Pro
 - Exchange
 - MX Plan Zimbra
 - Zimbra Starter / Pro
 
+</Region>
+
+<Region zones={['ca']}>
+
+- MX Plan OWA
+- Exchange
+
+</Region>
+
+<Region zones={['apac']}>
+
+- MX Plan OWA
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 W przypadku oferty **MX Plan Roundcube** zmiana hasła jest wykonywana tylko [w Panelu klienta](#controlpanel).
 
 :::
+
+</Region>
 
 
 #### OWA
@@ -185,6 +217,8 @@ Wprowadź nowe hasło na wszystkich urządzeniach, na których skonfigurowałeś
 
 <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/mxplan-password-new-step5.png" loading="lazy" />
 
+<Region zones={['eu']}>
+
 ### Zimbra
 
 Przejdź do strony [Webmail](https://www.ovhcloud.com/pl/mail/). Wpisz swój adres e-mail i hasło, a następnie kliknij <code className="action">Logowanie</code>.
@@ -192,6 +226,8 @@ Przejdź do strony [Webmail](https://www.ovhcloud.com/pl/mail/). Wpisz swój adr
 Kliknij nazwę konta e-mail w prawym górnym rogu interfejsu. W tym menu możesz <code className="action">Zmienić hasło</code>.
 
 <img className="thumbnail" alt="Zimbra - preferencje" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/zimbra-password.png" loading="lazy" />
+
+</Region>
 
 ### Odzyskiwanie hasła
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -54,16 +54,27 @@ Właśnie zakupiłeś usługę e-mail MX Plan. Umożliwia ona korzystanie z kont
 
 **Następnie postępuj zgodnie z technologią poczty elektronicznej używaną przez Twoją usługę MX Plan**.
 
-:::info
-**Sprawdzenie poprawności technologii poczty e-mail w usłudze MX Plan.**
+**Sprawdzenie poprawności technologii poczty e-mail w usłudze MX Plan**
 
-W zależności od daty aktywacji oferty MX Plan lub niedawnej migracji, przypisana technologia e-mail może się różnić. Wersja ta charakteryzuje się interfejsem webmaila. Aby ją zidentyfikować:
+<Region zones={['eu']}>
 
-- W zakładce <code className="action">Informacje ogólne</code> sprawdź technologię oznaczoną **Webmail** w ramce <code className="action">Subskrypcja</code> w sekcji <code className="action">Webmail</code>.
+W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation/technology-email.png" loading="lazy" />
+- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
+- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
+- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
 
-:::
+Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
+
+<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Sprawdzaj pocztę online, bez instalacji, przez webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ### OWA i Zimbra
@@ -295,7 +306,14 @@ Do wysyłki e-maili należy użyć następujących ustawień **SMTP**:
 **Czy wszystkie adresy e-mail zawarte w Twojej ofercie zostały wykorzystane?**
 
 - Sprawdź pytania dotyczące usługi [FAQ e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails).
-- Zapoznaj się z wszystkimi ofertami e-mail od OVH [Zimbra](https://www.ovhcloud.com/pl/emails/zimbra-emails/) lub [Exchange](https://www.ovhcloud.com/pl/emails-exchange/), aby uzupełnić ofertę MX Plan dla tej samej domeny.
+
+<Region zones={['eu']}>
+Zapoznaj się z wszystkimi ofertami e-mail od OVH [Zimbra](https://www.ovhcloud.com/pl/emails/zimbra-emails/) lub [Exchange](https://www.ovhcloud.com/pl/emails-exchange/), aby uzupełnić ofertę MX Plan dla tej samej domeny.
+</Region>
+
+<Region zones={['ca']}>
+Poznaj naszą ofertę e-mail [Exchange](https://www.ovhcloud.com/pl/emails-exchange/), aby uzupełnić ofertę MX Plan dla tej samej domeny.
+</Region>
 
 ## Sprawdź również <a name="go-further"></a>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -45,16 +45,27 @@ Właśnie zakupiłeś usługę MX Plan. Pozwala ona na korzystanie z kont e-mail
 1. Kliknij opcję <code className="action">MX Plan</code>.
 1. **Następnie postępuj zgodnie z technologią poczty elektronicznej używaną przez Twoją usługę MX Plan**.
 
-:::info
-**Sprawdzenie konfiguracji usługi MX Plan:**
+**Sprawdzenie konfiguracji usługi MX Plan**
 
-W zależności od daty aktywacji oferty MX Plan lub niedawnej migracji, przypisana technologia e-mail może się różnić. Wersja ta charakteryzuje się interfejsem webmaila. Aby ją zidentyfikować:
+<Region zones={['eu']}>
 
-- W zakładce <code className="action">Informacje ogólne</code> sprawdź technologię oznaczoną **Webmail** w ramce <code className="action">Subskrypcja</code> lub <code className="action">Logowanie</code>.
+W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities/technology-email.png" loading="lazy" />
+- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
+- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
+- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
 
-:::
+Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
+
+<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Sprawdzaj pocztę online, bez instalacji, przez webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 **Podsumowanie**

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -4,6 +4,8 @@ lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
+import { Region } from '@components/Zone';
+
 ## Wprowadzenie
 
 Dzięki rozwiązaniu OVHcloud MX Plan możesz wysyłać i odbierać e-maile za pośrednictwem programu pocztowego lub webmaila. OVHcloud udostępnia usługę poczty elektronicznej online o nazwie Roundcube, która pozwala na dostęp do konta e-mail za pośrednictwem przeglądarki internetowej.
@@ -16,19 +18,27 @@ Dzięki rozwiązaniu OVHcloud MX Plan możesz wysyłać i odbierać e-maile za p
 - Posiadanie danych logowania do adresu e-mail MX Plan, który chcesz sprawdzić. Więcej informacji znajdziesz w naszym przewodniku [Pierwsze kroki z rozwiązaniem MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Twoje rozwiązanie pocztowe OVHcloud **MX Plan** musi korzystać z technologii webmail **Roundcube**. Aby to sprawdzić, postępuj zgodnie z poniższymi wskazówkami.
 
-:::info
-**Jak rozpoznać technologię używaną w mojej usłudze MX Plan?**
+**Identyfikacja technologii e-mail oferty MX Plan**
 
-Technologia poczty używana dla Twojego rozwiązania MX Plan jest rozpoznawana po jej interfejsie webmail. Aby ją zidentyfikować z poziomu Panelu klienta, postępuj zgodnie z poniższą ścieżką:
+<Region zones={['eu']}>
 
-1. Zaloguj się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>.
-1. Przejdź do sekcji <code className="action">Web Cloud</code>.
-1. Kliknij <code className="action">MX Plan</code>.
-1. Wybierz odpowiednią domenę.
-1. Z poziomu zakładki <code className="action">Informacje ogólne</code> (wybranej domyślnie) sprawdź technologię używaną w pozycji **Webmail**.
+W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube/technology-email.png" loading="lazy" />
-:::
+- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
+- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
+- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
+
+Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
+
+<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Sprawdzaj pocztę online, bez instalacji, przez webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 ---

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -73,7 +73,15 @@ OVHcloud oferuje aktualnie 4 oferty e-mail. Poznaj ich funkcje, przechodząc prz
     
     1. Najstarsza oferta e-mail od OVHcloud, zawierająca kluczowe funkcje usługi e-mail z przestrzenią dyskową 5 GB na konto e-mail.
     2. Zawarty w ofercie hostingu www i może być zamówiony za pośrednictwem <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>.
-    3. Ta oferta jest dostępna dla 3 różnych technologii poczty elektronicznej. **Roundcube**, **OWA** (Outlook Web Access) i **Zimbra**.
+    3. Ta oferta jest dostępna w następujących technologiach webmail:
+
+       <Region zones={['eu']}>
+       **Roundcube**, **OWA** (Outlook Web Access) i **Zimbra**.
+       </Region>
+
+       <Region zones={['ca', 'apac']}>
+       **OWA** (Outlook Web Access).
+       </Region>
   </Tab>
   <Tab label="Zimbra Mail" availableIn={['eu']}>
     <img className="thumbnail" alt="Zimbra Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/zimbra01.png" loading="lazy" />
@@ -134,12 +142,25 @@ Poniżej znajduje się tabela podsumowująca najważniejsze funkcje poczty elekt
 <summary>Jak sprawdzić technologię używaną w ofercie **MX Plan**?</summary>
 
 
-Technologia poczty elektronicznej używana w usłudze MX Plan jest scharakteryzowana przez interfejs jej interfejsu webmail. Aby ją zidentyfikować w Panelu klienta:
+<Region zones={['eu']}>
 
-1. Wybierz domyślnie w zakładce <code className="action">Informacje ogólne</code>.
-1. Sprawdź technologię używaną pod napisem **Webmail**.
+W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/technology-email.png" loading="lazy" />
+- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
+- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
+- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
+
+Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
+
+<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Sprawdzaj pocztę online, bez instalacji, przez webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 </details>
 
@@ -386,7 +407,18 @@ Jeśli zamówiłeś [jedną z naszych ofert e-mail OVHcloud](https://www.ovhclou
 
 Chcesz zmienić [ofertę e-mail](https://www.ovhcloud.com/pl/emails/) na większą przestrzeń i więcej funkcji, ale chcesz zachować zawartość swojego istniejącego adresu. W tym celu skorzystaj z jednego z naszych przewodników:
 
-- [Przeniesienie adresu e-mail MX Plan na konto E-mail Pro lub Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+<Region zones={['eu']}>
+
+[Przeniesienie adresu e-mail MX Plan na konto E-mail Pro lub Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+
+</Region>
+
+<Region zones={['ca']}>
+
+[Przeniesienie adresu e-mail MX Plan na konto Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+
+</Region>
+
 - [Przenoszenie adresów e-mail z jednej platformy e-mail OVHcloud na inną](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
 - [Ręczna migracja Twojego konta e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration).
 - [Przeniesienie kont e-mail za pomocą OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -75,16 +75,27 @@ Każde konto e-mail OVHcloud dysponuje dedykowaną przestrzenią dyskową. Zarz�
 :::
 
 
-:::info
-**Sprawdzenie konfiguracji usługi MX Plan:**
+**Identyfikacja technologii e-mail oferty MX Plan**
 
-W zależności od daty aktywacji oferty MX Plan lub niedawnej migracji, przypisana technologia e-mail może się różnić. Wersja ta charakteryzuje się interfejsem webmaila. Aby ją zidentyfikować:
+<Region zones={['eu']}>
 
-- W zakładce <code className="action">Informacje ogólne</code> sprawdź technologię oznaczoną **Webmail** w ramce <code className="action">Subskrypcja</code> lub <code className="action">Logowanie</code>.
+W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/technology-email.png" loading="lazy" />
+- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
+- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
+- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
 
-:::
+Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
+
+<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Sprawdzaj pocztę online, bez instalacji, przez webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ## W praktyce <a name="instructions"></a>
@@ -134,11 +145,11 @@ Aby zalogować się do interfejsu Webmail, przejdź do strony [Webmail](https://
     Kliknij przycisk <i className="icons-gear-concept icons-masterbrand-blue"></i>w prawym górnym rogu ekranu, kliknij <code className="action">Opcje</code>. Kliknij <code className="action">Moje konto</code> w sekcji <code className="action">Ogólne</code> w kolumnie po lewej stronie. Możesz wyświetlić aktualny limit Twojego konta w dolnej prawej części formularza.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail01.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Roundcube: MX Plan">
+  <Tab label="Roundcube: MX Plan" availableIn={['eu']}>
     Po zalogowaniu się do interfejsu Webmail Roundcube limit jest widoczny w lewym dolnym rogu, widoczny na wykresie kołowym i w wykorzystanym procencie.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail02.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Zimbra: MX Plan / Zimbra Starter / Zimbra Pro">
+  <Tab label="Zimbra: MX Plan / Zimbra Starter / Zimbra Pro" availableIn={['eu']}>
     Po zalogowaniu do Zimbra Webmail kliknij na symbol koła zębatego( &#9881;) w prawym górnym rogu interfejsu, a następnie kliknij <code className="action">Parametry</code>. W zakładce <code className="action">Ogólne</code> wyświetla się wykorzystany limit pod napisem "Przestrzeń dyskowa".<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail03.png" loading="lazy" /><br/>
   </Tab>
@@ -230,7 +241,7 @@ Poniżej znajduje się niewyczerpująca lista przewodników konfiguracyjnych dla
 </Region>
 
 <ZoneTabs>
-  <Tab label="MX Plan i Zimbra Starter">
+  <Tab label="MX Plan i Zimbra Starter" availableIn={['eu']}>
     Konfiguracja konta MX Plan na **Windows** :<br/><br/>
     - [Poczta na urządzeniu z systemem Windows 10](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10) (zawarte w systemie Windows)<br/>
     - [Outlook for MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016)
@@ -296,7 +307,15 @@ Z poniższego menu wybierz aktualną ofertę Twojego konta e-mail:
 
 <ZoneTabs>
   <Tab label="MX Plan">
-    Jeśli rozmiar konta e-mail wynosi maksymalnie 5 GB, możesz przejść na ofertę [**E-mail Pro** o rozmiarze 10 GB](https://www.ovhcloud.com/pl/emails/email-pro/) lub [**Hosted Exchange** 50 GB](https://www.ovhcloud.com/pl/emails/hosted-exchange/). W tym celu zachęcamy do zamówienia wybranej oferty i zapoznania się z naszą dokumentacją "[Migracja konta e-mail MX Plan na konto E-mail Pro lub Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)". 
+    <Region zones={['eu']}>
+    Jeśli rozmiar konta e-mail wynosi maksymalnie 5 GB, możesz przejść na ofertę [**E-mail Pro** o rozmiarze 10 GB](https://www.ovhcloud.com/pl/emails/email-pro/) lub [**Hosted Exchange** 50 GB](https://www.ovhcloud.com/pl/emails/hosted-exchange/). W tym celu zachęcamy do zamówienia wybranej oferty i zapoznania się z naszą dokumentacją "[Migracja konta e-mail MX Plan na konto E-mail Pro lub Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)".
+    </Region>
+    <Region zones={['ca']}>
+    Jeśli rozmiar konta e-mail wynosi maksymalnie 5 GB, możesz przejść na ofertę [**Hosted Exchange** 50 GB](https://www.ovhcloud.com/pl/emails/hosted-exchange/). W tym celu zachęcamy do zamówienia wybranej oferty i zapoznania się z naszą dokumentacją "[Migracja konta e-mail MX Plan na konto Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)".
+    </Region>
+    <Region zones={['apac']}>
+    Aby zwiększyć pojemność, odkryj nasze [rozwiązania e-mail](https://www.ovhcloud.com/pl/emails/).
+    </Region>
   </Tab>
   <Tab label="E-mail Pro" availableIn={['eu']}>
     Oferta E-mail Pro posiada unikalną pojemność 10GB. Możesz wybrać opcję migracji na ofertę [**Hosted Exchange** 50 GB](https://www.ovhcloud.com/pl/emails/hosted-exchange/). W tym celu zachęcamy do zamówienia wybranej oferty i zapoznania się z naszą dokumentacją "[Migracja kont e-mail z jednej platformy e-mail OVHcloud do innej](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform)".
@@ -317,7 +336,13 @@ Z karty <code className="action">Konta e-mail</code> Twojej platformy Exchange k
 
 ## Sprawdź również
 
+<Region zones={['eu']}>
 [Przeniesienie konta e-mail MX Plan na konto E-mail Pro lub Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
+
+<Region zones={['ca']}>
+[Przeniesienie konta e-mail MX Plan na konto Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
 
 [Ręczna migracja Twojego konta e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -8,6 +8,7 @@ availableIn: [eu, ca, apac]
 import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
+import { Region } from '@components/Zone';
 
 
 ## Wprowadzenie
@@ -59,20 +60,27 @@ Gdy Twój adres e-mail zostaje zablokowany z powodu spamu, oznacza to, że podcz
 
 Zanim przejdziesz dalej, jeśli blokada dotyczy adresu e-mail w usłudze MX Plan, zidentyfikuj technologię e-mail wykorzystywaną przez Twoją usługę, aby postępować zgodnie z właściwą procedurą odblokowania. W przypadku usług **Zimbra Starter** i **Zimbra Pro** przejdź bezpośrednio do zakładki **Zimbra** w kroku 2, nie pomijając kontroli wymienionych w kroku 1.
 
-:::info
-**Zidentyfikuj technologię e-mail Twojej usługi MX Plan.**
+**Zidentyfikuj technologię e-mail Twojej usługi MX Plan**
 
-W zależności od daty aktywacji Twojej usługi MX Plan lub po ostatniej migracji, powiązana technologia e-mail może się różnić. Wersję tę można rozpoznać po interfejsie webmail. Aby ją zidentyfikować:
+<Region zones={['eu']}>
 
-- W zakładce <code className="action">Informacje ogólne</code> sprawdź wykorzystywaną technologię pod oznaczeniem **Webmail** w sekcji <code className="action">Abonament</code>.
+W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
 
-<img className="thumbnail" alt="Identyfikacja technologii e-mail w Panelu klienta usługi MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
+- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
+- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
+- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
 
-- Jeśli wyświetlana technologia to **Roundcube**, postępuj zgodnie z instrukcjami w zakładce **MX Plan - Roundcube**.
-- Jeśli wyświetlana technologia to **OWA** (Outlook Web App), postępuj zgodnie z instrukcjami w zakładce **MX Plan - OWA**.
-- Jeśli wyświetlana technologia to **Zimbra**, postępuj zgodnie z instrukcjami w zakładce **Zimbra** (procedura jest wspólna dla MX Plan - Zimbra, Zimbra Starter i Zimbra Pro).
+Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
 
-:::
+<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Sprawdzaj pocztę online, bez instalacji, przez webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ### Etap 1: Zrozum i usuń przyczynę blokady <a name="step1"></a>
@@ -149,7 +157,7 @@ Wybierz odpowiednią usługę e-mail w poniższych zakładkach:
     
     <img className="thumbnail" alt="Kolumna Status z wartością Spam w zakładce Konta e-mail dla MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra">
+  <Tab label="Zimbra" availableIn={['eu']}>
     Ta zakładka dotyczy wszystkich adresów wykorzystujących technologię **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** i **Zimbra Pro**. Procedura odblokowania jest identyczna dla tych trzech usług.
 
     Gdy blokada zostaje zastosowana, **żadne zgłoszenie pomocy technicznej nie jest generowane automatycznie**, a adres nie jest już dostępny (zarówno webmail Zimbra, jak i wysyłanie e-maili są wyłączone).
@@ -165,7 +173,7 @@ Wybierz odpowiednią usługę e-mail w poniższych zakładkach:
 
     Gdy zgłoszenie zostanie przetworzone przez pomoc techniczną, adres zostaje odblokowany. [Etap 3](#step3) nie ma w tym przypadku zastosowania.
   </Tab>
-  <Tab label="MX Plan - Roundcube">
+  <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     Jeśli blokada dotyczy adresu e-mail MX Plan z webmail **Roundcube**, żadne zgłoszenie pomocy technicznej nie jest generowane.
 
     Przed podjęciem jakichkolwiek działań **konieczne jest zidentyfikowanie przyczyny blokady** poprzez wykonanie kontroli z [etapu 1](#step1) (potencjalnie zainfekowane urządzenia, oprogramowanie zewnętrzne, przekierowania, filtry, autorespondery).

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -78,16 +78,27 @@ Deseja:
 
 <a name="whichmxplan"></a>
 
-:::info
-**Identificar a tecnologia de e-mail da sua oferta MX Plan.**
+**Identificar a tecnologia de e-mail da sua oferta MX Plan**
 
-Em função da data de ativação da sua oferta MX Plan ou de uma migração recente, a tecnologia de e-mail associada pode diferir. Esta tecnologia é caracterizada pela interface do seu webmail. Para a identificar:
+<Region zones={['eu']}>
 
-- A partir do separador <code className="action">Informações gerais</code>, registe a tecnologia utilizada sob a menção **Webmail** presente no quadro <code className="action">Subscrição</code>.
+Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/technology-email.png" loading="lazy" />
+- **Roundcube**: o webmail original, leve e simples de utilizar.
+- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
+- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
 
-:::
+Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
+
+<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte o seu e-mail online, sem instalação, através do webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ## Prática <a name="instructions"></a>
@@ -107,7 +118,7 @@ A OVHcloud propõe 4 soluções de e-mail, a noção de eliminação de conta é
 Selecione o separador correspondente à sua oferta de e-mail:
 
 <ZoneTabs>
-  <Tab label="MX Plan Roundcube">
+  <Tab label="MX Plan Roundcube" availableIn={['eu']}>
     Para identificar a tecnologia de e-mail associada ao seu serviço MX Plan, consulte a parte "[Identificar a tecnologia de e-mail da sua oferta MX Plan](#whichmxplan)" deste guia.
     
     1. Aceda ao separador <code className="action">Contas de e-mail</code>. Na nova janela, podem ver-se as contas de e-mail existentes.
@@ -115,7 +126,7 @@ Selecione o separador correspondente à sua oferta de e-mail:
     
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/email-reset-account/email-mxplan-legacy-reset.png" loading="lazy" />
   </Tab>
-  <Tab label="MX Plan Zimbra/OWA">
+  <Tab label="MX Plan">
     Para identificar a tecnologia de e-mail associada ao seu serviço MX Plan, consulte a parte "[Identificar a tecnologia de e-mail da sua oferta MX Plan](#whichmxplan)" deste guia.
     
     1. Aceda ao separador <code className="action">Contas de e-mail</code>. Na nova janela, podem ver-se as contas de e-mail existentes.

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -91,16 +91,27 @@ Por razões de segurança, recomendamos que não utilize duas vezes a mesma pala
 
 <a name="whichmxplan"></a>
 
-:::info
-**Identificar a tecnologia de e-mail da oferta MX Plan.**
+**Identificar a tecnologia de e-mail da oferta MX Plan**
 
-Em função da data de ativação da sua oferta MX Plan ou de uma migração recente, a tecnologia de e-mail associada pode diferir. Esta versão é caracterizada pela interface do seu webmail. Para identificá-lo:
+<Region zones={['eu']}>
 
-- No separador <code className="action">Informações gerais</code>, consulte a tecnologia utilizada sob a menção **Webmail** presente na caixa <code className="action">Subscrição</code> ou <code className="action">Ligação</code>.
+Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/technology-email.png" loading="lazy" />
+- **Roundcube**: o webmail original, leve e simples de utilizar.
+- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
+- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
 
-:::
+Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
+
+<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte o seu e-mail online, sem instalação, através do webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 Siga as instruções indicadas na oferta:
@@ -147,16 +158,37 @@ Clique no botão <code className="action">...</code> e, em seguida, em <code cla
 
 A modificação da sua palavra-passe através do webmail está disponível para as ofertas de e-mail OVHcloud que utilizam **OWA** (**O**utlook **W**eb **A**pp):
 
+<Region zones={['eu']}>
+
 - MX Plan OWA
 - E-mail Pro
 - Exchange
 - MX Plan Zimbra
 - Zimbra Starter / Pro
 
+</Region>
+
+<Region zones={['ca']}>
+
+- MX Plan OWA
+- Exchange
+
+</Region>
+
+<Region zones={['apac']}>
+
+- MX Plan OWA
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 Na oferta **MX Plan Roundcube**, a alteração da palavra-passe faz-se unicamente [através da Área de Cliente](#controlpanel).
 
 :::
+
+</Region>
 
 
 #### OWA
@@ -185,6 +217,8 @@ Deverá indicar a nova palavra-passe em todos os dispositivos onde o endereço d
 
 <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/mxplan-password-new-step5.png" loading="lazy" />
 
+<Region zones={['eu']}>
+
 #### Zimbra
 
 Aceda à página [Webmail](https://www.ovhcloud.com/pt/mail/). Introduza o seu endereço de e-mail e a palavra-passe e clique em <code className="action">Connection</code>.
@@ -192,6 +226,8 @@ Aceda à página [Webmail](https://www.ovhcloud.com/pt/mail/). Introduza o seu e
 Clique no nome da sua conta de e-mail na parte superior direita da sua interface. A partir deste menu, poderá <code className="action">Alterar a palavra-passe</code>.
 
 <img className="thumbnail" alt="Zimbra - preferências" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/zimbra-password.png" loading="lazy" />
+
+</Region>
 
 ### Recuperar uma palavra-passe
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -54,16 +54,27 @@ Adquiriu um serviço de e-mail MX Plan. que lhe permite beneficiar de endereços
 
 **Continuar com base na tecnologia de e-mail utilizada pelo serviço MX Plan**.
 
-:::info
-**Identificar a tecnologia de e-mail da oferta MX Plan.**
+**Identificar a tecnologia de e-mail da oferta MX Plan**
 
-Em função da data de ativação da sua oferta MX Plan ou de uma migração recente, a tecnologia de e-mail associada pode diferir. Esta versão é caracterizada pela interface do seu webmail. Para identificá-lo:
+<Region zones={['eu']}>
 
-- No separador <code className="action">Informações gerais</code>, leia a tecnologia utilizada com a menção **Webmail** presente na caixa <code className="action">Subscrição</code> em <code className="action">Webmail</code>.
+Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation/technology-email.png" loading="lazy" />
+- **Roundcube**: o webmail original, leve e simples de utilizar.
+- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
+- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
 
-:::
+Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
+
+<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte o seu e-mail online, sem instalação, através do webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ### OWA e Zimbra
@@ -295,7 +306,14 @@ Para o envio dos e-mails, encontre abaixo os parâmetros **SMTP** a utilizar:
 **Utilizou todos os endereços incluídos na sua oferta?**
 
 - Consulte as perguntas da [nossa FAQ e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails).
-- Consulte o conjunto das nossas ofertas e-mail [Zimbra](https://www.ovhcloud.com/pt/emails/zimbra-emails/) ou [Exchange](https://www.ovhcloud.com/pt/emails-exchange/) para completar a sua oferta MX Plan no mesmo domínio.
+
+<Region zones={['eu']}>
+Consulte o conjunto das nossas ofertas e-mail [Zimbra](https://www.ovhcloud.com/pt/emails/zimbra-emails/) ou [Exchange](https://www.ovhcloud.com/pt/emails-exchange/) para completar a sua oferta MX Plan no mesmo domínio.
+</Region>
+
+<Region zones={['ca']}>
+Descubra a nossa oferta e-mail [Exchange](https://www.ovhcloud.com/pt/emails-exchange/) para completar a sua oferta MX Plan no mesmo domínio.
+</Region>
 
 ## Quer saber mais? <a name="go-further"></a>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -44,16 +44,27 @@ Adquiriu um serviço MX Plan, que lhe permite beneficiar de endereços de e-mail
 
 **Continuar com base na tecnologia de e-mail utilizada pelo serviço MX Plan**.
 
-:::info
-**Identificar a tecnologia de e-mail da oferta MX Plan.**
+**Identificar a tecnologia de e-mail da oferta MX Plan**
 
-Em função da data de ativação da sua oferta MX Plan ou de uma migração recente, a tecnologia de e-mail associada pode diferir. Esta versão é caracterizada pela interface do seu webmail. Para identificá-lo:
+<Region zones={['eu']}>
 
-- No separador <code className="action">Informações gerais</code>, consulte a tecnologia utilizada sob a menção **Webmail** presente na caixa <code className="action">Subscrição</code> ou <code className="action">Ligação</code>.
+Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities/technology-email.png" loading="lazy" />
+- **Roundcube**: o webmail original, leve e simples de utilizar.
+- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
+- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
 
-:::
+Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
+
+<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte o seu e-mail online, sem instalação, através do webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 **Índice**

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -4,6 +4,8 @@ lastUpdated: 2026-06-08
 availableIn: [eu]
 ---
 
+import { Region } from '@components/Zone';
+
 ## Objetivo
 
 Com a oferta MX Plan da OVHcloud, pode enviar e receber e-mails a partir de um software de terceiros ou através de um webmail. A OVHcloud disponibiliza um serviço de mensagens online denominado Roundcube que permite, através de um browser web, aceder a uma conta de e-mail.
@@ -16,19 +18,27 @@ Com a oferta MX Plan da OVHcloud, pode enviar e receber e-mails a partir de um s
 - Dispor das informações de ligação ao endereço de e-mail MX Plan que pretende consultar. Para mais informações, consulte o nosso guia [Primeiros passos com a oferta MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - A sua solução de e-mail OVHcloud **MX Plan** deve utilizar a tecnologia de webmail **Roundcube**. Para a identificar, siga as instruções abaixo.
 
-:::info
-**Como identificar a tecnologia utilizada na minha oferta MX Plan?**
+**Identificar a tecnologia de e-mail da sua oferta MX Plan**
 
-A tecnologia de e-mail utilizada para a sua oferta MX Plan é caracterizada pela interface do seu webmail. Para a identificar a partir da sua área de cliente, siga o caminho abaixo:
+<Region zones={['eu']}>
 
-1. Aceda à sua <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>.
-1. Aceda à secção <code className="action">Web Cloud</code>.
-1. Clique em <code className="action">MX Plan</code>.
-1. Selecione o domínio em questão.
-1. No separador <code className="action">Informações gerais</code> (selecionado por predefinição), verifique a tecnologia utilizada na menção **Webmail**.
+Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube/technology-email.png" loading="lazy" />
-:::
+- **Roundcube**: o webmail original, leve e simples de utilizar.
+- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
+- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
+
+Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
+
+<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte o seu e-mail online, sem instalação, através do webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 ---

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -73,7 +73,15 @@ A OVHcloud oferece atualmente 4 ofertas de e-mail. Para compreender as suas espe
     
     1. A oferta de e-mail mais antiga da OVHcloud, que inclui as funções essenciais de um serviço de e-mail com 5 GB de espaço de armazenamento por conta de e-mail.
     2. Incluída com as ofertas de alojamento web e pode ser encomendada através da <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>.
-    3. Esta oferta está disponível em 3 tecnologias de correio eletrónico diferentes. **Roundcube**, **OWA** (Outlook Web Access) e **Zimbra**.
+    3. Esta oferta está disponível nas seguintes tecnologias de webmail:
+
+       <Region zones={['eu']}>
+       **Roundcube**, **OWA** (Outlook Web Access) e **Zimbra**.
+       </Region>
+
+       <Region zones={['ca', 'apac']}>
+       **OWA** (Outlook Web Access).
+       </Region>
   </Tab>
   <Tab label="Zimbra Mail" availableIn={['eu']}>
     <img className="thumbnail" alt="Zimbra Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/zimbra01.png" loading="lazy" />
@@ -134,12 +142,25 @@ Pode encontrar em seguida um quadro recapitulativo das principais funcionalidade
 <summary>Como identificar a tecnologia utilizada na minha oferta **MX Plan**?</summary>
 
 
-A tecnologia de e-mail utilizada para a oferta MX Plan é caracterizada pela interface do seu webmail. Para o identificar a partir da Área de Cliente, siga o seguinte caminho:
+<Region zones={['eu']}>
 
-1. No separador <code className="action">Informações gerais</code>, selecione por predefinição.
-1. Registe a tecnologia utilizada como **Webmail**.
+Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/technology-email.png" loading="lazy" />
+- **Roundcube**: o webmail original, leve e simples de utilizar.
+- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
+- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
+
+Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
+
+<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte o seu e-mail online, sem instalação, através do webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 </details>
 
@@ -385,7 +406,18 @@ Se subscreveu [um dos nossos serviços de e-mail OVHcloud](https://www.ovhcloud.
 
 Deseja mudar [de oferta de e-mail](https://www.ovhcloud.com/pt/emails/) para beneficiar de mais espaço e de funcionalidades, mas deseja conservar o conteúdo do seu endereço existente. Para isso, consulte um dos nossos manuais:
 
-- [Migrar um endereço de e-mail MX Plan para uma conta E-mail Pro ou Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+<Region zones={['eu']}>
+
+[Migrar um endereço de e-mail MX Plan para uma conta E-mail Pro ou Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+
+</Region>
+
+<Region zones={['ca']}>
+
+[Migrar um endereço de e-mail MX Plan para uma conta Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+
+</Region>
+
 - [Migrar os seus endereços de e-mail de uma plataforma de e-mail OVHcloud para outra](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
 - [Migrar manualmente o seu endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration).
 - [Migrar contas de e-mail através do OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -75,16 +75,27 @@ Cada conta de e-mail da OVHcloud dispõe de um espaço de armazenamento dedicado
 :::
 
 
-:::info
-**Identificar a tecnologia de e-mail da oferta MX Plan.**
+**Identificar a tecnologia de e-mail da oferta MX Plan**
 
-Em função da data de ativação da sua oferta MX Plan ou de uma migração recente, a tecnologia de e-mail associada pode diferir. Esta versão é caracterizada pela interface do seu webmail. Para identificá-lo:
+<Region zones={['eu']}>
 
-- No separador <code className="action">Informações gerais</code>, consulte a tecnologia utilizada sob a menção **Webmail** presente na caixa <code className="action">Subscrição</code> ou <code className="action">Ligação</code>.
+Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
 
-<img className="thumbnail" alt="MX plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/technology-email.png" loading="lazy" />
+- **Roundcube**: o webmail original, leve e simples de utilizar.
+- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
+- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
 
-:::
+Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
+
+<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte o seu e-mail online, sem instalação, através do webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ## Instruções <a name="instructions"></a>
@@ -134,11 +145,11 @@ Para se ligar ao webmail, aceda à página [Webmail](https://www.ovhcloud.com/pt
     Clique no botão <i className="icons-gear-concept icons-masterbrand-blue"></i>no canto superior direito do seu ecrã, clique em <code className="action">Opções</code>. Clique em <code className="action">A minha conta</code> na secção <code className="action">Geral</code> na coluna da esquerda. Pode visualizar o limite atual da sua conta na parte inferior direita do formulário.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail01.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Roundcube: MX Plan">
+  <Tab label="Roundcube: MX Plan" availableIn={['eu']}>
     Quando estiver conectado ao webmail Roundcube, o limite será visível na parte inferior esquerda, materializado por um diagrama circular e a percentagem consumida.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail02.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="Zimbra: MX Plan / Zimbra Starter / Zimbra Pro">
+  <Tab label="Zimbra: MX Plan / Zimbra Starter / Zimbra Pro" availableIn={['eu']}>
     Quando estiver ligado ao webmail Zimbra, clique na roda dentada ( &#9881;) no canto superior direito da sua interface e, a seguir, clique em <code className="action">Configurações</code>. No separador <code className="action">Geral</code>, o limite utilizado é visível sob a menção «Espaço de armazenamento».<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota/email-quota-webmail03.png" loading="lazy" /><br/>
   </Tab>
@@ -299,7 +310,15 @@ Selecione, no menu abaixo, a oferta atual da sua conta de e-mail:
 
 <ZoneTabs>
   <Tab label="MX Plan">
-    Se a capacidade da sua conta de e-mail já está a um máximo de 5GB, pode optar por uma migração para uma oferta [**E-mail Pro** de 10GB](https://www.ovhcloud.com/pt/emails/email-pro/) ou [**Hosted Exchange** de 50GB](https://www.ovhcloud.com/pt/emails/hosted-exchange/). Para isso, sugerimos que encomende a oferta mais adequada e siga a documentação "[Migrar um endereço de e-mail MX Plan para uma conta E-mail Pro ou Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)". 
+    <Region zones={['eu']}>
+    Se a capacidade da sua conta de e-mail já está a um máximo de 5GB, pode optar por uma migração para uma oferta [**E-mail Pro** de 10GB](https://www.ovhcloud.com/pt/emails/email-pro/) ou [**Hosted Exchange** de 50GB](https://www.ovhcloud.com/pt/emails/hosted-exchange/). Para isso, sugerimos que encomende a oferta mais adequada e siga a documentação "[Migrar um endereço de e-mail MX Plan para uma conta E-mail Pro ou Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)".
+    </Region>
+    <Region zones={['ca']}>
+    Se a capacidade da sua conta de e-mail já está a um máximo de 5GB, pode optar por uma migração para uma oferta [**Hosted Exchange** de 50GB](https://www.ovhcloud.com/pt/emails/hosted-exchange/). Para isso, sugerimos que encomende a oferta mais adequada e siga a documentação "[Migrar um endereço de e-mail MX Plan para uma conta Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)".
+    </Region>
+    <Region zones={['apac']}>
+    Para aumentar a sua capacidade de armazenamento, descubra as nossas [soluções de e-mail](https://www.ovhcloud.com/pt/emails/).
+    </Region>
   </Tab>
   <Tab label="E-mail Pro" availableIn={['eu']}>
     A oferta E-mail Pro dispõe de uma capacidade única de 10GB. Pode optar por uma migração para uma oferta [**Hosted Exchange** de 50GB](https://www.ovhcloud.com/pt/emails/hosted-exchange/). Para isso, sugerimos que encomende a oferta mais adequada e siga o nosso manual "[Migrar os endereços de e-mail de uma plataforma de e-mail da OVHcloud para outra](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform)".
@@ -320,7 +339,13 @@ No separador <code className="action">Contas de e-mail</code> da sua plataforma 
 
 ## Saiba mais
 
+<Region zones={['eu']}>
 [Migrar um endereço de e-mail MX Plan para uma conta E-mail Pro ou Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
+
+<Region zones={['ca']}>
+[Migrar um endereço de e-mail MX Plan para uma conta Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+</Region>
 
 [Migrar manualmente o seu endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -8,6 +8,7 @@ availableIn: [eu, ca, apac]
 import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
+import { Region } from '@components/Zone';
 
 
 ## Objetivo
@@ -59,20 +60,27 @@ Quando o seu endereço de e-mail é bloqueado por spam, isto significa que foi d
 
 Antes de prosseguir, e se o bloqueio disser respeito a um endereço de e-mail do tipo MX Plan, identifique a tecnologia de e-mail utilizada pela sua oferta para seguir o processo de desbloqueio correto. Para as ofertas **Zimbra Starter** e **Zimbra Pro**, dirija-se diretamente ao separador **Zimbra** da etapa 2, sem omitir as verificações da etapa 1.
 
-:::info
-**Identificar a tecnologia de e-mail da sua oferta MX Plan.**
+**Identificar a tecnologia de e-mail da sua oferta MX Plan**
 
-Em função da data de ativação da sua oferta MX Plan ou de uma migração recente, a tecnologia de e-mail associada pode diferir. Esta versão é caracterizada pela interface do respetivo webmail. Para a identificar:
+<Region zones={['eu']}>
 
-- A partir do separador <code className="action">Informações gerais</code>, consulte a tecnologia utilizada sob a menção **Webmail** presente na secção <code className="action">Subscrição</code>.
+Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
 
-<img className="thumbnail" alt="Identificar a tecnologia de e-mail na área de cliente MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/technology-email.png" loading="lazy" />
+- **Roundcube**: o webmail original, leve e simples de utilizar.
+- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
+- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
 
-- Se a tecnologia apresentada for **Roundcube**, siga as instruções do separador **MX Plan - Roundcube**.
-- Se a tecnologia apresentada for **OWA** (Outlook Web App), siga as instruções do separador **MX Plan - OWA**.
-- Se a tecnologia apresentada for **Zimbra**, siga as instruções do separador **Zimbra** (procedimento comum a MX Plan - Zimbra, Zimbra Starter e Zimbra Pro).
+Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
 
-:::
+<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Consulte o seu e-mail online, sem instalação, através do webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 
 ### Etapa 1: compreender e tratar a causa do bloqueio <a name="step1"></a>
@@ -149,7 +157,7 @@ Selecione a oferta de e-mail em causa nos seguintes separadores:
     
     <img className="thumbnail" alt="Coluna estado Spam no separador Contas de e-mail MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra">
+  <Tab label="Zimbra" availableIn={['eu']}>
     Este separador aplica-se a todos os endereços que utilizam a tecnologia **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** e **Zimbra Pro**. O processo de desbloqueio é idêntico para estas três ofertas.
 
     No momento do bloqueio, **não é gerado automaticamente nenhum ticket de assistência** e o endereço deixa de estar acessível (webmail Zimbra e envio desativados).
@@ -165,7 +173,7 @@ Selecione a oferta de e-mail em causa nos seguintes separadores:
 
     Assim que o ticket for tratado pelo suporte, o endereço será desbloqueado. A [etapa 3](#step3) não se aplica neste caso.
   </Tab>
-  <Tab label="MX Plan - Roundcube">
+  <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     Se o bloqueio disser respeito a um endereço de e-mail MX Plan com o webmail **Roundcube**, não é gerado nenhum ticket de assistência.
 
     Antes de qualquer ação, é **indispensável identificar a causa do bloqueio**, realizando as verificações da [etapa 1](#step1) (postos potencialmente infetados, softwares de terceiros, reencaminhamentos, filtros, respostas automáticas).


### PR DESCRIPTION
## Summary

- Zone-adapt 8 MX Plan email guides (56 files — 7 EU locales: de, en, es, fr, it, pl, pt)
- Rewrites the webmail technology identification block into `<Region>` gates:
  - EU → Roundcube / Zimbra / OWA with visual identifier
  - CA/APAC → OWA only (direct link, no tech selector)
- Removes or gates Roundcube and Zimbra references that were wrongly shown to CA/APAC users
- Guides covered: `email-generalities`, `email-roundcube`, `faq-emails`, `email-manage-quota`, `locked-for-spam`, `delete-email-account`, `email-change-password`, `email-creation`

> Lot 1/2 — MX Plan core guides. Lot 2/2 will cover Exchange + collaborative solutions guides.
