### PR TITLE
feat(build): add DEV_PATH to scope dev server to a route subtree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -422,7 +422,10 @@ Guide titles shown in the sidebar are read from each MDX file's frontmatter, **n
 pnpm install
 pnpm dev                       # defaults to fr + en
 DEV_LOCALES=en pnpm dev        # English only (faster)
+DEV_PATH=web-cloud/web-hosting pnpm dev   # scope to one subtree (fallback if dev shows a blank page)
 ```
+
+> Blank page on every route? See [README → Scoping to a route subtree (`DEV_PATH`)](README.md#scoping-to-a-route-subtree-dev_path--blank-page-fallback).
 
 1. Create or edit `.mdx` files under `docs/{locale}/guides/...` for each locale you're shipping.
 2. Drop new images under `docs/public/images/{universe}/{product}/{guide-slug}/`.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,32 @@ DEV_LOCALES=fr,en pnpm dev       # French + English (default)
 Only active locales have their content compiled, sidebar generated, and routes registered.
 This significantly reduces SSR time on the large MDX codebase.
 
+### Scoping to a route subtree (`DEV_PATH`) — blank-page fallback
+
+If `pnpm dev` shows a **blank page on every route** (browser console: `ChunkLoadError`
+on `_rspress_virtual-page-data...`), use this as a fallback to the classic `pnpm dev`.
+
+Cause: Rspress v2 inlines the page-data (frontmatter + toc + metadata) of *every* route
+into a single virtual chunk the browser must load before any page renders. With ~1635
+routes/locale that chunk is 10MB+ and exceeds the chunk-load timeout, so nothing mounts.
+`DEV_LOCALES` alone does not fix this (one locale is still ~10MB).
+
+`DEV_PATH` restricts the scanned routes to one subtree under `docs/{locale}/guides/`,
+shrinking the chunk below the timeout:
+
+```bash
+DEV_PATH=web-cloud/web-hosting pnpm dev          # one product
+DEV_PATH=web-cloud pnpm dev                       # one universe
+DEV_PATH=web-cloud/web-hosting DEV_LOCALES=en pnpm dev   # leanest: one product, one locale
+```
+
+EN-only web-hosting drops the chunk from ~10.4MB/1635 routes to ~3.3MB/122 routes; the
+page renders and the initial build goes from ~5s to ~0.2s.
+
+- **Opt-in:** unset `DEV_PATH` keeps the original full-tree behaviour. No effect on production builds.
+- **Caveat:** only the scoped subtree exists in dev — links to guides *outside* it 404 locally
+  (they resolve normally in production). Set `DEV_PATH` to cover whatever you need to click through.
+
 ### Dev Performance Notes
 
 With 9500+ MDX files, dev SSR is ~9s per page (Rspress MDX compilation overhead).

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -72,6 +72,40 @@ const excludedLocales = allLocales
   .filter((l) => !devLocales.includes(l.lang))
   .map((l) => l.lang);
 
+// Dev performance: optionally scope dev to a single route subtree.
+// Rspress v2 inlines the page-data (frontmatter + toc + metadata) of EVERY
+// route into one virtual chunk that the client must load before any page
+// renders. With ~1635 routes/locale that chunk is ~10MB+ and exceeds the
+// browser's chunkLoadingTimeout → blank page. Restricting the scanned routes
+// shrinks that chunk to the subtree you are working on.
+//
+//   DEV_PATH=web-cloud/web-hosting pnpm dev    # only that product
+//   DEV_PATH=web-cloud pnpm dev                # the whole universe
+//
+// The value is a path under `docs/{locale}/guides/`. When unset, the full
+// tree is served (original behaviour). Has no effect on production builds.
+//
+// NOTE: rspress's `route.exclude` does NOT honour `!`-negation re-includes,
+// so we cannot say "exclude everything, then add back X". Instead we exclude
+// the SIBLINGS at every level of the target path, which leaves the target
+// subtree (and the locale's index pages) as the only thing scanned.
+const devPath = (process.env.DEV_PATH || '').replace(/^\/+|\/+$/g, '');
+const pathExcludes = devPath
+  ? activeLocales.flatMap((l) => {
+      const segments = devPath.split('/');
+      // At each level, exclude that level's contents but keep the branch that
+      // leads to the target. e.g. for guides/web-cloud/web-hosting:
+      //   {l}/guides/*  except web-cloud   → exclude {l}/guides/!(web-cloud)
+      //   {l}/guides/web-cloud/* except web-hosting → !(web-hosting)
+      const excludes = [`${l.lang}/guides/!(${segments[0]})/**`];
+      for (let i = 1; i < segments.length; i++) {
+        const prefix = segments.slice(0, i).join('/');
+        excludes.push(`${l.lang}/guides/${prefix}/!(${segments[i]})/**`);
+      }
+      return excludes;
+    })
+  : [];
+
 export default defineConfig({
   root: path.join(__dirname, 'docs'),
   plugins: [pluginLastUpdatedFromCache()],
@@ -176,7 +210,7 @@ export default defineConfig({
 
   route: {
     cleanUrls: true,
-    exclude: excludedLocales.map((l) => `${l}/**/*`),
+    exclude: [...excludedLocales.map((l) => `${l}/**/*`), ...pathExcludes],
   },
   ssg: { experimentalWorker: true },
   llms: true,


### PR DESCRIPTION
## Problem

`pnpm dev` renders a **blank page on every route** (including `/`). The browser console shows:

    ChunkLoadError: Loading chunk _rspress_virtual-page-data_js-..._virtual-i18n-text_js-... failed.

**Cause:** Rspress v2 inlines the page-data (frontmatter + toc + metadata) of *every* route into a single virtual chunk that the client must download and parse before any page can render. With ~1635 routes/locale that chunk is **10 MB+** (≈22 MB for fr+en) and exceeds the browser's `chunkLoadingTimeout`, so the theme never mounts → blank page.

`DEV_LOCALES` alone does **not** fix it — one locale is still ~10 MB. Production builds are unaffected (they build one locale per process as static SSG, so the chunk never blocks first paint).

## Fix

Add an opt-in `DEV_PATH` env var that scopes the dev server to a single route subtree under `docs/{locale}/guides/`, shrinking the chunk below the timeout:

```bash
DEV_PATH=web-cloud/web-hosting pnpm dev                  # one product
DEV_PATH=web-cloud pnpm dev                              # one universe
DEV_PATH=web-cloud/web-hosting DEV_LOCALES=en pnpm dev   # leanest: one product, one locale
```

Implemented via extglob sibling-excludes in `route.exclude`, because rspress's `route.exclude` does **not** honour `!`-negation re-includes (verified — `{locale}/**/*` + `!{target}` silently drops everything).

## Verification (EN-only, `DEV_PATH=web-cloud/web-hosting`)

| Metric | Before | After |
|--------|--------|-------|
| Routes inlined in page-data | 1635 | **122** |
| page-data chunk | 10.37 MB | **3.26 MB** |
| Page render | blank (ChunkLoadError) | ✅ renders fully |
| Initial build | ~5 s | **~0.2 s** |

Confirmed in-browser: title, all `##` sections, cards and tabs render.

## Safety

- **Opt-in:** unset `DEV_PATH` preserves the original full-tree behaviour exactly.
- **Dev only:** no effect on production builds.
- **Caveat (documented):** with `DEV_PATH` set, only the scoped subtree exists in dev, so links to guides outside it 404 locally (they resolve normally in production).

## Docs

- `README.md` → new "Scoping to a route subtree (`DEV_PATH`)" section under Development.
- `CONTRIBUTING.md` → `DEV_PATH` command + pointer to the README section.
