### PR TITLE
docs: harmonize Telecom landing pages and SMS country callout

### DIFF
--- a/docs/en/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/en/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -13,7 +13,7 @@ goFurther:
       link: https://community.ovhcloud.com/
     - title: View the roadmap & changelog
       link: https://www.ovhcloud.com/en/roadmap-changelog/
-    - title: Join Discord
+    - title: Join the OVHcloud Discord
       link: https://discord.gg/ovhcloud
 cta:
   title: A question? Contact OVHcloud support

--- a/docs/en/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/en/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -9,14 +9,14 @@ availableIn: [eu]
 goFurther:
   title: Go further
   items:
-    - title: Visit the OVHcloud community
+    - title: Join our community of users
       link: https://community.ovhcloud.com/
     - title: View the roadmap & changelog
       link: https://www.ovhcloud.com/en/roadmap-changelog/
     - title: Join Discord
       link: https://discord.gg/ovhcloud
 cta:
-  title: Questions? Access OVHcloud support
+  title: A question? Contact OVHcloud support
   description: "Find answers to your questions in our help centre."
   actions:
     - text: Access support

--- a/docs/es/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/es/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -13,7 +13,7 @@ goFurther:
       link: https://community.ovhcloud.com/
     - title: "Consultar la hoja de ruta y el registro de cambios"
       link: https://www.ovhcloud.com/es/roadmap-changelog/
-    - title: Unirse a Discord
+    - title: "Únase al Discord de OVHcloud"
       link: https://discord.gg/ovhcloud
 cta:
   title: "¿Una pregunta? Contacte con el soporte de OVHcloud"

--- a/docs/es/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/es/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -9,14 +9,14 @@ availableIn: [eu]
 goFurther:
   title: "Más información"
   items:
-    - title: "Visitar la comunidad OVHcloud"
+    - title: "Interactúe con nuestra comunidad de usuarios"
       link: https://community.ovhcloud.com/
     - title: "Consultar la hoja de ruta y el registro de cambios"
       link: https://www.ovhcloud.com/es/roadmap-changelog/
     - title: Unirse a Discord
       link: https://discord.gg/ovhcloud
 cta:
-  title: "¿Tiene preguntas? Acceda al soporte de OVHcloud"
+  title: "¿Una pregunta? Contacte con el soporte de OVHcloud"
   description: "Encuentre la respuesta a sus preguntas en nuestro centro de ayuda."
   actions:
     - text: Acceder al soporte

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/n8n-sms.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/n8n-sms.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2025-12-02
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/internet/internet-access/landing-page-internet-access.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/landing-page-internet-access.mdx
@@ -15,7 +15,7 @@ goFurther:
       link: https://github.com/orgs/ovh/projects/18/views/1?sliceBy%5Bvalue%5D=ISP
     - title: "Changelog Accès Internet"
       link: https://github.com/orgs/ovh/projects/18/views/2?sliceBy%5Bvalue%5D=ISP
-    - title: Rejoindre Discord
+    - title: Rejoignez le Discord OVHcloud
       link: https://discord.gg/ovhcloud
 cta:
   title: "Une question ? Contactez le support OVHcloud"

--- a/docs/fr/guides/web-cloud/internet/internet-access/landing-page-internet-access.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/landing-page-internet-access.mdx
@@ -11,12 +11,14 @@ goFurther:
   items:
     - title: "Consulter la communauté OVHcloud"
       link: https://community.ovhcloud.com/
-    - title: "Consulter la roadmap & le changelog"
-      link: https://www.ovhcloud.com/fr/roadmap-changelog/
+    - title: "Roadmap Accès Internet"
+      link: https://github.com/orgs/ovh/projects/18/views/1?sliceBy%5Bvalue%5D=ISP
+    - title: "Changelog Accès Internet"
+      link: https://github.com/orgs/ovh/projects/18/views/2?sliceBy%5Bvalue%5D=ISP
     - title: Rejoindre Discord
       link: https://discord.gg/ovhcloud
 cta:
-  title: "Des questions ? Accédez au support OVHcloud"
+  title: "Une question ? Contactez le support OVHcloud"
   description: "Trouvez la réponse à vos questions dans notre centre d'aide."
   actions:
     - text: "Accéder au support"

