### PR TITLE
docs: drop redundant (EN) suffix on English-titled overview items

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/overview.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/overview.mdx
@@ -20,7 +20,7 @@ essentials:
 tutorials:
   - title: "PuTTY für SSH-Verbindungen und Authentifizierung verwenden"
     link: /guides/web-cloud/web-hosting/ssh-using-putty-on-windows
-  - title: Tutorial - Configuring pfSense network bridge (EN)
+  - title: Tutorial - Configuring pfSense network bridge
     link: /guides/bare-metal-cloud/dedicated-servers/pfsense-bridging
   - title: "Webserver (LAMP) auf Debian oder Ubuntu installieren"
     link: /guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18

--- a/docs/de/guides/hosted-private-cloud/powered-by-vmware/overview.mdx
+++ b/docs/de/guides/hosted-private-cloud/powered-by-vmware/overview.mdx
@@ -7,7 +7,7 @@ essentialsTitle: "Die wichtigsten Anleitungen für den Einstieg"
 essentials:
   - title: Erste Schritte mit NSX (EN)
     link: /guides/hosted-private-cloud/powered-by-vmware/nsx-first-steps
-  - title: How to enable NSX-T in a VMware on OVHcloud Hosted Private Cloud (EN)
+  - title: How to enable NSX-T in a VMware on OVHcloud Hosted Private Cloud
     link: /guides/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights
   - title: "Einführung in vRealize Operations - vROPS (EN)"
     link: /guides/hosted-private-cloud/powered-by-vmware/vrops-introduction

--- a/docs/de/guides/hosted-private-cloud/powered-by-vmware/public-vcf/overview.mdx
+++ b/docs/de/guides/hosted-private-cloud/powered-by-vmware/public-vcf/overview.mdx
@@ -11,24 +11,24 @@ essentials:
     link: /guides/hosted-private-cloud/powered-by-vmware/vsphere-interface-connexion
   - title: "Connexion à l'API OVH"
     link: /guides/hosted-private-cloud/powered-by-vmware/connect-to-ovh-api
-  - title: "Public VCF as-a-Service - Logging in to your organization (EN)"
+  - title: "Public VCF as-a-Service - Logging in to your organization"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-logging
-  - title: "Public VCF as-a-Service - Find out how to use the Public VCF as-a-Service user interface (EN)"
+  - title: "Public VCF as-a-Service - Find out how to use the Public VCF as-a-Service user interface"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-getting-started-dashboard-overview
 tutorials:
-  - title: "Public VCF as-a-Service - Enable the VCDA migration option on your Public VCF as-a-Service organisation (EN)"
+  - title: "Public VCF as-a-Service - Enable the VCDA migration option on your Public VCF as-a-Service organisation"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-enable-offer
-  - title: "Zerto LTR - Configure long-term retention (EN)"
+  - title: "Zerto LTR - Configure long-term retention"
     link: /guides/hosted-private-cloud/powered-by-vmware/zerto-ltr
-  - title: "Zerto VRA - Resize Virtual Replication Appliances (EN)"
+  - title: "Zerto VRA - Resize Virtual Replication Appliances"
     link: /guides/hosted-private-cloud/powered-by-vmware/zerto-vra
-  - title: "Public VCF as-a-Service Migration with VCDA - Getting Started (EN)"
+  - title: "Public VCF as-a-Service Migration with VCDA - Getting Started"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-getting-started
-  - title: "Trigger your first VCDA migration to Public VCF as-a-Service (EN)"
+  - title: "Trigger your first VCDA migration to Public VCF as-a-Service"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-trigger-migration
-  - title: "Public VCF as-a-Service - Creating a new virtual machine (EN)"
+  - title: "Public VCF as-a-Service - Creating a new virtual machine"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-network-creation
-  - title: "Public VCF as-a-Service - Backups with Veeam Data Platform (EN)"
+  - title: "Public VCF as-a-Service - Backups with Veeam Data Platform"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-backup
 goFurther:
   title: "Weiterführende Informationen"

--- a/docs/de/guides/manage-and-operate/api/overview.mdx
+++ b/docs/de/guides/manage-and-operate/api/overview.mdx
@@ -7,15 +7,15 @@ essentialsTitle: "Wichtige Anleitungen für den Einstieg"
 essentials:
   - title: Erste Schritte mit der OVHcloud API
     link: /guides/manage-and-operate/api/first-steps
-  - title: "Exploring the OVHcloud APIs (EN)"
+  - title: "Exploring the OVHcloud APIs"
     link: /guides/manage-and-operate/api/console-preview
   - title: "OVHcloud API v2 - Principles of operation"
     link: /guides/manage-and-operate/api/apiv2
   - title: Manage services
     link: /guides/manage-and-operate/api/services
-  - title: "Managing OVHcloud service accounts via the API (EN)"
+  - title: "Managing OVHcloud service accounts via the API"
     link: /guides/manage-and-operate/api/manage-service-account
