### PR TITLE
feat(OPCP prerequisites): improve s3 buckets prerequisites for backups

### DIFF
--- a/docs/en/guides/hosted-private-cloud/opcp/opcp-prerequisites.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/opcp-prerequisites.mdx
@@ -237,7 +237,9 @@ OPCP can back up the infrastructure state (configurations, control plane state, 
 - the **S3 endpoint** (for example: `s3.example.com:443`),
 - the **Access Key**,
 - the **Secret Key**,
-- the **bucket name** dedicated to backups (for example: `opcp01-backup-dc1`),
+- two **bucket names** dedicated to backups:
+    - one for the **Velero** backups (persistent volumes — PV), for example: `opcp01-backup-pv-dc1`,
+    - one for the **CNPG** backups (databases — DB), for example: `opcp01-backup-db-dc1`,
 - the **S3 region name** (for example: `paris`).
 
 The access keys must be transmitted through a secure channel agreed with your OVHcloud point of contact.

--- a/docs/en/guides/hosted-private-cloud/opcp/opcp-prerequisites.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/opcp-prerequisites.mdx
@@ -1,7 +1,7 @@
 ---
 title: Technical prerequisites for deployment
 description: Discover the list of configuration items you need to provide to OVHcloud to prepare and deploy your OPCP platform
-lastUpdated: 2026-06-03
+lastUpdated: 2026-07-03
 ---
 
 ## Objective

--- a/docs/fr/guides/hosted-private-cloud/opcp/opcp-prerequisites.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/opcp-prerequisites.mdx
@@ -1,7 +1,7 @@
 ---
 title: Prérequis techniques pour le déploiement
 description: Découvrez la liste des éléments de configuration que vous devez fournir à OVHcloud pour préparer et déployer votre plateforme OPCP
-lastUpdated: 2026-06-03
+lastUpdated: 2026-07-03
 ---
 
 ## Objectif

--- a/docs/fr/guides/hosted-private-cloud/opcp/opcp-prerequisites.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/opcp-prerequisites.mdx
@@ -237,7 +237,9 @@ OPCP peut sauvegarder l'état de l'infrastructure (configurations, état du plan
 - l'**endpoint S3** (exemple : `s3.exemple.com:443`),
 - la **clé d'accès** (Access Key),
 - la **clé secrète** (Secret Key),
-- le **nom du bucket** dédié aux sauvegardes (exemple : `opcp01-backup-dc1`),
+- deux **noms de bucket** dédiés aux sauvegardes :
+    - un pour les sauvegardes **Velero** (volumes persistants — PV), exemple : `opcp01-backup-pv-dc1`,
+    - un pour les sauvegardes **CNPG** (bases de données — DB), exemple : `opcp01-backup-db-dc1`,
 - le **nom de la région** S3 (exemple : `paris`).
 
 Les clés d'accès doivent être transmises via un canal sécurisé convenu avec votre point de contact OVHcloud.


### PR DESCRIPTION
Update the OPCP prerequisites to have 2 buckets provided by the customer.
This is already technically implemented in the product (the separation).