### PR TITLE
docs: enable tab sync on PAT guide

### DIFF
--- a/docs/de/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
+++ b/docs/de/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
@@ -55,7 +55,7 @@ Wenn Sie Zugangsdaten für automatisierte Produktionsintegrationen benötigen, d
 
 Ersetzen Sie `{user}` durch die Anmeldung Ihres lokalen Benutzers (zum Beispiel `1234-567-89/johnsmith`).
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Über das OVHcloud Kundencenter">
     Rufen Sie auf der Seite <ManagerLink to="/#/iam/identities/users">IAM Identitäten</ManagerLink> am Ende der Zeile des lokalen Benutzers auf die Schaltfläche <code className="action">…</code> und wählen Sie <code className="action">Token verwalten</code>.
 
@@ -169,7 +169,7 @@ Ersetzen Sie `<any_suffix>` durch eine beliebige ASCII-Zeichenkette zur Identifi
 
 #### Vorhandene Tokens auflisten
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Über das OVHcloud Kundencenter">
     Auf der Seite **Token verwalten** werden alle dem Benutzer zugeordneten PATs aufgelistet.
 
@@ -189,7 +189,7 @@ Ersetzen Sie `<any_suffix>` durch eine beliebige ASCII-Zeichenkette zur Identifi
 
 Das Löschen eines PAT verhindert sofort weitere API-Aufrufe mit diesem Token.
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Über das OVHcloud Kundencenter">
     Klicken Sie auf der Seite **Token verwalten** am Ende der Tokenzeile auf die Schaltfläche <code className="action">…</code> und wählen Sie <code className="action">Löschen</code>.
 

--- a/docs/en/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
+++ b/docs/en/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
@@ -55,7 +55,7 @@ If you need credentials for automated, production-grade integrations that are no
 
 Replace `{user}` with your local user login (for example, `1234-567-89/johnsmith`).
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Via the OVHcloud Control Panel">
     From the <ManagerLink to="/#/iam/identities/users">IAM Identities</ManagerLink> page, click the <code className="action">…</code> button at the end of the local user row, then select <code className="action">Manage tokens</code>.
 
@@ -169,7 +169,7 @@ Replace `<any_suffix>` with any ASCII string to identify the token.
 
 #### List existing tokens
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Via the OVHcloud Control Panel">
     On the **Manage Tokens** page, all PATs for the user are listed.
 
@@ -189,7 +189,7 @@ Replace `<any_suffix>` with any ASCII string to identify the token.
 
 Deleting a PAT immediately blocks further API calls.
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Via the OVHcloud Control Panel">
     From the **Manage Tokens** page, click the <code className="action">…</code> button at the end of the token row, then select <code className="action">Delete</code>.
 

--- a/docs/es/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
+++ b/docs/es/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
@@ -55,7 +55,7 @@ Si necesita credenciales para integraciones automatizadas de producción que no 
 
 Sustituya `{user}` por el identificador de su usuario local (por ejemplo, `1234-567-89/johnsmith`).
 
-<Tabs noSync>
+<Tabs>
   <Tab label="A través del área de cliente de OVHcloud">
     Desde la página <ManagerLink to="/#/iam/identities/users">Identidades IAM</ManagerLink>, haga clic en el botón <code className="action">…</code> al final de la fila del usuario local y seleccione <code className="action">Gestionar los tokens</code>.
 
@@ -169,7 +169,7 @@ Sustituya `<any_suffix>` por una cadena ASCII cualquiera para identificar el tok
 
 #### Listar los tokens existentes
 
-<Tabs noSync>
+<Tabs>
   <Tab label="A través del área de cliente de OVHcloud">
     En la página **Gestionar tokens**, se muestra la lista de PAT asociados al usuario.
 
@@ -189,7 +189,7 @@ Sustituya `<any_suffix>` por una cadena ASCII cualquiera para identificar el tok
 
 La eliminación de un PAT impide de forma inmediata su uso para nuevas llamadas a la API.
 
-<Tabs noSync>
+<Tabs>
   <Tab label="A través del área de cliente de OVHcloud">
     Desde la página **Gestionar tokens**, haga clic en el botón <code className="action">…</code> al final de la fila del token y seleccione <code className="action">Eliminar</code>.
 

--- a/docs/fr/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
+++ b/docs/fr/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
@@ -55,7 +55,7 @@ Si vous avez besoin d'identifiants pour des intégrations automatisées de produ
 
 Remplacez `{user}` par l'identifiant de votre utilisateur local (par exemple, `1234-567-89/johnsmith`).
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Via l'espace client OVHcloud">
     Depuis la page <ManagerLink to="/#/iam/identities/users">Identités IAM</ManagerLink>, cliquez sur le bouton <code className="action">…</code> en fin de ligne de l'utilisateur local, puis sélectionnez <code className="action">Gérer les tokens</code>.
 
@@ -169,7 +169,7 @@ Remplacez `<any_suffix>` par une chaîne ASCII quelconque pour identifier le tok
 
 #### Lister les tokens existants
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Via l'espace client OVHcloud">
     Sur la page **Manage Tokens**, la liste des PAT associés à l'utilisateur s'affiche.
 
