### PR TITLE
fix(sidebar): keep active branch when opening a multi-located guide

### DIFF
--- a/theme/components/Sidebar/SidebarGroup.tsx
+++ b/theme/components/Sidebar/SidebarGroup.tsx
@@ -63,13 +63,17 @@ export interface SidebarGroupProps {
 
 export function SidebarGroup(props: SidebarGroupProps) {
   const activeMatcher = useActiveMatcher();
-  const { activeId, notifyClick } = useActiveBranch();
+  const { activeId, notifyClick, shouldForceCollapse } = useActiveBranch();
   const { item, depth, id, setSidebarData, className } = props;
   // A linked category can itself be multi-located: highlight it only when it
   // is the single resolved-active instance, not merely a route match.
   const active = item.link && activeMatcher(item.link) && id === activeId;
-  const { collapsed = false, collapsible = true } =
+  const { collapsed: rawCollapsed = false, collapsible = true } =
     item as NormalizedSidebarGroup;
+  // A "wrong" branch of a multi-located guide is forced collapsed even though
+  // Rspress auto-expanded it (see ActiveBranchProvider). Otherwise honour the
+  // group's own collapse state (config default + user toggles).
+  const collapsed = shouldForceCollapse(id) || rawCollapsed;
 
   const toggleCollapse = (): void => {
     // update collapsed state

--- a/theme/components/Sidebar/SidebarGroup.tsx
+++ b/theme/components/Sidebar/SidebarGroup.tsx
@@ -9,6 +9,7 @@ import { IconArrowRight as ArrowRight, SvgWrapper } from '@theme-original';
 import clsx from 'clsx';
 import type React from 'react';
 import { SidebarDivider } from './SidebarDivider';
+import { useActiveBranch } from './useActiveBranch';
 import './SidebarGroup.scss';
 import { SidebarItem as SidebarItemComp, SidebarItemRaw } from './SidebarItem';
 import { SidebarSectionHeader } from './SidebarSectionHeader';
@@ -62,8 +63,11 @@ export interface SidebarGroupProps {
 
 export function SidebarGroup(props: SidebarGroupProps) {
   const activeMatcher = useActiveMatcher();
+  const { activeId, notifyClick } = useActiveBranch();
   const { item, depth, id, setSidebarData, className } = props;
-  const active = item.link && activeMatcher(item.link);
+  // A linked category can itself be multi-located: highlight it only when it
+  // is the single resolved-active instance, not merely a route match.
+  const active = item.link && activeMatcher(item.link) && id === activeId;
   const { collapsed = false, collapsible = true } =
     item as NormalizedSidebarGroup;
 
@@ -103,6 +107,7 @@ export function SidebarGroup(props: SidebarGroupProps) {
           // collapse on the way back. This keeps navigate + toggle in sync
           // whether the row is currently collapsed or expanded.
           if (item.link) {
+            notifyClick(id);
             collapsible && toggleCollapse();
             return;
           }
@@ -172,6 +177,7 @@ export function SidebarGroup(props: SidebarGroupProps) {
               <SidebarItemComp
                 // biome-ignore lint/suspicious/noArrayIndexKey: sidebar items have no stable unique ID
                 key={index}
+                id={`${id}-${index}`}
                 item={item}
                 depth={depth + 1}
                 className="rp-sidebar-item--group-item"

--- a/theme/components/Sidebar/SidebarItem.tsx
+++ b/theme/components/Sidebar/SidebarItem.tsx
@@ -9,6 +9,7 @@ import type React from 'react';
 import { useEffect, useRef, useTransition } from 'react';
 import './SidebarItem.scss';
 import scrollIntoView from 'scroll-into-view-if-needed';
+import { useActiveBranch } from './useActiveBranch';
 
 export function SidebarItemRaw({
   active,
@@ -120,14 +121,20 @@ export interface SidebarItemProps {
   item: SidebarItemType | NormalizedSidebarGroup;
   depth: number;
   className?: string;
+  /** Stable tree-path id of this instance (e.g. "3-2-1"). */
+  id: string;
 }
 
 export function SidebarItem(props: SidebarItemProps) {
-  const { item, depth, className } = props;
+  const { item, depth, className, id } = props;
   const activeMatcher = useActiveMatcher();
+  const { activeId, notifyClick } = useActiveBranch();
 
+  // Route match is necessary but not sufficient: a multi-located guide matches
+  // the route in every branch it appears in. Only THIS instance is active when
+  // it is also the single resolved-active instance for the current route.
   const active = Boolean(
-    'link' in item && item.link && activeMatcher(item.link),
+    'link' in item && item.link && activeMatcher(item.link) && id === activeId,
   );
 
   return (
@@ -139,6 +146,7 @@ export function SidebarItem(props: SidebarItemProps) {
       text={item.text}
       context={item.context}
       depth={depth}
+      onClick={() => notifyClick(id)}
     />
   );
 }

--- a/theme/components/Sidebar/index.tsx
+++ b/theme/components/Sidebar/index.tsx
@@ -15,6 +15,7 @@ import { SidebarDivider } from './SidebarDivider';
 import { SidebarGroup } from './SidebarGroup';
 import { SidebarItem } from './SidebarItem';
 import { SidebarSectionHeader } from './SidebarSectionHeader';
+import { ActiveBranchProvider } from './useActiveBranch';
 import {
   isSidebarDivider,
   isSidebarGroup,
@@ -84,19 +85,24 @@ export function SidebarList({
           <img src="/images/ai.svg" alt="AI assistant" className="w-6 h-6" />
         </button>
       </div>
-      <div className="overflow-auto">
-        {sidebarData.map((item, index) => {
-          return (
-            <SidebarListItem
-              // biome-ignore lint/suspicious/noArrayIndexKey: sidebar items have no stable unique ID
-              key={index}
-              item={item}
-              index={index}
-              setSidebarData={setSidebarData}
-            />
-          );
-        })}
-      </div>
+      <ActiveBranchProvider
+        sidebarData={sidebarData}
+        setSidebarData={setSidebarData}
+      >
+        <div className="overflow-auto">
+          {sidebarData.map((item, index) => {
+            return (
+              <SidebarListItem
+                // biome-ignore lint/suspicious/noArrayIndexKey: sidebar items have no stable unique ID
+                key={index}
+                item={item}
+                index={index}
+                setSidebarData={setSidebarData}
+              />
+            );
+          })}
+        </div>
+      </ActiveBranchProvider>
       <div className="grow"></div>
       <div className="flex flex-row align-items border-t border-gray-200 px-2">
         <SocialLinks />
@@ -147,5 +153,5 @@ function SidebarListItem(props: {
     );
   }
 
-  return <SidebarItem item={item} key={index} depth={0} />;
+  return <SidebarItem item={item} key={index} depth={0} id={String(index)} />;
 }

--- a/theme/components/Sidebar/index.tsx
+++ b/theme/components/Sidebar/index.tsx
@@ -85,10 +85,7 @@ export function SidebarList({
           <img src="/images/ai.svg" alt="AI assistant" className="w-6 h-6" />
         </button>
       </div>
-      <ActiveBranchProvider
-        sidebarData={sidebarData}
-        setSidebarData={setSidebarData}
-      >
+      <ActiveBranchProvider sidebarData={sidebarData}>
         <div className="overflow-auto">
           {sidebarData.map((item, index) => {
             return (

--- a/theme/components/Sidebar/useActiveBranch.tsx
+++ b/theme/components/Sidebar/useActiveBranch.tsx
@@ -1,0 +1,339 @@
+import type { NormalizedSidebarGroup, SidebarData } from '@rspress/core';
+import { useActiveMatcher } from '@rspress/core/runtime';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { isSidebarGroup } from './utils';
+
+/**
+ * Location-aware active-branch resolution for multi-located guides.
+ *
+ * ~12% of guides are listed in more than one sidebar group (e.g. the SSH
+ * introduction lives under both Dedicated Servers and VPS). Rspress keys
+ * "active" purely off the link string, so every branch containing the link
+ * expands and each active DOM node fights over `scrollIntoView`.
+ *
+ * We instead resolve a SINGLE active instance, identified by its position in
+ * the tree (the same `id` path SidebarGroup already uses, e.g. "3-2-1").
+ * Selection order:
+ *   1. If the user just clicked a specific sidebar instance, that instance.
+ *   2. Else, the candidate whose tree path shares the longest prefix with the
+ *      previously-active instance — i.e. keep the customer in the branch they
+ *      were browsing (works even when both branches share a top-level product
+ *      family and diverge only at the sub-group).
+ *   3. Else (cold deep-link / search / external entry), the first candidate
+ *      in tree order — the guide's canonical (first-listed) branch.
+ *
+ * The chosen branch is persisted in sessionStorage so it survives in-SPA
+ * navigations and reloads within the session.
+ */
+
+const STORAGE_KEY = 'ovh.sidebar.activeBranch';
+
+interface ActiveBranchContextValue {
+  /** Full tree-path id of the single resolved-active instance, or null. */
+  activeId: string | null;
+  /** Record that the user clicked a specific instance (by its tree-path id). */
+  notifyClick: (id: string) => void;
+}
+
+const ActiveBranchContext = createContext<ActiveBranchContextValue>({
+  activeId: null,
+  notifyClick: () => {},
+});
+
+/**
+ * Number of leading id segments two instance paths share. Multi-located guides
+ * often live under the SAME top-level product family (e.g. both SSH instances
+ * sit under "Bare Metal Cloud", diverging only at the product sub-group
+ * Dedicated Servers vs Virtual Private Servers). So a branch must be
+ * identified by its FULL path, and "same branch as before" means the candidate
+ * whose path shares the longest prefix with the previously-active one.
+ */
+function sharedPrefixLength(a: string, b: string): number {
+  const pa = a.split('-');
+  const pb = b.split('-');
+  let n = 0;
+  while (n < pa.length && n < pb.length && pa[n] === pb[n]) n++;
+  return n;
+}
+
+/** True when `groupId` is an ancestor of (or equal to) `id`. */
+export function isAncestorId(groupId: string, id: string | null): boolean {
+  if (!id) return false;
+  return id === groupId || id.startsWith(`${groupId}-`);
+}
+
+type SidebarNode = SidebarData[number];
+
+/**
+ * Walk the sidebar tree and collect the tree-path id of every instance whose
+ * link matches the active route, in depth-first (tree) order.
+ */
+function collectCandidates(
+  data: SidebarData,
+  activeMatcher: (link: string) => boolean,
+): string[] {
+  const candidates: string[] = [];
+  const visit = (node: SidebarNode, id: string): void => {
+    if ('link' in node && node.link && activeMatcher(node.link)) {
+      candidates.push(id);
+    }
+    if (isSidebarGroup(node)) {
+      (node as NormalizedSidebarGroup).items.forEach((child, index) => {
+        visit(child as SidebarNode, `${id}-${index}`);
+      });
+    }
+  };
+  data.forEach((node, index) => {
+    visit(node, String(index));
+  });
+  return candidates;
+}
+
+/** All ancestor-group ids of an instance id, excluding the instance itself. */
+function ancestorIdsOf(id: string): string[] {
+  const parts = id.split('-');
+  const ancestors: string[] = [];
+  for (let i = 1; i < parts.length; i++) {
+    ancestors.push(parts.slice(0, i).join('-'));
+  }
+  return ancestors;
+}
+
+/** Read `collapsed` of the group at `groupId`, or undefined if not a group. */
+function getCollapsedAt(
+  data: SidebarData,
+  groupId: string,
+): boolean | undefined {
+  const indexes = groupId.split('-').map(Number);
+  let current: SidebarNode | undefined = data[indexes[0]];
+  for (let i = 1; i < indexes.length && current; i++) {
+    if (!isSidebarGroup(current)) return undefined;
+    current = (current as NormalizedSidebarGroup).items[
+      indexes[i]
+    ] as SidebarNode;
+  }
+  return current && 'items' in current
+    ? (current as NormalizedSidebarGroup).collapsed
+    : undefined;
+}
+
+/** Set `collapsed` on the group at `groupId` within a cloned tree. */
+function setCollapsedAt(
+  data: SidebarData,
+  groupId: string,
+  collapsed: boolean,
+): void {
+  const indexes = groupId.split('-').map(Number);
+  let current: SidebarNode | undefined = data[indexes[0]];
+  for (let i = 1; i < indexes.length && current; i++) {
+    if (!isSidebarGroup(current)) return;
+    current = (current as NormalizedSidebarGroup).items[
+      indexes[i]
+    ] as SidebarNode;
+  }
+  if (current && 'items' in current) {
+    (current as NormalizedSidebarGroup).collapsed = collapsed;
+  }
+}
+
+/**
+ * Reconcile branch expansion for a multi-located guide:
+ *  - collapse, for each non-resolved candidate, its SHALLOWEST ancestor group
+ *    not shared with the resolved instance (closes the whole wrong branch);
+ *  - (re-)open every ancestor of the resolved instance, so a branch that a
+ *    prior transient resolution had collapsed is corrected in the same pass.
+ * The shared product family (a common ancestor) is thus always left open.
+ * Returns a new (mutated clone) sidebar tree; the caller passes the previous
+ * state. Returns the input unchanged when nothing needs to move.
+ */
+function collapseAncestorsOf(
+  data: SidebarData,
+  nonResolved: string[],
+  activeId: string,
+): SidebarData {
+  const openIds = ancestorIdsOf(activeId);
+  const keepOpen = new Set([activeId, ...openIds]);
+  const collapseIds = new Set<string>();
+  for (const id of nonResolved) {
+    // ancestorIdsOf returns shallow→deep; the first not shared with the
+    // resolved instance is the divergence point for this branch.
+    const divergent = ancestorIdsOf(id).find((a) => !keepOpen.has(a));
+    if (divergent) collapseIds.add(divergent);
+  }
+  if (collapseIds.size === 0) return data;
+
+  // No-op guard: if the tree is already in the desired state, return the SAME
+  // reference so React skips a needless re-render (and so this function can
+  // never drive a render loop even if effect deps change in future).
+  const alreadyDone =
+    openIds.every((id) => getCollapsedAt(data, id) !== true) &&
+    [...collapseIds].every((id) => getCollapsedAt(data, id) === true);
+  if (alreadyDone) return data;
+
+  const clone = structuredClone(data);
+  for (const id of openIds) setCollapsedAt(clone, id, false);
+  for (const id of collapseIds) setCollapsedAt(clone, id, true);
+  return clone;
+}
+
+function readStoredBranch(): string | null {
+  try {
+    return sessionStorage.getItem(STORAGE_KEY);
+  } catch {
+    // sessionStorage unavailable — fall back to canonical.
+    return null;
+  }
+}
+
+function writeStoredBranch(branch: string): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, branch);
+  } catch {
+    // ignore
+  }
+}
+
+export function ActiveBranchProvider({
+  sidebarData,
+  setSidebarData,
+  children,
+}: {
+  sidebarData: SidebarData;
+  setSidebarData: React.Dispatch<React.SetStateAction<SidebarData>>;
+  children: React.ReactNode;
+}) {
+  const activeMatcher = useActiveMatcher();
+
+  const rawCandidates = useMemo(
+    () => collectCandidates(sidebarData, activeMatcher),
+    [sidebarData, activeMatcher],
+  );
+  // Stabilise the reference so a `collapsed`-only change to sidebarData (e.g.
+  // our own correction below, or a user toggle) doesn't recompute a new array
+  // and re-fire route-scoped effects. The candidate ID set only truly changes
+  // when the route changes.
+  const candidatesKey = rawCandidates.join('|');
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed by candidatesKey
+  const candidates = useMemo(() => rawCandidates, [candidatesKey]);
+
+  // The instance the user most recently clicked, if any. A click happens on
+  // the SOURCE page and navigates to the DESTINATION route, so we can't key it
+  // on the current route — we key on the instance id itself and consume it
+  // once that id shows up among the destination route's candidates.
+  const clickedRef = useRef<string | null>(null);
+
+  // SSR / first paint: deterministic canonical fallback (first candidate), so
+  // server and client agree before the client reconciles to the preserved
+  // branch. `mounted` flips true after the first layout effect on the client.
+  const [mounted, setMounted] = useState(false);
+  useLayoutEffect(() => setMounted(true), []);
+
+  const activeId = useMemo<string | null>(() => {
+    if (candidates.length === 0) return null;
+    if (candidates.length === 1) return candidates[0];
+
+    // Multi-located guide: pick a single instance.
+    if (!mounted) {
+      // Canonical fallback for SSR / pre-hydration.
+      return candidates[0];
+    }
+
+    // 1. Just-clicked instance wins, once its destination route resolves to a
+    //    candidate set that includes it.
+    const clicked = clickedRef.current;
+    if (clicked && candidates.includes(clicked)) {
+      return clicked;
+    }
+
+    // 2. Preserve the previously-active branch: among candidates, the one
+    //    whose tree path shares the longest prefix with the last active
+    //    instance. This keeps the customer in e.g. the VPS branch even though
+    //    both branches sit under the same Bare Metal Cloud family. Requires a
+    //    real shared prefix (> 0) so an unrelated stored branch doesn't win by
+    //    default; ties fall through to tree order (canonical).
+    const storedId = readStoredBranch();
+    if (storedId) {
+      let best: string | null = null;
+      let bestLen = 0;
+      for (const id of candidates) {
+        const len = sharedPrefixLength(id, storedId);
+        if (len > bestLen) {
+          bestLen = len;
+          best = id;
+        }
+      }
+      if (best) return best;
+    }
+
+    // 3. Canonical: first candidate in tree order.
+    return candidates[0];
+  }, [candidates, mounted]);
+
+  // Persist the resolved instance (full path) for subsequent navigations in
+  // this session, and consume the click once it has been honoured so a later
+  // deep-link entry falls back to the preserved/canonical branch rather than a
+  // stale click.
+  //
+  // Gate on `mounted`: before mount the memo returns the canonical placeholder
+  // (candidates[0]) to keep SSR/hydration deterministic. Persisting that
+  // placeholder would overwrite the incoming stored branch BEFORE the
+  // post-mount re-resolution gets to read it, defeating branch preservation on
+  // a hard navigation/reload. So we only persist once resolution is final.
+  useLayoutEffect(() => {
+    if (!mounted || !activeId) return;
+    writeStoredBranch(activeId);
+    if (clickedRef.current === activeId) clickedRef.current = null;
+  }, [activeId, mounted]);
+
+  // Rspress's createInitialSidebar auto-expands EVERY group that contains the
+  // active link — so a multi-located guide opens all of its branches. Once we
+  // have resolved a single active instance, re-collapse the branches that were
+  // only expanded because they hold a NON-resolved candidate. Groups that are
+  // ancestors of the resolved instance are left untouched (they must stay
+  // open).
+  //
+  // This MUST be a passive effect (useEffect), not useLayoutEffect: Rspress's
+  // own useSidebarDynamic runs a useLayoutEffect that rebuilds+re-expands the
+  // sidebar on every route change. Child layout effects fire before the
+  // parent's, so a layout-effect collapse here would be clobbered by Rspress's
+  // re-expansion. A passive effect runs after all layout effects, so our
+  // collapse wins. Keyed on the resolved id + candidate set so it runs once
+  // per route, not on every user toggle within the same page — leaving manual
+  // expand/collapse intact.
+  useEffect(() => {
+    if (!mounted || !activeId || candidates.length < 2) return;
+    const toCollapse = candidates.filter(
+      (id) => id !== activeId && !isAncestorId(id, activeId),
+    );
+    if (toCollapse.length === 0) return;
+    setSidebarData((data) => collapseAncestorsOf(data, toCollapse, activeId));
+  }, [mounted, activeId, candidates, setSidebarData]);
+
+  const value = useMemo<ActiveBranchContextValue>(
+    () => ({
+      activeId,
+      notifyClick: (id: string) => {
+        clickedRef.current = id;
+      },
+    }),
+    [activeId],
+  );
+
+  return (
+    <ActiveBranchContext.Provider value={value}>
+      {children}
+    </ActiveBranchContext.Provider>
+  );
+}
+
+export function useActiveBranch(): ActiveBranchContextValue {
+  return useContext(ActiveBranchContext);
+}

--- a/theme/components/Sidebar/useActiveBranch.tsx
+++ b/theme/components/Sidebar/useActiveBranch.tsx
@@ -3,7 +3,6 @@ import { useActiveMatcher } from '@rspress/core/runtime';
 import {
   createContext,
   useContext,
-  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -41,11 +40,18 @@ interface ActiveBranchContextValue {
   activeId: string | null;
   /** Record that the user clicked a specific instance (by its tree-path id). */
   notifyClick: (id: string) => void;
+  /**
+   * True when the group at `id` holds a route-matching instance but is NOT on
+   * the resolved active path — i.e. it is a "wrong" branch of a multi-located
+   * guide and must be kept collapsed even though Rspress auto-expanded it.
+   */
+  shouldForceCollapse: (id: string) => boolean;
 }
 
 const ActiveBranchContext = createContext<ActiveBranchContextValue>({
   activeId: null,
   notifyClick: () => {},
+  shouldForceCollapse: () => false,
 });
 
 /**
@@ -97,93 +103,6 @@ function collectCandidates(
   return candidates;
 }
 
-/** All ancestor-group ids of an instance id, excluding the instance itself. */
-function ancestorIdsOf(id: string): string[] {
-  const parts = id.split('-');
-  const ancestors: string[] = [];
-  for (let i = 1; i < parts.length; i++) {
-    ancestors.push(parts.slice(0, i).join('-'));
-  }
-  return ancestors;
-}
-
-/** Read `collapsed` of the group at `groupId`, or undefined if not a group. */
-function getCollapsedAt(
-  data: SidebarData,
-  groupId: string,
-): boolean | undefined {
-  const indexes = groupId.split('-').map(Number);
-  let current: SidebarNode | undefined = data[indexes[0]];
-  for (let i = 1; i < indexes.length && current; i++) {
-    if (!isSidebarGroup(current)) return undefined;
-    current = (current as NormalizedSidebarGroup).items[
-      indexes[i]
-    ] as SidebarNode;
-  }
-  return current && 'items' in current
-    ? (current as NormalizedSidebarGroup).collapsed
-    : undefined;
-}
-
-/** Set `collapsed` on the group at `groupId` within a cloned tree. */
-function setCollapsedAt(
-  data: SidebarData,
-  groupId: string,
-  collapsed: boolean,
-): void {
-  const indexes = groupId.split('-').map(Number);
-  let current: SidebarNode | undefined = data[indexes[0]];
-  for (let i = 1; i < indexes.length && current; i++) {
-    if (!isSidebarGroup(current)) return;
-    current = (current as NormalizedSidebarGroup).items[
-      indexes[i]
-    ] as SidebarNode;
-  }
-  if (current && 'items' in current) {
-    (current as NormalizedSidebarGroup).collapsed = collapsed;
-  }
-}
-
-/**
- * Reconcile branch expansion for a multi-located guide:
- *  - collapse, for each non-resolved candidate, its SHALLOWEST ancestor group
- *    not shared with the resolved instance (closes the whole wrong branch);
- *  - (re-)open every ancestor of the resolved instance, so a branch that a
- *    prior transient resolution had collapsed is corrected in the same pass.
- * The shared product family (a common ancestor) is thus always left open.
- * Returns a new (mutated clone) sidebar tree; the caller passes the previous
- * state. Returns the input unchanged when nothing needs to move.
- */
-function collapseAncestorsOf(
-  data: SidebarData,
-  nonResolved: string[],
-  activeId: string,
-): SidebarData {
-  const openIds = ancestorIdsOf(activeId);
-  const keepOpen = new Set([activeId, ...openIds]);
-  const collapseIds = new Set<string>();
-  for (const id of nonResolved) {
-    // ancestorIdsOf returns shallow→deep; the first not shared with the
-    // resolved instance is the divergence point for this branch.
-    const divergent = ancestorIdsOf(id).find((a) => !keepOpen.has(a));
-    if (divergent) collapseIds.add(divergent);
-  }
-  if (collapseIds.size === 0) return data;
-
-  // No-op guard: if the tree is already in the desired state, return the SAME
-  // reference so React skips a needless re-render (and so this function can
-  // never drive a render loop even if effect deps change in future).
-  const alreadyDone =
-    openIds.every((id) => getCollapsedAt(data, id) !== true) &&
-    [...collapseIds].every((id) => getCollapsedAt(data, id) === true);
-  if (alreadyDone) return data;
-
-  const clone = structuredClone(data);
-  for (const id of openIds) setCollapsedAt(clone, id, false);
-  for (const id of collapseIds) setCollapsedAt(clone, id, true);
-  return clone;
-}
-
 function readStoredBranch(): string | null {
   try {
     return sessionStorage.getItem(STORAGE_KEY);
@@ -201,13 +120,47 @@ function writeStoredBranch(branch: string): void {
   }
 }
 
+/**
+ * The shallowest ancestor of `id` that is NOT shared with `activeId` — the
+ * point where this candidate's branch diverges from the resolved branch.
+ * Collapsing that one group hides the whole wrong branch.
+ */
+function divergencePoint(id: string, activeId: string): string | null {
+  const a = id.split('-');
+  const b = activeId.split('-');
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  // a[0..i] is the shared prefix; the divergent group is a[0..i] inclusive of
+  // the first differing segment, i.e. index i (must still be a group, i.e. not
+  // the leaf itself).
+  if (i >= a.length) return null;
+  return a.slice(0, i + 1).join('-');
+}
+
+const SUPPRESS_KEY = 'ovh.sidebar.suppressedBranches';
+
+function readSuppressed(): Set<string> {
+  try {
+    const raw = sessionStorage.getItem(SUPPRESS_KEY);
+    return new Set(raw ? (JSON.parse(raw) as string[]) : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function writeSuppressed(set: Set<string>): void {
+  try {
+    sessionStorage.setItem(SUPPRESS_KEY, JSON.stringify([...set]));
+  } catch {
+    // ignore
+  }
+}
+
 export function ActiveBranchProvider({
   sidebarData,
-  setSidebarData,
   children,
 }: {
   sidebarData: SidebarData;
-  setSidebarData: React.Dispatch<React.SetStateAction<SidebarData>>;
   children: React.ReactNode;
 }) {
   const activeMatcher = useActiveMatcher();
@@ -293,29 +246,60 @@ export function ActiveBranchProvider({
     if (clickedRef.current === activeId) clickedRef.current = null;
   }, [activeId, mounted]);
 
-  // Rspress's createInitialSidebar auto-expands EVERY group that contains the
-  // active link — so a multi-located guide opens all of its branches. Once we
-  // have resolved a single active instance, re-collapse the branches that were
-  // only expanded because they hold a NON-resolved candidate. Groups that are
-  // ancestors of the resolved instance are left untouched (they must stay
-  // open).
+  // Rspress's createInitialSidebar only ever sets `collapsed = false` and, on
+  // navigation, mutates the shared sidebar data IN PLACE (no clone) — so a
+  // branch opened for one route stays open forever, even after you navigate
+  // away. For a multi-located guide this means the "wrong" branch, opened the
+  // first time you visited, leaks open on every later page.
   //
-  // This MUST be a passive effect (useEffect), not useLayoutEffect: Rspress's
-  // own useSidebarDynamic runs a useLayoutEffect that rebuilds+re-expands the
-  // sidebar on every route change. Child layout effects fire before the
-  // parent's, so a layout-effect collapse here would be clobbered by Rspress's
-  // re-expansion. A passive effect runs after all layout effects, so our
-  // collapse wins. Keyed on the resolved id + candidate set so it runs once
-  // per route, not on every user toggle within the same page — leaving manual
-  // expand/collapse intact.
-  useEffect(() => {
-    if (!mounted || !activeId || candidates.length < 2) return;
-    const toCollapse = candidates.filter(
-      (id) => id !== activeId && !isAncestorId(id, activeId),
-    );
-    if (toCollapse.length === 0) return;
-    setSidebarData((data) => collapseAncestorsOf(data, toCollapse, activeId));
-  }, [mounted, activeId, candidates, setSidebarData]);
+  // We track those wrong branches in a session-scoped set (their divergence
+  // group id) and force-collapse them on every render until the visitor
+  // actually navigates INTO one (active item inside it), at which point it is
+  // un-suppressed. This is declarative (recomputed each render) so it survives
+  // Rspress's per-route rebuild, and session-scoped so it survives navigation.
+  const suppressedRef = useRef<Set<string>>(readSuppressed());
+  const [suppressedVersion, bumpSuppressed] = useState(0);
+
+  useLayoutEffect(() => {
+    if (!mounted || !activeId) return;
+    const set = suppressedRef.current;
+    let changed = false;
+
+    // Add the divergence point of every non-resolved candidate on this route.
+    if (candidates.length > 1) {
+      for (const id of candidates) {
+        if (id === activeId || isAncestorId(id, activeId)) continue;
+        const dp = divergencePoint(id, activeId);
+        if (dp && !set.has(dp)) {
+          set.add(dp);
+          changed = true;
+        }
+      }
+    }
+
+    // Un-suppress any branch the visitor is now inside (active item within it).
+    for (const dp of set) {
+      if (isAncestorId(dp, activeId)) {
+        set.delete(dp);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      writeSuppressed(set);
+      bumpSuppressed((v) => v + 1);
+    }
+  }, [mounted, activeId, candidates]);
+
+  // suppressedVersion is intentionally a trigger dep: it re-creates this
+  // callback (which reads the mutable suppressedRef) whenever the suppressed
+  // set changes, so SidebarGroup re-renders with the new collapse decision.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional trigger dep
+  const shouldForceCollapse = useMemo(() => {
+    const set = suppressedRef.current;
+    return (groupId: string): boolean =>
+      set.has(groupId) && !isAncestorId(groupId, activeId);
+  }, [activeId, suppressedVersion]);
 
   const value = useMemo<ActiveBranchContextValue>(
     () => ({
@@ -323,8 +307,9 @@ export function ActiveBranchProvider({
       notifyClick: (id: string) => {
         clickedRef.current = id;
       },
+      shouldForceCollapse,
     }),
-    [activeId],
+    [activeId, shouldForceCollapse],
   );
 
   return (


### PR DESCRIPTION
Guides listed in more than one sidebar group (~12% of guides) used to expand every branch containing them and scroll to whichever active DOM node won, because Rspress resolves "active" purely by link string.

Resolve a single active instance by its tree path instead. Selection order: just-clicked instance, else the branch sharing the longest path prefix with the previously-active one (persisted in sessionStorage), else the canonical first-listed branch for cold deep-links. Highlight and scrollIntoView target only that instance; a passive effect collapses the non-resolved branches while leaving any shared parent family and manual toggles intact.