-  - title: "How to use service accounts to connect to OVHcloud APIs (EN)"
+  - title: "How to use service accounts to connect to OVHcloud APIs"
     link: /guides/account-and-service-management/account-information/authenticate-api-with-service-account
 goFurther:
   title: Weiterführende Informationen

--- a/docs/de/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
+++ b/docs/de/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
@@ -5,9 +5,9 @@ description: "Nutzen Sie das OVHcloud AI Partners Ecosystem, um Anyscale, NVIDIA
 text: "Entdecken Sie die AI Partners Ecosystem-Anleitungen"
 essentialsTitle: Die wichtigsten Anleitungen für den Einstieg
 essentials:
-  - title: "AI Partners Ecosystem - Lettria - Models features, capabilities and billing (EN)"
+  - title: "AI Partners Ecosystem - Lettria - Models features, capabilities and billing"
     link: /guides/public-cloud/ai-machine-learning/ai-ecosystem-lettria-billing-features
-  - title: "AI Partners Ecosystem - Voxist - Models features, capabilities and billing (EN)"
+  - title: "AI Partners Ecosystem - Voxist - Models features, capabilities and billing"
     link: /guides/public-cloud/ai-machine-learning/ai-ecosystem-voxist-billing-features
 goFurther:
   title: Weiterführende Informationen

--- a/docs/de/guides/public-cloud/containers-orchestration/managed-rancher-service/overview.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-rancher-service/overview.mdx
@@ -7,7 +7,7 @@ essentialsTitle: Die wichtigsten Anleitungen für den Einstieg
 essentials:
   - title: Getting Started with Managed Rancher Service
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/getting-started
-  - title: "Creating, updating and accessing a Managed Rancher Service (EN)"
+  - title: "Creating, updating and accessing a Managed Rancher Service"
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/creation
   - title: Managing users and projects in Managed Rancher Service
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/managing-users-projects

--- a/docs/de/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
+++ b/docs/de/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
@@ -7,13 +7,13 @@ essentialsTitle: "Die wichtigsten Anleitungen für den Einstieg"
 essentials:
   - title: "Veeam Backup & Replication einrichten (EN)"
     link: /guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication
-  - title: Preparing a Bare Metal Server backup with Veeam Enterprise (EN)
+  - title: Preparing a Bare Metal Server backup with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-preparation
-  - title: Backing up a Bare Metal Linux Server with Veeam Enterprise (EN)
+  - title: Backing up a Bare Metal Linux Server with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux
-  - title: Backing Up a Bare Metal Windows Server Using Veeam Agent for Windows (EN)
+  - title: Backing Up a Bare Metal Windows Server Using Veeam Agent for Windows
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-windows-agent
-  - title: Restoring a Bare Metal Server with Veeam Enterprise (EN)
+  - title: Restoring a Bare Metal Server with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-restore
 goFurther:
   title: Weiterführende Informationen

--- a/docs/de/guides/web-cloud/domains/domain-names/overview.mdx
+++ b/docs/de/guides/web-cloud/domains/domain-names/overview.mdx
@@ -11,7 +11,7 @@ essentials:
     link: /guides/web-cloud/domains/domain-create-subdomains
   - title: "Weiterleitung von bei OVHcloud verwalteten Domainnamen"
     link: /guides/web-cloud/domains/redirect-domain-name
-  - title: Responsibility sharing - Domain Name service (EN)
+  - title: Responsibility sharing - Domain Name service
     link: /guides/web-cloud/domains/domains-responsibility-sharing
   - title: "OVHcloud Domainnamen verlängern"
     link: /guides/web-cloud/domains/autorenew-domain-name

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/overview.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/overview.mdx
@@ -20,7 +20,7 @@ essentials:
 tutorials:
   - title: "Cómo utilizar PuTTY para conexiones SSH y autenticación"
     link: /guides/web-cloud/web-hosting/ssh-using-putty-on-windows
-  - title: Tutorial - Configuring pfSense network bridge (EN)
+  - title: Tutorial - Configuring pfSense network bridge
     link: /guides/bare-metal-cloud/dedicated-servers/pfsense-bridging
   - title: "Tutorial - Instalar un servidor web (LAMP) en Debian o Ubuntu"
     link: /guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18

--- a/docs/es/guides/hosted-private-cloud/powered-by-vmware/overview.mdx
+++ b/docs/es/guides/hosted-private-cloud/powered-by-vmware/overview.mdx
@@ -7,7 +7,7 @@ essentialsTitle: "Las guías esenciales para empezar"
 essentials:
   - title: Primeros pasos con NSX (EN)
     link: /guides/hosted-private-cloud/powered-by-vmware/nsx-first-steps
-  - title: How to enable NSX-T in a VMware on OVHcloud Hosted Private Cloud (EN)
+  - title: How to enable NSX-T in a VMware on OVHcloud Hosted Private Cloud
     link: /guides/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights
   - title: "Introducción a vRealize Operations - vROPS (EN)"
     link: /guides/hosted-private-cloud/powered-by-vmware/vrops-introduction

