### PR TITLE
fix(i18n): translate leftover French residue in web-cloud guides

### DIFF
--- a/docs/en/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -42,16 +42,14 @@ The DKIM (**D**omain**K**eys **I**dentified **M**ail) record allows you to sign 
 
 ### OVHcloud Control Panel Access
 
-- **Lien direct :** <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Zones DNS</code> > Sélectionnez votre nom de domaine
+- **Direct link:** <ManagerLink to="/#/web/zone">DNS zones</ManagerLink>
+- **To access your services:** <code className="action">Web Cloud</code> > <code className="action">DNS zones</code> > Select your domain name
 
 ---
 {/* CP-NAV-END:web-dns-zone */}
 
 :::warning
-Si votre nom de domaine n'utilise pas les serveurs DNS d'OVHcloud, vous devez réaliser la modification du DKIM depuis l'interface du prestataire gérant la configuration de votre nom de domaine.
-
-Si votre nom de domaine est déposé chez OVHcloud, vous pouvez vérifier si ce dernier utilise notre configuration OVHcloud dans votre <ManagerLink to="/">espace client</ManagerLink> depuis l'onglet <code className="action">Zone DNS</code>, une fois le domaine concerné sélectionné.
+If your domain name does not use OVHcloud DNS servers, you will need to modify the DKIM records in the interface of the service provider that manages your domain name configuration.
 
 If your domain name is registered with OVHcloud, you can check if it is using the OVHcloud configuration in your <ManagerLink to="/">Control Panel</ManagerLink>. To do this, go to the <code className="action">DNS zones</code> tab, and select the domain concerned.
 :::
@@ -200,11 +198,11 @@ Click on the tab below corresponding to your offer.
 
 <ZoneTabs>
   <Tab label="MX Plan">
-    1. Connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
-    1. Rendez-vous dans la partie <code className="action">Web Cloud</code>.
-    1. Cliquez sur <code className="action">MX Plan</code>.
-    1. Sélectionnez le domaine concerné.
-    1. Enfin, allez dans l'onglet <code className="action">Informations générales</code>.
+    1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
+    1. Open the <code className="action">Web Cloud</code> section.
+    1. Click <code className="action">MX Plan</code>.
+    1. Select the domain concerned.
+    1. Finally, go to the <code className="action">General information</code> tab.
 
     In the **General informations** box, `DKIM` is displayed in red in the column **Diagnostic**.
 
@@ -221,11 +219,11 @@ Click on the tab below corresponding to your offer.
     This window asks you to enter two CNAME values in the DNS zone of the domain name, which links this domain name to the DKIM selectors of your email service. You need to enter these values and ensure they are propagated before clicking on <code className="action">Enable</code>.
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
-    1. Connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
-    1. Rendez-vous dans la partie <code className="action">Web Cloud</code>.
-    1. Dans la rubrique `MICROSOFT`, cliquez sur <code className="action">Exchange</code>.
-    1. Sélectionnez la plateforme concernée.
-    1. Enfin, allez dans l'onglet <code className="action">Domaines associés</code>.
+    1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
+    1. Open the <code className="action">Web Cloud</code> section.
+    1. In the `MICROSOFT` section, click <code className="action">Exchange</code>.
+    1. Select the service concerned.
+    1. Finally, go to the <code className="action">Associated domains</code> tab.
 
     To the right of the domain name concerned, `DKIM` is displayed in red.
 
@@ -236,11 +234,11 @@ Click on the tab below corresponding to your offer.
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto02.png" loading="lazy" />
   </Tab>
   <Tab label="E-mail Pro" availableIn={['eu']}>
-    1. Connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
-    1. Rendez-vous dans la partie <code className="action">Web Cloud</code>.
-    1. Cliquez sur <code className="action">Email Pro</code>.
-    1. Sélectionnez la plateforme concernée.
-    1. Enfin, allez dans l'onglet <code className="action">Domaines associés</code>.
+    1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
+    1. Open the <code className="action">Web Cloud</code> section.
+    1. Click <code className="action">Email Pro</code>.
+    1. Select the service concerned.
+    1. Finally, go to the <code className="action">Associated domains</code> tab.
 
     To the right of the relevant domain name, you can see that the `DKIM` badge is red.
 
@@ -251,11 +249,11 @@ Click on the tab below corresponding to your offer.
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto02.png" loading="lazy" />
   </Tab>
   <Tab label="Zimbra" availableIn={['eu']}>
-    1. Connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
-    1. Rendez-vous dans la partie <code className="action">Web Cloud</code>.
-    1. Cliquez sur <code className="action">Zimbra Mail</code>.
-    1. Enfin, allez dans l'onglet <code className="action">Domaine</code>.
-    1. À droite du domaine concerné, cliquez sur <code className="action">⁝</code>, puis sur <code className="action">Diagnostics</code>.
+    1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
+    1. Open the <code className="action">Web Cloud</code> section.
+    1. Click <code className="action">Zimbra Mail</code>.
+    1. Finally, go to the <code className="action">Domain</code> tab.
+    1. To the right of the relevant domain, click <code className="action">⁝</code>, then <code className="action">Diagnostics</code>.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/zimbra/domain/diagnostics/access.png" loading="lazy" />
 
@@ -264,11 +262,11 @@ Click on the tab below corresponding to your offer.
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/zimbra/domain/diagnostics/dkim-cname-conf.png" loading="lazy" />
 
     :::info
-    **Astuce pour créer un enregistrement CNAME**
+    **Tip for creating a CNAME record**
 
-    Depuis <ManagerLink to="/">l'espace client OVHcloud</ManagerLink> où est hébergé le nom de domaine de votre service e-mail, dans la partie <code className="action">Web Cloud</code>, cliquez sur <code className="action">Noms de domaine</code> dans la colonne de gauche et sélectionnez le nom de domaine concerné.<br/>
+    From the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> where the domain name of your email service is hosted, in the <code className="action">Web Cloud</code> section, click <code className="action">Domain names</code> in the left-hand column and select the relevant domain name.<br/>
 
-Sélectionnez l'onglet <code className="action">Zone DNS</code> puis cliquez sur <code className="action">Ajouter une entrée</code> dans la fenêtre qui s'affiche. Choisissez `CNAME` puis complétez selon les valeurs que vous avez relevées.
+Select the <code className="action">DNS zone</code> tab, then click <code className="action">Add an entry</code> in the window that appears. Choose `CNAME` and complete the fields according to the values you have noted.
 
     :::
 
@@ -299,20 +297,20 @@ Click on the tab below corresponding to your solution.
 
 <ZoneTabs>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
-    1. Connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
-    1. Rendez-vous dans la partie <code className="action">Web Cloud</code>.
-    1. Dans la rubrique `MICROSOFT`, cliquez sur <code className="action">Exchange</code>.
-    1. Sélectionnez la plateforme concernée.
+    1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
+    1. Open the <code className="action">Web Cloud</code> section.
+    1. In the `MICROSOFT` section, click <code className="action">Exchange</code>.
+    1. Select the service concerned.
 
     By default, your platform name will match its reference number, or it will be visible under the name you have given it (see image below).
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/general-information/dns-dkim-platform-exchange.png" loading="lazy" />
   </Tab>
   <Tab label="E-mail Pro" availableIn={['eu']}>
-    1. Connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
-    1. Rendez-vous dans la partie <code className="action">Web Cloud</code>.
-    1. Cliquez sur <code className="action">Email Pro</code>.
-    1. Sélectionnez la plateforme concernée.
+    1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
+    1. Open the <code className="action">Web Cloud</code> section.
+    1. Click <code className="action">Email Pro</code>.
+    1. Select the service concerned.
 
     By default, your platform name will match its reference number, or it will be visible under the name you have given it (see image below).
 
@@ -455,10 +453,10 @@ Follow the **5 steps** by clicking on each of the 5 tabs below:
 
     The values `"status": "toSet"` and `"status": "disabled"` mean that CNAME records are to be configured. Retrieve the 2 `cname` values in a text file and move on to the next step.
   </Tab>
-  <Tab label="4. Configurer l'enregistrement DNS">
-    Depuis <ManagerLink to="/">l'espace client OVHcloud</ManagerLink> où est hébergé le nom de domaine de votre service e-mail, dans l'onglet <code className="action">Web Cloud</code>, cliquez sur <code className="action">Noms de domaine</code> dans la colonne de gauche et sélectionnez le nom de domaine concerné.<br/>
+  <Tab label="4. Configure the DNS record">
+    From the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> where the domain name of your email service is hosted, in the <code className="action">Web Cloud</code> tab, click <code className="action">Domain names</code> in the left-hand column and select the relevant domain name.<br/>
 
-Dirigez-vous vers l'onglet <code className="action">Zone DNS</code> puis cliquez sur <code className="action">Ajouter une entrée</code> dans la fenêtre qui s'affiche. Choisissez `CNAME` puis complétez selon les valeurs que vous avez relevées.
+Go to the <code className="action">DNS zone</code> tab, then click <code className="action">Add an entry</code> in the window that appears. Choose `CNAME` and complete the fields according to the values you have noted.
 
     If you break down the values in the example in step "**3. Retrieve the DNS record**":
 
@@ -624,12 +622,10 @@ Follow the **5 steps** below by clicking on each tab.
     It is possible that the `status:` is in `todo`, this will not affect your DNS zone’s configuration.
     :::
   </Tab>
-  <Tab label="4. Configurer l'enregistrement DNS">
-    Depuis <ManagerLink to="/">l'espace client OVHcloud</ManagerLink> où est hébergé le nom de domaine de votre plateforme Exchange, dans l'onglet <code className="action">Web Cloud</code>, cliquez sur <code className="action">Noms de domaine</code> dans la colonne de gauche et sélectionnez le nom de domaine concerné.<br/>
+  <Tab label="4. Configure the DNS record">
+    From the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> where the domain name of your Exchange platform is hosted, in the <code className="action">Web Cloud</code> tab, click <code className="action">Domain names</code> in the left-hand column and select the relevant domain name.<br/>
 
-Dirigez-vous vers l'onglet <code className="action">Zone DNS</code> puis cliquez sur <code className="action">Ajouter une entrée</code> dans la fenêtre qui s'affiche. Choisissez `CNAME` puis complétez selon les valeurs que vous avez relevées.<br/>
-
-Si on prend les valeurs de l'exemple à l'étape "**3.Récupérer l'enregistrement DNS**":
+Go to the <code className="action">DNS zone</code> tab, then click <code className="action">Add an entry</code> in the window that appears. Choose `CNAME` and complete the fields according to the values you have noted.<br/>
 
     If we take the values of the example in step "**3. Retrieve the DNS record**":
 
@@ -784,12 +780,10 @@ Follow the **5 steps** below by clicking on each tab.
     It is possible that the `status:` is in `todo`, this will not affect your DNS zone’s configuration.
     :::
   </Tab>
-  <Tab label="4. Configurer l'enregistrement DNS">
-    Depuis <ManagerLink to="/">l'espace client OVHcloud</ManagerLink> où est hébergé le nom de domaine de votre plateforme E-mail Pro, dans l'onglet <code className="action">Web Cloud</code>, cliquez sur <code className="action">Noms de domaine</code> dans la colonne de gauche et sélectionnez le nom de domaine concerné.<br/>
+  <Tab label="4. Configure the DNS record">
+    From the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> where the domain name of your Email Pro platform is hosted, in the <code className="action">Web Cloud</code> tab, click <code className="action">Domain names</code> in the left-hand column and select the relevant domain name.<br/>
 
-Dirigez-vous vers l'onglet <code className="action">Zone DNS</code> puis cliquez sur <code className="action">Ajouter une entrée</code> dans la fenêtre qui s'affiche. Choisissez `CNAME` puis complétez selon les valeurs que vous avez relevées.<br/>
-
-Si on prend les valeurs de l'exemple à l'étape "**3.Récupérer l'enregistrement DNS**":
+Go to the <code className="action">DNS zone</code> tab, then click <code className="action">Add an entry</code> in the window that appears. Choose `CNAME` and complete the fields according to the values you have noted.<br/>
 
     If we take the values of the example in step **3. Retrieve the DNS record**:
 
@@ -1047,7 +1041,7 @@ Select the email solution concerned in the following tabs:
 
 If you would like to configure your DNS zone to add a DKIM record to it for your solution, follow the instructions below.
 
-Depuis <ManagerLink to="/">l'espace client OVHcloud</ManagerLink>, cliquez sur l'onglet <code className="action">Web Cloud</code> puis sur <code className="action">Noms de domaine</code> dans la colonne de gauche et sélectionnez le nom de domaine concerné.
+From the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, click the <code className="action">Web Cloud</code> tab, then <code className="action">Domain names</code> in the left-hand column and select the relevant domain name.
 
 Click on the <code className="action">DNS zones</code> tab, then <code className="action">Add an entry</code>. There are 3 ways to add a record to set the DKIM in your DNS zone:
 
@@ -1194,22 +1188,22 @@ Click on the tab below corresponding to your solution to check the status of the
 
 <ZoneTabs>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
-    1. Connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
-    1. Rendez-vous dans la partie <code className="action">Web Cloud</code>.
-    1. Dans la rubrique `MICROSOFT`, cliquez sur <code className="action">Exchange</code>.
-    1. Sélectionnez la plateforme concernée.
-    1. Enfin, allez dans l'onglet <code className="action">Domaines associés</code>.
+    1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
+    1. Open the <code className="action">Web Cloud</code> section.
+    1. In the `MICROSOFT` section, click <code className="action">Exchange</code>.
+    1. Select the service concerned.
+    1. Finally, go to the <code className="action">Associated domains</code> tab.
 
     In the <code className="action">Associated domains</code> section, check the colour of the `DKIM` icon to the right of the domain name concerned (see the image below).
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/red-dkim.png" loading="lazy" />
   </Tab>
   <Tab label="E-mail Pro" availableIn={['eu']}>
-    1. Connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
-    1. Rendez-vous dans la partie <code className="action">Web Cloud</code>.
-    1. Cliquez sur <code className="action">Email Pro</code>.
-    1. Sélectionnez la plateforme concernée.
-    1. Enfin, allez dans l'onglet <code className="action">Domaines associés</code>.
+    1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
+    1. Open the <code className="action">Web Cloud</code> section.
+    1. Click <code className="action">Email Pro</code>.
+    1. Select the service concerned.
+    1. Finally, go to the <code className="action">Associated domains</code> tab.
 
     In the <code className="action">Associated domains</code> section, check the colour of the `DKIM` icon to the right of the domain name concerned (see the image below).
 

--- a/docs/en/guides/web-cloud/domains/trade-doa.mdx
+++ b/docs/en/guides/web-cloud/domains/trade-doa.mdx
@@ -1,188 +1,188 @@
 ---
-title: "Changer le propriétaire d'un domaine avec une Demande d'Opération AFNIC (DOA)"
-excerpt: "Découvrez comment réaliser une Demande d'Opération AFNIC (DOA)"
+title: "Changing the owner of a domain name with an AFNIC Operation Request (DOA)"
+excerpt: "Find out how to submit an AFNIC Operation Request (DOA)"
 lastUpdated: 2024-10-10
 availableIn: [eu]
 ---
 
-## Objectif
+## Objective
 