--- a/docs/fr/guides/web-cloud/internet/internet-access/landing-page-internet-access.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/landing-page-internet-access.mdx
@@ -9,7 +9,7 @@ availableIn: [eu]
 goFurther:
   title: Aller plus loin
   items:
-    - title: "Consulter la communauté OVHcloud"
+    - title: Échangez avec notre communauté d'utilisateurs
       link: https://community.ovhcloud.com/
     - title: "Roadmap Accès Internet"
       link: https://github.com/orgs/ovh/projects/18/views/1?sliceBy%5Bvalue%5D=ISP

--- a/docs/fr/guides/web-cloud/internet/overthebox/landing-page-overthebox.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/landing-page-overthebox.mdx
@@ -9,7 +9,7 @@ availableIn: [eu]
 goFurther:
   title: Aller plus loin
   items:
-    - title: "Consulter la communauté OVHcloud"
+    - title: Échangez avec notre communauté d'utilisateurs
       link: https://community.ovhcloud.com/
     - title: "Roadmap OverTheBox"
       link: https://github.com/orgs/ovh/projects/18/views/1?sliceBy%5Bvalue%5D=OverTheBox

--- a/docs/fr/guides/web-cloud/internet/overthebox/landing-page-overthebox.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/landing-page-overthebox.mdx
@@ -15,7 +15,7 @@ goFurther:
       link: https://github.com/orgs/ovh/projects/18/views/1?sliceBy%5Bvalue%5D=OverTheBox
     - title: "Changelog OverTheBox"
       link: https://github.com/orgs/ovh/projects/18/views/2?sliceBy%5Bvalue%5D=OverTheBox
-    - title: Rejoindre Discord
+    - title: Rejoignez le Discord OVHcloud
       link: https://discord.gg/ovhcloud
 cta:
   title: "Une question ? Contactez le support OVHcloud"

--- a/docs/fr/guides/web-cloud/internet/overthebox/landing-page-overthebox.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/landing-page-overthebox.mdx
@@ -11,12 +11,14 @@ goFurther:
   items:
     - title: "Consulter la communauté OVHcloud"
       link: https://community.ovhcloud.com/
-    - title: "Consulter la roadmap & le changelog"
-      link: https://www.ovhcloud.com/fr/roadmap-changelog/
+    - title: "Roadmap OverTheBox"
+      link: https://github.com/orgs/ovh/projects/18/views/1?sliceBy%5Bvalue%5D=OverTheBox
+    - title: "Changelog OverTheBox"
+      link: https://github.com/orgs/ovh/projects/18/views/2?sliceBy%5Bvalue%5D=OverTheBox
     - title: Rejoindre Discord
       link: https://discord.gg/ovhcloud
 cta:
-  title: "Des questions ? Accédez au support OVHcloud"
+  title: "Une question ? Contactez le support OVHcloud"
   description: "Trouvez la réponse à vos questions dans notre centre d'aide."
   actions:
     - text: "Accéder au support"

--- a/docs/fr/guides/web-cloud/messaging/sms/activer-la-recharge-automatique-du-credit-sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/activer-la-recharge-automatique-du-credit-sms.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2026-06-15
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/api-sms-cookbook.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/api-sms-cookbook.mdx
@@ -7,7 +7,7 @@ lastUpdated: 2026-06-15
 import Api from '@components/Api';
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/envoi-de-sms-aux-etats-unis.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/envoi-de-sms-aux-etats-unis.mdx
@@ -7,7 +7,7 @@ lastUpdated: 2022-08-05
 import Api from '@components/Api';
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/faq-sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/faq-sms.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2026-03-27
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -13,7 +13,7 @@ goFurther:
       link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/
-    - title: Rejoindre Discord
+    - title: Rejoignez le Discord OVHcloud
       link: https://discord.gg/ovhcloud
 cta:
   title: "Une question ? Contactez le support OVHcloud"

--- a/docs/fr/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -16,7 +16,7 @@ goFurther:
     - title: Rejoindre Discord
       link: https://discord.gg/ovhcloud
 cta:
-  title: "Des questions ? Accédez au support OVHcloud"
+  title: "Une question ? Contactez le support OVHcloud"
   description: "Trouvez la réponse à vos questions dans notre centre d'aide."
   actions:
     - text: "Accéder au support"
@@ -27,7 +27,7 @@ cta:
 import { LinkCard } from '@components/LinkCard';
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Présentation du service SMS OVHcloud

--- a/docs/fr/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -9,7 +9,7 @@ availableIn: [eu]
 goFurther:
   title: Aller plus loin
   items:
-    - title: "Consulter la communauté OVHcloud"
+    - title: Échangez avec notre communauté d'utilisateurs
       link: https://community.ovhcloud.com/
     - title: "Consulter la roadmap & le changelog"
       link: https://www.ovhcloud.com/fr/roadmap-changelog/

--- a/docs/fr/guides/web-cloud/messaging/sms/liste-de-destinataire-sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/liste-de-destinataire-sms.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2022-08-05
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/ma-premiere-campagne-sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/ma-premiere-campagne-sms.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2022-08-05
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/send-sms-api-java.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/send-sms-api-java.mdx
@@ -7,7 +7,7 @@ lastUpdated: 2020-06-01
 import Api from '@components/Api';
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/send-sms-api-nodejs.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/send-sms-api-nodejs.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2020-06-18
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/send-sms-api-php.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/send-sms-api-php.mdx
@@ -7,7 +7,7 @@ lastUpdated: 2020-06-25
 import Api from '@components/Api';
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/send-sms-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/send-sms-control-panel.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2026-06-15
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/send-sms-email.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/send-sms-email.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2020-06-04
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/send-sms-http2sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/send-sms-http2sms.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2026-06-15
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/sending-via-api-c.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sending-via-api-c.mdx
@@ -7,7 +7,7 @@ lastUpdated: 2022-11-21
 import Api from '@components/Api';
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/smpp-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/smpp-control-panel.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2023-02-09
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/smpp-specification.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/smpp-specification.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2025-03-05
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/sms-address-books.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sms-address-books.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2022-08-05
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/sms-history.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sms-history.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2025-12-30
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/sms-hlr.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sms-hlr.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2026-03-25
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/sms-senders.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sms-senders.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2025-10-28
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/sms-users.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sms-users.mdx
@@ -7,7 +7,7 @@ lastUpdated: 2022-08-05
 import Api from '@components/Api';
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/sms-with-reply.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/sms-with-reply.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2023-12-29
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/messaging/sms/time-2-chat.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/time-2-chat.mdx
@@ -5,7 +5,7 @@ lastUpdated: 2025-11-27
 ---
 
 :::info
-Les offres SMS d’OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
 :::
 
 ## Objectif

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
@@ -1,26 +1,27 @@
 ---
-title: VoIP - Présentation de la documentation
+title: "VoIP OVHcloud - Documentation"
 description: "Toute la documentation de la téléphonie VoIP OVHcloud : configuration des lignes SIP, administration, numéros, sécurité et dépannage de vos services."
 lastUpdated: 2026-06-11
 pageType: landing
 banner: true
 tagline: "Configurez, utilisez et administrez vos services de téléphonie VoIP OVHcloud."
+availableIn: [eu]
 goFurther:
   title: Aller plus loin
   items:
-    - title: Échangez avec notre communauté d'utilisateurs
+    - title: "Consulter la communauté OVHcloud"
       link: https://community.ovhcloud.com/
     - title: "Roadmap VoIP"
       link: https://github.com/orgs/ovh/projects/18/views/1?sliceBy%5Bvalue%5D=VoIP
     - title: "Changelog VoIP"
       link: https://github.com/orgs/ovh/projects/18/views/2?sliceBy%5Bvalue%5D=VoIP
-    - title: Rejoignez le Discord OVHcloud
+    - title: Rejoindre Discord
       link: https://discord.gg/ovhcloud
 cta:
-  title: "Une question ? Contactez le support OVHcloud"
-  description: Trouvez la réponse à vos questions dans notre centre d'aide.
+  title: "Une question ? Contactez le support OVHcloud"
+  description: "Trouvez la réponse à vos questions dans notre centre d'aide."
   actions:
-    - text: Accéder au support
+    - text: "Accéder au support"
       link: https://help.ovhcloud.com/
       theme: brand
 ---

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
@@ -15,7 +15,7 @@ goFurther:
       link: https://github.com/orgs/ovh/projects/18/views/1?sliceBy%5Bvalue%5D=VoIP
     - title: "Changelog VoIP"
       link: https://github.com/orgs/ovh/projects/18/views/2?sliceBy%5Bvalue%5D=VoIP
-    - title: Rejoindre Discord
+    - title: Rejoignez le Discord OVHcloud
       link: https://discord.gg/ovhcloud
 cta:
   title: "Une question ? Contactez le support OVHcloud"

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
@@ -9,7 +9,7 @@ availableIn: [eu]
 goFurther:
   title: Aller plus loin
   items:
-    - title: "Consulter la communauté OVHcloud"
+    - title: Échangez avec notre communauté d'utilisateurs
       link: https://community.ovhcloud.com/
     - title: "Roadmap VoIP"
       link: https://github.com/orgs/ovh/projects/18/views/1?sliceBy%5Bvalue%5D=VoIP

--- a/docs/it/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/it/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -9,14 +9,14 @@ availableIn: [eu]
 goFurther:
   title: Per approfondire
   items:
-    - title: Visita la community OVHcloud
+    - title: Contatta la nostra community di utenti
       link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
     - title: Unisciti a Discord
       link: https://discord.gg/ovhcloud
 cta:
-  title: Hai domande? Accedi al supporto OVHcloud
+  title: Hai una domanda? Contatta il supporto OVHcloud
   description: "Trova la risposta alle tue domande nel nostro centro assistenza."
   actions:
     - text: Accedi al supporto

--- a/docs/it/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/it/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -13,7 +13,7 @@ goFurther:
       link: https://community.ovhcloud.com/
     - title: Consulta la roadmap e il changelog
       link: https://www.ovhcloud.com/it/roadmap-changelog/
-    - title: Unisciti a Discord
+    - title: Unisciti al Discord di OVHcloud
       link: https://discord.gg/ovhcloud
 cta:
   title: Hai una domanda? Contatta il supporto OVHcloud

--- a/docs/pl/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/pl/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -9,14 +9,14 @@ availableIn: [eu]
 goFurther:
   title: "Sprawdź również"
   items:
-    - title: "Odwiedź społeczność OVHcloud"
+    - title: "Przyłącz się do społeczności naszych użytkowników"
       link: https://community.ovhcloud.com/
     - title: "Zobacz roadmapę i changelog"
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
     - title: "Dołącz do Discord"
       link: https://discord.gg/ovhcloud
 cta:
-  title: "Masz pytania? Skontaktuj się z pomocą OVHcloud"
+  title: "Masz pytanie? Skontaktuj się z pomocą OVHcloud"
   description: "Znajdź odpowiedzi na swoje pytania w naszym centrum pomocy."
   actions:
     - text: "Przejdź do pomocy"

--- a/docs/pl/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/pl/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -13,7 +13,7 @@ goFurther:
       link: https://community.ovhcloud.com/
     - title: "Zobacz roadmapę i changelog"
       link: https://www.ovhcloud.com/pl/roadmap-changelog/
-    - title: "Dołącz do Discord"
+    - title: "Dołącz do Discorda OVHcloud"
       link: https://discord.gg/ovhcloud
 cta:
   title: "Masz pytanie? Skontaktuj się z pomocą OVHcloud"


### PR DESCRIPTION
Landing pages (VoIP, SMS, Internet Access, OverTheBox):
- VoIP: LP title in "<Product> OVHcloud - Documentation" format, add availableIn: [eu], align goFurther labels (community/Discord) and cta block
- Internet Access & OverTheBox: product roadmap/changelog via GitHub slice (ISP, OverTheBox) instead of the centralized link
- cta unified across the 4 LPs: "Une question ? Contactez le support OVHcloud"
- SMS: keeps its centralized roadmap/changelog link (no GitHub category)

SMS country callout (24 guides):
- "Les offres SMS d'OVHcloud" -> "Les offres SMS OVHcloud"