--- a/docs/es/guides/hosted-private-cloud/powered-by-vmware/public-vcf/overview.mdx
+++ b/docs/es/guides/hosted-private-cloud/powered-by-vmware/public-vcf/overview.mdx
@@ -11,24 +11,24 @@ essentials:
     link: /guides/hosted-private-cloud/powered-by-vmware/vsphere-interface-connexion
   - title: "Connexion à l'API OVH"
     link: /guides/hosted-private-cloud/powered-by-vmware/connect-to-ovh-api
-  - title: "Public VCF as-a-Service - Logging in to your organization (EN)"
+  - title: "Public VCF as-a-Service - Logging in to your organization"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-logging
-  - title: "Public VCF as-a-Service - Find out how to use the Public VCF as-a-Service user interface (EN)"
+  - title: "Public VCF as-a-Service - Find out how to use the Public VCF as-a-Service user interface"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-getting-started-dashboard-overview
 tutorials:
-  - title: "Public VCF as-a-Service - Enable the VCDA migration option on your Public VCF as-a-Service organisation (EN)"
+  - title: "Public VCF as-a-Service - Enable the VCDA migration option on your Public VCF as-a-Service organisation"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-enable-offer
-  - title: "Zerto LTR - Configure long-term retention (EN)"
+  - title: "Zerto LTR - Configure long-term retention"
     link: /guides/hosted-private-cloud/powered-by-vmware/zerto-ltr
-  - title: "Zerto VRA - Resize Virtual Replication Appliances (EN)"
+  - title: "Zerto VRA - Resize Virtual Replication Appliances"
     link: /guides/hosted-private-cloud/powered-by-vmware/zerto-vra
-  - title: "Public VCF as-a-Service Migration with VCDA - Getting Started (EN)"
+  - title: "Public VCF as-a-Service Migration with VCDA - Getting Started"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-getting-started
-  - title: "Trigger your first VCDA migration to Public VCF as-a-Service (EN)"
+  - title: "Trigger your first VCDA migration to Public VCF as-a-Service"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-trigger-migration
-  - title: "Public VCF as-a-Service - Creating a new virtual machine (EN)"
+  - title: "Public VCF as-a-Service - Creating a new virtual machine"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-network-creation
-  - title: "Public VCF as-a-Service - Backups with Veeam Data Platform (EN)"
+  - title: "Public VCF as-a-Service - Backups with Veeam Data Platform"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-backup
 goFurther:
   title: "Más información"

--- a/docs/es/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
+++ b/docs/es/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
@@ -5,9 +5,9 @@ description: "Utilice el AI Partners Ecosystem de OVHcloud para integrar Anyscal
 text: Descubra las guías de AI Partners Ecosystem
 essentialsTitle: Las guías esenciales para empezar
 essentials:
-  - title: "AI Partners Ecosystem - Lettria - Models features, capabilities and billing (EN)"
+  - title: "AI Partners Ecosystem - Lettria - Models features, capabilities and billing"
     link: /guides/public-cloud/ai-machine-learning/ai-ecosystem-lettria-billing-features
-  - title: "AI Partners Ecosystem - Voxist - Models features, capabilities and billing (EN)"
+  - title: "AI Partners Ecosystem - Voxist - Models features, capabilities and billing"
     link: /guides/public-cloud/ai-machine-learning/ai-ecosystem-voxist-billing-features
 goFurther:
   title: Más información

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-rancher-service/overview.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-rancher-service/overview.mdx
@@ -7,7 +7,7 @@ essentialsTitle: Las guías esenciales para empezar
 essentials:
   - title: Getting Started with Managed Rancher Service
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/getting-started
-  - title: "Creating, updating and accessing a Managed Rancher Service (EN)"
+  - title: "Creating, updating and accessing a Managed Rancher Service"
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/creation
   - title: Managing users and projects in Managed Rancher Service
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/managing-users-projects

--- a/docs/es/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
+++ b/docs/es/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
@@ -7,13 +7,13 @@ essentialsTitle: "Las guías esenciales para empezar"
 essentials:
   - title: "Implementar Veeam Backup & Replication (EN)"
     link: /guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication
-  - title: Preparing a Bare Metal Server backup with Veeam Enterprise (EN)
+  - title: Preparing a Bare Metal Server backup with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-preparation
-  - title: Backing up a Bare Metal Linux Server with Veeam Enterprise (EN)
+  - title: Backing up a Bare Metal Linux Server with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux
-  - title: Backing Up a Bare Metal Windows Server Using Veeam Agent for Windows (EN)
+  - title: Backing Up a Bare Metal Windows Server Using Veeam Agent for Windows
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-windows-agent
-  - title: Restoring a Bare Metal Server with Veeam Enterprise (EN)
+  - title: Restoring a Bare Metal Server with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-restore
 goFurther:
   title: Más información

