### PR TITLE
[SK-2696] WEB - Emails - alloffers - feat(components): add email troubleshooting landing page

### DIFF
--- a/components/EmailChainDiagram/EmailChainDiagram.css
+++ b/components/EmailChainDiagram/EmailChainDiagram.css
@@ -1,0 +1,70 @@
+.email-chain {
+  display: flex;
+  align-items: stretch;
+  gap: 0.6rem;
+  margin: 1.75rem 0;
+}
+
+.email-chain__node {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 1.1rem;
+  border: 1px solid var(--rp-c-divider);
+  border-radius: 12px;
+  background: var(--rp-c-bg-soft);
+}
+
+.email-chain__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  color: #6696e7;
+  background: rgba(102, 150, 231, 0.12);
+}
+
+.email-chain__step {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6696e7;
+}
+
+.email-chain__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.3;
+  color: var(--rp-c-text-1);
+}
+
+.email-chain__desc {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--rp-c-text-2);
+}
+
+.email-chain__arrow {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--rp-c-text-2);
+}
+
+@media (max-width: 900px) {
+  .email-chain {
+    flex-direction: column;
+  }
+
+  .email-chain__arrow {
+    align-self: center;
+    transform: rotate(90deg);
+  }
+}

--- a/components/EmailChainDiagram/EmailChainDiagram.tsx
+++ b/components/EmailChainDiagram/EmailChainDiagram.tsx
@@ -1,0 +1,307 @@
+import { useLang } from '@rspress/core/runtime';
+import { Fragment, type ReactNode } from 'react';
+import './EmailChainDiagram.css';
+
+const svg = {
+  width: 26,
+  height: 26,
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.7,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  'aria-hidden': true,
+  focusable: 'false' as const,
+};
+
+const ServerIcon = () => (
+  <svg {...svg} aria-hidden="true">
+    <rect x="3" y="4" width="18" height="7" rx="1.5" />
+    <rect x="3" y="13" width="18" height="7" rx="1.5" />
+    <path d="M6.5 7.5h.01" />
+    <path d="M6.5 16.5h.01" />
+  </svg>
+);
+
+const DnsIcon = () => (
+  <svg {...svg} aria-hidden="true">
+    <circle cx="12" cy="12" r="8.5" />
+    <path d="M3.5 12h17" />
+    <path d="M5 7.5h14" />
+    <path d="M5 16.5h14" />
+    <ellipse cx="12" cy="12" rx="4" ry="8.5" />
+  </svg>
+);
+
+const DeviceIcon = () => (
+  <svg {...svg} aria-hidden="true">
+    <rect x="3" y="4.5" width="18" height="12" rx="2" />
+    <path d="M9 20h6" />
+    <path d="M12 16.5V20" />
+  </svg>
+);
+
+const AppIcon = () => (
+  <svg {...svg} aria-hidden="true">
+    <rect x="3.5" y="4.5" width="17" height="15" rx="2" />
+    <path d="M3.5 9h17" />
+    <path d="M6.2 6.7h.01" />
+    <path d="M8.7 6.7h.01" />
+  </svg>
+);
+
+const Arrow = () => (
+  <span className="email-chain__arrow" aria-hidden="true">
+    <svg
+      width={22}
+      height={22}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M5 12h14M13 6l6 6-6 6" />
+    </svg>
+  </span>
+);
+
+interface NodeText {
+  step: string;
+  title: string;
+  desc: string;
+}
+
+interface Strings {
+  ariaLabel: string;
+  nodes: NodeText[];
+}
+
+// Localized copy. Only the icon order is shared (server → DNS → device → app);
+// the text is keyed by language. Falls back to English for locales not yet
+// provided (de/es/it/pl/pt) — see the landing page's locale coverage.
+const STRINGS: Record<string, Strings> = {
+  fr: {
+    ariaLabel:
+      'Les quatre origines possibles d’un problème d’e-mail : le serveur de messagerie, la configuration DNS du domaine, le terminal utilisé et le logiciel ou l’application.',
+    nodes: [
+      {
+        step: 'Maillon 1',
+        title: 'Le serveur de messagerie',
+        desc: 'Le service OVHcloud qui héberge vos boîtes et achemine les messages. En cause lors d’une adresse bloquée pour spam, d’une boîte pleine ou d’une interruption de service.',
+      },
+      {
+        step: 'Maillon 2',
+        title: 'La configuration du domaine (DNS)',
+        desc: 'Les enregistrements MX, SPF et DKIM qui aiguillent les e-mails vers le bon serveur et prouvent leur authenticité. En cause quand les messages ne sont pas reçus ou partent en spam.',
+      },
+      {
+        step: 'Maillon 3',
+        title: 'Le terminal',
+        desc: 'L’ordinateur, le smartphone ou la tablette utilisé, et sa connexion réseau. En cause en l’absence de connexion, avec une date/heure incorrecte ou un réseau qui filtre les ports.',
+      },
+      {
+        step: 'Maillon 4',
+        title: 'Le logiciel ou l’application',
+        desc: 'Le client de messagerie (Outlook, Thunderbird, Mail…) ou le webmail, et ses réglages. En cause si le mot de passe, les serveurs ou les ports sont mal configurés.',
+      },
+    ],
+  },
+  en: {
+    ariaLabel:
+      'The four possible origins of an email problem: the mail server, the domain DNS configuration, the device used, and the software or app.',
+    nodes: [
+      {
+        step: 'Link 1',
+        title: 'The mail server',
+        desc: 'The OVHcloud service that hosts your mailboxes and routes messages. The culprit when an address is blocked for spam, a mailbox is full, or the service is interrupted.',
+      },
+      {
+        step: 'Link 2',
+        title: 'The domain configuration (DNS)',
+        desc: 'The MX, SPF and DKIM records that route emails to the right server and prove their authenticity. The culprit when messages are not received or land in spam.',
+      },
+      {
+        step: 'Link 3',
+        title: 'The device',
+        desc: 'The computer, smartphone or tablet you use, and its network connection. The culprit when there is no connection, an incorrect date/time, or a network that filters ports.',
+      },
+      {
+        step: 'Link 4',
+        title: 'The software or app',
+        desc: 'The email client (Outlook, Thunderbird, Mail…) or the webmail, and its settings. The culprit when the password, servers or ports are misconfigured.',
+      },
+    ],
+  },
+  de: {
+    ariaLabel:
+      'Die vier möglichen Ursachen eines E-Mail-Problems: der Mailserver, die DNS-Konfiguration der Domain, das verwendete Endgerät und die Software oder App.',
+    nodes: [
+      {
+        step: 'Glied 1',
+        title: 'Der Mailserver',
+        desc: 'Der OVHcloud-Dienst, der Ihre Postfächer hostet und Nachrichten zustellt. Ursache bei einer wegen Spam gesperrten Adresse, einem vollen Postfach oder einer Dienstunterbrechung.',
+      },
+      {
+        step: 'Glied 2',
+        title: 'Die Domain-Konfiguration (DNS)',
+        desc: 'Die MX-, SPF- und DKIM-Einträge, die E-Mails an den richtigen Server leiten und ihre Echtheit belegen. Ursache, wenn Nachrichten nicht ankommen oder im Spam landen.',
+      },
+      {
+        step: 'Glied 3',
+        title: 'Das Endgerät',
+        desc: 'Der Computer, das Smartphone oder das Tablet, das Sie nutzen, und dessen Netzwerkverbindung. Ursache bei fehlender Verbindung, falschem Datum/falscher Uhrzeit oder einem Netzwerk, das Ports filtert.',
+      },
+      {
+        step: 'Glied 4',
+        title: 'Die Software oder App',
+        desc: 'Das E-Mail-Programm (Outlook, Thunderbird, Mail …) oder das Webmail und dessen Einstellungen. Ursache, wenn Passwort, Server oder Ports falsch konfiguriert sind.',
+      },
+    ],
+  },
+  es: {
+    ariaLabel:
+      'Los cuatro posibles orígenes de un problema de correo: el servidor de correo, la configuración DNS del dominio, el terminal utilizado y el software o la aplicación.',
+    nodes: [
+      {
+        step: 'Eslabón 1',
+        title: 'El servidor de correo',
+        desc: 'El servicio de OVHcloud que aloja sus buzones y enruta los mensajes. Responsable cuando una dirección está bloqueada por spam, un buzón está lleno o el servicio se interrumpe.',
+      },
+      {
+        step: 'Eslabón 2',
+        title: 'La configuración del dominio (DNS)',
+        desc: 'Los registros MX, SPF y DKIM que dirigen los correos al servidor correcto y prueban su autenticidad. Responsable cuando los mensajes no se reciben o acaban en spam.',
+      },
+      {
+        step: 'Eslabón 3',
+        title: 'El terminal',
+        desc: 'El ordenador, smartphone o tableta que utiliza, y su conexión de red. Responsable cuando no hay conexión, la fecha/hora es incorrecta o una red filtra los puertos.',
+      },
+      {
+        step: 'Eslabón 4',
+        title: 'El software o la aplicación',
+        desc: 'El cliente de correo (Outlook, Thunderbird, Mail…) o el webmail, y sus parámetros. Responsable cuando la contraseña, los servidores o los puertos están mal configurados.',
+      },
+    ],
+  },
+  it: {
+    ariaLabel:
+      'Le quattro possibili origini di un problema e-mail: il server di posta, la configurazione DNS del dominio, il dispositivo utilizzato e il software o l’applicazione.',
+    nodes: [
+      {
+        step: 'Anello 1',
+        title: 'Il server di posta',
+        desc: 'Il servizio OVHcloud che ospita le vostre caselle e instrada i messaggi. Responsabile in caso di indirizzo bloccato per spam, casella piena o interruzione del servizio.',
+      },
+      {
+        step: 'Anello 2',
+        title: 'La configurazione del dominio (DNS)',
+        desc: 'I record MX, SPF e DKIM che instradano le e-mail verso il server giusto e ne provano l’autenticità. Responsabile quando i messaggi non vengono ricevuti o finiscono nello spam.',
+      },
+      {
+        step: 'Anello 3',
+        title: 'Il dispositivo',
+        desc: 'Il computer, lo smartphone o il tablet che utilizzate e la sua connessione di rete. Responsabile in assenza di connessione, con data/ora errata o una rete che filtra le porte.',
+      },
+      {
+        step: 'Anello 4',
+        title: 'Il software o l’applicazione',
+        desc: 'Il client di posta (Outlook, Thunderbird, Mail…) o la webmail e le sue impostazioni. Responsabile quando password, server o porte sono configurati in modo errato.',
+      },
+    ],
+  },
+  pl: {
+    ariaLabel:
+      'Cztery możliwe źródła problemu z pocztą: serwer poczty, konfiguracja DNS domeny, używane urządzenie oraz oprogramowanie lub aplikacja.',
+    nodes: [
+      {
+        step: 'Ogniwo 1',
+        title: 'Serwer poczty',
+        desc: 'Usługa OVHcloud, która hostuje Twoje skrzynki i kieruje wiadomości. Odpowiada za adres zablokowany z powodu spamu, pełną skrzynkę lub przerwę w działaniu usługi.',
+      },
+      {
+        step: 'Ogniwo 2',
+        title: 'Konfiguracja domeny (DNS)',
+        desc: 'Rekordy MX, SPF i DKIM, które kierują wiadomości do właściwego serwera i potwierdzają ich autentyczność. Odpowiadają za nieodebrane wiadomości lub te trafiające do spamu.',
+      },
+      {
+        step: 'Ogniwo 3',
+        title: 'Urządzenie',
+        desc: 'Komputer, smartfon lub tablet, którego używasz, oraz jego połączenie sieciowe. Odpowiada za brak połączenia, nieprawidłową datę/godzinę lub sieć filtrującą porty.',
+      },
+      {
+        step: 'Ogniwo 4',
+        title: 'Oprogramowanie lub aplikacja',
+        desc: 'Klient poczty (Outlook, Thunderbird, Mail…) lub poczta web oraz jego ustawienia. Odpowiada za nieprawidłowo skonfigurowane hasło, serwery lub porty.',
+      },
+    ],
+  },
+  pt: {
+    ariaLabel:
+      'As quatro origens possíveis de um problema de e-mail: o servidor de correio, a configuração DNS do domínio, o terminal utilizado e o software ou a aplicação.',
+    nodes: [
+      {
+        step: 'Elo 1',
+        title: 'O servidor de correio',
+        desc: 'O serviço OVHcloud que aloja as suas caixas de correio e encaminha as mensagens. Responsável quando um endereço está bloqueado por spam, uma caixa está cheia ou o serviço é interrompido.',
+      },
+      {
+        step: 'Elo 2',
+        title: 'A configuração do domínio (DNS)',
+        desc: 'Os registos MX, SPF e DKIM que encaminham os e-mails para o servidor certo e comprovam a sua autenticidade. Responsáveis quando as mensagens não são recebidas ou vão para o spam.',
+      },
+      {
+        step: 'Elo 3',
+        title: 'O terminal',
+        desc: 'O computador, smartphone ou tablet que utiliza e a respetiva ligação de rede. Responsável na ausência de ligação, com data/hora incorreta ou uma rede que filtra as portas.',
+      },
+      {
+        step: 'Elo 4',
+        title: 'O software ou a aplicação',
+        desc: 'O cliente de e-mail (Outlook, Thunderbird, Mail…) ou o webmail e as suas definições. Responsável quando a palavra-passe, os servidores ou as portas estão mal configurados.',
+      },
+    ],
+  },
+};
+
+const ICONS: ReactNode[] = [
+  <ServerIcon key="server" />,
+  <DnsIcon key="dns" />,
+  <DeviceIcon key="device" />,
+  <AppIcon key="app" />,
+];
+
+/**
+ * Diagnostic schema for the email troubleshooting landing page: the four links
+ * of the mail chain where a problem can originate, from the OVHcloud server to
+ * the user's app. Pure HTML + inline SVG so it inherits the theme colors
+ * (via Rspress CSS variables) and adapts to light/dark — no external assets.
+ *
+ * Copy is localized via `useLang()`; locales without their own strings fall
+ * back to English.
+ */
+export function EmailChainDiagram() {
+  const lang = useLang();
+  const t = STRINGS[lang] ?? STRINGS.en;
+  return (
+    <div className="email-chain" role="img" aria-label={t.ariaLabel}>
+      {t.nodes.map((node, i) => (
+        <Fragment key={node.title}>
+          <div className="email-chain__node">
+            <span className="email-chain__icon">{ICONS[i]}</span>
+            <span className="email-chain__step">{node.step}</span>
+            <p className="email-chain__title">{node.title}</p>
+            <p className="email-chain__desc">{node.desc}</p>
+          </div>
+          {i < t.nodes.length - 1 && <Arrow />}
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+export default EmailChainDiagram;

--- a/components/EmailChainDiagram/index.ts
+++ b/components/EmailChainDiagram/index.ts
@@ -1,0 +1,4 @@
+export {
+  EmailChainDiagram,
+  EmailChainDiagram as default,
+} from './EmailChainDiagram';

--- a/components/LinkCard/LinkCard.css
+++ b/components/LinkCard/LinkCard.css
@@ -14,10 +14,27 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
+.link-card--with-icon {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+}
+
 .link-card__content {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.link-card--with-icon .link-card__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.link-card__icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: #6696e7; /* matches the card arrow accent */
 }
 
 .link-card__title {

--- a/components/LinkCard/LinkCard.tsx
+++ b/components/LinkCard/LinkCard.tsx
@@ -16,12 +16,22 @@ interface LinkCardProps {
    */
   description?: React.ReactNode;
   /**
+   * Optional icon rendered above the title (e.g. a <ProblemIcon />).
+   */
+  icon?: React.ReactNode;
+  /**
    * The style of the link card.
    */
   style?: React.CSSProperties;
 }
 
-export function LinkCard({ href, title, description, style }: LinkCardProps) {
+export function LinkCard({
+  href,
+  title,
+  description,
+  icon,
+  style,
+}: LinkCardProps) {
   const localizeHref = useLocalizeHref();
   const isExternal = href.startsWith('http://') || href.startsWith('https://');
   const resolvedHref = isExternal ? href : localizeHref(href);
@@ -29,10 +39,15 @@ export function LinkCard({ href, title, description, style }: LinkCardProps) {
   return (
     <a
       href={resolvedHref}
-      className="link-card"
+      className={icon ? 'link-card link-card--with-icon' : 'link-card'}
       style={style}
       {...(isExternal && { target: '_blank', rel: 'noopener noreferrer' })}
     >
+      {icon && (
+        <span className="link-card__icon" aria-hidden="true">
+          {icon}
+        </span>
+      )}
       <div className="link-card__content">
         <h3 className="link-card__title">
           {title}

--- a/components/ProblemIcon/ProblemIcon.tsx
+++ b/components/ProblemIcon/ProblemIcon.tsx
@@ -1,0 +1,100 @@
+import type { CSSProperties } from 'react';
+
+export type Problem =
+  | 'send-receive'
+  | 'spam-blocked'
+  | 'mailbox-full'
+  | 'password'
+  | 'deleted';
+
+interface ProblemIconProps {
+  /** Which troubleshooting symptom this card is about. */
+  name: Problem;
+  /** Square size in px. Defaults to 28. */
+  size?: number;
+  style?: CSSProperties;
+}
+
+/**
+ * Small monochrome line glyph for the "Quel est votre problème ?" cards of the
+ * email troubleshooting landing page. Each SVG uses `stroke="currentColor"`
+ * with no fill, so it inherits the surrounding color and adapts to the
+ * light/dark theme automatically — unlike an <img>, which renders in isolation.
+ *
+ * Deliberately simple, trademark-neutral marks in a consistent 24×24 outline
+ * style. Swap for official brand assets if the OVHcloud charte requires it.
+ */
+export function ProblemIcon({ name, size = 28, style }: ProblemIconProps) {
+  const common = {
+    width: size,
+    height: size,
+    viewBox: '0 0 24 24',
+    fill: 'none',
+    stroke: 'currentColor',
+    strokeWidth: 1.7,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    'aria-hidden': true,
+    focusable: 'false' as const,
+    style,
+  };
+
+  if (name === 'send-receive') {
+    // Envelope with a detached warning triangle — "something is wrong with your mail".
+    return (
+      <svg {...common} aria-hidden="true">
+        <rect x="1.5" y="4" width="11" height="8.5" rx="2" />
+        <path d="M2 4.8 7 8.3 12 4.8" />
+        <path d="M16.5 9 21.8 19H11.2Z" />
+        <path d="M16.5 12.6v2.6" />
+        <path d="M16.5 17.4h0.01" />
+      </svg>
+    );
+  }
+
+  if (name === 'spam-blocked') {
+    // No-entry / ban circle.
+    return (
+      <svg {...common} aria-hidden="true">
+        <circle cx="12" cy="12" r="8.5" />
+        <path d="M6 6 18 18" />
+      </svg>
+    );
+  }
+
+  if (name === 'mailbox-full') {
+    // Storage gauge with the needle near maximum — "your mailbox is full".
+    return (
+      <svg {...common} aria-hidden="true">
+        <path d="M4 17a8 8 0 0 1 16 0" />
+        <path d="M12 17 16.5 12.5" />
+        <circle cx="12" cy="17" r="1" />
+      </svg>
+    );
+  }
+
+  if (name === 'password') {
+    // Key.
+    return (
+      <svg {...common} aria-hidden="true">
+        <circle cx="8" cy="12" r="3.5" />
+        <path d="M11.5 12H20" />
+        <path d="M17 12v3" />
+        <path d="M20 12v3" />
+      </svg>
+    );
+  }
+
+  // deleted — trash can.
+  return (
+    <svg {...common} aria-hidden="true">
+      <path d="M4 7h16" />
+      <path d="M6 7l1 12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1l1-12" />
+      <path d="M9.5 7V5a1 1 0 0 1 1-1h3a1 1 0 0 1 1 1v2" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
+  );
+}
+
+export default ProblemIcon;

--- a/components/ProblemIcon/index.ts
+++ b/components/ProblemIcon/index.ts
@@ -1,0 +1,5 @@
+export {
+  type Problem,
+  ProblemIcon,
+  ProblemIcon as default,
+} from './ProblemIcon';

--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -1947,7 +1947,7 @@
             + [Manually migrate your email account](web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)
             + [Migrating email accounts using OVHcloud Mail Migrator](web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud)
             + [Migrating your email account from one OVHcloud email platform to another](web-cloud/email-and-collaborative-solutions/migrating/migration-platform)
-        + [Troubleshooting](web-cloud-email-collaborative-solutions-troubleshooting)
+        + [Troubleshooting](web-cloud-email-collaborative-solutions-troubleshooting){landing=web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting}
             + [Unable to send or receive emails](web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-advanced)
             + [What to do if your account is blocked for spam](web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam)
             + [Retrieving email headers](web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers)

--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -1948,11 +1948,13 @@
             + [Migrating email accounts using OVHcloud Mail Migrator](web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud)
             + [Migrating your email account from one OVHcloud email platform to another](web-cloud/email-and-collaborative-solutions/migrating/migration-platform)
         + [Troubleshooting](web-cloud-email-collaborative-solutions-troubleshooting){landing=web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting}
-            + [Unable to send or receive emails](web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-advanced)
-            + [What to do if your account is blocked for spam](web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam)
-            + [Retrieving email headers](web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers)
-            + [Managing the storage space for an email account](web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota)
-            + [Restoring deleted items from your email account](web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention)
+            + [Unable to send or receive emails](web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-advanced){label=Cannot send or receive}
+            + [What to do if your account is blocked for spam](web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam){label=Blocked for spam}
+            + [Retrieving email headers](web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers){label=Email headers (.eml)}
+            + [Managing the storage space for an email account](web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota){label=Mailbox storage}
+            + [Restoring deleted items from your email account](web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention){label=Restore deleted emails}
+            + [Exchange - Outlook sign-in prompts to Office 365](web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365){label=Outlook sign-in prompts}
+            + [Exchange - How to manage logs](web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-manage-logs){label=Managing logs}
         + [MX Plan](products/web-cloud-email-collaborative-solutions-mx-plan){landing=web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan}
             + [Getting started](web-cloud-email-collaborative-solutions-mx-plan-getting-started)
                 + [Getting started with the MX Plan solution](web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities)

--- a/config/sidebar/parser.ts
+++ b/config/sidebar/parser.ts
@@ -379,10 +379,12 @@ export function parseIndexMd(
     // multiple markers on one line are supported.
     //   - `{landing=<slug>}` : turns a product/section into a clickable group.
     //   - `{label=<text>}`   : overrides the sidebar label of a guide leaf,
-    //                          independently of the guide's frontmatter title
-    //                          (verbatim, applied to every locale). Lets the
-    //                          sidebar rename an entry without touching the
-    //                          guide or adding a wrapper category.
+    //                          independently of the guide's frontmatter title.
+    //                          Emitted as a translatable i18n key (seeded from
+    //                          this EN text via `pnpm sidebar:sync-i18n`);
+    //                          translators then fill the per-locale values in
+    //                          i18n.json. Lets the sidebar rename/shorten an
+    //                          entry without touching the guide.
     const markers: Record<string, string> = {};
     const markerRe = /\s*\{([a-zA-Z]+)=([^}]+)\}\s*$/;
     let markerMatch = stripped.match(markerRe);
@@ -430,12 +432,17 @@ export function parseIndexMd(
       }
 
       // Resolve the sidebar label, in priority order:
-      //   1. an explicit `{label=…}` marker (verbatim, wins over everything)
+      //   1. an explicit `{label=…}` marker → emitted as a translatable i18n
+      //      key (like non-leaf nodes), so the label is localised via i18n.json
+      //      instead of baking the verbatim EN string into every locale. The EN
+      //      text is the default, seeded by scripts/sidebar-sync-i18n.ts.
       //   2. the translated "Overview" label for `/overview` leaves
       //   3. the target guide's locale-specific frontmatter title
       let guideText = label;
       if (labelOverride) {
-        guideText = labelOverride;
+        const labelKey = `sidebar.gen.${toCamelCase((ref as string).replace(/\//g, '-'))}`;
+        i18nEntries[labelKey] = { en: labelOverride };
+        guideText = labelKey;
       } else if ((ref as string).endsWith('/overview') && locale) {
         guideText = OVERVIEW_TRANSLATIONS[locale as Locale] ?? 'Overview';
       } else if (docsDir && locale) {

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E-Mail-Diagnose und Fehlerbehebung - OVHcloud E-Mail-Dokumentation"
 description: "Lösen Sie Ihre OVHcloud-E-Mail-Probleme: Senden oder Empfangen nicht möglich, wegen Spam gesperrte Adresse, volles Postfach, vergessenes Passwort oder Wiederherstellung gelöschter E-Mails."
-lastUpdated: 2026-06-26
+lastUpdated: 2026-06-30
 pageType: landing
 banner: true
 tagline: "Erkennen und beheben Sie die häufigsten Probleme mit Ihrem OVHcloud-Postfach."

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -64,6 +64,10 @@ Sie bereiten sich auf den Kontakt mit dem Support vor oder möchten eine E-Mail 
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Header und .eml-Datei einer E-Mail abrufen" description="Extrahieren Sie die technischen Informationen einer Nachricht zur Analyse oder für den Support." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Microsoft Exchange-Fehlerdiagnose" description="Nutzen Sie das Diagnosetool für Exchange-Konten." />
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Wiederkehrende Outlook-Anmeldeaufforderungen" description="Beheben Sie wiederholte Outlook-Anmeldeaufforderungen bei Office 365 auf einem Exchange-Postfach." />
+  </Region>
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-manage-logs" title="Exchange-Logs verwalten" description="Zeigen Sie die Logs Ihres Private- oder Trusted-Exchange-Angebots an und verwalten Sie sie." />
   </Region>
 </CardGrid>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,0 +1,77 @@
+---
+title: "E-Mail-Diagnose und Fehlerbehebung - OVHcloud E-Mail-Dokumentation"
+description: "Lösen Sie Ihre OVHcloud-E-Mail-Probleme: Senden oder Empfangen nicht möglich, wegen Spam gesperrte Adresse, volles Postfach, vergessenes Passwort oder Wiederherstellung gelöschter E-Mails."
+lastUpdated: 2026-06-26
+pageType: landing
+banner: true
+tagline: "Erkennen und beheben Sie die häufigsten Probleme mit Ihrem OVHcloud-Postfach."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Weiterführende Informationen
+  items:
+    - title: OVHcloud Community besuchen
+      link: https://community.ovhcloud.com/
+    - title: Roadmap & Changelog ansehen
+      link: https://www.ovhcloud.com/de/roadmap-changelog/
+    - title: Discord beitreten
+      link: https://discord.gg/ovhcloud
+cta:
+  title: Besteht das Problem weiterhin? Wenden Sie sich an den OVHcloud Support
+  description: "Wenn keine Anleitung Ihre Situation löst, hilft Ihnen unser Support-Team gerne weiter."
+  actions:
+    - text: Support aufrufen
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+import { ProblemIcon } from '@components/ProblemIcon';
+import { EmailChainDiagram } from '@components/EmailChainDiagram';
+import { Region } from '@components/Zone';
+
+## Wo soll ich anfangen?
+
+Ein E-Mail-Problem entsteht nie zufällig: Es liegt fast immer an einem der **vier Glieder** der E-Mail-Kette, vom OVHcloud-Server bis zur von Ihnen genutzten Anwendung. Das richtige Glied zu erkennen, ist bereits die halbe Fehlerbehebung: Es grenzt die möglichen Ursachen deutlich ein und führt Sie zur passenden Anleitung.
+
+<EmailChainDiagram />
+
+Ein und dasselbe Symptom kann übrigens von mehreren Gliedern herrühren: Ein fehlgeschlagener E-Mail-Empfang kann am Server (volles Postfach), an der Domain (fehlerhafter MX-Eintrag), am Endgerät (keine Verbindung) oder an der Software (falsche Einstellungen) liegen. Beginnen Sie im Zweifelsfall mit dem Glied, das Ihnen am nächsten ist – der Software oder Anwendung – und arbeiten Sie sich dann die Kette hinauf.
+
+Sobald Sie die wahrscheinliche Ursache eingegrenzt haben, finden Sie unten Ihr **Symptom**: Die meisten gängigen Störungen lassen sich in wenigen Schritten beheben, ohne den Support zu kontaktieren. Diese Anleitungen gelten für alle E-Mail-Angebote von OVHcloud, unabhängig von Ihrem Tarif.
+
+## Worin besteht Ihr Problem?
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="send-receive" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-advanced" title="Ich kann keine E-Mails senden oder empfangen" description="Diagnostizieren und beheben Sie Störungen beim Senden oder Empfangen." />
+  <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="Meine Adresse ist wegen Spam gesperrt" description="Ermitteln Sie die Ursache der verdächtigen Aktivität und entsperren Sie Ihre Adresse." />
+  <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="Mein Postfach ist voll" description="Verwalten und optimieren Sie den Speicherplatz Ihres E-Mail-Kontos." />
+  <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="Ich habe mein Passwort vergessen" description="Setzen Sie das Passwort einer E-Mail-Adresse zurück oder ändern Sie es." />
+</CardGrid>
+
+<Region zones={['eu', 'ca']}>
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="deleted" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention" title="Ich habe eine E-Mail versehentlich gelöscht" description="Stellen Sie gelöschte Elemente Ihres E-Mail-Kontos über das Webmail wieder her." />
+</CardGrid>
+
+</Region>
+
+## Erweiterte Diagnosetools
+
+Sie bereiten sich auf den Kontakt mit dem Support vor oder möchten eine E-Mail genauer analysieren? Diese Anleitungen gehen noch weiter.
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Header und .eml-Datei einer E-Mail abrufen" description="Extrahieren Sie die technischen Informationen einer Nachricht zur Analyse oder für den Support." />
+  <Region zones={['eu', 'ca']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Microsoft Exchange-Fehlerdiagnose" description="Nutzen Sie das Diagnosetool für Exchange-Konten." />
+  </Region>
+</CardGrid>
+
+## Häufig gestellte Fragen
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails" title="OVHcloud E-Mail-FAQ" description="Antworten auf die häufigsten Fragen rund um E-Mails." />
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra" title="Zimbra-FAQ" description="Antworten auf häufige Fragen zur Zimbra-Lösung." />
+  </Region>
+</CardGrid>

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -64,6 +64,10 @@ Preparing to contact support, or want to analyse an email in depth? These guides
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Retrieve an email's header and .eml file" description="Extract the technical information of a message for analysis or support." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Microsoft Exchange error diagnostics" description="Use the diagnostic tool dedicated to Exchange accounts." />
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Recurring Outlook sign-in prompts" description="Fix Outlook repeatedly asking to sign in to Office 365 on an Exchange mailbox." />
+  </Region>
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-manage-logs" title="Managing Exchange logs" description="View and manage the logs of your Private or Trusted Exchange offer." />
   </Region>
 </CardGrid>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,0 +1,77 @@
+---
+title: "Email diagnostics and troubleshooting - OVHcloud documentation"
+description: "Solve your OVHcloud email problems: cannot send or receive, address blocked for spam, full mailbox, forgotten password, or recovering deleted emails."
+lastUpdated: 2026-06-26
+pageType: landing
+banner: true
+tagline: "Identify and resolve the common problems with your OVHcloud mailbox."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Go further
+  items:
+    - title: Visit the OVHcloud community
+      link: https://community.ovhcloud.com/
+    - title: View the roadmap & changelog
+      link: https://www.ovhcloud.com/en-gb/roadmap-changelog/
+    - title: Join Discord
+      link: https://discord.gg/ovhcloud
+cta:
+  title: Still stuck? Access OVHcloud Support
+  description: "If no guide resolves your situation, our Support team is here to help."
+  actions:
+    - text: Access Support
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+import { ProblemIcon } from '@components/ProblemIcon';
+import { EmailChainDiagram } from '@components/EmailChainDiagram';
+import { Region } from '@components/Zone';
+
+## Where to start?
+
+An email problem never happens by chance: it almost always sits on one of the **four links** of the email chain, from the OVHcloud server to the app you use. Spotting the right link is already half the troubleshooting: it greatly narrows down the possible causes and points you to the right guide.
+
+<EmailChainDiagram />
+
+The same symptom can in fact come from several links: a failure to receive email may be down to the server (full mailbox), the domain (incorrect MX record), the device (no connection) or the software (wrong settings). When in doubt, start from the link closest to you — the software or app — then work back up the chain.
+
+Once you have identified the likely origin, find your **symptom** below: most common problems are solved in a few steps, without contacting support. These guides apply to all OVHcloud email offers, whatever yours is.
+
+## What is your problem?
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="send-receive" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-advanced" title="I cannot send or receive emails" description="Diagnose and fix problems when sending or receiving emails." />
+  <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="My address is blocked for spam" description="Identify the cause of the suspicious activity and unblock your address." />
+  <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="My mailbox is full" description="Manage and optimise the storage space of your email account." />
+  <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="I forgot my password" description="Reset or change the password of an email address." />
+</CardGrid>
+
+<Region zones={['eu', 'ca']}>
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="deleted" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention" title="I deleted an email by mistake" description="Restore deleted items from your email account via the webmail." />
+</CardGrid>
+
+</Region>
+
+## Advanced diagnostic tools
+
+Preparing to contact support, or want to analyse an email in depth? These guides go further.
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Retrieve an email's header and .eml file" description="Extract the technical information of a message for analysis or support." />
+  <Region zones={['eu', 'ca']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Microsoft Exchange error diagnostics" description="Use the diagnostic tool dedicated to Exchange accounts." />
+  </Region>
+</CardGrid>
+
+## Frequently asked questions
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails" title="OVHcloud email FAQ" description="Answers to the most common questions about email." />
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra" title="Zimbra FAQ" description="Answers to frequently asked questions about the Zimbra solution." />
+  </Region>
+</CardGrid>

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Email diagnostics and troubleshooting - OVHcloud documentation"
 description: "Solve your OVHcloud email problems: cannot send or receive, address blocked for spam, full mailbox, forgotten password, or recovering deleted emails."
-lastUpdated: 2026-06-26
+lastUpdated: 2026-06-30
 pageType: landing
 banner: true
 tagline: "Identify and resolve the common problems with your OVHcloud mailbox."

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,0 +1,77 @@
+---
+title: "Diagnóstico y resolución de problemas de correo - Documentación de correo OVHcloud"
+description: "Resuelva sus problemas de correo de OVHcloud: no puede enviar ni recibir, dirección bloqueada por spam, buzón lleno, contraseña olvidada o recuperación de correos eliminados."
+lastUpdated: 2026-06-26
+pageType: landing
+banner: true
+tagline: "Identifique y resuelva los problemas habituales de su mensajería OVHcloud."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Más información
+  items:
+    - title: Visitar la comunidad OVHcloud
+      link: https://community.ovhcloud.com/
+    - title: Consultar el roadmap y el changelog
+      link: https://www.ovhcloud.com/es/roadmap-changelog/
+    - title: Unirse a Discord
+      link: https://discord.gg/ovhcloud
+cta:
+  title: ¿El problema persiste? Acceda al soporte de OVHcloud
+  description: "Si ninguna guía resuelve su situación, nuestro equipo de soporte está aquí para ayudarle."
+  actions:
+    - text: Acceder al soporte
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+import { ProblemIcon } from '@components/ProblemIcon';
+import { EmailChainDiagram } from '@components/EmailChainDiagram';
+import { Region } from '@components/Zone';
+
+## ¿Por dónde empezar?
+
+Un problema de correo electrónico nunca surge por casualidad: casi siempre se encuentra en uno de los **cuatro eslabones** de la cadena de correo, desde el servidor de OVHcloud hasta la aplicación que utiliza. Identificar el eslabón correcto ya es la mitad de la solución: reduce considerablemente las posibles causas y le orienta hacia la guía adecuada.
+
+<EmailChainDiagram />
+
+De hecho, un mismo síntoma puede provenir de varios eslabones: una recepción imposible puede deberse al servidor (buzón lleno), al dominio (registro MX incorrecto), al terminal (sin conexión) o al software (parámetros erróneos). En caso de duda, empiece por el eslabón más cercano a usted —el software o la aplicación— y vaya remontando la cadena.
+
+Una vez identificado el origen probable, localice su **síntoma** más abajo: la mayoría de las incidencias habituales se resuelven en unos pocos pasos, sin contactar con el soporte. Estas guías se aplican a todas las ofertas de correo de OVHcloud, sea cual sea la suya.
+
+## ¿Cuál es su problema?
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="send-receive" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-advanced" title="No puedo enviar ni recibir correos" description="Diagnostique y corrija los fallos al enviar o recibir correos." />
+  <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="Mi dirección está bloqueada por spam" description="Identifique la causa de la actividad sospechosa y desbloquee su dirección." />
+  <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="Mi buzón está lleno" description="Gestione y optimice el espacio de almacenamiento de su cuenta de correo." />
+  <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="He olvidado mi contraseña" description="Restablezca o cambie la contraseña de una dirección de correo." />
+</CardGrid>
+
+<Region zones={['eu', 'ca']}>
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="deleted" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention" title="He eliminado un correo por error" description="Restaure los elementos eliminados de su cuenta de correo a través del webmail." />
+</CardGrid>
+
+</Region>
+
+## Herramientas de diagnóstico avanzadas
+
+¿Se está preparando para contactar con el soporte o quiere analizar un correo en profundidad? Estas guías van más allá.
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Recuperar la cabecera y el archivo .eml de un correo" description="Extraiga la información técnica de un mensaje para su análisis o para el soporte." />
+  <Region zones={['eu', 'ca']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnóstico de errores de Microsoft Exchange" description="Utilice la herramienta de diagnóstico específica para cuentas Exchange." />
+  </Region>
+</CardGrid>
+
+## Preguntas frecuentes
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails" title="FAQ de correo OVHcloud" description="Respuestas a las preguntas más habituales sobre el correo." />
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra" title="FAQ de Zimbra" description="Respuestas a las preguntas frecuentes sobre la solución Zimbra." />
+  </Region>
+</CardGrid>

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnóstico y resolución de problemas de correo - Documentación de correo OVHcloud"
 description: "Resuelva sus problemas de correo de OVHcloud: no puede enviar ni recibir, dirección bloqueada por spam, buzón lleno, contraseña olvidada o recuperación de correos eliminados."
-lastUpdated: 2026-06-26
+lastUpdated: 2026-06-30
 pageType: landing
 banner: true
 tagline: "Identifique y resuelva los problemas habituales de su mensajería OVHcloud."

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -64,6 +64,10 @@ Una vez identificado el origen probable, localice su **síntoma** más abajo: la
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Recuperar la cabecera y el archivo .eml de un correo" description="Extraiga la información técnica de un mensaje para su análisis o para el soporte." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnóstico de errores de Microsoft Exchange" description="Utilice la herramienta de diagnóstico específica para cuentas Exchange." />
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Solicitudes de conexión de Outlook recurrentes" description="Corrija las solicitudes repetidas de conexión de Outlook a Office 365 en un buzón Exchange." />
+  </Region>
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-manage-logs" title="Gestionar los logs de Exchange" description="Consulte y gestione los logs de su oferta Private o Trusted Exchange." />
   </Region>
 </CardGrid>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,0 +1,77 @@
+---
+title: "Diagnostic et dépannage e-mail OVHcloud"
+description: "Résolvez vos problèmes d'e-mail OVHcloud : envoi ou réception impossible, adresse bloquée pour spam, boîte pleine, mot de passe oublié ou récupération d'e-mails supprimés."
+lastUpdated: 2026-06-26
+pageType: landing
+banner: true
+tagline: "Identifiez et résolvez les problèmes courants de votre messagerie OVHcloud."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Aller plus loin
+  items:
+    - title: Consulter la communauté OVHcloud
+      link: https://community.ovhcloud.com/
+    - title: Consulter la roadmap & le changelog
+      link: https://www.ovhcloud.com/fr/roadmap-changelog/
+    - title: Rejoindre Discord
+      link: https://discord.gg/ovhcloud
+cta:
+  title: Le problème persiste ? Contactez le support OVHcloud
+  description: "Si aucun guide ne résout votre situation, notre support est là pour vous aider."
+  actions:
+    - text: Accéder au support
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+import { ProblemIcon } from '@components/ProblemIcon';
+import { EmailChainDiagram } from '@components/EmailChainDiagram';
+import { Region } from '@components/Zone';
+
+## Par où commencer ?
+
+Un problème avec votre messagerie ne survient jamais par hasard : il se loge presque toujours sur l'un des **quatre maillons** de la chaîne e-mail, du serveur OVHcloud jusqu'à l'application que vous utilisez. Repérer le bon maillon, c'est déjà la moitié du dépannage : cela réduit nettement le champ des causes possibles et vous oriente vers le bon guide.
+
+<EmailChainDiagram />
+
+Un même symptôme peut d'ailleurs venir de plusieurs maillons : une réception impossible peut tenir au serveur (boîte pleine), au domaine (enregistrement MX erroné), au terminal (pas de connexion) ou au logiciel (mauvais paramètres). En cas de doute, partez du maillon le plus proche de vous — le logiciel ou l'application — puis remontez la chaîne.
+
+Une fois l'origine probable repérée, identifiez le **symptôme** ci-dessous : la plupart des pannes courantes se résolvent en quelques étapes, sans contacter le support. Ces guides s'appliquent à l'ensemble des offres e-mail OVHcloud, quelle que soit la vôtre.
+
+## Quel est votre problème ?
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="send-receive" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-advanced" title="Je ne peux pas envoyer ou recevoir d'e-mails" description="Diagnostiquez et corrigez les dysfonctionnements à l'envoi ou à la réception." />
+  <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="Mon adresse est bloquée pour spam" description="Identifiez la cause de l'activité suspecte et débloquez votre adresse." />
+  <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="Ma boîte e-mail est pleine" description="Gérez et optimisez l'espace de stockage de votre compte e-mail." />
+  <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="J'ai oublié mon mot de passe" description="Réinitialisez ou modifiez le mot de passe d'une adresse e-mail." />
+</CardGrid>
+
+<Region zones={['eu', 'ca']}>
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="deleted" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention" title="J'ai supprimé un e-mail par erreur" description="Restaurez les éléments supprimés de votre compte e-mail via le webmail." />
+</CardGrid>
+
+</Region>
+
+## Outils de diagnostic avancés
+
+Vous préparez un échange avec le support, ou vous voulez analyser un e-mail en profondeur ? Ces guides vont plus loin.
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Récupérer l'en-tête et le fichier .eml d'un e-mail" description="Extrayez les informations techniques d'un message pour analyse ou support." />
+  <Region zones={['eu', 'ca']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnostic d'erreurs Microsoft Exchange" description="Utilisez l'outil de diagnostic dédié aux comptes Exchange." />
+  </Region>
+</CardGrid>
+
+## Questions fréquentes
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails" title="FAQ e-mails OVHcloud" description="Les réponses aux questions les plus posées sur la messagerie." />
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra" title="FAQ Zimbra" description="Les réponses aux questions fréquentes sur la solution Zimbra." />
+  </Region>
+</CardGrid>

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnostic et dépannage e-mail OVHcloud"
 description: "Résolvez vos problèmes d'e-mail OVHcloud : envoi ou réception impossible, adresse bloquée pour spam, boîte pleine, mot de passe oublié ou récupération d'e-mails supprimés."
-lastUpdated: 2026-06-26
+lastUpdated: 2026-06-30
 pageType: landing
 banner: true
 tagline: "Identifiez et résolvez les problèmes courants de votre messagerie OVHcloud."

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -64,6 +64,10 @@ Vous préparez un échange avec le support, ou vous voulez analyser un e-mail en
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Récupérer l'en-tête et le fichier .eml d'un e-mail" description="Extrayez les informations techniques d'un message pour analyse ou support." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnostic d'erreurs Microsoft Exchange" description="Utilisez l'outil de diagnostic dédié aux comptes Exchange." />
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Invites de connexion Outlook répétées" description="Corrigez les demandes de connexion Outlook à Office 365 sur une boîte Exchange." />
+  </Region>
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-manage-logs" title="Gérer les logs Exchange" description="Consultez et gérez les logs de votre offre Private ou Trusted Exchange." />
   </Region>
 </CardGrid>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,0 +1,77 @@
+---
+title: "Diagnostica e risoluzione dei problemi e-mail - Documentazione email OVHcloud"
+description: "Risolvete i vostri problemi e-mail OVHcloud: invio o ricezione impossibili, indirizzo bloccato per spam, casella piena, password dimenticata o recupero di e-mail eliminate."
+lastUpdated: 2026-06-26
+pageType: landing
+banner: true
+tagline: "Individuate e risolvete i problemi più comuni della vostra messaggistica OVHcloud."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Per saperne di più
+  items:
+    - title: Visitare la community OVHcloud
+      link: https://community.ovhcloud.com/
+    - title: Consultare la roadmap e il changelog
+      link: https://www.ovhcloud.com/it/roadmap-changelog/
+    - title: Unirsi a Discord
+      link: https://discord.gg/ovhcloud
+cta:
+  title: Il problema persiste? Contattate il supporto OVHcloud
+  description: "Se nessuna guida risolve la vostra situazione, il nostro team di supporto è a vostra disposizione."
+  actions:
+    - text: Accedere al supporto
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+import { ProblemIcon } from '@components/ProblemIcon';
+import { EmailChainDiagram } from '@components/EmailChainDiagram';
+import { Region } from '@components/Zone';
+
+## Da dove cominciare?
+
+Un problema e-mail non si verifica mai per caso: si trova quasi sempre in uno dei **quattro anelli** della catena e-mail, dal server OVHcloud fino all'applicazione che utilizzate. Individuare l'anello giusto è già metà della risoluzione: riduce notevolmente le possibili cause e vi indirizza alla guida adatta.
+
+<EmailChainDiagram />
+
+Uno stesso sintomo può infatti derivare da più anelli: una ricezione impossibile può dipendere dal server (casella piena), dal dominio (record MX errato), dal terminale (assenza di connessione) o dal software (parametri errati). In caso di dubbio, partite dall'anello più vicino a voi — il software o l'applicazione — e poi risalite la catena.
+
+Una volta individuata l'origine probabile, trovate qui sotto il vostro **sintomo**: la maggior parte dei problemi più comuni si risolve in pochi passaggi, senza contattare il supporto. Queste guide si applicano a tutte le offerte e-mail di OVHcloud, qualunque sia la vostra.
+
+## Qual è il vostro problema?
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="send-receive" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-advanced" title="Non riesco a inviare o ricevere e-mail" description="Diagnosticate e correggete i malfunzionamenti nell'invio o nella ricezione." />
+  <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="Il mio indirizzo è bloccato per spam" description="Individuate la causa dell'attività sospetta e sbloccate il vostro indirizzo." />
+  <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="La mia casella è piena" description="Gestite e ottimizzate lo spazio di archiviazione del vostro account e-mail." />
+  <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="Ho dimenticato la mia password" description="Reimpostate o modificate la password di un indirizzo e-mail." />
+</CardGrid>
+
+<Region zones={['eu', 'ca']}>
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="deleted" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention" title="Ho eliminato un'e-mail per errore" description="Ripristinate gli elementi eliminati del vostro account e-mail tramite la webmail." />
+</CardGrid>
+
+</Region>
+
+## Strumenti di diagnostica avanzati
+
+Vi state preparando a contattare il supporto o volete analizzare un'e-mail in modo approfondito? Queste guide vanno oltre.
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Recuperare l'intestazione e il file .eml di un'e-mail" description="Estraete le informazioni tecniche di un messaggio per l'analisi o il supporto." />
+  <Region zones={['eu', 'ca']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnostica degli errori di Microsoft Exchange" description="Utilizzate lo strumento di diagnostica dedicato agli account Exchange." />
+  </Region>
+</CardGrid>
+
+## Domande frequenti
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails" title="FAQ e-mail OVHcloud" description="Le risposte alle domande più frequenti sulla messaggistica." />
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra" title="FAQ Zimbra" description="Le risposte alle domande frequenti sulla soluzione Zimbra." />
+  </Region>
+</CardGrid>

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnostica e risoluzione dei problemi e-mail - Documentazione email OVHcloud"
 description: "Risolvete i vostri problemi e-mail OVHcloud: invio o ricezione impossibili, indirizzo bloccato per spam, casella piena, password dimenticata o recupero di e-mail eliminate."
-lastUpdated: 2026-06-26
+lastUpdated: 2026-06-30
 pageType: landing
 banner: true
 tagline: "Individuate e risolvete i problemi più comuni della vostra messaggistica OVHcloud."

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -64,6 +64,10 @@ Vi state preparando a contattare il supporto o volete analizzare un'e-mail in mo
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Recuperare l'intestazione e il file .eml di un'e-mail" description="Estraete le informazioni tecniche di un messaggio per l'analisi o il supporto." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnostica degli errori di Microsoft Exchange" description="Utilizzate lo strumento di diagnostica dedicato agli account Exchange." />
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Richieste di accesso ripetute di Outlook" description="Risolvi le richieste ripetute di accesso di Outlook a Office 365 su una casella Exchange." />
+  </Region>
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-manage-logs" title="Gestire i log di Exchange" description="Visualizzate e gestite i log della vostra offerta Private o Trusted Exchange." />
   </Region>
 </CardGrid>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnostyka i rozwiązywanie problemów z pocztą - Dokumentacja e-mail OVHcloud"
 description: "Rozwiąż problemy z pocztą OVHcloud: brak możliwości wysyłania lub odbierania, adres zablokowany z powodu spamu, pełna skrzynka, zapomniane hasło lub odzyskiwanie usuniętych wiadomości."
-lastUpdated: 2026-06-26
+lastUpdated: 2026-06-30
 pageType: landing
 banner: true
 tagline: "Zidentyfikuj i rozwiąż najczęstsze problemy ze swoją skrzynką OVHcloud."

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -64,6 +64,10 @@ Przygotowujesz się do kontaktu z pomocą techniczną lub chcesz dokładnie prze
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Pobierz nagłówek i plik .eml wiadomości" description="Wyodrębnij informacje techniczne wiadomości do analizy lub dla pomocy technicznej." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnostyka błędów Microsoft Exchange" description="Skorzystaj z narzędzia diagnostycznego dla kont Exchange." />
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Powtarzające się monity logowania Outlook" description="Rozwiąż powtarzające się monity logowania Outlook do Office 365 na skrzynce Exchange." />
+  </Region>
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-manage-logs" title="Zarządzanie logami Exchange" description="Wyświetl i zarządzaj logami oferty Private lub Trusted Exchange." />
   </Region>
 </CardGrid>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,0 +1,77 @@
+---
+title: "Diagnostyka i rozwiązywanie problemów z pocztą - Dokumentacja e-mail OVHcloud"
+description: "Rozwiąż problemy z pocztą OVHcloud: brak możliwości wysyłania lub odbierania, adres zablokowany z powodu spamu, pełna skrzynka, zapomniane hasło lub odzyskiwanie usuniętych wiadomości."
+lastUpdated: 2026-06-26
+pageType: landing
+banner: true
+tagline: "Zidentyfikuj i rozwiąż najczęstsze problemy ze swoją skrzynką OVHcloud."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Sprawdź również
+  items:
+    - title: Odwiedź społeczność OVHcloud
+      link: https://community.ovhcloud.com/
+    - title: Przejrzyj mapę drogową i rejestr zmian
+      link: https://www.ovhcloud.com/pl/roadmap-changelog/
+    - title: Dołącz do Discorda
+      link: https://discord.gg/ovhcloud
+cta:
+  title: Problem nadal występuje? Skontaktuj się z pomocą techniczną OVHcloud
+  description: "Jeśli żaden przewodnik nie rozwiązuje Twojego problemu, nasz zespół pomocy technicznej służy pomocą."
+  actions:
+    - text: Przejdź do pomocy technicznej
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+import { ProblemIcon } from '@components/ProblemIcon';
+import { EmailChainDiagram } from '@components/EmailChainDiagram';
+import { Region } from '@components/Zone';
+
+## Od czego zacząć?
+
+Problem z pocztą e-mail nigdy nie pojawia się przypadkowo: niemal zawsze tkwi w jednym z **czterech ogniw** łańcucha poczty, od serwera OVHcloud aż po używaną aplikację. Wskazanie właściwego ogniwa to już połowa sukcesu: znacznie zawęża możliwe przyczyny i kieruje do odpowiedniego przewodnika.
+
+<EmailChainDiagram />
+
+Ten sam objaw może zresztą wynikać z kilku ogniw: brak możliwości odbioru wiadomości może być spowodowany serwerem (pełna skrzynka), domeną (błędny rekord MX), urządzeniem (brak połączenia) lub oprogramowaniem (nieprawidłowe ustawienia). W razie wątpliwości zacznij od ogniwa najbliższego Tobie — oprogramowania lub aplikacji — a następnie przesuwaj się w górę łańcucha.
+
+Po ustaleniu prawdopodobnego źródła odszukaj poniżej swój **objaw**: większość typowych problemów rozwiązuje się w kilku krokach, bez kontaktu z pomocą techniczną. Te przewodniki dotyczą wszystkich ofert e-mail OVHcloud, niezależnie od tego, którą posiadasz.
+
+## Na czym polega problem?
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="send-receive" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-advanced" title="Nie mogę wysyłać ani odbierać wiadomości" description="Zdiagnozuj i napraw problemy z wysyłaniem lub odbieraniem wiadomości." />
+  <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="Mój adres jest zablokowany z powodu spamu" description="Ustal przyczynę podejrzanej aktywności i odblokuj swój adres." />
+  <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="Moja skrzynka jest pełna" description="Zarządzaj przestrzenią dyskową swojego konta e-mail i optymalizuj ją." />
+  <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="Zapomniałem hasła" description="Zresetuj lub zmień hasło do adresu e-mail." />
+</CardGrid>
+
+<Region zones={['eu', 'ca']}>
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="deleted" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention" title="Przypadkowo usunąłem wiadomość" description="Przywróć usunięte elementy ze swojego konta e-mail przez webmail (OWA)." />
+</CardGrid>
+
+</Region>
+
+## Zaawansowane narzędzia diagnostyczne
+
+Przygotowujesz się do kontaktu z pomocą techniczną lub chcesz dokładnie przeanalizować wiadomość e-mail? Te przewodniki idą dalej.
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Pobierz nagłówek i plik .eml wiadomości" description="Wyodrębnij informacje techniczne wiadomości do analizy lub dla pomocy technicznej." />
+  <Region zones={['eu', 'ca']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnostyka błędów Microsoft Exchange" description="Skorzystaj z narzędzia diagnostycznego dla kont Exchange." />
+  </Region>
+</CardGrid>
+
+## Najczęściej zadawane pytania
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails" title="FAQ e-mail OVHcloud" description="Odpowiedzi na najczęstsze pytania dotyczące poczty." />
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra" title="FAQ Zimbra" description="Odpowiedzi na najczęstsze pytania dotyczące rozwiązania Zimbra." />
+  </Region>
+</CardGrid>

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,0 +1,77 @@
+---
+title: "Diagnóstico e resolução de problemas de e-mail - Documentação de e-mail OVHcloud"
+description: "Resolva os seus problemas de e-mail OVHcloud: envio ou receção impossível, endereço bloqueado por spam, caixa cheia, palavra-passe esquecida ou recuperação de e-mails eliminados."
+lastUpdated: 2026-06-26
+pageType: landing
+banner: true
+tagline: "Identifique e resolva os problemas comuns do seu serviço de e-mail OVHcloud."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Quer saber mais?
+  items:
+    - title: Visitar a comunidade OVHcloud
+      link: https://community.ovhcloud.com/
+    - title: Consultar o roadmap e o changelog
+      link: https://www.ovhcloud.com/pt/roadmap-changelog/
+    - title: Juntar-se ao Discord
+      link: https://discord.gg/ovhcloud
+cta:
+  title: O problema persiste? Aceda ao suporte OVHcloud
+  description: "Se nenhum guia resolver a sua situação, a nossa equipa de suporte está aqui para ajudar."
+  actions:
+    - text: Aceder ao suporte
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+import { ProblemIcon } from '@components/ProblemIcon';
+import { EmailChainDiagram } from '@components/EmailChainDiagram';
+import { Region } from '@components/Zone';
+
+## Por onde começar?
+
+Um problema de e-mail nunca surge por acaso: situa-se quase sempre num dos **quatro elos** da cadeia de e-mail, desde o servidor OVHcloud até à aplicação que utiliza. Identificar o elo certo já é metade da resolução: reduz consideravelmente as causas possíveis e orienta-o para o guia adequado.
+
+<EmailChainDiagram />
+
+Aliás, um mesmo sintoma pode ter origem em vários elos: uma receção impossível pode dever-se ao servidor (caixa cheia), ao domínio (registo MX incorreto), ao terminal (sem ligação) ou ao software (parâmetros errados). Em caso de dúvida, comece pelo elo mais próximo de si — o software ou a aplicação — e depois suba a cadeia.
+
+Depois de identificar a origem provável, localize o seu **sintoma** abaixo: a maioria dos problemas comuns resolve-se em poucos passos, sem contactar o suporte. Estes guias aplicam-se a todas as ofertas de e-mail da OVHcloud, seja qual for a sua.
+
+## Qual é o seu problema?
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="send-receive" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-advanced" title="Não consigo enviar ou receber e-mails" description="Diagnostique e corrija as falhas no envio ou na receção." />
+  <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="O meu endereço está bloqueado por spam" description="Identifique a causa da atividade suspeita e desbloqueie o seu endereço." />
+  <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="A minha caixa de e-mail está cheia" description="Faça a gestão e otimize o espaço de armazenamento da sua conta de e-mail." />
+  <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="Esqueci-me da minha palavra-passe" description="Reponha ou altere a palavra-passe de um endereço de e-mail." />
+</CardGrid>
+
+<Region zones={['eu', 'ca']}>
+
+<CardGrid>
+  <LinkCard icon={<ProblemIcon name="deleted" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention" title="Eliminei um e-mail por engano" description="Restaure os elementos eliminados da sua conta de e-mail através do webmail." />
+</CardGrid>
+
+</Region>
+
+## Ferramentas de diagnóstico avançadas
+
+Está a preparar-se para contactar o suporte ou pretende analisar um e-mail em pormenor? Estes guias vão mais longe.
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Obter o cabeçalho e o ficheiro .eml de um e-mail" description="Extraia as informações técnicas de uma mensagem para análise ou suporte." />
+  <Region zones={['eu', 'ca']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnóstico de erros do Microsoft Exchange" description="Utilize a ferramenta de diagnóstico dedicada às contas Exchange." />
+  </Region>
+</CardGrid>
+
+## Perguntas frequentes
+
+<CardGrid>
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails" title="FAQ de e-mail OVHcloud" description="Respostas às perguntas mais frequentes sobre o e-mail." />
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra" title="FAQ do Zimbra" description="Respostas às perguntas frequentes sobre a solução Zimbra." />
+  </Region>
+</CardGrid>

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnóstico e resolução de problemas de e-mail - Documentação de e-mail OVHcloud"
 description: "Resolva os seus problemas de e-mail OVHcloud: envio ou receção impossível, endereço bloqueado por spam, caixa cheia, palavra-passe esquecida ou recuperação de e-mails eliminados."
-lastUpdated: 2026-06-26
+lastUpdated: 2026-06-30
 pageType: landing
 banner: true
 tagline: "Identifique e resolva os problemas comuns do seu serviço de e-mail OVHcloud."

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -64,6 +64,10 @@ Está a preparar-se para contactar o suporte ou pretende analisar um e-mail em p
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Obter o cabeçalho e o ficheiro .eml de um e-mail" description="Extraia as informações técnicas de uma mensagem para análise ou suporte." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnóstico de erros do Microsoft Exchange" description="Utilize a ferramenta de diagnóstico dedicada às contas Exchange." />
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Pedidos de início de sessão recorrentes do Outlook" description="Corrija os pedidos repetidos de início de sessão do Outlook no Office 365 numa caixa Exchange." />
+  </Region>
+  <Region zones={['eu']}>
+    <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-manage-logs" title="Gerir os logs do Exchange" description="Consulte e faça a gestão dos logs da sua oferta Private ou Trusted Exchange." />
   </Region>
 </CardGrid>
 

--- a/i18n.json
+++ b/i18n.json
@@ -23272,5 +23272,86 @@
     "it": "Il programma dettagliato di questo corso sarà presto disponibile.",
     "pl": "Szczegółowy program tego kursu będzie wkrótce dostępny.",
     "pt": "O programa detalhado deste curso estará disponível em breve."
+  },
+  "sidebar.gen.webCloudEmailAndCollaborativeSolutionsMicrosoftExchangeExchangeManageLogs": {
+    "fr": "Gérer les logs",
+    "en": "Managing logs",
+    "de": "Logs verwalten",
+    "es": "Gestionar los logs",
+    "it": "Gestire i log",
+    "pl": "Zarządzanie logami",
+    "pt": "Gerir os logs"
+  },
+  "sidebar.gen.webCloudEmailAndCollaborativeSolutionsMicrosoftExchangeOutlookConnectingToOffice365": {
+    "fr": "Invites de connexion Outlook",
+    "en": "Outlook sign-in prompts",
+    "de": "Outlook-Anmeldeaufforderungen",
+    "es": "Solicitudes de conexión Outlook",
+    "it": "Richieste di accesso Outlook",
+    "pl": "Monity logowania Outlook",
+    "pt": "Pedidos de início de sessão Outlook"
+  },
+  "sidebar.gen.webCloudEmailAndCollaborativeSolutionsMxPlanEmailRoundcube": {
+    "fr": "Webmail Roundcube",
+    "en": "Webmail Roundcube",
+    "de": "Webmail Roundcube",
+    "es": "Webmail Roundcube",
+    "it": "Webmail Roundcube",
+    "pl": "Webmail Roundcube",
+    "pt": "Webmail Roundcube"
+  },
+  "sidebar.gen.webCloudEmailAndCollaborativeSolutionsMxPlanEmailZimbra": {
+    "fr": "Webmail Zimbra",
+    "en": "Webmail Zimbra",
+    "de": "Webmail Zimbra",
+    "es": "Webmail Zimbra",
+    "it": "Webmail Zimbra",
+    "pl": "Webmail Zimbra",
+    "pt": "Webmail Zimbra"
+  },
+  "sidebar.gen.webCloudEmailAndCollaborativeSolutionsTroubleshootingDiagnosticAdvanced": {
+    "fr": "Envoi/réception impossible",
+    "en": "Cannot send or receive",
+    "de": "Senden/Empfangen nicht möglich",
+    "es": "No se puede enviar/recibir",
+    "it": "Invio/ricezione impossibile",
+    "pl": "Nie można wysłać/odebrać",
+    "pt": "Envio/receção impossível"
+  },
+  "sidebar.gen.webCloudEmailAndCollaborativeSolutionsTroubleshootingDiagnosticHeaders": {
+    "fr": "En-tête d'e-mail (.eml)",
+    "en": "Email headers (.eml)",
+    "de": "E-Mail-Header (.eml)",
+    "es": "Cabecera de correo (.eml)",
+    "it": "Header email (.eml)",
+    "pl": "Nagłówek e-mail (.eml)",
+    "pt": "Cabeçalho de e-mail (.eml)"
+  },
+  "sidebar.gen.webCloudEmailAndCollaborativeSolutionsTroubleshootingDiagnosticRetention": {
+    "fr": "Restaurer les e-mails supprimés",
+    "en": "Restore deleted emails",
+    "de": "Gelöschte E-Mails wiederherstellen",
+    "es": "Restaurar correos eliminados",
+    "it": "Ripristinare email eliminate",
+    "pl": "Przywróć usunięte e-maile",
+    "pt": "Restaurar e-mails eliminados"
+  },
+  "sidebar.gen.webCloudEmailAndCollaborativeSolutionsTroubleshootingEmailManageQuota": {
+    "fr": "Stockage de la boîte",
+    "en": "Mailbox storage",
+    "de": "Postfach-Speicher",
+    "es": "Almacenamiento del buzón",
+    "it": "Spazio della casella",
+    "pl": "Pojemność skrzynki",
+    "pt": "Armazenamento da caixa"
+  },
+  "sidebar.gen.webCloudEmailAndCollaborativeSolutionsTroubleshootingLockedForSpam": {
+    "fr": "Bloquée pour spam",
+    "en": "Blocked for spam",
+    "de": "Wegen Spam gesperrt",
+    "es": "Bloqueada por spam",
+    "it": "Bloccato per spam",
+    "pl": "Zablokowany za spam",
+    "pt": "Bloqueado por spam"
   }
 }


### PR DESCRIPTION
## What

Add a symptom-first **Diagnostic & troubleshooting** landing page for the
Email & Collaborative Solutions hub (new-docs, Rspress/MDX), giving users a
single entry point to troubleshooting content that is currently scattered
across products.

## Changes (FR first)

- New `pageType: landing` page at
  `email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx`,
  organised by symptom ("What is your problem?") rather than by product:
  cannot send/receive, address blocked for spam, mailbox full, forgotten
  password, deleted email (zone-gated `eu`/`ca`).
- "Where to start?" diagnostic schema illustrating the four origins of an
  email problem — mail server, domain DNS config, device, mail software/app.
- Wired as a dedicated email sidebar entry (`{landing=...}` on the existing
  *Troubleshooting* category).

## New reusable components

- `ProblemIcon` — inline, theme-aware SVG symptom icons.
- `EmailChainDiagram` — responsive, theme-aware diagram of the mail chain
  (no external assets).
- `LinkCard` extended with an optional `icon` prop (backward-compatible).

## Validation

- `sidebar:validate`, `overview:validate` ✅ — no broken links, no orphans.
- Rendered and reviewed on the local Rspress dev server.

## Follow-up (out of scope)

- EN parity (page + sidebar already points at the shared landing).
- Screenshots.