### PR TITLE
docs: harmonise security & troubleshooting LP

### DIFF
--- a/docs/de/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ Ist Ihre Website nicht erreichbar, langsam, zeigt eine Fehlermeldung an oder ver
 
 Um die passende Anleitung für Ihre Situation zu finden:
 
-- **Website nicht erreichbar oder Fehlerseite** (Website nicht erreichbar, Fehler 500, 403, "Index of", "Seite nicht installiert", Langsamkeit): Beginnen Sie mit dem Abschnitt *Website nicht erreichbar oder Fehlerseite*.
-- **Blockierter Zugang oder Sicherheitswarnung** (keine sichere Verbindung, gesperrte IP, blockierte Anfrage, gehackte Website, ungewöhnliche Aktivität): Siehe Abschnitt *Sicherheit und blockierter Zugang*.
-- **Komponente mit Fehler** (Datenbank, "1-Klick-Modul", automatische E-Mails, FTP): Siehe Abschnitt *Datenbanken, 1-Klick-Module und FTP*.
+- **Ist Ihre Website nicht erreichbar, langsam oder zeigt einen Fehler (500, 403, usw.)?** Siehe Abschnitt *Website nicht erreichbar oder Fehlerseite*.
+- **Blockierter Zugang oder eine Sicherheitswarnung (gesperrte IP, gehackte Website)?** Siehe Abschnitt *Sicherheit und blockierter Zugang*.
+- **Eine Komponente funktioniert nicht (Datenbank, 1-Klick-Modul, E-Mails, FTP)?** Siehe Abschnitt *Datenbanken, 1-Klick-Module und FTP*.
 
 ## Häufigste Diagnosen
 

--- a/docs/de/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ Ist Ihre Website nicht erreichbar, langsam, zeigt eine Fehlermeldung an oder ver
 
 Um die passende Anleitung für Ihre Situation zu finden:
 
-- **Ist Ihre Website nicht erreichbar, langsam oder zeigt einen Fehler (500, 403, usw.)?** Siehe Abschnitt *Website nicht erreichbar oder Fehlerseite*.
-- **Blockierter Zugang oder eine Sicherheitswarnung (gesperrte IP, gehackte Website)?** Siehe Abschnitt *Sicherheit und blockierter Zugang*.
-- **Eine Komponente funktioniert nicht (Datenbank, 1-Klick-Modul, E-Mails, FTP)?** Siehe Abschnitt *Datenbanken, 1-Klick-Module und FTP*.
+- **Ist Ihre Website nicht erreichbar, langsam oder zeigt einen Fehler?** Siehe Abschnitt *Website nicht erreichbar oder Fehlerseite* (Website nicht erreichbar, Fehler 500, 403, "Index of", "Seite nicht installiert", Langsamkeit).
+- **Blockierter Zugang oder eine Sicherheitswarnung?** Siehe Abschnitt *Sicherheit und blockierter Zugang* (keine sichere Verbindung, gesperrte IP, blockierte Anfrage, gehackte Website, ungewöhnliche Aktivität).
+- **Eine Komponente funktioniert nicht?** Siehe Abschnitt *Datenbanken, 1-Klick-Module und FTP* (Datenbank, "1-Klick-Modul", automatische E-Mails, FTP).
 
 ## Häufigste Diagnosen
 

--- a/docs/de/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ Um die passende Anleitung für Ihren Bedarf zu finden:
 
 - **Möchten Sie Ihre Website und ihre Besucher schützen?** Siehe Abschnitt *Website absichern* (Best Practices, Web Application Firewall).
 - **Möchten Sie ein Zertifikat verwalten oder auf HTTPS umstellen?** Siehe Abschnitt *SSL-Zertifikat und HTTPS*.