--- a/docs/es/guides/web-cloud/domains/domain-names/overview.mdx
+++ b/docs/es/guides/web-cloud/domains/domain-names/overview.mdx
@@ -11,7 +11,7 @@ essentials:
     link: /guides/web-cloud/domains/domain-create-subdomains
   - title: "Redirigir un nombre de dominio gestionado por OVHcloud"
     link: /guides/web-cloud/domains/redirect-domain-name
-  - title: Responsibility sharing - Domain Name service (EN)
+  - title: Responsibility sharing - Domain Name service
     link: /guides/web-cloud/domains/domains-responsibility-sharing
   - title: "Renovar los dominios de OVHcloud"
     link: /guides/web-cloud/domains/autorenew-domain-name

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
@@ -5,9 +5,9 @@ description: "Intégrez Anyscale, NVIDIA, LangChain, Weaviate et d'autres outils
 text: Découvrez les guides AI Partners Ecosystem
 essentialsTitle: Les guides essentiels pour commencer
 essentials:
-  - title: "AI Partners Ecosystem - Lettria - Models features, capabilities and billing (EN)"
+  - title: "AI Partners Ecosystem - Lettria - Models features, capabilities and billing"
     link: /guides/public-cloud/ai-machine-learning/ai-ecosystem-lettria-billing-features
-  - title: "AI Partners Ecosystem - Voxist - Models features, capabilities and billing (EN)"
+  - title: "AI Partners Ecosystem - Voxist - Models features, capabilities and billing"
     link: /guides/public-cloud/ai-machine-learning/ai-ecosystem-voxist-billing-features
 goFurther:
   title: Aller plus loin

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/overview.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/overview.mdx
@@ -7,7 +7,7 @@ essentialsTitle: Les guides essentiels pour commencer
 essentials:
   - title: Getting Started with Managed Rancher Service
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/getting-started
-  - title: "Creating, updating and accessing a Managed Rancher Service (EN)"
+  - title: "Creating, updating and accessing a Managed Rancher Service"
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/creation
   - title: Managing users and projects in Managed Rancher Service
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/managing-users-projects

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/overview.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/overview.mdx
@@ -20,7 +20,7 @@ essentials:
 tutorials:
   - title: "Tutorial - Come utilizzare PuTTY per le connessioni SSH e l'autenticazione"
     link: /guides/web-cloud/web-hosting/ssh-using-putty-on-windows
-  - title: Tutorial - Configuring pfSense network bridge (EN)
+  - title: Tutorial - Configuring pfSense network bridge
     link: /guides/bare-metal-cloud/dedicated-servers/pfsense-bridging
   - title: Tutorial - Installare un server Web (LAMP) su Debian o Ubuntu
     link: /guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18

--- a/docs/it/guides/hosted-private-cloud/powered-by-vmware/overview.mdx
+++ b/docs/it/guides/hosted-private-cloud/powered-by-vmware/overview.mdx
@@ -7,7 +7,7 @@ essentialsTitle: "Le guide essenziali per iniziare"
 essentials:
   - title: Iniziare con NSX (EN)
     link: /guides/hosted-private-cloud/powered-by-vmware/nsx-first-steps
-  - title: How to enable NSX-T in a VMware on OVHcloud Hosted Private Cloud (EN)
+  - title: How to enable NSX-T in a VMware on OVHcloud Hosted Private Cloud
     link: /guides/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights
   - title: "Introduzione a vRealize Operations - vROPS (EN)"
     link: /guides/hosted-private-cloud/powered-by-vmware/vrops-introduction

--- a/docs/it/guides/hosted-private-cloud/powered-by-vmware/public-vcf/overview.mdx
+++ b/docs/it/guides/hosted-private-cloud/powered-by-vmware/public-vcf/overview.mdx
@@ -11,24 +11,24 @@ essentials:
     link: /guides/hosted-private-cloud/powered-by-vmware/vsphere-interface-connexion
   - title: "Connexion à l'API OVH"
     link: /guides/hosted-private-cloud/powered-by-vmware/connect-to-ovh-api
-  - title: "Public VCF as-a-Service - Logging in to your organization (EN)"
+  - title: "Public VCF as-a-Service - Logging in to your organization"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-logging
-  - title: "Public VCF as-a-Service - Find out how to use the Public VCF as-a-Service user interface (EN)"
+  - title: "Public VCF as-a-Service - Find out how to use the Public VCF as-a-Service user interface"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-getting-started-dashboard-overview
 tutorials:
-  - title: "Public VCF as-a-Service - Enable the VCDA migration option on your Public VCF as-a-Service organisation (EN)"
+  - title: "Public VCF as-a-Service - Enable the VCDA migration option on your Public VCF as-a-Service organisation"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-enable-offer
-  - title: "Zerto LTR - Configure long-term retention (EN)"
+  - title: "Zerto LTR - Configure long-term retention"
     link: /guides/hosted-private-cloud/powered-by-vmware/zerto-ltr
