### PR TITLE
fix(docs): normalize community links batch 14: Hosted Private Cloud (3/3)

### DIFF
--- a/docs/de/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
+++ b/docs/de/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
@@ -113,6 +113,6 @@ A backup has been created and stored in the S3 bucket.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or go to the [Professional Services page](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
+++ b/docs/de/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
@@ -320,4 +320,4 @@ A no-script alternative is available directly in the Keycloak interface: **Clien
 
 For training or technical assistance with implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and a custom project analysis from our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
+++ b/docs/de/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
@@ -180,4 +180,4 @@ openstack baremetal node show <node-id>
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
+++ b/docs/de/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
@@ -249,5 +249,5 @@ mdadm --detail /dev/md0
 
 If you need training or technical assistance to implement our solutions, please contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project reviewed by our Professional Services experts.
 
-Join our [user community](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/de/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
+++ b/docs/de/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
@@ -425,4 +425,4 @@ These commands only return users who have **already authenticated** at least onc
 
 For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/opcp/install-controller.mdx
+++ b/docs/de/guides/hosted-private-cloud/opcp/install-controller.mdx
@@ -201,6 +201,6 @@ lvresize -r -L200G -v /dev/mapper/vg-var
 
 If you need training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to get a quote and request a custom analysis of your project from our Professional Services team.
 
-Join our [community of users](https://community.ovh.com/).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/de/guides/hosted-private-cloud/opcp/overview.mdx
+++ b/docs/de/guides/hosted-private-cloud/opcp/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Weiterführende Informationen"
   items:
     - title: "OVHcloud Community besuchen"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/de/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
+++ b/docs/de/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
@@ -401,4 +401,4 @@ Your instance can now communicate on multiple isolated networks through a single
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/opcp/use-terraform.mdx
+++ b/docs/de/guides/hosted-private-cloud/opcp/use-terraform.mdx
@@ -287,4 +287,4 @@ terraform destroy
 
 For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
+++ b/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
@@ -173,4 +173,4 @@ Configuring the secondary SAProuter requires the same care and vigilance as the 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
+++ b/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
@@ -147,4 +147,4 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
+++ b/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
@@ -771,4 +771,4 @@ In this case, the expected behaviour is only the detection of the loss of the se
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
+++ b/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
@@ -380,4 +380,4 @@ Otherwise, please set paths.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
+++ b/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
@@ -264,4 +264,4 @@ You can proceed to its installation following the [official SAP guide](https://h
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
+++ b/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
@@ -284,4 +284,4 @@ systemctl enable chronyd.service
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
+++ b/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
@@ -241,4 +241,4 @@ Destroy complete! Resources: 1 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
+++ b/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
@@ -266,4 +266,4 @@ Destroy complete! Resources: 1 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
+++ b/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
@@ -350,4 +350,4 @@ Destroy complete! Resources: 2 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
   
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
+++ b/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
@@ -149,4 +149,4 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
+++ b/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
@@ -216,4 +216,4 @@ To improve the security of your backups, we advise you to set the [object immuta
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
+++ b/docs/de/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: "Weiterführende Informationen"
   items:
     - title: "OVHcloud Community besuchen"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
     - title: Discord beitreten

--- a/docs/en/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
+++ b/docs/en/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
@@ -113,6 +113,6 @@ A backup has been created and stored in the S3 bucket.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or go to the [Professional Services page](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/hosted-private-cloud/baremetal-pod/snc-getting-started.mdx
+++ b/docs/en/guides/hosted-private-cloud/baremetal-pod/snc-getting-started.mdx
@@ -142,4 +142,4 @@ For more information on how networks work with OpenStack, we recommend you consu
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
+++ b/docs/en/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
@@ -320,4 +320,4 @@ A no-script alternative is available directly in the Keycloak interface: **Clien
 
 For training or technical assistance with implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and a custom project analysis from our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/getting-started.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/getting-started.mdx
@@ -141,4 +141,4 @@ To find out more about how networks work with OpenStack, we recommend reading th
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
@@ -178,4 +178,4 @@ openstack baremetal node show `<node-id>`
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-instance-from-cli.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-instance-from-cli.mdx
@@ -364,4 +364,4 @@ The operation may take several minutes before the node is `Available` again and 
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-instance.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-instance.mdx
@@ -183,4 +183,4 @@ To learn more, refer to the [official OpenStack documentation](https://docs.open
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-lacp-on-node.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-lacp-on-node.mdx
@@ -358,4 +358,4 @@ Your instance is now ready to leverage the full available bandwidth of the aggre
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
@@ -268,5 +268,5 @@ Disabling RAID will erase all data on the disks used for the RAID configuration.
 
 If you need training or technical assistance to implement our solutions, please contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project reviewed by our Professional Services experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
@@ -201,4 +201,4 @@ If these commands return results, the **Keycloak ↔ OpenStack** integration is 
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
@@ -425,4 +425,4 @@ These commands only return users who have **already authenticated** at least onc
 
 For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/install-controller.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/install-controller.mdx
@@ -201,6 +201,6 @@ lvresize -r -L200G -v /dev/mapper/vg-var
 
 If you need training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to get a quote and request a custom analysis of your project from our Professional Services team.
 
-Join our [community of users](https://community.ovh.com/).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/hosted-private-cloud/opcp/node-lifecycle.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/node-lifecycle.mdx
@@ -146,4 +146,4 @@ baremetal node maintenance unset $BAREMETAL_NODE_ID
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/overview.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/en/guides/hosted-private-cloud/opcp/s3-opcp-limitations.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/s3-opcp-limitations.mdx
@@ -70,4 +70,4 @@ Improvements for user policy management are planned for future updates.
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
@@ -380,4 +380,4 @@ Your instance can now communicate on multiple isolated networks through a single
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/storage-ceph-rbd-overview.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/storage-ceph-rbd-overview.mdx
@@ -95,4 +95,4 @@ The **Ceph RBD** backend offers advanced tools for volume lifecycle management, 
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/use-terraform.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/use-terraform.mdx
@@ -287,4 +287,4 @@ terraform destroy
 
 For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
@@ -173,4 +173,4 @@ Configuring the secondary SAProuter requires the same care and vigilance as the 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
@@ -147,4 +147,4 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
@@ -771,4 +771,4 @@ In this case, the expected behaviour is only the detection of the loss of the se
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
@@ -380,4 +380,4 @@ Otherwise, please set paths.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
@@ -263,4 +263,4 @@ You can proceed to its installation following the [official SAP guide](https://h
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
@@ -284,4 +284,4 @@ systemctl enable chronyd.service
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-analyze-and-work-with-your-logs.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-analyze-and-work-with-your-logs.mdx
@@ -113,4 +113,4 @@ The OVHcloud API available at [api.ovh.com](/links/api) can helps you to retriev
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-index-of-sap-logs.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-index-of-sap-logs.mdx
@@ -79,4 +79,4 @@ If you haven't configured your OVHcloud Logs Data Platform service, please take 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-solution-setup.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-solution-setup.mdx
@@ -334,4 +334,4 @@ rm -r /etc/systemd/system/ovhcloud-sap-audit.service.d
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-preinstallation-wizard.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-preinstallation-wizard.mdx
@@ -254,4 +254,4 @@ The OVHcloud SAP pre-installation wizard does not support adding additional comp
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
@@ -241,4 +241,4 @@ Destroy complete! Resources: 1 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
@@ -266,4 +266,4 @@ Destroy complete! Resources: 1 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
@@ -350,4 +350,4 @@ Destroy complete! Resources: 2 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
   
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-veeam-backup-sap-hana.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-veeam-backup-sap-hana.mdx
@@ -473,4 +473,4 @@ If you want to perform communication via the HTTPS protocol, the ports are:
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-vmware-saprouter.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-vmware-saprouter.mdx
@@ -196,4 +196,4 @@ Find more information about the firewall rule with an NSX gateway in [our guide]
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
@@ -149,4 +149,4 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
@@ -216,4 +216,4 @@ To improve the security of your backups, we advise you to set the [object immuta
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: Go further
   items:
     - title: Visit the OVHcloud community
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "View the roadmap & changelog"
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord

--- a/docs/es/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
+++ b/docs/es/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
@@ -113,6 +113,6 @@ A backup has been created and stored in the S3 bucket.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or go to the [Professional Services page](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
+++ b/docs/es/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
@@ -320,4 +320,4 @@ A no-script alternative is available directly in the Keycloak interface: **Clien
 
 For training or technical assistance with implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and a custom project analysis from our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
+++ b/docs/es/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
@@ -180,4 +180,4 @@ openstack baremetal node show <node-id>
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
+++ b/docs/es/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
@@ -249,5 +249,5 @@ mdadm --detail /dev/md0
 
 If you need training or technical assistance to implement our solutions, please contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project reviewed by our Professional Services experts.
 
-Join our [user community](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/es/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
+++ b/docs/es/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
@@ -425,4 +425,4 @@ These commands only return users who have **already authenticated** at least onc
 
 For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/opcp/install-controller.mdx
+++ b/docs/es/guides/hosted-private-cloud/opcp/install-controller.mdx
@@ -201,6 +201,6 @@ lvresize -r -L200G -v /dev/mapper/vg-var
 
 If you need training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to get a quote and request a custom analysis of your project from our Professional Services team.
 
-Join our [community of users](https://community.ovh.com/).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/hosted-private-cloud/opcp/overview.mdx
+++ b/docs/es/guides/hosted-private-cloud/opcp/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Más información"
   items:
     - title: "Visitar la comunidad OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consultar la hoja de ruta y el registro de cambios"
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: "Unirse a Discord"

--- a/docs/es/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
+++ b/docs/es/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
@@ -401,4 +401,4 @@ Your instance can now communicate on multiple isolated networks through a single
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/opcp/use-terraform.mdx
+++ b/docs/es/guides/hosted-private-cloud/opcp/use-terraform.mdx
@@ -287,4 +287,4 @@ terraform destroy
 
 For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
+++ b/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
@@ -173,4 +173,4 @@ Configuring the secondary SAProuter requires the same care and vigilance as the 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
+++ b/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
@@ -147,4 +147,4 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
+++ b/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
@@ -771,4 +771,4 @@ In this case, the expected behaviour is only the detection of the loss of the se
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
+++ b/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
@@ -380,4 +380,4 @@ Otherwise, please set paths.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
+++ b/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
@@ -264,4 +264,4 @@ You can proceed to its installation following the [official SAP guide](https://h
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
+++ b/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
@@ -284,4 +284,4 @@ systemctl enable chronyd.service
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
+++ b/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
@@ -241,4 +241,4 @@ Destroy complete! Resources: 1 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
+++ b/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
@@ -266,4 +266,4 @@ Destroy complete! Resources: 1 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
+++ b/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
@@ -350,4 +350,4 @@ Destroy complete! Resources: 2 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
   
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
+++ b/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
@@ -149,4 +149,4 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
+++ b/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
@@ -216,4 +216,4 @@ To improve the security of your backups, we advise you to set the [object immuta
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
+++ b/docs/es/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: "Más información"
   items:
     - title: "Visitar la comunidad OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consultar la hoja de ruta y el registro de cambios"
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord

--- a/docs/fr/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
+++ b/docs/fr/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
@@ -113,6 +113,6 @@ Une sauvegarde a été créée et stockée dans le bucket S3.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour mettre en œuvre nos solutions, contactez votre commercial ou rendez-vous sur [la page Professional Services](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/hosted-private-cloud/baremetal-pod/snc-getting-started.mdx
+++ b/docs/fr/guides/hosted-private-cloud/baremetal-pod/snc-getting-started.mdx
@@ -142,4 +142,4 @@ Pour en savoir plus sur le fonctionnement des réseaux avec OpenStack, nous vous
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
+++ b/docs/fr/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
@@ -320,4 +320,4 @@ Une alternative sans script est disponible directement dans l'interface Keycloak
 
 Pour une formation ou une assistance technique sur la mise en œuvre de nos solutions, contactez votre commercial ou rendez-vous sur la page [Professional Services](https://www.ovhcloud.com/fr/professional-services/) afin d'obtenir un devis et une analyse personnalisée de votre projet par nos experts.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/cloud-platform/getting-started.mdx
+++ b/docs/fr/guides/hosted-private-cloud/cloud-platform/getting-started.mdx
@@ -145,4 +145,4 @@ Il est aussi possible d'en créer de nouveau via le bouton **Request new Access 
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-backup-object-storage-bucket.mdx
+++ b/docs/fr/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-backup-object-storage-bucket.mdx
@@ -141,4 +141,4 @@ journalctl -u rclone-backup.service
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-save-instance.mdx
+++ b/docs/fr/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-save-instance.mdx
@@ -113,6 +113,6 @@ Une sauvegarde a été créée et stockée dans le bucket S3.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/hosted-private-cloud/opcp/getting-started.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/getting-started.mdx
@@ -142,4 +142,4 @@ Pour en savoir plus sur le fonctionnement des réseaux avec OpenStack, nous vous
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
@@ -178,4 +178,4 @@ openstack baremetal node show `<node-id>`
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-setup-instance-from-cli.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-setup-instance-from-cli.mdx
@@ -367,4 +367,4 @@ L'opération peut prendre plusieurs minutes avant que le nœud soit de nouveau `
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-setup-instance.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-setup-instance.mdx
@@ -177,4 +177,4 @@ Pour aller plus loin, consultez la [documentation officielle OpenStack](https://
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-setup-lacp-on-node.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-setup-lacp-on-node.mdx
@@ -357,4 +357,4 @@ Votre instance est désormais prête à exploiter toute la bande passante dispon
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
@@ -268,4 +268,4 @@ La désactivation du RAID effacera toutes les données présentes sur les disque
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour demander un devis et faire analyser votre projet par nos experts de l'équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
@@ -201,4 +201,4 @@ Si ces commandes retournent des résultats, l’intégration **Keycloak ↔ Open
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
@@ -425,4 +425,4 @@ Ces commandes ne retournent que les utilisateurs qui se sont **déjà authentifi
 
 Pour une formation ou une assistance technique sur la mise en œuvre de nos solutions, contactez votre commercial ou consultez la page [Professional Services](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et faire analyser votre projet par nos experts.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/opcp/install-controller.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/install-controller.mdx
@@ -201,6 +201,6 @@ lvresize -r -L200G -v /dev/mapper/vg-var
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou consultez notre page [Professional Services](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l'équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovh.com/).
+Échangez avec notre [communauté d’utilisateurs](/links/community).
 
 <sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/hosted-private-cloud/opcp/node-lifecycle.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/node-lifecycle.mdx
@@ -146,4 +146,4 @@ baremetal node maintenance unset $BAREMETAL_NODE_ID
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/fr/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/fr).
+Join our [community of users](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/opcp/overview.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: "Consulter la communauté OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/fr/guides/hosted-private-cloud/opcp/s3-opcp-limitations.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/s3-opcp-limitations.mdx
@@ -70,4 +70,4 @@ Des améliorations pour la gestion des stratégies utilisateur sont prévues dan
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
@@ -380,4 +380,4 @@ Votre instance peut désormais communiquer sur plusieurs réseaux isolés grâce
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts du service Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/opcp/use-terraform.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/use-terraform.mdx
@@ -287,4 +287,4 @@ terraform destroy
 
 Pour une formation ou une assistance technique sur la mise en œuvre de nos solutions, contactez votre commercial ou consultez la page [Professional Services](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et faire analyser votre projet par nos experts.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
@@ -173,4 +173,4 @@ La configuration du SAProuter secondaire nécessite le même soin et la même vi
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre communauté d'utilisateurs sur [https://community.ovh.com](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
@@ -147,4 +147,4 @@ Pour garantir la continuité de la connexion avec le support SAP, nous recommand
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
@@ -775,4 +775,4 @@ Dans ce cas, le comportement attendu est uniquement la détection de la perte du
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/?_gl=1*835bqy*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
@@ -380,4 +380,4 @@ Dans le cas contraire, veuillez indiquer le chemin.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
@@ -264,4 +264,4 @@ Vous pouvez procéder à l'installation SAP HANA. Pour cela, nous vous recommand
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
@@ -286,4 +286,4 @@ systemctl enable chronyd.service
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/?_gl=1*39h6u1*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-analyze-and-work-with-your-logs.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-analyze-and-work-with-your-logs.mdx
@@ -113,4 +113,4 @@ L’API OVHcloud disponible sur [api.ovh.com](/links/api) peut vous aider à ré
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-index-of-sap-logs.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-index-of-sap-logs.mdx
@@ -79,4 +79,4 @@ Si vous n'avez pas configuré votre service OVHcloud Logs Data Platform, veuille
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-solution-setup.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-solution-setup.mdx
@@ -332,4 +332,4 @@ rm -r /etc/systemd/system/ovhcloud-sap-audit.service.d
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-preinstallation-wizard.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-preinstallation-wizard.mdx
@@ -265,4 +265,4 @@ L'assistant de pré-installation SAP d'OVHcloud ne prend pas en charge l'ajout d
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
@@ -241,4 +241,4 @@ Destroy complete! Resources: 1 destroyed.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
@@ -266,4 +266,4 @@ Destroy complete! Resources: 1 destroyed.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
@@ -350,4 +350,4 @@ Destroy complete! Resources: 2 destroyed.
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-veeam-backup-sap-hana.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-veeam-backup-sap-hana.mdx
@@ -473,4 +473,4 @@ Si vous désirez effectuer la communication via le protocole HTTPS, les ports so
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-vmware-saprouter.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-vmware-saprouter.mdx
@@ -193,4 +193,4 @@ Nous vous conseillons de mettre à jour régulièrement le SAProuter et de le po
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
@@ -149,4 +149,4 @@ Pour garantir la continuité de la connexion avec le support SAP, nous recommand
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
@@ -212,4 +212,4 @@ Afin d'améliorer la sécurité de vos sauvegardes, nous vous conseillons de met
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
+++ b/docs/fr/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: Aller plus loin
   items:
     - title: "Consulter la communauté OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
     - title: Rejoindre Discord

--- a/docs/it/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
+++ b/docs/it/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
@@ -113,6 +113,6 @@ A backup has been created and stored in the S3 bucket.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or go to the [Professional Services page](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
+++ b/docs/it/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
@@ -320,4 +320,4 @@ A no-script alternative is available directly in the Keycloak interface: **Clien
 
 For training or technical assistance with implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and a custom project analysis from our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
+++ b/docs/it/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
@@ -180,4 +180,4 @@ openstack baremetal node show <node-id>
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
+++ b/docs/it/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
@@ -249,5 +249,5 @@ mdadm --detail /dev/md0
 
 If you need training or technical assistance to implement our solutions, please contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project reviewed by our Professional Services experts.
 
-Join our [user community](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/it/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
+++ b/docs/it/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
@@ -425,4 +425,4 @@ These commands only return users who have **already authenticated** at least onc
 
 For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/opcp/install-controller.mdx
+++ b/docs/it/guides/hosted-private-cloud/opcp/install-controller.mdx
@@ -201,6 +201,6 @@ lvresize -r -L200G -v /dev/mapper/vg-var
 
 If you need training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to get a quote and request a custom analysis of your project from our Professional Services team.
 
-Join our [community of users](https://community.ovh.com/).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/it/guides/hosted-private-cloud/opcp/overview.mdx
+++ b/docs/it/guides/hosted-private-cloud/opcp/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: "Visita la community OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulta la roadmap e il changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: "Unisciti a Discord"

--- a/docs/it/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
+++ b/docs/it/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
@@ -401,4 +401,4 @@ Your instance can now communicate on multiple isolated networks through a single
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/opcp/use-terraform.mdx
+++ b/docs/it/guides/hosted-private-cloud/opcp/use-terraform.mdx
@@ -287,4 +287,4 @@ terraform destroy
 
 For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
+++ b/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
@@ -173,4 +173,4 @@ Configuring the secondary SAProuter requires the same care and vigilance as the 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
+++ b/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
@@ -147,4 +147,4 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
+++ b/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
@@ -771,4 +771,4 @@ In this case, the expected behaviour is only the detection of the loss of the se
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
+++ b/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
@@ -380,4 +380,4 @@ Otherwise, please set paths.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
+++ b/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
@@ -264,4 +264,4 @@ You can proceed to its installation following the [official SAP guide](https://h
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
+++ b/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
@@ -284,4 +284,4 @@ systemctl enable chronyd.service
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
+++ b/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
@@ -241,4 +241,4 @@ Destroy complete! Resources: 1 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
+++ b/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
@@ -266,4 +266,4 @@ Destroy complete! Resources: 1 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
+++ b/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
@@ -350,4 +350,4 @@ Destroy complete! Resources: 2 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
   
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
+++ b/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
@@ -149,4 +149,4 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
+++ b/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
@@ -216,4 +216,4 @@ To improve the security of your backups, we advise you to set the [object immuta
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
+++ b/docs/it/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: Per approfondire
   items:
     - title: "Visita la community OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consulta la roadmap e il changelog"
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord

--- a/docs/pl/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
+++ b/docs/pl/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
@@ -113,6 +113,6 @@ A backup has been created and stored in the S3 bucket.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or go to the [Professional Services page](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
+++ b/docs/pl/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
@@ -320,4 +320,4 @@ A no-script alternative is available directly in the Keycloak interface: **Clien
 
 For training or technical assistance with implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and a custom project analysis from our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
+++ b/docs/pl/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
@@ -180,4 +180,4 @@ openstack baremetal node show <node-id>
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
+++ b/docs/pl/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
@@ -249,5 +249,5 @@ mdadm --detail /dev/md0
 
 If you need training or technical assistance to implement our solutions, please contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project reviewed by our Professional Services experts.
 
-Join our [user community](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pl/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
+++ b/docs/pl/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
@@ -425,4 +425,4 @@ These commands only return users who have **already authenticated** at least onc
 
 For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/opcp/install-controller.mdx
+++ b/docs/pl/guides/hosted-private-cloud/opcp/install-controller.mdx
@@ -201,6 +201,6 @@ lvresize -r -L200G -v /dev/mapper/vg-var
 
 If you need training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to get a quote and request a custom analysis of your project from our Professional Services team.
 
-Join our [community of users](https://community.ovh.com/).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pl/guides/hosted-private-cloud/opcp/overview.mdx
+++ b/docs/pl/guides/hosted-private-cloud/opcp/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz roadmapę i changelog"
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: "Dołącz do Discord"

--- a/docs/pl/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
+++ b/docs/pl/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
@@ -401,4 +401,4 @@ Your instance can now communicate on multiple isolated networks through a single
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/opcp/use-terraform.mdx
+++ b/docs/pl/guides/hosted-private-cloud/opcp/use-terraform.mdx
@@ -287,4 +287,4 @@ terraform destroy
 
 For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
+++ b/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
@@ -173,4 +173,4 @@ Configuring the secondary SAProuter requires the same care and vigilance as the 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
+++ b/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
@@ -147,4 +147,4 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
+++ b/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
@@ -771,4 +771,4 @@ In this case, the expected behaviour is only the detection of the loss of the se
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
+++ b/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
@@ -380,4 +380,4 @@ Otherwise, please set paths.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
+++ b/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
@@ -264,4 +264,4 @@ You can proceed to its installation following the [official SAP guide](https://h
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
+++ b/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
@@ -284,4 +284,4 @@ systemctl enable chronyd.service
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
+++ b/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
@@ -241,4 +241,4 @@ Destroy complete! Resources: 1 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
+++ b/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
@@ -266,4 +266,4 @@ Destroy complete! Resources: 1 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
+++ b/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
@@ -350,4 +350,4 @@ Destroy complete! Resources: 2 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
   
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
+++ b/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
@@ -149,4 +149,4 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
+++ b/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
@@ -216,4 +216,4 @@ To improve the security of your backups, we advise you to set the [object immuta
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
+++ b/docs/pl/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: "Sprawdź również"
   items:
     - title: "Odwiedź społeczność OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Zobacz roadmapę i changelog"
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: "Dołącz do Discord"

--- a/docs/pt/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
+++ b/docs/pt/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
@@ -113,6 +113,6 @@ A backup has been created and stored in the S3 bucket.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or go to the [Professional Services page](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
+++ b/docs/pt/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
@@ -320,4 +320,4 @@ A no-script alternative is available directly in the Keycloak interface: **Clien
 
 For training or technical assistance with implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and a custom project analysis from our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
+++ b/docs/pt/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
@@ -180,4 +180,4 @@ openstack baremetal node show <node-id>
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
+++ b/docs/pt/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
@@ -249,5 +249,5 @@ mdadm --detail /dev/md0
 
 If you need training or technical assistance to implement our solutions, please contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project reviewed by our Professional Services experts.
 
-Join our [user community](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).
 

--- a/docs/pt/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
+++ b/docs/pt/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
@@ -425,4 +425,4 @@ These commands only return users who have **already authenticated** at least onc
 
 For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/opcp/install-controller.mdx
+++ b/docs/pt/guides/hosted-private-cloud/opcp/install-controller.mdx
@@ -201,6 +201,6 @@ lvresize -r -L200G -v /dev/mapper/vg-var
 
 If you need training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to get a quote and request a custom analysis of your project from our Professional Services team.
 
-Join our [community of users](https://community.ovh.com/).
+Join our [community of users](/links/community).
 
 <sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/pt/guides/hosted-private-cloud/opcp/overview.mdx
+++ b/docs/pt/guides/hosted-private-cloud/opcp/overview.mdx
@@ -21,7 +21,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: "Visitar a comunidade OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consultar o roadmap e o changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: "Juntar-se ao Discord"

--- a/docs/pt/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
+++ b/docs/pt/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
@@ -401,4 +401,4 @@ Your instance can now communicate on multiple isolated networks through a single
 
 If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/opcp/use-terraform.mdx
+++ b/docs/pt/guides/hosted-private-cloud/opcp/use-terraform.mdx
@@ -287,4 +287,4 @@ terraform destroy
 
 For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
+++ b/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
@@ -173,4 +173,4 @@ Configuring the secondary SAProuter requires the same care and vigilance as the 
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
+++ b/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
@@ -147,4 +147,4 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
+++ b/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
@@ -771,4 +771,4 @@ In this case, the expected behaviour is only the detection of the loss of the se
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
+++ b/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
@@ -380,4 +380,4 @@ Otherwise, please set paths.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
+++ b/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
@@ -264,4 +264,4 @@ You can proceed to its installation following the [official SAP guide](https://h
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
+++ b/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
@@ -284,4 +284,4 @@ systemctl enable chronyd.service
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
+++ b/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
@@ -241,4 +241,4 @@ Destroy complete! Resources: 1 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
+++ b/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
@@ -266,4 +266,4 @@ Destroy complete! Resources: 1 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
+++ b/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
@@ -350,4 +350,4 @@ Destroy complete! Resources: 2 destroyed.
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
   
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
+++ b/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
@@ -149,4 +149,4 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
+++ b/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
@@ -216,4 +216,4 @@ To improve the security of your backups, we advise you to set the [object immuta
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
-Join our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/).
+Join our [community of users](/links/community).

--- a/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
+++ b/docs/pt/guides/hosted-private-cloud/sap-on-ovhcloud/overview.mdx
@@ -17,7 +17,7 @@ goFurther:
   title: "Saiba mais"
   items:
     - title: "Visitar a comunidade OVHcloud"
-      link: https://community.ovh.com/
+      link: https://community.ovhcloud.com/
     - title: "Consultar o roadmap e o changelog"
       link: https://www.ovhcloud.com/pt/roadmap-changelog/
     - title: Juntar-se ao Discord


### PR DESCRIPTION
### Scope: Hosted Private Cloud - OPCP

- Replace (dead) links to legacy community page with proper keys
- Fix hard URL in Overview pages to the correct one