-Un [changement de propriétaire d'un nom de domaine](/guides/web-cloud/domains/trade-domain) se fait conventionnellement via une double validation par e-mail.<br />
-Dans certains cas de figure, cette méthode ne peut pas être mise en oeuvre. Pour pallier à cela, le registre de [l'AFNIC (Association Française pour le Nommage Internet en Coopération)](https://www.afnic.fr/) met à disposition un document pour récupérer la propriété d'un domaine géré par ce registre : **La Demande d'Opération AFNIC (DOA)**.
+A [change of owner for a domain name](/guides/web-cloud/domains/trade-domain) is conventionally carried out through a double validation by email.<br />
+In certain situations, this method cannot be used. To address this, the [AFNIC (Association Française pour le Nommage Internet en Coopération)](https://www.afnic.fr/) registry provides a document to recover ownership of a domain managed by this registry: **the AFNIC Operation Request (DOA)**.
 
-Cette opération permet de récupérer la propriété d'un domaine dont l'extension est [gérée par l'AFNIC](https://www.afnic.fr/produits-services/) dans les cas suivants :
+This operation lets you recover ownership of a domain whose extension is [managed by AFNIC](https://www.afnic.fr/produits-services/) in the following cases:
 
-- **Transmission volontaire (Trade)** : utile si, par exemple, vous ne pouvez pas valider l'e-mail reçu sur l'adresse de contact du propriétaire actuel du domaine.
-- **Transmission forcée (Recover)** : permet de récupérer la propriété du domaine dans le cadre d'une décision judiciaire, d'une liquidation judiciaire ou d'un décès.
+- **Voluntary transfer (Trade)**: useful, for example, if you cannot validate the email received at the contact address of the domain's current owner.
+- **Forced transfer (Recover)**: lets you recover ownership of the domain in the context of a court decision, a compulsory liquidation, or a death.
 
-Si les situations décrites ci-dessus ne vous correspondent pas, sachez que l'AFNIC met à disposition [d'autres procédures pour résoudre vos litiges](https://www.afnic.fr/noms-de-domaine/resoudre-un-litige/).
+If the situations described above do not apply to you, note that AFNIC provides [other procedures for resolving your disputes](https://www.afnic.fr/noms-de-domaine/resoudre-un-litige/).
 
 :::info
-Cette opération ne déplace pas votre nom de domaine vers un autre compte client OVHcloud et est limitée uniquement aux [extensions gérées par l'AFNIC](https://www.afnic.fr/produits-services/).
+This operation does not move your domain name to another OVHcloud customer account and is limited solely to [extensions managed by AFNIC](https://www.afnic.fr/produits-services/).
 
-Vous pourrez être amené à [modifier les contacts](/guides/account-and-service-management/account-information/managing-contacts) du nom de domaine une fois le domaine récupéré avec la DOA.
+You may need to [modify the contacts](/guides/account-and-service-management/account-information/managing-contacts) of the domain name once the domain has been recovered with the DOA.
 
-La DOA doit obligatoirement être effectuée auprès de l'actuel bureau d'enregistrement du nom de domaine. Si le nom de domaine n'est pas enregistré chez OVHcloud, contactez le bureau d'enregistrement actuel du nom de domaine concerné pour réaliser une DOA à leur niveau.
+The DOA must be carried out with the domain name's current registrar. If the domain name is not registered with OVHcloud, contact the current registrar of the domain name concerned to submit a DOA on their side.
 
-Exception faite de la procédure [SYRELI](https://www.syreli.fr/fr/) évoquée [plus bas](#doa-syreli) dans ce guide, une DOA ne peut pas être couplée à une opération de transfert du nom de domaine. Vous devrez d'abord réaliser votre DOA, puis réaliser une [opération de transfert entrant](/guides/web-cloud/domains/transfer-incoming-generic-domain) ou [sortant](/guides/web-cloud/domains/transfer-outgoing-domain) de votre nom de domaine.
+With the exception of the [SYRELI](https://www.syreli.fr/fr/) procedure mentioned [further down](#doa-syreli) in this guide, a DOA cannot be combined with a domain name transfer operation. You must first carry out your DOA, then perform an [incoming](/guides/web-cloud/domains/transfer-incoming-generic-domain) or [outgoing](/guides/web-cloud/domains/transfer-outgoing-domain) transfer of your domain name.
 :::
 
-**Découvrez comment réaliser une Demande d'Opération AFNIC (DOA)**
+**Find out how to submit an AFNIC Operation Request (DOA)**
 
-## Prérequis
+## Requirements
 
-- Avoir **initié une demande de changement de propriétaire** pour un domaine ayant une [extension gérée par l'AFNIC](https://www.afnic.fr/produits-services/) et pour lequel les procédures indiquées dans notre documentation sur le [changement de propriétaire d'un domaine](/guides/web-cloud/domains/trade-domain) **ne peuvent pas être appliquées**.
-- Avoir un bon de commande de **changement de propriétaire d'un domaine** dans le statut "en cours".
-- Télécharger la **Demande d'Opération AFNIC (DOA)** via le lien suivant : [https://www.afnic.fr/wp-media/uploads/2021/03/doa.pdf](https://www.afnic.fr/wp-media/uploads/2021/03/doa.pdf).
-- Accéder à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
+- You have **initiated a change of owner request** for a domain with an [extension managed by AFNIC](https://www.afnic.fr/produits-services/) and for which the procedures described in our documentation on the [change of owner of a domain](/guides/web-cloud/domains/trade-domain) **cannot be applied**.
+- You have a **change of owner of a domain** order in the "in progress" status.
+- Download the **AFNIC Operation Request (DOA)** using the following link: [https://www.afnic.fr/wp-media/uploads/2021/03/doa.pdf](https://www.afnic.fr/wp-media/uploads/2021/03/doa.pdf).
+- You are logged in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
 
-## En pratique
+## Instructions
 
-La première étape consiste à initier une demande de changement de propriétaire pour votre domaine ayant une [extension gérée par l'AFNIC](https://www.afnic.fr/produits-services/) à l'aide de notre documentation sur le [changement de propriétaire d'un domaine](/guides/web-cloud/domains/trade-domain).
+The first step is to initiate a change of owner request for your domain with an [extension managed by AFNIC](https://www.afnic.fr/produits-services/), using our documentation on the [change of owner of a domain](/guides/web-cloud/domains/trade-domain).
 
-Téléchargez ensuite le document présent sur la page [https://www.afnic.fr/wp-media/uploads/2021/03/doa.pdf](https://www.afnic.fr/wp-media/uploads/2021/03/doa.pdf).
+Then download the document available on the page [https://www.afnic.fr/wp-media/uploads/2021/03/doa.pdf](https://www.afnic.fr/wp-media/uploads/2021/03/doa.pdf).
 
-### Présentation de la DOA
+### Overview of the DOA
 
 ![DOA](/images/assets/screens/other/administrative/doa.png)
 
-Voici un descriptif des éléments pouvant être renseignés dans la DOA :
+Here is a description of the elements that can be filled in on the DOA:
 
-- Dans la zone **1**, vous pouvez renseigner le nom de domaine concerné et cocher l'une des deux opérations (volontaire ou forcée). Vous pouvez indiquer « OVHcloud » dans le formulaire `Bureau d'enregistrement demandeur`.
-- Dans la zone **2**, vous pouvez renseigner les informations du propriétaire actuel du domaine.
-- Dans la zone **3**, vous pouvez renseigner les informations du nouveau propriétaire demandé pour le domaine.
-- Dans la zone **4**, vous pouvez lister les documents justificatifs complémentaires transmis avec la DOA.
+- In area **1**, you can enter the domain name concerned and tick one of the two operations (voluntary or forced). You can enter "OVHcloud" in the `Requesting registrar` field.
+- In area **2**, you can enter the information of the domain's current owner.
+- In area **3**, you can enter the information of the requested new owner of the domain.
+- In area **4**, you can list the additional supporting documents submitted with the DOA.
 
-### DOA dans le cadre d'une transmission volontaire (Trade)
+### DOA in the context of a voluntary transfer (Trade)
 
 :::info
-Un bon de commande pour l'opération de changement de propriétaire doit obligatoirement être en cours.
+A change of owner order must be in progress.
 :::
 
-La validation des e-mails envoyés lors de l'initialisation du changement de propriétaire ne sera pas nécessaire, chacune des parties complète le document et le retourne à OVHcloud en créant un ticket d'assistance depuis son <ManagerLink to="/">espace client OVHcloud</ManagerLink> respectif.
+Validation of the emails sent when initiating the change of owner will not be necessary; each party completes the document and returns it to OVHcloud by creating a support ticket from their respective <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
 
-La DOA devra également être accompagnée des documents justificatifs de l'ancien propriétaire ci-dessous.
+The DOA must also be accompanied by the following supporting documents from the former owner.
 
-- Si l'ancien propriétaire est une société :
-    - Extrait K-Bis de moins de 3 mois (ou équivalent s'il s'agit d'une société étrangère).
-    - Photocopie recto-verso d'une pièce d'identité de l'un des gérants apparaissant sur l'extrait K-Bis.
+- If the former owner is a company:
+    - A K-Bis extract less than 3 months old (or equivalent for a foreign company).
+    - A double-sided photocopy of an ID document of one of the directors appearing on the K-Bis extract.
 
-- Si l'ancien propriétaire est une association :
-    - Extrait du Journal Officiel de moins de 3 mois (ou équivalent s'il s'agit d'une association étrangère).
-    - Photocopie recto-verso d'une pièce d'identité de l'un des gérants apparaissant sur l'extrait du Journal Officiel.
+- If the former owner is an association:
+    - An extract from the Official Journal less than 3 months old (or equivalent for a foreign association).
+    - A double-sided photocopy of an ID document of one of the directors appearing on the Official Journal extract.
 
-- Si l'ancien propriétaire est un particulier :
-    - Photocopie recto-verso d'une pièce d'identité.
-    - Justificatif de domicile de moins de 3 mois (facture d'électricité par exemple).
+- If the former owner is an individual:
+    - A double-sided photocopy of an ID document.
+    - A proof of address less than 3 months old (an electricity bill, for example).
 
 :::warning
-Vous devez obligatoirement signer la DOA et renseigner le cachet de la société si nécessaire.
+You must sign the DOA and provide the company stamp if necessary.
 :::
 
-### DOA dans le cadre d'une transmission forcée (Recover) <a id="doa-recover"></a>
+### DOA in the context of a forced transfer (Recover) <a id="doa-recover"></a>
 
 :::info
-Un bon de commande pour l'opération de changement de propriétaire doit obligatoirement être en cours.
+A change of owner order must be in progress.
 :::
 
-Cette DOA est utilisée dans le cas où le propriétaire actuel du domaine ne peut pas fournir son accord (décision de justice, liquidation judiciaire, décès, etc.).<br />
-Seul le nouveau propriétaire complète le document et le retourne à OVHcloud, accompagné des pièces justifiant ce changement forcé, en créant un ticket d'assistance depuis son <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
+This DOA is used when the domain's current owner cannot provide their agreement (court decision, compulsory liquidation, death, etc.).<br />
+Only the new owner completes the document and returns it to OVHcloud, along with the documents justifying this forced change, by creating a support ticket from their <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
 
 :::info
-Dans certains situations nécessitant une opération de transmission forcée (Recover), il n'est pas obligatoire de renseigner les informations du propriétaire actuel du domaine.
+In certain situations requiring a forced transfer operation (Recover), it is not mandatory to enter the information of the domain's current owner.
 :::
 
-Retrouvez ci-dessous la liste des documents à fournir en fonction de la situation rencontrée.
+Below is the list of documents to provide depending on the situation encountered.
 
-#### DOA suite à une décision judiciaire
+#### DOA following a court decision
 
-- Si le nouveau propriétaire est une société :
-    - Extrait K-Bis de moins de 3 mois (ou équivalent s'il s'agit d'une société étrangère).
-    - Photocopie recto-verso d'une pièce d'identité de l'un des gérants apparaissant sur l'extrait K-Bis.
-    - Procès-verbal en lien avec la décision judiciaire.
+- If the new owner is a company:
+    - A K-Bis extract less than 3 months old (or equivalent for a foreign company).
+    - A double-sided photocopy of an ID document of one of the directors appearing on the K-Bis extract.
+    - The minutes (procès-verbal) related to the court decision.
 
-- Si le nouveau propriétaire est une association :
-    - Extrait du Journal Officiel de moins de 3 mois (ou équivalent s'il s'agit d'une association étrangère).
-    - Photocopie recto-verso d'une pièce d'identité de l'un des gérants apparaissant sur l'extrait du Journal Officiel.
-    - Procès-verbal en lien avec la décision judiciaire.
+- If the new owner is an association:
+    - An extract from the Official Journal less than 3 months old (or equivalent for a foreign association).
+    - A double-sided photocopy of an ID document of one of the directors appearing on the Official Journal extract.
+    - The minutes (procès-verbal) related to the court decision.
 
-- Si le nouveau propriétaire est un particulier :
-    - Photocopie recto-verso d'une pièce d'identité.
-    - Justificatif de domicile de moins de 3 mois (facture d'électricité par exemple).
-    - Procès-verbal en lien avec la décision judiciaire.
+- If the new owner is an individual:
+    - A double-sided photocopy of an ID document.
+    - A proof of address less than 3 months old (an electricity bill, for example).
+    - The minutes (procès-verbal) related to the court decision.
 
-#### DOA suite à une liquidation judiciaire
+#### DOA following a compulsory liquidation
 
-- Si le nouveau propriétaire est une société :
-    - Extrait K-Bis de moins de 3 mois (ou équivalent s'il s'agit d'une société étrangère).
-    - Photocopie recto-verso d'une pièce d'identité de l'un des gérants apparaissant sur l'extrait K-Bis.
-    - Le mandataire judiciaire doit signer la partie concernant l'ancien propriétaire du domaine et fournir une attestation sur l'honneur justifiant son statut.
+- If the new owner is a company:
+    - A K-Bis extract less than 3 months old (or equivalent for a foreign company).
+    - A double-sided photocopy of an ID document of one of the directors appearing on the K-Bis extract.
+    - The judicial administrator must sign the section concerning the former owner of the domain and provide a sworn statement justifying their status.
 
-- Si le nouveau propriétaire est une association :
-    - Extrait du Journal Officiel de moins de 3 mois (ou équivalent s'il s'agit d'une association étrangère).
-    - Photocopie recto-verso d'une pièce d'identité de l'un des gérants apparaissant sur l'extrait du Journal Officiel.
-    - Le mandataire judiciaire doit signer la partie concernant l'ancien propriétaire du domaine et fournir une attestation sur l'honneur justifiant son statut.
+- If the new owner is an association:
+    - An extract from the Official Journal less than 3 months old (or equivalent for a foreign association).
+    - A double-sided photocopy of an ID document of one of the directors appearing on the Official Journal extract.
+    - The judicial administrator must sign the section concerning the former owner of the domain and provide a sworn statement justifying their status.
 
-- Si le nouveau propriétaire est un particulier :
-    - Photocopie recto-verso d'une pièce d'identité.
-    - Justificatif de domicile de moins de 3 mois (facture d'électricité par exemple).
-    - Le mandataire judiciaire doit signer la partie concernant l'ancien propriétaire du domaine et fournir une attestation sur l'honneur justifiant son statut.
+- If the new owner is an individual:
+    - A double-sided photocopy of an ID document.
+    - A proof of address less than 3 months old (an electricity bill, for example).
+    - The judicial administrator must sign the section concerning the former owner of the domain and provide a sworn statement justifying their status.
 
-#### DOA suite à un décès
+#### DOA following a death
 
-- Si le nouveau propriétaire est une société :
-    - Extrait K-Bis de moins de 3 mois (ou équivalent s'il s'agit d'une société étrangère).
-    - Photocopie recto-verso d'une pièce d'identité de l'un des gérants apparaissant sur l'extrait K-Bis.
-    - Un acte de décès.
-    - Un acte notarié désignant le nouveau propriétaire.
+- If the new owner is a company:
+    - A K-Bis extract less than 3 months old (or equivalent for a foreign company).
+    - A double-sided photocopy of an ID document of one of the directors appearing on the K-Bis extract.
+    - A death certificate.
+    - A notarial deed designating the new owner.
 
-- Si le nouveau propriétaire est une association :
-    - Extrait du Journal Officiel de moins de 3 mois (ou équivalent s'il s'agit d'une association étrangère).
-    - Photocopie recto-verso d'une pièce d'identité de l'un des gérants apparaissant sur l'extrait du Journal Officiel.
-    - Un acte de décès.
-    - Un acte notarié désignant le nouveau propriétaire.
+- If the new owner is an association:
+    - An extract from the Official Journal less than 3 months old (or equivalent for a foreign association).
+    - A double-sided photocopy of an ID document of one of the directors appearing on the Official Journal extract.
+    - A death certificate.
+    - A notarial deed designating the new owner.
 
-- Si le nouveau propriétaire est un particulier :
-    - Photocopie recto-verso d'une pièce d'identité.
-    - Justificatif de domicile de moins de 3 mois (facture d'électricité par exemple).
-    - Un acte de décès.
-    - Un acte notarié désignant le nouveau propriétaire.
+- If the new owner is an individual:
+    - A double-sided photocopy of an ID document.
+    - A proof of address less than 3 months old (an electricity bill, for example).
+    - A death certificate.
+    - A notarial deed designating the new owner.
 
 :::info
-Si vous vous trouvez dans l'incapacité de réaliser vous-même le bon de commande de changement de propriétaire depuis votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, vous pouvez, dans ce cas précis, contacter directement le support en créant un ticket d'assistance depuis votre espace client.
+If you are unable to create the change of owner order yourself from your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, you can, in this specific case, contact support directly by creating a support ticket from your Control Panel.
 :::
 
-### Cas particulier : DOA dans le cadre d'une SYRELI (transmission forcée : Recover) + transfert entrant du nom de domaine chez OVHcloud <a id="doa-syreli"></a>
+### Special case: DOA in the context of a SYRELI procedure (forced transfer: Recover) + incoming transfer of the domain name to OVHcloud <a id="doa-syreli"></a>
 
-La [procédure de **SY**stème de **RE**solution de **LI**tiges (**SYRELI**)](https://www.syreli.fr/fr/) a été mise au point par [l'AFNIC](https://www.afnic.fr/produits-services/) pour résoudre des situations particulières sur un nom de domaine au sens des articles [L.45-2 et L.45-6 du **C**ode des **P**ostes et des **C**ommunications **E**lectroniques (**CPCE**)](https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006150688). 
+The [**SY**stème de **RE**solution de **LI**tiges (**SYRELI**) procedure](https://www.syreli.fr/fr/) was developed by [AFNIC](https://www.afnic.fr/produits-services/) to resolve specific situations on a domain name within the meaning of articles [L.45-2 and L.45-6 of the **C**ode of **P**ostal and **E**lectronic **C**ommunications (**CPCE**)](https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006150688).
 
-La procédure SYRELI étant payante, nous vous recommandons de vous assurer qu'elle correspond parfaitement à votre situation. Pour cela, n'hésitez pas à consulter le **règlement**, les **ressources** et les **cas de jurisprudence** mis à disposition par l'AFNIC sur leur site web dédié à la [procédure SYRELI](https://www.syreli.fr/fr/).
+As the SYRELI procedure is paid, we recommend that you make sure it perfectly matches your situation. To do so, feel free to consult the **regulations**, the **resources**, and the **case law** made available by AFNIC on their website dedicated to the [SYRELI procedure](https://www.syreli.fr/fr/).
 
-Si vous bénéficiez par la suite d'une décision SYRELI favorable pour récupérer la propriété de votre nom de domaine et que vous souhaitez transférer ce dernier chez OVHcloud, suivez les **4 étapes** ci-dessous :
+If you subsequently obtain a favourable SYRELI decision to recover ownership of your domain name and you wish to transfer it to OVHcloud, follow the **4 steps** below:
 
-1. Si cela n'a pas déjà été réalisé lors de votre procédure SYRELI, remplissez une [DOA dans le cadre d'une transmission forcée (Recover)](#doa-recover).
-2. Préparez les documents à fournir avec la [DOA dans le cadre d'une transmission forcée (Recover)](#doa-recover), en fonction du statut du nouveau propriétaire (société, association, particulier).
-3. Initiez le [transfert entrant](/guides/web-cloud/domains/transfer-incoming-generic-domain) du nom de domaine concerné chez OVHcloud. Lors de cette étape, vérifiez que le nouveau propriétaire déclaré correspond bien au nouveau propriétaire bénéficiant de la procédure SYRELI. Lorsque vous arriverez à l'étape de demande du code de transfert du nom de domaine, l'opération tombera automatiquement en erreur. Cette situation est normale et est liée au fait qu'il ne s'agit pas là d'un transfert classique. L'essentiel ici est que la commande soit initiée pour que le support OVHcloud puisse agir à partir de l'étape qui suit.
-4. Contactez le support OVHcloud en créant [un ticket d'assistance depuis le Centre d'Aide](/links/support-contact). Précisez dans le ticket le nom de domaine concerné, la décision SYRELI, la DOA complétée et l'ensemble des documents relatifs au nouveau propriétaire que vous avez préparés lors de l'**étape 2**.
+1. If this has not already been done during your SYRELI procedure, complete a [DOA in the context of a forced transfer (Recover)](#doa-recover).
+2. Prepare the documents to provide with the [DOA in the context of a forced transfer (Recover)](#doa-recover), depending on the status of the new owner (company, association, individual).
+3. Initiate the [incoming transfer](/guides/web-cloud/domains/transfer-incoming-generic-domain) of the domain name concerned to OVHcloud. During this step, check that the declared new owner does indeed correspond to the new owner benefiting from the SYRELI procedure. When you reach the step requesting the domain name transfer code, the operation will automatically fail. This situation is normal and is due to the fact that this is not a standard transfer. The key point here is that the order is initiated so that OVHcloud support can act from the step that follows.
+4. Contact OVHcloud support by creating [a support ticket from the Help Centre](/links/support-contact). In the ticket, specify the domain name concerned, the SYRELI decision, the completed DOA, and all the documents relating to the new owner that you prepared in **step 2**.
 
-Dès que le support prend en charge votre demande et en fonction des délais de traitement de l'AFNIC, le processus de traitement prend généralement entre 24 et 48 heures. En effet, l'AFNIC vérifiera les éléments fournis dans votre ticket d'assistance et validera ou non l'opération de Recover.
+Once support takes charge of your request and depending on AFNIC's processing times, the handling process generally takes between 24 and 48 hours. AFNIC will check the items provided in your support ticket and either validate the Recover operation or not.
 
-Dès que l'AFNIC transmet un retour favorable, OVHcloud finalise l'opération de Recover auprès de l'AFNIC grâce a un code obtenu de leur part. OVHcloud peut ensuite valider le transfert entrant du nom de domaine. Vous pourrez ainsi l'administrer directement depuis votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
+As soon as AFNIC provides a favourable response, OVHcloud finalises the Recover operation with AFNIC using a code obtained from them. OVHcloud can then validate the incoming transfer of the domain name. You will then be able to manage it directly from your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
 
 :::info
-Si vous disposez d'une décision SYRELI favorable pour un nom de domaine chez OVHcloud et si vous souhaitez réaliser un transfert sortant vers un autre bureau d'enregistrement, contactez le nouveau bureau d'enregistrement souhaité afin de connaître les modalités à suivre à leur niveau pour réaliser ce transfert de nom de domaine.
+If you have a favourable SYRELI decision for a domain name with OVHcloud and you wish to carry out an outgoing transfer to another registrar, contact the desired new registrar to find out the steps to follow on their side to perform this domain name transfer.
 :::
 
-## Aller plus loin
+## Go further
 
-[Gérer les contacts de ses services](/guides/account-and-service-management/account-information/managing-contacts)
+[Managing the contacts of your services](/guides/account-and-service-management/account-information/managing-contacts)
 
-[Procédures OVHcloud](https://www.ovh.com/fr/support/procedures/)
+[OVHcloud procedures](https://www.ovh.com/fr/support/procedures/)
 
-[Changer la propriété d'un nom de domaine](/guides/web-cloud/domains/trade-domain)
+[Changing the owner of a domain name](/guides/web-cloud/domains/trade-domain)
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner).
+For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
 
-Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our different [support offers](/links/support).
 
-Échangez avec notre [communauté d'utilisateurs](/links/community).
+Join our [community of users](/links/community).

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-send-connector.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-send-connector.mdx
@@ -43,8 +43,8 @@ Here is the context of the diagram above:
 
 ### OVHcloud Control Panel Access
 
-- **Lien direct :** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Sélectionnez votre plateforme
+- **Direct link:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
+- **To access your services:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Select your service
 
 ---
 {/* CP-NAV-END:web-exchange */}

--- a/docs/en/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/getting-started-cloud-web.mdx
@@ -24,8 +24,8 @@ For our new [Cloud Web](/links/web/hosting-cloud-web-offer) solution, we have co
 
 ### OVHcloud Control Panel Access
 
-- **Lien direct :** <ManagerLink to="/#/web/hosting">Hébergements</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Hébergements</code> > Sélectionnez votre hébergement web
+- **Direct link:** <ManagerLink to="/#/web/hosting">Hosting plans</ManagerLink>
+- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Hosting plans</code> > Select your web hosting plan
 
 ---
 {/* CP-NAV-END:web-hosting */}
@@ -55,7 +55,7 @@ The languages currently available are:
 - Python
 - Ruby
 
-Pour accéder aux moteurs d'exécution de votre hébergement [Cloud Web](https://www.ovhcloud.com/fr/web-hosting/cloud-web-offer/), connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>. Cliquez sur <code className="action">Web Cloud</code> dans la barre de services à gauche, puis sur <code className="action">Hébergements</code>. Choisissez le nom de l'hébergement Cloud Web concerné et positionnez-vous sur l'onglet <code className="action">Moteurs d'exécution</code>.
+To access the runtime software applications for your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan, click on the tabs below to view each of the **3** steps.
 
 <Tabs>
   <Tab label="Step 1">
@@ -75,7 +75,7 @@ Pour accéder aux moteurs d'exécution de votre hébergement [Cloud Web](https:/
 
 {/* CP-STEPS-END:access-runtime-software */}
 
-Pour vérifier que vous disposez bien de 2 vCores avec votre hébergement Cloud Web, connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, cliquez sur <code className="action">Hébergements</code> dans la barre de services à gauche, puis choisissez le nom de l'hébergement Cloud Web concerné. Sur la page qui s'affiche, dans l'encadré **Abonnement** et sous la mention `Offre`, vérifiez que la référence <code className="action">Cloud Web 3</code> y est indiquée.
+Once you have done this, please ensure that you have the runtime software application (or applications) required for your project before you continue.
 
 {/* CP-STEPS-START:check-cloud-web-vcores */}
 To check that you have 2 vCores with your Cloud Web hosting plan, click on the tabs below to view each of the **2** steps.
@@ -230,17 +230,17 @@ There are several OVHcloud DNS records. We will focus on two particular records,
 
 |DNS record|Associated service|Where to find it|
 |---|---|---|
-|A|Pour le site internet|Dans votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, positionné dans la section <code className="action">Hébergements</code> sur l'hébergement Cloud Web concerné. Récupérez l'adresse IP qui apparaît à côté de « IPv4 » depuis l'onglet <code className="action">Informations générales</code>.|
-|MX|Pour les e-mails|Dans votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, positionné dans la section <code className="action">Emails</code> sur le nom de domaine concerné. Récupérez les informations qui apparaissent à côté de « Champs MX » depuis l'onglet <code className="action">Informations générales</code>.|
+|A|For the website|In your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, go to the <code className="action">Hosting plans</code> section and select the Cloud Web hosting plan concerned. Retrieve the IP address shown next to "IPv4" from the <code className="action">General information</code> tab.|
+|MX|For emails|In your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, go to the <code className="action">Emails</code> section and select the domain name concerned. Retrieve the information shown next to "MX records" from the <code className="action">General information</code> tab.|
 
 #### 2. Check and/or modify the DNS records
 
 Now that you are more familiar with the OVHcloud DNS records for your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan and your OVHcloud email solution, you can check if they have been configured properly, and edit them if required. These two changes must be made with the service provider managing your domain name's DNS configuration (DNS zone).
 
 :::warning
-- Si votre nom de domaine n'utilise pas la configuration DNS OVHcloud, vous devez réaliser la modification depuis l'interface du prestataire gérant cette dernière.
+- If your domain name does not use the OVHcloud DNS configuration, you will need to make changes using the interface given by the service provider managing your domain name.
 
-- Si votre nom de domaine est enregistré chez OVHcloud, vous pouvez vérifier si ce dernier utilise notre configuration DNS. Pour cela, rendez-vous dans votre <ManagerLink to="/">espace client</ManagerLink>, onglet <code className="action">Serveurs DNS</code> une fois positionné sur le nom de domaine concerné.
+- If your domain name is registered with OVHcloud, you can check if the domain name is using our DNS configuration. To do this, go to your <ManagerLink to="/">Control Panel</ManagerLink> and open the <code className="action">DNS servers</code> tab once you have selected the domain name concerned.
 
 - If your domain name is registered with OVHcloud, you can check if the domain name is using our DNS configuration. To do this, refer to our guide [Modifying the DNS servers for an OVHcloud domain name](/guides/web-cloud/domains/dns-server-edit).
 
@@ -250,8 +250,8 @@ Please read the instructions below to see where you should make the changes:
 
 |DNS configuration used|Where to make the changes|
 |---|---|
-|OVHcloud|Depuis votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la partie <code className="action">Web Cloud</code>. Cliquez sur le menu <code className="action">Zones DNS</code>, puis choisissez le nom de domaine concerné. Consultez notre documentation «[Éditer une zone DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit)» si nécessaire.|
-|Autre|Depuis l'interface du prestataire gérant la configuration DNS de votre nom de domaine. Nous vous invitons à prendre contact avec ce dernier si vous éprouvez des difficultés pour réaliser les manipulations.|
+|OVHcloud|From your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, open the <code className="action">Web Cloud</code> section. Click the <code className="action">DNS zones</code> menu, then select the domain name concerned. Read our documentation "[Editing an OVHcloud DNS zone](/guides/web-cloud/domains/dns-zone-edit)" if necessary.|
+|Other|From the interface given by the service provider managing your domain name's DNS configuration. Please contact your service provider if you encounter any difficulties making these changes.|
 
 Once you have modified your domain name's DNS configuration, you will need to allow a maximum of 24 hours for the changes to fully propagate and take effect. If you have added several domain names to your Cloud Web hosting plan as a multisite, you will need to make these two changes for each individual domain name.
 

--- a/docs/en/guides/web-cloud/web-hosting/install-camaleon.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/install-camaleon.mdx
@@ -1,126 +1,126 @@
 ---
-title: "Installer Camaleon CMS sur son hébergement Cloud Web"
-excerpt: "Découvrez comment installer un Camaleon CMS sur Cloud Web"
+title: "Installing Camaleon CMS on your Cloud Web hosting plan"
+excerpt: "Find out how to install Camaleon CMS on Cloud Web"
 lastUpdated: 2022-05-04
 availableIn: [eu]
 ---
 
-## Objectif
+## Objective
 
-[Camaleon CMS](http://camaleon.tuzitio.com/) est un système de gestion de contenu (Content System Management, CMS en anglais) écrit en Ruby, basé sur le framework web [Ruby on Rails](https://rubyonrails.org/). L'[hébergement Cloud Web OVHcloud](/links/web/hosting-cloud-web-offer) permet d'utiliser Ruby comme moteur d'exécution pour vos sites web et donc d'y installer et héberger Camaleon CMS ou toute autre application web conçue en Ruby. Dans ce tutoriel, nous allons installer un site web avec Camaleon CMS sur un hébergement Cloud Web d'OVH et le mettre à disposition derrière votre nom de domaine.
+[Camaleon CMS](http://camaleon.tuzitio.com/) is a Content Management System (CMS) written in Ruby and based on the [Ruby on Rails](https://rubyonrails.org/) web framework. [OVHcloud Cloud Web hosting](/links/web/hosting-cloud-web-offer) allows you to use Ruby as a runtime engine for your websites, and therefore to install and host Camaleon CMS or any other web application built in Ruby. In this tutorial, we will install a website with Camaleon CMS on an OVHcloud Cloud Web hosting plan and make it available through your domain name.
 
-**Découvrez comment installer un Camaleon CMS sur Cloud Web**
+**Find out how to install Camaleon CMS on Cloud Web**
 
-## Prérequis
+## Requirements
 
-- Disposer d'un [hébergement Cloud Web OVHcloud](/links/web/hosting-cloud-web-offer).
-- Être connecté à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, partie `Web Cloud`.
-- Ce que vous devez savoir :
-    - Les bases de l'écosystème Ruby.
-    - Se connecter en SSH.
-    - Éditer un fichier en ligne de commande via Vim, Emacs ou Nano parexemple.
+- A [OVHcloud Cloud Web hosting plan](/links/web/hosting-cloud-web-offer).
+- Access to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, in the `Web Cloud` section.
+- What you should know:
+    - The basics of the Ruby ecosystem.
+    - How to connect via SSH.
+    - How to edit a file from the command line using Vim, Emacs or Nano, for example.
 
-## En pratique
+## Instructions
 
-### Étape 1 : activer Ruby comme moteur d'exécution
+### Step 1: enabling Ruby as a runtime engine
 
-Pour accéder aux moteurs d'exécution de votre hébergement Cloud Web, connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>. Cliquez sur `Hébergements` dans la barre de services à gauche, puis choisissez le nom de l'hébergement Cloud Web concerné. Positionnez-vous enfin sur l'onglet `Moteurs d'exécution`. 
+To access the runtime engines of your Cloud Web hosting plan, log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>. Click `Hosting` in the services bar on the left, then choose the name of the relevant Cloud Web hosting plan. Finally, go to the `Runtime engines` tab.
 
-Le tableau qui apparaît affiche les moteurs d'exécution ajoutés actuellement. Assurez-vous alors que le moteur d'exécution Ruby est bien activé. Si tel est le cas, poursuivez vers l'étape 2  *Associer Ruby à un multisite* 
+The table that appears displays the runtime engines currently added. Make sure that the Ruby runtime engine is enabled. If it is, proceed to Step 2 *Associating Ruby with a multisite*.
 
-![Le moteur d'exécution Ruby doit être présent](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/runtime-software-application/tab-phpfpm7-4.png) 
+![The Ruby runtime engine must be present](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/runtime-software-application/tab-phpfpm7-4.png) 
 
-Si ce n'est pas le cas, ajoutez-en un nouveau (si votre offre vous le permet) ou modifiez le moteur d'exécutionexistant.
+If it is not, add a new one (if your plan allows it) or modify the existing runtime engine.
 
-- **Si vous souhaitez ajouter un moteur** : cliquez sur `Actions` au-dessus du tableau, puis sur `Ajouter un moteur d'exécution`.
-- **Si vous souhaitez modifier un moteur** : cliquez sur le bouton `...` à droite du moteur concerné, puis sur `Modifier`.
+- **If you want to add an engine**: click `Actions` above the table, then `Add a runtime engine`.
+- **If you want to modify an engine**: click the `...` button to the right of the relevant engine, then `Edit`.
 
-Dans la fenêtre qui s'affiche, complétez les informations demandées avec les valeurs suivantes de notre exemple ou adaptez-les à votre situationpersonnelle.
+In the window that appears, fill in the requested information with the following values from our example, or adapt them to your own situation.
 
-| Information                                  | Valeur  renseigner            |
+| Information                                  | Value to enter                |
 |----------------------------------------------|-------------------------------|
-|  Nom personnalisé                            |    Ruby 2.6                   |
-|  Moteur d'exécution                          |    ruby-2.6                   |
-|  Chemin d'accès au répertoire public         |    public                     |
-|  Environnement de l'application              |    production                 |
-|  Script de lancement de l'application        |    config.ru                  |
+|  Custom name                                 |    Ruby 2.6                   |
+|  Runtime engine                              |    ruby-2.6                   |
+|  Path to the public directory                |    public                     |
+|  Application environment                     |    production                 |
+|  Application launch script                   |    config.ru                  |
 
-Une fois les informations complétées, cliquez sur `Valider`. Si vous souhaitez obtenir plus d'informations sur la gestion des moteurs d'exécution, reportez-vous à notre guide *[Gérer les moteurs d'exécution de Cloud Web](/guides/web-cloud/web-hosting/manage-runtime-software-applications)*. 
+Once the information is filled in, click `Confirm`. If you would like more information about managing runtime engines, refer to our guide *[Managing the runtime engines of Cloud Web](/guides/web-cloud/web-hosting/manage-runtime-software-applications)*.
 
-![Ajouter le moteur d'exécution Ruby](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/runtime-software-application/modify-a-runtime-software-application-ruby2-6.png) 
+![Adding the Ruby runtime engine](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/runtime-software-application/modify-a-runtime-software-application-ruby2-6.png) 
 
-### Étape 2 : associer Ruby à un multisite
+### Step 2: associating Ruby with a multisite
 
-Maintenant que Ruby est activé en tant que moteur d'exécution, vous devez l'associer à l'un de vos multisites. Pour cela, positionnez-vous sur l'onglet `Multisite`. Le tableau qui s'affiche contient tous les noms de domaine qui ont été ajoutés en tant que multisite. 
+Now that Ruby is enabled as a runtime engine, you must associate it with one of your multisites. To do this, go to the `Multisite` tab. The table that appears contains all the domain names that have been added as a multisite.
 
-![Associer Ruby à un multisite](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/multisite/tab-phpfpm7-4-full-disabled.png) 
+![Associating Ruby with a multisite](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/multisite/tab-phpfpm7-4-full-disabled.png) 
 
-Deux colonnes doivent retenir votre attention dans le tableau ci-dessus. Vérifiez alors que le moteur d'exécution Ruby est bien lié aux domaines concernés et que le dossier racine est correct. Aidez-vous des informations ci-dessous si nécessaire. Si tel est le cas, poursuivez vers l'étape 3 [Se connecter à votre Cloud Web via SSH](#sshconnexion).
+Two columns should draw your attention in the table above. Check that the Ruby runtime engine is properly linked to the relevant domains and that the root folder is correct. Use the information below if needed. If it is, proceed to Step 3 [Connecting to your Cloud Web via SSH](#sshconnexion).
 
-| Colonne                     | Description                                                                  |
+| Column                      | Description                                                                  |
 |-----------------------------|------------------------------------------------------------------------------|
-| Dossier racine              | Il s'agit du dossier racine qui devra contenir le code source du domaine concerné (il correspond au « DocumentRoot »). Dans notre exemple, nous choisissons de spécifier « camaleon ». Celui-ci devra donc contenir notre code source Ruby. |
-| Moteur d'exécution          | Il s'agit du moteur d'exécution associé au domaine concerné. Le nom qui s'affiche correspond au *Nom personnalisé* que vous avez défini lors de la création du moteur d'exécution. Dans notre exemple, vous devriez retrouver *Ruby 2.6*.  |
+| Root folder                 | This is the root folder that must contain the source code of the relevant domain (it corresponds to the "DocumentRoot"). In our example, we choose to specify "camaleon". It must therefore contain our Ruby source code. |
+| Runtime engine              | This is the runtime engine associated with the relevant domain. The name displayed corresponds to the *Custom name* you defined when creating the runtime engine. In our example, you should find *Ruby 2.6*.  |
 
-Si ce n'est pas le cas, ajoutez un nouveau multisite ou modifiez celui existant.
+If it is not, add a new multisite or modify the existing one.
 
-*   **Si vous souhaitez ajouter un multisite** : cliquez sur `Actions`, puis sur `Ajouter un domaine ou sous-domaine` à droite dutableau.
-*   **Si vous souhaitez modifier un multisite** : cliquez sur le bouton `...` à droite du nom de domaine concerné, puis sur `Modifier`.
+*   **If you want to add a multisite**: click `Actions`, then `Add a domain or subdomain` to the right of the table.
+*   **If you want to modify a multisite**: click the `...` button to the right of the relevant domain name, then `Edit`.
 
-Dans la fenêtre qui s'affiche, complétez les informations demandées selon votre situation personnelle. Le tableau ci-dessous montre celles utilisées pour cetutoriel.
+In the window that appears, fill in the requested information according to your own situation. The table below shows the values used for this tutorial.
 
-| Information                | Valeur utilisée en exemple pour ce tutoriel            |
+| Information                | Example value used for this tutorial                   |
 |----------------------------|--------------------------------------------------------|
-| Domaine                    |  `camaleon.demo-cloudweb.ovh`                          |
-| Dossier racine             |  `camaleon`                                            |
-| Moteur d'exécution         |  Ruby 2.6                                              |
+| Domain                     |  `camaleon.demo-cloudweb.ovh`                          |
+| Root folder                |  `camaleon`                                            |
+| Runtime engine             |  Ruby 2.6                                              |
 
-En ce qui concerne les options supplémentaires, choisissez celles que vous souhaitez activer. Une fois les informations complétées, cliquez sur `Suivant`, puis finalisez la manipulation. Cet ajout peut prendre jusqu'à une heure. Cependant, la modification de la configuration DNS peut prendre jusqu'à 24 heures avant d'être pleinement effective. Si vous souhaitez obtenir plus d'informations sur la gestion des multisites, reportez-vous à notre guide « [Partager son hébergement entre plusieurs sites](/guides/web-cloud/web-hosting/multisites-configure-multisite) ». 
+As for the additional options, choose the ones you want to enable. Once the information is filled in, click `Next`, then finalise the operation. This addition can take up to one hour. However, the change to the DNS configuration can take up to 24 hours to become fully effective. If you would like more information about managing multisites, refer to our guide "[Sharing your hosting plan between several websites](/guides/web-cloud/web-hosting/multisites-configure-multisite)".
 
-![Partager son hébergement entre plusieurs sites](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/multisite/add-a-domain-or-sub-domain-step-2-django.png) 
+![Sharing your hosting plan between several websites](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/multisite/add-a-domain-or-sub-domain-step-2-django.png) 
 
-### Étape 3 : se connecter à votre Cloud Web via SSH <a id="sshconnexion"></a>
+### Step 3: connecting to your Cloud Web via SSH <a id="sshconnexion"></a>
 
-Récupérez d'abord les informations vous permettant de vous connecter. Pour cela, positionnez-vous sur l'onglet `FTP - SSH`. Si celui-ci n'apparaît pas dans la liste, appuyez au préalable sur le bouton représentant trois barres. Les informations liées à votre espace de stockage apparaissent alors. Repérez celles mentionnées dans le tableau :
+First, retrieve the information you need to connect. To do this, go to the `FTP - SSH` tab. If it does not appear in the list, first click the button with three bars. The information related to your storage space then appears. Locate the details listed in the table:
 
-- **SSH** : L'élément qui apparaît vous permet de récupérer deux informations. 
-  - **l'adresse du serveur** : elle débute après `ssh://` et se termine avant les `:`
-  - **le port de connexion** : le numéro est mentionné après les `:`
-  On pourrait par exemple retrouver : `ssh://sshcloud.cluster000.hosting.ovh.net:12345`, donc `sshcloud.cluster000.hosting.ovh.net` en adresse de serveur et `12345` en port de connexion.
-- **Login** : Il s'agit de l'identifiant SSH principal créé sur votre hébergement.
+- **SSH**: The element that appears lets you retrieve two pieces of information.
+  - **the server address**: it starts after `ssh://` and ends before the `:`
+  - **the connection port**: the number is shown after the `:`
+  For example, you might find: `ssh://sshcloud.cluster000.hosting.ovh.net:12345`, so `sshcloud.cluster000.hosting.ovh.net` as the server address and `12345` as the connection port.
+- **Login**: This is the main SSH username created on your hosting plan.
 
-Si vous ne connaissez plus le mot de passe de l'utilisateur SSH, cliquez sur le bouton `...` à droite de l'utilisateur concerné dans le tableau, puis sur `Changer le mot de passe`. 
+If you no longer know the password of the SSH user, click the `...` button to the right of the relevant user in the table, then `Change password`.
 
-![Se connecter à votre Cloud Web viaSSH](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/ftp-ssh/change-password.png) 
+![Connecting to your Cloud Web via SSH](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/ftp-ssh/change-password.png) 
 
-À présent, pour vous connecter en SSH, vous devez utiliser un terminal. Cet outil est installé par défaut sur macOS ou Linux. Un environnement Windows nécessitera l'installation d'un logiciel comme PuTTY ou l'ajout de la fonctionnalité « OpenSSH ». Cette démarche étant spécifique au système d'exploitation que vous utilisez, nous ne pouvons pas la détailler dans cettedocumentation. 
+Now, to connect via SSH, you need to use a terminal. This tool is installed by default on macOS and Linux. A Windows environment will require the installation of software such as PuTTY or the addition of the "OpenSSH" feature. As this procedure is specific to the operating system you use, we cannot detail it in this documentation.
 
-Voici l'exemple d'une ligne de commande que vous pouvez utiliser. Remplacez les éléments « sshlogin », « sshserver » et « connectionport » par ceux adaptés à votre situation personnelle. Une fois la commande envoyée, vous serez invité à renseigner le mot de passe de l'utilisateur SSH.
+Here is an example of a command line you can use. Replace the "sshlogin", "sshserver" and "connectionport" elements with the ones matching your own situation. Once the command is sent, you will be prompted to enter the password of the SSH user.
 
 ```
-ssh sshlogin@sshserver -p connectionport
+ssh sshlogin@sshserver -p connectionport
 ```
 
-### Étape 4 : préparer l'environnement Ruby
+### Step 4: preparing the Ruby environment
 
-Nous allons maintenant préparer l'environnement Ruby nécessaire pour héberger notre application Camaleon CMS. Depuis la connexion SSH ouverte sur votre Cloud Web, définissez les variables d'environnement PATH et GEM\_HOME
+We will now prepare the Ruby environment needed to host our Camaleon CMS application. From the SSH connection opened on your Cloud Web, define the PATH and GEM\_HOME environment variables.
 
 ```sh
 democld@cloudweb-ssh:~ $ export PATH=$PATH:/usr/local/ruby2.6/bin:~/.gem/ruby/2.6.0/bin
 democld@cloudweb-ssh:~ $ export GEM_HOME=~/.gem/ruby/2.6.0
 ```
 
-Vous pouvez persister ces changements en ajoutant les exports dans le fichier `~/.profile` :
+You can make these changes persistent by adding the exports to the `~/.profile` file:
 
 ```sh
-democld@cloudweb-ssh:~ $ echo 'export PATH=$PATH:/usr/local/ruby2.6/bin:~/.gem/ruby/2.6.0/bin' >> ~/.profile
-democld@cloudweb-ssh:~ $ echo 'export GEM_HOME=~/.gem/ruby/2.6.0' >> ~/.profile
+democld@cloudweb-ssh:~ $ echo 'export PATH=$PATH:/usr/local/ruby2.6/bin:~/.gem/ruby/2.6.0/bin' >> ~/.profile
+democld@cloudweb-ssh:~ $ echo 'export GEM_HOME=~/.gem/ruby/2.6.0' >> ~/.profile
 ```
 
-Installez le framework Ruby on Rails
+Install the Ruby on Rails framework.
 
 ```sh
-democld@cloudweb-ssh:~ $ gem install rails --user --no-doc
+democld@cloudweb-ssh:~ $ gem install rails --user --no-doc
 Fetching thread_safe-0.3.6.gem
 Fetching rack-test-1.1.0.gem
 Fetching mini_portile2-2.4.0.gem
@@ -128,138 +128,138 @@ Fetching mini_portile2-2.4.0.gem
 Successfully installed sprockets-3.7.2
 Successfully installed sprockets-rails-3.2.1
 Successfully installed rails-5.2.3
-37 gems installed
-democld@cloudweb-ssh:~ $ rails -v
-Rails 5.2.3
+37 gems installed
+democld@cloudweb-ssh:~ $ rails -v
+Rails 5.2.3
 ```
 
-Vous pouvez maintenant vous placer dans le dossier `camaleon` et créer votre projet :
+You can now move into the `camaleon` folder and create your project:
 
 ```sh
 democld@cloudweb-ssh:~ $ cd camaleon/
-democld@cloudweb-ssh:~/camaleon $ rm -f config.ru
+democld@cloudweb-ssh:~/camaleon $ rm -f config.ru
 democld@cloudweb-ssh:~/camaleon $ RAILS_ENV=production rails new .
-exist 
-create  README.md
-create  Rakefile
-identical  .ruby-version
-create  config.ru
-create  .gitignore
-create  Gemfile
-run  git init from "."
+exist 
+create  README.md
+create  Rakefile
+identical  .ruby-version
+create  config.ru
+create  .gitignore
+create  Gemfile
+run  git init from "."
 ...
-run  bundle exec spring binstub --all
-* bin/rake: Spring inserted
-* bin/rails: Spring inserted
+run  bundle exec spring binstub --all
+* bin/rake: Spring inserted
+* bin/rails: Spring inserted
 ```
 
-### Étape 5 : Installer et configurer Camaleon CMS
+### Step 5: installing and configuring Camaleon CMS
 
-Modification du Gemfile pour installer Camaleon CMS ( source : [https://github.com/owen2345/camaleon-cms](https://github.com/owen2345/camaleon-cms) )
+Edit the Gemfile to install Camaleon CMS (source: [https://github.com/owen2345/camaleon-cms](https://github.com/owen2345/camaleon-cms)).
 
 ```sh
-democld@cloudweb-ssh:~/camaleon $ echo 'gem "camaleon_cms",  ">= 2.4.6"' >> Gemfile
-democld@cloudweb-ssh:~/camaleon $ echo 'gem "draper", "~> 3"' >> Gemfile
+democld@cloudweb-ssh:~/camaleon $ echo 'gem "camaleon_cms",  ">= 2.4.6"' >> Gemfile
+democld@cloudweb-ssh:~/camaleon $ echo 'gem "draper", "~> 3"' >> Gemfile
 ```
 
-Installation des prérequis et des dépendances
+Install the prerequisites and dependencies.
 
 ```sh
 democld@cloudweb-ssh:~/camaleon $ bundle install
-Fetching gem metadata from https://rubygems.org/.........
-Fetching gem metadata from https://rubygems.org/.
+Fetching gem metadata from https://rubygems.org/.........
+Fetching gem metadata from https://rubygems.org/.
 Resolving dependencies.....
-Using rake 12.3.2
-Using concurrent-ruby 1.1.5
+Using rake 12.3.2
+Using concurrent-ruby 1.1.5
 ...
-Using uglifier 4.1.20
-Using web-console 3.7.0
-Bundle complete! 20 Gemfile dependencies, 103 gems now installed.
-Use bundle info [gemname] to see where a bundled gem is installed.
+Using uglifier 4.1.20
+Using web-console 3.7.0
+Bundle complete! 20 Gemfile dependencies, 103 gems now installed.
+Use bundle info [gemname] to see where a bundled gem is installed.
 ```
-  
-Camaleon CMS utilise execjs qui nécessite un moteur d'exécution JS. Nous allons utiliser NodeJS 8 comme moteur d'exécution JS
+  
+Camaleon CMS uses execjs, which requires a JS runtime engine. We will use NodeJS 8 as the JS runtime engine.
 
 ```sh
-democld@cloudweb-ssh:~/camaleon $ sed -i 's@\["nodejs", "node"\],@["/usr/local/nodejs8/bin/node"],@' ${GEM_HOME}/gems/execjs-2.7.0/lib/execjs/runtimes.rb
+democld@cloudweb-ssh:~/camaleon $ sed -i 's@\["nodejs", "node"\],@["/usr/local/nodejs8/bin/node"],@' ${GEM_HOME}/gems/execjs-2.7.0/lib/execjs/runtimes.rb
 ```
 
-Installation de Camaleon CMS (pour la démo on utilisera une base de données SQLite)
+Install Camaleon CMS (for the demo, we will use an SQLite database).
 
 ```sh
 democld@cloudweb-ssh:~/camaleon $ RAILS_ENV=production rails generate camaleon_cms:install
 rails generate camaleon_cms:install
-Running via Spring preloader in process 12603
-create  config/system.json
-create  lib/plugin_routes.rb
-exist  app/apps
-create  app/apps/themes/readme.txt
-exist  app/apps/themes
+Running via Spring preloader in process 12603
+create  config/system.json
+create  lib/plugin_routes.rb
+exist  app/apps
+create  app/apps/themes/readme.txt
+exist  app/apps/themes
 ...
-create  app/apps/themes/new/views/post_type.html.erb
-create  app/apps/themes/new/views/search.html.erb
-append  Gemfile
+create  app/apps/themes/new/views/post_type.html.erb
+create  app/apps/themes/new/views/search.html.erb
+append  Gemfile
 democld@cloudweb-ssh:~/camaleon $ RAILS_ENV=production rake camaleon_cms:generate_migrations
-Copied migration 20190625130636_create_active_storage_tables.active_storage.rb from active_storage
-Copied migration 20190625130637_create_db_structure.cama_contact_form_engine.rb from cama_contact_form_engine
-Copied migration 20190625130638_post_table_into_utf8.camaleon_cms_engine.rb from camaleon_cms_engine
-Copied migration 20190625130639_rename_column_posts.camaleon_cms_engine.rb from camaleon_cms_engine
-Copied migration 20190625130640_add_confirm_token_to_users.camaleon_cms_engine.rb from camaleon_cms_engine
-Copied migration 20190625130641_add_feature_to_posts.camaleon_cms_engine.rb from camaleon_cms_engine
-Copied migration 20190625130642_move_first_name_of_users.camaleon_cms_engine.rb from camaleon_cms_engine
-Copied migration 20190625130643_improve_menus_structure.camaleon_cms_engine.rb from camaleon_cms_engine
-Copied migration 20190625130644_add_group_to_custom_field_values.camaleon_cms_engine.rb from camaleon_cms_engine
-Copied migration 20190625130645_install_migrated_seo_plugin.camaleon_cms_engine.rb from camaleon_cms_engine
-Copied migration 20190625130646_drop_user_relationship_table.camaleon_cms_engine.rb from camaleon_cms_engine
-Copied migration 20190625130647_create_media.camaleon_cms_engine.rb from camaleon_cms_engine
-Copied migration 20190625130648_adjust_field_length.camaleon_cms_engine.rb from camaleon_cms_engine
-democld@cloudweb-ssh:~/camaleon $ RAILS_ENV=production rake db:migrate
-== 20190625130636 CreateActiveStorageTables: migrating ========================
--- create_table(:active_storage_blobs)
--> 0.0076s
--- create_table(:active_storage_attachments)
--> 0.0170s
+Copied migration 20190625130636_create_active_storage_tables.active_storage.rb from active_storage
+Copied migration 20190625130637_create_db_structure.cama_contact_form_engine.rb from cama_contact_form_engine
+Copied migration 20190625130638_post_table_into_utf8.camaleon_cms_engine.rb from camaleon_cms_engine
+Copied migration 20190625130639_rename_column_posts.camaleon_cms_engine.rb from camaleon_cms_engine
+Copied migration 20190625130640_add_confirm_token_to_users.camaleon_cms_engine.rb from camaleon_cms_engine
+Copied migration 20190625130641_add_feature_to_posts.camaleon_cms_engine.rb from camaleon_cms_engine
+Copied migration 20190625130642_move_first_name_of_users.camaleon_cms_engine.rb from camaleon_cms_engine
+Copied migration 20190625130643_improve_menus_structure.camaleon_cms_engine.rb from camaleon_cms_engine
+Copied migration 20190625130644_add_group_to_custom_field_values.camaleon_cms_engine.rb from camaleon_cms_engine
+Copied migration 20190625130645_install_migrated_seo_plugin.camaleon_cms_engine.rb from camaleon_cms_engine
+Copied migration 20190625130646_drop_user_relationship_table.camaleon_cms_engine.rb from camaleon_cms_engine
+Copied migration 20190625130647_create_media.camaleon_cms_engine.rb from camaleon_cms_engine
+Copied migration 20190625130648_adjust_field_length.camaleon_cms_engine.rb from camaleon_cms_engine
+democld@cloudweb-ssh:~/camaleon $ RAILS_ENV=production rake db:migrate
+== 20190625130636 CreateActiveStorageTables: migrating ========================
+-- create_table(:active_storage_blobs)
+-> 0.0076s
+-- create_table(:active_storage_attachments)
+-> 0.0170s
 ...
--- change_column("cama_term_taxonomy", :name, :text, {})
--> 0.1065s
-== 20190625130648 AdjustFieldLength: migrated (0.2999s) =======================
+-- change_column("cama_term_taxonomy", :name, :text, {})
+-> 0.1065s
+== 20190625130648 AdjustFieldLength: migrated (0.2999s) =======================
 democld@cloudweb-ssh:~/camaleon $ RAILS_ENV=production rake assets:precompile
 ```
 
-### Étape 6 : redémarrer le *daemon* Ruby
+### Step 6: restarting the Ruby *daemon*
 
-Pour redémarrer le *daemon* Ruby, retournez sur votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>. Positionnez-vous sur l'onglet `Multisite`, cliquez à droite du nom de domaine concerné sur le bouton `...`, puis sur `Redémarrer`. 
+To restart the Ruby *daemon*, go back to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>. Go to the `Multisite` tab, click the `...` button to the right of the relevant domain name, then click `Restart`.
 
-Une fois ceci fait, l'application sera accessible via le nom de domaine choisi dans la configuration de votre multisite. 
+Once this is done, the application will be accessible through the domain name chosen in your multisite configuration.
 
-Félicitation, votre site utilisant Camaleon CMS est maintenant disponible ! Il ne vous reste plus qu'à le configurer.  
+Congratulations, your website using Camaleon CMS is now available! All that is left is to configure it.
 
-### Étape 7 : utiliserHTTPS
+### Step 7: using HTTPS
 
-Pour plus de sécurité sur votre site, vous pouvez mettre en place une redirection automatique HTTP vers HTTPS. Pour ce faire, toujours positionné dans le dossier `camaleon`, créez un fichier `.htaccess` avec le contenu suivant:
+For added security on your website, you can set up an automatic HTTP to HTTPS redirection. To do this, while still in the `camaleon` folder, create a `.htaccess` file with the following content:
 
 ```
 RewriteEngine On
-RewriteCond %{ENV:HTTPS} !on
+RewriteCond %{ENV:HTTPS} !on
 RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 ```
 
 ## Conclusion
 
-Nous avons vu comment installer une application Ruby sur un hébergement Cloud Web en respectant les différentes étapes. Il ne vous reste plus qu'à utiliser Camaleon CMS et y publier vos premiers contenus! Vous trouverez plus de documentation propre à Camaleon CMS et ses fonctionnalités sur la [documentation officielle du projet](http://camaleon.tuzitio.com/).
+We have seen how to install a Ruby application on a Cloud Web hosting plan by following the various steps. All that is left is to use Camaleon CMS and publish your first content! You will find more documentation specific to Camaleon CMS and its features in the [project's official documentation](http://camaleon.tuzitio.com/).
 
-## Aller plus loin
+## Go further
 
-[Migrer mon site chez OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
+[Migrating my website to OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
 
-[Mettre mon site en ligne](/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online)
+[Putting my website online](/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online)
 
-[Installer son site avec les modules en 1 clic](/guides/web-cloud/web-hosting/cms-install-1-click-modules)
+[Installing your website with 1-click modules](/guides/web-cloud/web-hosting/cms-install-1-click-modules)
 
-[Partager son hébergement entre plusieurs sites](/guides/web-cloud/web-hosting/multisites-configure-multisite)
+[Sharing your hosting plan between several websites](/guides/web-cloud/web-hosting/multisites-configure-multisite)
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner).
+For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
 
-Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).
+If you would like assistance using and configuring your OVHcloud solutions, we invite you to consult our various [support offers](/links/support).
 
-Échangez avec notre [communauté d'utilisateurs](/links/community).
+Join our [community of users](/links/community).

--- a/docs/en/guides/web-cloud/web-hosting/install-django-cms-on-cloud-web.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/install-django-cms-on-cloud-web.mdx
@@ -1,112 +1,112 @@
 ---
-title: "Comment installer Django CMS sur son hébergement Cloud Web"
-excerpt: "Apprenez à installer Django CMS avec Python sur votre hébergement Cloud Web OVHcloud"
+title: "How to install Django CMS on your Cloud Web hosting"
+excerpt: "Learn how to install Django CMS with Python on your OVHcloud Cloud Web hosting"
 lastUpdated: 2022-05-04
 availableIn: [eu]
 ---
 
-## Objectif
+## Objective
 
-Django CMS est un système de gestion de contenu (CMS) écrit en Python et basé sur le framework web Django.
+Django CMS is a content management system (CMS) written in Python and based on the Django web framework.
 
-L'[hébergement Cloud Web OVHcloud](/links/web/hosting-cloud-web-offer) permet d'utiliser Python comme moteur d'exécution pour vos sites web. Vous pouvez donc y installer et héberger Django CMS, ainsi que toute autre application web conçue dans ce langage.
+[OVHcloud Cloud Web hosting](/links/web/hosting-cloud-web-offer) lets you use Python as a runtime for your websites. You can therefore install and host Django CMS on it, as well as any other web application designed in this language.
 
-À travers ce tutoriel, nous allons installer un site web avec Django CMS sur un hébergement Cloud Web d'OVHcloud. Puis nous le mettrons à disposition derrière votre nom de domaine.
+In this tutorial, we will install a website with Django CMS on an OVHcloud Cloud Web hosting plan. We will then make it available behind your domain name.
 
-## Prérequis
+## Requirements
 
-- Disposer d'un [hébergement Cloud Web OVHcloud](/links/web/hosting-cloud-web-offer).
-- Être connecté à votre <ManagerLink to="/">espace client</ManagerLink>, partie `Web Cloud`.
-- Ce que vous devez savoir:
-    - Les bases de l'écosystème Python.
-    - Se connecter en SSH.
-    - Éditer un fichier en ligne de commande, via Vim, Emacs ou Nano par exemple.
+- An [OVHcloud Cloud Web hosting plan](/links/web/hosting-cloud-web-offer).
+- Being logged in to your <ManagerLink to="/">Control Panel</ManagerLink>, in the `Web Cloud` section.
+- What you need to know:
+    - The basics of the Python ecosystem.
+    - How to connect via SSH.
+    - How to edit a file from the command line, using Vim, Emacs or Nano for example.
 
-## En pratique
+## Instructions
 
-### Étape 1 : activez Python comme moteur d'exécution
+### Step 1: enable Python as a runtime
 
-Pour accéder aux moteurs d'exécution de votre hébergement Cloud Web, connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>. Cliquez sur `Hébergements` dans la barre de services à gauche, puis choisissez le nom de l'hébergement Cloud Web concerné. Positionnez-vous enfin sur l'onglet `Moteurs d'exécution`.
+To access the runtimes of your Cloud Web hosting, log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>. Click `Hostings` in the services bar on the left, then choose the name of the relevant Cloud Web hosting. Finally, go to the `Runtimes` tab.
 
-Le tableau qui apparaît affiche les moteurs d'exécution ajoutés actuellement. Assurez-vous alors que le moteur d'exécution Python est bien activé. Si tel est le cas, poursuivez vers l'étape 2 : [« Associez Python à un multisite »](#etape-2-associez-python-a-un-multisite).
+The table that appears displays the runtimes currently added. Make sure that the Python runtime is enabled. If so, proceed to Step 2: [“Associate Python with a multisite”](#step-2-associate-python-with-a-multisite).
 
 ![django-cloud-web](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/runtime-software-application/tab-python3.png)
 
-Si ce n'est pas le cas, ajoutez-en un nouveau (si votre offre vous le permet) ou modifiez le moteur d'exécution existant.
+If it is not, add a new one (if your plan allows it) or modify the existing runtime.
 
-- **Si vous souhaitez ajouter un moteur** : cliquez sur `Actions` au-dessus du tableau, puis sur `Ajouter un moteur d'exécution`.
-- **Si vous souhaitez modifier un moteur** : cliquez sur le bouton `...` à droite du moteur concerné, puis sur `Modifier`.
+- **If you want to add a runtime**: click `Actions` above the table, then `Add a runtime`.
+- **If you want to modify a runtime**: click the `...` button to the right of the relevant runtime, then `Modify`.
 
-Dans la fenêtre qui s'affiche, complétez les informations demandées avec les valeurs suivantes de notre exemple ou adaptez-les à votre situation.
+In the window that appears, fill in the requested information with the following values from our example, or adapt them to your situation.
 
-|  Information  |  Valeur à renseigner  |
+|  Information  |  Value to enter  |
 |  :-----          |  :-----          |
-|  Nom personnalisé |  Python 3 |
-|  Moteur d'exécution |  python-3 |
-|  Chemin d'accès au répertoire public |  public |
-|  Environnement de l'application |  production |
-|  Script de lancement de l'application |  server.py |
+|  Custom name |  Python 3 |
+|  Runtime |  python-3 |
+|  Path to the public directory |  public |
+|  Application environment |  production |
+|  Application launch script |  server.py |
 
-Une fois les informations complétées, cliquez sur `Valider`. Si vous souhaitez obtenir plus d'informations sur la gestion des moteurs d'exécution, reportez-vous à notre guide [« Gérer les moteurs d'exécution de Cloud Web »](/guides/web-cloud/web-hosting/manage-runtime-software-applications).
+Once the information is filled in, click `Confirm`. If you want more information about managing runtimes, refer to our guide [“Managing Cloud Web runtimes”](/guides/web-cloud/web-hosting/manage-runtime-software-applications).
 
 ![django-cloud-web](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/runtime-software-application/modify-a-runtime-software-application-python3.png)
 
-### Étape 2 : associez Python à un multisite
+### Step 2: associate Python with a multisite
 
-Maintenant que Python est activé en tant que moteur d'exécution, vous devez l'associer à l'un de vos multisites. Pour cela, positionnez-vous sur l'onglet `Multisite`. Le tableau qui s'affiche contient tous les noms de domaine qui ont été ajoutés en tant que multisite.
+Now that Python is enabled as a runtime, you need to associate it with one of your multisites. To do this, go to the `Multisite` tab. The table that appears contains all the domain names that have been added as a multisite.
 
 ![django-cloud-web](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/multisite/tab-python3-full-disabled.png)
 
-Deux colonnes doivent retenir votre attention dans le tableau ci-dessus. Vérifiez alors que le moteur d'exécution Python est bien lié aux domaines concernés et que le dossier racine est correct ; aidez-vous des informations ci-dessous si nécessaire. Si tel est le cas, poursuivez vers l'étape 3 : [« Connectez-vous à votre Cloud Web via SSH »](#etape-3-se-connecter-a-votre-cloud-web-via-ssh).
+Two columns in the table above deserve your attention. Check that the Python runtime is properly linked to the relevant domains and that the root folder is correct; use the information below if necessary. If so, proceed to Step 3: [“Connect to your Cloud Web via SSH”](#step-3-connect-to-your-cloud-web-via-ssh).
 
-|  Colonne  |  Description  |
+|  Column  |  Description  |
 |  :-----          |  :-----          |
-|  Dossier racine |  Il s'agit du dossier racine qui devra contenir le code source du domaine concerné (il correspond au « DocumentRoot »). Dans notre exemple, nous choisissons de spécifier « django ». Celui-ci devra donc contenir notre code source Python. |
-|  Moteur d'exécution |  Il s'agit du moteur d'exécution associé au domaine concerné. Le nom qui s'affiche correspond au « Nom personnalisé » que vous avez défini lors de la création du moteur d'exécution. Dans notre exemple, vous devriez retrouver « Python 3 ». |
+|  Root folder |  This is the root folder that must contain the source code of the relevant domain (it corresponds to the “DocumentRoot”). In our example, we choose to specify “django”. It must therefore contain our Python source code. |
+|  Runtime |  This is the runtime associated with the relevant domain. The name displayed corresponds to the “Custom name” you defined when creating the runtime. In our example, you should find “Python 3”. |
 
-Si ce n'est pas le cas, ajoutez un nouveau multisite ou modifiez celui existant.
+If it is not, add a new multisite or modify the existing one.
 
-- Si vous souhaitez ajouter un multisite** : cliquez sur `Ajouter un domaine ou sous-domaine` à droite du tableau.
-- Si vous souhaitez modifier un multisite** : cliquez sur le bouton `...` à droite du nom de domaine concerné, puis sur `Modifier`.
+- If you want to add a multisite**: click `Add a domain or subdomain` to the right of the table.
+- If you want to modify a multisite**: click the `...` button to the right of the relevant domain name, then `Modify`.
 
-Dans la fenêtre qui s'affiche, complétez les informations demandées selon votre situation personnelle. Le tableau ci-dessous montre celles utilisées pour ce tutoriel.
+In the window that appears, fill in the requested information according to your own situation. The table below shows the values used for this tutorial.
 
-|  Information  |  Valeur utilisée en exemple pour ce tutoriel  |
+|  Information  |  Value used as an example for this tutorial  |
 |  :-----          |  :-----          |
-|  Domaine |  django.demo-cloudweb.ovh |
-|  Dossier racine |  django |
-|  Moteur d'exécution |  Python 3 |
+|  Domain |  django.demo-cloudweb.ovh |
+|  Root folder |  django |
+|  Runtime |  Python 3 |
 
-En ce qui concerne les options supplémentaires, choisissez celles que vous souhaitez activer. Une fois les informations complétées, cliquez sur `Suivant`, puis finalisez la manipulation. Cet ajout peut prendre jusqu'à une heure. Cependant, la modification de la configuration DNS nécessite jusqu'à 24 heures avant d'être pleinement effective. Si vous désirez obtenir plus d'informations sur la gestion des multisites, reportez-vous à notre guide [« Partager son hébergement entre plusieurs sites »](/guides/web-cloud/web-hosting/multisites-configure-multisite).
+As for the additional options, choose the ones you want to enable. Once the information is filled in, click `Next`, then complete the operation. This addition can take up to one hour. However, changing the DNS configuration can take up to 24 hours to become fully effective. If you want more information about managing multisites, refer to our guide [“Sharing your hosting between several websites”](/guides/web-cloud/web-hosting/multisites-configure-multisite).
 
 ![django-cloud-web](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/multisite/add-a-domain-or-sub-domain-step-2-django.png)
 
-### Étape 3 : connectez-vous à votre Cloud Web via SSH
+### Step 3: connect to your Cloud Web via SSH
 
-Récupérez d'abord les informations vous permettant de vous connecter. Pour cela, positionnez-vous sur l'onglet `FTP - SSH`. Si celui-ci n'apparaît pas dans la liste, appuyez au préalable sur le bouton représentant trois barres. Les informations liées à votre espace de stockage s'affichent alors. Repérez celles mentionnées à côté des éléments suivants :
+First, retrieve the information that lets you connect. To do this, go to the `FTP - SSH` tab. If it does not appear in the list, first click the button with three bars. The information related to your storage space is then displayed. Locate the items mentioned next to the following elements:
 
-|  Éléments  |  Description  |
+|  Elements  |  Description  |
 |  :-----          |  :-----          |
-|  Accès SSH au cluster |  L'élément qui apparaît vous permet de récupérer deux informations : l'adresse de serveur (elle débute après « ssh:// » et se termine avant les « : ») et le port de connexion (le numéro est mentionné après les « : »). Nous pourrions par exemple retrouver : _ssh://sshcloud.cluster024.hosting.ovh.net:12345/_, donc « _sshcloud.cluster024.hosting.ovh.net_ » en adresse de serveur et « 12345 » en port de connexion. |
-|  Login SSH principal |  Il s'agit de l'identifiant SSH principal créé sur votre hébergement. |
+|  SSH access to the cluster |  The element that appears lets you retrieve two pieces of information: the server address (it starts after “ssh://” and ends before the “:”) and the connection port (the number is mentioned after the “:”). For example, we might find: _ssh://sshcloud.cluster024.hosting.ovh.net:12345/_, so “_sshcloud.cluster024.hosting.ovh.net_” as the server address and “12345” as the connection port. |
+|  Main SSH login |  This is the main SSH username created on your hosting. |
 
-Si vous ne connaissez plus le mot de passe de l'utilisateur SSH, cliquez sur le bouton `...` à droite de l'utilisateur concerné dans le tableau, puis sur `Changer le mot de passe`.
+If you no longer know the password of the SSH user, click the `...` button to the right of the relevant user in the table, then `Change password`.
 
 ![django-cloud-web](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/ftp-ssh/change-password.png)
 
-À présent, pour vous connecter en SSH, vous devez utiliser un terminal. Cet outil est installé par défaut sur macOS ou Linux. Un environnement Windows nécessitera l'installation d'un logiciel comme PuTTY ou l'ajout de la fonctionnalité « OpenSSH ». Cette démarche étant spécifique au système d'exploitation que vous utilisez, nous ne pouvons pas la détailler dans cette documentation.
+Now, to connect via SSH, you need to use a terminal. This tool is installed by default on macOS or Linux. A Windows environment will require installing software such as PuTTY or adding the “OpenSSH” feature. As this procedure is specific to the operating system you use, we cannot detail it in this documentation.
 
-Voici l'exemple d'une ligne de commande que vous pouvez utiliser. Remplacez les éléments « sshlogin », « sshserver » et « connectionport » par ceux adaptés à votre situation personnelle. Une fois la commande envoyée, vous serez invité à renseigner le mot de passe de l'utilisateur SSH.
+Here is an example of a command line you can use. Replace the elements “sshlogin”, “sshserver” and “connectionport” with the ones suited to your own situation. Once the command is sent, you will be prompted to enter the password of the SSH user.
 
 ```sh
 ssh sshlogin@sshserver -p connectionport
 ```
 
-### Étape 4 : préparez l'environnement Python
+### Step 4: prepare the Python environment
 
-Nous allons maintenant préparer l'environnement Python nécessaire pour héberger notre application Django CMS. Le but est d'isoler les fichiers Python ainsi que les dépendances de notre application du reste des fichiers et librairies Python présents sur le système. Dans l'écosystème Python cette isolation est simple à mettre en place grâce à l'utilitaire `virtualenv`.
+We will now prepare the Python environment needed to host our Django CMS application. The goal is to isolate the Python files and the dependencies of our application from the rest of the Python files and libraries present on the system. In the Python ecosystem, this isolation is easy to set up thanks to the `virtualenv` utility.
 
-Depuis la connexion SSH ouverte sur votre Cloud Web, installez virtualenv via pip (il s'agit du gestionnaire de paquets le plus répandu pour le langage Python) :
+From the SSH connection open on your Cloud Web, install virtualenv via pip (it is the most widely used package manager for the Python language):
 
 ```sh
 democld@cloudweb-ssh:~ $ pip3 install --user virtualenv
@@ -116,19 +116,19 @@ Collecting virtualenv
 Installing collected packages: virtualenv
 Successfully installed virtualenv-16.5.0
 ```
-Modifiez la variable d'environnement PATH pour y ajouter la commande « virtualenv » fraîchement installée :
+Modify the PATH environment variable to add the freshly installed “virtualenv” command:
 
 ```sh
 democld@cloudweb-ssh:~ $ export PATH=$PATH:~/.local/bin
 democld@cloudweb-ssh:~ $ virtualenv --version
 16.5.0
 ```
-Vous avez la possibilité de faire persister ce changement dans votre « PATH », en ajoutant l'export dans le fichier « ~/.profile » :
+You can make this change to your “PATH” persistent by adding the export to the “~/.profile” file:
 
 ```sh
 democld@cloudweb-ssh:~ $ echo "export PATH=$PATH:~/.local/bin" >> ~/.profile
 ```
-Vous pouvez maintenant vous placer dans le dossier « django » et créer un _virtualenv_, que nous nommerons « venv » pour ce tutoriel.
+You can now move into the “django” folder and create a _virtualenv_, which we will name “venv” for this tutorial.
 
 ```sh
 democld@cloudweb-ssh:~ $ cd django/
@@ -141,19 +141,19 @@ Installing setuptools, pip, wheel...
 done.
 ```
 
-Maintenant que votre _virtualenv_ est en place, vous pouvez y accéder via la commande « source \< nom du virtualenv \>bin/activate ». Une fois dans votre _virtualenv_, tous les paquets et librairies que vous installerez le seront uniquement ici.
+Now that your _virtualenv_ is in place, you can access it via the command “source \< virtualenv name \>bin/activate”. Once inside your _virtualenv_, all the packages and libraries you install will be installed only here.
 
-Quand votre _virtualenv_ est activé, vous voyez dans votre terminal votre prompt précédé de « (venv) » (ou un autre nom, si vous en avez choisi un différent au moment de la création du _virtualenv_). Vous pouvez sortir de ce _virtualenv_ à tout moment, en utilisant la commande « deactivate ».
+When your _virtualenv_ is activated, you see in your terminal your prompt preceded by “(venv)” (or another name, if you chose a different one when creating the _virtualenv_). You can exit this _virtualenv_ at any time, using the “deactivate” command.
 
 ```sh
 democld@cloudweb-ssh:~/django $ source venv/bin/activate
 (venv) democld@cloudweb-ssh:~/django $
 ```
-### Étape 5 : installez et configurez Django CMS
+### Step 5: install and configure Django CMS
 
-Django CMS met à disposition un utilitaire nommé « djangocms-installer » pour faciliter son installation. 
+Django CMS provides a utility named “djangocms-installer” to ease its installation. 
 
-Toujours depuis votre _virtualenv_, installez cet utilitaire avec pip :
+Still from within your _virtualenv_, install this utility with pip:
 
 ```sh
 (venv) democld@cloudweb-ssh:~/django $ pip install djangocms-installer
@@ -181,18 +181,18 @@ Successfully installed dj-database-url-0.5.0 djangocms-installer-1.1.0 pytz-2019
 /home/democld/django/venv/bin/djangocms
 ```
 
-Maintenant que cet utilitaire est installé, nous allons l'utiliser pour créer notre application Django CMS. Toujours depuis votre _virtualenv_ et placé dans le répertoire racine de votre site (django dans ce tutoriel), lancez la commande suivante :
+Now that this utility is installed, we will use it to create our Django CMS application. Still from within your _virtualenv_ and placed in the root directory of your site (django in this tutorial), run the following command:
 
 ```sh
 djangocms -f -p . mysite -s
 ```
 
-Voici des informations concernant la signification des options (vous pouvez retrouver toutes les options disponibles via la commande « djangocms --help ») :
+Here is some information about the meaning of the options (you can find all the available options via the command “djangocms --help”):
 
-*     -f : installe et configure les plugins « django-filer » ;
-*     -p . : utilise le dossier courant comme dossier parent de notre nouveau projet Django CMS ;
-*     mysite : nom de votre nouveau projet ;
-*     -s : ne pas vérifier si le dossier courant est vide.
+*     -f: installs and configures the “django-filer” plugins;
+*     -p . : uses the current folder as the parent folder of our new Django CMS project;
+*     mysite: name of your new project;
+*     -s: do not check whether the current folder is empty.
 
 ```sh
 (venv) democld@cloudweb-ssh:~/django $ djangocms -f -p . mysite -s
@@ -227,11 +227,11 @@ drwxr-xr-x 2 democld democld      2 May  7 10:54 static
 drwxr-xr-x 4 democld democld      4 May  6 11:33 venv
 ```
 
-### Étape 6 : faites le lien entre Django CMS et le moteur d'exécution de votre Cloud Web
+### Step 6: link Django CMS to your Cloud Web runtime
 
-Django CMS est désormais installé sur votre Cloud Web.
+Django CMS is now installed on your Cloud Web.
 
-Le fichier « manage.py » a été créé automatiquement lors de cette opération. Modifiez-le avec le contenu suivant :
+The “manage.py” file was created automatically during this operation. Modify it with the following content:
 
 ```sh
 (venv) democld@cloudweb-ssh:~/django $ cat /dev/null > manage.py
@@ -254,7 +254,7 @@ from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()
 ```
 
-Lors de la configuration du moteur d'exécution Python (voir l'étape 1), nous avons défini le script de lancement de notre application comme étant « server.py ». Hors Django CMS utilise un fichier nommé « manage.py ». Pour faire le lien entre Django CMS et votre moteur d'exécution, créez donc un lien symbolique entre « server.py » et « manage.py » :
+When configuring the Python runtime (see Step 1), we defined the launch script of our application as “server.py”. However, Django CMS uses a file named “manage.py”. To link Django CMS to your runtime, create a symbolic link between “server.py” and “manage.py”:
 
 ```sh
 (venv) democld@cloudweb-ssh:~/django $ ln -fs manage.py server.py
@@ -272,27 +272,27 @@ drwxr-xr-x 2 democld democld      2 May  7 10:54 static
 drwxr-xr-x 4 democld democld      4 May  6 11:33 venv
 ```
 
-Modifiez le fichier « mysite/settings.py » avec la commande suivante, en remplaçant « django.demo-cloudweb.ovh » par l'adresse de votre multisite (configuré lors de l'étape 2) :
+Modify the “mysite/settings.py” file with the following command, replacing “django.demo-cloudweb.ovh” with the address of your multisite (configured in Step 2):
 
 ```sh
 (venv) democld@cloudweb-ssh:~/django $ sed -i "s/ALLOWED_HOSTS = \[\]/ALLOWED_HOSTS = ['django.demo-cloudweb.ovh']/" mysite/settings.py
 ```
 
-### Étape 7 : redémarrez le _daemon_ Python
+### Step 7: restart the Python _daemon_
 
-Pour redémarrer le _daemon_ Python, retournez dans votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>. Positionnez-vous sur l'onglet `Multisite`, cliquez à droite du nom de domaine concerné sur le bouton `...` à droite, puis choisissez `Redémarrer`.
+To restart the Python _daemon_, return to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>. Go to the `Multisite` tab, click the `...` button to the right of the relevant domain name, then choose `Restart`.
 
-Une fois ceci fait, l'application sera accessible via le nom de domaine choisi dans la configuration de votre multisite.
+Once this is done, the application will be accessible via the domain name chosen in your multisite configuration.
 
 ![django-cloud-web](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/multisite/restart-python3.png)
 
-Félicitations, votre site utilisant Django CMS est maintenant disponible ! Un compte administrateur a été créé par défaut, avec pour login/password « admin »/« admin ». Pensez à changer ce mot de passe.
+Congratulations, your website using Django CMS is now available! An administrator account has been created by default, with “admin”/“admin” as the login/password. Remember to change this password.
 
 ![django-cloud-web](/images/assets/screens/other/cms/django/installation-successfull.png)
 
-### Étape 8 : utilisez HTTPS
+### Step 8: use HTTPS
 
-Pour plus de sécurité sur votre site, vous pouvez mettre en place une redirection automatique HTTP vers HTTPS. Pour ce faire, toujours positionné dans le dossier django, créez un fichier .htaccess avec le contenu suivant :
+For added security on your site, you can set up an automatic redirect from HTTP to HTTPS. To do this, while still in the django folder, create a .htaccess file with the following content:
 
 ```sh
 RewriteEngine On
@@ -302,22 +302,22 @@ RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
 ### Conclusion
 
-Nous avons vu comment installer une application Python sur un hébergement Cloud Web, en respectant les différentes étapes. Il ne vous reste plus qu'à utiliser Django CMS et à y publier vos premiers contenus !
+We have seen how to install a Python application on a Cloud Web hosting plan, following the various steps. All that remains is to use Django CMS and publish your first content!
 
-Vous trouverez plus d'informations sur Django CMS et ses fonctionnalités dans la [documentation officielle du projet](https://docs.django-cms.org/en/latest/).
+You will find more information about Django CMS and its features in the [official project documentation](https://docs.django-cms.org/en/latest/).
 
-## Aller plus loin
+## Go further
 
-[Migrer mon site chez OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
+[Migrating my website to OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
 
-[Mettre mon site en ligne](/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online)
+[Putting my website online](/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online)
 
-[Installer son site avec les modules en 1 clic](/guides/web-cloud/web-hosting/cms-install-1-click-modules)
+[Installing your website with the 1-click modules](/guides/web-cloud/web-hosting/cms-install-1-click-modules)
 
-[Partager son hébergement entre plusieurs sites](/guides/web-cloud/web-hosting/multisites-configure-multisite)
+[Sharing your hosting between several websites](/guides/web-cloud/web-hosting/multisites-configure-multisite)
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner).
+For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
 
-Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).
+If you would like assistance using and configuring your OVHcloud solutions, we invite you to consult our various [support offers](/links/support).
 
-Échangez avec notre [communauté d'utilisateurs](/links/community).
+Join our [community of users](/links/community).

--- a/docs/en/guides/web-cloud/web-hosting/install-etherpad.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/install-etherpad.mdx
@@ -1,111 +1,111 @@
 ---
-title: "Installer Etherpad sur son hébergement Cloud Web"
-excerpt: "Installez l'éditeur de texte Etherpad sur votre hébergement Cloud Web et rendez-le accessible avec votre nom de domaine"
+title: "Installing Etherpad on your Cloud Web hosting plan"
+excerpt: "Install the Etherpad text editor on your Cloud Web hosting plan and make it accessible through your domain name"
 lastUpdated: 2022-05-04
 availableIn: [eu]
 ---
 
 ## Objective
 
-[Etherpad](https://etherpad.org/) est un éditeur de texte en ligne collaboratif en temps réel. Il permet à plusieurs personnes d'écrire simultanément des fichiers texte via une interface web. Etherpad est écrit en JavaScript et utilise Node.js, une plateforme logicielle permettant de créer vos sites et API en JavaScript côté serveur.
+[Etherpad](https://etherpad.org/) is a collaborative online text editor that works in real time. It allows several people to write text files simultaneously through a web interface. Etherpad is written in JavaScript and uses Node.js, a software platform for building your websites and APIs in server-side JavaScript.
 
-L'[hébergement Cloud Web OVHcloud](/links/web/hosting-cloud-web-offer) vous permet d'utiliser Node.js comme moteur d'exécution pour vos sites web, et donc d'y installer Etherpad ou toute autre application conçue pour Node.js.
+[OVHcloud Cloud Web hosting](/links/web/hosting-cloud-web-offer) allows you to use Node.js as a runtime engine for your websites, and therefore to install Etherpad or any other application designed for Node.js.
 
-**Dans ce tutoriel, nous allons installer un serveur Etherpad sur un hébergement Cloud Web OVHcloud et le mettre à disposition derrière votre nom de domaine.**
+**In this tutorial, we will install an Etherpad server on an OVHcloud Cloud Web hosting plan and make it available through your domain name.**
 
-## Prérequis
+## Requirements
 
-- Disposer d'un [hébergement Cloud Web OVHcloud](/links/web/hosting-cloud-web-offer).
-- Avoir activé Node.js comme moteur d'exécution.
-- Avoir ajouté le nom de domaine concerné en tant que multisite et avoir défini Node.js comme étant son moteur d'exécution.
-- Être connecté à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, partie `Web Cloud`.
-- Ce que vous devez savoir:
-    - Les bases de l'écosystème Node.js.
-    - Se connecter en SSH.
+- A [OVHcloud Cloud Web hosting plan](/links/web/hosting-cloud-web-offer).
+- Node.js enabled as a runtime engine.
+- The relevant domain name added as a multisite, with Node.js set as its runtime engine.
+- Access to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, in the `Web Cloud` section.
+- What you should know:
+    - The basics of the Node.js ecosystem.
+    - How to connect via SSH.
 
-## En pratique
+## Instructions
 
-### Étape 1 : activer Node.js comme moteur d'exécution
+### Step 1: enabling Node.js as a runtime engine
 
-Pour accéder aux moteurs d'exécution de votre hébergement Cloud Web, connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>. Cliquez sur `Hébergements` dans la barre de services à gauche, puis choisissez le nom de l'hébergement Cloud Web concerné. Positionnez-vous enfin sur l'onglet `Moteurs d'exécution`.
+To access the runtime engines of your Cloud Web hosting plan, log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>. Click `Hosting` in the services bar on the left, then choose the name of the relevant Cloud Web hosting plan. Finally, go to the `Runtime engines` tab.
 
-Le tableau qui apparaît affiche les moteurs d'exécution ajoutés actuellement. Assurez-vous alors que le moteur d'exécution Node.js est bien activé. Si tel est le cas, poursuivez vers l'étape 2 « [Associer Node.js à un multisite](#etape-2-associer-nodejs-a-un-multisite) ».
+The table that appears displays the runtime engines currently added. Make sure that the Node.js runtime engine is enabled. If it is, proceed to Step 2 "[Associating Node.js with a multisite](#step-2-associating-nodejs-with-a-multisite)".
 
 ![etherpadcloudweb](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/runtime-software-application/tab-nodejs8.png)
 
-Si ce n'est pas le cas, ajoutez-en un nouveau, si votre offre vous le permet, ou modifiez le moteur d'exécution existant.
+If it is not, add a new one (if your plan allows it) or modify the existing runtime engine.
 
-- **Si vous souhaitez ajouter un moteur** : cliquez sur `Actions` au-dessus du tableau, puis sur `Ajouter un moteur d'exécution`.
-- **Si vous souhaitez modifier un moteur** : cliquez sur le bouton `...` à droite du moteur concerné, puis sur `Modifier`.
+- **If you want to add an engine**: click `Actions` above the table, then `Add a runtime engine`.
+- **If you want to modify an engine**: click the `...` button to the right of the relevant engine, then `Edit`.
 
-Dans la fenêtre qui s'affiche, complétez les informations demandées avec les valeurs suivantes de notre exemple ou adaptez-les à votre situation personnelle :
+In the window that appears, fill in the requested information with the following values from our example, or adapt them to your own situation:
 
-|Information|Valeur à renseigner| 
+|Information|Value to enter| 
 |---|---| 
-|Nom personnalisé|NodeJS 8|
-|Moteur d'exécution|nodejs-8|
-|Chemin d'accès au répertoire public|public|
-|Environnement de l'application|production|
-|Script de lancement de l'application|server.js|
+|Custom name|NodeJS 8|
+|Runtime engine|nodejs-8|
+|Path to the public directory|public|
+|Application environment|production|
+|Application launch script|server.js|
 
-Une fois les informations complétées, cliquez sur `Valider`. Si vous souhaitez obtenir plus d'informations sur la gestion des moteurs d'exécution, reportez-vous à notre guide « [Gérer les moteurs d'exécution de Cloud Web](/guides/web-cloud/web-hosting/manage-runtime-software-applications) ».
+Once the information is filled in, click `Confirm`. If you would like more information about managing runtime engines, refer to our guide "[Managing the runtime engines of Cloud Web](/guides/web-cloud/web-hosting/manage-runtime-software-applications)".
 
 ![etherpadcloudweb](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/runtime-software-application/modify-a-runtime-software-application-nodejs8.png)
 
-### Étape 2 : associer Node.js à un multisite
+### Step 2: associating Node.js with a multisite
 
-Maintenant que Node.js est activé en tant que moteur d'exécution, vous devez l'associer à l'un de vos multisites. Pour cela, positionnez-vous sur l'onglet `Multisite`. Le tableau qui s'affiche contient tous les noms de domaine qui ont été ajoutés en tant que multisite. Deux colonnes doivent retenir votre attention.
+Now that Node.js is enabled as a runtime engine, you must associate it with one of your multisites. To do this, go to the `Multisite` tab. The table that appears contains all the domain names that have been added as a multisite. Two columns should draw your attention.
 
-|Colonne|Description| 
+|Column|Description| 
 |---|---| 
-|Dossier racine|Il s'agit du dossier racine qui devra contenir le code source du domaine concerné et correspond au « DocumentRoot ». Dans notre exemple, nous choisissons de spécifier « etherpad ». Celui-ci devra donc contenir notre code source Node.js.|
-|Moteur d'exécution|Il s'agit du moteur d'exécution associé au nom de domaine concerné. Le nom qui s'affiche correspond au « Nom personnalisé » que vous avez défini lors de la création du moteur d'exécution. Dans notre exemple, vous devriez retrouver « NodeJS 8 ».|
+|Root folder|This is the root folder that must contain the source code of the relevant domain; it corresponds to the "DocumentRoot". In our example, we choose to specify "etherpad". It must therefore contain our Node.js source code.|
+|Runtime engine|This is the runtime engine associated with the relevant domain name. The name displayed corresponds to the "Custom name" you defined when creating the runtime engine. In our example, you should find "NodeJS 8".|
 
-Dans le tableau, vérifiez que le moteur d'exécution Node.js est bien lié aux domaines concernés et que le dossier racine est correct. Si tel est le cas, poursuivez vers l'étape 3 « [Se connecter à votre Cloud Web via SSH](#etape-3-se-connecter-a-cotre-cloud-web-via-ssh) ».
+In the table, check that the Node.js runtime engine is properly linked to the relevant domains and that the root folder is correct. If it is, proceed to Step 3 "[Connecting to your Cloud Web via SSH](#step-3-connecting-to-your-cloud-web-via-ssh)".
 
 ![etherpadcloudweb](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/multisite/tab-nodejs8-full-disabled.png)
 
-Si ce n'est pas le cas, ajoutez un nouveau multisite ou modifiez celui existant.
+If it is not, add a new multisite or modify the existing one.
 
-- **Si vous souhaitez ajouter un multisite** : cliquez sur `Ajouter un domaine ou sous-domaine` à droite du tableau.
-- **Si vous souhaitez modifier un multisite** : cliquez sur le bouton `...` à droite du domaine concerné, puis sur `Modifier`.
+- **If you want to add a multisite**: click `Add a domain or subdomain` to the right of the table.
+- **If you want to modify a multisite**: click the `...` button to the right of the relevant domain, then `Edit`.
 
-Dans la fenêtre qui s'affiche, complétez les informations demandées selon votre situation personnelle. Voici celles que nous avons utilisées pour ce tutoriel :
+In the window that appears, fill in the requested information according to your own situation. Here are the values we used for this tutorial:
 
-|Information|Valeur utilisée en exemple pour ce tutoriel| 
+|Information|Example value used for this tutorial| 
 |---|---| 
-|Nom de domaine|etherpad.demo-nodejs.ovh|
-|Dossier racine|etherpad|
-|Moteur d'exécution|NodeJS 8|
+|Domain name|etherpad.demo-nodejs.ovh|
+|Root folder|etherpad|
+|Runtime engine|NodeJS 8|
 
-En ce qui concerne les options supplémentaires, choisissez celles que vous souhaitez activer. Une fois les informations complétées, cliquez sur `Suivant`, puis finalisez la manipulation. Cet ajout peut prendre jusqu'à une heure. Cependant, la modification de la configuration DNS peut prendre jusqu'à 24 heures avant d'être pleinement effective. Si vous souhaitez obtenir plus d'informations sur la gestion des multisites, reportez-vous à notre guide « [Partager son hébergement entre plusieurs sites](/guides/web-cloud/web-hosting/multisites-configure-multisite) ».
+As for the additional options, choose the ones you want to enable. Once the information is filled in, click `Next`, then finalise the operation. This addition can take up to one hour. However, the change to the DNS configuration can take up to 24 hours to become fully effective. If you would like more information about managing multisites, refer to our guide "[Sharing your hosting plan between several websites](/guides/web-cloud/web-hosting/multisites-configure-multisite)".
 
 ![etherpadcloudweb](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/multisite/add-a-domain-or-sub-domain-step-2-nodejs.png)
 
-### Étape 3 : se connecter à votre Cloud Web via SSH
+### Step 3: connecting to your Cloud Web via SSH
 
-Commencez en  récupérant les informations vous permettant de vous connecter. Pour cela, positionnez-vous sur l'onglet `FTP - SSH`. Si celui-ci n'apparaît pas dans la liste, appuyez au préalable sur le bouton représentant trois barres. Les informations liées à votre espace de stockage apparaissent alors. Repérez celles mentionnées à côté des éléments suivants :
+Start by retrieving the information you need to connect. To do this, go to the `FTP - SSH` tab. If it does not appear in the list, first click the button with three bars. The information related to your storage space then appears. Locate the details listed next to the following items:
 
-|Éléments|Description| 
+|Items|Description| 
 |---|---| 
-|Accès SSH au cluster|L'élément qui apparaît vous permet de récupérer deux informations : <br />**- l'adresse de serveur** : elle débute après « ssh:// » et se termine avant les « : » ;<br /> **- le port de connexion** : le numéro est mentionné après les « : ». <br /><br />On pourrait par exemple retrouver : ssh://`sshcloud.cluster024.hosting.ovh.net`:`12345`/, donc « sshcloud.cluster024.hosting.ovh.net » en adresse de serveur et « 12345 » en port de connexion.|
-|Login SSH principal|Il s'agit de l'identifiant SSH principal créé sur votre hébergement.|
+|SSH access to the cluster|The element that appears lets you retrieve two pieces of information: <br />**- the server address**: it starts after "ssh://" and ends before the ":";<br /> **- the connection port**: the number is shown after the ":". <br /><br />For example, you might find: ssh://`sshcloud.cluster024.hosting.ovh.net`:`12345`/, so "sshcloud.cluster024.hosting.ovh.net" as the server address and "12345" as the connection port.|
+|Main SSH login|This is the main SSH username created on your hosting plan.|
 
-Si vous ne connaissez plus le mot de passe de l'utilisateur SSH, cliquez sur le bouton `...` à droite de l'utilisateur concerné dans le tableau, puis sur `Changer le mot de passe`.
+If you no longer know the password of the SSH user, click the `...` button to the right of the relevant user in the table, then `Change password`.
 
 ![etherpadcloudweb](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/ftp-ssh/change-password.png)
 
-À présent, pour vous connecter en SSH, vous devez utiliser un terminal. Cet outil est installé par défaut sur macOS ou Linux. Un environnement Windows nécessitera l'installation d'un logiciel comme PuTTY ou l'ajout de la fonctionnalité « OpenSSH ». Cette démarche étant spécifique au système d'exploitation que vous utilisez, nous ne pouvons pas la détailler dans cette documentation.
+Now, to connect via SSH, you need to use a terminal. This tool is installed by default on macOS and Linux. A Windows environment will require the installation of software such as PuTTY or the addition of the "OpenSSH" feature. As this procedure is specific to the operating system you use, we cannot detail it in this documentation.
 
-Voici l'exemple d'une ligne de commande que vous pouvez utiliser. Remplacez les éléments « sshlogin », « sshserver » et « connectionport » par ceux adaptés à votre situation personnelle. Une fois la commande envoyée, vous serez invité à renseigner le mot de passe de l'utilisateur SSH.
+Here is an example of a command line you can use. Replace the "sshlogin", "sshserver" and "connectionport" elements with the ones matching your own situation. Once the command is sent, you will be prompted to enter the password of the SSH user.
 
 ```sh
 ssh sshlogin@sshserver -p connectionport
 ```
 
-### Étape 4 : installer Etherpad
+### Step 4: installing Etherpad
 
-Commencez en vous plaçant dans le dossier racine que vous avez spécifié [lors de l'étape 2](#etape-2-associer-nodejs-a-un-multisite). Dans notre tutoriel, il s'agit du répertoire « etherpad ». Vous pourrez alors y récupérer le code de l'application.
+Start by moving into the root folder you specified [in Step 2](#step-2-associating-nodejs-with-a-multisite). In our tutorial, this is the "etherpad" directory. You can then retrieve the application code there.
 
 ```sh
 demonon@cloudweb-ssh:~ $ cd etherpad/
@@ -121,7 +121,7 @@ From https://github.com/ether/etherpad-lite
  * [new branch]      master     -> origin/master
 ```
 
-Installez alors les dépendances d'Etherpad :
+Now install Etherpad's dependencies:
 
 ```sh
 demonon@cloudweb-ssh:~/etherpad [master]$ export PATH=$PATH:/usr/local/nodejs8/bin  
@@ -139,38 +139,38 @@ Clearing minified cache...
 Ensure custom css/js files are created...
 ```
 
-Pour Etherpad, l'installation des dépendances est effectuée par un script Bash. De manière générale, pour les applications Node.js, l'installation de ces dépendances se fera via la commande « npm-node8 install ».
+For Etherpad, the dependencies are installed by a Bash script. In general, for Node.js applications, these dependencies are installed using the "npm-node8 install" command.
 
-La configuration réalisée en Node.js s'attend à trouver un fichier « server.js » dans le dossier racine de votre multisite (que vous avez paramétré [lors de l'étape 1](#etape-1-activer-nodejs-comme-moteur-dexecution)). Nous allons alors créer un lien symbolique permettant de faire pointer « server.js » vers le fichier du même nom d'Eteherpad.
+The configuration set up in Node.js expects to find a "server.js" file in the root folder of your multisite (which you configured [in Step 1](#step-1-enabling-nodejs-as-a-runtime-engine)). We will therefore create a symbolic link to point "server.js" to Etherpad's file of the same name.
 
 ```sh
 demonon@cloudweb-ssh:~/etherpad [master]$ ln -fs node_modules/ep_etherpad-lite/node/server.js server.js
 ```
 
-### Étape 5 : redémarrer le *daemon* Node.js
+### Step 5: restarting the Node.js *daemon*
 
-Pour redémarrer le *daemon* Node.js, retournez sur votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>. Positionnez-vous sur l'onglet `Multisite`, cliquez à droite du nom de domaine concerné sur le bouton `...` à droite, puis sur `Redémarrer`
+To restart the Node.js *daemon*, go back to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>. Go to the `Multisite` tab, click the `...` button to the right of the relevant domain name, then click `Restart`.
 
-Une fois ceci fait, l'application sera accessible via le nom de domaine choisi dans la configuration de votre multisite.
+Once this is done, the application will be accessible through the domain name chosen in your multisite configuration.
 
 ![etherpadcloudweb](/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/multisite/restart-nodejs8.png)
 
 ## Conclusion
 
-Nous avons vu comment installer une application Node.js sur un hébergement Cloud Web en respectant les différentes étapes. Il ne vous reste plus qu'à utiliser Etherpad et à collaborer tous ensemble ! 
+We have seen how to install a Node.js application on a Cloud Web hosting plan by following the various steps. All that is left is to use Etherpad and collaborate together!
 
-## Aller plus loin
+## Go further
 
-[Migrer mon site chez OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
+[Migrating my website to OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
 
-[Mettre mon site en ligne](/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online)
+[Putting my website online](/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online)
 
-[Installer son site avec les modules en 1 clic](/guides/web-cloud/web-hosting/cms-install-1-click-modules)
+[Installing your website with 1-click modules](/guides/web-cloud/web-hosting/cms-install-1-click-modules)
 
-[Partager son hébergement entre plusieurs sites](/guides/web-cloud/web-hosting/multisites-configure-multisite)
+[Sharing your hosting plan between several websites](/guides/web-cloud/web-hosting/multisites-configure-multisite)
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner).
+For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
 
-Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).
+If you would like assistance using and configuring your OVHcloud solutions, we invite you to consult our various [support offers](/links/support).
 
-Échangez avec notre [communauté d'utilisateurs](/links/community).
+Join our [community of users](/links/community).

--- a/docs/en/guides/web-cloud/web-hosting/premiers-pas-avec-visibilite-pro.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/premiers-pas-avec-visibilite-pro.mdx
@@ -1,140 +1,140 @@
 ---
-title: "Premiers pas avec la solution Visibilité Pro"
-excerpt: "Découvrez comment bien débuter avec la solution Visibilité Pro"
+title: "Getting started with Visibilité Pro"
+excerpt: "Find out how to get started with the Visibilité Pro solution"
 lastUpdated: 2024-07-09
 availableIn: [eu]
 ---
 
-## Objectif
+## Objective
 
-Visibilité Pro est une solution de référencement local vous permettant de gérer les informations et coordonnées de votre entreprise dans plusieurs annuaires en ligne, mais aussi d'interagir avec vos clients via la publication de contenus leur étant destinés ou la réponse à des avis. Cette gestion s'effectue via une interface unique et intuitive. 
+Visibilité Pro is a local SEO solution that lets you manage your business information and contact details across multiple online directories, as well as interact with your customers by publishing content for them or replying to reviews. This is all managed through a single, intuitive interface.
 
-**Découvrez comment bien débuter avec la solution Visibilité Pro.**
+**Find out how to get started with the Visibilité Pro solution.**
 
-## Prérequis
+## Requirements
 
-- Disposer d'une offre d'[hébergement web OVHcloud](/links/web/hosting).
-- Disposer d'une offre [Visibilité Pro](https://www.ovhcloud.com/fr/web-hosting/options/pro-visibility/).
-- Être connecté à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
+- An [OVHcloud web hosting](/links/web/hosting) plan.
+- A [Visibilité Pro](https://www.ovhcloud.com/fr/web-hosting/options/pro-visibility/) plan.
+- You must be logged in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
 
-## En pratique
+## Instructions
 
-### Étape 1 : accéder à la gestion de la solution Visibilité Pro
+### Step 1: Access the management of the Visibilité Pro solution
 
-Pour débuter la manipulation, connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink> et rendez-vous dans la partie `Web Cloud`. Cliquez sur `Hébergements`, puis sélectionnez l'hébergement auquel la solution Visibilité Pro a été liée. 
+To get started, log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> and go to the `Web Cloud` section. Click `Hosting plans`, then select the hosting plan that the Visibilité Pro solution is linked to.
 
-Cliquez sur l'onglet `Plus`, puis sur `Visibilité Pro`.
+Click the `More` tab, then `Visibilité Pro`.
 
 ![visibilitypro](/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/visibility-pro/tab.png)
 
-Le tableau qui apparaît affiche les solutions Visibilité Pro commandées et liées à votre offre d'hébergement web. Chaque ligne correspond à une solution Visibilité Pro permettant de gérer le référencement local d'un seul établissement.
+The table that appears displays the Visibilité Pro solutions ordered and linked to your web hosting plan. Each row corresponds to a Visibilité Pro solution that lets you manage the local SEO of a single business location.
 
-Si vous possédez plusieurs établissements et souhaitez gérer leur référencement local de la même manière, nous vous recommandons d'effectuer un test de référencement local depuis la page : [https://www.ovhcloud.com/fr/web-hosting/options/pro-visibility/](https://www.ovhcloud.com/fr/web-hosting/options/pro-visibility/), puis de souscrire une solution Visibilité Pro pour chacun d'entre eux.
+If you have several business locations and want to manage their local SEO in the same way, we recommend running a local SEO test from the following page: [https://www.ovhcloud.com/fr/web-hosting/options/pro-visibility/](https://www.ovhcloud.com/fr/web-hosting/options/pro-visibility/), then subscribing to a Visibilité Pro solution for each of them.
 
-Pour accéder à l'interface de gestion de la solution Visibilité Pro, cliquez sur le bouton représentant trois points à droite de la ligne concernée, puis sur `Accéder à l'interface`.
+To access the Visibilité Pro management interface, click the button with three dots to the right of the relevant row, then click `Access the interface`.
 
 ![visibilitypro](/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/visibility-pro/acces-to-the-interface.png)
 
-### Étape 2 : renseignez le profil de votre établissement
+### Step 2: Fill in your business location profile
 
-Sur la page qui s'affiche, vous êtes invité à renseigner le profil de votre établissement. Pour cela, complétez les informations demandées :
+On the page that appears, you are prompted to fill in your business location profile. To do so, complete the requested information:
 
-|Informations|Description|
+|Information|Description|
 |---|---|
-|Nom de l'établissement|Renseignez le nom exact de votre établissement. Celui-ci peut reprendre le nom de votre entreprise ou différer si vous possédez plusieurs points de vente, par exemple.|
-|Adresse postale|Indiquez l'adresse postale complète de votre établissement.|
-|Je n'accueille pas de clients à l'adresse de mon établissement|Cochez impérativement cette case si vous n'accueillez pas de clients à l'adresse postale que vous venez de renseigner. Ceci masquera votre adresse postale dans les annuaires en ligne.|
-|Numéro principal|Indiquez le numéro de téléphone sur lequel vos clients peuvent vous contacter.|
-|Catégories|Sélectionnez cinq catégories qui définissent votre activité. Débutez par la catégorie la plus importante.|
+|Business name|Enter the exact name of your business location. This can be the same as your company name, or different if you have several points of sale, for example.|
+|Postal address|Enter the full postal address of your business location.|
+|I do not receive customers at my business address|Make sure you tick this box if you do not receive customers at the postal address you have just entered. This will hide your postal address in online directories.|
+|Main phone number|Enter the phone number on which your customers can reach you.|
+|Categories|Select five categories that define your activity. Start with the most important category.|
 
-Une fois les informations complétées, cliquez sur le bouton `C'est parti !`. Si l'outil nécessite de mieux localiser votre établissement, vous pourrez être amené à préciser son emplacement.
+Once you have completed the information, click the `Let's go!` button. If the tool needs to locate your business location more precisely, you may be asked to specify its location.
 
 ![visibilitypro](/images/assets/screens/other/web-tools/visibility-pro/establishment-infos.png)
 
-Vous êtes ensuite invité à renseigner d'autres informations liées à votre établissement :
+You are then prompted to fill in further information related to your business location:
 
-|Informations|Description|
+|Information|Description|
 |---|---|
-|Site web|Renseignez le site internet de votre établissement ou celui de votre groupe.|
-|Adresse e-mail|Indiquez une adresse e-mail valide grâce à laquelle vos clients peuvent vous contacter.|
-|Horaires|Renseignez les horaires de votre établissement. Vous pourrez préciser des fermetures exceptionnelles une fois votre profil complété.|
+|Website|Enter your business location's website or that of your group.|
+|Email address|Enter a valid email address through which your customers can reach you.|
+|Opening hours|Enter your business location's opening hours. You will be able to specify exceptional closures once your profile is complete.|
 
-Une fois les informations complétées, cliquez sur le bouton `Vous y êtes presque !`. 
+Once you have completed the information, click the `You're almost there!` button.
 
 ![visibilitypro](/images/assets/screens/other/web-tools/visibility-pro/establishment-infos-2.png)
 
-Si vous disposez d'un profil Google My Business ou Facebook, vous avez la possibilité de lier ces derniers à votre profil Visibilité Pro et de les gérer depuis l'interface de gestion Visibilité Pro. 
+If you have a Google My Business or Facebook profile, you can link them to your Visibilité Pro profile and manage them from the Visibilité Pro management interface.
 
-Pour relier votre profil Google My Business, cliquez sur le bouton `Connecter Google`. Pour relier votre compte Facebook, cliquez sur le bouton `Connecter Facebook`. Vous serez ensuite invité à vous connecter à votre compte Google ou Facebook. Suivez les étapes qui apparaissent.
+To link your Google My Business profile, click the `Connect Google` button. To link your Facebook account, click the `Connect Facebook` button. You will then be prompted to log in to your Google or Facebook account. Follow the steps that appear.
 
-Si vous ne souhaitez pas relier votre profil Google My Business et/ou votre compte Facebook, cliquez sur `Sauter cette étape`. Ce choix n'est pas définitif, vous pourrez réaliser cette manipulation une fois votre profil complété si vous le souhaitez.
+If you do not want to link your Google My Business profile and/or your Facebook account, click `Skip this step`. This choice is not final: you will be able to do this later once your profile is complete, should you wish to.
 
 ![visibilitypro](/images/assets/screens/other/web-tools/visibility-pro/google-facebook-connection.png)
 
-Une page vous informe que les informations de votre établissement vont être transmises aux annuaires en ligne et plateformes. Ceci indique que vous avez terminé la complétion des informations de base de votre profil.
+A page informs you that your business location's information will be sent to online directories and platforms. This indicates that you have finished completing your profile's basic information.
 
-Cliquez alors sur le bouton `C'est parti !`.
+Then click the `Let's go!` button.
 
 ![visibilitypro](/images/assets/screens/other/web-tools/visibility-pro/congratulations.png)
 
-### Étape 3 : modifier et enrichir les informations de votre établissement
+### Step 3: Edit and enrich your business location's information
 
-Une fois connecté à l'interface de gestion Visibilité Pro, nous vous recommandons vivement d'enrichir les informations du profil de votre établissement. Pour cela, positionnez-vous sur l'onglet `Profil`.
+Once you are logged in to the Visibilité Pro management interface, we strongly recommend enriching your business location's profile information. To do so, go to the `Profile` tab.
 
 ![visibilitypro](/images/assets/screens/other/web-tools/visibility-pro/profil-page.png)
 
-Les informations que vous pouvez compléter sont réparties en trois sous-onglets :
+The information you can complete is split across three sub-tabs:
 
-|Sous-onglets|Description|
+|Sub-tabs|Description|
 |---|---|
-|Infos générales|Il s'agit des informations générales de votre établissement. Vous pouvez y renseigner des informations de contact, ainsi que des descriptions et mots-clés qui aideront à vous identifier plus facilement en ligne.|
-|Infos supplémentaires|Vous pouvez par exemple y renseigner les URL de vos réseaux sociaux, les modes de paiement que votre établissement accepte ainsi que la ou les langues dans lesquelles vous pouvez servir vos clients.|
-|Photos et vidéos|Vous pouvez par exemple envoyer le logo de votre établissement, ainsi que des photos de ce dernier dans le but de le mettre en avant et de vous démarquer de vos concurrents.|
+|General info|This is the general information about your business location. Here you can enter contact information, as well as descriptions and keywords that will help identify you more easily online.|
+|Additional info|Here you can enter, for example, your social media URLs, the payment methods your business location accepts, as well as the language(s) in which you can serve your customers.|
+|Photos and videos|Here you can, for example, upload your business location's logo, as well as photos of it in order to showcase it and stand out from your competitors.|
 
-Une fois que vous avez terminé de modifier ces informations, cliquez sur le bouton `Enregistrer les modifications` en bas de la fenêtre. 
+Once you have finished editing this information, click the `Save changes` button at the bottom of the window.
 
-Si vous souhaitez que ces modifications soient envoyées automatiquement vers les différents annuaires en ligne, assurez-vous que l'`Auto-sync` est bien activé. Dans le cas contraire, vous devrez lancer manuellement une sycnhronisation ou activer l'auto-synchronisation. 
+If you want these changes to be sent automatically to the various online directories, make sure that `Auto-sync` is enabled. Otherwise, you will need to manually run a synchronisation or enable auto-synchronisation.
 
 :::info
-Sachez que la mise à jour de vos informations dans les différents annuaires et plateformes peut nécessiter plusieurs heures avant d'apparaître en ligne.
+Please note that updating your information in the various directories and platforms may take several hours before it appears online.
 :::
 
 ![visibilitypro](/images/assets/screens/other/web-tools/visibility-pro/autosync-enable.png)
 
-### Étape 4 : commencer à interagir avec vos clients
+### Step 4: Start interacting with your customers
 
-Une fois votre profil complété, vous pouvez à présent vous familiariser avec les autres fonctionnalités à votre disposition dans l'interface de gestion Visibilité Pro. 
+Once your profile is complete, you can now familiarise yourself with the other features available to you in the Visibilité Pro management interface.
 
-#### Publier vos premiers contenus
+#### Publish your first content
 
-Positionnez-vous sur l'onglet `Publier`, puis cliquez sur `Créer votre première publication`.
+Go to the `Publish` tab, then click `Create your first post`.
 
 ![visibilitypro](/images/assets/screens/other/web-tools/visibility-pro/to-publish.png)
 
-Choisissez le type de publication, l'endroit où vous souhaitez la publier, puis définissez son contenu. Vous pouvez vous aider de la fenêtre d'aperçu vous permettant de mieux visualiser le rendu final qu'aura votre publication une fois en ligne.
+Choose the type of post, where you want to publish it, then define its content. You can use the preview window to get a better idea of how your post will look once it is online.
 
-Sélectionnez enfin la date de publication, puis cliquez sur le bouton `Publier` une fois que vous êtes prêt. 
+Finally, select the publication date, then click the `Publish` button once you are ready.
 
-Revenez autant de fois que nécessaire dans l'onglet `Publier` pour continuer de communiquer avec vos clients en créant de nouvelles publications ou en suivant celles déjà publiées ou programmées.
+Return to the `Publish` tab as often as needed to keep communicating with your customers by creating new posts or tracking those already published or scheduled.
 
 ![visibilitypro](/images/assets/screens/other/web-tools/visibility-pro/create-new-publication.png)
 
-#### Répondre aux avis de vos clients
+#### Reply to your customers' reviews
 
-Positionnez-vous sur l'onglet `Avis clients` pour afficher ces derniers. Si aucun avis ne s'affiche, c'est qu'aucun de vos clients ne vous a encore laissé d'avis en ligne sur l'ensemble des annuaires dans lesquels votre établissement est inscrit. 
+Go to the `Customer reviews` tab to display them. If no reviews appear, it means none of your customers have left you an online review yet across all the directories your business location is listed in.
 
-Dès qu'un avis est disponible, vous pourrez alors le visionner et y répondre directement depuis l'interface Visibilité Pro. Utilisez les outils de filtrage et de recherche en cas de nécessité. 
+As soon as a review is available, you will be able to view it and reply to it directly from the Visibilité Pro interface. Use the filtering and search tools if needed.
 
-Nous vous recommandons vivement de répondre à tous les avis que vous recevrez, qu'ils soient positifs ou négatifs !
+We strongly recommend replying to all the reviews you receive, whether they are positive or negative!
 
 ![visibilitypro](/images/assets/screens/other/web-tools/visibility-pro/customers-advisors.png)
 
-#### Piloter la performance de votre visibilité en ligne
+#### Monitor the performance of your online visibility
 
-Positionnez-vous sur l'onglet `Tableau de bord` pour avoir accès à différents indicateurs vous permettant de piloter la performance de la visibilité de votre établissement en ligne. Nous vous conseillons de revenir régulièrement sur cet onglet afin de visionner en un coup d'œil cette performance. 
+Go to the `Dashboard` tab to access various indicators that let you monitor the performance of your business location's online visibility. We advise you to come back to this tab regularly so that you can view this performance at a glance.
 
 ![visibilitypro](/images/assets/screens/other/web-tools/visibility-pro/dashboard.png)
 
-## Aller plus loin
+## Go further
 
-Échangez avec notre [communauté d'utilisateurs](/links/community).
+Join our [community of users](/links/community).

--- a/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -628,7 +628,7 @@ Siga los **5 pasos** que se indican a continuación haciendo clic en cada una de
 
     Si se toman los valores del ejemplo en el paso "**3. Obtener el registro DNS**":
 
-    - `customerRecord: "ovhex123456-selector1._domainkey.mydomain.ovh"` corresponde al subdominio del registro CNAME. Solo se conserva `ovhex123456-selector1._domainkey`, ya que el `.mydomain.ovh` est ya se ha completado. <br/>
+    - `customerRecord: "ovhex123456-selector1._domainkey.mydomain.ovh"` corresponde al subdominio del registro CNAME. Solo se conserva `ovhex123456-selector1._domainkey`, ya que el `.mydomain.ovh` ya se ha completado. <br/>
     - `targetRecord: "ovhex123456-selector1._domainkey.1500.ab.dkim.mail.ovh.net"` corresponde al destino del registro. Se agrega un punto al final para calcular el valor. Esto da `ovhex123456-selector1._domainkey.1500.ab.dkim.mail.ovh.net.`<br/>
 
     <img className="thumbnail" alt="Correo electrónico" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/dns-dkim-api02.png" loading="lazy" /> <br/>
@@ -717,7 +717,7 @@ Siga los **5 pasos** que se indican a continuación haciendo clic en cada una de
 
     - `domainName`: introduzca el dominio asociado a la plataforma Email Pro en la que quiere activar el DKIM.
     - `service`: introduzca el nombre de su plataforma Email Pro, que aparece en el formato "emailpro-zz11111-1" . <br/>
-    - `"selectorName"`: Dans l'onglet **EXAMPLE** de la section **REQUEST BODY**, saisissez le nom d'un sélecteur que vous avez relevé à l'étape précédente. (exemple: "ovhemp123456-selector1") <br/>
+    - `"selectorName"`: en la pestaña **EXAMPLE** de la sección **REQUEST BODY**, introduzca el nombre de un selector que haya detectado en el paso anterior (por ejemplo: "ovhemp123456-selector1"). <br/>
 
     *Ejemplo de entrada:*
 
@@ -729,7 +729,7 @@ Siga los **5 pasos** que se indican a continuación haciendo clic en cada una de
     }
     ```
 
-    Cliquez sur <code className="action">EXECUTE</code> pour lancer la création du sélecteur.<br/>
+    Haga clic en <code className="action">EXECUTE</code> para comenzar la creación del selector.<br/>
 
     :::info
     Le recomendamos que realice esta operación dos veces para cada uno de los selectores que ha indicado anteriormente. El segundo selector le permitirá realizar un cambio de par de claves cuando sea necesario. Le invitamos a consultar nuestro caso de uso "[Cómo cambiar su par de claves DKIM](#2selectors)" cuando quiera cambiar al segundo selector.
@@ -785,7 +785,7 @@ Siga los **5 pasos** que se indican a continuación haciendo clic en cada una de
 
     Si se toman los valores del ejemplo en el paso "**3. Obtener el registro DNS**":
 
-    - `customerRecord: "ovhemp123456-selector1._domainkey.mydomain.ovh"` corresponde al subdominio del registro CNAME. Solo se conserva `ovhemp123456-selector1._domainkey`, ya que el `.mydomain.ovh`est ya se ha completado. <br/>
+    - `customerRecord: "ovhemp123456-selector1._domainkey.mydomain.ovh"` corresponde al subdominio del registro CNAME. Solo se conserva `ovhemp123456-selector1._domainkey`, ya que el `.mydomain.ovh` ya se ha completado. <br/>
     - `targetRecord: "ovhemp123456-selector1._domainkey.1500.ab.dkim.mail.ovh.net"` corresponde al destino del registro. Se agrega un punto al final para calcular el valor. Esto da `ovhemp123456-selector1._domainkey.1500.ab.dkim.mail.ovh.net.`<br/>
 
     <img className="thumbnail" alt="Correo electrónico" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/dns-dkim-api02.png" loading="lazy" /> <br/>

--- a/docs/it/guides/web-cloud/web-hosting/exporter-son-site-web.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/exporter-son-site-web.mdx
@@ -84,7 +84,7 @@ Una volta recuperati tutti gli elementi, il recupero dei tuoi file sullo spazio 
 
 Una volta connesso al tuo spazio di archiviazione, ti rimane solo da scaricare i file del tuo sito. **Ti invitiamo a prestare particolare attenzione al percorso in cui hai installato il tuo sito**. Nell'uso comune, il sito deve essere scaricato nella cartella "www". Tuttavia, se utilizzi il tuo spazio di hosting per ospitare diversi siti web, è probabile che tu abbia dichiarato diversi siti web.
 
-Per verificare la cartella in cui è memorizzato il tuo sito web, vai sull'onglet <code className="action">Multisito</code> dal tuo Spazio Cliente OVHcloud. Nella tabella visualizzata, per il dominio desiderato, guarda il <code className="action">Cartella di root</code> che appare.
+Per verificare la cartella in cui è memorizzato il tuo sito web, vai sulla scheda <code className="action">Multisito</code> dal tuo Spazio Cliente OVHcloud. Nella tabella visualizzata, per il dominio desiderato, guarda il <code className="action">Cartella di root</code> che appare.
 
 <img className="thumbnail" alt="export-website" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/multisite/root-folders.png" loading="lazy" />
 

--- a/docs/pt/guides/web-cloud/domains/domain-verify-holder.mdx
+++ b/docs/pt/guides/web-cloud/domains/domain-verify-holder.mdx
@@ -50,7 +50,7 @@ Após a encomenda, o titular do nome de domínio receberá um e-mail da OVHcloud
 
 <img className="thumbnail" alt="Verificação do endereço de e-mail" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/general-information/email-address-verification-for-one-of-your-domain-names.png" loading="lazy" />
 
-Ao clicar em <code className="action">Confirmer votre adresse e-mail</code>, uma nova página será aberta num link que validará diretamente o endereço de e-mail do titular.
+Ao clicar em <code className="action">Confirmar o seu endereço de e-mail</code>, uma nova página será aberta num link que validará diretamente o endereço de e-mail do titular.
 
 <img className="thumbnail" alt="Validação do e-mail CGI" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/general-information/validation-email-CGI.png" loading="lazy" />
 


### PR DESCRIPTION
What this fixes
The new-docs migration left untranslated French in several Web Cloud guides. A user reported it on the English dns-zone-dkim page (mixed FR/EN), and an audit showed it was not a one-off. This PR cleans it up for Web Cloud only.

How to review
The diff is locale text only — no structural changes. For each file, the change is either targeted (a few French CP-NAV / procedural lines → target language) or full (a guide copied over entirely in French, now translated).

What to check:

 Translations read naturally and use the right OVHcloud Manager labels.
 No MDX breakage — <ManagerLink>, <code className="action">, <Region>, <Tab>/<Tabs>/<ZoneTabs>, <Api>, callouts and code fences untouched.
 In-page anchor links still resolve (repointed where headings were translated).
Files (11)
en — domains/dns-zone-dkim, domains/trade-doa, email-and-collaborative-solutions/microsoft-exchange/feature-send-connector, web-hosting/getting-started-cloud-web, web-hosting/install-camaleon, web-hosting/install-django-cms-on-cloud-web, web-hosting/install-etherpad, web-hosting/premiers-pas-avec-visibilite-pro
es — domains/dns-zone-dkim
it — web-hosting/exporter-son-site-web
pt — domains/domain-verify-holder
The fr source tree is intentionally untouched.

