### PR TITLE
fix(docs): normalize community links batch 13: Hosted Private Cloud (2/3)

### DIFF
--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
@@ -219,4 +219,4 @@ The licence has been deleted.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
@@ -77,4 +77,4 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -210,4 +210,4 @@ If you need training or technical assistance to implement our solutions, please 
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
@@ -775,4 +775,4 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
@@ -140,4 +140,4 @@ The task list appears.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
@@ -54,5 +54,5 @@ Below is a summary table of the licences included in the Nutanix on OVHcloud pac
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
@@ -107,4 +107,4 @@ acli vm.reset
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
@@ -227,4 +227,4 @@ The **Load Balancer** is reconfigured during redeployment, and points the FQDN a
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
@@ -250,4 +250,4 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
@@ -211,4 +211,4 @@ Use the [Plik tool](https://plik.ovhcloud.com/#/) tool to upload your .zip files
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
@@ -69,4 +69,4 @@ Asynchronous replication between two sites is integrated with the OVHcloud **Nut
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
@@ -521,4 +521,4 @@ You can also [secure access to Prism Central](/guides/hosted-private-cloud/nutan
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
@@ -411,4 +411,4 @@ The rule you created is in the list of rules.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
@@ -73,4 +73,4 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
@@ -405,4 +405,4 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
   
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
@@ -860,4 +860,4 @@ The database is restored into a new database.
 
 If you need training or technical assistance for implementing our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and request a personalized analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
@@ -82,4 +82,4 @@ The imported image appears in the images dashboard in Prism Central.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -991,4 +991,4 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
@@ -54,4 +54,4 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
@@ -98,4 +98,4 @@ By following this guide, you will learn how to leverage **Nutanix's data-at-rest
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
@@ -1102,4 +1102,4 @@ The list of events appears, click <code className="action">Close</code> to close
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
@@ -430,4 +430,4 @@ The disk controller has been modified and the virtual machine boots properly.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
@@ -76,4 +76,4 @@ The query result appears below `availableVersions` with both versions supported 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
@@ -120,4 +120,4 @@ Visit the website [https://www.nutanixbible.com/](https://www.nutanixbible.com/)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
@@ -515,4 +515,4 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
@@ -398,6 +398,6 @@ OVHcloud storage solutions
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 _<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc._

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
@@ -258,7 +258,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 [Nutanix Objects documentation](https://portal.nutanix.com/page/documents/details?targetId=Objects-v3_6:top-intro-c.html).
 

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: "Weiterführende Informationen"
   items:
     - title: OVHcloud Community besuchen
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
@@ -301,4 +301,4 @@ Wait a few minutes for the VM to take into account all settings.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -252,4 +252,4 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
@@ -437,4 +437,4 @@ You can now connect to your VM with SSH through the public IP address.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
@@ -70,4 +70,4 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
@@ -1011,6 +1011,6 @@ The application is completely deleted.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 [Nutanix NCM Self Service (CALM)](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Calm-Admin-Operations-Guide-v3_6_0:Nutanix-Calm-Admin-Operations-Guide-v3_6_0).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -500,4 +500,4 @@ Your VLAN 2 is now connected to the Internet.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
@@ -120,4 +120,4 @@ The **Volume Group** will then appear in the list.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
@@ -201,4 +201,4 @@ The update process can be very long, it is possible that some slowdowns occur bu
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
@@ -287,4 +287,4 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
@@ -243,4 +243,4 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
@@ -219,4 +219,4 @@ The licence has been deleted.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
@@ -77,4 +77,4 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -210,4 +210,4 @@ If you need training or technical assistance to implement our solutions, please 
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
@@ -775,4 +775,4 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
@@ -140,4 +140,4 @@ The task list appears.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
@@ -54,4 +54,4 @@ Below is a summary table of the licences included in the Nutanix on OVHcloud pac
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
@@ -107,4 +107,4 @@ acli vm.reset
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
@@ -227,4 +227,4 @@ The **Load Balancer** is reconfigured during redeployment, and points the FQDN a
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
@@ -250,4 +250,4 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
@@ -211,4 +211,4 @@ Use the [Plik tool](https://plik.ovhcloud.com/#/) tool to upload your .zip files
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
@@ -69,4 +69,4 @@ Asynchronous replication between two sites is integrated with the OVHcloud **Nut
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
@@ -521,4 +521,4 @@ You can also [secure access to Prism Central](/guides/hosted-private-cloud/nutan
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
@@ -411,4 +411,4 @@ The rule you created is in the list of rules.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
@@ -73,4 +73,4 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
@@ -405,4 +405,4 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
   
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
@@ -860,4 +860,4 @@ The database is restored into a new database.
 
 If you need training or technical assistance for implementing our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a personalized analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
@@ -82,4 +82,4 @@ The imported image appears in the images dashboard in Prism Central.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -991,4 +991,4 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
@@ -54,4 +54,4 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
@@ -98,4 +98,4 @@ By following this guide, you will learn how to leverage **Nutanix's data-at-rest
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
@@ -1102,4 +1102,4 @@ The list of events appears, click <code className="action">Close</code> to close
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
@@ -430,4 +430,4 @@ The disk controller has been modified and the virtual machine boots properly.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
@@ -76,4 +76,4 @@ The query result appears below `availableVersions` with both versions supported 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
@@ -117,4 +117,4 @@ If you need training or technical assistance to implement our solutions, please 
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
@@ -120,4 +120,4 @@ Visit the website [https://www.nutanixbible.com/](https://www.nutanixbible.com/)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
@@ -515,4 +515,4 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
@@ -398,6 +398,6 @@ OVHcloud storage solutions
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 _<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc._

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
@@ -258,7 +258,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 [Nutanix Objects documentation](https://portal.nutanix.com/page/documents/details?targetId=Objects-v3_6:top-intro-c.html).
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
@@ -301,4 +301,4 @@ Wait a few minutes for the VM to take into account all settings.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -252,4 +252,4 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
@@ -437,4 +437,4 @@ You can now connect to your VM with SSH through the public IP address.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
@@ -70,4 +70,4 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
@@ -226,6 +226,6 @@ Once you have deployed an MST and connected it to your Object Storage bucket, yo
 
 If you require training or technical support to implement our solutions, please contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
@@ -223,6 +223,6 @@ The first backup starts immediately after validating the S3 target and lasts **a
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a personalized analysis of your project by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark owned by Amazon Technologies, Inc. OVHcloud services are not sponsored, approved, or affiliated in any way.

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -500,4 +500,4 @@ Your VLAN 2 is now connected to the Internet.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
@@ -120,4 +120,4 @@ The **Volume Group** will then appear in the list.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
@@ -201,4 +201,4 @@ The update process can be very long, it is possible that some slowdowns occur bu
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
@@ -287,4 +287,4 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
@@ -243,5 +243,5 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
@@ -219,4 +219,4 @@ The licence has been deleted.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
@@ -77,4 +77,4 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -210,4 +210,4 @@ If you need training or technical assistance to implement our solutions, please 
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
@@ -775,4 +775,4 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
@@ -140,4 +140,4 @@ The task list appears.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
@@ -54,4 +54,4 @@ Below is a summary table of the licences included in the Nutanix on OVHcloud pac
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
@@ -107,4 +107,4 @@ acli vm.reset
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
@@ -227,4 +227,4 @@ The **Load Balancer** is reconfigured during redeployment, and points the FQDN a
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
@@ -250,4 +250,4 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
@@ -211,4 +211,4 @@ Use the [Plik tool](https://plik.ovhcloud.com/#/) tool to upload your .zip files
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
@@ -69,4 +69,4 @@ Asynchronous replication between two sites is integrated with the OVHcloud **Nut
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
@@ -521,4 +521,4 @@ You can also [secure access to Prism Central](/guides/hosted-private-cloud/nutan
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
@@ -411,4 +411,4 @@ The rule you created is in the list of rules.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
@@ -73,4 +73,4 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
@@ -405,4 +405,4 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
   
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
@@ -860,4 +860,4 @@ The database is restored into a new database.
 
 If you need training or technical assistance for implementing our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and request a personalized analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
@@ -82,4 +82,4 @@ The imported image appears in the images dashboard in Prism Central.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -991,4 +991,4 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
@@ -54,4 +54,4 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
@@ -98,4 +98,4 @@ By following this guide, you will learn how to leverage **Nutanix's data-at-rest
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
@@ -1102,4 +1102,4 @@ The list of events appears, click <code className="action">Close</code> to close
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
@@ -430,4 +430,4 @@ The disk controller has been modified and the virtual machine boots properly.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
@@ -76,4 +76,4 @@ The query result appears below `availableVersions` with both versions supported 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
@@ -120,4 +120,4 @@ Visit the website [https://www.nutanixbible.com/](https://www.nutanixbible.com/)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
@@ -515,4 +515,4 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
@@ -398,6 +398,6 @@ OVHcloud storage solutions
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 _<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc._

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
@@ -258,7 +258,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 [Nutanix Objects documentation](https://portal.nutanix.com/page/documents/details?targetId=Objects-v3_6:top-intro-c.html).
 

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: "Más información"
   items:
     - title: Visitar la comunidad OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consultar la hoja de ruta y el registro de cambios"
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
@@ -301,4 +301,4 @@ Wait a few minutes for the VM to take into account all settings.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -252,4 +252,4 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
@@ -437,4 +437,4 @@ You can now connect to your VM with SSH through the public IP address.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
@@ -70,4 +70,4 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
@@ -1011,6 +1011,6 @@ The application is completely deleted.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 [Nutanix NCM Self Service (CALM)](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Calm-Admin-Operations-Guide-v3_6_0:Nutanix-Calm-Admin-Operations-Guide-v3_6_0).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -500,4 +500,4 @@ Your VLAN 2 is now connected to the Internet.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
@@ -120,4 +120,4 @@ The **Volume Group** will then appear in the list.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
@@ -201,4 +201,4 @@ The update process can be very long, it is possible that some slowdowns occur bu
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
@@ -287,4 +287,4 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
@@ -243,4 +243,4 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
@@ -219,4 +219,4 @@ La suppression de la licence est effective.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
@@ -76,4 +76,4 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -209,4 +209,4 @@ Si vous avez besoin d'une formation ou d'une assistance technique pour la mise e
 
 Posez des questions, donnez votre avis et interagissez directement avec l’équipe qui construit nos services Hosted Private Cloud sur le canal [Discord](https://discord.gg/ovhcloud) dédié.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
@@ -773,4 +773,4 @@ La nouvelle machine virtuelle doit apparaitre dans **Prism Central**, elle est a
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
@@ -140,4 +140,4 @@ La liste des tâches apparaît.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
@@ -53,4 +53,4 @@ Ci-dessous se trouve un tableau récapitulatif des licences incluses dans l'offr
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
@@ -105,4 +105,4 @@ acli vm.reset
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
@@ -229,4 +229,4 @@ Le **Load Balancer** est reconfiguré lors du redéploiement et fait pointer l'a
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
@@ -250,4 +250,4 @@ Merci de ne pas ouvrir de nouveau ticket, il suffit de rajouter des commentaires
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
@@ -211,4 +211,4 @@ Utilisez l'outil [Plik](https://plik.ovhcloud.com/#/) pour téléverser vos fich
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
@@ -69,5 +69,5 @@ La réplication asynchrone entre deux sites est intégrée avec l'offre OVHcloud
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
@@ -521,4 +521,4 @@ Vous pouvez également [sécuriser l'accès à Prism Central](/guides/hosted-pri
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
@@ -411,4 +411,4 @@ La règle créée se trouve dans la liste des règles.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
@@ -75,4 +75,4 @@ L'accès à Prism Central est disponible à l'adresse suivante : `https://<fqdn>
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
@@ -404,4 +404,4 @@ Le test dure 10 secondes et vous obtiendrez la bande passante de votre cluster a
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
@@ -858,4 +858,4 @@ La base de données est restaurée dans une nouvelle base de données.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
@@ -82,4 +82,4 @@ L'image importée apparaît dans le tableau de bord des images dans Prism Centra
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -991,4 +991,4 @@ Le paramétrage du VPN est terminé sur les deux clusters. Il est maintenant pos
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
@@ -54,4 +54,4 @@ Donnez un nom à votre réseau, puis choisissez un VLAN ID, un cluster et le swi
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
@@ -98,4 +98,4 @@ En suivant ce guide, vous apprendrez à utiliser les fonctionnalités de **chiff
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
@@ -1102,4 +1102,4 @@ La liste des événements survenus apparaît, cliquez sur <code className="actio
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
@@ -429,4 +429,4 @@ Le contrôleur de disque a été modifié et la machine virtuelle demarre correc
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
@@ -76,4 +76,4 @@ Le résultat de la requête apparaît en dessous de `availableVersions` avec les
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
@@ -134,4 +134,4 @@ Si vous avez besoin de formation ou d’assistance technique pour mettre en œuv
 
 Posez vos questions, donnez votre avis et interagissez directement avec l’équipe en charge de nos services Hosted Private Cloud sur notre canal [Discord](https://discord.gg/ovhcloud).
 
-Rejoignez également notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
@@ -120,4 +120,4 @@ Visitez le site [https://www.nutanixbible.com/](https://www.nutanixbible.com/) p
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
@@ -515,4 +515,4 @@ La machine virtuelle membre du plan de reprise d'activité va démarrer sur le c
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
@@ -397,6 +397,6 @@ Les solutions de stockage OVHcloud
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 _<sup>1</sup>: S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit._

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
@@ -271,6 +271,6 @@ Vous voyez le bucket que vous avez créé en ligne de commande. Vous pouvez cré
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 **\*** : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: "Consulter la communauté OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
@@ -292,4 +292,4 @@ Attendez quelques minutes pour que la VM prenne en compte tous les paramètres.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -252,4 +252,4 @@ Les machines virtuelles apparaîtront dans la console de **Prism Element** dans 
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
@@ -437,4 +437,4 @@ Vous pouvez maintenant vous connecter à votre VM en SSH via l'adresse IP publiq
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
@@ -70,4 +70,4 @@ Dans les paramètres avancés, vous pouvez désormais ajouter l'adresse IP de vo
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
@@ -1003,6 +1003,6 @@ L'application est maintenant supprimée.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 [Nutanix NCM Self Service (CALM)](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Calm-Admin-Operations-Guide-v3_6_0:Nutanix-Calm-Admin-Operations-Guide-v3_6_0).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
@@ -226,6 +226,6 @@ Une fois MST déployé et connecté à votre bucket Object Storage, vous pouvez 
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
@@ -223,6 +223,6 @@ La première sauvegarde démarre immédiatement après la validation de la cible
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -499,4 +499,4 @@ Votre VLAN2 est maintenant connecté à Internet.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
@@ -120,4 +120,4 @@ Le **Volume Group** apparait alors dans la liste.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
@@ -201,4 +201,4 @@ Le processus de mise à jour peut être très long, il est possible que quelques
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
@@ -287,4 +287,4 @@ Le nom du nouveau nœud apparaîtra en face de **Host** si la  migration s'est b
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
@@ -243,5 +243,5 @@ Le Load Balancer est relié au vRack commun aux deux sites et l'accès à Prism 
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
@@ -219,4 +219,4 @@ The licence has been deleted.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
@@ -77,4 +77,4 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -210,4 +210,4 @@ If you need training or technical assistance to implement our solutions, please 
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
@@ -775,4 +775,4 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
@@ -140,4 +140,4 @@ The task list appears.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
@@ -54,5 +54,5 @@ Below is a summary table of the licences included in the Nutanix on OVHcloud pac
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
@@ -107,4 +107,4 @@ acli vm.reset
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
@@ -227,4 +227,4 @@ The **Load Balancer** is reconfigured during redeployment, and points the FQDN a
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
@@ -250,4 +250,4 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
@@ -211,4 +211,4 @@ Use the [Plik tool](https://plik.ovhcloud.com/#/) tool to upload your .zip files
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
@@ -69,4 +69,4 @@ Asynchronous replication between two sites is integrated with the OVHcloud **Nut
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
@@ -521,4 +521,4 @@ You can also [secure access to Prism Central](/guides/hosted-private-cloud/nutan
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
@@ -411,4 +411,4 @@ The rule you created is in the list of rules.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
@@ -73,4 +73,4 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
@@ -405,4 +405,4 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
   
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
@@ -860,4 +860,4 @@ The database is restored into a new database.
 
 If you need training or technical assistance for implementing our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and request a personalized analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
@@ -82,4 +82,4 @@ The imported image appears in the images dashboard in Prism Central.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -991,4 +991,4 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
@@ -54,4 +54,4 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
@@ -98,4 +98,4 @@ By following this guide, you will learn how to leverage **Nutanix's data-at-rest
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
@@ -1102,4 +1102,4 @@ The list of events appears, click <code className="action">Close</code> to close
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
@@ -430,4 +430,4 @@ The disk controller has been modified and the virtual machine boots properly.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
@@ -76,4 +76,4 @@ The query result appears below `availableVersions` with both versions supported 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
@@ -120,4 +120,4 @@ Visit the website [https://www.nutanixbible.com/](https://www.nutanixbible.com/)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
@@ -515,4 +515,4 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
@@ -398,6 +398,6 @@ OVHcloud storage solutions
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 _<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc._

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
@@ -258,7 +258,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 [Nutanix Objects documentation](https://portal.nutanix.com/page/documents/details?targetId=Objects-v3_6:top-intro-c.html).
 

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: Visita la community OVHcloud
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulta la roadmap e il changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
@@ -301,4 +301,4 @@ Wait a few minutes for the VM to take into account all settings.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -252,4 +252,4 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
@@ -437,4 +437,4 @@ You can now connect to your VM with SSH through the public IP address.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
@@ -70,4 +70,4 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
@@ -1011,6 +1011,6 @@ The application is completely deleted.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 [Nutanix NCM Self Service (CALM)](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Calm-Admin-Operations-Guide-v3_6_0:Nutanix-Calm-Admin-Operations-Guide-v3_6_0).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -500,4 +500,4 @@ Your VLAN 2 is now connected to the Internet.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
@@ -120,4 +120,4 @@ The **Volume Group** will then appear in the list.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
@@ -201,4 +201,4 @@ The update process can be very long, it is possible that some slowdowns occur bu
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
@@ -287,4 +287,4 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
@@ -243,4 +243,4 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
@@ -219,4 +219,4 @@ The licence has been deleted.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
@@ -77,4 +77,4 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -210,4 +210,4 @@ If you need training or technical assistance to implement our solutions, please 
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
@@ -775,4 +775,4 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
@@ -140,4 +140,4 @@ The task list appears.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
@@ -54,4 +54,4 @@ Below is a summary table of the licences included in the Nutanix on OVHcloud pac
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
@@ -107,4 +107,4 @@ acli vm.reset
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
@@ -227,4 +227,4 @@ The **Load Balancer** is reconfigured during redeployment, and points the FQDN a
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
@@ -250,4 +250,4 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
@@ -211,4 +211,4 @@ Use the [Plik tool](https://plik.ovhcloud.com/#/) tool to upload your .zip files
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
@@ -69,4 +69,4 @@ Asynchronous replication between two sites is integrated with the OVHcloud **Nut
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
@@ -521,4 +521,4 @@ You can also [secure access to Prism Central](/guides/hosted-private-cloud/nutan
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
@@ -411,4 +411,4 @@ The rule you created is in the list of rules.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
@@ -73,4 +73,4 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
@@ -405,4 +405,4 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
   
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
@@ -860,4 +860,4 @@ The database is restored into a new database.
 
 If you need training or technical assistance for implementing our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and request a personalized analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
@@ -82,4 +82,4 @@ The imported image appears in the images dashboard in Prism Central.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -991,4 +991,4 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
@@ -54,4 +54,4 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
@@ -98,4 +98,4 @@ By following this guide, you will learn how to leverage **Nutanix's data-at-rest
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
@@ -1102,4 +1102,4 @@ The list of events appears, click <code className="action">Close</code> to close
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
@@ -430,4 +430,4 @@ The disk controller has been modified and the virtual machine boots properly.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
@@ -76,4 +76,4 @@ The query result appears below `availableVersions` with both versions supported 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
@@ -120,4 +120,4 @@ Visit the website [https://www.nutanixbible.com/](https://www.nutanixbible.com/)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
@@ -515,4 +515,4 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
@@ -398,6 +398,6 @@ OVHcloud storage solutions
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 _<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc._

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
@@ -258,7 +258,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 [Nutanix Objects documentation](https://portal.nutanix.com/page/documents/details?targetId=Objects-v3_6:top-intro-c.html).
 

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz roadmapę i changelog"
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: "Dołącz do Discord"

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
@@ -301,4 +301,4 @@ Wait a few minutes for the VM to take into account all settings.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -252,4 +252,4 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
@@ -437,4 +437,4 @@ You can now connect to your VM with SSH through the public IP address.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
@@ -70,4 +70,4 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
@@ -1011,6 +1011,6 @@ The application is completely deleted.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 [Nutanix NCM Self Service (CALM)](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Calm-Admin-Operations-Guide-v3_6_0:Nutanix-Calm-Admin-Operations-Guide-v3_6_0).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -500,4 +500,4 @@ Your VLAN 2 is now connected to the Internet.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
@@ -120,4 +120,4 @@ The **Volume Group** will then appear in the list.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
@@ -201,4 +201,4 @@ The update process can be very long, it is possible that some slowdowns occur bu
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
@@ -287,4 +287,4 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
@@ -243,4 +243,4 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
@@ -219,4 +219,4 @@ The licence has been deleted.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
@@ -77,4 +77,4 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -210,4 +210,4 @@ If you need training or technical assistance to implement our solutions, please 
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
@@ -775,4 +775,4 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
@@ -140,4 +140,4 @@ The task list appears.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
@@ -54,4 +54,4 @@ Below is a summary table of the licences included in the Nutanix on OVHcloud pac
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
@@ -107,4 +107,4 @@ acli vm.reset
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
@@ -227,4 +227,4 @@ The **Load Balancer** is reconfigured during redeployment, and points the FQDN a
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
@@ -250,4 +250,4 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
@@ -211,4 +211,4 @@ Use the [Plik tool](https://plik.ovhcloud.com/#/) tool to upload your .zip files
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
@@ -69,4 +69,4 @@ Asynchronous replication between two sites is integrated with the OVHcloud **Nut
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
@@ -521,4 +521,4 @@ You can also [secure access to Prism Central](/guides/hosted-private-cloud/nutan
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
@@ -411,4 +411,4 @@ The rule you created is in the list of rules.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
@@ -73,4 +73,4 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
@@ -405,4 +405,4 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
   
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
@@ -860,4 +860,4 @@ The database is restored into a new database.
 
 If you need training or technical assistance for implementing our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and request a personalized analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
@@ -82,4 +82,4 @@ The imported image appears in the images dashboard in Prism Central.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -991,4 +991,4 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
@@ -54,4 +54,4 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
@@ -98,4 +98,4 @@ By following this guide, you will learn how to leverage **Nutanix's data-at-rest
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
@@ -1102,4 +1102,4 @@ The list of events appears, click <code className="action">Close</code> to close
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
@@ -430,4 +430,4 @@ The disk controller has been modified and the virtual machine boots properly.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
@@ -76,4 +76,4 @@ The query result appears below `availableVersions` with both versions supported 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
@@ -120,4 +120,4 @@ Visit the website [https://www.nutanixbible.com/](https://www.nutanixbible.com/)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
@@ -515,4 +515,4 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
@@ -398,6 +398,6 @@ OVHcloud storage solutions
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 _<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc._

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
@@ -258,7 +258,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 [Nutanix Objects documentation](https://portal.nutanix.com/page/documents/details?targetId=Objects-v3_6:top-intro-c.html).
 

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/overview.mdx
@@ -28,7 +28,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: "Visitar a comunidade OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consultar o roadmap e o changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
@@ -301,4 +301,4 @@ Wait a few minutes for the VM to take into account all settings.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -252,4 +252,4 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
@@ -437,4 +437,4 @@ You can now connect to your VM with SSH through the public IP address.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
@@ -70,4 +70,4 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/self-service-calm.mdx
@@ -1011,6 +1011,6 @@ The application is completely deleted.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).
 
 [Nutanix NCM Self Service (CALM)](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Calm-Admin-Operations-Guide-v3_6_0:Nutanix-Calm-Admin-Operations-Guide-v3_6_0).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -500,4 +500,4 @@ Your VLAN 2 is now connected to the Internet.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
@@ -120,4 +120,4 @@ The **Volume Group** will then appear in the list.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
@@ -201,4 +201,4 @@ The update process can be very long, it is possible that some slowdowns occur bu
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
@@ -287,4 +287,4 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
@@ -243,4 +243,4 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).


### PR DESCRIPTION
### Scope: Hosted Private Cloud - Nutanix

- Replace (dead) links to legacy community page with proper keys
- Fix hard URL in Overview pages to the correct one