### PR TITLE
fix(landing-pages): clean titles, tab labels and sidebar collapse

### DIFF
--- a/config/links.ts
+++ b/config/links.ts
@@ -76,6 +76,15 @@ export const externalLinks: LinkMap = {
     'pl': 'https://www.ovhcloud.com/pl/bare-metal/game/',
     'pt': 'https://www.ovhcloud.com/pt/bare-metal/game/',
   },
+  'bare-metal/game-hub': {
+    'fr': 'https://www.ovhcloud.com/fr/lp/game-hub/',
+    'en': 'https://www.ovhcloud.com/en-gb/lp/game-hub/',
+    'de': 'https://www.ovhcloud.com/de/lp/game-hub/',
+    'es': 'https://www.ovhcloud.com/es-es/lp/game-hub/',
+    'it': 'https://www.ovhcloud.com/it/lp/game-hub/',
+    'pl': 'https://www.ovhcloud.com/pl/lp/game-hub/',
+    'pt': 'https://www.ovhcloud.com/pt/lp/game-hub/',
+  },
   'bare-metal/hg': {
     'fr': 'https://www.ovhcloud.com/fr/bare-metal/high-grade/',
     'en': 'https://www.ovhcloud.com/en-gb/bare-metal/high-grade/',

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -389,7 +389,7 @@ ip link set eth1 up
 #### GNU/Linux-Konfigurationen
 
 <Tabs>
-<Tab label="**Debian 11**">
+<Tab label="Debian 11">
 **Additional IP konfigurieren**
 
 Öffnen Sie die Netzwerkkonfigurationsdatei in `/etc/network/interfaces.d` mit einem Texteditor Ihrer Wahl. Hier heißt die Datei `50-cloud-init`.
@@ -453,7 +453,7 @@ Starten Sie den Server neu, um die Änderungen zu übernehmen, oder aktivieren S
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**CentOS, AlmaLinux und Rocky Linux (8/9)**">
+<Tab label="CentOS, AlmaLinux und Rocky Linux (8/9)">
 **Die Datei für die sekundäre Netzwerkschnittstelle erstellen**
 
 Kopieren Sie die Konfiguration der primären Netzwerkschnittstelle und passen Sie sie nach Bedarf an:
@@ -541,7 +541,7 @@ Starten Sie den Server neu, um die Änderungen zu übernehmen, oder aktivieren S
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**Ubuntu und Debian 12+**">
+<Tab label="Ubuntu und Debian 12+">
 - Additional IP konfigurieren
 
 Öffnen Sie die Netzwerkkonfigurationsdatei in `/etc/netplan` mit einem Texteditor Ihrer Wahl. Hier heißt die Datei `50-cloud-init.yaml`.
@@ -581,7 +581,7 @@ Wenden Sie die Konfiguration mit dem folgenden Befehl an:
 sudo netplan apply
 ```
 </Tab>
-<Tab label="**Fedora, AlmaLinux und Rocky Linux (10)**">
+<Tab label="Fedora, AlmaLinux und Rocky Linux (10)">
 Überprüfen Sie zunächst, dass Ihre vRack-Schnittstelle den Status `connected` oder `connecting` hat. In unserem Beispiel heißt die Schnittstelle `eno2`.
 
 ```sh

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
@@ -1,5 +1,5 @@
 ---
-title: Game Panel Dokumentation
+title: "Game Panel"
 description: "Die gesamte Dokumentation zum OVHcloud Game Panel: Game-Server auf Ihrem VPS oder dedizierten Server bereitstellen und verwalten, mehr als 140 Titel installieren, Server konfigurieren, Benutzer, Backups und Dateien verwalten."
 lastUpdated: 2026-06-30
 pageType: landing
@@ -25,7 +25,7 @@ cta:
 
 import { LinkCard } from '@components/LinkCard';
 
-Willkommen bei der Dokumentation, die dem [OVHcloud Game Panel](/links/bare-metal/vps) gewidmet ist. Mit dem Game Panel können Sie direkt von Ihrem OVHcloud VPS oder dedizierten Server aus Game-Server für eine breite Auswahl beliebter Titel bereitstellen und verwalten. Hier finden Sie alle verfügbaren Anleitungen, um Ihre Game-Server zu installieren, zu konfigurieren und zu administrieren.
+Willkommen bei der Dokumentation, die dem [OVHcloud Game Panel](/links/bare-metal/game-hub) gewidmet ist. Mit dem Game Panel können Sie direkt von Ihrem OVHcloud VPS oder dedizierten Server aus Game-Server für eine breite Auswahl beliebter Titel bereitstellen und verwalten. Hier finden Sie alle verfügbaren Anleitungen, um Ihre Game-Server zu installieren, zu konfigurieren und zu administrieren.
 
 ## Was ist das Game Panel?
 

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -27,20 +27,20 @@ Windows-Startprotokolle können bei der Diagnose von Serverfehlern hilfreich sei
 Um sie zu aktivieren, gehen Sie wie folgt vor, indem Sie durch die Registerkarten navigieren:
 
 <Tabs>
-  <Tab label="1. **Mit dem Server verbinden**">
+  <Tab label="1. Mit dem Server verbinden">
     Verbinden Sie sich mit Ihrem Server über eine Remote-Desktop-Verbindung oder eine [KVM-Sitzung](/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps).
   </Tab>
-  <Tab label="2. **Das Run-Tool öffnen**">
+  <Tab label="2. Das Run-Tool öffnen">
     Öffnen Sie das Windows `Start`-Menü und klicken Sie auf <code className="action">Run</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-start-run.png" loading="lazy" />
   </Tab>
-  <Tab label="3. **`msconfig` öffnen**">
+  <Tab label="3. msconfig öffnen">
     Geben Sie `msconfig` ein und klicken Sie auf <code className="action">OK</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-msconfig.png" loading="lazy" />
   </Tab>
-  <Tab label="4. **Protokolle aktivieren**">
+  <Tab label="4. Protokolle aktivieren">
     Im neuen Fenster aktivieren Sie die Protokolloption neben `Boot log`. Klicken Sie anschließend auf <code className="action">OK</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-log.png" loading="lazy" />

--- a/docs/de/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/de/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -41,14 +41,14 @@ Klicken Sie auf <code className="action">Create Network</code>
 
 
 <Tabs>
-  <Tab label="1. **Network (Netzwerk)**">
+  <Tab label="1. Network (Netzwerk)">
     **Network Name:** Geben Sie einen Namen für Ihr Netzwerk ein.<br/>
     **Enable Admin State:** Lassen Sie diese Option aktiviert, um das Netzwerk zu aktivieren.<br/>
     **Create Subnet:** Lassen Sie diese Option aktiviert, um das Subnetz zu erstellen.<br/>
     **Availability Zone Hints:** Behalten Sie die Standardoption bei.<br/><br/>
     <img className="thumbnail" alt="network" src="/images/public-cloud/compute/create-instance-in-horizon/network_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="2. **Subnet (Subnetz)**">
+  <Tab label="2. Subnet (Subnetz)">
     **Subnet Name:** Geben Sie einen Namen für Ihr Subnetz ein.<br/>
     **Network Address:** Wählen Sie einen privaten Netzwerkbereich aus. Beispiel: `192.168.0.0/24`.<br/>
     **IP Version:** Behalten Sie den Wert IPv4 bei.<br/>
@@ -56,7 +56,7 @@ Klicken Sie auf <code className="action">Create Network</code>
     **Disable Gateway:** Lassen Sie diese Option deaktiviert.<br/><br/>
     <img className="thumbnail" alt="subnet" src="/images/public-cloud/compute/create-instance-in-horizon/subnet_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="3. **Subnet Details (Subnetzdetails)**">
+  <Tab label="3. Subnet Details (Subnetzdetails)">
     **Enable DHCP:** Lassen Sie diese Option aktiviert.<br/>
     **Allocation Pools:** Optional. Sie können den Bereich angeben, in dem IP-Adressen ausgewählt werden.<br/>
     **DNS Name Servers:** Optional. Sie können einen beliebigen DNS-Server angeben.<br/>

--- a/docs/de/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/de/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -115,7 +115,7 @@ Follow the one you prefer.
     Logged in to ovh-tuto-27gm21h6v46 as gitpod (s3://pulumi?endpoint=s3.gra.perf.cloud.ovh.net&region=gra)
     ```
   </Tab>
-  <Tab label="Backend configuration in the `Pulumi.yaml` file">
+  <Tab label="Backend configuration in the Pulumi.yaml file">
     Or if you don't want to type the URL every time, you can define a backend property in the `Pulumi.yaml` config file as below:
     
     ```bash

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MX Plan - OVHcloud E-Mail-Dokumentation"
+title: "MX Plan - OVHcloud E-Mail"
 description: "Erstellen Sie E-Mail-Postfächer mit MX Plan OVHcloud, nutzen Sie das Webmail und konfigurieren Sie Ihre E-Mail-Programme."
 lastUpdated: 2026-06-19
 pageType: landing

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -379,7 +379,7 @@ ip link set eth1 up
 #### GNU/Linux configurations
 
 <Tabs>
-<Tab label="**Debian 11**">
+<Tab label="Debian 11">
 **Configure the Additional IP**
 
 Using a text editor of your choice, open the network configuration file located in `/etc/network/interfaces.d` for editing. Here the file is called `50-cloud-init`.
@@ -443,7 +443,7 @@ Now reboot your server to apply the changes or alternatively simply enable the n
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**CentOS, AlmaLinux and Rocky Linux (8/9)**">
+<Tab label="CentOS, AlmaLinux and Rocky Linux (8/9)">
 **Create the file for the secondary network interface**
 
 First, copy the primary network interface configuration and adjust it as needed:
@@ -531,7 +531,7 @@ Now reboot your server to apply the changes or alternatively simply enable the n
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**Ubuntu & Debian 12+**">
+<Tab label="Ubuntu & Debian 12+">
 - Configure the Additional IP
 
 Using a text editor of your choice, open the network configuration file located in `/etc/netplan` for editing. Here the file is called `50-cloud-init.yaml`.
@@ -571,7 +571,7 @@ Apply the configuration with the following command:
 sudo netplan apply
 ```
 </Tab>
-<Tab label="**Fedora, AlmaLinux and Rocky Linux (10)**">
+<Tab label="Fedora, AlmaLinux and Rocky Linux (10)">
 First, verify that your vRack interface is `connected` or `connecting` state. In our example, the interface is called `eno2`.
 
 ```sh

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
@@ -1,5 +1,5 @@
 ---
-title: Game Panel documentation
+title: "Game Panel"
 description: "All the OVHcloud Game Panel documentation: deploy and manage game servers on your VPS or dedicated server, install 140+ titles, configure servers, manage users, backups and files."
 lastUpdated: 2026-06-30
 pageType: landing
@@ -25,7 +25,7 @@ cta:
 
 import { LinkCard } from '@components/LinkCard';
 
-Welcome to the documentation dedicated to the [OVHcloud Game Panel](/links/bare-metal/vps). The Game Panel lets you deploy and manage game servers for a wide range of popular titles directly from your OVHcloud VPS or dedicated server. Here you will find every guide available to install, configure, and administer your game servers.
+Welcome to the documentation dedicated to the [OVHcloud Game Panel](/links/bare-metal/game-hub). The Game Panel lets you deploy and manage game servers for a wide range of popular titles directly from your OVHcloud VPS or dedicated server. Here you will find every guide available to install, configure, and administer your game servers.
 
 ## What is the Game Panel?
 

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -25,20 +25,20 @@ They are particularly useful for **diagnosing boot issues**, **blue screens**, o
 To enable boot logs, follow the steps below:
 
 <Tabs>
-  <Tab label="1. **Connect to the server**">
+  <Tab label="1. Connect to the server">
     Connect to your server via a remote desktop or a [KVM session](/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps).
   </Tab>
-  <Tab label="2. **Open the Run utility**">
+  <Tab label="2. Open the Run utility">
     Open the Windows `Start` menu and click <code className="action">Run</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-start-run.png" loading="lazy" />
   </Tab>
-  <Tab label="3. **Open `msconfig`**">
+  <Tab label="3. Open msconfig">
     Type `msconfig` and click <code className="action">OK</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-msconfig.png" loading="lazy" />
   </Tab>
-  <Tab label="4. **Enable logs**">
+  <Tab label="4. Enable logs">
     In the new window, enable the log option next to `Boot log`. Then click <code className="action">OK</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-log.png" loading="lazy" />

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-bgp-between-pcc-inside-vrack.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-bgp-between-pcc-inside-vrack.mdx
@@ -56,7 +56,7 @@ Create an overlay segment in the location where we plan to deploy our virtual ma
     <img className="thumbnail" alt="OverlaySegmentDE" src="/images/hosted-private-cloud/powered-by-vmware/nsx-configure-bgp-between-pcc-inside-vRack/segment_overlay_de.png" loading="lazy" />
     <img className="thumbnail" alt="OverlaySegmentDE2" src="/images/hosted-private-cloud/powered-by-vmware/nsx-configure-bgp-between-pcc-inside-vRack/segment_overlay_de_2.png" loading="lazy" />
   </Tab>
-  <Tab label="**UK**">
+  <Tab label="UK">
     <img className="thumbnail" alt="OverlaySegmentUK" src="/images/hosted-private-cloud/powered-by-vmware/nsx-configure-bgp-between-pcc-inside-vRack/segment_overlay_uk.png" loading="lazy" />
     <img className="thumbnail" alt="OverlaySegmentUK2" src="/images/hosted-private-cloud/powered-by-vmware/nsx-configure-bgp-between-pcc-inside-vRack/segment_overlay_uk_2.png" loading="lazy" />
   </Tab>

--- a/docs/en/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/en/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -35,14 +35,14 @@ Click on <code className="action">Create Network</code>
 <img className="thumbnail" alt="network" src="/images/public-cloud/compute/create-instance-in-horizon/create-network-1.png" loading="lazy" />
 
 <Tabs>
-  <Tab label="1. **Network**">
+  <Tab label="1. Network">
     **Network Name:** Enter a name for your network.<br/>
     **Enable Admin State:** Leave this option checked to activate the network.<br/>
     **Create Subnet:** Leave this option checked to create the subnet.<br/>
     **Availability Zone Hints:** Leave the default option.<br/><br/>
     <img className="thumbnail" alt="network" src="/images/public-cloud/compute/create-instance-in-horizon/network_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="2. **Subnet**">
+  <Tab label="2. Subnet">
     **Subnet Name:** Enter a name for your subnet.<br/>
     **Network Address:** Choose a private network range. For example: `192.168.0.0/24`.<br/>
     **IP Version:** Leave this value at IPv4.<br/>
@@ -50,7 +50,7 @@ Click on <code className="action">Create Network</code>
     **Disable Gateway:** Leave this unchecked.<br/><br/>
     <img className="thumbnail" alt="subnet" src="/images/public-cloud/compute/create-instance-in-horizon/subnet_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="3. **Subnet Details**">
+  <Tab label="3. Subnet Details">
     **Enable DHCP:** Leave this option checked.<br/>
     **Allocation Pools:** Optional. You can specify the range from which IPs are selected.<br/>
     **DNS Name Servers:** Optional. You can specify any DNS name servers.<br/>

--- a/docs/en/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/en/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -115,7 +115,7 @@ Follow the one you prefer.
     Logged in to ovh-tuto-27gm21h6v46 as gitpod (s3://pulumi?endpoint=s3.gra.perf.cloud.ovh.net&region=gra)
     ```
   </Tab>
-  <Tab label="Backend configuration in the `Pulumi.yaml` file">
+  <Tab label="Backend configuration in the Pulumi.yaml file">
     Or if you don't want to type the URL every time, you can define a backend property in the `Pulumi.yaml` config file as below:
     
     ```bash

--- a/docs/en/guides/web-cloud/domains/api-domain-rules.mdx
+++ b/docs/en/guides/web-cloud/domains/api-domain-rules.mdx
@@ -554,7 +554,7 @@ These two rules can be combined using the `and` operator of the `rule` object. T
 
 {/* prettier-ignore */}
 <Tabs>
-  <Tab label="Rules merged into one with an `and` operator">
+  <Tab label="Rules merged into one with an and operator">
     ```json
     {
       "and": [
@@ -601,7 +601,7 @@ To represent rules on an object, the `fields` node is used. Each field is repres
   <Tab label="Hide">
     Click "Show" to see the JSON
   </Tab>
-  <Tab label="Show: Constraint on the fields of a `contact`">
+  <Tab label="Show: Constraint on the fields of a contact">
     ```json
     {
       "label": "OWNER_CONTACT",
@@ -794,7 +794,7 @@ Let's now take the more concrete example explained at the beginning of this.
   <Tab label="Hide">
     Click "Show" to see the JSON
   </Tab>
-  <Tab label="Show: Example condition on a `contact` field">
+  <Tab label="Show: Example condition on a contact field">
     ```json
     {
       "label": "OWNER_CONTACT",
@@ -2466,7 +2466,7 @@ This is represented by the following rule. For the sake of clarity, the rules on
   <Tab label="Hide">
     Click "Show" to see the JSON
   </Tab>
-  <Tab label="Show: Eligibility rule of `.berlin`">
+  <Tab label="Show: Eligibility rule of .berlin">
     ```json
     {
       "and": [

--- a/docs/en/guides/web-cloud/domains/dns-zone-records.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-records.mdx
@@ -42,7 +42,7 @@ Select the record you want by clicking each of the following tabs.
     **A**ddress <br/><br/>
     Links a domain name to a `X.X.X.X` IPv4 address (where `X` is a number between `0` and `255`). For example, the IPv4 address of the server your website is hosted on.
   </Tab>
-  <Tab label="**AAAA**">
+  <Tab label="AAAA">
     Four **A** characters because this record is encoded on four times more bits than the historical **A** field. <br/><br/>
     Links a domain name to an IPv6 address. For example, the IPv6 address of the server your website is hosted on.
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MX Plan - OVHcloud email documentation"
+title: "MX Plan - OVHcloud email"
 description: "Create and manage your OVHcloud MX Plan email addresses — webmail access, email client configuration, features and troubleshooting."
 lastUpdated: 2026-06-19
 pageType: landing

--- a/docs/en/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/en/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -1,5 +1,5 @@
 ---
-title: "OVHcloud SMS - Documentation"
+title: "OVHcloud SMS"
 description: "Send SMS messages and manage your SMS campaigns with OVHcloud — senders, recipients, credits, replies, and API integration."
 lastUpdated: 2026-06-29
 pageType: landing

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -389,7 +389,7 @@ ip link set eth1 up
 #### Configuraciones GNU/Linux
 
 <Tabs>
-<Tab label="**Debian 11**">
+<Tab label="Debian 11">
 **Configurar la Additional IP**
 
 Abra el archivo de configuración de red ubicado en `/etc/network/interfaces.d` con el editor de texto de su elección. Aquí el archivo se llama `50-cloud-init`.
@@ -453,7 +453,7 @@ Reinicie el servidor para aplicar los cambios o habilite simplemente la nueva in
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**CentOS, AlmaLinux y Rocky Linux (8/9)**">
+<Tab label="CentOS, AlmaLinux y Rocky Linux (8/9)">
 **Crear el archivo para la interfaz de red secundaria**
 
 Copie la configuración de la interfaz de red primaria y ajústela según sus necesidades:
@@ -541,7 +541,7 @@ Reinicie el servidor para aplicar los cambios o habilite simplemente la nueva in
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**Ubuntu y Debian 12+**">
+<Tab label="Ubuntu y Debian 12+">
 - Configurar la Additional IP
 
 Abra el archivo de configuración de red ubicado en `/etc/netplan` con el editor de texto de su elección. Aquí el archivo se llama `50-cloud-init.yaml`.
@@ -581,7 +581,7 @@ Aplique la configuración con el siguiente comando:
 sudo netplan apply
 ```
 </Tab>
-<Tab label="**Fedora, AlmaLinux y Rocky Linux (10)**">
+<Tab label="Fedora, AlmaLinux y Rocky Linux (10)">
 En primer lugar, compruebe que su interfaz vRack está en estado `connected` o `connecting`. En nuestro ejemplo, la interfaz se llama `eno2`.
 
 ```sh

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing.mdx
@@ -425,7 +425,7 @@ Seleccione la pestaña correspondiente a su sistema operativo.
     
     <img className="thumbnail" alt="configuración IP actual" src="/images/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing/plesk-final-configuration.png" loading="lazy" />
   </Tab>
-  <Tab label="**Windows Server**">
+  <Tab label="Windows Server">
     Windows Server
     
     **1\. comprobar la configuración de red**

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
@@ -1,5 +1,5 @@
 ---
-title: Documentación Game Panel
+title: "Game Panel"
 description: "Toda la documentación del Game Panel de OVHcloud: desplegar y gestionar servidores de juego en su VPS o servidor dedicado, instalar más de 140 títulos, configurar servidores, gestionar usuarios, copias de seguridad y archivos."
 lastUpdated: 2026-06-30
 pageType: landing
@@ -25,7 +25,7 @@ cta:
 
 import { LinkCard } from '@components/LinkCard';
 
-Bienvenido a la documentación dedicada al [Game Panel de OVHcloud](/links/bare-metal/vps). El Game Panel le permite desplegar y gestionar servidores de juego para una amplia gama de títulos populares directamente desde su VPS o servidor dedicado de OVHcloud. Aquí encontrará todas las guías disponibles para instalar, configurar y administrar sus servidores de juego.
+Bienvenido a la documentación dedicada al [Game Panel de OVHcloud](/links/bare-metal/game-hub). El Game Panel le permite desplegar y gestionar servidores de juego para una amplia gama de títulos populares directamente desde su VPS o servidor dedicado de OVHcloud. Aquí encontrará todas las guías disponibles para instalar, configurar y administrar sus servidores de juego.
 
 ## ¿Qué es el Game Panel?
 

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -27,20 +27,20 @@ Los registros de inicio de Windows pueden ser útiles para diagnosticar errores 
 Para activarlos, siga los pasos que se indican a continuación navegando por las pestañas:
 
 <Tabs>
-  <Tab label="1. **Conectarse al servidor**">
+  <Tab label="1. Conectarse al servidor">
     Conéctese a su servidor a través de un escritorio remoto o una [sesión KVM](/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps).
   </Tab>
-  <Tab label="2. **Abrir la utilidad &quot;Ejecutar&quot;**">
+  <Tab label="2. Abrir la utilidad &quot;Ejecutar&quot;">
     Abra el menú `Inicio` de Windows y haga clic en <code className="action">Ejecutar</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-start-run.png" loading="lazy" />
   </Tab>
-  <Tab label="3. **Abrir `msconfig`**">
+  <Tab label="3. Abrir msconfig">
     Escriba `msconfig` y haga clic en <code className="action">Aceptar</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-msconfig.png" loading="lazy" />
   </Tab>
-  <Tab label="4. **Activar los registros**">
+  <Tab label="4. Activar los registros">
     En la nueva ventana, active la opción de registros junto a `Boot log`. A continuación, haga clic en <code className="action">Aceptar</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-log.png" loading="lazy" />

--- a/docs/es/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/es/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -40,14 +40,14 @@ Haga clic en <code className="action">Create Network</code>
 <img className="thumbnail" alt="network" src="/images/public-cloud/compute/create-instance-in-horizon/create-network-1.png" loading="lazy" />
 
 <Tabs>
-  <Tab label="1. **Network**">
+  <Tab label="1. Network">
     **Network Name:** Introduzca un nombre para la red.<br/>
     **Enable Admin State:** Deje esta opción marcada para activar la red.<br/>
     **Create Subnet:** Deje esta opción marcada para crear la subred.<br/>
     **Availability Zone Hints:** Deje la opción por defecto.<br/><br/>
     <img className="thumbnail" alt="network" src="/images/public-cloud/compute/create-instance-in-horizon/network_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="2. **Subnet**">
+  <Tab label="2. Subnet">
     **Subnet Name:** Introduzca un nombre para su subred.<br/>
     **Network Address:** Seleccione un rango de red privada. Por ejemplo, `192.168.0.0/24`.<br/>
     **IP Version:** Deje este valor a IPv4.<br/>
@@ -55,7 +55,7 @@ Haga clic en <code className="action">Create Network</code>
     **Disable Gateway:** Deje esta opción desactivada.<br/><br/>
     <img className="thumbnail" alt="subnet" src="/images/public-cloud/compute/create-instance-in-horizon/subnet_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="3. **Subnet Details**">
+  <Tab label="3. Subnet Details">
     **Enable DHCP:** Deje esta opción activada.<br/>
     **Allocation Pools:** Opcional. Puede especificar el intervalo en el que se seleccionan las direcciones IP.<br/>
     **DNS Name Servers:** Opcional. Puede especificar cualquier servidor de nombres DNS.<br/>

--- a/docs/es/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/es/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -115,7 +115,7 @@ Follow the one you prefer.
     Logged in to ovh-tuto-27gm21h6v46 as gitpod (s3://pulumi?endpoint=s3.gra.perf.cloud.ovh.net&region=gra)
     ```
   </Tab>
-  <Tab label="Backend configuration in the `Pulumi.yaml` file">
+  <Tab label="Backend configuration in the Pulumi.yaml file">
     Or if you don't want to type the URL every time, you can define a backend property in the `Pulumi.yaml` config file as below:
     
     ```bash

--- a/docs/es/guides/web-cloud/domains/dns-zone-records.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-records.mdx
@@ -42,7 +42,7 @@ Seleccione el registro que desee haciendo clic en cada una de las fichas siguien
     **A**ddress <br/><br/>
     Conecta un nombre de dominio a una dirección IPv4 `X.X.X` (donde las `X` son cifras entre `0` y `255`). Por ejemplo, la dirección IPv4 del servidor en el que está alojado el sitio web.
   </Tab>
-  <Tab label="**AAAA**">
+  <Tab label="AAAA">
     4 letras **A**, ya que este registro está codificado en cuatro veces más bits que el puntero **A** histórico<br/><br/>
     Conecta un nombre de dominio a una dirección IPv6. Por ejemplo, la dirección IPv6 del servidor en el que está alojado el sitio web.
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MX Plan - Documentación de correo OVHcloud"
+title: "MX Plan - Correo OVHcloud"
 description: "Configure su solución MX Plan OVHcloud: cree buzones, acceda al webmail y configure sus clientes de correo electrónico."
 lastUpdated: 2026-06-19
 pageType: landing

--- a/docs/es/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/es/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -1,5 +1,5 @@
 ---
-title: "SMS de OVHcloud - Documentación"
+title: "SMS de OVHcloud"
 description: "Envíe SMS y gestione sus campañas de SMS con OVHcloud: remitentes, destinatarios, créditos e integración mediante la API."
 lastUpdated: 2026-06-29
 pageType: landing

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -394,7 +394,7 @@ ip link set eth1 up
 #### Configurations GNU/Linux
 
 <Tabs>
-<Tab label="**Debian 11**">
+<Tab label="Debian 11">
 **Configurer l'Additional IP**
 
 Ouvrez le fichier de configuration réseau situé dans `/etc/network/interfaces.d` avec un éditeur de texte de votre choix. Ici, le fichier s'appelle `50-cloud-init`.
@@ -458,7 +458,7 @@ Redémarrez le serveur pour appliquer les modifications ou activez simplement la
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**CentOS, AlmaLinux et Rocky Linux (8/9)**">
+<Tab label="CentOS, AlmaLinux et Rocky Linux (8/9)">
 **Créer le fichier pour l'interface réseau secondaire**
 
 Copiez la configuration de l'interface réseau principale et adaptez-la selon vos besoins :
@@ -546,7 +546,7 @@ Redémarrez le serveur pour appliquer les modifications ou activez simplement la
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**Ubuntu et Debian 12+**">
+<Tab label="Ubuntu et Debian 12+">
 - Configurer l'Additional IP
 
 Ouvrez le fichier de configuration réseau situé dans `/etc/netplan` avec un éditeur de texte de votre choix. Ici, le fichier s'appelle `50-cloud-init.yaml`.
@@ -586,7 +586,7 @@ Appliquez la configuration avec la commande suivante :
 sudo netplan apply
 ```
 </Tab>
-<Tab label="**Fedora, AlmaLinux et Rocky Linux (10)**">
+<Tab label="Fedora, AlmaLinux et Rocky Linux (10)">
 Vérifiez d'abord que votre interface vRack est à l'état `connected` ou `connecting`. Dans notre exemple, l'interface s'appelle `eno2`.
 
 ```sh

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
@@ -1,5 +1,5 @@
 ---
-title: Documentation Game Panel
+title: "Game Panel"
 description: "Toute la documentation du Game Panel OVHcloud : déployez et gérez des serveurs de jeu sur votre VPS ou serveur dédié, installez plus de 140 titres, configurez vos serveurs, gérez les utilisateurs, les sauvegardes et les fichiers."
 lastUpdated: 2026-06-30
 pageType: landing
@@ -25,7 +25,7 @@ cta:
 
 import { LinkCard } from '@components/LinkCard';
 
-Bienvenue dans la documentation dédiée au [Game Panel OVHcloud](/links/bare-metal/vps). Le Game Panel vous permet de déployer et de gérer des serveurs de jeu pour un large éventail de titres populaires, directement depuis votre VPS ou serveur dédié OVHcloud. Vous y trouverez tous les guides disponibles pour installer, configurer et administrer vos serveurs de jeu.
+Bienvenue dans la documentation dédiée au [Game Panel OVHcloud](/links/bare-metal/game-hub). Le Game Panel vous permet de déployer et de gérer des serveurs de jeu pour un large éventail de titres populaires, directement depuis votre VPS ou serveur dédié OVHcloud. Vous y trouverez tous les guides disponibles pour installer, configurer et administrer vos serveurs de jeu.
 
 ## Qu'est-ce que le Game Panel ?
 

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -25,20 +25,20 @@ Ils sont particulièrement utiles pour le **diagnostic des problèmes de démarr
 Pour activer les logs de démarrage, suivez les étapes ci-dessous :
 
 <Tabs>
-  <Tab label="1. **Se connecter au serveur**">
+  <Tab label="1. Se connecter au serveur">
     Connectez-vous à votre serveur via un bureau à distance ou une [session KVM](/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps).
   </Tab>
-  <Tab label="2. **Ouvrir l'utilitaire « Exécuter »**">
+  <Tab label="2. Ouvrir l'utilitaire « Exécuter »">
     Ouvrez le menu `Démarrer` de Windows et cliquez sur <code className="action">Exécuter</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-start-run.png" loading="lazy" />
   </Tab>
-  <Tab label="3. **Ouvrir `msconfig`**">
+  <Tab label="3. Ouvrir msconfig">
     Entrez `msconfig` et cliquez sur <code className="action">OK</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-msconfig.png" loading="lazy" />
   </Tab>
-  <Tab label="4. **Activer les logs**">
+  <Tab label="4. Activer les logs">
     Dans la nouvelle fenêtre, activez l'option logs à côté de `Boot log`. Cliquez ensuite sur <code className="action">OK</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-log.png" loading="lazy" />

--- a/docs/fr/guides/hosted-private-cloud/opcp/landing-page-opcp.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/landing-page-opcp.mdx
@@ -37,7 +37,7 @@ La plateforme s'articule autour de trois briques, couvertes par ces guides :
 
 Pour trouver le guide adapté à votre besoin :
 
-- **Vous préparez, déployez ou exploitez votre plateforme ?** Consultez la section *Mise en route* pour les prérequis, l'installation d'un contrôleur, l'exploitation des nœuds et des instances.
+- **Vous préparez, déployez ou exploitez votre plateforme ?** Consultez la section *Premiers pas* pour les prérequis, l'installation d'un contrôleur, l'exploitation des nœuds et des instances.
 - **Vous gérez les identités et les permissions ?** Consultez la section *Sécurité*.
 - **Vous utilisez le CloudStore ou le Landing Zone Manager ?** Consultez les sections correspondantes.
 
@@ -55,7 +55,7 @@ Pour trouver le guide adapté à votre besoin :
 <CategoryColumns
   categories={[
     {
-      title: 'Mise en route',
+      title: 'Premiers pas',
       items: [
         { title: 'Intégration réseau et connectivité pour OPCP', link: '/guides/hosted-private-cloud/opcp/opcp-network-architecture' },
         { title: 'Prérequis techniques pour le déploiement', link: '/guides/hosted-private-cloud/opcp/opcp-prerequisites' },
@@ -93,7 +93,7 @@ Pour trouver le guide adapté à votre besoin :
       ],
     },
     {
-      title: 'Ressources supplémentaires',
+      title: 'Ressources additionnelles',
       items: [
         { title: 'Matrice de compatibilité OPCP Core', link: '/guides/hosted-private-cloud/opcp/opcp-compatibility-matrix' },
         { title: 'Fonctionnalités et spécifications d\'Object Storage sur OPCP', link: '/guides/hosted-private-cloud/opcp/s3-opcp-limitations' },
@@ -107,9 +107,9 @@ Pour trouver le guide adapté à votre besoin :
 </div>
 
 <style>{`
-  /* « Mise en route » est une longue liste : on la garde sur toute la hauteur
+  /* « Premiers pas » est une longue liste : on la garde sur toute la hauteur
      de la colonne de gauche et on empile les groupes plus courts (Sécurité,
-     CloudStore, Landing Zone Manager, Ressources supplémentaires) dans la
+     CloudStore, Landing Zone Manager, Ressources additionnelles) dans la
      colonne de droite pour équilibrer les deux côtés. */
   .opcp-landing-cols .rp-category-columns {
     grid-template-rows: repeat(4, auto);

--- a/docs/fr/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-bgp-between-pcc-inside-vrack.mdx
+++ b/docs/fr/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-bgp-between-pcc-inside-vrack.mdx
@@ -56,7 +56,7 @@ Créez un segment d'overlay à l'emplacement prévu pour le déploiement de notr
     <img className="thumbnail" alt="OverlaySegmentDE" src="/images/hosted-private-cloud/powered-by-vmware/nsx-configure-bgp-between-pcc-inside-vRack/segment_overlay_de.png" loading="lazy" />
     <img className="thumbnail" alt="OverlaySegmentDE2" src="/images/hosted-private-cloud/powered-by-vmware/nsx-configure-bgp-between-pcc-inside-vRack/segment_overlay_de_2.png" loading="lazy" />
   </Tab>
-  <Tab label="**UK**">
+  <Tab label="UK">
     <img className="thumbnail" alt="OverlaySegmentUK" src="/images/hosted-private-cloud/powered-by-vmware/nsx-configure-bgp-between-pcc-inside-vRack/segment_overlay_uk.png" loading="lazy" />
     <img className="thumbnail" alt="OverlaySegmentUK2" src="/images/hosted-private-cloud/powered-by-vmware/nsx-configure-bgp-between-pcc-inside-vRack/segment_overlay_uk_2.png" loading="lazy" />
   </Tab>

--- a/docs/fr/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/fr/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -36,14 +36,14 @@ Cliquez sur <code className="action">Create Network</code>
 
 
 <Tabs>
-  <Tab label="1. **Network (Réseau)**">
+  <Tab label="1. Network (Réseau)">
     **Network Name :** Entrez un nom pour votre réseau.<br/>
     **Enable Admin State :** Laissez cette option cochée pour activer le réseau.<br/>
     **Create Subnet :** Laissez cette option cochée pour créer le sous-réseau.<br/>
     **Availability Zone Hints :** Laissez l’option par défaut.<br/><br/>
     <img className="thumbnail" alt="network" src="/images/public-cloud/compute/create-instance-in-horizon/network_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="2. **Subnet (Sous-réseau)**">
+  <Tab label="2. Subnet (Sous-réseau)">
     **Subnet Name :** Entrez un nom pour votre sous-réseau.<br/>
     **Network Address :** Choisissez une plage de réseau privé. Par exemple : `192.168.0.0/24`.<br/>
     **IP Version :** Laissez cette valeur à IPv4.<br/>
@@ -51,7 +51,7 @@ Cliquez sur <code className="action">Create Network</code>
     **Disable Gateway :** Laissez cette option désactivée.<br/><br/>
     <img className="thumbnail" alt="subnet" src="/images/public-cloud/compute/create-instance-in-horizon/subnet_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="3. **Subnet Details (Détails du sous-réseau)**">
+  <Tab label="3. Subnet Details (Détails du sous-réseau)">
     **Enable DHCP :**  Laissez cette option activée.<br/>
     **Allocation Pools :** Facultatif. Vous pouvez spécifier la plage dans laquelle les adresses IP sont sélectionnées.<br/>
     **DNS Name Servers :** Facultatif. Vous pouvez spécifier n'importe quel serveur de noms DNS.<br/>

--- a/docs/fr/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/fr/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -115,7 +115,7 @@ Follow the one you prefer.
     Logged in to ovh-tuto-27gm21h6v46 as gitpod (s3://pulumi?endpoint=s3.gra.perf.cloud.ovh.net&region=gra)
     ```
   </Tab>
-  <Tab label="Backend configuration in the `Pulumi.yaml` file">
+  <Tab label="Backend configuration in the Pulumi.yaml file">
     Or if you don't want to type the URL every time, you can define a backend property in the `Pulumi.yaml` config file as below:
     
     ```bash

--- a/docs/fr/guides/web-cloud/domains/api-domain-rules.mdx
+++ b/docs/fr/guides/web-cloud/domains/api-domain-rules.mdx
@@ -556,7 +556,7 @@ Ces deux règles peuvent êtres combinées à l’aide de l’opérateur `and` d
 
 {/* prettier-ignore */}
 <Tabs>
-  <Tab label="Règles fusionnées en une seule par un `and`">
+  <Tab label="Règles fusionnées en une seule par un and">
     ```json
     {
       "and": [
@@ -603,7 +603,7 @@ Pour représenter les règles sur un objet, le nœud `fields` est utilisé. Chaq
   <Tab label="Masquer">
     Cliquez sur "Afficher" pour voir le JSON
   </Tab>
-  <Tab label="Afficher : Contrainte sur les champs d’un `contact`">
+  <Tab label="Afficher : Contrainte sur les champs d’un contact">
     ```json
     {
       "label": "OWNER_CONTACT",
@@ -797,7 +797,7 @@ Prenons maintenant l’exemple plus concret énoncé au début de cette section 
   <Tab label="Masquer">
     Cliquez sur "Afficher" pour voir le JSON
   </Tab>
-  <Tab label="Afficher : Exemple de condition sur un champ de `contact`">
+  <Tab label="Afficher : Exemple de condition sur un champ de contact">
     ```json
     {
       "label": "OWNER_CONTACT",
@@ -2469,7 +2469,7 @@ Cela se traduit de cette manière. Pour une raison de clarté, les règles sur l
   <Tab label="Masquer">
     Cliquez sur "Afficher" pour voir le JSON
   </Tab>
-  <Tab label="Afficher : Règle d’éligibilité du `.berlin`">
+  <Tab label="Afficher : Règle d’éligibilité du .berlin">
     ```json
     {
       "and": [

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MX Plan - Documentation e-mail OVHcloud"
+title: "MX Plan - E-mail OVHcloud"
 description: "Créez vos adresses e-mail MX Plan OVHcloud, accédez au webmail, configurez vos logiciels de messagerie et gérez vos fonctionnalités."
 lastUpdated: 2026-06-19
 pageType: landing

--- a/docs/fr/guides/web-cloud/internet/internet-access/landing-page-internet-access.mdx
+++ b/docs/fr/guides/web-cloud/internet/internet-access/landing-page-internet-access.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Accès Internet OVHcloud - Documentation"
+title: "Accès Internet OVHcloud"
 description: "Configurez, gérez et dépannez votre accès Internet xDSL et Fibre OVHcloud : box, identifiants PPPoE, IPv6, reverse DNS, options et résolution d'incidents."
 lastUpdated: 2026-06-29
 pageType: landing

--- a/docs/fr/guides/web-cloud/internet/overthebox/landing-page-overthebox.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/landing-page-overthebox.mdx
@@ -1,5 +1,5 @@
 ---
-title: "OverTheBox - Documentation"
+title: "OverTheBox"
 description: "Installez, configurez et administrez OverTheBox : agrégation et secours d'accès Internet, mise en service, configuration réseau, accès à distance et FAQ."
 lastUpdated: 2026-06-29
 pageType: landing

--- a/docs/fr/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -1,5 +1,5 @@
 ---
-title: "SMS OVHcloud - Documentation"
+title: "SMS OVHcloud"
 description: "Envoyez des SMS et gérez vos campagnes SMS avec OVHcloud : expéditeurs, destinataires, crédits, réponses et intégration via l'API."
 lastUpdated: 2026-06-29
 pageType: landing

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/landing-page-voip.mdx
@@ -1,5 +1,5 @@
 ---
-title: "VoIP OVHcloud - Documentation"
+title: "VoIP OVHcloud"
 description: "Toute la documentation de la téléphonie VoIP OVHcloud : configuration des lignes SIP, administration, numéros, sécurité et dépannage de vos services."
 lastUpdated: 2026-06-11
 pageType: landing

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -389,7 +389,7 @@ ip link set eth1 up
 #### Configurazioni GNU/Linux
 
 <Tabs>
-<Tab label="**Debian 11**">
+<Tab label="Debian 11">
 **Configurare l'Additional IP**
 
 Aprire il file di configurazione di rete situato in `/etc/network/interfaces.d` con un editor di testo a scelta. Qui il file si chiama `50-cloud-init`.
@@ -453,7 +453,7 @@ Riavviare il server per applicare le modifiche oppure abilitare semplicemente la
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**CentOS, AlmaLinux e Rocky Linux (8/9)**">
+<Tab label="CentOS, AlmaLinux e Rocky Linux (8/9)">
 **Creare il file per l'interfaccia di rete secondaria**
 
 Copiare la configurazione dell'interfaccia di rete primaria e adattarla alle proprie esigenze:
@@ -541,7 +541,7 @@ Riavviare il server per applicare le modifiche oppure abilitare semplicemente la
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**Ubuntu e Debian 12+**">
+<Tab label="Ubuntu e Debian 12+">
 - Configurare l'Additional IP
 
 Aprire il file di configurazione di rete situato in `/etc/netplan` con un editor di testo a scelta. Qui il file si chiama `50-cloud-init.yaml`.
@@ -581,7 +581,7 @@ Applicare la configurazione con il seguente comando:
 sudo netplan apply
 ```
 </Tab>
-<Tab label="**Fedora, AlmaLinux e Rocky Linux (10)**">
+<Tab label="Fedora, AlmaLinux e Rocky Linux (10)">
 Per prima cosa, verificare che l'interfaccia vRack sia nello stato `connected` o `connecting`. Nel nostro esempio, l'interfaccia si chiama `eno2`.
 
 ```sh

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/raid-soft-uefi.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/raid-soft-uefi.mdx
@@ -280,7 +280,7 @@ Puoi utilizzare il comando `lsblk` per verificare se la tua partizione fa parte 
     
     Dai risultati sopra, possiamo vedere che una sola partizione di sistema EFI è montata in `/boot/efi`. Gli ESP quindi non sono in mirror (replicati).
   </Tab>
-  <Tab label="**ESP in mirror** (replicati)">
+  <Tab label="ESP in mirror (replicati)">
     ```sh
     lsblk
     NAME        MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINTS

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
@@ -1,5 +1,5 @@
 ---
-title: Documentazione Game Panel
+title: "Game Panel"
 description: "Tutta la documentazione del Game Panel OVHcloud: distribuire e gestire server di gioco sul vostro VPS o server dedicato, installare oltre 140 titoli, configurare i server, gestire utenti, backup e file."
 lastUpdated: 2026-06-30
 pageType: landing
@@ -25,7 +25,7 @@ cta:
 
 import { LinkCard } from '@components/LinkCard';
 
-Benvenuti nella documentazione dedicata al [Game Panel OVHcloud](/links/bare-metal/vps). Il Game Panel vi permette di distribuire e gestire server di gioco per un'ampia gamma di titoli popolari, direttamente dal vostro VPS o server dedicato OVHcloud. Qui troverete tutte le guide disponibili per installare, configurare e amministrare i vostri server di gioco.
+Benvenuti nella documentazione dedicata al [Game Panel OVHcloud](/links/bare-metal/game-hub). Il Game Panel vi permette di distribuire e gestire server di gioco per un'ampia gamma di titoli popolari, direttamente dal vostro VPS o server dedicato OVHcloud. Qui troverete tutte le guide disponibili per installare, configurare e amministrare i vostri server di gioco.
 
 ## Cos'è il Game Panel?
 

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -27,20 +27,20 @@ I log di avvio di Windows possono essere utili per la diagnostica degli errori d
 Per attivarli, segui le seguenti fasi scorrendo le schede:
 
 <Tabs>
-  <Tab label="1. **Connettersi al server**">
+  <Tab label="1. Connettersi al server">
     Connetti il tuo server tramite desktop remoto o una [sessione KVM](/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps).
   </Tab>
-  <Tab label="2. **Aprire l'utilità &quot;Esegui&quot;**">
+  <Tab label="2. Aprire l'utilità &quot;Esegui&quot;">
     Apri il menu `Start` di Windows e clicca su <code className="action">Esegui</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-start-run.png" loading="lazy" />
   </Tab>
-  <Tab label="3. **Aprire `msconfig`**">
+  <Tab label="3. Aprire msconfig">
     Digita `msconfig` e clicca su <code className="action">OK</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-msconfig.png" loading="lazy" />
   </Tab>
-  <Tab label="4. **Attivare i log**">
+  <Tab label="4. Attivare i log">
     Nella nuova finestra, attiva l'opzione log accanto a `Boot log`. Clicca quindi su <code className="action">OK</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-log.png" loading="lazy" />

--- a/docs/it/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/it/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -40,14 +40,14 @@ Clicca su <code className="action">Create Network</code>
 <img className="thumbnail" alt="network" src="/images/public-cloud/compute/create-instance-in-horizon/create-network-1.png" loading="lazy" />
 
 <Tabs>
-  <Tab label="1. **Network (Rete)**">
+  <Tab label="1. Network (Rete)">
     **Network Name:** Immettere un nome per la rete.<br/>
     **Enable Admin State:** Selezionare questa opzione per attivare la rete.<br/>
     **Create Subnet:** Selezionare questa opzione per creare la sottorete.<br/>
     **Availability Zone Hints:** Lasciare l'opzione predefinita.<br/><br/>
     <img className="thumbnail" alt="network" src="/images/public-cloud/compute/create-instance-in-horizon/network_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="2. **Subnet (Sottorete)**">
+  <Tab label="2. Subnet (Sottorete)">
     **Subnet Name:** Immettere un nome per la sottorete.<br/>
     **Network Address:** Scegli un intervallo di rete privato. Ad esempio: `192.168.0.0/24`.<br/>
     **IP Version:** Lascia questo valore a IPv4.<br/>
@@ -55,7 +55,7 @@ Clicca su <code className="action">Create Network</code>
     **Disable Gateway:** Disattivare questa opzione.<br/><br/>
     <img className="thumbnail" alt="subnet" src="/images/public-cloud/compute/create-instance-in-horizon/subnet_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="3. **Subnet Details (Dettagli sottorete)**">
+  <Tab label="3. Subnet Details (Dettagli sottorete)">
     **Enable DHCP:** Lascia questa opzione abilitata.<br/>
     **Allocation Pools:** Facoltativo. È possibile specificare l'intervallo in cui vengono selezionati gli indirizzi IP.<br/>
     **DNS Name Server:** Facoltativo. È possibile specificare qualsiasi server dei nomi DNS.<br/>

--- a/docs/it/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/it/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -115,7 +115,7 @@ Follow the one you prefer.
     Logged in to ovh-tuto-27gm21h6v46 as gitpod (s3://pulumi?endpoint=s3.gra.perf.cloud.ovh.net&region=gra)
     ```
   </Tab>
-  <Tab label="Backend configuration in the `Pulumi.yaml` file">
+  <Tab label="Backend configuration in the Pulumi.yaml file">
     Or if you don't want to type the URL every time, you can define a backend property in the `Pulumi.yaml` config file as below:
     
     ```bash

--- a/docs/it/guides/web-cloud/domains/dns-zone-records.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zone-records.mdx
@@ -42,7 +42,7 @@ Selezionare il record desiderato facendo clic su ognuna delle schede seguenti.
     **A**ddress <br/><br/>
     Collega un nome di dominio a un indirizzo IPv4 `X.X.X.X` (dove le `X` sono cifre comprese tra `0` e `255`). ad esempio, l'indirizzo IPv4 del server in cui è ospitato il tuo sito Web.
   </Tab>
-  <Tab label="**AAAA**">
+  <Tab label="AAAA">
     4 lettere **A** perché questa registrazione è codificata su quattro volte più bit del campo di puntamento **A** storico<br/><br/>
     Collega un nome di dominio a un indirizzo IPv6. ad esempio, l'indirizzo IPv6 del server in cui è ospitato il tuo sito Web.
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MX Plan - Documentazione email OVHcloud"
+title: "MX Plan - Email OVHcloud"
 description: "Create caselle di posta MX Plan OVHcloud, accedete alla webmail e configurate i client di posta elettronica."
 lastUpdated: 2026-06-19
 pageType: landing

--- a/docs/it/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/it/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -1,5 +1,5 @@
 ---
-title: "SMS OVHcloud - Documentazione"
+title: "SMS OVHcloud"
 description: "Invia SMS e gestisci le tue campagne SMS con OVHcloud: mittenti, destinatari, crediti e integrazione tramite API."
 lastUpdated: 2026-06-29
 pageType: landing

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -389,7 +389,7 @@ ip link set eth1 up
 #### Konfiguracje GNU/Linux
 
 <Tabs>
-<Tab label="**Debian 11**">
+<Tab label="Debian 11">
 **Konfiguracja Additional IP**
 
 Otwórz plik konfiguracji sieci znajdujący się w `/etc/network/interfaces.d` za pomocą wybranego edytora tekstu. Tutaj plik nazywa się `50-cloud-init`.
@@ -453,7 +453,7 @@ Uruchom ponownie serwer, aby zastosować zmiany, lub włącz po prostu nowy inte
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**CentOS, AlmaLinux i Rocky Linux (8/9)**">
+<Tab label="CentOS, AlmaLinux i Rocky Linux (8/9)">
 **Tworzenie pliku dla dodatkowego interfejsu sieciowego**
 
 Skopiuj konfigurację głównego interfejsu sieciowego i dostosuj ją do swoich potrzeb:
@@ -541,7 +541,7 @@ Uruchom ponownie serwer, aby zastosować zmiany, lub włącz po prostu nowy inte
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**Ubuntu i Debian 12+**">
+<Tab label="Ubuntu i Debian 12+">
 - Konfiguracja Additional IP
 
 Otwórz plik konfiguracji sieci znajdujący się w `/etc/netplan` za pomocą wybranego edytora tekstu. Tutaj plik nazywa się `50-cloud-init.yaml`.
@@ -581,7 +581,7 @@ Zastosuj konfigurację za pomocą następującego polecenia:
 sudo netplan apply
 ```
 </Tab>
-<Tab label="**Fedora, AlmaLinux i Rocky Linux (10)**">
+<Tab label="Fedora, AlmaLinux i Rocky Linux (10)">
 Najpierw sprawdź, czy interfejs vRack ma status `connected` lub `connecting`. W naszym przykładzie interfejs nazywa się `eno2`.
 
 ```sh

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
@@ -1,5 +1,5 @@
 ---
-title: Dokumentacja Game Panel
+title: "Game Panel"
 description: "Cała dokumentacja OVHcloud Game Panel: wdrażaj serwery gier na VPS lub serwerze dedykowanym i zarządzaj nimi, instaluj ponad 140 tytułów, konfiguruj serwery, zarządzaj użytkownikami, kopiami zapasowymi i plikami."
 lastUpdated: 2026-06-30
 pageType: landing
@@ -25,7 +25,7 @@ cta:
 
 import { LinkCard } from '@components/LinkCard';
 
-Witamy w dokumentacji poświęconej [OVHcloud Game Panel](/links/bare-metal/vps). Game Panel umożliwia wdrażanie serwerów gier dla szerokiej gamy popularnych tytułów oraz zarządzanie nimi bezpośrednio z poziomu Twojego VPS lub serwera dedykowanego OVHcloud. Znajdziesz tu wszystkie dostępne przewodniki dotyczące instalacji, konfiguracji i administrowania serwerami gier.
+Witamy w dokumentacji poświęconej [OVHcloud Game Panel](/links/bare-metal/game-hub). Game Panel umożliwia wdrażanie serwerów gier dla szerokiej gamy popularnych tytułów oraz zarządzanie nimi bezpośrednio z poziomu Twojego VPS lub serwera dedykowanego OVHcloud. Znajdziesz tu wszystkie dostępne przewodniki dotyczące instalacji, konfiguracji i administrowania serwerami gier.
 
 ## Czym jest Game Panel?
 

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -27,20 +27,20 @@ Logi uruchamiania Windows mogą być przydatne do diagnozowania błędów serwer
 Aby je włączyć, wykonaj poniższe kroki, przechodząc przez zakładki:
 
 <Tabs>
-  <Tab label="1. **Połącz się z serwerem**">
+  <Tab label="1. Połącz się z serwerem">
     Połącz się z serwerem za pomocą pulpitu zdalnego lub [sesji KVM](/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps).
   </Tab>
-  <Tab label="2. **Otwórz uchwyt uruchamiania**">
+  <Tab label="2. Otwórz uchwyt uruchamiania">
     Otwórz menu `Start` systemu Windows i kliknij <code className="action">Uruchom</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-start-run.png" loading="lazy" />
   </Tab>
-  <Tab label="3. **Otwórz `msconfig`**">
+  <Tab label="3. Otwórz msconfig">
     Wpisz `msconfig` i kliknij <code className="action">OK</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-msconfig.png" loading="lazy" />
   </Tab>
-  <Tab label="4. **Włącz logi**">
+  <Tab label="4. Włącz logi">
     W nowym oknie włącz opcję logowania obok `Boot log`. Następnie kliknij <code className="action">OK</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-log.png" loading="lazy" />

--- a/docs/pl/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/pl/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -41,14 +41,14 @@ Kliknij <code className="action">Create Network</code>
 
 
 <Tabs>
-  <Tab label="1. **Network (Sieć)**">
+  <Tab label="1. Network (Sieć)">
     **Network Name:** Wprowadź nazwę sieci.<br/>
     **Enable Admin State:** Pozostaw zaznaczoną opcję, aby włączyć sieć.<br/>
     **Create Subnet:** Pozostaw zaznaczoną opcję, aby utworzyć podsieć.<br/>
     **Availability Zone Hints:** Pozostaw opcję domyślną.<br/><br/>
     <img className="thumbnail" alt="network" src="/images/public-cloud/compute/create-instance-in-horizon/network_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="2. **Subnet (Podsieć)**">
+  <Tab label="2. Subnet (Podsieć)">
     **Subnet Name:** Wprowadź nazwę podsieci.<br/>
     **Network Address:** Wybierz zakres sieci prywatnej. Na przykład: `192.168.0.0/24`.<br/>
     **IP Version:** Pozostaw tę wartość dla adresu IPv4.<br/>
@@ -56,7 +56,7 @@ Kliknij <code className="action">Create Network</code>
     **Disable Gateway:** Pozostaw tę opcję wyłączoną.<br/><br/>
     <img className="thumbnail" alt="subnet" src="/images/public-cloud/compute/create-instance-in-horizon/subnet_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="3. **Subnet Szczegóły (Szczegóły podsieci)**">
+  <Tab label="3. Subnet Szczegóły (Szczegóły podsieci)">
     **Enable DHCP:** Pozostaw tę opcję włączoną.<br/>
     **Allocation Pools:** Opcjonalnie. Możesz określić zakres, w którym wybrane są adresy IP.<br/>
     **DNS Name Server:** Opcjonalnie. Możesz określić dowolny serwer nazw DNS.<br/>

--- a/docs/pl/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/pl/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -115,7 +115,7 @@ Follow the one you prefer.
     Logged in to ovh-tuto-27gm21h6v46 as gitpod (s3://pulumi?endpoint=s3.gra.perf.cloud.ovh.net&region=gra)
     ```
   </Tab>
-  <Tab label="Backend configuration in the `Pulumi.yaml` file">
+  <Tab label="Backend configuration in the Pulumi.yaml file">
     Or if you don't want to type the URL every time, you can define a backend property in the `Pulumi.yaml` config file as below:
     
     ```bash

--- a/docs/pl/guides/web-cloud/domains/dns-zone-records.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-records.mdx
@@ -42,7 +42,7 @@ Wybierz odpowiedni rekord, klikając każdą z następujących zakładek.
     **A**ddress <br/><br/>
     Powiąż nazwę domeny z adresem IPv4 `X.X.X.X` (gdzie `X` to cyfry od `0` do `255`). Na przykład adres IPv4 serwera, na którym hostowana jest Twoja strona WWW.
   </Tab>
-  <Tab label="**AAAA**">
+  <Tab label="AAAA">
     Four **A** characters because this record is encoded on four times more bits than the historical **A** field.
     Powiąż nazwę domeny z adresem IPv6. Na przykład adres IPv6 serwera, na którym hostowana jest Twoja strona WWW.
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MX Plan - Dokumentacja e-mail OVHcloud"
+title: "MX Plan - E-mail OVHcloud"
 description: "Konfiguruj MX Plan OVHcloud: twórz skrzynki pocztowe, korzystaj z webmaila i konfiguruj klientów poczty elektronicznej."
 lastUpdated: 2026-06-19
 pageType: landing

--- a/docs/pl/guides/web-cloud/messaging/sms/landing-page-sms.mdx
+++ b/docs/pl/guides/web-cloud/messaging/sms/landing-page-sms.mdx
@@ -1,5 +1,5 @@
 ---
-title: "SMS OVHcloud - Dokumentacja"
+title: "SMS OVHcloud"
 description: "Wysyłaj wiadomości SMS i zarządzaj kampaniami SMS w OVHcloud: nadawcy, odbiorcy, środki i integracja z API."
 lastUpdated: 2026-06-29
 pageType: landing

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -389,7 +389,7 @@ ip link set eth1 up
 #### Configurações GNU/Linux
 
 <Tabs>
-<Tab label="**Debian 11**">
+<Tab label="Debian 11">
 **Configurar o Additional IP**
 
 Abra o ficheiro de configuração de rede situado em `/etc/network/interfaces.d` com um editor de texto à sua escolha. Aqui, o ficheiro chama-se `50-cloud-init`.
@@ -453,7 +453,7 @@ Reinicie o servidor para aplicar as alterações ou ative simplesmente a nova in
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**CentOS, AlmaLinux e Rocky Linux (8/9)**">
+<Tab label="CentOS, AlmaLinux e Rocky Linux (8/9)">
 **Criar o ficheiro para a interface de rede secundária**
 
 Copie a configuração da interface de rede primária e ajuste-a de acordo com as suas necessidades:
@@ -541,7 +541,7 @@ Reinicie o servidor para aplicar as alterações ou ative simplesmente a nova in
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="**Ubuntu e Debian 12+**">
+<Tab label="Ubuntu e Debian 12+">
 - Configurar o Additional IP
 
 Abra o ficheiro de configuração de rede situado em `/etc/netplan` com um editor de texto à sua escolha. Aqui, o ficheiro chama-se `50-cloud-init.yaml`.
@@ -581,7 +581,7 @@ Aplique a configuração com o seguinte comando:
 sudo netplan apply
 ```
 </Tab>
-<Tab label="**Fedora, AlmaLinux e Rocky Linux (10)**">
+<Tab label="Fedora, AlmaLinux e Rocky Linux (10)">
 Em primeiro lugar, verifique que a sua interface vRack está no estado `connected` ou `connecting`. No nosso exemplo, a interface chama-se `eno2`.
 
 ```sh

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/landing-page-game-panel.mdx
@@ -1,5 +1,5 @@
 ---
-title: Documentação Game Panel
+title: "Game Panel"
 description: "Toda a documentação do Game Panel OVHcloud: implemente e faça a gestão de servidores de jogo no seu VPS ou servidor dedicado, instale mais de 140 títulos, configure servidores, faça a gestão de utilizadores, backups e ficheiros."
 lastUpdated: 2026-06-30
 pageType: landing
@@ -25,7 +25,7 @@ cta:
 
 import { LinkCard } from '@components/LinkCard';
 
-Bem-vindo à documentação dedicada ao [Game Panel OVHcloud](/links/bare-metal/vps). O Game Panel permite-lhe implementar e fazer a gestão de servidores de jogo para uma vasta gama de títulos populares diretamente a partir do seu VPS ou servidor dedicado OVHcloud. Aqui encontra todos os guias disponíveis para instalar, configurar e administrar os seus servidores de jogo.
+Bem-vindo à documentação dedicada ao [Game Panel OVHcloud](/links/bare-metal/game-hub). O Game Panel permite-lhe implementar e fazer a gestão de servidores de jogo para uma vasta gama de títulos populares diretamente a partir do seu VPS ou servidor dedicado OVHcloud. Aqui encontra todos os guias disponíveis para instalar, configurar e administrar os seus servidores de jogo.
 
 ## O que é o Game Panel?
 

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/windows-boot-logs.mdx
@@ -27,20 +27,20 @@ Os registos de arranque do Windows podem ser úteis para diagnósticos de erros 
 Para os ativar, siga os passos abaixo, navegando pelos separadores:
 
 <Tabs>
-  <Tab label="1. **Ligar-se ao servidor**">
+  <Tab label="1. Ligar-se ao servidor">
     Ligue-se ao seu servidor através de um ambiente de trabalho remoto ou uma [sessão KVM](/guides/bare-metal-cloud/virtual-private-servers/using-kvm-for-vps).
   </Tab>
-  <Tab label="2. **Abrir o utilitário &quot;Executar&quot;**">
+  <Tab label="2. Abrir o utilitário &quot;Executar&quot;">
     Abra o menu `Iniciar` do Windows e clique em <code className="action">Executar</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-start-run.png" loading="lazy" />
   </Tab>
-  <Tab label="3. **Abrir `msconfig`**">
+  <Tab label="3. Abrir msconfig">
     Introduza `msconfig` e clique em <code className="action">OK</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-msconfig.png" loading="lazy" />
   </Tab>
-  <Tab label="4. **Ativar os registos**">
+  <Tab label="4. Ativar os registos">
     Na nova janela, ative a opção de registos ao lado de `Boot log`. Clique depois em <code className="action">OK</code>.
     
     <img className="thumbnail" alt="KVM" src="/images/assets/screens/other/windows/windows-log.png" loading="lazy" />

--- a/docs/pt/guides/public-cloud/compute/create-instance-in-horizon.mdx
+++ b/docs/pt/guides/public-cloud/compute/create-instance-in-horizon.mdx
@@ -40,14 +40,14 @@ Clique em <code className="action">Create Network</code>
 <img className="thumbnail" alt="network" src="/images/public-cloud/compute/create-instance-in-horizon/create-network-1.png" loading="lazy" />
 
 <Tabs>
-  <Tab label="1. **Network (Rede)**">
+  <Tab label="1. Network (Rede)">
     **Network Name:** Introduza um nome para a sua rede.<br/>
     **Enable Admin State:** Deixe esta opção selecionada para ativar a rede.<br/>
     **Create Subnet:** Deixe esta opção selecionada para criar a sub-rede.<br/>
     **Availability Zone Hints:** Deixe a opção predefinida.<br/><br/>
     <img className="thumbnail" alt="network" src="/images/public-cloud/compute/create-instance-in-horizon/network_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="2. **Subnet (Sub-rede)**">
+  <Tab label="2. Subnet (Sub-rede)">
     **Subnet Name:** Introduza um nome para a sua sub-rede.<br/>
     **Network Address:** Escolha um intervalo da rede privada. Por exemplo: `192.168.0.0/24`.<br/>
     **IP Version:** Deixe este valor para IPv4.<br/>
@@ -55,7 +55,7 @@ Clique em <code className="action">Create Network</code>
     **Disable Gateway:** Deixe esta opção desativada.<br/><br/>
     <img className="thumbnail" alt="subnet" src="/images/public-cloud/compute/create-instance-in-horizon/subnet_information.png" loading="lazy" /><br/>
   </Tab>
-  <Tab label="3. **Subnet Details (Detalhes da sub-rede)**">
+  <Tab label="3. Subnet Details (Detalhes da sub-rede)">
     **Enable DHCP:** Deixe esta opção ativada.<br/>
     **Allocation Pools:** Opcional. Pode especificar o intervalo no qual os endereços IP são selecionados.<br/>
     **DNS Name Servers:** Opcional. Pode especificar qualquer servidor de nomes DNS.<br/>

--- a/docs/pt/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/pt/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -115,7 +115,7 @@ Follow the one you prefer.
     Logged in to ovh-tuto-27gm21h6v46 as gitpod (s3://pulumi?endpoint=s3.gra.perf.cloud.ovh.net&region=gra)
     ```
   </Tab>
-  <Tab label="Backend configuration in the `Pulumi.yaml` file">
+  <Tab label="Backend configuration in the Pulumi.yaml file">
     Or if you don't want to type the URL every time, you can define a backend property in the `Pulumi.yaml` config file as below:
     
     ```bash

--- a/docs/pt/guides/web-cloud/domains/dns-zone-records.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zone-records.mdx
@@ -42,7 +42,7 @@ Selecione o registo à sua escolha clicando nos separadores seguintes.
     **A**ddress <br/><br/>
     Liga um nome de domínio a um endereço IPv4 `X.X.X.X` (em que os `X` são números entre `0` e `255`). Por exemplo, o endereço IPv4 do servidor onde está alojado o seu website.
   </Tab>
-  <Tab label="**AAAA**">
+  <Tab label="AAAA">
     4 letras **A**, pois este registo está codificado em quatro vezes mais bits que o registo histórico de apontamento **A**
     Associe um nome de domínio a um endereço IPv6. Por exemplo, o endereço IPv6 do servidor onde está alojado o seu website.
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MX Plan - Documentação de e-mail OVHcloud"
+title: "MX Plan - E-mail OVHcloud"
 description: "Configure o MX Plan OVHcloud: crie caixas de correio, aceda ao webmail e configure os seus clientes de e-mail."
 lastUpdated: 2026-06-19
 pageType: landing

--- a/theme/components/Sidebar/SidebarGroup.tsx
+++ b/theme/components/Sidebar/SidebarGroup.tsx
@@ -98,13 +98,12 @@ export function SidebarGroup(props: SidebarGroupProps) {
         depth={depth}
         onClick={(e) => {
           // Linked category (has a landing page): let the underlying <Link>
-          // handle navigation. We only ensure the group expands — clicking the
-          // row never collapses it (the chevron does that). This gives the
-          // "navigate + keep expanded" behaviour for landing categories.
+          // handle navigation, but also toggle the group so a click on the
+          // row behaves like a container category — expand on the way in,
+          // collapse on the way back. This keeps navigate + toggle in sync
+          // whether the row is currently collapsed or expanded.
           if (item.link) {
-            if (collapsible && collapsed) {
-              toggleCollapse();
-            }
+            collapsible && toggleCollapse();
             return;
           }
           // Container-only category: clicking the row toggles expand/collapse.


### PR DESCRIPTION
Landing page and cross-cutting UI fixes:

- Titles: drop redundant "Documentation" from landing page titles (Game Panel, MX Plan, SMS, VoIP, OverTheBox, Internet Access), aligning with the clean OPCP pattern. Keep product/brand qualifiers and email-family taglines.
- Tab labels: strip literal Markdown that does not render inside JSX attributes: ** (91 labels) and backticks (22 labels) across Tab label="..." values, repo-wide, all locales.
- Game Panel landing: first link now points to the Game Hub landing page via a new locale-aware /links/bare-metal/game-hub token (was /links/bare-metal/vps).
- OPCP FR landing: category names match the sidebar (Premiers pas, Ressources additionnelles).
- Sidebar: clicking the title of a landing-page category now toggles collapse like a container category, instead of only expanding.