-  - title: "Zerto VRA - Resize Virtual Replication Appliances (EN)"
+  - title: "Zerto VRA - Resize Virtual Replication Appliances"
     link: /guides/hosted-private-cloud/powered-by-vmware/zerto-vra
-  - title: "Public VCF as-a-Service Migration with VCDA - Getting Started (EN)"
+  - title: "Public VCF as-a-Service Migration with VCDA - Getting Started"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-getting-started
-  - title: "Trigger your first VCDA migration to Public VCF as-a-Service (EN)"
+  - title: "Trigger your first VCDA migration to Public VCF as-a-Service"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-trigger-migration
-  - title: "Public VCF as-a-Service - Creating a new virtual machine (EN)"
+  - title: "Public VCF as-a-Service - Creating a new virtual machine"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-network-creation
-  - title: "Public VCF as-a-Service - Backups with Veeam Data Platform (EN)"
+  - title: "Public VCF as-a-Service - Backups with Veeam Data Platform"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-backup
 goFurther:
   title: Per approfondire

--- a/docs/it/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
+++ b/docs/it/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
@@ -5,9 +5,9 @@ description: "Utilizza l'OVHcloud AI Partners Ecosystem per integrare Anyscale, 
 text: Scopri le guide AI Partners Ecosystem
 essentialsTitle: Le guide essenziali per iniziare
 essentials:
-  - title: "AI Partners Ecosystem - Lettria - Models features, capabilities and billing (EN)"
+  - title: "AI Partners Ecosystem - Lettria - Models features, capabilities and billing"
     link: /guides/public-cloud/ai-machine-learning/ai-ecosystem-lettria-billing-features
-  - title: "AI Partners Ecosystem - Voxist - Models features, capabilities and billing (EN)"
+  - title: "AI Partners Ecosystem - Voxist - Models features, capabilities and billing"
     link: /guides/public-cloud/ai-machine-learning/ai-ecosystem-voxist-billing-features
 goFurther:
   title: Per approfondire

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-rancher-service/overview.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-rancher-service/overview.mdx
@@ -7,7 +7,7 @@ essentialsTitle: Le guide essenziali per iniziare
 essentials:
   - title: Getting Started with Managed Rancher Service
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/getting-started
-  - title: "Creating, updating and accessing a Managed Rancher Service (EN)"
+  - title: "Creating, updating and accessing a Managed Rancher Service"
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/creation
   - title: Managing users and projects in Managed Rancher Service
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/managing-users-projects

--- a/docs/it/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
+++ b/docs/it/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
@@ -7,13 +7,13 @@ essentialsTitle: "Le guide essenziali per iniziare"
 essentials:
   - title: "Installare Veeam Backup & Replication (EN)"
     link: /guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication
-  - title: Preparing a Bare Metal Server backup with Veeam Enterprise (EN)
+  - title: Preparing a Bare Metal Server backup with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-preparation
-  - title: Backing up a Bare Metal Linux Server with Veeam Enterprise (EN)
+  - title: Backing up a Bare Metal Linux Server with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux
-  - title: Backing Up a Bare Metal Windows Server Using Veeam Agent for Windows (EN)
+  - title: Backing Up a Bare Metal Windows Server Using Veeam Agent for Windows
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-windows-agent
-  - title: Restoring a Bare Metal Server with Veeam Enterprise (EN)
+  - title: Restoring a Bare Metal Server with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-restore
 goFurther:
   title: Per approfondire

--- a/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
+++ b/docs/it/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
@@ -7,7 +7,7 @@ essentialsTitle: "Le guide essenziali per iniziare"
 essentials:
   - title: "Cloud Disk Array - Creazione dell'utente (EN)"
     link: /guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user
-  - title: Cloud Disk Array - Pool creation (EN)
+  - title: Cloud Disk Array - Pool creation
     link: /guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool
   - title: Cloud Disk Array - Creazione ACL IP (EN)
     link: /guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl

--- a/docs/it/guides/web-cloud/domains/domain-names/overview.mdx
+++ b/docs/it/guides/web-cloud/domains/domain-names/overview.mdx
@@ -11,7 +11,7 @@ essentials:
     link: /guides/web-cloud/domains/domain-create-subdomains
   - title: "Reindirizzare un nome di dominio gestito da OVHcloud"
     link: /guides/web-cloud/domains/redirect-domain-name
-  - title: Responsibility sharing - Domain Name service (EN)
+  - title: Responsibility sharing - Domain Name service
     link: /guides/web-cloud/domains/domains-responsibility-sharing
   - title: "Rinnovare i miei domini OVHcloud"
     link: /guides/web-cloud/domains/autorenew-domain-name

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/overview.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/overview.mdx
@@ -20,7 +20,7 @@ essentials:
 tutorials:
   - title: "Tutorial - Jak używać PuTTY do połączeń SSH i uwierzytelniania"
     link: /guides/web-cloud/web-hosting/ssh-using-putty-on-windows
