### PR TITLE
feat(components): add SIRET reminder banner to FR account guides

### DIFF
--- a/components/Banner/Banner.css
+++ b/components/Banner/Banner.css
@@ -1,0 +1,141 @@
+/* Manually-triggered page banner — follows the OVHcloud Campaign Creative
+   Guidelines "longtext" horizontal format (icon · headline + subcopy · CTA).
+   Deep-blue brand gradient, white text, yellow CTA pill (14px).
+
+   NOTE: class prefix is `ovh-promo-banner`, NOT `rp-banner` — rspress ships a
+   reserved built-in `.rp-banner` (a sticky 36px announcement bar) that would
+   otherwise override these styles and collapse the layout. */
+
+.ovh-promo-banner {
+  /* Query container so the inner row stacks based on the banner's OWN width,
+     not the viewport — the docs content column narrows independently (sidebar
+     + TOC), so a viewport media query would be wrong here. */
+  container-type: inline-size;
+  container-name: ovhpromobanner;
+  /* Generous top margin so the banner clears the floating page-actions
+     toolbar (markdown/PDF/Ask-AI) that rspress injects above the content. */
+  margin: 2.5rem 0 1.75rem;
+}
+
+.ovh-promo-banner__row {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 28px 32px;
+  border-radius: 12px;
+  color: #fff;
+  background: linear-gradient(120deg, #000e9c 0%, #0050d7 100%);
+}
+
+/* Icon + text stay side-by-side in BOTH layouts (icon always left of text). */
+.ovh-promo-banner__main {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* ---- action icon ----------------------------------------------------- */
+
+.ovh-promo-banner__icon {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+}
+
+.ovh-promo-banner__icon img {
+  display: block;
+  width: 56px;
+  height: 56px;
+  /* Override the default .rspress-doc img frame (border + radius + padding). */
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  background: none;
+}
+
+/* ---- text block ------------------------------------------------------ */
+
+.ovh-promo-banner__body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.ovh-promo-banner__title {
+  margin: 0;
+  font-size: 1.0625rem;
+  font-weight: 700;
+  line-height: 1.3;
+  color: #fff;
+}
+
+.ovh-promo-banner__subcopy {
+  margin: 4px 0 0;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: #ffffff;
+}
+
+.ovh-promo-banner__link {
+  /* Override .rspress-doc anchor styling, which forces standalone links to
+     display:block + centered — that would break the sentence onto its own line. */
+  display: inline;
+  width: auto;
+  margin: 0;
+  text-align: inherit;
+  color: #ffffff;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.ovh-promo-banner__link:hover {
+  text-decoration: none;
+}
+
+/* ---- CTA pill -------------------------------------------------------- */
+
+.ovh-promo-banner__cta {
+  flex: 0 0 auto;
+}
+
+.ovh-promo-banner__cta a {
+  display: inline-block;
+  padding: 9px 18px;
+  border-radius: 999px;
+  background: #ffed00;
+  color: #000e9c;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-decoration: none;
+  white-space: nowrap;
+  transition:
+    background 0.15s ease,
+    transform 0.15s ease;
+}
+
+.ovh-promo-banner__cta a:hover {
+  background: #fff34d;
+  transform: translateY(-1px);
+}
+
+/* ---- responsive: stack when the banner itself is narrow -------------- */
+
+@container ovhpromobanner (max-width: 560px) {
+  /* Stack the CTA below the icon+text group; the icon stays left of the text
+     (the __main group keeps its own horizontal layout). */
+  .ovh-promo-banner__row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 20px;
+  }
+
+  .ovh-promo-banner__cta a {
+    display: block;
+    text-align: center;
+  }
+}
+
+/* Dark mode: the brand gradient already reads as dark; keep it as-is. */

--- a/components/Banner/Banner.tsx
+++ b/components/Banner/Banner.tsx
@@ -1,0 +1,66 @@
+import { useLang } from '@rspress/core/runtime';
+import { BANNERS } from './registry';
+import './Banner.css';
+
+/**
+ * Generic, manually-triggered page banner — the new-docs successor to the
+ * legacy `templates/banners/<key>/banner.<locale>.html` fragments. Follows the
+ * OVHcloud Campaign Creative Guidelines "longtext" horizontal format:
+ * icon · headline + subcopy · CTA pill (14px), on the brand-blue gradient.
+ *
+ * This component is content-agnostic: it renders whichever banner is named by
+ * `kind`. Each banner's content lives in its own file under ./banners and is
+ * collected in ./registry. Nothing renders automatically — a guide opts in by
+ * placing the tag in its MDX (typically right under the H1).
+ *
+ * @example
+ *   <Banner kind="siret-fr" />
+ */
+interface BannerProps {
+  /** Which predefined banner to render (a key of the ./registry BANNERS map). */
+  kind: string;
+}
+
+export function Banner({ kind }: BannerProps) {
+  const lang = useLang();
+  const banner = BANNERS[kind];
+
+  if (!banner) return null;
+  if (banner.langs && !banner.langs.includes(lang)) return null;
+
+  return (
+    <aside
+      className="ovh-promo-banner"
+      aria-label={typeof banner.title === 'string' ? banner.title : undefined}
+    >
+      <div className="ovh-promo-banner__row">
+        <div className="ovh-promo-banner__main">
+          <span className="ovh-promo-banner__icon" aria-hidden="true">
+            <img
+              src={banner.icon}
+              alt=""
+              width={56}
+              height={56}
+              className="no-zoom"
+            />
+          </span>
+
+          <div className="ovh-promo-banner__body">
+            <p className="ovh-promo-banner__title">{banner.title}</p>
+            {banner.subcopy && (
+              <p className="ovh-promo-banner__subcopy">{banner.subcopy}</p>
+            )}
+          </div>
+        </div>
+
+        <span className="ovh-promo-banner__cta">
+          <a href={banner.cta.href} target="_blank" rel="noopener noreferrer">
+            {banner.cta.label}
+          </a>
+        </span>
+      </div>
+    </aside>
+  );
+}
+
+export default Banner;

--- a/components/Banner/banners/siret-fr.tsx
+++ b/components/Banner/banners/siret-fr.tsx
@@ -1,0 +1,30 @@
+import type { BannerDef } from '../types';
+
+/**
+ * Informational, required notice: prompt French customers to fill in their
+ * SIRET number in their account details. FR-only — SIRET is a French
+ * company-registration concept. The "numéro SIRET" link points to the VAT/SIRET
+ * guide; the CTA deep-links to the Control Panel profile page.
+ */
+export const siretFr: BannerDef = {
+  langs: ['fr'],
+  icon: '/images/banner-doc-check.svg',
+  title: 'Vous êtes une entreprise française ?',
+  subcopy: (
+    <>
+      Renseignez votre{' '}
+      <a
+        className="ovh-promo-banner__link"
+        href="/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate"
+      >
+        numéro SIRET
+      </a>{' '}
+      dans les informations de votre compte : à partir du 1er septembre 2026,
+      il est nécessaire pour votre facturation et vos démarches administratives.
+    </>
+  ),
+  cta: {
+    label: 'Compléter mon profil',
+    href: 'https://manager.eu.ovhcloud.com/?_gl=1*eybhq8*_gcl_au*MTI5NDg4NTU4My4xNzc5MTk1MzU4#/account/useraccount/infos?fieldToFocus=siretForm',
+  },
+};

--- a/components/Banner/index.ts
+++ b/components/Banner/index.ts
@@ -1,0 +1,1 @@
+export { default, Banner } from './Banner';

--- a/components/Banner/registry.ts
+++ b/components/Banner/registry.ts
@@ -1,0 +1,13 @@
+import type { BannerDef } from './types';
+import { siretFr } from './banners/siret-fr';
+
+/**
+ * Registry of all manually-triggered banners, keyed by the `kind` used in MDX:
+ * `<Banner kind="siret-fr" />`.
+ *
+ * To add a banner: create `./banners/<kind>.tsx` exporting a BannerDef, then
+ * add one line here. No engine (Banner.tsx) changes needed.
+ */
+export const BANNERS: Record<string, BannerDef> = {
+  'siret-fr': siretFr,
+};

--- a/components/Banner/types.ts
+++ b/components/Banner/types.ts
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+/**
+ * One banner's content + targeting. The generic <Banner> engine renders any
+ * BannerDef; each concrete banner (SIRET, future promos, …) lives in its own
+ * file under ./banners and is collected in ./registry.
+ */
+export interface BannerDef {
+  /** Locales the banner renders on. Omit to render on every locale. */
+  langs?: string[];
+  /** Leading icon, served from /public/images (e.g. "/images/banner-x.svg"). */
+  icon: string;
+  /** Bold headline (guideline pattern B: headline + subcopy). */
+  title: ReactNode;
+  /** Supporting line under the headline. */
+  subcopy?: ReactNode;
+  /** CTA pill: visible label + URL it links to (opens in a new tab). */
+  cta: { label: string; href: string };
+}

--- a/docs/fr/guides/account-and-service-management/account-information/all-about-username.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/all-about-username.mdx
@@ -4,6 +4,8 @@ description: "Découvrez comment optimiser la sécurité de votre compte OVHclou
 lastUpdated: 2025-05-22
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 La gestion de vos services et données s'effectue principalement via l'espace client OVHcloud.

--- a/docs/fr/guides/account-and-service-management/account-information/authenticate-api-with-service-account.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/authenticate-api-with-service-account.mdx
@@ -6,6 +6,8 @@ lastUpdated: 2023-08-24
 
 import Api from '@components/Api';
 
+<Banner kind="siret-fr" />
+
 
 ## Objectif
 

--- a/docs/fr/guides/account-and-service-management/account-information/faq-account-management.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/faq-account-management.mdx
@@ -6,6 +6,8 @@ lastUpdated: 2025-12-18
 
 import Api from '@components/Api';
 
+<Banner kind="siret-fr" />
+
 
 
 
@@ -213,7 +215,7 @@ Cette page contient toutes les informations nécessaires concernant nos contrats
 </details>
 
 
-<details>
+<details id="siret">
 
 <summary>Où dois-je renseigner mon numéro SIRET ?</summary>
 

--- a/docs/fr/guides/account-and-service-management/account-information/faq-support.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/faq-support.mdx
@@ -4,6 +4,8 @@ description: Retrouvez les questions les plus fréquemment posées sur le suppor
 lastUpdated: 2025-10-30
 ---
 
+<Banner kind="siret-fr" />
+
 
 
 ## Objectif

--- a/docs/fr/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/iam-control-panel-access.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment octroyer les droits minimums nécessaires pour v
 lastUpdated: 2024-10-02
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 Ce guide explique comment fournir à un utilisateur les droits essentiels lui permettant de se connecter à l'espace client OVHcloud.

--- a/docs/fr/guides/account-and-service-management/account-information/iam-permission-groups.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/iam-permission-groups.mdx
@@ -4,6 +4,8 @@ description: Détail des groupes de permissions mis à disposition par OVHcloud
 lastUpdated: 2025-04-15
 ---
 
+<Banner kind="siret-fr" />
+
 
 
 ## Objectif

--- a/docs/fr/guides/account-and-service-management/account-information/iam-policies-api.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/iam-policies-api.mdx
@@ -4,6 +4,8 @@ description: "Découvrez comment donner des droits d'accès spécifiques aux uti
 lastUpdated: 2025-10-10
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 Ce guide explique comment fournir des droits d'accès spécifiques aux utilisateurs d'un compte OVHcloud.

--- a/docs/fr/guides/account-and-service-management/account-information/iam-policy-ui.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/iam-policy-ui.mdx
@@ -4,6 +4,8 @@ description: "Découvrez comment donner des droits d'accès spécifiques aux uti
 lastUpdated: 2025-10-27
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 Ce guide vous explique comment fournir des droits d'accès spécifiques aux utilisateurs d'un compte OVHcloud.

--- a/docs/fr/guides/account-and-service-management/account-information/manage-messages.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/manage-messages.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment ajouter des adresses e-mail de contact suppléme
 lastUpdated: 2025-12-03
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 Lors de la création de votre compte OVHcloud, vous avez spécifié une adresse e-mail de contact. Si vous souhaitez partager ou déléguer la gestion de vos communications liées à votre espace client, vous pouvez ajouter de nouvelles adresses e-mail de contact et configurer des règles pour gérer ces communications.

--- a/docs/fr/guides/account-and-service-management/account-information/manage-ovh-password.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/manage-ovh-password.mdx
@@ -4,6 +4,8 @@ description: Apprenez à définir, modifier et gérer le mot de passe de votre e
 lastUpdated: 2025-04-28
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 Le mot de passe de votre espace client OVHcloud est la clé d'accès à tous vos services et informations. Il doit être suffisamment complexe et régulièrement renouvelé pour garantir leur sécurité.

--- a/docs/fr/guides/account-and-service-management/account-information/managing-contacts.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/managing-contacts.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment gérer les contacts de vos services OVHcloud
 lastUpdated: 2026-02-11
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 La plupart des services créés chez OVHcloud sont gérés par plusieurs contacts. Chacun de ces contacts est associé à un identifiant client. 

--- a/docs/fr/guides/account-and-service-management/account-information/new-control-panel-navigation.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/new-control-panel-navigation.mdx
@@ -4,6 +4,8 @@ description: "Découvrez comment accéder à votre compte et à vos services dan
 lastUpdated: 2025-04-24
 ---
 
+<Banner kind="siret-fr" />
+
 
 
 ## Objectif

--- a/docs/fr/guides/account-and-service-management/account-information/ovhcloud-account-connect-saml-adfs.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/ovhcloud-account-connect-saml-adfs.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment associer votre service Active Directory Federati
 lastUpdated: 2025-05-15
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 Vous pouvez utiliser l'authentification **SSO** (*Single Sign-On*) pour vous connecter à votre compte OVHcloud. Pour activer ces connexions, votre compte et vos services AD FS (*Active Directory Federation Services*) doivent être configurés à l'aide des authentifications SAML (*Security Assertion Markup Language*).

--- a/docs/fr/guides/account-and-service-management/account-information/ovhcloud-account-connect-saml-azure-ad.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/ovhcloud-account-connect-saml-azure-ad.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment associer votre Entra ID (anciennement Azure Acti
 lastUpdated: 2025-05-15
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 Vous pouvez utiliser l'authentification **SSO** (*Single Sign-On*) pour vous connecter à votre compte OVHcloud. Pour activer ces connexions, votre compte et votre Entra ID (anciennement Azure Active Directory) doivent être configurés à l'aide de SAML (*Security Assertion Markup Language*).

--- a/docs/fr/guides/account-and-service-management/account-information/ovhcloud-account-connect-saml-google-workspace.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/ovhcloud-account-connect-saml-google-workspace.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment associer votre service Google Workspace à votre
 lastUpdated: 2025-05-15
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 Vous pouvez utiliser l'authentification SSO (*Single Sign-On*) pour vous connecter à votre compte OVHcloud. Pour activer ces connexions, votre compte OVHcloud et vos comptes Google Workspace doivent être configurés à l'aide des authentifications SAML (*Security Assertion Markup Language*).

--- a/docs/fr/guides/account-and-service-management/account-information/ovhcloud-account-connect-saml-okta.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/ovhcloud-account-connect-saml-okta.mdx
@@ -4,6 +4,8 @@ description: Apprenez à associer votre service Okta à votre compte OVHcloud vi
 lastUpdated: 2025-05-15
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 Vous pouvez utiliser l'authentification SSO (*Single Sign-On*) pour vous connecter à votre compte OVHcloud. Pour activer ces connexions, votre compte et vos comptes Okta doivent être configurés à l'aide de SAML (*Security Assertion Markup Language*).

--- a/docs/fr/guides/account-and-service-management/account-information/ovhcloud-account-creation.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/ovhcloud-account-creation.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment créer votre compte OVHcloud
 lastUpdated: 2026-02-26
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 Pour utiliser les services OVHcloud, vous devez d'abord créer votre compte.

--- a/docs/fr/guides/account-and-service-management/account-information/ovhcloud-account-login.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/ovhcloud-account-login.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment vous authentifier sur votre compte OVHcloud
 lastUpdated: 2025-04-28
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 La gestion de vos services s'effectue principalement via l'espace client OVHcloud.

--- a/docs/fr/guides/account-and-service-management/account-information/ovhcloud-control-panel-ip-restriction.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/ovhcloud-control-panel-ip-restriction.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment sécuriser votre compte OVHcloud en limitant les
 lastUpdated: 2025-04-28
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 OVHcloud met à votre disposition des options pour renforcer la sécurité de votre espace client OVHcloud et de vos services.

--- a/docs/fr/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/ovhcloud-users-management.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment ajouter des utilisateurs locaux depuis votre com
 lastUpdated: 2025-05-16
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 OVHcloud vous donne la possibilité de créer des utilisateurs locaux, qui peuvent agir en lecture ou en écriture sur votre espace client. Cela vous permet de donner aux membres de votre entreprise un accès à vos services OVHcloud. Et ce, sans avoir à recourir à des pratiques hasardeuses de partage de mot de passe ou de code de double authentification.

--- a/docs/fr/guides/account-and-service-management/account-information/phishing-care.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/phishing-care.mdx
@@ -4,6 +4,8 @@ description: Comment reconnaître un e-mail ou SMS de phishing et que faire si v
 lastUpdated: 2026-03-03
 ---
 
+<Banner kind="siret-fr" />
+
 
 
 ## Objectif

--- a/docs/fr/guides/account-and-service-management/account-information/secure-ovhcloud-account-with-2fa.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/secure-ovhcloud-account-with-2fa.mdx
@@ -6,6 +6,8 @@ lastUpdated: 2025-04-28
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
+<Banner kind="siret-fr" />
+
 
 
 

--- a/docs/fr/guides/account-and-service-management/account-information/use-plik.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/use-plik.mdx
@@ -4,6 +4,8 @@ description: "Découvrez comment utiliser l'outil Plik pour envoyer des fichiers
 lastUpdated: 2022-02-14
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 L'outil en ligne [Plik](https://plik.ovhcloud.com) permet de partager des fichiers entre différentes personnes, en offrant des options de sécurisation d'accès à ces fichiers.

--- a/docs/public/images/banner-doc-check.svg
+++ b/docs/public/images/banner-doc-check.svg
@@ -1,0 +1,15 @@
+<svg width="48" height="48" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs>
+<linearGradient id="bannerDocGrad" x1="4" y1="2" x2="20" y2="22" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ffffff"/>
+<stop offset="1" stop-color="#99E8FF"/>
+</linearGradient>
+</defs>
+<g stroke="url(#bannerDocGrad)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+<!-- Document body with folded corner (Lucide file-check) -->
+<path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2Z"/>
+<path d="M14 2v6h6"/>
+<!-- Checkmark -->
+<path d="m9 15 2 2 4-4"/>
+</g>
+</svg>

--- a/rspress.config.build.ts
+++ b/rspress.config.build.ts
@@ -131,6 +131,7 @@ export default defineConfig({
       path.join(BASE_DIR, 'components/Tooltip/Tooltip.tsx'),
       path.join(BASE_DIR, 'components/CardGrid/CardGrid.tsx'),
       path.join(BASE_DIR, 'components/CategoryColumns/CategoryColumns.tsx'),
+      path.join(BASE_DIR, 'components/Banner/Banner.tsx'),
     ],
     link: {
       checkDeadLinks: true,

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -182,6 +182,7 @@ export default defineConfig({
       path.join(__dirname, 'components/Tooltip/Tooltip.tsx'),
       path.join(__dirname, 'components/CardGrid/CardGrid.tsx'),
       path.join(__dirname, 'components/CategoryColumns/CategoryColumns.tsx'),
+      path.join(__dirname, 'components/Banner/Banner.tsx'),
     ],
     link: {
       checkDeadLinks: true,


### PR DESCRIPTION
Add a reusable, manually-triggered <Banner> component (the new-docs successor to the legacy templates/banners HTML fragments) and place a SIRET-completion banner on the FR account-information guides.

The banner is FR-only (SIRET is a French company-registration concept), follows the Campaign Creative Guidelines longtext format, links "numero SIRET" to the FAQ #siret anchor, and CTAs to the Control Panel profile.

- components/Banner: component, styles, doc-check icon; registered as a global MDX component in both rspress configs
- faq-account-management: add id="siret" anchor on the SIRET Q&A
- 23 account-information FR guides: insert the banner tag