### PR TITLE
docs(account): add SIRET retrieval tip to update-vat-rate guide

### DIFF
--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mettre à jour votre taux de TVA
 description: Découvrez comment renseigner votre numéro de SIRET pour mettre à jour le taux de TVA de votre compte de facturation OVHcloud
-lastUpdated: 2026-06-26
+lastUpdated: 2026-06-29
 ---
 
 ## Objectif
@@ -44,6 +44,13 @@ Vous pouvez également enregistrer une mise à jour de votre adresse postale.
 L'enregistrement de votre numéro de SIRET, dans la section **Votre activité**, déclenchera une mise à jour automatique des coordonnées de la société, dont le taux de TVA. Cette mise à jour se base sur le catalogue gouvernemental des déclarations de société.
 
 <img className="thumbnail" alt="Section Votre activité avec le numéro de SIRET dans l'espace client OVHcloud" src="/images/account-and-service-management/managing-billing-payments-and-services/update-vat-rate/company-activity-siret.png" loading="lazy" />
+
+:::tip
+**Où trouver mon numéro SIRET ?**
+
+Votre numéro SIRET est composé de 14 chiffres. Cette donnée étant publique, vous pouvez la retrouver sur l’Annuaire des entreprises et sur le site de l’Insee. Vous la retrouvez également sur votre Kbis ou en tapant votre nom d’entreprise + SIRET sur un moteur de recherche.
+
+:::
 
 :::info
 Vous n'aurez pas la possibilité de changer le statut de l'entreprise de société à particulier, par exemple.


### PR DESCRIPTION
## What

Adds a tip to the *Mettre à jour votre taux de TVA* guide explaining where to find your SIRET number (Annuaire des entreprises, Insee, Kbis, or a web search).

## Why

The guide tells users to enter their SIRET but not how to find it. The tip is reused verbatim from the account-management FAQ, placed right where the number is entered.

## Notes

- FR-only guide (SIRET is France-specific) — no locale propagation.
- Bumped `lastUpdated` to 2026-06-29.