### PR TITLE
docs: restructure SMS and Internet access landing pages

### DIFF
--- a/docs/en/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/en/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -1,7 +1,7 @@
 ---
-title: "SMS - OVHcloud SMS messaging"
+title: "OVHcloud SMS - Documentation"
 description: "Send SMS messages and manage your SMS campaigns with OVHcloud — senders, recipients, credits, replies, and API integration."
-lastUpdated: 2026-06-25
+lastUpdated: 2026-06-29
 pageType: landing
 banner: true
 tagline: "Send SMS messages and manage your SMS campaigns with OVHcloud."
@@ -42,7 +42,7 @@ With this service, you can:
 - Receive replies from your recipients and hold two-way conversations with them using Time2Chat
 - Keep track of your history and top up your SMS credits automatically
 
-## Getting started with SMS
+### Getting started with SMS
 
 <CardGrid>
   <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-control-panel" title="Sending SMS from the Control Panel" description="Send your first SMS directly from the OVHcloud Control Panel." />
@@ -51,28 +51,16 @@ With this service, you can:
   <LinkCard href="/guides/web-cloud/messaging/sms/faq-sms" title="SMS FAQ" description="Find answers to the most frequently asked questions about SMS." />
 </CardGrid>
 
-## Managing senders and recipients
-
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-senders" title="SMS senders" description="Everything you need to know about creating and managing your senders." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-users" title="SMS users" description="Create and manage the users of your SMS service." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/liste-de-destinataire-sms" title="Recipient lists" description="Organise your contacts into reusable recipient lists." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-address-books" title="Address books" description="Manage your SMS address books." />
-</CardGrid>
-
-## Sending SMS via the API
-
-Automate your SMS sends from your own applications. Start with the API SMS Cookbook, then use the code examples for your programming language.
-
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/messaging/sms/api-sms-cookbook" title="API SMS Cookbook" description="Ready-to-use examples to send SMS messages through the OVHcloud API." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-php" title="PHP" description="Send SMS messages with the OVHcloud API in PHP." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-nodejs" title="Node.js" description="Send SMS messages with the OVHcloud API in Node.js." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-java" title="Java" description="Send SMS messages with the OVHcloud API in Java." />
-</CardGrid>
-
 <CategoryColumns
   categories={[
+    {
+      title: 'Senders and recipients',
+      items: [
+        { title: 'SMS senders', link: '/guides/web-cloud/messaging/sms/sms-senders' },
+        { title: 'Recipient lists', link: '/guides/web-cloud/messaging/sms/liste-de-destinataire-sms' },
+        { title: 'Address books', link: '/guides/web-cloud/messaging/sms/sms-address-books' },
+      ],
+    },
     {
       title: 'Sending options',
       items: [
@@ -84,15 +72,25 @@ Automate your SMS sends from your own applications. Start with the API SMS Cookb
       ],
     },
     {
-      title: 'Developers (API & SMPP)',
+      title: 'SMS API',
       items: [
+        { title: 'SMS users', link: '/guides/web-cloud/messaging/sms/sms-users' },
+        { title: 'API SMS Cookbook', link: '/guides/web-cloud/messaging/sms/api-sms-cookbook' },
+        { title: 'Sending SMS with the OVHcloud API in PHP', link: '/guides/web-cloud/messaging/sms/send-sms-api-php' },
+        { title: 'Sending SMS with the OVHcloud API in Node.js', link: '/guides/web-cloud/messaging/sms/send-sms-api-nodejs' },
+        { title: 'Sending SMS with the OVHcloud API in Java', link: '/guides/web-cloud/messaging/sms/send-sms-api-java' },
         { title: 'Sending SMS with the API in C#', link: '/guides/web-cloud/messaging/sms/sending-via-api-c' },
+      ],
+    },
+    {
+      title: 'SMPP',
+      items: [
         { title: 'Managing an SMS SMPP account', link: '/guides/web-cloud/messaging/sms/smpp-control-panel' },
         { title: 'SMPP technical specifications', link: '/guides/web-cloud/messaging/sms/smpp-specification' },
       ],
     },
     {
-      title: 'Tools & monitoring',
+      title: 'Tools and tracking',
       items: [
         { title: 'Managing your SMS history', link: '/guides/web-cloud/messaging/sms/sms-history' },
         { title: 'Checking number validity with HLR Lookup', link: '/guides/web-cloud/messaging/sms/sms-hlr' },

--- a/docs/es/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/es/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -1,7 +1,7 @@
 ---
-title: "SMS - Documentación de SMS de OVHcloud"
+title: "SMS de OVHcloud - Documentación"
 description: "Envíe SMS y gestione sus campañas de SMS con OVHcloud: remitentes, destinatarios, créditos e integración mediante la API."
-lastUpdated: 2026-06-25
+lastUpdated: 2026-06-29
 pageType: landing
 banner: true
 tagline: "Envíe SMS y gestione sus campañas de SMS con OVHcloud."
@@ -41,7 +41,7 @@ Con este servicio, puede:
 - Gestionar sus remitentes, sus usuarios y sus listas de destinatarios
 - Hacer un seguimiento de su historial y recargar automáticamente sus créditos de SMS
 
-## Primeros pasos con el servicio SMS
+### Primeros pasos con el servicio SMS
 
 <CardGrid>
   <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-control-panel" title="Enviar SMS desde el área de cliente" description="Envíe sus primeros SMS directamente desde el área de cliente de OVHcloud." />
@@ -50,28 +50,16 @@ Con este servicio, puede:
   <LinkCard href="/guides/web-cloud/messaging/sms/faq-sms" title="FAQ SMS" description="Encuentre respuestas a las preguntas más frecuentes sobre los SMS." />
 </CardGrid>
 
-## Gestionar los remitentes y los destinatarios
-
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-senders" title="Remitentes SMS" description="Todo lo que necesita saber para crear y gestionar sus remitentes." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-users" title="Usuarios SMS" description="Cree y gestione los usuarios de su servicio SMS." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/liste-de-destinataire-sms" title="Listas de destinatarios" description="Organice sus contactos en listas de destinatarios reutilizables." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-address-books" title="Libretas de direcciones" description="Gestione sus libretas de direcciones SMS." />
-</CardGrid>
-
-## Enviar SMS mediante la API
-
-Automatice sus envíos de SMS desde sus propias aplicaciones. Empiece por la API SMS Cookbook y, a continuación, utilice los ejemplos de código adaptados a su lenguaje de programación.
-
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/messaging/sms/api-sms-cookbook" title="API SMS Cookbook" description="Ejemplos listos para usar para enviar SMS mediante la API de OVHcloud." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-php" title="PHP" description="Envíe SMS con la API de OVHcloud en PHP." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-nodejs" title="Node.js" description="Envíe SMS con la API de OVHcloud en Node.js." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-java" title="Java" description="Envíe SMS con la API de OVHcloud en Java." />
-</CardGrid>
-
 <CategoryColumns
   categories={[
+    {
+      title: 'Remitentes y destinatarios',
+      items: [
+        { title: 'Remitentes SMS', link: '/guides/web-cloud/messaging/sms/sms-senders' },
+        { title: 'Listas de destinatarios', link: '/guides/web-cloud/messaging/sms/liste-de-destinataire-sms' },
+        { title: 'Libretas de direcciones', link: '/guides/web-cloud/messaging/sms/sms-address-books' },
+      ],
+    },
     {
       title: 'Opciones de envío',
       items: [
@@ -81,15 +69,25 @@ Automatice sus envíos de SMS desde sus propias aplicaciones. Empiece por la API
       ],
     },
     {
-      title: 'Desarrolladores (API y SMPP)',
+      title: 'API SMS',
       items: [
+        { title: 'Usuarios SMS', link: '/guides/web-cloud/messaging/sms/sms-users' },
+        { title: 'API SMS Cookbook', link: '/guides/web-cloud/messaging/sms/api-sms-cookbook' },
+        { title: 'Enviar SMS con la API de OVHcloud en PHP', link: '/guides/web-cloud/messaging/sms/send-sms-api-php' },
+        { title: 'Enviar SMS con la API de OVHcloud en Node.js', link: '/guides/web-cloud/messaging/sms/send-sms-api-nodejs' },
+        { title: 'Enviar SMS con la API de OVHcloud en Java', link: '/guides/web-cloud/messaging/sms/send-sms-api-java' },
         { title: 'Enviar SMS con la API en C#', link: '/guides/web-cloud/messaging/sms/sending-via-api-c' },
+      ],
+    },
+    {
+      title: 'SMPP',
+      items: [
         { title: 'Gestionar una cuenta SMS SMPP', link: '/guides/web-cloud/messaging/sms/smpp-control-panel' },
         { title: 'Especificaciones técnicas de SMPP', link: '/guides/web-cloud/messaging/sms/smpp-specification' },
       ],
     },
     {
-      title: 'Herramientas y seguimiento',
+      title: 'Seguimiento',
       items: [
         { title: 'Gestionar su historial de SMS', link: '/guides/web-cloud/messaging/sms/sms-history' },
       ],

--- a/docs/fr/guides/web-cloud/internet/internet-access/landing-page-internet-access.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/landing-page-internet-access.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Accès Internet - Documentation OVHcloud"
+title: "Accès Internet OVHcloud - Documentation"
 description: "Configurez, gérez et dépannez votre accès Internet xDSL et Fibre OVHcloud : box, identifiants PPPoE, IPv6, reverse DNS, options et résolution d'incidents."
-lastUpdated: 2026-06-26
+lastUpdated: 2026-06-29
 pageType: landing
 banner: true
 tagline: "Configurez, gérez et dépannez votre accès Internet xDSL et Fibre OVHcloud."
@@ -24,14 +24,13 @@ cta:
       theme: brand
 ---
 
-import { Tab, Tabs } from '@rspress/core/theme';
 import { LinkCard } from '@components/LinkCard';
 
 ## Présentation de l'accès Internet OVHcloud
 
 L'[accès Internet OVHcloud](https://www.ovhcloud.com/fr/internet/) vous permet de connecter votre domicile ou votre entreprise à Internet via une offre xDSL ou [Fibre](https://www.ovhcloud.com/fr/internet/fibre/). Retrouvez ici tous les guides pour mettre en service, configurer, administrer et dépanner votre connexion.
 
-Avec votre accès Internet OVHcloud, vous pouvez :
+Avec votre accès Internet OVHcloud, vous pouvez :
 
 - Configurer votre box et personnaliser votre profil de synchronisation
 - Gérer vos paramètres réseau avancés (IPv6, reverse DNS, bloc IP /29, mode bridge)
@@ -39,67 +38,76 @@ Avec votre accès Internet OVHcloud, vous pouvez :
 - Surveiller la stabilité de votre lien et diagnostiquer les interruptions de service
 - Faire évoluer ou déménager votre offre xDSL/Fibre
 
-## Premiers pas avec votre accès Internet
+### Premiers pas avec votre accès Internet
 
 <CardGrid>
+  <LinkCard href="/guides/web-cloud/internet/internet-access/configuration-du-modem-a-partir-de-votre-espace-client" title="Configurer votre box" description="Paramétrez votre box directement depuis l'espace client OVHcloud." />
+  <LinkCard href="/guides/web-cloud/internet/internet-access/comment-activer-mes-lignes-telephoniques-offre-adsl-vdsl" title="Activer vos lignes téléphoniques" description="Activez les lignes téléphoniques incluses dans votre offre FTTH/xDSL." />
+  <LinkCard href="/guides/web-cloud/internet/internet-access/comment-gerer-mes-adresses-e-mails" title="Activer vos adresses e-mail" description="Activez les adresses e-mail incluses dans votre offre FTTH/xDSL." />
   <LinkCard href="/guides/web-cloud/internet/internet-access/faq" title="FAQ solutions Internet" description="Les réponses aux questions les plus fréquentes sur les solutions Internet OVHcloud." />
-  <LinkCard href="/guides/web-cloud/internet/internet-access/obtenir-id-ppp" title="Obtenir les identifiants PPPoE" description="Récupérez les identifiants nécessaires à la connexion de votre accès." />
-  <LinkCard href="/guides/web-cloud/internet/internet-access/configuration-du-modem-a-partir-de-votre-espace-client" title="Configurer sa box" description="Paramétrez votre box directement depuis l'espace client OVHcloud." />
-  <LinkCard href="/guides/web-cloud/internet/internet-access/comment-activer-mes-lignes-telephoniques-offre-adsl-vdsl" title="Activer vos lignes téléphoniques" description="Activez les lignes téléphoniques incluses dans votre offre ADSL/VDSL/FTTH." />
 </CardGrid>
-
-## Configurer et administrer votre accès
-
-<Tabs>
-  <Tab label="Mise en service">
-    - [Modification du profil de synchronisation](/guides/web-cloud/internet/internet-access/modification-du-profil-de-synchronisation)
-    - [Comment configurer le reverse DNS de ma connexion](/guides/web-cloud/internet/internet-access/comment-configurer-le-reverse-dns-de-ma-connexion)
-    - [Activer l'adresse IPv6 d'une connexion Internet OVHcloud](/guides/web-cloud/internet/internet-access/comment-gerer-ipv6)
-    - [Activer les adresses e-mail incluses dans votre offre FTTH/xDSL](/guides/web-cloud/internet/internet-access/comment-gerer-mes-adresses-e-mails)
-  </Tab>
-  <Tab label="Gérer mon offre">
-    - [Comment changer mon offre xDSL/Fibre](/guides/web-cloud/internet/internet-access/comment-changer-mon-offre-xdsl)
-    - [Fin du cuivre - Comment migrer mon offre xDSL vers la Fibre ?](/guides/web-cloud/internet/internet-access/end-of-copper-migration-ftth)
-    - [Comment déménager mon accès xDSL/Fibre](/guides/web-cloud/internet/internet-access/comment-demenager-mon-acces-xdsl)
-    - [Comment résilier un accès xDSL/Fibre](/guides/web-cloud/internet/internet-access/comment-resilier-mon-acces-xdsl)
-    - [VoIP / Accès Internet - Déroulement d'un RMA](/guides/web-cloud/phone-and-fax/voip/deroulement-d-un-rma)
-  </Tab>
-  <Tab label="Configuration avancée">
-    - [Comment activer le mode bridge sur un modem Zyxel](/guides/web-cloud/internet/internet-access/comment-activer-bridge-zyxel)
-    - [Comment réutiliser le WiFi d'un modem Zyxel avec OverTheBox](/guides/web-cloud/internet/internet-access/comment-reutiliser-wifi-zyxel-otb)
-    - [Activer ou désactiver l'envoi d'e-mails depuis le SMTP OVHcloud](/guides/web-cloud/internet/internet-access/comment-activer-envoi-mail)
-    - [Gérer et configurer un bloc IP /29](/guides/web-cloud/internet/internet-access/comment-commander-et-gerer-un-bloc-ip-29)
-    - [Comment changer le backend ACS du modem](/guides/web-cloud/internet/internet-access/comment-changer-backend-acs)
-    - [Premiers pas avec l'API Connectivity OVHcloud](/guides/web-cloud/internet/internet-access/connectivity-api)
-    - [Configurer un routeur manuellement](/guides/web-cloud/internet/internet-access/advanced-config-router-manually)
-  </Tab>
-</Tabs>
 
 <CategoryColumns
   categories={[
     {
-      title: 'Concepts clés',
+      title: 'Configuration de la box',
       items: [
-        { title: 'La desserte interne', link: '/guides/web-cloud/internet/internet-access/la-desserte-interne' },
-        { title: 'Comprendre le cycle de vie des commandes FTTE et FTTO', link: '/guides/web-cloud/internet/internet-access/cycle-de-vie-des-commandes-ftte-ftto' },
+        { title: 'Comment activer le mode bridge sur un modem Zyxel', link: '/guides/web-cloud/internet/internet-access/comment-activer-bridge-zyxel' },
+        { title: "Comment réutiliser le WiFi d'un modem Zyxel avec OverTheBox", link: '/guides/web-cloud/internet/internet-access/comment-reutiliser-wifi-zyxel-otb' },
+        { title: 'Comment changer le backend ACS du modem', link: '/guides/web-cloud/internet/internet-access/comment-changer-backend-acs' },
+        { title: 'Obtenir les identifiants PPPoE', link: '/guides/web-cloud/internet/internet-access/obtenir-id-ppp' },
+        { title: 'Configurer un routeur manuellement', link: '/guides/web-cloud/internet/internet-access/advanced-config-router-manually' },
       ],
     },
     {
-      title: 'Dépannage',
+      title: 'Configuration réseau',
       items: [
-        { title: 'Redémarrer ou réinitialiser une box OVHcloud', link: '/guides/web-cloud/internet/internet-access/restart-reboot-modem' },
-        { title: 'Dépanner son accès Internet fibre', link: '/guides/web-cloud/internet/internet-access/ftth-fix-access' },
-        { title: 'Résoudre une interruption ou des lenteurs de navigation', link: '/guides/web-cloud/internet/internet-access/resoudre-interruption-lenteurs-navigation' },
-        { title: 'Rétablir la synchronisation suite à une coupure', link: '/guides/web-cloud/internet/internet-access/reestablish-synchronization' },
-        { title: 'Rétablir son service suite à une coupure complète ou partielle', link: '/guides/web-cloud/internet/internet-access/interruption-de-service' },
+        { title: 'Modification du profil de synchronisation', link: '/guides/web-cloud/internet/internet-access/modification-du-profil-de-synchronisation' },
+        { title: 'Comment configurer le reverse DNS de ma connexion', link: '/guides/web-cloud/internet/internet-access/comment-configurer-le-reverse-dns-de-ma-connexion' },
+        { title: "Activer l'adresse IPv6 d'une connexion Internet OVHcloud", link: '/guides/web-cloud/internet/internet-access/comment-gerer-ipv6' },
+        { title: 'Gérer et configurer un bloc IP /29', link: '/guides/web-cloud/internet/internet-access/comment-commander-et-gerer-un-bloc-ip-29' },
+      ],
+    },
+    {
+      title: 'Gérer mon offre',
+      items: [
+        { title: 'Comment changer mon offre xDSL/Fibre', link: '/guides/web-cloud/internet/internet-access/comment-changer-mon-offre-xdsl' },
+        { title: 'Fin du cuivre - Comment migrer mon offre xDSL vers la Fibre ?', link: '/guides/web-cloud/internet/internet-access/end-of-copper-migration-ftth' },
+        { title: "Comment déménager mon accès xDSL/Fibre", link: '/guides/web-cloud/internet/internet-access/comment-demenager-mon-acces-xdsl' },
+        { title: 'Comment résilier un accès xDSL/Fibre', link: '/guides/web-cloud/internet/internet-access/comment-resilier-mon-acces-xdsl' },
+        { title: "VoIP / Accès Internet - Déroulement d'un RMA", link: '/guides/web-cloud/phone-and-fax/voip/deroulement-d-un-rma' },
       ],
     },
     {
       title: 'Surveillance et diagnostic',
       items: [
+        { title: 'Activer une alerte de monitoring', link: '/guides/web-cloud/internet/internet-access/monitoring' },
         { title: 'Vérifier si son lien xDSL est saturé', link: '/guides/web-cloud/internet/internet-access/verifier-lien-xdsl-sature' },
         { title: 'Vérifier la stabilité de son accès via les logs radius', link: '/guides/web-cloud/internet/internet-access/verifier-stabilite-acces' },
-        { title: 'Activer une alerte de monitoring', link: '/guides/web-cloud/internet/internet-access/monitoring' },
+      ],
+    },
+    {
+      title: "Résolution d'incidents",
+      items: [
+        { title: 'Résoudre une interruption ou des lenteurs de navigation', link: '/guides/web-cloud/internet/internet-access/resoudre-interruption-lenteurs-navigation' },
+        { title: 'Redémarrer ou réinitialiser une box OVHcloud', link: '/guides/web-cloud/internet/internet-access/restart-reboot-modem' },
+        { title: 'Dépanner son accès Internet fibre', link: '/guides/web-cloud/internet/internet-access/ftth-fix-access' },
+        { title: 'Rétablir la synchronisation suite à une coupure', link: '/guides/web-cloud/internet/internet-access/reestablish-synchronization' },
+        { title: 'Rétablir son service suite à une coupure complète ou partielle', link: '/guides/web-cloud/internet/internet-access/interruption-de-service' },
+      ],
+    },
+    {
+      title: 'E-mail et API',
+      items: [
+        { title: "Activer ou désactiver l'envoi d'e-mails depuis le SMTP OVHcloud", link: '/guides/web-cloud/internet/internet-access/comment-activer-envoi-mail' },
+        { title: "Premiers pas avec l'API Connectivity OVHcloud", link: '/guides/web-cloud/internet/internet-access/connectivity-api' },
+      ],
+    },
+    {
+      title: 'Concepts clés',
+      items: [
+        { title: 'La desserte interne', link: '/guides/web-cloud/internet/internet-access/la-desserte-interne' },
+        { title: 'Comprendre le cycle de vie des commandes FTTE et FTTO', link: '/guides/web-cloud/internet/internet-access/cycle-de-vie-des-commandes-ftte-ftto' },
       ],
     },
   ]}

--- a/docs/fr/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -1,7 +1,7 @@
 ---
-title: "SMS - Documentation SMS OVHcloud"
+title: "SMS OVHcloud - Documentation"
 description: "Envoyez des SMS et gérez vos campagnes SMS avec OVHcloud : expéditeurs, destinataires, crédits, réponses et intégration via l'API."
-lastUpdated: 2026-06-25
+lastUpdated: 2026-06-29
 pageType: landing
 banner: true
 tagline: "Envoyez des SMS et gérez vos campagnes SMS avec OVHcloud."
@@ -30,9 +30,9 @@ import { LinkCard } from '@components/LinkCard';
 Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
-## Présentation du service SMS d'OVHcloud
+## Présentation du service SMS OVHcloud
 
-Le [service SMS d'OVHcloud](/links/telecom/sms) vous permet d'envoyer des SMS à vos clients et à vos contacts, à l'unité ou en campagnes de masse, depuis l'espace client OVHcloud ou directement depuis vos applications via l'API. Retrouvez ici tous les guides pour configurer, envoyer et gérer vos SMS.
+Le [service SMS OVHcloud](/links/telecom/sms) vous permet d'envoyer des SMS à vos clients et à vos contacts, à l'unité ou en campagnes de masse, depuis l'espace client OVHcloud ou directement depuis vos applications via l'API. Retrouvez ici tous les guides pour configurer, envoyer et gérer vos SMS.
 
 Avec ce service, vous pouvez :
 
@@ -42,7 +42,7 @@ Avec ce service, vous pouvez :
 - Recevoir les réponses de vos destinataires et dialoguer avec eux grâce à Time2Chat
 - Suivre votre historique et recharger automatiquement vos crédits SMS
 
-## Premiers pas avec le service SMS
+### Premiers pas avec le service SMS
 
 <CardGrid>
   <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-control-panel" title="Envoyer des SMS depuis l'espace client" description="Envoyez vos premiers SMS directement depuis l'espace client OVHcloud." />
@@ -51,28 +51,16 @@ Avec ce service, vous pouvez :
   <LinkCard href="/guides/web-cloud/messaging/sms/faq-sms" title="FAQ SMS" description="Retrouvez les réponses aux questions les plus fréquentes sur les SMS." />
 </CardGrid>
 
-## Gérer les expéditeurs et les destinataires
-
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-senders" title="Expéditeurs SMS" description="Tout savoir sur la création et la gestion de vos expéditeurs." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-users" title="Utilisateurs SMS" description="Créez et gérez les utilisateurs de votre service SMS." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/liste-de-destinataire-sms" title="Listes de destinataires" description="Organisez vos contacts en listes de destinataires réutilisables." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-address-books" title="Carnets d'adresses" description="Gérez vos carnets d'adresses SMS." />
-</CardGrid>
-
-## Envoyer des SMS via l'API
-
-Automatisez vos envois de SMS depuis vos propres applications. Commencez par l'API SMS Cookbook, puis utilisez les exemples de code adaptés à votre langage de programmation.
-
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/messaging/sms/api-sms-cookbook" title="API SMS Cookbook" description="Des exemples prêts à l'emploi pour envoyer des SMS via l'API OVHcloud." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-php" title="PHP" description="Envoyez des SMS avec l'API OVHcloud en PHP." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-nodejs" title="Node.js" description="Envoyez des SMS avec l'API OVHcloud en Node.js." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-java" title="Java" description="Envoyez des SMS avec l'API OVHcloud en Java." />
-</CardGrid>
-
 <CategoryColumns
   categories={[
+    {
+      title: 'Expéditeurs et destinataires',
+      items: [
+        { title: 'Expéditeurs SMS', link: '/guides/web-cloud/messaging/sms/sms-senders' },
+        { title: 'Listes de destinataires', link: '/guides/web-cloud/messaging/sms/liste-de-destinataire-sms' },
+        { title: "Carnets d'adresses", link: '/guides/web-cloud/messaging/sms/sms-address-books' },
+      ],
+    },
     {
       title: "Options d'envoi",
       items: [
@@ -84,9 +72,19 @@ Automatisez vos envois de SMS depuis vos propres applications. Commencez par l'A
       ],
     },
     {
-      title: 'Développeurs (API & SMPP)',
+      title: 'API SMS',
       items: [
+        { title: 'Utilisateurs SMS', link: '/guides/web-cloud/messaging/sms/sms-users' },
+        { title: 'API SMS Cookbook', link: '/guides/web-cloud/messaging/sms/api-sms-cookbook' },
+        { title: "Envoyer des SMS avec l'API OVHcloud en PHP", link: '/guides/web-cloud/messaging/sms/send-sms-api-php' },
+        { title: "Envoyer des SMS avec l'API OVHcloud en Node.js", link: '/guides/web-cloud/messaging/sms/send-sms-api-nodejs' },
+        { title: "Envoyer des SMS avec l'API OVHcloud en Java", link: '/guides/web-cloud/messaging/sms/send-sms-api-java' },
         { title: "Envoyer des SMS avec l'API en C#", link: '/guides/web-cloud/messaging/sms/sending-via-api-c' },
+      ],
+    },
+    {
+      title: 'SMPP',
+      items: [
         { title: 'Gérer un compte SMS SMPP', link: '/guides/web-cloud/messaging/sms/smpp-control-panel' },
         { title: 'Spécifications techniques du SMPP', link: '/guides/web-cloud/messaging/sms/smpp-specification' },
       ],

--- a/docs/it/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/it/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -1,7 +1,7 @@
 ---
-title: "SMS - Documentazione SMS OVHcloud"
+title: "SMS OVHcloud - Documentazione"
 description: "Invia SMS e gestisci le tue campagne SMS con OVHcloud: mittenti, destinatari, crediti e integrazione tramite API."
-lastUpdated: 2026-06-25
+lastUpdated: 2026-06-29
 pageType: landing
 banner: true
 tagline: "Invia SMS e gestisci le tue campagne SMS con OVHcloud."
@@ -37,7 +37,7 @@ Con questo servizio puoi:
 - Gestire i tuoi mittenti, i tuoi utenti e le tue liste di destinatari
 - Monitorare lo storico e ricaricare automaticamente i tuoi crediti SMS
 
-## Primi passi con il servizio SMS
+### Primi passi con il servizio SMS
 
 <CardGrid>
   <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-control-panel" title="Inviare SMS dallo Spazio Cliente" description="Invia i tuoi primi SMS direttamente dallo Spazio Cliente OVHcloud." />
@@ -46,28 +46,16 @@ Con questo servizio puoi:
   <LinkCard href="/guides/web-cloud/messaging/sms/faq-sms" title="FAQ SMS" description="Trova le risposte alle domande più frequenti sugli SMS." />
 </CardGrid>
 
-## Gestire i mittenti e i destinatari
-
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-senders" title="Mittenti SMS" description="Tutto ciò che devi sapere per creare e gestire i tuoi mittenti." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-users" title="Utenti SMS" description="Crea e gestisci gli utenti del tuo servizio SMS." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/liste-de-destinataire-sms" title="Liste di destinatari" description="Organizza i tuoi contatti in liste di destinatari riutilizzabili." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-address-books" title="Rubriche" description="Gestisci le tue rubriche SMS." />
-</CardGrid>
-
-## Inviare SMS tramite l'API
-
-Automatizza i tuoi invii di SMS dalle tue applicazioni. Inizia con l'API SMS Cookbook, poi utilizza gli esempi di codice adatti al tuo linguaggio di programmazione.
-
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/messaging/sms/api-sms-cookbook" title="API SMS Cookbook" description="Esempi pronti all'uso per inviare SMS tramite l'API OVHcloud." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-php" title="PHP" description="Invia SMS con l'API OVHcloud in PHP." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-nodejs" title="Node.js" description="Invia SMS con l'API OVHcloud in Node.js." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-java" title="Java" description="Invia SMS con l'API OVHcloud in Java." />
-</CardGrid>
-
 <CategoryColumns
   categories={[
+    {
+      title: 'Mittenti e destinatari',
+      items: [
+        { title: 'Mittenti SMS', link: '/guides/web-cloud/messaging/sms/sms-senders' },
+        { title: 'Liste di destinatari', link: '/guides/web-cloud/messaging/sms/liste-de-destinataire-sms' },
+        { title: 'Rubriche', link: '/guides/web-cloud/messaging/sms/sms-address-books' },
+      ],
+    },
     {
       title: 'Opzioni di invio',
       items: [
@@ -77,15 +65,25 @@ Automatizza i tuoi invii di SMS dalle tue applicazioni. Inizia con l'API SMS Coo
       ],
     },
     {
-      title: 'Sviluppatori (API e SMPP)',
+      title: 'API SMS',
       items: [
+        { title: 'Utenti SMS', link: '/guides/web-cloud/messaging/sms/sms-users' },
+        { title: 'API SMS Cookbook', link: '/guides/web-cloud/messaging/sms/api-sms-cookbook' },
+        { title: "Inviare SMS con l'API OVHcloud in PHP", link: '/guides/web-cloud/messaging/sms/send-sms-api-php' },
+        { title: "Inviare SMS con l'API OVHcloud in Node.js", link: '/guides/web-cloud/messaging/sms/send-sms-api-nodejs' },
+        { title: "Inviare SMS con l'API OVHcloud in Java", link: '/guides/web-cloud/messaging/sms/send-sms-api-java' },
         { title: "Inviare SMS con l'API in C#", link: '/guides/web-cloud/messaging/sms/sending-via-api-c' },
+      ],
+    },
+    {
+      title: 'SMPP',
+      items: [
         { title: 'Gestire un account SMS SMPP', link: '/guides/web-cloud/messaging/sms/smpp-control-panel' },
         { title: 'Specifiche tecniche di SMPP', link: '/guides/web-cloud/messaging/sms/smpp-specification' },
       ],
     },
     {
-      title: 'Strumenti e monitoraggio',
+      title: 'Monitoraggio',
       items: [
         { title: 'Gestire lo storico SMS', link: '/guides/web-cloud/messaging/sms/sms-history' },
       ],

--- a/docs/pl/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/pl/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -1,7 +1,7 @@
 ---
-title: "SMS - Dokumentacja SMS OVHcloud"
+title: "SMS OVHcloud - Dokumentacja"
 description: "Wysyłaj wiadomości SMS i zarządzaj kampaniami SMS w OVHcloud: nadawcy, odbiorcy, środki i integracja z API."
-lastUpdated: 2026-06-25
+lastUpdated: 2026-06-29
 pageType: landing
 banner: true
 tagline: "Wysyłaj wiadomości SMS i zarządzaj kampaniami SMS w OVHcloud."
@@ -37,7 +37,7 @@ Dzięki tej usłudze możesz:
 - Zarządzać nadawcami, użytkownikami i listami odbiorców
 - Śledzić historię i automatycznie doładowywać środki na koncie SMS
 
-## Pierwsze kroki z usługą SMS
+### Pierwsze kroki z usługą SMS
 
 <CardGrid>
   <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-control-panel" title="Wysyłanie SMS z Panelu klienta" description="Wyślij pierwsze wiadomości SMS bezpośrednio z Panelu klienta OVHcloud." />
@@ -46,28 +46,16 @@ Dzięki tej usłudze możesz:
   <LinkCard href="/guides/web-cloud/messaging/sms/faq-sms" title="FAQ SMS" description="Znajdź odpowiedzi na najczęściej zadawane pytania dotyczące SMS." />
 </CardGrid>
 
-## Zarządzanie nadawcami i odbiorcami
-
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-senders" title="Nadawcy SMS" description="Wszystko, co musisz wiedzieć o tworzeniu nadawców i zarządzaniu nimi." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-users" title="Użytkownicy SMS" description="Twórz użytkowników usługi SMS i zarządzaj nimi." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/liste-de-destinataire-sms" title="Listy odbiorców" description="Uporządkuj kontakty w listy odbiorców do wielokrotnego użytku." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/sms-address-books" title="Książki adresowe" description="Zarządzaj książkami adresowymi SMS." />
-</CardGrid>
-
-## Wysyłanie SMS za pośrednictwem API
-
-Zautomatyzuj wysyłkę wiadomości SMS z własnych aplikacji. Zacznij od API SMS Cookbook, a następnie skorzystaj z przykładów kodu dostosowanych do Twojego języka programowania.
-
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/messaging/sms/api-sms-cookbook" title="API SMS Cookbook" description="Gotowe przykłady wysyłania wiadomości SMS za pośrednictwem API OVHcloud." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-php" title="PHP" description="Wysyłaj wiadomości SMS za pomocą API OVHcloud w PHP." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-nodejs" title="Node.js" description="Wysyłaj wiadomości SMS za pomocą API OVHcloud w Node.js." />
-  <LinkCard href="/guides/web-cloud/messaging/sms/send-sms-api-java" title="Java" description="Wysyłaj wiadomości SMS za pomocą API OVHcloud w Java." />
-</CardGrid>
-
 <CategoryColumns
   categories={[
+    {
+      title: 'Nadawcy i odbiorcy',
+      items: [
+        { title: 'Nadawcy SMS', link: '/guides/web-cloud/messaging/sms/sms-senders' },
+        { title: 'Listy odbiorców', link: '/guides/web-cloud/messaging/sms/liste-de-destinataire-sms' },
+        { title: 'Książki adresowe', link: '/guides/web-cloud/messaging/sms/sms-address-books' },
+      ],
+    },
     {
       title: 'Opcje wysyłki',
       items: [
@@ -77,15 +65,25 @@ Zautomatyzuj wysyłkę wiadomości SMS z własnych aplikacji. Zacznij od API SMS
       ],
     },
     {
-      title: 'Dla programistów (API i SMPP)',
+      title: 'API SMS',
       items: [
+        { title: 'Użytkownicy SMS', link: '/guides/web-cloud/messaging/sms/sms-users' },
+        { title: 'API SMS Cookbook', link: '/guides/web-cloud/messaging/sms/api-sms-cookbook' },
+        { title: 'Wysyłanie SMS za pomocą API OVHcloud w PHP', link: '/guides/web-cloud/messaging/sms/send-sms-api-php' },
+        { title: 'Wysyłanie SMS za pomocą API OVHcloud w Node.js', link: '/guides/web-cloud/messaging/sms/send-sms-api-nodejs' },
+        { title: 'Wysyłanie SMS za pomocą API OVHcloud w Java', link: '/guides/web-cloud/messaging/sms/send-sms-api-java' },
         { title: 'Wysyłanie SMS za pomocą API w C#', link: '/guides/web-cloud/messaging/sms/sending-via-api-c' },
+      ],
+    },
+    {
+      title: 'SMPP',
+      items: [
         { title: 'Zarządzanie kontem SMS SMPP', link: '/guides/web-cloud/messaging/sms/smpp-control-panel' },
         { title: 'Specyfikacja techniczna SMPP', link: '/guides/web-cloud/messaging/sms/smpp-specification' },
       ],
     },
     {
-      title: 'Narzędzia i monitorowanie',
+      title: 'Monitorowanie',
       items: [
         { title: 'Zarządzanie historią SMS', link: '/guides/web-cloud/messaging/sms/sms-history' },
       ],


### PR DESCRIPTION
Drop the tabbed sections in favour of a single balanced CategoryColumns under the cards, with "Getting started" nested as H3.

SMS LP (fr/en/es/it/pl):
- replace the tabbed section with one CategoryColumns: Senders & recipients, Sending options, SMS API, SMPP, Tools & tracking
- move "SMS users" into the API column (first item)
- es/it/pl keep their leaner link set (no reply/Time2Chat/HLR guides in those locales); single-item tracking column renamed accordingly
- fr: use "service SMS OVHcloud" (drop "d'") in title and body

Internet access LP (fr):
- replace the tabbed section with one balanced CategoryColumns: box config, network config, manage offer, monitoring & diagnostics, incident resolution, email & API, key concepts
- move email-address activation into the getting-started cards
- terminology/wording fixes (FTTH/xDSL, NBSP before colon)

Standardize landing page titles to "<Product> OVHcloud - Documentation" (removes the duplicate "SMS"); bump lastUpdated to 2026-06-29.