### PR TITLE
fix(banner): stop SIRET icon zooming + roll banner out to FR billing guides

### DIFF
--- a/components/Banner/Banner.css
+++ b/components/Banner/Banner.css
@@ -53,6 +53,14 @@
   border-radius: 0;
   padding: 0;
   background: none;
+  /* The icon is decorative (aria-hidden, empty alt) and must never open the
+     medium-zoom overlay. The `.no-zoom` opt-out on the <img> proved unreliable
+     in the production SPA (the global mediumZoom selector re-attaches on client
+     navigation, racing the class check), so we also kill pointer events: no
+     click can reach the image, so medium-zoom's click handler never fires.
+     cursor:default keeps it from *looking* clickable. */
+  pointer-events: none;
+  cursor: default;
 }
 
 /* ---- text block ------------------------------------------------------ */

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/add-cloud-credit-to-project.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment ajouter du crédit ou des vouchers à votre proj
 lastUpdated: 2026-06-11
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 L'option de « crédit cloud » vous permet d'allouer un montant spécifique à votre projet Public Cloud, qui servira de moyen de paiement par défaut pour la [facturation de votre projet](/guides/public-cloud/cross-functional/analyze-billing).<br/>

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/automatic-renewal.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/automatic-renewal.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment gérer vos services et leur renouvellement dans 
 lastUpdated: 2025-01-28
 ---
 
+<Banner kind="siret-fr" />
+
 import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objectif

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/best-practices.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/best-practices.mdx
@@ -4,6 +4,8 @@ description: Retrouvez ici les éléments indispensables pour la bonne gestion d
 lastUpdated: 2025-04-28
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 Ce guide contient les éléments indispensables à une bonne gestion de votre compte et de la facturation de vos services OVHcloud.

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/changing-hourly-monthly-billing.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment modifier le type de facturation de votre instanc
 lastUpdated: 2025-09-05
 ---
 
+<Banner kind="siret-fr" />
+
 import Api from '@components/Api';
 
 ## Objectif

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/correct-bank-details-error.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/correct-bank-details-error.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment corriger une erreur de coordonnées bancaires su
 lastUpdated: 2026-06-26
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 **L'espace client OVHcloud vous permet d'ajouter et de modifier le moyen de paiement renseigné sur votre compte client.**

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/facturation-private-cloud.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/facturation-private-cloud.mdx
@@ -4,6 +4,8 @@ description: "Explication des différents types de facturation (horaire et mensu
 lastUpdated: 2024-03-21
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 L'offre Hosted Private Cloud dispose de deux types de facturation (horaire et mensuelle) pour le renouvellement et la commande de ressources supplémentaires.

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/faq-billing.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/faq-billing.mdx
@@ -4,6 +4,8 @@ description: Retrouvez les questions les plus fréquemment posées sur la factur
 lastUpdated: 2025-04-28
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 **Retrouvez ici les questions les plus fréquemment posées sur la facturation et le paiement pour vos services OVHcloud.**

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/faq-order-tracking.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/faq-order-tracking.mdx
@@ -4,6 +4,8 @@ description: Retrouvez les questions les plus fréquemment posées sur le suivi 
 lastUpdated: 2025-04-28
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 **Retrouvez ici les questions les plus fréquemment posées sur le suivi de commande OVHcloud.**

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/invoice-management.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/invoice-management.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment gérer vos factures et les paiements liés à ce
 lastUpdated: 2025-04-28
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 OVHcloud met à votre disposition un espace vous permettant de consulter, gérer et régler vos différentes factures.

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/manage-payment-methods.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/manage-payment-methods.mdx
@@ -4,6 +4,8 @@ description: Apprenez à ajouter et gérer vos moyens de paiement au sein de l�
 lastUpdated: 2025-04-28
 ---
 
+<Banner kind="siret-fr" />
+
 import Api from '@components/Api';
 
 ## Objectif

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/order-project-api.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/order-project-api.mdx
@@ -4,6 +4,8 @@ description: "Découvrez comment commander votre projet Public Cloud avec l'API 
 lastUpdated: 2020-12-09
 ---
 
+<Banner kind="siret-fr" />
+
 import Api from '@components/Api';
 
 ## Objectif

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment gérer vos commandes chez OVHcloud
 lastUpdated: 2025-04-28
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 Lorsque vous effectuez une commande, vous pouvez la suivre et interagir avec elle depuis la page <ManagerLink to="/#/billing/orders">Mes commandes</ManagerLink>.

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/purchase-order.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/purchase-order.mdx
@@ -4,6 +4,8 @@ description: Comprendre la notion de numéro de commande ou purchase order et l�
 lastUpdated: 2025-04-28
 ---
 
+<Banner kind="siret-fr" />
+
 ## Objectif
 
 **Ce guide vous explique la notion de Numéro de commande ou Purchase Order (PO) appliqué à la facturation OVHcloud.**

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/renewing-service-via-api.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/renewing-service-via-api.mdx
@@ -4,6 +4,8 @@ description: Découvrez comment renouveler vos services via l’API OVHcloud
 lastUpdated: 2020-05-05
 ---
 
+<Banner kind="siret-fr" />
+
 import Api from '@components/Api';
 
 ## Objectif


### PR DESCRIPTION
The banner icon (decorative, aria-hidden) still opened the medium-zoom overlay on prod despite its `no-zoom` class: the global mediumZoom selector re-attaches on client-side SPA navigation and races the class check. Kill pointer-events on the icon so no click can reach it, so medium-zoom's handler never fires; keep `no-zoom` as a secondary guard.

Also add `<Banner kind="siret-fr" />` to 14 FR guides in the managing-billing-payments-and-services folder. Excludes update-vat-rate (the banner links to it), carbon-footprint (off-topic), the public-administration EN-fallback symlink, and the three cancellation/deletion guides.