### PR TITLE
fix(iam): include OVHcloud in PAT guide tab labels (en/fr/pl)

### DIFF
--- a/docs/en/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
+++ b/docs/en/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
@@ -56,7 +56,7 @@ If you need credentials for automated, production-grade integrations that are no
 Replace `{user}` with your local user login (for example, `1234-567-89/johnsmith`).
 
 <Tabs noSync>
-  <Tab label="Control Panel">
+  <Tab label="Via the OVHcloud Control Panel">
     From the <ManagerLink to="/#/iam/identities/users">IAM Identities</ManagerLink> page, click the <code className="action">…</code> button at the end of the local user row, then select <code className="action">Manage tokens</code>.
 
     <img className="thumbnail" alt="Manage tokens option in the local user actions menu" src="/images/manage-and-operate/iam/configure-personal-access-token-pat/PAT_manage_token_button.png" loading="lazy" />
@@ -78,7 +78,7 @@ Replace `{user}` with your local user login (for example, `1234-567-89/johnsmith
     :::
 
   </Tab>
-  <Tab label="API">
+  <Tab label="Via the OVHcloud API">
     Use the following API call:
 
     <Api version="v1" section="/me" method="POST" route={"/me/identity/user/\\{user\\}/token"} />
@@ -111,7 +111,7 @@ Replace `{user}` with your local user login (for example, `1234-567-89/johnsmith
 
     To set an expiration date, add an `expiresAt` field to the payload using the RFC3339 format (for example, `"expiresAt": "2026-12-31T23:59:59Z"`).
   </Tab>
-  <Tab label="CLI">
+  <Tab label="Via the OVHcloud CLI">
     Use the [OVHcloud CLI](/guides/manage-and-operate/cli/getting-started) to create the PAT:
 
     ```bash
@@ -170,15 +170,15 @@ Replace `<any_suffix>` with any ASCII string to identify the token.
 #### List existing tokens
 
 <Tabs noSync>
-  <Tab label="Control Panel">
+  <Tab label="Via the OVHcloud Control Panel">
     On the **Manage Tokens** page, all PATs for the user are listed.
 
     <img className="thumbnail" alt="Manage Tokens page listing personal access tokens for a local user" src="/images/manage-and-operate/iam/configure-personal-access-token-pat/PAT_Manage_token.png" loading="lazy" />
   </Tab>
-  <Tab label="API">
+  <Tab label="Via the OVHcloud API">
     <Api version="v1" section="/me" method="GET" route={"/me/identity/user/\\{user\\}/token"} />
   </Tab>
-  <Tab label="CLI">
+  <Tab label="Via the OVHcloud CLI">
     ```bash
     ovhcloud iam user token list {user}
     ```
@@ -190,17 +190,17 @@ Replace `<any_suffix>` with any ASCII string to identify the token.
 Deleting a PAT immediately blocks further API calls.
 
 <Tabs noSync>
-  <Tab label="Control Panel">
+  <Tab label="Via the OVHcloud Control Panel">
     From the **Manage Tokens** page, click the <code className="action">…</code> button at the end of the token row, then select <code className="action">Delete</code>.
 
     Click <code className="action">Delete</code> in the confirmation window to revoke the token.
   </Tab>
-  <Tab label="API">
+  <Tab label="Via the OVHcloud API">
     <Api version="v1" section="/me" method="DELETE" route={"/me/identity/user/\\{user\\}/token/\\{name\\}"} />
 
     Replace `{name}` with the token name (for example, `pat-my-script`).
   </Tab>
-  <Tab label="CLI">
+  <Tab label="Via the OVHcloud CLI">
     ```bash
     ovhcloud iam user token delete {user} pat-my-script
     ```

--- a/docs/fr/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
+++ b/docs/fr/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
@@ -78,7 +78,7 @@ Remplacez `{user}` par l'identifiant de votre utilisateur local (par exemple, `1
     :::
 
   </Tab>
-  <Tab label="Via l'API">
+  <Tab label="Via l'API OVHcloud">
     Utilisez l'appel API suivant :
 
     <Api version="v1" section="/me" method="POST" route={"/me/identity/user/\\{user\\}/token"} />
@@ -111,7 +111,7 @@ Remplacez `{user}` par l'identifiant de votre utilisateur local (par exemple, `1
 
     Pour définir une date d'expiration, ajoutez un champ `expiresAt` à la charge utile au format RFC3339 (par exemple, `"expiresAt": "2026-12-31T23:59:59Z"`).
   </Tab>
-  <Tab label="Via la CLI">
+  <Tab label="Via la CLI OVHcloud">
     Utilisez l'[OVHcloud CLI](/guides/manage-and-operate/cli/getting-started) pour créer le PAT :
 
     ```bash
@@ -175,10 +175,10 @@ Remplacez `<any_suffix>` par une chaîne ASCII quelconque pour identifier le tok
 
     <img className="thumbnail" alt="Page de gestion des tokens listant les tokens d'accès personnels d'un utilisateur local" src="/images/manage-and-operate/iam/configure-personal-access-token-pat/PAT_Manage_token.png" loading="lazy" />
   </Tab>
-  <Tab label="Via l'API">
+  <Tab label="Via l'API OVHcloud">
     <Api version="v1" section="/me" method="GET" route={"/me/identity/user/\\{user\\}/token"} />
   </Tab>
-  <Tab label="Via la CLI">
+  <Tab label="Via la CLI OVHcloud">
     ```bash
     ovhcloud iam user token list {user}
     ```
@@ -195,12 +195,12 @@ La suppression d'un PAT bloque immédiatement tout nouvel appel API.
 
     Cliquez sur <code className="action">Supprimer</code> dans la fenêtre de confirmation pour révoquer le token.
   </Tab>
-  <Tab label="Via l'API">
+  <Tab label="Via l'API OVHcloud">
     <Api version="v1" section="/me" method="DELETE" route={"/me/identity/user/\\{user\\}/token/\\{name\\}"} />
 
     Remplacez `{name}` par le nom du token (par exemple, `pat-my-script`).
   </Tab>
-  <Tab label="Via la CLI">
+  <Tab label="Via la CLI OVHcloud">
     ```bash
     ovhcloud iam user token delete {user} pat-my-script
     ```

--- a/docs/pl/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
+++ b/docs/pl/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
@@ -56,7 +56,7 @@ Jeśli potrzebujesz danych logowania do zautomatyzowanych integracji produkcyjny
 Zastąp `{user}` identyfikatorem użytkownika lokalnego (na przykład `1234-567-89/johnsmith`).
 
 <Tabs noSync>
-  <Tab label="W Panelu klienta">
+  <Tab label="W Panelu klienta OVHcloud">
     Na stronie <ManagerLink to="/#/iam/identities/users">Tożsamości IAM</ManagerLink> kliknij przycisk <code className="action">…</code> na końcu wiersza użytkownika lokalnego, a następnie wybierz <code className="action">Zarządzanie tokenami</code>.
 
     <img className="thumbnail" alt="Opcja Zarządzanie tokenami w menu akcji użytkownika lokalnego" src="/images/manage-and-operate/iam/configure-personal-access-token-pat/PAT_manage_token_button.png" loading="lazy" />
@@ -170,7 +170,7 @@ Zastąp `<any_suffix>` dowolnym ciągiem ASCII identyfikującym token.
 #### Wyświetlanie istniejących tokenów
 
 <Tabs noSync>
-  <Tab label="W Panelu klienta">
+  <Tab label="W Panelu klienta OVHcloud">
     Na stronie **Zarządzanie tokenami** wyświetlana jest lista PAT przypisanych do użytkownika.
 
     <img className="thumbnail" alt="Strona Zarządzanie tokenami z listą tokenów dostępu osobistego użytkownika lokalnego" src="/images/manage-and-operate/iam/configure-personal-access-token-pat/PAT_Manage_token.png" loading="lazy" />
@@ -190,7 +190,7 @@ Zastąp `<any_suffix>` dowolnym ciągiem ASCII identyfikującym token.
 Usunięcie PAT natychmiast uniemożliwia jego dalsze wykorzystanie w wywołaniach API.
 
 <Tabs noSync>
-  <Tab label="W Panelu klienta">
+  <Tab label="W Panelu klienta OVHcloud">
     Na stronie **Zarządzanie tokenami** kliknij przycisk <code className="action">…</code> na końcu wiersza tokena, a następnie wybierz <code className="action">Usuń</code>.
 
     Kliknij <code className="action">Usuń</code> w oknie potwierdzenia, aby unieważnić token.

--- a/docs/pt/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
+++ b/docs/pt/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
@@ -57,7 +57,7 @@ Substitua `{user}` pelo identificador do seu utilizador local (por exemplo, `123
 
 <Tabs noSync>
   <Tab label="Via Área de Cliente OVHcloud">
-    Na página <ManagerLink to="/#/iam/identities/users">IAM Identities</ManagerLink>, clique no botão <code className="action">…</code> no final da linha do utilizador local e selecione <code className="action">Gerir os tokens</code>.
+    Na página <ManagerLink to="/#/iam/identities/users">Identidades IAM</ManagerLink>, clique no botão <code className="action">…</code> no final da linha do utilizador local e selecione <code className="action">Gerir os tokens</code>.
 
     <img className="thumbnail" alt="Opção Gerir os tokens no menu de ações do utilizador local" src="/images/manage-and-operate/iam/configure-personal-access-token-pat/PAT_manage_token_button.png" loading="lazy" />
 


### PR DESCRIPTION
- en: align access-method tabs to the "Via the OVHcloud …" convention (Control Panel / API / CLI)
- fr: add "OVHcloud" to the API and CLI tab labels
- pl: add "OVHcloud" to the Control Panel tab label
- pt: localize a leftover "IAM Identities" ManagerLink label to "Identidades IAM"