-  - title: Tutorial - Configuring pfSense network bridge (EN)
+  - title: Tutorial - Configuring pfSense network bridge
     link: /guides/bare-metal-cloud/dedicated-servers/pfsense-bridging
   - title: "Tutorial - Instalacja serwera www (LAMP) na Debian lub Ubuntu"
     link: /guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18

--- a/docs/pl/guides/hosted-private-cloud/powered-by-vmware/overview.mdx
+++ b/docs/pl/guides/hosted-private-cloud/powered-by-vmware/overview.mdx
@@ -7,7 +7,7 @@ essentialsTitle: "Najważniejsze przewodniki na start"
 essentials:
   - title: Pierwsze kroki z NSX (EN)
     link: /guides/hosted-private-cloud/powered-by-vmware/nsx-first-steps
-  - title: How to enable NSX-T in a VMware on OVHcloud Hosted Private Cloud (EN)
+  - title: How to enable NSX-T in a VMware on OVHcloud Hosted Private Cloud
     link: /guides/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights
   - title: "Wprowadzenie do vRealize Operations - vROPS (EN)"
     link: /guides/hosted-private-cloud/powered-by-vmware/vrops-introduction

--- a/docs/pl/guides/hosted-private-cloud/powered-by-vmware/public-vcf/overview.mdx
+++ b/docs/pl/guides/hosted-private-cloud/powered-by-vmware/public-vcf/overview.mdx
@@ -11,24 +11,24 @@ essentials:
     link: /guides/hosted-private-cloud/powered-by-vmware/vsphere-interface-connexion
   - title: "Connexion à l'API OVH"
     link: /guides/hosted-private-cloud/powered-by-vmware/connect-to-ovh-api
-  - title: "Public VCF as-a-Service - Logging in to your organization (EN)"
+  - title: "Public VCF as-a-Service - Logging in to your organization"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-logging
-  - title: "Public VCF as-a-Service - Find out how to use the Public VCF as-a-Service user interface (EN)"
+  - title: "Public VCF as-a-Service - Find out how to use the Public VCF as-a-Service user interface"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-getting-started-dashboard-overview
 tutorials:
-  - title: "Public VCF as-a-Service - Enable the VCDA migration option on your Public VCF as-a-Service organisation (EN)"
+  - title: "Public VCF as-a-Service - Enable the VCDA migration option on your Public VCF as-a-Service organisation"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-enable-offer
-  - title: "Zerto LTR - Configure long-term retention (EN)"
+  - title: "Zerto LTR - Configure long-term retention"
     link: /guides/hosted-private-cloud/powered-by-vmware/zerto-ltr
-  - title: "Zerto VRA - Resize Virtual Replication Appliances (EN)"
+  - title: "Zerto VRA - Resize Virtual Replication Appliances"
     link: /guides/hosted-private-cloud/powered-by-vmware/zerto-vra
-  - title: "Public VCF as-a-Service Migration with VCDA - Getting Started (EN)"
+  - title: "Public VCF as-a-Service Migration with VCDA - Getting Started"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-getting-started
-  - title: "Trigger your first VCDA migration to Public VCF as-a-Service (EN)"
+  - title: "Trigger your first VCDA migration to Public VCF as-a-Service"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-trigger-migration
-  - title: "Public VCF as-a-Service - Creating a new virtual machine (EN)"
+  - title: "Public VCF as-a-Service - Creating a new virtual machine"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-network-creation
-  - title: "Public VCF as-a-Service - Backups with Veeam Data Platform (EN)"
+  - title: "Public VCF as-a-Service - Backups with Veeam Data Platform"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-backup
 goFurther:
   title: "Sprawdź również"

--- a/docs/pl/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
+++ b/docs/pl/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
@@ -5,9 +5,9 @@ description: "Wykorzystaj OVHcloud AI Partners Ecosystem, aby zintegrować Anysc
 text: Odkryj przewodniki AI Partners Ecosystem
 essentialsTitle: Najważniejsze przewodniki na start
 essentials:
-  - title: "AI Partners Ecosystem - Lettria - Models features, capabilities and billing (EN)"
+  - title: "AI Partners Ecosystem - Lettria - Models features, capabilities and billing"
     link: /guides/public-cloud/ai-machine-learning/ai-ecosystem-lettria-billing-features
-  - title: "AI Partners Ecosystem - Voxist - Models features, capabilities and billing (EN)"
+  - title: "AI Partners Ecosystem - Voxist - Models features, capabilities and billing"
     link: /guides/public-cloud/ai-machine-learning/ai-ecosystem-voxist-billing-features
 goFurther:
   title: Sprawdź również

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-rancher-service/overview.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-rancher-service/overview.mdx
@@ -7,7 +7,7 @@ essentialsTitle: Najważniejsze przewodniki na start
 essentials:
   - title: Getting Started with Managed Rancher Service
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/getting-started
-  - title: "Creating, updating and accessing a Managed Rancher Service (EN)"
+  - title: "Creating, updating and accessing a Managed Rancher Service"
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/creation
   - title: Managing users and projects in Managed Rancher Service
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/managing-users-projects