-- **Möchten Sie das passende SSL-Zertifikat auswählen?** Siehe Abschnitt *SSL-Zertifikat aktivieren* (kostenloses Let's Encrypt, Sectigo DV/EV, eigenes Zertifikat).
+- **Suchen Sie ein SSL-Zertifikat, das zu Ihren Anforderungen passt?** Siehe Abschnitt *SSL-Zertifikat aktivieren* (kostenloses Let's Encrypt, Sectigo DV/EV, eigenes Zertifikat).
 
 ## Wichtige Anleitungen
 

--- a/docs/de/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ Um die passende Anleitung für Ihren Bedarf zu finden:
 
 - **Möchten Sie Ihre Website und ihre Besucher schützen?** Siehe Abschnitt *Website absichern* (Best Practices, Web Application Firewall).
 - **Möchten Sie ein Zertifikat verwalten oder auf HTTPS umstellen?** Siehe Abschnitt *SSL-Zertifikat und HTTPS*.
-- **Sie sind unsicher, welches SSL-Zertifikat Sie wählen sollen?** Siehe Abschnitt *SSL-Zertifikat aktivieren* (kostenloses Let's Encrypt, Sectigo DV/EV, eigenes Zertifikat).
+- **Möchten Sie das passende SSL-Zertifikat auswählen?** Siehe Abschnitt *SSL-Zertifikat aktivieren* (kostenloses Let's Encrypt, Sectigo DV/EV, eigenes Zertifikat).
 
 ## Wichtige Anleitungen
 

--- a/docs/de/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -33,9 +33,9 @@ Schützen Sie Ihre Website und ihre Besucher: Aktivieren Sie die HTTPS-Verschlü
 
 Um die passende Anleitung für Ihren Bedarf zu finden:
 
-- **Sicherheit der Website** (Best Practices, Web Application Firewall): Beginnen Sie mit dem Abschnitt *Website absichern*.
-- **SSL-Zertifikat und HTTPS** (ein Zertifikat verwalten, auf HTTPS umstellen): Siehe Abschnitt *SSL-Zertifikat und HTTPS*.
-- **Ein SSL-Zertifikat auswählen** (kostenloses Let's Encrypt, Sectigo DV/EV, eigenes Zertifikat): Siehe Abschnitt *SSL-Zertifikat aktivieren*.
+- **Möchten Sie Ihre Website und ihre Besucher schützen?** Siehe Abschnitt *Website absichern* (Best Practices, Web Application Firewall).
+- **Möchten Sie ein Zertifikat verwalten oder auf HTTPS umstellen?** Siehe Abschnitt *SSL-Zertifikat und HTTPS*.
+- **Sie sind unsicher, welches SSL-Zertifikat Sie wählen sollen?** Siehe Abschnitt *SSL-Zertifikat aktivieren* (kostenloses Let's Encrypt, Sectigo DV/EV, eigenes Zertifikat).
 
 ## Wichtige Anleitungen
 

--- a/docs/en/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ Is your website down, slow, displaying an error message or behaving abnormally? 
 
 To find the right guide for your situation:
 
-- **Is your site unreachable, slow or showing an error (500, 403, etc.)?** See the *Website down or error page* section.
-- **Blocked access or a security alert (banned IP, hacked site)?** See the *Security and blocked access* section.
-- **Is a component failing (database, 1-click module, emails, FTP)?** See the *Databases, 1-click modules and FTP* section.
+- **Is your site unreachable, slow or showing an error?** See the *Website down or error page* section (website not accessible, 500 error, 403, "Index of", "Site not installed", slowness).
+- **Blocked access or a security alert?** See the *Security and blocked access* section (connection not private, banned IP, blocked request, hacked website, abnormal activity).
+- **Is a component failing?** See the *Databases, 1-click modules and FTP* section (database, "1-click module", automated emails, FTP).
 
 ## Most common diagnostics
 

--- a/docs/en/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ Is your website down, slow, displaying an error message or behaving abnormally? 
 
 To find the right guide for your situation:
 
-- **Website down or error page** (website not accessible, 500 error, 403, "Index of", "Site not installed", slowness): start with the *Website down or error page* section.
-- **Blocked access or security alert** (connection not private, banned IP, blocked request, hacked website, abnormal activity): see the *Security and blocked access* section.
-- **Component error** (database, "1-click module", automated emails, FTP): refer to the *Databases, 1-click modules and FTP* section.
+- **Is your site unreachable, slow or showing an error (500, 403, etc.)?** See the *Website down or error page* section.
+- **Blocked access or a security alert (banned IP, hacked site)?** See the *Security and blocked access* section.
+- **Is a component failing (database, 1-click module, emails, FTP)?** See the *Databases, 1-click modules and FTP* section.
 
 ## Most common diagnostics
 

--- a/docs/en/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ To find the right guide for your needs:
 
 - **Want to protect your website and its visitors?** See the *Secure your website* section (best practices, application firewall).
 - **Want to manage a certificate or switch to HTTPS?** See the *SSL certificate and HTTPS* section.
-- **Want to choose the right SSL certificate?** See the *Activate an SSL certificate* section (free Let's Encrypt, Sectigo DV/EV, custom certificate).
+- **Looking for an SSL certificate suited to your needs?** See the *Activate an SSL certificate* section (free Let's Encrypt, Sectigo DV/EV, custom certificate).
 
 ## Essential guides
 

--- a/docs/en/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -31,11 +31,11 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Protect your website and its visitors: enable HTTPS encryption with an SSL certificate, set up an application firewall and apply security best practices on your OVHcloud Web Hosting plan. This page brings together all the guides to secure your website.
 
-To find the right guide for your need:
+To find the right guide for your needs:
 
-- **Website security** (best practices, application firewall): start with the *Secure your website* section.
-- **SSL certificate and HTTPS** (manage a certificate, switch to HTTPS): see the *SSL certificate and HTTPS* section.
-- **Choosing an SSL certificate** (free Let's Encrypt, Sectigo DV/EV, custom certificate): refer to the *Activate an SSL certificate* section.
+- **Want to protect your website and its visitors?** See the *Secure your website* section (best practices, application firewall).
+- **Want to manage a certificate or switch to HTTPS?** See the *SSL certificate and HTTPS* section.
+- **Not sure which SSL certificate to choose?** See the *Activate an SSL certificate* section (free Let's Encrypt, Sectigo DV/EV, custom certificate).
 
 ## Essential guides
 

--- a/docs/en/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ To find the right guide for your needs:
 
 - **Want to protect your website and its visitors?** See the *Secure your website* section (best practices, application firewall).
 - **Want to manage a certificate or switch to HTTPS?** See the *SSL certificate and HTTPS* section.
-- **Not sure which SSL certificate to choose?** See the *Activate an SSL certificate* section (free Let's Encrypt, Sectigo DV/EV, custom certificate).
+- **Want to choose the right SSL certificate?** See the *Activate an SSL certificate* section (free Let's Encrypt, Sectigo DV/EV, custom certificate).
 
 ## Essential guides
 

--- a/docs/es/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ import { LinkCard } from '@components/LinkCard';
 
 Para orientarse según su situación:
 
-- **Sitio no disponible o página de error** (sitio inaccesible, error 500, 403, "Index of", "Sitio no instalado", lentitud): empiece por la sección *Sitio no disponible o página de error*.
-- **Acceso bloqueado o alerta de seguridad** (conexión no privada, IP bloqueada, solicitud bloqueada, sitio pirateado, actividad anormal): consulte la sección *Seguridad y acceso bloqueado*.
-- **Componente con error** (base de datos, "módulo en un clic", correos automatizados, FTP): consulte la sección *Bases de datos, módulos en un clic y FTP*.
+- **¿Su sitio está inaccesible, lento o muestra un error (500, 403, etc.)?** Consulte la sección *Sitio no disponible o página de error*.
+- **¿Acceso bloqueado o alerta de seguridad (IP bloqueada, sitio pirateado)?** Consulte la sección *Seguridad y acceso bloqueado*.
+- **¿Algún componente falla (base de datos, módulo en un clic, correos, FTP)?** Consulte la sección *Bases de datos, módulos en un clic y FTP*.
 
 ## Diagnósticos más frecuentes
 

--- a/docs/es/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ import { LinkCard } from '@components/LinkCard';
 
 Para orientarse según su situación:
 
-- **¿Su sitio está inaccesible, lento o muestra un error (500, 403, etc.)?** Consulte la sección *Sitio no disponible o página de error*.
-- **¿Acceso bloqueado o alerta de seguridad (IP bloqueada, sitio pirateado)?** Consulte la sección *Seguridad y acceso bloqueado*.
-- **¿Algún componente falla (base de datos, módulo en un clic, correos, FTP)?** Consulte la sección *Bases de datos, módulos en un clic y FTP*.
+- **¿Su sitio está inaccesible, lento o muestra un error?** Consulte la sección *Sitio no disponible o página de error* (sitio inaccesible, error 500, 403, "Index of", "Sitio no instalado", lentitud).
+- **¿Acceso bloqueado o alerta de seguridad?** Consulte la sección *Seguridad y acceso bloqueado* (conexión no privada, IP bloqueada, solicitud bloqueada, sitio pirateado, actividad anormal).
+- **¿Algún componente falla?** Consulte la sección *Bases de datos, módulos en un clic y FTP* (base de datos, "módulo en un clic", correos automatizados, FTP).
 
 ## Diagnósticos más frecuentes
 

--- a/docs/es/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ Para orientarse según su necesidad:
 
 - **¿Desea proteger su sitio web y a sus visitantes?** Consulte la sección *Proteger su sitio web* (buenas prácticas, firewall de aplicación).
 - **¿Desea gestionar un certificado o habilitar HTTPS?** Consulte la sección *Certificado SSL y HTTPS*.
-- **¿No sabe qué certificado SSL elegir?** Consulte la sección *Activar un certificado SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificado personalizado).
+- **¿Desea elegir el certificado SSL adecuado?** Consulte la sección *Activar un certificado SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificado personalizado).
 
 ## Guías esenciales
 

--- a/docs/es/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ Para orientarse según su necesidad:
 
 - **¿Desea proteger su sitio web y a sus visitantes?** Consulte la sección *Proteger su sitio web* (buenas prácticas, firewall de aplicación).
 - **¿Desea gestionar un certificado o habilitar HTTPS?** Consulte la sección *Certificado SSL y HTTPS*.
-- **¿Desea elegir el certificado SSL adecuado?** Consulte la sección *Activar un certificado SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificado personalizado).
+- **¿Busca un certificado SSL adaptado a sus necesidades?** Consulte la sección *Activar un certificado SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificado personalizado).
 
 ## Guías esenciales
 

--- a/docs/es/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -33,9 +33,9 @@ Proteja su sitio web y a sus visitantes: active el cifrado HTTPS con un certific
 
 Para orientarse según su necesidad:
 
-- **Seguridad del sitio** (buenas prácticas, firewall de aplicación): empiece por la sección *Proteger su sitio web*.
-- **Certificado SSL y HTTPS** (gestionar un certificado, habilitar HTTPS): consulte la sección *Certificado SSL y HTTPS*.
-- **Elegir un certificado SSL** (Let's Encrypt gratuito, Sectigo DV/EV, certificado personalizado): consulte la sección *Activar un certificado SSL*.
+- **¿Desea proteger su sitio web y a sus visitantes?** Consulte la sección *Proteger su sitio web* (buenas prácticas, firewall de aplicación).
+- **¿Desea gestionar un certificado o habilitar HTTPS?** Consulte la sección *Certificado SSL y HTTPS*.
+- **¿No sabe qué certificado SSL elegir?** Consulte la sección *Activar un certificado SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificado personalizado).
 
 ## Guías esenciales
 

--- a/docs/fr/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ Votre site web est inaccessible, lent, affiche un message d'erreur ou a un compo
 
 Pour vous orienter selon la situation rencontrée :
 
-- **Votre site est inaccessible, lent ou affiche une erreur (500, 403, etc.) ?** Consultez la section *Site inaccessible ou page d'erreur*.
-- **Accès bloqué ou alerte de sécurité (IP bannie, site piraté) ?** Consultez la section *Sécurité et accès bloqué*.
-- **Un composant est en erreur (base de données, module en 1 clic, e-mails, FTP) ?** Consultez la section *Bases de données, modules en 1 clic et FTP*.
+- **Votre site est inaccessible, lent ou affiche une erreur ?** Consultez la section *Site inaccessible ou page d'erreur* (site inaccessible, erreur 500, 403, « Index of », « Site non installé », lenteurs).
+- **Accès bloqué ou alerte de sécurité ?** Consultez la section *Sécurité et accès bloqué* (connexion non privée, IP bannie, requête bloquée, site piraté, activité anormale).
+- **Un composant est en erreur ?** Consultez la section *Bases de données, modules en 1 clic et FTP* (base de données, « module en 1 clic », e-mails automatisés, FTP).
 
 ## Diagnostics les plus courants
 

--- a/docs/fr/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ Votre site web est inaccessible, lent, affiche un message d'erreur ou a un compo
 
 Pour vous orienter selon la situation rencontrée :
 
-- **Site indisponible ou page d'erreur** (site inaccessible, erreur 500, 403, « Index of », « Site non installé », lenteurs) : commencez par la section *Site inaccessible ou page d'erreur*.
-- **Accès bloqué ou alerte de sécurité** (connexion non privée, IP bannie, requête bloquée, site piraté, activité anormale) : consultez la section *Sécurité et accès bloqué*.
-- **Composant en erreur** (base de données, « module en 1 clic », e-mails automatisés, FTP) : reportez-vous à la section *Bases de données, modules en 1 clic et FTP*.
+- **Votre site est inaccessible, lent ou affiche une erreur (500, 403, etc.) ?** Consultez la section *Site inaccessible ou page d'erreur*.
+- **Accès bloqué ou alerte de sécurité (IP bannie, site piraté) ?** Consultez la section *Sécurité et accès bloqué*.
+- **Un composant est en erreur (base de données, module en 1 clic, e-mails, FTP) ?** Consultez la section *Bases de données, modules en 1 clic et FTP*.
 
 ## Diagnostics les plus courants
 

--- a/docs/fr/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ Pour vous orienter selon votre besoin :
 
 - **Vous souhaitez protéger votre site web et vos visiteurs ?** Consultez la section *Sécuriser votre site web* (bonnes pratiques, pare-feu applicatif).
 - **Vous souhaitez gérer un certificat ou passer en HTTPS ?** Consultez la section *Certificat SSL et HTTPS*.
-- **Vous ne savez pas quel certificat SSL choisir ?** Consultez la section *Activer un certificat SSL* (Let's Encrypt gratuit, Sectigo DV/EV, certificat personnalisé).
+- **Vous souhaitez choisir le bon certificat SSL ?** Consultez la section *Activer un certificat SSL* (Let's Encrypt gratuit, Sectigo DV/EV, certificat personnalisé).
 
 ## Les guides essentiels
 

--- a/docs/fr/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ Pour vous orienter selon votre besoin :
 
 - **Vous souhaitez protéger votre site web et vos visiteurs ?** Consultez la section *Sécuriser votre site web* (bonnes pratiques, pare-feu applicatif).
 - **Vous souhaitez gérer un certificat ou passer en HTTPS ?** Consultez la section *Certificat SSL et HTTPS*.
-- **Vous souhaitez choisir le bon certificat SSL ?** Consultez la section *Activer un certificat SSL* (Let's Encrypt gratuit, Sectigo DV/EV, certificat personnalisé).
+- **Vous cherchez un certificat SSL adapté à vos besoins ?** Consultez la section *Activer un certificat SSL* (Let's Encrypt gratuit, Sectigo DV/EV, certificat personnalisé).
 
 ## Les guides essentiels
 

--- a/docs/fr/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -33,9 +33,9 @@ Protégez votre site web et vos visiteurs : activez le chiffrement HTTPS grâce
 
 Pour vous orienter selon votre besoin :
 
-- **Sécurité du site** (bonnes pratiques, pare-feu applicatif) : commencez par la section *Sécuriser votre site web*.
-- **Certificat SSL et HTTPS** (gérer un certificat, passer en HTTPS) : consultez la section *Certificat SSL et HTTPS*.
-- **Choisir un certificat SSL** (Let's Encrypt gratuit, Sectigo DV/EV, certificat personnalisé) : reportez-vous à la section *Activer un certificat SSL*.
+- **Vous souhaitez protéger votre site web et vos visiteurs ?** Consultez la section *Sécuriser votre site web* (bonnes pratiques, pare-feu applicatif).
+- **Vous souhaitez gérer un certificat ou passer en HTTPS ?** Consultez la section *Certificat SSL et HTTPS*.
+- **Vous ne savez pas quel certificat SSL choisir ?** Consultez la section *Activer un certificat SSL* (Let's Encrypt gratuit, Sectigo DV/EV, certificat personnalisé).
 
 ## Les guides essentiels
 

--- a/docs/it/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ Il tuo sito web è inaccessibile, lento, mostra un messaggio di errore o ha un c
 
 Per orientarti in base alla tua situazione:
 
-- **Sito non disponibile o pagina di errore** (sito inaccessibile, errore 500, 403, "Index of", "Sito non installato", lentezza): inizia dalla sezione *Sito non disponibile o pagina di errore*.
-- **Accesso bloccato o avviso di sicurezza** (connessione non privata, IP bloccato, richiesta bloccata, sito violato, attività anomala): consulta la sezione *Sicurezza e accesso bloccato*.
-- **Componente in errore** (database, "modulo in 1 click", email automatiche, FTP): consulta la sezione *Database, moduli in 1 click e FTP*.
+- **Il tuo sito è inaccessibile, lento o mostra un errore (500, 403, ecc.)?** Consulta la sezione *Sito non disponibile o pagina di errore*.
+- **Accesso bloccato o un avviso di sicurezza (IP bloccato, sito violato)?** Consulta la sezione *Sicurezza e accesso bloccato*.
+- **Un componente non funziona (database, modulo in 1 click, email, FTP)?** Consulta la sezione *Database, moduli in 1 click e FTP*.
 
 ## Diagnostiche più frequenti
 

--- a/docs/it/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ Il tuo sito web è inaccessibile, lento, mostra un messaggio di errore o ha un c
 
 Per orientarti in base alla tua situazione:
 
-- **Il tuo sito è inaccessibile, lento o mostra un errore (500, 403, ecc.)?** Consulta la sezione *Sito non disponibile o pagina di errore*.
-- **Accesso bloccato o un avviso di sicurezza (IP bloccato, sito violato)?** Consulta la sezione *Sicurezza e accesso bloccato*.
-- **Un componente non funziona (database, modulo in 1 click, email, FTP)?** Consulta la sezione *Database, moduli in 1 click e FTP*.
+- **Il tuo sito è inaccessibile, lento o mostra un errore?** Consulta la sezione *Sito non disponibile o pagina di errore* (sito inaccessibile, errore 500, 403, "Index of", "Sito non installato", lentezza).
+- **Accesso bloccato o un avviso di sicurezza?** Consulta la sezione *Sicurezza e accesso bloccato* (connessione non privata, IP bloccato, richiesta bloccata, sito violato, attività anomala).
+- **Un componente non funziona?** Consulta la sezione *Database, moduli in 1 click e FTP* (database, "modulo in 1 click", email automatiche, FTP).
 
 ## Diagnostiche più frequenti
 

--- a/docs/it/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ Per orientarti in base alla tua esigenza:
 
 - **Vuoi proteggere il tuo sito web e i suoi visitatori?** Consulta la sezione *Proteggere il tuo sito web* (best practice, firewall applicativo).
 - **Vuoi gestire un certificato o passare a HTTPS?** Consulta la sezione *Certificato SSL e HTTPS*.
-- **Non sai quale certificato SSL scegliere?** Consulta la sezione *Attivare un certificato SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificato personalizzato).
+- **Vuoi scegliere il certificato SSL giusto?** Consulta la sezione *Attivare un certificato SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificato personalizzato).
 
 ## Guide essenziali
 

--- a/docs/it/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ Per orientarti in base alla tua esigenza:
 
 - **Vuoi proteggere il tuo sito web e i suoi visitatori?** Consulta la sezione *Proteggere il tuo sito web* (best practice, firewall applicativo).
 - **Vuoi gestire un certificato o passare a HTTPS?** Consulta la sezione *Certificato SSL e HTTPS*.
-- **Vuoi scegliere il certificato SSL giusto?** Consulta la sezione *Attivare un certificato SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificato personalizzato).
+- **Cerchi un certificato SSL adatto alle tue esigenze?** Consulta la sezione *Attivare un certificato SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificato personalizzato).
 
 ## Guide essenziali
 

--- a/docs/it/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -33,9 +33,9 @@ Proteggi il tuo sito web e i suoi visitatori: attiva la cifratura HTTPS con un c
 
 Per orientarti in base alla tua esigenza:
 
-- **Sicurezza del sito** (best practice, firewall applicativo): inizia dalla sezione *Proteggere il tuo sito web*.
-- **Certificato SSL e HTTPS** (gestire un certificato, passare a HTTPS): consulta la sezione *Certificato SSL e HTTPS*.
-- **Scegliere un certificato SSL** (Let's Encrypt gratuito, Sectigo DV/EV, certificato personalizzato): consulta la sezione *Attivare un certificato SSL*.
+- **Vuoi proteggere il tuo sito web e i suoi visitatori?** Consulta la sezione *Proteggere il tuo sito web* (best practice, firewall applicativo).
+- **Vuoi gestire un certificato o passare a HTTPS?** Consulta la sezione *Certificato SSL e HTTPS*.
+- **Non sai quale certificato SSL scegliere?** Consulta la sezione *Attivare un certificato SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificato personalizzato).
 
 ## Guide essenziali
 

--- a/docs/pl/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ Czy Twoja strona jest niedostępna, powolna, wyświetla komunikat o błędzie lu
 
 Aby znaleźć odpowiedni przewodnik dla swojej sytuacji:
 
-- **Strona niedostępna lub strona błędu** (strona niedostępna, błąd 500, 403, "Index of", "Strona nie została zainstalowana", powolność): zacznij od sekcji *Strona niedostępna lub strona błędu*.
-- **Zablokowany dostęp lub alert bezpieczeństwa** (połączenie nie jest prywatne, zablokowany adres IP, zablokowane żądanie, zhakowana strona, nietypowa aktywność): zobacz sekcję *Bezpieczeństwo i zablokowany dostęp*.
-- **Komponent z błędem** (baza danych, "moduł za pomocą 1 kliknięcia", automatyczne wiadomości e-mail, FTP): zobacz sekcję *Bazy danych, moduły za pomocą 1 kliknięcia i FTP*.
+- **Twoja strona jest niedostępna, powolna lub wyświetla błąd (500, 403, itp.)?** Zobacz sekcję *Strona niedostępna lub strona błędu*.
+- **Zablokowany dostęp lub alert bezpieczeństwa (zablokowany adres IP, zhakowana strona)?** Zobacz sekcję *Bezpieczeństwo i zablokowany dostęp*.
+- **Komponent nie działa (baza danych, moduł 1 kliknięcia, e-maile, FTP)?** Zobacz sekcję *Bazy danych, moduły za pomocą 1 kliknięcia i FTP*.
 
 ## Najczęstsze diagnozy
 

--- a/docs/pl/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ Czy Twoja strona jest niedostępna, powolna, wyświetla komunikat o błędzie lu
 
 Aby znaleźć odpowiedni przewodnik dla swojej sytuacji:
 
-- **Twoja strona jest niedostępna, powolna lub wyświetla błąd (500, 403, itp.)?** Zobacz sekcję *Strona niedostępna lub strona błędu*.
-- **Zablokowany dostęp lub alert bezpieczeństwa (zablokowany adres IP, zhakowana strona)?** Zobacz sekcję *Bezpieczeństwo i zablokowany dostęp*.
-- **Komponent nie działa (baza danych, moduł 1 kliknięcia, e-maile, FTP)?** Zobacz sekcję *Bazy danych, moduły za pomocą 1 kliknięcia i FTP*.
+- **Twoja strona jest niedostępna, powolna lub wyświetla błąd?** Zobacz sekcję *Strona niedostępna lub strona błędu* (strona niedostępna, błąd 500, 403, "Index of", "Strona nie została zainstalowana", powolność).
+- **Zablokowany dostęp lub alert bezpieczeństwa?** Zobacz sekcję *Bezpieczeństwo i zablokowany dostęp* (połączenie nie jest prywatne, zablokowany adres IP, zablokowane żądanie, zhakowana strona, nietypowa aktywność).
+- **Komponent nie działa?** Zobacz sekcję *Bazy danych, moduły za pomocą 1 kliknięcia i FTP* (baza danych, "moduł za pomocą 1 kliknięcia", automatyczne wiadomości e-mail, FTP).
 
 ## Najczęstsze diagnozy
 

--- a/docs/pl/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -33,9 +33,9 @@ Chroń swoją stronę i jej odwiedzających: włącz szyfrowanie HTTPS za pomoc�
 
 Aby znaleźć odpowiedni przewodnik dla swoich potrzeb:
 
-- **Bezpieczeństwo strony** (najlepsze praktyki, zapora aplikacji): zacznij od sekcji *Zabezpiecz swoją stronę*.
-- **Certyfikat SSL i HTTPS** (zarządzanie certyfikatem, ustawienie HTTPS): zobacz sekcję *Certyfikat SSL i HTTPS*.
-- **Wybór certyfikatu SSL** (darmowy Let's Encrypt, Sectigo DV/EV, własny certyfikat): zobacz sekcję *Aktywacja certyfikatu SSL*.
+- **Chcesz chronić swoją stronę i jej odwiedzających?** Zobacz sekcję *Zabezpiecz swoją stronę* (najlepsze praktyki, zapora aplikacji).
+- **Chcesz zarządzać certyfikatem lub ustawić HTTPS?** Zobacz sekcję *Certyfikat SSL i HTTPS*.
+- **Nie wiesz, który certyfikat SSL wybrać?** Zobacz sekcję *Aktywacja certyfikatu SSL* (darmowy Let's Encrypt, Sectigo DV/EV, własny certyfikat).
 
 ## Najważniejsze przewodniki
 

--- a/docs/pl/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ Aby znaleźć odpowiedni przewodnik dla swoich potrzeb:
 
 - **Chcesz chronić swoją stronę i jej odwiedzających?** Zobacz sekcję *Zabezpiecz swoją stronę* (najlepsze praktyki, zapora aplikacji).
 - **Chcesz zarządzać certyfikatem lub ustawić HTTPS?** Zobacz sekcję *Certyfikat SSL i HTTPS*.
-- **Chcesz wybrać odpowiedni certyfikat SSL?** Zobacz sekcję *Aktywacja certyfikatu SSL* (darmowy Let's Encrypt, Sectigo DV/EV, własny certyfikat).
+- **Szukasz certyfikatu SSL dopasowanego do Twoich potrzeb?** Zobacz sekcję *Aktywacja certyfikatu SSL* (darmowy Let's Encrypt, Sectigo DV/EV, własny certyfikat).
 
 ## Najważniejsze przewodniki
 

--- a/docs/pl/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ Aby znaleźć odpowiedni przewodnik dla swoich potrzeb:
 
 - **Chcesz chronić swoją stronę i jej odwiedzających?** Zobacz sekcję *Zabezpiecz swoją stronę* (najlepsze praktyki, zapora aplikacji).
 - **Chcesz zarządzać certyfikatem lub ustawić HTTPS?** Zobacz sekcję *Certyfikat SSL i HTTPS*.
-- **Nie wiesz, który certyfikat SSL wybrać?** Zobacz sekcję *Aktywacja certyfikatu SSL* (darmowy Let's Encrypt, Sectigo DV/EV, własny certyfikat).
+- **Chcesz wybrać odpowiedni certyfikat SSL?** Zobacz sekcję *Aktywacja certyfikatu SSL* (darmowy Let's Encrypt, Sectigo DV/EV, własny certyfikat).
 
 ## Najważniejsze przewodniki
 

--- a/docs/pt/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ O seu site está inacessível, lento, apresenta uma mensagem de erro ou tem um c
 
 Para se orientar consoante a sua situação:
 
-- **O seu site está inacessível, lento ou apresenta um erro (500, 403, etc.)?** Consulte a secção *Site indisponível ou página de erro*.
-- **Acesso bloqueado ou alerta de segurança (IP banido, site pirateado)?** Consulte a secção *Segurança e acesso bloqueado*.
-- **Um componente está em erro (base de dados, módulo 1 clique, e-mails, FTP)?** Consulte a secção *Bases de dados, módulos 1 clique e FTP*.
+- **O seu site está inacessível, lento ou apresenta um erro?** Consulte a secção *Site indisponível ou página de erro* (site inacessível, erro 500, 403, "Index of", "Site não instalado", lentidão).
+- **Acesso bloqueado ou alerta de segurança?** Consulte a secção *Segurança e acesso bloqueado* (ligação não privada, IP banido, pedido bloqueado, site pirateado, atividade anormal).
+- **Um componente está em erro?** Consulte a secção *Bases de dados, módulos 1 clique e FTP* (base de dados, "módulo 1 clique", e-mails automatizados, FTP).
 
 ## Diagnósticos mais frequentes
 

--- a/docs/pt/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/landing-page-diagnostic.mdx
@@ -32,9 +32,9 @@ O seu site está inacessível, lento, apresenta uma mensagem de erro ou tem um c
 
 Para se orientar consoante a sua situação:
 
-- **Site indisponível ou página de erro** (site inacessível, erro 500, 403, "Index of", "Site não instalado", lentidão): comece pela secção *Site indisponível ou página de erro*.
-- **Acesso bloqueado ou alerta de segurança** (ligação não privada, IP banido, pedido bloqueado, site pirateado, atividade anormal): consulte a secção *Segurança e acesso bloqueado*.
-- **Componente com erro** (base de dados, "módulo 1 clique", e-mails automatizados, FTP): consulte a secção *Bases de dados, módulos 1 clique e FTP*.
+- **O seu site está inacessível, lento ou apresenta um erro (500, 403, etc.)?** Consulte a secção *Site indisponível ou página de erro*.
+- **Acesso bloqueado ou alerta de segurança (IP banido, site pirateado)?** Consulte a secção *Segurança e acesso bloqueado*.
+- **Um componente está em erro (base de dados, módulo 1 clique, e-mails, FTP)?** Consulte a secção *Bases de dados, módulos 1 clique e FTP*.
 
 ## Diagnósticos mais frequentes
 

--- a/docs/pt/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -33,9 +33,9 @@ Proteja o seu website e os seus visitantes: ative a encriptação HTTPS com um c
 
 Para se orientar consoante a sua necessidade:
 
-- **Segurança do site** (boas práticas, firewall de aplicação): comece pela secção *Proteger o seu site*.
-- **Certificado SSL e HTTPS** (gerir um certificado, passar para HTTPS): consulte a secção *Certificado SSL e HTTPS*.
-- **Escolher um certificado SSL** (Let's Encrypt gratuito, Sectigo DV/EV, certificado personalizado): consulte a secção *Ativar um certificado SSL*.
+- **Pretende proteger o seu site e os seus visitantes?** Consulte a secção *Proteger o seu site* (boas práticas, firewall de aplicação).
+- **Pretende gerir um certificado ou passar para HTTPS?** Consulte a secção *Certificado SSL e HTTPS*.
+- **Não sabe que certificado SSL escolher?** Consulte a secção *Ativar um certificado SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificado personalizado).
 
 ## Guias essenciais
 

--- a/docs/pt/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ Para se orientar consoante a sua necessidade:
 
 - **Pretende proteger o seu site e os seus visitantes?** Consulte a secção *Proteger o seu site* (boas práticas, firewall de aplicação).
 - **Pretende gerir um certificado ou passar para HTTPS?** Consulte a secção *Certificado SSL e HTTPS*.
-- **Pretende escolher o certificado SSL adequado?** Consulte a secção *Ativar um certificado SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificado personalizado).
+- **Procura um certificado SSL adequado às suas necessidades?** Consulte a secção *Ativar um certificado SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificado personalizado).
 
 ## Guias essenciais
 

--- a/docs/pt/guides/web-cloud/web-hosting/landing-page-security.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/landing-page-security.mdx
@@ -35,7 +35,7 @@ Para se orientar consoante a sua necessidade:
 
 - **Pretende proteger o seu site e os seus visitantes?** Consulte a secção *Proteger o seu site* (boas práticas, firewall de aplicação).
 - **Pretende gerir um certificado ou passar para HTTPS?** Consulte a secção *Certificado SSL e HTTPS*.
-- **Não sabe que certificado SSL escolher?** Consulte a secção *Ativar um certificado SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificado personalizado).
+- **Pretende escolher o certificado SSL adequado?** Consulte a secção *Ativar um certificado SSL* (Let's Encrypt gratuito, Sectigo DV/EV, certificado personalizado).
 
 ## Guias essenciais
 


### PR DESCRIPTION
 — question-based orientation

Rewrite the orientation block of the Security and Troubleshooting web-hosting landing pages into the question-based format used by the other landing pages, removing the section-title duplications. Security uses the intent form (want/souhaitez/…), Troubleshooting stays situational. Also fixes the EN "for your needs" wording on the Security page. All 7 locales.