@@ -189,7 +189,7 @@ Remplacez `<any_suffix>` par une chaîne ASCII quelconque pour identifier le tok
 
 La suppression d'un PAT bloque immédiatement tout nouvel appel API.
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Via l'espace client OVHcloud">
     Depuis la page **Manage Tokens**, cliquez sur le bouton <code className="action">…</code> en fin de ligne du token, puis sélectionnez <code className="action">Supprimer</code>.
 

--- a/docs/it/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
+++ b/docs/it/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
@@ -55,7 +55,7 @@ Se hai bisogno di credenziali per integrazioni automatizzate di produzione non c
 
 Sostituisci `{user}` con l'identificativo del tuo utente locale (ad esempio, `1234-567-89/johnsmith`).
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Attraverso lo Spazio Cliente OVHcloud">
     Dalla pagina <ManagerLink to="/#/iam/identities/users">Identità IAM</ManagerLink>, clicca sul pulsante <code className="action">…</code> alla fine della riga dell'utente locale, quindi seleziona <code className="action">Gestire i token</code>.
 
@@ -169,7 +169,7 @@ Sostituisci `<any_suffix>` con una stringa ASCII qualsiasi per identificare il t
 
 #### Elencare i token esistenti
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Attraverso lo Spazio Cliente OVHcloud">
     Nella pagina **Gestire i token**, vengono elencati tutti i PAT associati all'utente.
 
@@ -189,7 +189,7 @@ Sostituisci `<any_suffix>` con una stringa ASCII qualsiasi per identificare il t
 
 L'eliminazione di un PAT impedisce immediatamente il suo utilizzo per ulteriori chiamate API.
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Attraverso lo Spazio Cliente OVHcloud">
     Dalla pagina **Gestire i token**, clicca sul pulsante <code className="action">…</code> alla fine della riga del token, quindi seleziona <code className="action">Eliminare</code>.
 

--- a/docs/pl/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
+++ b/docs/pl/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
@@ -55,7 +55,7 @@ Jeśli potrzebujesz danych logowania do zautomatyzowanych integracji produkcyjny
 
 Zastąp `{user}` identyfikatorem użytkownika lokalnego (na przykład `1234-567-89/johnsmith`).
 
-<Tabs noSync>
+<Tabs>
   <Tab label="W Panelu klienta OVHcloud">
     Na stronie <ManagerLink to="/#/iam/identities/users">Tożsamości IAM</ManagerLink> kliknij przycisk <code className="action">…</code> na końcu wiersza użytkownika lokalnego, a następnie wybierz <code className="action">Zarządzanie tokenami</code>.
 
@@ -169,7 +169,7 @@ Zastąp `<any_suffix>` dowolnym ciągiem ASCII identyfikującym token.
 
 #### Wyświetlanie istniejących tokenów
 
-<Tabs noSync>
+<Tabs>
   <Tab label="W Panelu klienta OVHcloud">
     Na stronie **Zarządzanie tokenami** wyświetlana jest lista PAT przypisanych do użytkownika.
 
@@ -189,7 +189,7 @@ Zastąp `<any_suffix>` dowolnym ciągiem ASCII identyfikującym token.
 
 Usunięcie PAT natychmiast uniemożliwia jego dalsze wykorzystanie w wywołaniach API.
 
-<Tabs noSync>
+<Tabs>
   <Tab label="W Panelu klienta OVHcloud">
     Na stronie **Zarządzanie tokenami** kliknij przycisk <code className="action">…</code> na końcu wiersza tokena, a następnie wybierz <code className="action">Usuń</code>.
 

--- a/docs/pt/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
+++ b/docs/pt/guides/manage-and-operate/iam/configure-personal-access-token-pat.mdx
@@ -55,7 +55,7 @@ Se precisar de credenciais para integrações automatizadas de produção que n�
 
 Substitua `{user}` pelo identificador do seu utilizador local (por exemplo, `1234-567-89/johnsmith`).
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Via Área de Cliente OVHcloud">
     Na página <ManagerLink to="/#/iam/identities/users">Identidades IAM</ManagerLink>, clique no botão <code className="action">…</code> no final da linha do utilizador local e selecione <code className="action">Gerir os tokens</code>.
 
@@ -169,7 +169,7 @@ Substitua `<any_suffix>` por uma cadeia ASCII qualquer para identificar o token.
 
 #### Listar tokens existentes
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Via Área de Cliente OVHcloud">
     Na página **Manage Tokens**, é apresentada a lista de PAT associados ao utilizador.
 
@@ -189,7 +189,7 @@ Substitua `<any_suffix>` por uma cadeia ASCII qualquer para identificar o token.
 
 A eliminação de um PAT impede imediatamente a sua utilização para novas chamadas API.
 
-<Tabs noSync>
+<Tabs>
   <Tab label="Via Área de Cliente OVHcloud">
     Na página **Manage Tokens**, clique no botão <code className="action">…</code> no final da linha do token e selecione <code className="action">Eliminar</code>.
 


### PR DESCRIPTION
Remove noSync from the three <Tabs> blocks so the Control Panel/API/CLI tab selection stays in sync across the guide (all 7 locales).