--- a/docs/pl/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
@@ -7,13 +7,13 @@ essentialsTitle: "Najważniejsze przewodniki na start"
 essentials:
   - title: "Instalacja Veeam Backup & Replication (EN)"
     link: /guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication
-  - title: Preparing a Bare Metal Server backup with Veeam Enterprise (EN)
+  - title: Preparing a Bare Metal Server backup with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-preparation
-  - title: Backing up a Bare Metal Linux Server with Veeam Enterprise (EN)
+  - title: Backing up a Bare Metal Linux Server with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux
-  - title: Backing Up a Bare Metal Windows Server Using Veeam Agent for Windows (EN)
+  - title: Backing Up a Bare Metal Windows Server Using Veeam Agent for Windows
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-windows-agent
-  - title: Restoring a Bare Metal Server with Veeam Enterprise (EN)
+  - title: Restoring a Bare Metal Server with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-restore
 goFurther:
   title: Sprawdź również

--- a/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
+++ b/docs/pl/guides/storage-and-backup/block-storage/cloud-disk-array/overview.mdx
@@ -7,7 +7,7 @@ essentialsTitle: "Najważniejsze przewodniki na start"
 essentials:
   - title: Cloud Disk Array - Tworzenie użytkownika (EN)
     link: /guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user
-  - title: Cloud Disk Array - Pool creation (EN)
+  - title: Cloud Disk Array - Pool creation
     link: /guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-pool
   - title: Cloud Disk Array - Tworzenie IP ACL (EN)
     link: /guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl

--- a/docs/pl/guides/web-cloud/domains/domain-names/overview.mdx
+++ b/docs/pl/guides/web-cloud/domains/domain-names/overview.mdx
@@ -11,7 +11,7 @@ essentials:
     link: /guides/web-cloud/domains/domain-create-subdomains
   - title: "Przekierowanie nazwy domeny zarządzanej w OVHcloud"
     link: /guides/web-cloud/domains/redirect-domain-name
-  - title: Responsibility sharing - Domain Name service (EN)
+  - title: Responsibility sharing - Domain Name service
     link: /guides/web-cloud/domains/domains-responsibility-sharing
   - title: "Odnowienie domen OVHcloud"
     link: /guides/web-cloud/domains/autorenew-domain-name

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/overview.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/overview.mdx
@@ -20,7 +20,7 @@ essentials:
 tutorials:
   - title: "Tutorial - Como usar o PuTTY para conexões SSH e autenticação"
     link: /guides/web-cloud/web-hosting/ssh-using-putty-on-windows
-  - title: Tutorial - Configuring pfSense network bridge (EN)
+  - title: Tutorial - Configuring pfSense network bridge
     link: /guides/bare-metal-cloud/dedicated-servers/pfsense-bridging
   - title: Tutorial - Instalar um servidor web (LAMP) em Debian ou Ubuntu
     link: /guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18

--- a/docs/pt/guides/hosted-private-cloud/powered-by-vmware/overview.mdx
+++ b/docs/pt/guides/hosted-private-cloud/powered-by-vmware/overview.mdx
@@ -7,7 +7,7 @@ essentialsTitle: "Os guias essenciais para começar"
 essentials:
   - title: Introdução ao NSX (EN)
     link: /guides/hosted-private-cloud/powered-by-vmware/nsx-first-steps
-  - title: How to enable NSX-T in a VMware on OVHcloud Hosted Private Cloud (EN)
+  - title: How to enable NSX-T in a VMware on OVHcloud Hosted Private Cloud
     link: /guides/hosted-private-cloud/powered-by-vmware/nsx-add-user-rights
   - title: "Introdução ao vRealize Operations - vROPS (EN)"
     link: /guides/hosted-private-cloud/powered-by-vmware/vrops-introduction

--- a/docs/pt/guides/hosted-private-cloud/powered-by-vmware/public-vcf/overview.mdx
+++ b/docs/pt/guides/hosted-private-cloud/powered-by-vmware/public-vcf/overview.mdx
@@ -11,24 +11,24 @@ essentials:
     link: /guides/hosted-private-cloud/powered-by-vmware/vsphere-interface-connexion
   - title: "Connexion à l'API OVH"
     link: /guides/hosted-private-cloud/powered-by-vmware/connect-to-ovh-api
-  - title: "Public VCF as-a-Service - Logging in to your organization (EN)"
+  - title: "Public VCF as-a-Service - Logging in to your organization"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-logging
-  - title: "Public VCF as-a-Service - Find out how to use the Public VCF as-a-Service user interface (EN)"
+  - title: "Public VCF as-a-Service - Find out how to use the Public VCF as-a-Service user interface"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-getting-started-dashboard-overview
 tutorials:
