### PR TITLE
fix(components): balance CategoryColumns and close gaps between sections

### DIFF
--- a/components/CategoryColumns/CategoryColumns.css
+++ b/components/CategoryColumns/CategoryColumns.css
@@ -1,14 +1,30 @@
+/* Two flex columns, filled row by row in the component. Sections stack tightly
+   from the top with a fixed gap — no empty space opens between them — and the
+   component balances the two columns' heights. */
 .rp-category-columns {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  column-gap: 3rem;
-  row-gap: 2.5rem;
+  display: flex;
+  gap: 2.5rem 3rem;
   margin: 1.5rem 0;
 }
 
+.rp-category-columns__group {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
 @media (max-width: 768px) {
+  /* Collapse to one column: dissolve the column wrappers so every section
+     becomes a direct flex child, then let each section's `order` (its source
+     index) restore the original top-to-bottom reading sequence. */
   .rp-category-columns {
-    grid-template-columns: 1fr;
+    flex-direction: column;
+  }
+
+  .rp-category-columns__group {
+    display: contents;
   }
 
   /* In a single column, a blank continuation heading would inject a stray

--- a/components/CategoryColumns/CategoryColumns.tsx
+++ b/components/CategoryColumns/CategoryColumns.tsx
@@ -54,39 +54,61 @@ export function CategoryColumns({ categories }: CategoryColumnsProps) {
     return null;
   }
 
+  // Deal the sections, in source order, each onto the currently shorter column
+  // (ties to the left). This keeps the two columns as close in height as
+  // possible whatever the section sizes — a lone big section pairs with several
+  // small ones instead of piling up on one side. Each section keeps its source
+  // index as `order`, so the single-column mobile stack still reads in order.
+  const weight = (cat: Category) => cat.items.length + 2;
+  const columns: { cat: Category; order: number }[][] = [[], []];
+  const heights = [0, 0];
+  visibleCategories.forEach((cat, i) => {
+    const col = heights[0] <= heights[1] ? 0 : 1;
+    columns[col].push({ cat, order: i });
+    heights[col] += weight(cat);
+  });
+
   return (
     <div className="rp-category-columns">
-      {visibleCategories.map((cat) => (
-        <section className="rp-category-columns__col" key={cat.title}>
-          {cat.title ? (
-            <h3 className="rp-category-columns__heading">{cat.title}</h3>
-          ) : (
-            <div
-              className="rp-category-columns__heading rp-category-columns__heading--spacer"
-              aria-hidden="true"
-            />
-          )}
-          <ul className="rp-category-columns__list">
-            {cat.items.map((item) => (
-              <li key={item.title}>
-                <a
-                  href={item.link ? localizeHref(item.link) : '#'}
-                  className="rp-category-columns__link"
-                  {...(item.link &&
-                    isExternal(item.link) && {
-                      target: '_blank',
-                      rel: 'noopener noreferrer',
-                    })}
-                >
-                  <span className="rp-category-columns__link-text">
-                    {item.title}
-                  </span>
-                  <span className="rp-category-columns__link-arrow">→</span>
-                </a>
-              </li>
-            ))}
-          </ul>
-        </section>
+      {columns.map((column, colIndex) => (
+        <div className="rp-category-columns__group" key={colIndex}>
+          {column.map(({ cat, order }) => (
+            <section
+              className="rp-category-columns__col"
+              style={{ order }}
+              key={cat.title}
+            >
+              {cat.title ? (
+                <h3 className="rp-category-columns__heading">{cat.title}</h3>
+              ) : (
+                <div
+                  className="rp-category-columns__heading rp-category-columns__heading--spacer"
+                  aria-hidden="true"
+                />
+              )}
+              <ul className="rp-category-columns__list">
+                {cat.items.map((item) => (
+                  <li key={item.title}>
+                    <a
+                      href={item.link ? localizeHref(item.link) : '#'}
+                      className="rp-category-columns__link"
+                      {...(item.link &&
+                        isExternal(item.link) && {
+                          target: '_blank',
+                          rel: 'noopener noreferrer',
+                        })}
+                    >
+                      <span className="rp-category-columns__link-text">
+                        {item.title}
+                      </span>
+                      <span className="rp-category-columns__link-arrow">→</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
       ))}
     </div>
   );


### PR DESCRIPTION
Deal each section into the currently shorter of the two columns (greedy) and stack them tightly, so the left and right columns stay as close in height as possible whatever the section sizes and no empty space opens between sections. Collapses to a single column on mobile, preserving source order.