-  - title: "Public VCF as-a-Service - Enable the VCDA migration option on your Public VCF as-a-Service organisation (EN)"
+  - title: "Public VCF as-a-Service - Enable the VCDA migration option on your Public VCF as-a-Service organisation"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-enable-offer
-  - title: "Zerto LTR - Configure long-term retention (EN)"
+  - title: "Zerto LTR - Configure long-term retention"
     link: /guides/hosted-private-cloud/powered-by-vmware/zerto-ltr
-  - title: "Zerto VRA - Resize Virtual Replication Appliances (EN)"
+  - title: "Zerto VRA - Resize Virtual Replication Appliances"
     link: /guides/hosted-private-cloud/powered-by-vmware/zerto-vra
-  - title: "Public VCF as-a-Service Migration with VCDA - Getting Started (EN)"
+  - title: "Public VCF as-a-Service Migration with VCDA - Getting Started"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-getting-started
-  - title: "Trigger your first VCDA migration to Public VCF as-a-Service (EN)"
+  - title: "Trigger your first VCDA migration to Public VCF as-a-Service"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcda-trigger-migration
-  - title: "Public VCF as-a-Service - Creating a new virtual machine (EN)"
+  - title: "Public VCF as-a-Service - Creating a new virtual machine"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-network-creation
-  - title: "Public VCF as-a-Service - Backups with Veeam Data Platform (EN)"
+  - title: "Public VCF as-a-Service - Backups with Veeam Data Platform"
     link: /guides/hosted-private-cloud/powered-by-vmware/vcd-backup
 goFurther:
   title: Saiba mais

--- a/docs/pt/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
+++ b/docs/pt/guides/public-cloud/ai-machine-learning/ai-ecosystem/overview.mdx
@@ -5,9 +5,9 @@ description: "Utilize o OVHcloud AI Partners Ecosystem para integrar Anyscale, N
 text: Descubra os guias AI Partners Ecosystem
 essentialsTitle: Os guias essenciais para começar
 essentials:
-  - title: "AI Partners Ecosystem - Lettria - Models features, capabilities and billing (EN)"
+  - title: "AI Partners Ecosystem - Lettria - Models features, capabilities and billing"
     link: /guides/public-cloud/ai-machine-learning/ai-ecosystem-lettria-billing-features
-  - title: "AI Partners Ecosystem - Voxist - Models features, capabilities and billing (EN)"
+  - title: "AI Partners Ecosystem - Voxist - Models features, capabilities and billing"
     link: /guides/public-cloud/ai-machine-learning/ai-ecosystem-voxist-billing-features
 goFurther:
   title: Saiba mais

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-rancher-service/overview.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-rancher-service/overview.mdx
@@ -7,7 +7,7 @@ essentialsTitle: Os guias essenciais para começar
 essentials:
   - title: Getting Started with Managed Rancher Service
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/getting-started
-  - title: "Creating, updating and accessing a Managed Rancher Service (EN)"
+  - title: "Creating, updating and accessing a Managed Rancher Service"
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/creation
   - title: Managing users and projects in Managed Rancher Service
     link: /guides/public-cloud/containers-orchestration/managed-rancher-service/managing-users-projects

--- a/docs/pt/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/overview.mdx
@@ -7,13 +7,13 @@ essentialsTitle: "Os guias essenciais para começar"
 essentials:
   - title: "Instalar o Veeam Backup & Replication (EN)"
     link: /guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication
-  - title: Preparing a Bare Metal Server backup with Veeam Enterprise (EN)
+  - title: Preparing a Bare Metal Server backup with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-preparation
-  - title: Backing up a Bare Metal Linux Server with Veeam Enterprise (EN)
+  - title: Backing up a Bare Metal Linux Server with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux
-  - title: Backing Up a Bare Metal Windows Server Using Veeam Agent for Windows (EN)
+  - title: Backing Up a Bare Metal Windows Server Using Veeam Agent for Windows
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-windows-agent
-  - title: Restoring a Bare Metal Server with Veeam Enterprise (EN)
+  - title: Restoring a Bare Metal Server with Veeam Enterprise
     link: /guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-restore
 goFurther:
   title: Saiba mais

--- a/docs/pt/guides/web-cloud/domains/domain-names/overview.mdx
+++ b/docs/pt/guides/web-cloud/domains/domain-names/overview.mdx
@@ -11,7 +11,7 @@ essentials:
     link: /guides/web-cloud/domains/domain-create-subdomains
   - title: "Reencaminhar um nome de domínio gerido pela OVHcloud"
     link: /guides/web-cloud/domains/redirect-domain-name
-  - title: Responsibility sharing - Domain Name service (EN)
+  - title: Responsibility sharing - Domain Name service
     link: /guides/web-cloud/domains/domains-responsibility-sharing
   - title: "Renovar os meus nomes de domínio OVHcloud"
     link: /guides/web-cloud/domains/autorenew-domain-name


### PR DESCRIPTION
On pageType: overview pages, the (EN) marker flags links whose target opens in English. It is only meaningful when the item title is translated; on an item whose title is already in English, (EN) adds nothing. Remove it from the English-titled items across the overview files (all locales); keep it on the translated-title items.