### PR TITLE
fix(public-cloud): document First sector step in disk resize guide to prevent data loss (#347)

### DIFF
--- a/docs/de/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/de/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,25 +1,22 @@
 ---
 title: Die Größe einer zusätzlichen Disk erweitern
-description: Erfahren Sie hier, wie Sie die Kapazität eines zusätzlichen Volumes vergrößern und die Hauptpartition anpassen
-lastUpdated: 2026-02-26
+description: Erfahren Sie, wie Sie die Größe eines zusätzlichen Volumes erhöhen und die Hauptpartition entsprechend erweitern
+lastUpdated: 2026-07-07
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-
-
-
 ## Ziel
 
-Wenn Sie die maximale Kapazität Ihrer zusätzlichen Disk erreicht haben, können Sie Speicherplatz hinzufügen, indem Sie deren Größe erweitern. 
+Wenn Sie die maximale Kapazität Ihrer zusätzlichen Disk erreicht haben, können Sie mehr Speicherplatz hinzufügen, indem Sie deren Größe erweitern.
 
-**Diese Anleitung erklärt, wie Sie die Größe einer zusätzlichen Disk erweitern und die Hauptpartition entsprechend erweitern.**
+**Diese Anleitung erklärt, wie Sie die Größe einer zusätzlichen Disk erhöhen und die Hauptpartition entsprechend erweitern.**
 
 ## Voraussetzungen
 
-- Sie verfügen über eine [Public Cloud Instanz](https://www.ovhcloud.com/de/public-cloud/compute/) in Ihrem Public Cloud Projekt.
+- Sie verfügen über eine [Public Cloud Instanz](/links/public-cloud/compute) in Ihrem Public Cloud Projekt.
 - Sie haben eine [zusätzliche Disk](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance) in Ihrem Projekt erstellt.
-- Sie haben administrativen Zugriff auf Ihre Instanz über SSH (Linux) oder RDP (Windows).
+- Sie haben administrativen (Sudo-)Zugriff auf Ihre Instanz über SSH (Linux) oder RDP (Windows).
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -34,140 +31,205 @@ Wenn Sie die maximale Kapazität Ihrer zusätzlichen Disk erreicht haben, könne
 
 ## In der praktischen Anwendung
 
-In den folgenden Schritten wird vorausgesetzt, dass Sie bereits eine zusätzliche Disk erstellt haben, wie [in unserer Anleitung beschrieben](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
+Die folgenden Schritte setzen voraus, dass Sie bereits eine zusätzliche Disk konfiguriert haben, wie unter [Zusätzliches Volume auf einer Instanz erstellen und konfigurieren](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance) beschrieben.
 
-### Überwachen der Datenträgerverwendung vor der Größenänderung
+### Überwachen der Datenträgernutzung vor der Größenänderung
 
 :::warning
-Wir empfehlen, dass Sie mindestens 20% freien Speicherplatz auf Ihren Storage-Volumes beibehalten. Dies sorgt für eine optimale Leistung und vermeidet das Risiko von Systemschäden oder -ausfällen, wenn das Volume seine maximale Kapazität erreicht.
-
+Wir empfehlen, auf Ihren Storage-Volumes stets mindestens 20 % freien Speicherplatz vorzuhalten. Dies sorgt für eine optimale Leistung und vermeidet das Risiko einer Systemverschlechterung oder eines Systemausfalls, wenn das Volume seine maximale Kapazität erreicht.
 :::
 
-
-Um sicherzustellen, dass Sie die Größe Ihrer Disk rechtzeitig ändern, ist es wichtig, die Datenträgernutzung regelmäßig zu prüfen. Im Folgenden finden Sie entsprechende Kommandozeilentools für Windows und Linux, mit denen Sie den Speicherplatz anzeigen und im Voraus planen können, wann ein Upgrade erforderlich ist.
+Um Ihre Disk rechtzeitig zu vergrößern, überwachen Sie regelmäßig die Datenträgernutzung. Im Folgenden finden Sie kurze Anleitungen für Windows und Linux, mit denen Sie den Speicherplatz nachverfolgen und vorausschauend erkennen können, wann ein Upgrade erforderlich ist.
 
 <Tabs>
-  <Tab label="Windows">
+  <Tab label="Unter Windows">
     <details>
     <summary>Verwenden der Eingabeaufforderung</summary>
 
-    
-    Eingabeaufforderung öffnen (Win + R → cmd → Enter).
-    
+    Öffnen Sie die Eingabeaufforderung (Win + R → cmd → Eingabetaste).
+
     Führen Sie den folgenden Befehl aus:
-    
-    ```bash
+
+    ```cmd
     wmic logicaldisk get name, size, freespace
     ```
-    
-    Hier werden der freie Speicherplatz und die Gesamtgröße der einzelnen Datenträger angezeigt.
-    
+
+    Dadurch werden der freie Speicherplatz und die Gesamtgröße jeder Disk angezeigt.
 
     </details>
-    
+
     <details>
     <summary>Verwenden von PowerShell</summary>
 
-    
     Öffnen Sie PowerShell als Administrator.
-    
+
     Führen Sie den folgenden Befehl aus:
-    
-    ```bash
+
+    ```powershell
     Get-PSDrive | Where-Object {$_.Free -ne $null} | Select-Object Name, Used, Free
     ```
-    
-    Hier wird der belegte und verfügbare Speicherplatz angezeigt.
-    
+
+    Dadurch werden der belegte und der verfügbare Speicherplatz angezeigt.
 
     </details>
   </Tab>
-  <Tab label="Linux">
+  <Tab label="Unter Linux">
     <details>
-    <summary>Verwenden des Befehls "df"</summary>
+    <summary>Verwenden des Befehls `df`</summary>
 
-    
-    Um die allgemeine Datenträgerauslastung zu überprüfen, führen Sie Folgendes aus:
-    
+    Um die gesamte Speicherplatznutzung zu überprüfen, führen Sie Folgendes aus:
+
     ```bash
     df -h
     ```
-    
-    Dadurch wird die Speicherplatzverwendung in einem expliziten Format angezeigt.
-    
+
+    Dadurch wird die Speicherplatznutzung in einem lesbaren Format angezeigt.
 
     </details>
-    
-    <details>
-    <summary>Verwenden des Befehls "lsblk"</summary>
 
-    
-    So zeigen Sie Disk-Partitionen und ihre Größe an:
-    
+    <details>
+    <summary>Verwenden des Befehls `lsblk`</summary>
+
+    So zeigen Sie die Partitionen der Disk und deren Größe an:
+
     ```bash
     lsblk
     ```
-    
 
     </details>
   </Tab>
 </Tabs>
 
+:::warning
+Wir empfehlen, vor der Größenänderung einen Snapshot Ihres Volumes zu erstellen, um Ihre Daten zu schützen. Sollte während der Größenänderung oder der Partitionserweiterung ein Fehler auftreten, können Sie anhand des Snapshots wiederherstellen. Eine Anleitung dazu finden Sie unter [Erstellen eines Volume-Snapshots](/guides/public-cloud/compute/storage-create-volume-snapshot).
+:::
 
 ### Größe der Disk ändern
 
-Loggen Sie sich in Ihr <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> ein und wählen Sie Ihr <code className="action">Public Cloud</code> Projekt aus. Klicken Sie dann im linken Menü unter **Storage und Backups** auf <code className="action">Block Storage</code>
+Klicken Sie in Ihrem Public Cloud Projekt im linken Menü unter **Storage & Backup** auf <code className="action">Block Storage</code>.
 
-Wenn das Volume mit einer **Windows-Instanz** verbunden ist, klicken Sie auf <code className="action">...</code> rechts neben dem betreffenden Volume und wählen Sie <code className="action">Instanz trennen</code> aus.
+Wenn das Volume mit einer **Windows-Instanz** verbunden ist, klicken Sie in der Zeile des Volumes auf <code className="action">...</code> und wählen Sie <code className="action">Von Instanz trennen</code> aus.
 
-Klicken Sie auf den Button <code className="action">...</code> rechts neben dem betreffenden Volume und wählen Sie <code className="action">Bearbeiten</code>.
+Klicken Sie in der Zeile des Volumes auf <code className="action">...</code> und wählen Sie <code className="action">Bearbeiten</code> aus.
 
-<img className="thumbnail" alt="Dashboard" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-02.png" loading="lazy" />
+<img className="thumbnail" alt="Kundencenter" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-02.png" loading="lazy" />
 
-Geben Sie im neuen Fenster die gewünschte Größe des Volumes ein und klicken Sie auf <code className="action">Volume bearbeiten</code>.
+:::warning
+Die Größenänderung eines Volumes ist unwiderruflich. Sie können die Größe eines Volumes nur erhöhen, niemals verringern. Stellen Sie sicher, dass die neue Größe korrekt ist, bevor Sie sie bestätigen.
+:::
 
-<img className="thumbnail" alt="Dashboard" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-03.png" loading="lazy" />
+Geben Sie im Popup-Fenster die neue Größe für das Volume ein und klicken Sie auf <code className="action">Volume bearbeiten</code>.
+
+<img className="thumbnail" alt="Kundencenter" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-03.png" loading="lazy" />
 
 ### Partition erweitern (Linux-Instanz)
 
-Stellen Sie eine SSH-Verbindung zu Ihrer Instanz her, um die Partition an die skalierte Disk anzupassen.
+Stellen Sie eine SSH-Verbindung zu Ihrer Instanz her, um die Partition an die vergrößerte Disk anzupassen.
 
-Hängen Sie zuerst die Disk mit folgendem Befehl aus:
+Überprüfen Sie zunächst den Dateisystemtyp:
 
 ```bash
-admin@server~$ sudo umount /mnt/disk
+admin@server:~$ lsblk -f /dev/vdb1
 ```
 
-Die Partition neu erstellen:
+```console
+NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
+vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+Die folgenden Schritte gelten für **ext2/ext3/ext4**-Dateisysteme. Im Gegensatz zu ext4 kann XFS nicht im ausgehängten Zustand vergrößert werden – das Tool `xfs_growfs` benötigt ein eingehängtes Dateisystem. Wenn Ihr Dateisystem **XFS** ist, hängen Sie die Disk trotzdem wie unten beschrieben aus und erstellen Sie die Partition neu, überspringen Sie dabei jedoch die Schritte `e2fsck` und `resize2fs`: Hängen Sie die Disk stattdessen erneut ein und führen Sie anschließend `sudo xfs_growfs /mnt/disk` aus.
+
+Überprüfen Sie vor dem Aushängen das aktuelle Partitionslayout:
+
+```bash
+admin@server:~$ sudo fdisk -l /dev/vdb
+```
+
+```console
+Disk /dev/vdb: 70 GiB, 75161927680 bytes, 146800640 sectors
+Units: sectors of 1 * 512 = 512 bytes
+Sector size (logical/physical): 512 bytes / 512 bytes
+I/O size (minimum/optimal): 512 bytes / 512 bytes
+Disklabel type: dos
+Disk identifier: 0x00000001
+
+Device     Boot  Start       End   Sectors  Size Id Type
+/dev/vdb1        2048  104857599 104855552   50G 83 Linux
+```
+
+:::warning
+Notieren Sie sich den Wert der Spalte `Start` (in diesem Beispiel `2048`). Sie müssen genau diesen Wert erneut eingeben, wenn Sie die Partition im nächsten Schritt neu erstellen. Ein abweichender Startsektor führt zu einer Fehlausrichtung des Dateisystems und kann Datenkorruption oder Datenverlust verursachen.
+:::
+
+Hängen Sie die Disk zunächst aus:
+
+```bash
+admin@server:~$ sudo umount /mnt/disk
+```
+
+In unserem Beispiel:
+
+```bash
+admin@server:~$ sudo umount /mnt/vdb
+```
+
+Erstellen Sie die Partition mit folgendem Befehl neu. Dabei wird lediglich die Partitionstabelle neu geschrieben – die Daten Ihres Dateisystems werden nicht angetastet und bleiben erhalten, sofern Sie bei der entsprechenden Abfrage genau denselben Startsektor erneut eingeben.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
 ```
+
 ```console
 Welcome to fdisk (util-linux 2.25.2).
 Changes will remain in memory only, until you decide to write them.
 Be careful before using the write command
 ```
+
+Geben Sie `d` ein, um die Partition zu löschen:
+
 ```console
 Command (m for help): d
 
 Selected partition 1
 Partition 1 has been deleted.
 ```
+
+Geben Sie `n` ein, um die Partition neu zu erstellen:
+
 ```console
 Command (m for help): n
 
 Partition type
 p primary (0 primary, 0 extended, 4 free)
 e extended (container for logical partitions)
+```
+
+Geben Sie `p` ein, um den primären Partitionstyp auszuwählen:
+
+```console
 Select (default p):
 Using default response p.
-Partition number (1-4, default 1):
-First sector (2048-146800639, default 2048):
+```
+
+Geben Sie die Partitionsnummer ein, in unserem Beispiel `1`:
+
+```console
+Partition number (1-4, default 1): 1
+```
+
+Geben Sie den zuvor notierten Startsektor ein (2048) und übernehmen Sie anschließend den vorgeschlagenen letzten Sektor, um die Partition über den gesamten verbleibenden verfügbaren Speicherplatz der Disk zu erweitern:
+
+```console
+First sector (2048-146800639, default 2048): 2048
 Last sector, +sectors or +size{K,M,G,T,P} (2048-146800639, default 146800639):
 
 Created a new partition 1 of type 'Linux' and of size 70 GiB.
 ```
+
+Um die Änderungen anzuzeigen, geben Sie erneut `p` ein.
+
+Geben Sie anschließend `w` ein, um die vorgenommenen Änderungen zu speichern:
+
 ```console
 Command (m for help): w
 
@@ -176,7 +238,7 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Die Partition überprüfen:
+Überprüfen Sie die Partition (für **ext2/ext3/ext4**-Dateisysteme):
 
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
@@ -187,7 +249,7 @@ Pass 2: Checking directory structure
 Pass 3: Checking directory connectivity
 Pass 4: Checking reference counts
 Pass 5: Checking group summary information
-/dev/vdb: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
+/dev/vdb1: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
 ```
 
 ```bash
@@ -198,64 +260,66 @@ Resizing the filesystem on /dev/vdb to 18350080 (4k) blocks.
 The filesystem on /dev/vdb is now 18350080 (4k) blocks long.
 ```
 
-Abschließend mounten Sie die Disk und überprüfen Sie sie:
+Hängen Sie die Disk abschließend wieder ein und überprüfen Sie sie:
 
 ```bash
 admin@server:~$ sudo mount /dev/vdb1 /mnt/disk/
 ```
 
 ```bash
-admin@server~$ df -h
+admin@server:~$ df -h
 Filesystem Size Used Avail Use% Mounted on
 /dev/vda1 9.8G 840M 8.6G 9% /
 udev 10M 0 10M 0% /dev
-393M 5,2M 388M 2% /run
+tmpfs 393M 5.2M 388M 2% /run
 tmpfs 982M 0 982M 0% /dev/shm
 tmpfs 5.0M 0 5.0M 0% /run/lock
-982M 0 982M 0% /sys/fs/cgroup
+tmpfs 982M 0 982M 0% /sys/fs/cgroup
 /dev/vdb1 69G 52M 66G 1% /mnt/disk
 ```
 
-Nachdem dies abgeschlossen ist, trennen Sie das Volume von der Instanz und hängen Sie es erneut an, um sicherzustellen, dass die aktualisierten QoS-Einstellungen (IOPS und Bandbreite) ordnungsgemäß angewendet werden.
+Sobald dies abgeschlossen ist, trennen Sie das Volume von der Instanz und hängen Sie es erneut an, um sicherzustellen, dass die aktualisierten QoS-Einstellungen (IOPS und Bandbreite) ordnungsgemäß angewendet werden.
+
+Nach dem erneuten Anhängen können Sie die aktualisierte Volume-Konfiguration in Ihrem Public Cloud Projekt unter <code className="action">Block Storage</code> überprüfen.
 
 ### Partition erweitern (Windows-Instanz)
 
-Bevor Sie fortfahren, hängen Sie das Volume erneut an die Instanz an. Klicken Sie auf <code className="action">...</code> in der Zeile des Volumes und wählen Sie <code className="action">Mit Instanz verbinden</code> aus.
+Hängen Sie das Volume zunächst wieder an die Instanz an. Klicken Sie dazu in der Zeile des Volumes auf <code className="action">...</code> und wählen Sie <code className="action">An Instanz anhängen</code> aus.
 
-Stellen Sie eine RDP-Verbindung (Remote Desktop) zu Ihrer Windows-Instanz her.
+Stellen Sie eine Remotedesktopverbindung (RDP) zu Ihrer Windows-Instanz her.
 
-Wenn Sie eingeloggt sind, klicken Sie mit der rechten Maustaste auf das <code className="action">Startmenü</code> und öffnen Sie <code className="action">Disk Management</code>.
+Klicken Sie nach der Anmeldung mit der rechten Maustaste auf die Schaltfläche <code className="action">Startmenü</code> und öffnen Sie <code className="action">Datenträgerverwaltung</code>.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-01.png" loading="lazy" />
 
-Die erweiterte Disk zeigt nun die zusätzliche Kapazität als nicht zugewiesenen Speicherplatz an.
+Die erweiterte Disk zeigt die zusätzliche Kapazität nun als nicht zugewiesenen Speicherplatz an.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-02.png" loading="lazy" />
 
-Klicken Sie mit der rechten Maustaste auf das Volume und wählen Sie <code className="action">Extend Volume</code> im Kontextmenü aus.
+Klicken Sie mit der rechten Maustaste auf das Volume und wählen Sie im Kontextmenü <code className="action">Volume erweitern</code> aus.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-03.png" loading="lazy" />
 
-Klicken Sie im "Extend Volume Wizard" auf <code className="action">Next</code>, um fortzufahren.
+Klicken Sie im "Volume erweitern-Assistenten" auf <code className="action">Weiter</code>.
 
-Sie können in diesem Schritt den Speicherplatz ändern, wenn Sie weniger als die Gesamtkapazität zur Partition hinzufügen möchten.
-
-Klicken Sie auf <code className="action">Next</code>.
+In diesem Schritt können Sie den Speicherplatz anpassen, wenn Sie der Partition weniger als die gesamte verfügbare Kapazität hinzufügen möchten. Klicken Sie auf <code className="action">Weiter</code>.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-04.png" loading="lazy" />
 
-Klicken Sie auf <code className="action">Finish</code>, um den Vorgang abzuschließen.
+Klicken Sie auf <code className="action">Fertig stellen</code>, um den Vorgang abzuschließen.
 
-Das skalierte Volume beinhaltet nun den zusätzlichen Speicherplatz.
+Das vergrößerte Volume enthält nun den zusätzlichen Speicherplatz.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-05.png" loading="lazy" />
 
-Nachdem dies abgeschlossen ist, trennen Sie das Volume von der Instanz und hängen Sie es erneut an, um sicherzustellen, dass die aktualisierten QoS-Einstellungen (IOPS und Bandbreite) ordnungsgemäß angewendet werden.
+Sobald dies abgeschlossen ist, trennen Sie das Volume von der Instanz und hängen Sie es erneut an, um sicherzustellen, dass die aktualisierten QoS-Einstellungen (IOPS und Bandbreite) ordnungsgemäß angewendet werden.
+
+Öffnen Sie nach dem erneuten Anhängen wieder <code className="action">Datenträgerverwaltung</code>, um zu überprüfen, ob das Volume die korrekte Gesamtgröße anzeigt. Sie können die aktualisierte Volume-Konfiguration außerdem in Ihrem Public Cloud Projekt unter <code className="action">Block Storage</code> überprüfen.
 
 ## Weiterführende Informationen
 
 [Zusätzliches Volume auf einer Instanz erstellen und konfigurieren](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
 
-[Typ des Block Storage-Volumes ändern](/guides/public-cloud/compute/switch-volume-type)
+[Ihren Block Storage Volume-Typ ändern](/guides/public-cloud/compute/switch-volume-type)
 
 Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/de/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Die Größe einer zusätzlichen Disk erweitern
 description: Erfahren Sie, wie Sie die Größe eines zusätzlichen Volumes erhöhen und die Hauptpartition entsprechend erweitern
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -108,7 +108,7 @@ Wir empfehlen, vor der Größenänderung einen Snapshot Ihres Volumes zu erstell
 
 Klicken Sie in Ihrem Public Cloud Projekt im linken Menü unter **Storage & Backup** auf <code className="action">Block Storage</code>.
 
-Wenn das Volume mit einer **Windows-Instanz** verbunden ist, klicken Sie in der Zeile des Volumes auf <code className="action">...</code> und wählen Sie <code className="action">Von Instanz trennen</code> aus.
+Wenn das Volume mit einer **Windows-Instanz** verbunden ist, klicken Sie in der Zeile des Volumes auf <code className="action">...</code> und wählen Sie <code className="action">Instanz trennen</code> aus.
 
 Klicken Sie in der Zeile des Volumes auf <code className="action">...</code> und wählen Sie <code className="action">Bearbeiten</code> aus.
 
@@ -284,7 +284,7 @@ Nach dem erneuten Anhängen können Sie die aktualisierte Volume-Konfiguration i
 
 ### Partition erweitern (Windows-Instanz)
 
-Hängen Sie das Volume zunächst wieder an die Instanz an. Klicken Sie dazu in der Zeile des Volumes auf <code className="action">...</code> und wählen Sie <code className="action">An Instanz anhängen</code> aus.
+Hängen Sie das Volume zunächst wieder an die Instanz an. Klicken Sie dazu in der Zeile des Volumes auf <code className="action">...</code> und wählen Sie <code className="action">Mit Instanz verbinden</code> aus.
 
 Stellen Sie eine Remotedesktopverbindung (RDP) zu Ihrer Windows-Instanz her.
 
@@ -320,6 +320,6 @@ Sobald dies abgeschlossen ist, trennen Sie das Volume von der Instanz und hänge
 
 [Zusätzliches Volume auf einer Instanz erstellen und konfigurieren](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
 
-[Ihren Block Storage Volume-Typ ändern](/guides/public-cloud/compute/switch-volume-type)
+[Block Storage Volume bearbeiten](/guides/public-cloud/compute/switch-volume-type)
 
 Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/en/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/en/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -36,7 +36,7 @@ If you have reached the maximum capacity on your additional disk, you can add mo
 
 The following steps presume that you have configured an additional disk according to [our guide](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
 
-## Monitoring disk usage before resizing
+### Monitoring disk usage before resizing
 
 :::warning
 We recommend that you always maintain 20% free space on your storage volumes. This ensures optimum performance and avoids the risk of system degradation or failure when the volume reaches its maximum capacity.
@@ -56,7 +56,7 @@ To ensure that you resize your disk at the right moment, it is essential to moni
     
     Run the following command:
     
-    ```bash
+    ```cmd
     wmic logicaldisk get name, size, freespace
     ```
     
@@ -73,7 +73,7 @@ To ensure that you resize your disk at the right moment, it is essential to moni
     
     Run the following command:
     
-    ```bash
+    ```powershell
     Get-PSDrive | Where-Object {$_.Free -ne $null} | Select-Object Name, Used, Free
     ```
     
@@ -114,15 +114,23 @@ To ensure that you resize your disk at the right moment, it is essential to moni
 </Tabs>
 
 
+:::warning
+Before resizing, we recommend creating a snapshot of your volume to protect your data. If something goes wrong during the resize or partition extension, you can restore from the snapshot. See [Creating a volume snapshot](/guides/public-cloud/compute/storage-create-volume-snapshot) for instructions.
+:::
+
 ### Modifying the size of the disk
 
-Click on <code className="action">Block Storage</code> in the left-hand menu under **Storage & backup**.
+In your Public Cloud project, click on <code className="action">Block Storage</code> in the left-hand menu under **Storage & backup**.
 
 If the volume is attached to a **Windows instance**, click on <code className="action">...</code> in the row of the volume and select <code className="action">Detach from instance</code>.
 
 Click on <code className="action">...</code> in the row of the volume and select <code className="action">Edit</code>.
 
 <img className="thumbnail" alt="control panel" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-02.png" loading="lazy" />
+
+:::warning
+Volume resizing is irreversible. You can only increase the size of a volume, never decrease it. Make sure the new size is correct before confirming.
+:::
 
 In the popup window, enter the new size for the volume and click on <code className="action">Modify the volume</code>.
 
@@ -132,13 +140,35 @@ In the popup window, enter the new size for the volume and click on <code classN
 
 Establish an SSH connection to your instance in order to adjust the partition to the resized disk.
 
+Before unmounting, check the current partition layout:
+
+```bash
+admin@server:~$ sudo fdisk -l /dev/vdb
+```
+
+```console
+Disk /dev/vdb: 70 GiB, 75161927680 bytes, 146800640 sectors
+Units: sectors of 1 * 512 = 512 bytes
+Sector size (logical/physical): 512 bytes / 512 bytes
+I/O size (minimum/optimal): 512 bytes / 512 bytes
+Disklabel type: dos
+Disk identifier: 0x00000001
+
+Device     Boot  Start       End   Sectors  Size Id Type
+/dev/vdb1        2048  104857599 104855552   50G 83 Linux
+```
+
+:::warning
+Note the `Start` sector value (in this example, `2048`). You must re-enter this exact value when recreating the partition in the next step. Using a different start sector will misalign the filesystem and cause data corruption or loss.
+:::
+
 Unmount the disk first by using this command:
 
 ```bash
 admin@server:~$ sudo umount /mnt/disk
 ```
 
-Recreate the partition:
+Recreate the partition. This process only rewrites the partition table — your filesystem data is not touched and will be preserved, provided you re-enter the exact same start sector when prompted.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
@@ -154,6 +184,7 @@ Command (m for help): d
 Selected partition 1
 Partition 1 has been deleted.
 ```
+
 ```console
 Command (m for help): n
 
@@ -163,11 +194,12 @@ e extended (container for logical partitions)
 Select (default p):
 Using default response p.
 Partition number (1-4, default 1):
-First sector (2048-146800639, default 2048):
+First sector (2048-146800639, default 2048): 2048
 Last sector, +sectors or +size{K,M,G,T,P} (2048-146800639, default 146800639):
 
 Created a new partition 1 of type 'Linux' and of size 70 GiB.
 ```
+
 ```console
 Command (m for help): w
 
@@ -175,6 +207,19 @@ The partition table has been altered.
 Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
+
+Before resizing the filesystem, check its type:
+
+```bash
+admin@server:~$ lsblk -f /dev/vdb1
+```
+
+```console
+NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
+vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+The steps below apply to **ext2/ext3/ext4** filesystems. Unlike ext4, XFS cannot be resized while unmounted — the `xfs_growfs` tool requires the filesystem to be mounted. If your filesystem is **XFS**, skip the `umount`, `e2fsck`, and `resize2fs` steps, remount the disk after recreating the partition, then run `sudo xfs_growfs /mnt/disk`.
 
 Verify and check the partition:
 
@@ -187,7 +232,7 @@ Pass 2: Checking directory structure
 Pass 3: Checking directory connectivity
 Pass 4: Checking reference counts
 Pass 5: Checking group summary information
-/dev/vdb: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
+/dev/vdb1: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
 ```
 
 ```bash
@@ -217,6 +262,15 @@ tmpfs 982M 0 982M 0% /sys/fs/cgroup
 ```
 
 Once this is completed, detach the volume from the instance and reattach it to ensure the updated QoS settings (IOPS and bandwidth) are properly applied.
+
+After reattaching, remount the disk and confirm the volume is visible with the correct size:
+
+```bash
+admin@server:~$ sudo mount /dev/vdb1 /mnt/disk/
+admin@server:~$ lsblk /dev/vdb
+```
+
+You can also verify the updated volume configuration in your Public Cloud project under <code className="action">Block Storage</code>.
 
 ### Extending the partition (Windows instance)
 
@@ -249,6 +303,8 @@ The resized volume now includes the additional disk space.
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-05.png" loading="lazy" />
 
 Once this is completed, detach the volume from the instance and reattach it to ensure the updated QoS settings (IOPS and bandwidth) are properly applied.
+
+After reattaching, open <code className="action">Disk Management</code> again to confirm the volume displays the correct total size. You can also verify the updated volume configuration in your Public Cloud project under <code className="action">Block Storage</code>.
 
 ## Go further
 

--- a/docs/en/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/en/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Increasing the size of an additional disk
 description: Find out how to increase the size of an additional volume and enlarge its main partition
-lastUpdated: 2026-07-06
+lastUpdated: 2026-07-07
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -151,7 +151,7 @@ NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
 vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
 ```
 
-The steps below apply to **ext2/ext3/ext4** filesystems. Unlike ext4, XFS cannot be resized while unmounted — the `xfs_growfs` tool requires the filesystem to be mounted. If your filesystem is **XFS**, skip the `umount`, `e2fsck`, and `resize2fs` steps, remount the disk after recreating the partition, then run `sudo xfs_growfs /mnt/disk`.
+The steps below apply to **ext2/ext3/ext4** filesystems. Unlike ext4, XFS cannot be resized while unmounted — the `xfs_growfs` tool requires the filesystem to be mounted. If your filesystem is **XFS**, still unmount the disk and recreate the partition as described below, but skip the `e2fsck` and `resize2fs` steps: remount the disk instead, then run `sudo xfs_growfs /mnt/disk`.
 
 Before unmounting, check the current partition layout:
 
@@ -231,7 +231,7 @@ Type the partition number, in our example `1`:
 Partition number (1-4, default 1): 1
 ```
 
-Specify the `sector` value previously retrieved (2048) and the end point to extend the partition to the available space on the disk:
+Enter the first sector value you noted earlier (2048), then accept the default last sector to extend the partition across all remaining available space on the disk:
 
 ```console
 First sector (2048-146800639, default 2048): 2048

--- a/docs/en/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/en/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Increasing the size of an additional disk
 description: Find out how to increase the size of an additional volume and enlarge its main partition
-lastUpdated: 2026-02-26
+lastUpdated: 2026-07-06
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ If you have reached the maximum capacity on your additional disk, you can add mo
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-gb/public-cloud/) in your Public Cloud project
+- A [Public Cloud instance](/links/public-cloud/compute) in your Public Cloud project
 - An [additional disk](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance) created in your project
 - Administrative (sudo) access to your instance via SSH (Linux) or RDP (Windows)
 
@@ -34,7 +34,7 @@ If you have reached the maximum capacity on your additional disk, you can add mo
 
 ## Instructions
 
-The following steps presume that you have configured an additional disk according to [our guide](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
+These steps assume you have already configured an additional disk as described in [Creating and configuring an additional disk on an instance](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
 
 ### Monitoring disk usage before resizing
 
@@ -44,7 +44,7 @@ We recommend that you always maintain 20% free space on your storage volumes. Th
 :::
 
 
-To ensure that you resize your disk at the right moment, it is essential to monitor disk usage regularly. Below are quick tutorials for both Windows and Linux to help you track disk space and anticipate when an upgrade is needed.
+To resize your disk at the right time, monitor disk usage regularly. Below are quick tutorials for both Windows and Linux to help you track disk space and anticipate when an upgrade is needed.
 
 <Tabs>
   <Tab label="On Windows">
@@ -138,7 +138,20 @@ In the popup window, enter the new size for the volume and click on <code classN
 
 ### Extending the partition (Linux instance)
 
-Establish an SSH connection to your instance in order to adjust the partition to the resized disk.
+Establish an SSH connection to your instance to adjust the partition to the resized disk.
+
+First, check the filesystem type:
+
+```bash
+admin@server:~$ lsblk -f /dev/vdb1
+```
+
+```console
+NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
+vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+The steps below apply to **ext2/ext3/ext4** filesystems. Unlike ext4, XFS cannot be resized while unmounted — the `xfs_growfs` tool requires the filesystem to be mounted. If your filesystem is **XFS**, skip the `umount`, `e2fsck`, and `resize2fs` steps, remount the disk after recreating the partition, then run `sudo xfs_growfs /mnt/disk`.
 
 Before unmounting, check the current partition layout:
 
@@ -162,22 +175,32 @@ Device     Boot  Start       End   Sectors  Size Id Type
 Note the `Start` sector value (in this example, `2048`). You must re-enter this exact value when recreating the partition in the next step. Using a different start sector will misalign the filesystem and cause data corruption or loss.
 :::
 
-Unmount the disk first by using this command:
+First, unmount the disk:
 
 ```bash
 admin@server:~$ sudo umount /mnt/disk
 ```
 
-Recreate the partition. This process only rewrites the partition table — your filesystem data is not touched and will be preserved, provided you re-enter the exact same start sector when prompted.
+In our example:
+
+```bash
+admin@server:~$ sudo umount /mnt/vdb
+```
+
+Recreate the partition using the following command. This process only rewrites the partition table — your filesystem data is not touched and will be preserved, provided you re-enter the exact same start sector when prompted.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
 ```
+
 ```console
 Welcome to fdisk (util-linux 2.25.2).
 Changes will remain in memory only, until you decide to write them.
 Be careful before using the write command
 ```
+
+Type `d` to delete the partition:
+
 ```console
 Command (m for help): d
 
@@ -185,20 +208,41 @@ Selected partition 1
 Partition 1 has been deleted.
 ```
 
+Type `n` to recreate the partition:
+
 ```console
 Command (m for help): n
 
 Partition type
 p primary (0 primary, 0 extended, 4 free)
 e extended (container for logical partitions)
+```
+
+Type `p` to select the primary partition type:
+
+```console
 Select (default p):
 Using default response p.
-Partition number (1-4, default 1):
+```
+
+Type the partition number, in our example `1`:
+
+```console
+Partition number (1-4, default 1): 1
+```
+
+Specify the `sector` value previously retrieved (2048) and the end point to extend the partition to the available space on the disk:
+
+```console
 First sector (2048-146800639, default 2048): 2048
 Last sector, +sectors or +size{K,M,G,T,P} (2048-146800639, default 146800639):
 
 Created a new partition 1 of type 'Linux' and of size 70 GiB.
 ```
+
+To list the changes, type `p` again.
+
+Next, type `w` to save the changes made:
 
 ```console
 Command (m for help): w
@@ -208,20 +252,7 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Before resizing the filesystem, check its type:
-
-```bash
-admin@server:~$ lsblk -f /dev/vdb1
-```
-
-```console
-NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
-vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
-```
-
-The steps below apply to **ext2/ext3/ext4** filesystems. Unlike ext4, XFS cannot be resized while unmounted — the `xfs_growfs` tool requires the filesystem to be mounted. If your filesystem is **XFS**, skip the `umount`, `e2fsck`, and `resize2fs` steps, remount the disk after recreating the partition, then run `sudo xfs_growfs /mnt/disk`.
-
-Verify and check the partition:
+Verify and check the partition (for **ext2/ext3/ext4** filesystems):
 
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
@@ -263,14 +294,7 @@ tmpfs 982M 0 982M 0% /sys/fs/cgroup
 
 Once this is completed, detach the volume from the instance and reattach it to ensure the updated QoS settings (IOPS and bandwidth) are properly applied.
 
-After reattaching, remount the disk and confirm the volume is visible with the correct size:
-
-```bash
-admin@server:~$ sudo mount /dev/vdb1 /mnt/disk/
-admin@server:~$ lsblk /dev/vdb
-```
-
-You can also verify the updated volume configuration in your Public Cloud project under <code className="action">Block Storage</code>.
+After reattaching, you can verify the updated volume configuration in your Public Cloud project under <code className="action">Block Storage</code>.
 
 ### Extending the partition (Windows instance)
 
@@ -290,7 +314,7 @@ Right-click on the volume and select <code className="action">Extend Volume</cod
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-03.png" loading="lazy" />
 
-In the "Extend Volume Wizard", click on <code className="action">Next</code> to proceed.
+In the "Extend Volume Wizard", click <code className="action">Next</code>.
 
 You can modify the disk space in this step if you want to add less than the entire amount to the partition. Click on <code className="action">Next</code>.
 

--- a/docs/en/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/en/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Increasing the size of an additional disk
 description: Find out how to increase the size of an additional volume and enlarge its main partition
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/es/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/es/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aumentar el tamaño de un disco adicional
-description: Cómo aumentar el tamaño de un volumen adicional y aumentar su partición principal
-lastUpdated: 2026-02-26
+description: Descubra cómo aumentar el tamaño de un volumen adicional y ampliar su partición principal
+lastUpdated: 2026-07-07
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -13,12 +13,12 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Si ha alcanzado la capacidad máxima de su disco adicional, puede añadir almacenamiento aumentando su tamaño. 
 
-**Esta guía explica cómo aumentar el tamaño de un disco adicional y cómo ampliar la partición principal en consecuencia.**
+**Esta guía explica cómo aumentar el tamaño de un disco adicional y cómo extender la partición principal en consecuencia.**
 
 ## Requisitos
 
-- Tener una [instancia Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/compute/) en su proyecto de Public Cloud.
-- Tener un [disco adicional](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance) creado en su proyecto.
+- Una [instancia de Public Cloud](/links/public-cloud/compute) en su proyecto de Public Cloud.
+- Un [disco adicional](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance) creado en su proyecto.
 - Tener acceso administrativo (sudo) a su instancia a través de SSH (Linux) o RDP (Windows).
 
 {/* CP-NAV-START:publiccloud-projects */}
@@ -26,41 +26,41 @@ Si ha alcanzado la capacidad máxima de su disco adicional, puede añadir almace
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
-- **Ruta de navegación:** <code className="action">Public Cloud</code> > Seleccione su proyecto
+- **Enlace directo:** <ManagerLink to="/#/pci/projects">Proyectos de Public Cloud</ManagerLink>
+- **Para acceder a sus servicios:** <code className="action">Public Cloud</code> > Seleccione su proyecto
 
 ---
 {/* CP-NAV-END:publiccloud-projects */}
 
 ## Procedimiento
 
-Los siguientes pasos suponen que ya ha configurado un disco adicional según las instrucciones de [nuestra guía](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
+Estos pasos suponen que ya ha configurado un disco adicional como se describe en [Crear y configurar un disco adicional en una instancia](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
 
-## Supervisión del uso del disco antes de cambiar el tamaño
+### Supervisión del uso del disco antes de cambiar el tamaño
 
 :::warning
-Le recomendamos que mantenga siempre un 20% de espacio libre en sus volúmenes de almacenamiento. Esto garantiza un rendimiento óptimo y evita el riesgo de degradación o fallo del sistema cuando el volumen alcanza su capacidad máxima.
+Se recomienda mantener siempre un 20% de espacio libre en sus volúmenes de almacenamiento. Esto permite garantizar un rendimiento óptimo y evitar riesgos de degradación o fallo del sistema cuando el volumen alcanza su capacidad máxima.
 
 :::
 
 
-Para asegurarse de que cambia el tamaño del disco en el momento adecuado, es esencial supervisar el uso del disco con regularidad. A continuación, encontrará tutoriales rápidos para Windows y Linux que le ayudarán a realizar un seguimiento del espacio en disco y anticipar cuándo se necesita una actualización.
+Para cambiar el tamaño del disco en el momento adecuado, supervise el uso del disco con regularidad. A continuación, encontrará tutoriales rápidos para Windows y Linux que le ayudarán a supervisar el espacio en disco y a anticipar el momento en que sea necesaria una actualización.
 
 <Tabs>
-  <Tab label="En Windows">
+  <Tab label="Para Windows">
     <details>
-    <summary>Utilizando El Símbolo Del Sistema</summary>
+    <summary>Uso del símbolo del sistema</summary>
 
     
-    Abra el símbolo del sistema (Win + R → cmd → Enter).
+    Abra el símbolo del sistema (Windows + R → cmd → Enter).
     
     Ejecute el siguiente comando:
     
-    ```bash
+    ```cmd
     wmic logicaldisk get name, size, freespace
     ```
     
-    Esto mostrará el espacio libre y el tamaño total de cada disco.
+    Se muestran el espacio libre y el tamaño total de cada disco.
     
 
     </details>
@@ -73,36 +73,36 @@ Para asegurarse de que cambia el tamaño del disco en el momento adecuado, es es
     
     Ejecute el siguiente comando:
     
-    ```bash
+    ```powershell
     Get-PSDrive | Where-Object {$_.Free -ne $null} | Select-Object Name, Used, Free
     ```
     
-    Esto mostrará el espacio en disco utilizado y disponible.
+    Se muestran el espacio en disco utilizado y el espacio en disco disponible.
     
 
     </details>
   </Tab>
-  <Tab label="En Linux">
+  <Tab label="Para Linux">
     <details>
-    <summary>Utilizando el comando 'df'</summary>
+    <summary>Uso del comando 'df'</summary>
 
     
-    Para comprobar el uso general del disco, ejecute:
+    Para comprobar el uso global del disco, ejecute el comando
     
     ```bash
     df -h
     ```
     
-    Esto mostrará el uso del disco en un formato legible por las personas.
+    Esta función muestra el uso del disco en un formato legible.
     
 
     </details>
     
     <details>
-    <summary>Utilizando el comando 'lsblk'</summary>
+    <summary>Uso del comando 'lsblk'</summary>
 
     
-    Para ver las particiones de disco y sus tamaños:
+    Para ver las particiones del disco y su tamaño:
     
     ```bash
     lsblk
@@ -114,60 +114,130 @@ Para asegurarse de que cambia el tamaño del disco en el momento adecuado, es es
 </Tabs>
 
 
+:::warning
+Antes de cambiar el tamaño, le recomendamos crear una instantánea de su volumen para proteger sus datos. Si se produce un problema durante el cambio de tamaño o la extensión de la partición, podrá restaurar desde esta instantánea. Consulte [Crear una instantánea de un volumen](/guides/public-cloud/compute/storage-create-volume-snapshot) para obtener instrucciones.
+:::
+
 ### Cambiar el tamaño del disco
 
-Conéctese al <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink> y abra su proyecto de <code className="action">Public Cloud</code>. A continuación, haga clic en <code className="action">Block Storage</code> en el menú de la izquierda en **Backup Storage**
+En su proyecto de Public Cloud, haga clic en <code className="action">Block Storage</code> en el menú izquierdo, en **Storage & Backup**.
 
 Si el volumen está asociado a una **instancia Windows**, haga clic en el botón <code className="action">...</code> a la derecha del volumen correspondiente y seleccione <code className="action">Desvincular de la instancia</code>.
 
 Haga clic en el botón <code className="action">...</code> a la derecha del volumen correspondiente y seleccione <code className="action">Editar</code>.
 
-<img className="thumbnail" alt="cuadro de mando" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-02.png" loading="lazy" />
+<img className="thumbnail" alt="panel de control" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-02.png" loading="lazy" />
 
-En la nueva ventana, introduzca el nuevo tamaño del volumen y haga clic en <code className="action">Editar volumen</code>.
+:::warning
+El cambio de tamaño de un volumen es irreversible. Solo puede aumentar el tamaño de un volumen, nunca reducirlo. Compruebe que el nuevo tamaño es correcto antes de confirmar.
+:::
 
-<img className="thumbnail" alt="cuadro de mando" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-03.png" loading="lazy" />
+En la ventana que aparece, indique el nuevo tamaño del volumen y haga clic en <code className="action">Modificar el volumen</code>.
 
-### Ampliar la partición (instancia Linux)
+<img className="thumbnail" alt="panel de control" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-03.png" loading="lazy" />
 
-Conéctese por SSH a su instancia para ajustar la partición al disco redimensionado.
+### Extender la partición (instancia Linux)
 
-Desmonte el disco utilizando este comando:
+Abra una conexión SSH a su instancia para ajustar la partición al disco redimensionado.
+
+Compruebe primero el tipo de sistema de archivos:
+
+```bash
+admin@server:~$ lsblk -f /dev/vdb1
+```
+
+```console
+NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
+vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+Los siguientes pasos se aplican a los sistemas de archivos **ext2/ext3/ext4**. A diferencia de ext4, XFS no se puede redimensionar cuando está desmontado: la herramienta `xfs_growfs` requiere que el sistema de archivos esté montado. Si su sistema de archivos es **XFS**, desmonte el disco y vuelva a crear la partición como se indica a continuación, pero omita los pasos `e2fsck` y `resize2fs`: vuelva a montar el disco y ejecute `sudo xfs_growfs /mnt/disk`.
+
+Antes de desmontar, compruebe la disposición actual de la partición:
+
+```bash
+admin@server:~$ sudo fdisk -l /dev/vdb
+```
+
+```console
+Disk /dev/vdb: 70 GiB, 75161927680 bytes, 146800640 sectors
+Units: sectors of 1 * 512 = 512 bytes
+Sector size (logical/physical): 512 bytes / 512 bytes
+I/O size (minimum/optimal): 512 bytes / 512 bytes
+Disklabel type: dos
+Disk identifier: 0x00000001
+
+Device     Boot  Start       End   Sectors  Size Id Type
+/dev/vdb1        2048  104857599 104855552   50G 83 Linux
+```
+
+:::warning
+Anote el valor del sector `Start` (en este ejemplo, `2048`). Debe introducir este valor exacto al volver a crear la partición en el siguiente paso. El uso de un sector de inicio diferente provocará un desalineamiento del sistema de archivos y ocasionará corrupción o pérdida de datos.
+:::
+
+Desmonte primero el disco:
 
 ```bash
 admin@server:~$ sudo umount /mnt/disk
 ```
 
-Recargue la partición:
+Vuelva a crear la partición con el siguiente comando. Este proceso solo reescribe la tabla de particiones: sus datos no se ven afectados y se conservarán, siempre que introduzca el mismo sector de inicio cuando se le solicite.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
 ```
+
 ```console
 Welcome to fdisk (util-linux 2.25.2).
 Changes will remain in memory only, until you decide to write them.
 Be careful before using the write command
 ```
+
+Introduzca `d` para eliminar la partición:
+
 ```console
 Command (m for help): d
 
 Selected partition 1
 Partition 1 has been deleted.
 ```
+
+Introduzca `n` para volver a crear la partición:
+
 ```console
 Command (m for help): n
 
 Partition type
 p primary (0 primary, 0 extended, 4 free)
 e extended (container for logical partitions)
+```
+
+Introduzca `p` para seleccionar el tipo de partición principal:
+
+```console
 Select (default p):
 Using default response p.
-Partition number (1-4, default 1):
-First sector (2048-146800639, default 2048):
+```
+
+Introduzca el número de partición, en nuestro ejemplo `1`:
+
+```console
+Partition number (1-4, default 1): 1
+```
+
+Introduzca el valor del primer sector anotado anteriormente (2048) y, a continuación, acepte el último sector predeterminado para extender la partición a todo el espacio disponible en el disco:
+
+```console
+First sector (2048-146800639, default 2048): 2048
 Last sector, +sectors or +size{K,M,G,T,P} (2048-146800639, default 146800639):
 
 Created a new partition 1 of type 'Linux' and of size 70 GiB.
 ```
+
+Para ver la lista de los cambios realizados, introduzca de nuevo `p`.
+
+A continuación, introduzca `w` para guardar los cambios:
+
 ```console
 Command (m for help): w
 
@@ -176,18 +246,18 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Compruebe la partición:
+Compruebe y verifique la partición (para los sistemas de archivos **ext2/ext3/ext4**):
 
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
 
-e2fsck 1.42.12 (29-Aug-2014)
+e2fsck 1.42.12 (29-août-2014)
 Pass 1: Checking inodes, blocks, and sizes
 Pass 2: Checking directory structure
 Pass 3: Checking directory connectivity
 Pass 4: Checking reference counts
 Pass 5: Checking group summary information
-/dev/vdb: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
+/dev/vdb1: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
 ```
 
 ```bash
@@ -198,7 +268,7 @@ Resizing the filesystem on /dev/vdb to 18350080 (4k) blocks.
 The filesystem on /dev/vdb is now 18350080 (4k) blocks long.
 ```
 
-Por último, remonte y verifique el disco:
+Por último, vuelva a montar y verifique el disco:
 
 ```bash
 admin@server:~$ sudo mount /dev/vdb1 /mnt/disk/
@@ -216,46 +286,50 @@ tmpfs 982M 0 982M 0% /sys/fs/cgroup
 /dev/vdb1 69G 52M 66G 1% /mnt/disk
 ```
 
-Una vez finalizada esta operación, desmonte el volumen de la instancia y vuelva a montarlo para asegurarse de que los parámetros QoS actualizados (IOPS y ancho de banda) se hayan aplicado correctamente.
+Una vez finalizada esta operación, desvincule el volumen de la instancia y vuelva a asociarlo para asegurarse de que los parámetros de QoS actualizados (IOPS y ancho de banda) se aplican correctamente.
 
-### Ampliar la partición (instancia Windows)
+Tras la reasociación, puede comprobar la configuración actualizada del volumen en su proyecto de Public Cloud, en <code className="action">Block Storage</code>.
 
-Antes de continuar, monte el volumen en la instancia. Haga clic en <code className="action">...</code> en la fila del volumen y seleccione <code className="action">Asociar a la instancia</code>.
+### Extender la partición (instancia Windows)
 
-Establezca una conexión RDP (Remote Desktop) en su instancia Windows.
+Antes de continuar, vuelva a asociar el volumen a la instancia. Haga clic en <code className="action">...</code> en la fila del volumen y seleccione <code className="action">Asociar a la instancia</code>.
 
-Una vez que se haya conectado, haga clic derecho en el botón <code className="action">Iniciar</code> y abra la <code className="action">Gestión de discos</code>.
+Establezca una conexión RDP (Remote Desktop) con su instancia Windows.
+
+Una vez conectado, haga clic con el botón derecho en <code className="action">Menú Inicio</code> y abra la <code className="action">Administración de discos</code>.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-01.png" loading="lazy" />
 
-El disco ampliado muestra ahora la capacidad adicional en forma de espacio no asignado.
+El disco ampliado ahora muestra la capacidad adicional en forma de espacio no asignado.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-02.png" loading="lazy" />
 
-Haga clic derecho en el volumen y seleccione <code className="action">Ampliar el volumen</code> en el menú contextual.
+Haga clic con el botón derecho en el volumen y seleccione <code className="action">Extender volumen</code> en el menú contextual.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-03.png" loading="lazy" />
 
-En el Asistente para la extensión de volumen, haga clic en <code className="action">Siguiente</code> para continuar.
+En el asistente para extender volumen, haga clic en <code className="action">Siguiente</code>.
 
-Si desea añadir una capacidad inferior a la de la partición en su totalidad, puede modificar el espacio en disco.
+En este paso, puede modificar el espacio en disco si desea añadir una capacidad menor que la totalidad de la partición.
 
 Haga clic en <code className="action">Siguiente</code>.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-04.png" loading="lazy" />
 
-Haga clic en <code className="action">Finalizar</code> para finalizar el proceso.
+Haga clic en <code className="action">Finalizar</code> para completar el proceso.
 
-El volumen redimensionado incluye ahora el espacio en disco adicional.
+El volumen redimensionado ahora incluye el espacio en disco adicional.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-05.png" loading="lazy" />
 
-Una vez finalizada esta operación, desmonte el volumen de la instancia y vuelva a montarlo para asegurarse de que los parámetros QoS actualizados (IOPS y ancho de banda) se hayan aplicado correctamente.
+Una vez finalizada esta operación, desvincule el volumen de la instancia y vuelva a asociarlo para asegurarse de que los parámetros de QoS actualizados (IOPS y ancho de banda) se aplican correctamente.
+
+Tras la reasociación, vuelva a abrir la <code className="action">Administración de discos</code> para confirmar que el volumen muestra el tamaño total correcto. También puede comprobar la configuración actualizada del volumen en su proyecto de Public Cloud, en <code className="action">Block Storage</code>.
 
 ## Más información
 
 [Crear y configurar un disco adicional en una instancia](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
 
-[Cambie el tipo de volumen en su Block Storage](/guides/public-cloud/compute/switch-volume-type)
+[Modificar un volumen de Block Storage](/guides/public-cloud/compute/switch-volume-type)
 
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/es/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aumentar el tamaño de un disco adicional
 description: Descubra cómo aumentar el tamaño de un volumen adicional y ampliar su partición principal
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -132,7 +132,7 @@ Haga clic en el botón <code className="action">...</code> a la derecha del volu
 El cambio de tamaño de un volumen es irreversible. Solo puede aumentar el tamaño de un volumen, nunca reducirlo. Compruebe que el nuevo tamaño es correcto antes de confirmar.
 :::
 
-En la ventana que aparece, indique el nuevo tamaño del volumen y haga clic en <code className="action">Modificar el volumen</code>.
+En la ventana que aparece, indique el nuevo tamaño del volumen y haga clic en <code className="action">Editar volumen</code>.
 
 <img className="thumbnail" alt="panel de control" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-03.png" loading="lazy" />
 
@@ -251,7 +251,7 @@ Compruebe y verifique la partición (para los sistemas de archivos **ext2/ext3/e
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
 
-e2fsck 1.42.12 (29-août-2014)
+e2fsck 1.42.12 (29-Aug-2014)
 Pass 1: Checking inodes, blocks, and sizes
 Pass 2: Checking directory structure
 Pass 3: Checking directory connectivity

--- a/docs/fr/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/fr/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
-title: Augmenter la taille d’un disque supplémentaire
+title: Augmenter la taille d'un disque supplémentaire
 description: "Découvrez comment augmenter la taille d'un volume supplémentaire et agrandir sa partition principale"
-lastUpdated: 2026-02-26
+lastUpdated: 2026-07-06
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -17,7 +17,7 @@ Si vous avez atteint la capacité maximale de votre disque supplémentaire, vous
 
 ## Prérequis
 
-- Une [instance Public Cloud](https://www.ovhcloud.com/fr/public-cloud/compute/) dans votre projet Public Cloud.
+- Une [instance Public Cloud](/links/public-cloud/compute) dans votre projet Public Cloud.
 - Un [disque supplémentaire](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance) créé dans votre projet.
 - Avoir un accès administratif (sudo) à votre instance via SSH (Linux) ou RDP (Windows).
 
@@ -34,9 +34,9 @@ Si vous avez atteint la capacité maximale de votre disque supplémentaire, vous
 
 ## En pratique
 
-Les étapes suivantes supposent que vous avez déjà configuré un disque supplémentaire selon les instructions de [notre guide](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
+Ces étapes supposent que vous avez déjà configuré un disque supplémentaire comme décrit dans [Créer et configurer un disque additionnel sur une instance](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
 
-## Monitorer l'utilisation du disque avant le redimensionnement
+### Monitorer l'utilisation du disque avant le redimensionnement
 
 :::warning
 Il est recommandé de toujours maintenir 20% d'espace libre sur vos volumes de stockage. Cela permet d'assurer des performances optimales et d'éviter des risques de dégradation ou de panne du système lorsque le volume atteint sa capacité maximale.
@@ -44,7 +44,7 @@ Il est recommandé de toujours maintenir 20% d'espace libre sur vos volumes de s
 :::
 
 
-Pour vous assurer de redimensionner votre disque au bon moment, il est essentiel de surveiller régulièrement l'utilisation du disque. Vous trouverez ci-dessous des tutoriels rapides pour Windows et Linux qui vous aideront à surveiller l'espace disque et à anticiper le moment où une mise à niveau est nécessaire.
+Pour redimensionner votre disque au bon moment, surveillez régulièrement l'utilisation du disque. Vous trouverez ci-dessous des tutoriels rapides pour Windows et Linux qui vous aideront à surveiller l'espace disque et à anticiper le moment où une mise à niveau est nécessaire.
 
 <Tabs>
   <Tab label="Pour Windows">
@@ -56,7 +56,7 @@ Pour vous assurer de redimensionner votre disque au bon moment, il est essentiel
     
     Exécutez la commande suivante :
     
-    ```bash
+    ```cmd
     wmic logicaldisk get name, size, freespace
     ```
     
@@ -73,7 +73,7 @@ Pour vous assurer de redimensionner votre disque au bon moment, il est essentiel
     
     Exécutez la commande suivante :
     
-    ```bash
+    ```powershell
     Get-PSDrive | Where-Object {$_.Free -ne $null} | Select-Object Name, Used, Free
     ```
     
@@ -114,15 +114,23 @@ Pour vous assurer de redimensionner votre disque au bon moment, il est essentiel
 </Tabs>
 
 
+:::warning
+Avant de redimensionner, nous recommandons de créer un snapshot de votre volume pour protéger vos données. En cas de problème lors du redimensionnement ou de l'extension de la partition, vous pourrez restaurer depuis ce snapshot. Consultez [Créer un snapshot d'un volume](/guides/public-cloud/compute/storage-create-volume-snapshot) pour les instructions.
+:::
+
 ### Modifier la taille du disque
 
-Cliquez sur <code className="action">Block Storage</code> dans le menu de gauche sous **Storage & Backup**.
+Dans votre projet Public Cloud, cliquez sur <code className="action">Block Storage</code> dans le menu de gauche sous **Storage & Backup**.
 
 Si le volume est attaché à une **instance Windows**, cliquez sur le bouton <code className="action">...</code> à droite du volume concerné et sélectionnez <code className="action">Détacher de l'instance</code>.
 
 Cliquez sur le bouton <code className="action">...</code> à droite du volume concerné et sélectionnez <code className="action">Éditer</code>.
 
 <img className="thumbnail" alt="tableau de bord" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-02.png" loading="lazy" />
+
+:::warning
+Le redimensionnement d'un volume est irréversible. Vous pouvez uniquement augmenter la taille d'un volume, jamais la diminuer. Vérifiez que la nouvelle taille est correcte avant de confirmer.
+:::
 
 Dans la fenêtre qui apparaît, indiquez la nouvelle taille du volume et cliquez sur <code className="action">Modifier le volume</code>.
 
@@ -132,13 +140,48 @@ Dans la fenêtre qui apparaît, indiquez la nouvelle taille du volume et cliquez
 
 Ouvrez une connexion SSH à votre instance pour ajuster la partition au disque redimensionné.
 
-Démontez d’abord le disque en utilisant cette commande :
+Vérifiez d'abord le type de système de fichiers :
+
+```bash
+admin@server:~$ lsblk -f /dev/vdb1
+```
+
+```console
+NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
+vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+Les étapes ci-dessous s'appliquent aux systèmes de fichiers **ext2/ext3/ext4**. Contrairement à ext4, XFS ne peut pas être redimensionné lorsqu'il est démonté — l'outil `xfs_growfs` nécessite que le système de fichiers soit monté. Si votre système de fichiers est **XFS**, ignorez les étapes `umount`, `e2fsck` et `resize2fs`, remontez le disque après avoir recréé la partition, puis exécutez `sudo xfs_growfs /mnt/disk`.
+
+Avant de démonter, vérifiez la disposition actuelle de la partition :
+
+```bash
+admin@server:~$ sudo fdisk -l /dev/vdb
+```
+
+```console
+Disk /dev/vdb: 70 GiB, 75161927680 bytes, 146800640 sectors
+Units: sectors of 1 * 512 = 512 bytes
+Sector size (logical/physical): 512 bytes / 512 bytes
+I/O size (minimum/optimal): 512 bytes / 512 bytes
+Disklabel type: dos
+Disk identifier: 0x00000001
+
+Device     Boot  Start       End   Sectors  Size Id Type
+/dev/vdb1        2048  104857599 104855552   50G 83 Linux
+```
+
+:::warning
+Notez la valeur du secteur `Start` (dans cet exemple, `2048`). Vous devez saisir cette valeur exacte lors de la recréation de la partition à l'étape suivante. L'utilisation d'un secteur de départ différent entraînera un désalignement du système de fichiers et provoquera une corruption ou une perte de données.
+:::
+
+Démontez d'abord le disque :
 
 ```bash
 admin@server:~$ sudo umount /mnt/disk
 ```
 
-Recréez la partition :
+Recréez la partition à l'aide de la commande suivante. Ce processus réécrit uniquement la table de partitions — vos données ne sont pas touchées et seront préservées, à condition de saisir le même secteur de départ lorsqu'on vous le demande.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
@@ -150,6 +193,8 @@ Changes will remain in memory only, until you decide to write them.
 Be careful before using the write command
 ```
 
+Saisissez `d` pour supprimer la partition :
+
 ```console
 Command (m for help): d
 
@@ -157,20 +202,41 @@ Selected partition 1
 Partition 1 has been deleted.
 ```
 
+Saisissez `n` pour recréer la partition :
+
 ```console
 Command (m for help): n
 
 Partition type
 p primary (0 primary, 0 extended, 4 free)
 e extended (container for logical partitions)
+```
+
+Saisissez `p` pour sélectionner le type de partition principale :
+
+```console
 Select (default p):
 Using default response p.
-Partition number (1-4, default 1):
-First sector (2048-146800639, default 2048):
+```
+
+Saisissez le numéro de partition, dans notre exemple `1` :
+
+```console
+Partition number (1-4, default 1): 1
+```
+
+Indiquez la valeur du secteur `Start` récupérée précédemment (2048) et le point de fin pour étendre la partition à l'espace disponible sur le disque :
+
+```console
+First sector (2048-146800639, default 2048): 2048
 Last sector, +sectors or +size{K,M,G,T,P} (2048-146800639, default 146800639):
 
 Created a new partition 1 of type 'Linux' and of size 70 GiB.
 ```
+
+Pour lister les modifications effectuées, saisissez à nouveau `p`.
+
+Saisissez ensuite `w` pour enregistrer les modifications :
 
 ```console
 Command (m for help): w
@@ -180,7 +246,7 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Vérifiez la partition :
+Vérifiez et contrôlez la partition (pour les systèmes de fichiers **ext2/ext3/ext4**) :
 
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
@@ -191,7 +257,7 @@ Pass 2: Checking directory structure
 Pass 3: Checking directory connectivity
 Pass 4: Checking reference counts
 Pass 5: Checking group summary information
-/dev/vdb: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
+/dev/vdb1: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
 ```
 
 ```bash
@@ -222,6 +288,8 @@ tmpfs 982M 0 982M 0% /sys/fs/cgroup
 
 Une fois cette opération terminée, détachez le volume de l'instance et rattachez-le afin de vous assurer que les paramètres QoS mis à jour (IOPS et bande passante) soient correctement appliqués.
 
+Après rattachement, vous pouvez vérifier la configuration mise à jour du volume dans votre projet Public Cloud sous <code className="action">Block Storage</code>.
+
 ### Étendre la partition (instance Windows)
 
 Avant de continuer, rattachez le volume à l'instance. Cliquez sur <code className="action">...</code> dans la ligne du volume et sélectionnez <code className="action">Attacher à l'instance</code>.
@@ -240,7 +308,7 @@ Faites un clic-droit sur le volume et sélectionnez <code className="action">Ét
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-03.png" loading="lazy" />
 
-Dans l'assistant d'extension de volume, cliquez sur <code className="action">Suivant</code> pour continuer.
+Dans l'assistant d'extension de volume, cliquez sur <code className="action">Suivant</code>.
 
 Vous pouvez modifier l'espace disque à cette étape si vous souhaitez ajouter une capacité moindre que la totalité de la partition.
 
@@ -256,10 +324,12 @@ Le volume redimensionné inclut désormais l'espace disque supplémentaire.
 
 Une fois cette opération terminée, détachez le volume de l'instance et rattachez-le afin de vous assurer que les paramètres QoS mis à jour (IOPS et bande passante) soient correctement appliqués.
 
+Après rattachement, ouvrez à nouveau la <code className="action">Gestion des disques</code> pour confirmer que le volume affiche la taille totale correcte. Vous pouvez également vérifier la configuration mise à jour du volume dans votre projet Public Cloud sous <code className="action">Block Storage</code>.
+
 ## Aller plus loin
 
 [Créer et configurer un disque additionnel sur une instance](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
 
 [Modifier un Volume Block Storage](/guides/public-cloud/compute/switch-volume-type)
 
-Échangez avec notre [communauté d’utilisateurs](/links/community).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/fr/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Augmenter la taille d'un disque supplémentaire
 description: "Découvrez comment augmenter la taille d'un volume supplémentaire et agrandir sa partition principale"
-lastUpdated: 2026-07-06
+lastUpdated: 2026-07-07
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -151,7 +151,7 @@ NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
 vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
 ```
 
-Les étapes ci-dessous s'appliquent aux systèmes de fichiers **ext2/ext3/ext4**. Contrairement à ext4, XFS ne peut pas être redimensionné lorsqu'il est démonté — l'outil `xfs_growfs` nécessite que le système de fichiers soit monté. Si votre système de fichiers est **XFS**, ignorez les étapes `umount`, `e2fsck` et `resize2fs`, remontez le disque après avoir recréé la partition, puis exécutez `sudo xfs_growfs /mnt/disk`.
+Les étapes ci-dessous s'appliquent aux systèmes de fichiers **ext2/ext3/ext4**. Contrairement à ext4, XFS ne peut pas être redimensionné lorsqu'il est démonté — l'outil `xfs_growfs` nécessite que le système de fichiers soit monté. Si votre système de fichiers est **XFS**, démontez le disque et recréez la partition comme indiqué ci-dessous, mais ignorez les étapes `e2fsck` et `resize2fs` : remontez plutôt le disque, puis exécutez `sudo xfs_growfs /mnt/disk`.
 
 Avant de démonter, vérifiez la disposition actuelle de la partition :
 
@@ -225,7 +225,7 @@ Saisissez le numéro de partition, dans notre exemple `1` :
 Partition number (1-4, default 1): 1
 ```
 
-Indiquez la valeur du secteur `Start` récupérée précédemment (2048) et le point de fin pour étendre la partition à l'espace disponible sur le disque :
+Saisissez la valeur du premier secteur notée précédemment (2048), puis acceptez le dernier secteur par défaut pour étendre la partition à tout l'espace disponible sur le disque :
 
 ```console
 First sector (2048-146800639, default 2048): 2048

--- a/docs/fr/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/fr/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Augmenter la taille d'un disque supplémentaire
 description: "Découvrez comment augmenter la taille d'un volume supplémentaire et agrandir sa partition principale"
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -251,7 +251,7 @@ Vérifiez et contrôlez la partition (pour les systèmes de fichiers **ext2/ext3
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
 
-e2fsck 1.42.12 (29-août-2014)
+e2fsck 1.42.12 (29-Aug-2014)
 Pass 1: Checking inodes, blocks, and sizes
 Pass 2: Checking directory structure
 Pass 3: Checking directory connectivity

--- a/docs/it/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/it/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
-title: Aumenta la dimensione di un disco aggiuntivo
-description: Come aumentare la dimensione di un volume aggiuntivo e aumentare la sua partizione principale
-lastUpdated: 2026-02-26
+title: Aumentare la dimensione di un disco aggiuntivo
+description: Scopri come aumentare la dimensione di un volume aggiuntivo ed estendere la sua partizione principale
+lastUpdated: 2026-07-07
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -11,15 +11,15 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Obiettivo
 
-Se hai raggiunto la capacità massima del tuo disco aggiuntivo, aggiungi spazio di storage aumentandone la dimensione.  
+Se hai raggiunto la capacità massima del tuo disco aggiuntivo, puoi aggiungere spazio di storage aumentandone la dimensione.
 
-**Questa guida ti mostra come aumentare la dimensione di un disco aggiuntivo e come estendere di conseguenza la partizione principale.**
+**Questa guida spiega come aumentare la dimensione di un disco aggiuntivo e come estendere di conseguenza la partizione principale.**
 
 ## Prerequisiti
 
-- Aver creato un’istanza [Public Cloud](https://www.ovhcloud.com/it/public-cloud/compute/) nel tuo progetto Public Cloud.
-- Disporre di un [disco aggiuntivo](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance) creato nel tuo progetto.
-- Avere accesso amministrativo (sudo) alla tua istanza via SSH (Linux) o RDP (Windows).
+- Un'[istanza Public Cloud](/links/public-cloud/compute) nel tuo progetto Public Cloud.
+- Un [disco aggiuntivo](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance) creato nel tuo progetto.
+- Avere un accesso amministrativo (sudo) alla tua istanza via SSH (Linux) o RDP (Windows).
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -34,33 +34,33 @@ Se hai raggiunto la capacità massima del tuo disco aggiuntivo, aggiungi spazio 
 
 ## Procedura
 
-Per gli step successivi, è necessario aver già configurato un disco aggiuntivo in base alle istruzioni della [nostra guida](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
+Questi passaggi presuppongono che tu abbia già configurato un disco aggiuntivo come descritto in [Crea e configura un disco aggiuntivo sulla tua istanza](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
 
-## Monitoraggio dell'utilizzo del disco prima del ridimensionamento
+### Monitora l'utilizzo del disco prima del ridimensionamento
 
 :::warning
-Si consiglia di mantenere sempre il 20% di spazio libero sui volumi di storage. In questo modo è possibile garantire prestazioni ottimali ed evitare il rischio di danneggiamento o guasto del sistema quando il volume raggiunge la capacità massima.
+Si consiglia di mantenere sempre il 20% di spazio libero sui volumi di storage. In questo modo è possibile garantire prestazioni ottimali ed evitare rischi di danneggiamento o guasto del sistema quando il volume raggiunge la capacità massima.
 
 :::
 
 
-Per permettere di ridimensionare il disco al momento giusto, è fondamentale controllare regolarmente l'utilizzo del disco. Di seguito sono riportate esercitazioni rapide per Windows e Linux che consentono di tenere traccia dello spazio su disco e anticipare quando è necessario un aggiornamento.
+Per ridimensionare il disco al momento giusto, controlla regolarmente l'utilizzo del disco. Di seguito trovi alcuni tutorial rapidi per Windows e Linux che ti aiuteranno a monitorare lo spazio disco e ad anticipare il momento in cui è necessario un aggiornamento.
 
 <Tabs>
-  <Tab label="Su Windows">
+  <Tab label="Per Windows">
     <details>
     <summary>Utilizzo del prompt dei comandi</summary>
 
     
-    Apri prompt dei comandi (Win + R → cmd → Enter).
+    Apri il prompt dei comandi (Windows + R → cmd → Invio).
     
     Esegui il seguente comando:
     
-    ```bash
+    ```cmd
     wmic logicaldisk get name, size, freespace
     ```
     
-    Visualizza lo spazio libero e le dimensioni totali di ciascun disco.
+    Vengono visualizzati lo spazio libero e la dimensione totale di ciascun disco.
     
 
     </details>
@@ -69,31 +69,31 @@ Per permettere di ridimensionare il disco al momento giusto, è fondamentale con
     <summary>Utilizzo di PowerShell</summary>
 
     
-    Aprire PowerShell come amministratore.
+    Apri PowerShell come amministratore.
     
     Esegui il seguente comando:
     
-    ```bash
+    ```powershell
     Get-PSDrive | Where-Object {$_.Free -ne $null} | Select-Object Name, Used, Free
     ```
     
-    Mostra lo spazio su disco utilizzato e disponibile.
+    Vengono visualizzati lo spazio disco utilizzato e quello disponibile.
     
 
     </details>
   </Tab>
-  <Tab label="Su Linux">
+  <Tab label="Per Linux">
     <details>
     <summary>Utilizzo del comando 'df'</summary>
 
     
-    Per verificare l'utilizzo complessivo del disco, eseguire:
+    Per verificare l'utilizzo complessivo del disco, esegui il comando
     
     ```bash
     df -h
     ```
     
-    Visualizza l'utilizzo del disco in un formato leggibile.
+    Questa funzione mostra l'utilizzo del disco in un formato leggibile.
     
 
     </details>
@@ -114,17 +114,25 @@ Per permettere di ridimensionare il disco al momento giusto, è fondamentale con
 </Tabs>
 
 
+:::warning
+Prima di ridimensionare, ti consigliamo di creare uno snapshot del tuo volume per proteggere i tuoi dati. In caso di problemi durante il ridimensionamento o l'estensione della partizione, potrai eseguire il ripristino da questo snapshot. Consulta [Creare uno Snapshot di un volume](/guides/public-cloud/compute/storage-create-volume-snapshot) per le istruzioni.
+:::
+
 ### Modifica la dimensione del disco
 
-Accedi allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> e apri il tuo progetto <code className="action">Public Cloud</code>. Clicca su <code className="action">Block Storage</code> nel menu a sinistra sotto **Storage e Backup**.
+Nel tuo progetto Public Cloud, fai clic su <code className="action">Block Storage</code> nel menu a sinistra sotto **Storage e Backup**.
 
-Se il volume è associato a un'**istanza Windows**, clicca sul pulsante <code className="action">...</code> a destra del volume corrispondente e seleziona <code className="action">Scollega dall'istanza</code>.
+Se il volume è collegato a un'**istanza Windows**, fai clic sul pulsante <code className="action">...</code> a destra del volume in questione e seleziona <code className="action">Scollega</code>.
 
-Clicca sui tre puntini <code className="action">...</code> in corrispondenza del volume interessato e seleziona <code className="action">Modifica</code>.
+Fai clic sul pulsante <code className="action">...</code> a destra del volume in questione e seleziona <code className="action">Modifica</code>.
 
 <img className="thumbnail" alt="dashboard" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-02.png" loading="lazy" />
 
-Nella nuova finestra, indica la nuova dimensione del volume e clicca su <code className="action">Modifica il volume</code>.
+:::warning
+Il ridimensionamento di un volume è irreversibile. Puoi solo aumentare la dimensione di un volume, mai diminuirla. Verifica che la nuova dimensione sia corretta prima di confermare.
+:::
+
+Nella finestra che appare, indica la nuova dimensione del volume e fai clic su <code className="action">Modifica volume</code>.
 
 <img className="thumbnail" alt="dashboard" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-03.png" loading="lazy" />
 
@@ -132,42 +140,104 @@ Nella nuova finestra, indica la nuova dimensione del volume e clicca su <code cl
 
 Apri una connessione SSH alla tua istanza per adattare la partizione al disco ridimensionato.
 
-Per prima cosa, smonta il disco utilizzando questo comando:
+Verifica innanzitutto il tipo di file system:
+
+```bash
+admin@server:~$ lsblk -f /dev/vdb1
+```
+
+```console
+NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
+vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+I passaggi seguenti si applicano ai file system **ext2/ext3/ext4**. A differenza di ext4, XFS non può essere ridimensionato quando è smontato — lo strumento `xfs_growfs` richiede che il file system sia montato. Se il tuo file system è **XFS**, smonta il disco e ricrea la partizione come indicato di seguito, ma ignora i passaggi `e2fsck` e `resize2fs`: rimonta invece il disco, quindi esegui `sudo xfs_growfs /mnt/disk`.
+
+Prima di smontare, verifica la disposizione attuale della partizione:
+
+```bash
+admin@server:~$ sudo fdisk -l /dev/vdb
+```
+
+```console
+Disk /dev/vdb: 70 GiB, 75161927680 bytes, 146800640 sectors
+Units: sectors of 1 * 512 = 512 bytes
+Sector size (logical/physical): 512 bytes / 512 bytes
+I/O size (minimum/optimal): 512 bytes / 512 bytes
+Disklabel type: dos
+Disk identifier: 0x00000001
+
+Device     Boot  Start       End   Sectors  Size Id Type
+/dev/vdb1        2048  104857599 104855552   50G 83 Linux
+```
+
+:::warning
+Prendi nota del valore del settore `Start` (in questo esempio, `2048`). Dovrai inserire questo valore esatto durante la ricreazione della partizione nel passaggio successivo. L'utilizzo di un settore di partenza diverso causerà un disallineamento del file system e potrà provocare corruzione o perdita di dati.
+:::
+
+Smonta innanzitutto il disco:
 
 ```bash
 admin@server:~$ sudo umount /mnt/disk
 ```
 
-Ricrea la partizione:
+Ricrea la partizione utilizzando il comando seguente. Questo processo riscrive solo la tabella delle partizioni — i tuoi dati non vengono toccati e saranno preservati, a condizione di inserire lo stesso settore di partenza quando richiesto.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
 ```
+
 ```console
 Welcome to fdisk (util-linux 2.25.2).
 Changes will remain in memory only, until you decide to write them.
 Be careful before using the write command
 ```
+
+Digita `d` per eliminare la partizione:
+
 ```console
 Command (m for help): d
 
 Selected partition 1
 Partition 1 has been deleted.
 ```
+
+Digita `n` per ricreare la partizione:
+
 ```console
 Command (m for help): n
 
 Partition type
 p primary (0 primary, 0 extended, 4 free)
 e extended (container for logical partitions)
+```
+
+Digita `p` per selezionare il tipo di partizione primaria:
+
+```console
 Select (default p):
 Using default response p.
-Partition number (1-4, default 1):
-First sector (2048-146800639, default 2048):
+```
+
+Digita il numero della partizione, nel nostro esempio `1`:
+
+```console
+Partition number (1-4, default 1): 1
+```
+
+Digita il valore del primo settore annotato precedentemente (2048), quindi accetta l'ultimo settore predefinito per estendere la partizione a tutto lo spazio disponibile sul disco:
+
+```console
+First sector (2048-146800639, default 2048): 2048
 Last sector, +sectors or +size{K,M,G,T,P} (2048-146800639, default 146800639):
 
 Created a new partition 1 of type 'Linux' and of size 70 GiB.
 ```
+
+Per elencare le modifiche effettuate, digita di nuovo `p`.
+
+Digita quindi `w` per salvare le modifiche:
+
 ```console
 Command (m for help): w
 
@@ -176,18 +246,18 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Verifica la partizione:
+Verifica e controlla la partizione (per i file system **ext2/ext3/ext4**):
 
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
 
-e2fsck 1.42.12 (29-Aug-2014)
+e2fsck 1.42.12 (29-août-2014)
 Pass 1: Checking inodes, blocks, and sizes
 Pass 2: Checking directory structure
 Pass 3: Checking directory connectivity
 Pass 4: Checking reference counts
 Pass 5: Checking group summary information
-/dev/vdb: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
+/dev/vdb1: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
 ```
 
 ```bash
@@ -198,7 +268,7 @@ Resizing the filesystem on /dev/vdb to 18350080 (4k) blocks.
 The filesystem on /dev/vdb is now 18350080 (4k) blocks long.
 ```
 
-Salva e verifica il disco:
+Infine, rimonta e verifica il disco:
 
 ```bash
 admin@server:~$ sudo mount /dev/vdb1 /mnt/disk/
@@ -216,46 +286,50 @@ tmpfs 982M 0 982M 0% /sys/fs/cgroup
 /dev/vdb1 69G 52M 66G 1% /mnt/disk
 ```
 
-Una volta completata questa operazione, scollegate il volume dall'istanza e ricollegatelo per verificare che le impostazioni QoS aggiornate (IOPS e larghezza di banda) vengano applicate correttamente.
+Una volta completata questa operazione, scollega il volume dall'istanza e ricollegalo per assicurarti che le impostazioni QoS aggiornate (IOPS e larghezza di banda) vengano applicate correttamente.
+
+Dopo il ricollegamento, puoi verificare la configurazione aggiornata del volume nel tuo progetto Public Cloud sotto <code className="action">Block Storage</code>.
 
 ### Estendi la partizione (istanza Windows)
 
-Prima di procedere, ricollegate il volume all'istanza. Cliccate su <code className="action">...</code> nella riga del volume e selezionate <code className="action">Associa all'istanza</code>.
+Prima di continuare, ricollega il volume all'istanza. Fai clic su <code className="action">...</code> nella riga del volume e seleziona <code className="action">Collega a un'istanza</code>.
 
 Stabilisci una connessione RDP (Remote Desktop) sulla tua istanza Windows.
 
-Una volta connesso, clicca con il tasto destro sul pulsante <code className="action">Inizia</code> e apri la <code className="action">Gestione dei dischi</code>.
+Una volta connesso, fai clic con il tasto destro sul pulsante <code className="action">Start</code> e apri <code className="action">Gestione disco</code>.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-01.png" loading="lazy" />
 
-Il disco esteso mostra la capacità aggiuntiva sotto forma di spazio non allocato.
+Il disco esteso mostra ora la capacità aggiuntiva sotto forma di spazio non allocato.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-02.png" loading="lazy" />
 
-Clicca con il tasto destro sul volume e seleziona <code className="action">Estendi il volume</code> nel menu contestuale.
+Fai clic con il tasto destro sul volume e seleziona <code className="action">Estendi volume</code> nel menu contestuale.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-03.png" loading="lazy" />
 
-Nell'assistente all'estensione del volume, clicca su <code className="action">Avanti</code> per continuare.
+Nella procedura guidata di estensione del volume, fai clic su <code className="action">Avanti</code>.
 
-È possibile modificare lo spazio disco in questo step per aggiungere una capacità inferiore alla totalità della partizione.
+In questo passaggio puoi modificare lo spazio disco se desideri aggiungere una capacità inferiore rispetto all'intera partizione.
 
-Clicca su <code className="action">Avanti</code>.
+Fai clic su <code className="action">Avanti</code>.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-04.png" loading="lazy" />
 
-Clicca su <code className="action">Terminare</code> per completare il processo.
+Fai clic su <code className="action">Fine</code> per completare il processo.
 
-Il volume ridimensionato include lo spazio disco aggiuntivo.
+Il volume ridimensionato include ora lo spazio disco aggiuntivo.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-05.png" loading="lazy" />
 
-Una volta completata questa operazione, scollegate il volume dall'istanza e ricollegatelo per verificare che le impostazioni QoS aggiornate (IOPS e larghezza di banda) vengano applicate correttamente.
+Una volta completata questa operazione, scollega il volume dall'istanza e ricollegalo per assicurarti che le impostazioni QoS aggiornate (IOPS e larghezza di banda) vengano applicate correttamente.
+
+Dopo il ricollegamento, apri nuovamente <code className="action">Gestione disco</code> per confermare che il volume mostri la dimensione totale corretta. Puoi anche verificare la configurazione aggiornata del volume nel tuo progetto Public Cloud sotto <code className="action">Block Storage</code>.
 
 ## Per saperne di più
 
 [Crea e configura un disco aggiuntivo sulla tua istanza](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
 
-[Modifica il tipo di volume di Block Storage](/guides/public-cloud/compute/switch-volume-type)
+[Modificare un Volume Block Storage](/guides/public-cloud/compute/switch-volume-type)
 
 Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/it/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aumentare la dimensione di un disco aggiuntivo
 description: Scopri come aumentare la dimensione di un volume aggiuntivo ed estendere la sua partizione principale
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -122,7 +122,7 @@ Prima di ridimensionare, ti consigliamo di creare uno snapshot del tuo volume pe
 
 Nel tuo progetto Public Cloud, fai clic su <code className="action">Block Storage</code> nel menu a sinistra sotto **Storage e Backup**.
 
-Se il volume è collegato a un'**istanza Windows**, fai clic sul pulsante <code className="action">...</code> a destra del volume in questione e seleziona <code className="action">Scollega</code>.
+Se il volume è collegato a un'**istanza Windows**, fai clic sul pulsante <code className="action">...</code> a destra del volume in questione e seleziona <code className="action">Scollega dall'istanza</code>.
 
 Fai clic sul pulsante <code className="action">...</code> a destra del volume in questione e seleziona <code className="action">Modifica</code>.
 
@@ -132,7 +132,7 @@ Fai clic sul pulsante <code className="action">...</code> a destra del volume in
 Il ridimensionamento di un volume è irreversibile. Puoi solo aumentare la dimensione di un volume, mai diminuirla. Verifica che la nuova dimensione sia corretta prima di confermare.
 :::
 
-Nella finestra che appare, indica la nuova dimensione del volume e fai clic su <code className="action">Modifica volume</code>.
+Nella finestra che appare, indica la nuova dimensione del volume e fai clic su <code className="action">Modifica il volume</code>.
 
 <img className="thumbnail" alt="dashboard" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-03.png" loading="lazy" />
 
@@ -251,7 +251,7 @@ Verifica e controlla la partizione (per i file system **ext2/ext3/ext4**):
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
 
-e2fsck 1.42.12 (29-août-2014)
+e2fsck 1.42.12 (29-Aug-2014)
 Pass 1: Checking inodes, blocks, and sizes
 Pass 2: Checking directory structure
 Pass 3: Checking directory connectivity
@@ -292,7 +292,7 @@ Dopo il ricollegamento, puoi verificare la configurazione aggiornata del volume 
 
 ### Estendi la partizione (istanza Windows)
 
-Prima di continuare, ricollega il volume all'istanza. Fai clic su <code className="action">...</code> nella riga del volume e seleziona <code className="action">Collega a un'istanza</code>.
+Prima di continuare, ricollega il volume all'istanza. Fai clic su <code className="action">...</code> nella riga del volume e seleziona <code className="action">Associa all'istanza</code>.
 
 Stabilisci una connessione RDP (Remote Desktop) sulla tua istanza Windows.
 

--- a/docs/pl/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/pl/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zwiększanie rozmiaru dodatkowego dysku
 description: Dowiedz się, jak zwiększyć rozmiar dodatkowego wolumenu i powiększyć jego partycję główną
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -122,7 +122,7 @@ Przed zmianą rozmiaru zalecamy utworzenie migawki woluminu, aby zabezpieczyć d
 
 W swoim projekcie Public Cloud kliknij <code className="action">Block Storage</code> w menu po lewej stronie, w sekcji **Przechowywanie i kopie zapasowe**.
 
-Jeśli wolumen jest podłączony do **instancji Windows**, kliknij <code className="action">...</code> w wierszu woluminu i wybierz <code className="action">Odłącz od instancji</code>.
+Jeśli wolumen jest podłączony do **instancji Windows**, kliknij <code className="action">...</code> w wierszu woluminu i wybierz <code className="action">Odłącz instancję</code>.
 
 Kliknij <code className="action">...</code> w wierszu woluminu i wybierz <code className="action">Edytuj</code>.
 
@@ -132,7 +132,7 @@ Kliknij <code className="action">...</code> w wierszu woluminu i wybierz <code c
 Zmiana rozmiaru woluminu jest nieodwracalna. Możesz jedynie zwiększyć rozmiar woluminu, nigdy go zmniejszyć. Przed potwierdzeniem sprawdź, czy nowy rozmiar jest prawidłowy.
 :::
 
-W wyskakującym oknie wpisz nowy rozmiar woluminu i kliknij <code className="action">Zmodyfikuj wolumen</code>.
+W wyskakującym oknie wpisz nowy rozmiar woluminu i kliknij <code className="action">Zmień wolumen</code>.
 
 <img className="thumbnail" alt="control panel" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-03.png" loading="lazy" />
 
@@ -298,7 +298,7 @@ Po ponownym podłączeniu możesz zweryfikować zaktualizowaną konfigurację wo
 
 ### Rozszerzanie partycji (instancja Windows)
 
-Przed kontynuowaniem podłącz wolumen do instancji. Kliknij <code className="action">...</code> w wierszu woluminu i wybierz <code className="action">Podłącz do instancji</code>.
+Przed kontynuowaniem podłącz wolumen do instancji. Kliknij <code className="action">...</code> w wierszu woluminu i wybierz <code className="action">Połącz do instancji</code>.
 
 Nawiąż połączenie zdalnego pulpitu (RDP) z instancją Windows.
 

--- a/docs/pl/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/pl/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
-title: Zwiększ rozmiar dodatkowego dysku
+title: Zwiększanie rozmiaru dodatkowego dysku
 description: Dowiedz się, jak zwiększyć rozmiar dodatkowego wolumenu i powiększyć jego partycję główną
-lastUpdated: 2026-02-26
+lastUpdated: 2026-07-07
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -11,22 +11,22 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Wprowadzenie
 
-Jeśli osiągniesz maksymalną pojemność dodatkowego dysku, możesz dodać przestrzeń dyskową, zwiększając jej rozmiar. 
+Jeśli osiągnąłeś maksymalną pojemność dodatkowego dysku, możesz dodać więcej przestrzeni dyskowej, zwiększając jego rozmiar.
 
-**Niniejszy przewodnik wyjaśnia, jak zwiększyć rozmiar dodatkowego dysku i jak odpowiednio rozszerzyć partycję główną.**
+**Niniejszy przewodnik wyjaśnia, jak zwiększyć rozmiar dodatkowego dysku i odpowiednio rozszerzyć jego partycję główną.**
 
 ## Wymagania początkowe
 
-- Instancja [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/compute/) w Twoim projekcie Public Cloud
+- [Instancja Public Cloud](/links/public-cloud/compute) w Twoim projekcie Public Cloud
 - [Dodatkowy dysk](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance) utworzony w Twoim projekcie
-- Dostęp administracyjny (sudo) do Twojej instancji przez SSH (Linux) lub RDP (Windows)
+- Dostęp administracyjny (sudo) do instancji za pomocą SSH (Linux) lub RDP (Windows)
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
+- **Link bezpośredni:** <ManagerLink to="/#/pci/projects">Projekty Public Cloud</ManagerLink>
 - **Ścieżka nawigacji:** <code className="action">Public Cloud</code> > Wybierz projekt
 
 ---
@@ -34,75 +34,75 @@ Jeśli osiągniesz maksymalną pojemność dodatkowego dysku, możesz dodać prz
 
 ## W praktyce
 
-Kolejne etapy zakładają, że skonfigurowałeś już dodatkowy dysk zgodnie z instrukcjami zawartymi w [naszym przewodniku](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
+Poniższe kroki zakładają, że skonfigurowałeś już dodatkowy dysk zgodnie z opisem w przewodniku [Tworzenie i konfigurowanie dodatkowego dysku na instancji](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
 
-## Monitorowanie wykorzystania dysku przed zmianą rozmiaru
+### Monitorowanie wykorzystania dysku przed zmianą rozmiaru
 
 :::warning
-Zalecamy utrzymanie 20% darmowej przestrzeni dyskowej. Dzięki temu zyskujesz optymalną wydajność i unikasz ryzyka uszkodzenia systemu, gdy wolumen osiągnie swoją maksymalną pojemność.
+Zalecamy, aby zawsze zachowywać 20% wolnej przestrzeni na woluminach dyskowych. Zapewnia to optymalną wydajność i pozwala uniknąć ryzyka degradacji lub awarii systemu, gdy wolumen osiągnie swoją maksymalną pojemność.
 
 :::
 
 
-Aby mieć pewność, że rozmiar dysku zostanie zwiększony we właściwym momencie, należy regularnie monitorować wykorzystanie zasobów. Poniżej znajdują się krótkie tutoriale dla systemu Windows i Linux, które pomogą Ci śledzić przestrzeń dyskową i przewidzieć, kiedy aktualizacja będzie konieczna.
+Aby zmienić rozmiar dysku w odpowiednim momencie, regularnie monitoruj wykorzystanie dysku. Poniżej znajdziesz krótkie instrukcje dla systemów Windows i Linux, które pomogą Ci śledzić przestrzeń dyskową i przewidzieć, kiedy będzie potrzebna aktualizacja.
 
 <Tabs>
   <Tab label="W systemie Windows">
     <details>
-    <summary>Za Pomocą Wiersza Polecenia</summary>
+    <summary>Za pomocą Wiersza polecenia</summary>
 
     
-    Otwórz wiersz polecenia (Win + R → cmd → Enter).
+    Otwórz Wiersz polecenia (Win + R → cmd → Enter).
     
     Uruchom następujące polecenie:
     
-    ```bash
-    WMIC Logical Disk Get Name, Size, FreeSpace
+    ```cmd
+    wmic logicaldisk get name, size, freespace
     ```
     
-    Zostanie wyświetlona wolna przestrzeń i całkowity rozmiar każdego dysku.
+    Spowoduje to wyświetlenie wolnej przestrzeni i całkowitego rozmiaru każdego dysku.
     
 
     </details>
     
     <details>
-    <summary>Używanie programu PowerShell</summary>
+    <summary>Za pomocą programu PowerShell</summary>
 
     
     Otwórz program PowerShell jako administrator.
     
     Uruchom następujące polecenie:
     
-    ```bash
+    ```powershell
     Get-PSDrive | Where-Object {$_.Free -ne $null} | Select-Object Name, Used, Free
     ```
     
-    Zostanie wyświetlona wykorzystana i dostępna przestrzeń dyskowa.
+    Spowoduje to wyświetlenie wykorzystanej i dostępnej przestrzeni dyskowej.
     
 
     </details>
   </Tab>
-  <Tab label="W Systemie Linux">
+  <Tab label="W systemie Linux">
     <details>
-    <summary>Używanie polecenia 'df'</summary>
+    <summary>Za pomocą polecenia 'df'</summary>
 
     
-    Aby sprawdzić wykorzystanie dysku, uruchom:
+    Aby sprawdzić całkowite wykorzystanie dysku, uruchom:
     
     ```bash
     df -h
     ```
     
-    Zostanie wyświetlone użycie dysku w formacie czytelnym dla człowieka.
+    Spowoduje to wyświetlenie wykorzystania dysku w formacie czytelnym dla człowieka.
     
 
     </details>
     
     <details>
-    <summary>Używanie polecenia 'lsblk'</summary>
+    <summary>Za pomocą polecenia 'lsblk'</summary>
 
     
-    Aby sprawdzić partycje dysków i ich rozmiar:
+    Aby wyświetlić partycje dysków i ich rozmiary:
     
     ```bash
     lsblk
@@ -114,60 +114,136 @@ Aby mieć pewność, że rozmiar dysku zostanie zwiększony we właściwym momen
 </Tabs>
 
 
-### Zmień rozmiar dysku
+:::warning
+Przed zmianą rozmiaru zalecamy utworzenie migawki woluminu, aby zabezpieczyć dane. Jeśli podczas zmiany rozmiaru lub rozszerzania partycji coś pójdzie nie tak, będziesz mógł przywrócić dane z migawki. Instrukcje znajdziesz w przewodniku [Tworzenie migawki woluminu](/guides/public-cloud/compute/storage-create-volume-snapshot).
+:::
 
-Zaloguj się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink> i otwórz swój projekt <code className="action">Public Cloud</code>. Następnie w menu po lewej stronie kliknij <code className="action">Block Storage</code> pod **Storage i Backup**
+### Zmiana rozmiaru dysku
 
-Jeśli wolumen jest przypisany do **instancji Windows**, kliknij przycisk <code className="action">...</code> z prawej strony odpowiedniego wolumenu i wybierz opcję <code className="action">Odłącz instancję</code>.
+W swoim projekcie Public Cloud kliknij <code className="action">Block Storage</code> w menu po lewej stronie, w sekcji **Przechowywanie i kopie zapasowe**.
 
-Kliknij przycisk <code className="action">...</code> po prawej stronie odpowiedniego wolumenu i wybierz <code className="action">Edytuj</code>.
+Jeśli wolumen jest podłączony do **instancji Windows**, kliknij <code className="action">...</code> w wierszu woluminu i wybierz <code className="action">Odłącz od instancji</code>.
 
-<img className="thumbnail" alt="dashboard" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-02.png" loading="lazy" />
+Kliknij <code className="action">...</code> w wierszu woluminu i wybierz <code className="action">Edytuj</code>.
 
-W oknie, które się wyświetli wskaż nowy rozmiar wolumenu i kliknij <code className="action">Zmień wolumen</code>.
+<img className="thumbnail" alt="control panel" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-02.png" loading="lazy" />
 
-<img className="thumbnail" alt="dashboard" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-03.png" loading="lazy" />
+:::warning
+Zmiana rozmiaru woluminu jest nieodwracalna. Możesz jedynie zwiększyć rozmiar woluminu, nigdy go zmniejszyć. Przed potwierdzeniem sprawdź, czy nowy rozmiar jest prawidłowy.
+:::
 
-### Rozszerzenie partycji (instancja Linux)
+W wyskakującym oknie wpisz nowy rozmiar woluminu i kliknij <code className="action">Zmodyfikuj wolumen</code>.
 
-Otwórz połączenie SSH z Twoją instancją, aby dostosować partycję do zmienionego dysku.
+<img className="thumbnail" alt="control panel" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-03.png" loading="lazy" />
 
-Rozmontuj najpierw dysk, używając polecenia:
+### Rozszerzanie partycji (instancja Linux)
+
+Nawiąż połączenie SSH z instancją, aby dopasować partycję do zmienionego rozmiaru dysku.
+
+Najpierw sprawdź typ systemu plików:
+
+```bash
+admin@server:~$ lsblk -f /dev/vdb1
+```
+
+```console
+NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
+vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+Poniższe kroki dotyczą systemów plików **ext2/ext3/ext4**. W przeciwieństwie do ext4, systemu plików XFS nie można rozszerzyć, gdy jest odmontowany — narzędzie `xfs_growfs` wymaga, aby system plików był zamontowany. Jeśli Twój system plików to **XFS**, wciąż odmontuj dysk i odtwórz partycję zgodnie z poniższym opisem, ale pomiń kroki `e2fsck` i `resize2fs`: zamiast tego ponownie zamontuj dysk, a następnie uruchom `sudo xfs_growfs /mnt/disk`.
+
+Przed odmontowaniem sprawdź bieżący układ partycji:
+
+```bash
+admin@server:~$ sudo fdisk -l /dev/vdb
+```
+
+```console
+Disk /dev/vdb: 70 GiB, 75161927680 bytes, 146800640 sectors
+Units: sectors of 1 * 512 = 512 bytes
+Sector size (logical/physical): 512 bytes / 512 bytes
+I/O size (minimum/optimal): 512 bytes / 512 bytes
+Disklabel type: dos
+Disk identifier: 0x00000001
+
+Device     Boot  Start       End   Sectors  Size Id Type
+/dev/vdb1        2048  104857599 104855552   50G 83 Linux
+```
+
+:::warning
+Zwróć uwagę na wartość sektora `Start` (w tym przykładzie `2048`). Musisz ponownie wprowadzić tę dokładną wartość podczas odtwarzania partycji w następnym kroku. Użycie innego sektora początkowego spowoduje niewłaściwe wyrównanie systemu plików i może doprowadzić do uszkodzenia lub utraty danych.
+:::
+
+Najpierw odmontuj dysk:
 
 ```bash
 admin@server:~$ sudo umount /mnt/disk
 ```
 
-Odtwórz partycję:
+W naszym przykładzie:
+
+```bash
+admin@server:~$ sudo umount /mnt/vdb
+```
+
+Odtwórz partycję za pomocą następującego polecenia. Ten proces zmienia jedynie tabelę partycji — dane w systemie plików nie są modyfikowane i zostaną zachowane, o ile podczas monitu wprowadzisz ten sam sektor początkowy.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
 ```
+
 ```console
 Welcome to fdisk (util-linux 2.25.2).
 Changes will remain in memory only, until you decide to write them.
 Be careful before using the write command
 ```
+
+Wpisz `d`, aby usunąć partycję:
+
 ```console
 Command (m for help): d
 
 Selected partition 1
 Partition 1 has been deleted.
 ```
+
+Wpisz `n`, aby odtworzyć partycję:
+
 ```console
 Command (m for help): n
 
 Partition type
 p primary (0 primary, 0 extended, 4 free)
 e extended (container for logical partitions)
+```
+
+Wpisz `p`, aby wybrać typ partycji podstawowej:
+
+```console
 Select (default p):
 Using default response p.
-Partition number (1-4, default 1):
-First sector (2048-146800639, default 2048):
+```
+
+Wpisz numer partycji, w naszym przykładzie `1`:
+
+```console
+Partition number (1-4, default 1): 1
+```
+
+Wprowadź wcześniej zanotowaną wartość pierwszego sektora (2048), a następnie zaakceptuj domyślny ostatni sektor, aby rozszerzyć partycję na całą pozostałą dostępną przestrzeń na dysku:
+
+```console
+First sector (2048-146800639, default 2048): 2048
 Last sector, +sectors or +size{K,M,G,T,P} (2048-146800639, default 146800639):
 
 Created a new partition 1 of type 'Linux' and of size 70 GiB.
 ```
+
+Aby wyświetlić listę zmian, wpisz ponownie `p`.
+
+Następnie wpisz `w`, aby zapisać wprowadzone zmiany:
+
 ```console
 Command (m for help): w
 
@@ -176,7 +252,7 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Sprawdź partycję:
+Zweryfikuj i sprawdź partycję (dla systemów plików **ext2/ext3/ext4**):
 
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
@@ -187,7 +263,7 @@ Pass 2: Checking directory structure
 Pass 3: Checking directory connectivity
 Pass 4: Checking reference counts
 Pass 5: Checking group summary information
-/dev/vdb: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
+/dev/vdb1: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
 ```
 
 ```bash
@@ -198,7 +274,7 @@ Resizing the filesystem on /dev/vdb to 18350080 (4k) blocks.
 The filesystem on /dev/vdb is now 18350080 (4k) blocks long.
 ```
 
-Podnieś i sprawdź dysk:
+Na koniec ponownie zamontuj dysk i sprawdź go:
 
 ```bash
 admin@server:~$ sudo mount /dev/vdb1 /mnt/disk/
@@ -212,50 +288,52 @@ udev 10M 0 10M 0% /dev
 tmpfs 393M 5.2M 388M 2% /run
 tmpfs 982M 0 982M 0% /dev/shm
 tmpfs 5.0M 0 5.0M 0% /run/lock
-tmpfs 982M 0 982M 0% /sys/fs/group
+tmpfs 982M 0 982M 0% /sys/fs/cgroup
 /dev/vdb1 69G 52M 66G 1% /mnt/disk
 ```
 
-Po wykonaniu tych czynności odłącz wolumin od instancji i ponownie dołącz go, aby upewnić się, że zaktualizowane ustawienia QoS (IOPS i przepustowość) zostały poprawnie zastosowane.
+Po wykonaniu tych czynności odłącz wolumen od instancji i podłącz go ponownie, aby zapewnić prawidłowe zastosowanie zaktualizowanych ustawień QoS (IOPS i przepustowość).
 
-### Rozszerzenie partycji (instancja Windows)
+Po ponownym podłączeniu możesz zweryfikować zaktualizowaną konfigurację woluminu w swoim projekcie Public Cloud w sekcji <code className="action">Block Storage</code>.
 
-Przed kontynuowaniem dołącz wolumin do instancji. Kliknij <code className="action">...</code> w wierszu woluminu i wybierz <code className="action">Połącz do instancji</code>.
+### Rozszerzanie partycji (instancja Windows)
 
-Utwórz połączenie RDP (Remote Desktop) dla Twojej instancji Windows.
+Przed kontynuowaniem podłącz wolumen do instancji. Kliknij <code className="action">...</code> w wierszu woluminu i wybierz <code className="action">Podłącz do instancji</code>.
 
-Po zalogowaniu kliknij prawym przyciskiem myszy przycisk <code className="action">Start</code> i otwórz <code className="action">Zarządzanie dyskami</code>.
+Nawiąż połączenie zdalnego pulpitu (RDP) z instancją Windows.
+
+Po zalogowaniu kliknij prawym przyciskiem myszy przycisk <code className="action">Menu Start</code> i otwórz <code className="action">Zarządzanie dyskami</code>.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-01.png" loading="lazy" />
 
-Rozszerzony dysk posiada większą pojemność w postaci nieprzydzielonej przestrzeni.
+Rozszerzony dysk wyświetla teraz dodatkową pojemność jako nieprzydzieloną przestrzeń.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-02.png" loading="lazy" />
 
-Kliknij prawym przyciskiem myszy wolumen i wybierz <code className="action">Rozszerz wolumen</code> z menu kontekstowego.
+Kliknij prawym przyciskiem myszy wolumen i wybierz <code className="action">Rozszerz wolumin</code> z menu kontekstowego.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-03.png" loading="lazy" />
 
-W asystencie rozszerzenia wolumenu kliknij Dalej, <code className="action">aby kontynuować</code>.
+W "Kreatorze rozszerzania woluminu" kliknij <code className="action">Dalej</code>.
 
-Możesz zmienić przestrzeń dyskową na tym etapie, jeśli chcesz dodać pojemność mniejszą niż cała partycja.
-
-Kliknij <code className="action">Dalej</code>.
+W tym kroku możesz zmodyfikować przestrzeń dyskową, jeśli chcesz dodać do partycji mniej niż całą dostępną pojemność. Kliknij <code className="action">Dalej</code>.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-04.png" loading="lazy" />
 
-Kliknij przycisk <code className="action">Zakończ</code>, aby zakończyć proces.
+Kliknij <code className="action">Zakończ</code>, aby zakończyć proces.
 
-Zmieniony rozmiar przestrzeni dyskowej zawiera teraz dodatkową przestrzeń dyskową.
+Wolumen o zmienionym rozmiarze zawiera teraz dodatkową przestrzeń dyskową.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-05.png" loading="lazy" />
 
-Po wykonaniu tych czynności odłącz wolumin od instancji i ponownie dołącz go, aby upewnić się, że zaktualizowane ustawienia QoS (IOPS i przepustowość) zostały poprawnie zastosowane.
+Po wykonaniu tych czynności odłącz wolumen od instancji i podłącz go ponownie, aby zapewnić prawidłowe zastosowanie zaktualizowanych ustawień QoS (IOPS i przepustowość).
+
+Po ponownym podłączeniu otwórz ponownie <code className="action">Zarządzanie dyskami</code>, aby sprawdzić, czy wolumen wyświetla prawidłowy całkowity rozmiar. Możesz również zweryfikować zaktualizowaną konfigurację woluminu w swoim projekcie Public Cloud w sekcji <code className="action">Block Storage</code>.
 
 ## Sprawdź również
 
-[Zarządzanie wolumenem instancji Public Cloud](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
+[Tworzenie i konfigurowanie dodatkowego dysku na instancji](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
 
-[Zmień typ wolumenu Block Storage](/guides/public-cloud/compute/switch-volume-type)
+[Zmiana typu woluminu Block Storage](/guides/public-cloud/compute/switch-volume-type)
 
 Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pt/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/pt/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aumentar o tamanho de um disco suplementar
 description: Descubra como aumentar o tamanho de um volume suplementar e expandir a sua partição principal
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -108,7 +108,7 @@ Antes de redimensionar, recomendamos que crie uma snapshot do seu volume para pr
 
 No seu projeto Public Cloud, clique em <code className="action">Block Storage</code> no menu à esquerda, sob **Storage & Backup**.
 
-Se o volume estiver associado a uma **instância Windows**, clique no botão <code className="action">...</code> à direita do volume em questão e selecione <code className="action">Desassociar da instância</code>.
+Se o volume estiver associado a uma **instância Windows**, clique no botão <code className="action">...</code> à direita do volume em questão e selecione <code className="action">Desassociar a instância</code>.
 
 Clique no botão <code className="action">...</code> à direita do volume em questão e selecione <code className="action">Editar</code>.
 
@@ -237,7 +237,7 @@ Verifique e valide a partição (para os sistemas de ficheiros **ext2/ext3/ext4*
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
 
-e2fsck 1.42.12 (29-août-2014)
+e2fsck 1.42.12 (29-Aug-2014)
 Pass 1: Checking inodes, blocks, and sizes
 Pass 2: Checking directory structure
 Pass 3: Checking directory connectivity
@@ -278,7 +278,7 @@ Depois de o associar novamente, pode verificar a configuração atualizada do vo
 
 ### Estender a partição (instância Windows)
 
-Antes de continuar, volte a associar o volume à instância. Clique em <code className="action">...</code> na linha do volume e selecione <code className="action">Associar à instância</code>.
+Antes de continuar, volte a associar o volume à instância. Clique em <code className="action">...</code> na linha do volume e selecione <code className="action">Associar a instância</code>.
 
 Estabeleça uma ligação RDP (Remote Desktop) à sua instância Windows.
 

--- a/docs/pt/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/pt/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -1,130 +1,124 @@
 ---
-title: Aumentar o tamanho de um disco adicional
-description: Saiba como aumentar o tamanho de um volume adicional e aumentar a sua partição principal
-lastUpdated: 2026-02-26
+title: Aumentar o tamanho de um disco suplementar
+description: Descubra como aumentar o tamanho de um volume suplementar e expandir a sua partição principal
+lastUpdated: 2026-07-07
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-
-
-
 ## Objetivo
 
-Se atingiu a capacidade máxima do seu disco suplementar, pode adicionar armazenamento aumentando o seu tamanho. 
+Se atingiu a capacidade máxima do seu disco suplementar, pode adicionar armazenamento aumentando o seu tamanho.
 
-**Este guia explica como aumentar o tamanho de um disco adicional e como expandir a partição principal em conformidade.**
+**Este guia explica como aumentar o tamanho de um disco suplementar e como estender a partição principal em conformidade.**
 
 ## Requisitos
 
-- Uma [instância Public Cloud](https://www.ovhcloud.com/pt/public-cloud/compute/) no seu projeto Public Cloud
-- Um [disco adicional](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance) criado no seu projeto
-- Ter acesso administrativo (sudo) à sua instância através de SSH (Linux) ou RDP (Windows)
+- Uma [instância Public Cloud](/links/public-cloud/compute) no seu projeto Public Cloud.
+- Um [disco suplementar](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance) criado no seu projeto.
+- Ter acesso administrativo (sudo) à sua instância via SSH (Linux) ou RDP (Windows).
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
-- **Caminho de navegação:** <code className="action">Public Cloud</code> > Selecione o seu projeto
+- **Ligação direta:** <ManagerLink to="/#/pci/projects">Projetos Public Cloud</ManagerLink>
+- **Para aceder aos seus serviços:** <code className="action">Public Cloud</code> > Selecione o seu projeto
 
 ---
 {/* CP-NAV-END:publiccloud-projects */}
 
 ## Instruções
 
-Os passos seguintes pressupõem que já configurou um disco suplementar de acordo com as instruções do [nosso guia](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
+Estes passos pressupõem que já configurou um disco suplementar conforme descrito em [Criar e configurar um disco suplementar numa instância](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance).
 
-## Monitorização do consumo dos discos antes do redimensionamento
+### Monitorizar a utilização do disco antes do redimensionamento
 
 :::warning
-Recomendamos que mantenha sempre 20% de espaço livre nos seus volumes de armazenamento. Isto assegura um desempenho máximo e evita o risco de degradação ou falha do sistema quando o volume atinge a sua capacidade máxima.
-
+Recomenda-se manter sempre 20% de espaço livre nos seus volumes de armazenamento. Isto permite garantir um desempenho ótimo e evitar riscos de degradação ou falha do sistema quando o volume atinge a sua capacidade máxima.
 :::
 
-
-Para garantir que redimensione o disco no momento certo, é essencial monitorizar a utilização do disco regularmente. Seguem-se tutoriais rápidos para Windows e Linux para o ajudar a monitorizar o espaço em disco e antecipar quando é necessário um upgrade.
+Para redimensionar o disco no momento certo, monitorize regularmente a utilização do disco. Encontrará a seguir tutoriais rápidos para Windows e Linux que o ajudarão a monitorizar o espaço em disco e a antecipar o momento em que é necessária uma atualização.
 
 <Tabs>
-  <Tab label="Em Windows">
+  <Tab label="Para Windows">
     <details>
-    <summary>A utilizar linha de comandos</summary>
+    <summary>Utilização da linha de comandos</summary>
 
-    
-    Abrir linha de comandos (Win + R → cmd → Enter).
-    
+    Abra a linha de comandos (Windows + R → cmd → Enter).
+
     Execute o seguinte comando:
-    
-    ```bash
+
+    ```cmd
     wmic logicaldisk get name, size, freespace
     ```
-    
-    Isso exibirá o espaço livre e o tamanho total de cada disco.
-    
+
+    O espaço livre e o tamanho total de cada disco são apresentados.
 
     </details>
-    
-    <details>
-    <summary>Utilizar o PowerShell</summary>
 
-    
+    <details>
+    <summary>Utilização do PowerShell</summary>
+
     Abra o PowerShell como Administrador.
-    
+
     Execute o seguinte comando:
-    
-    ```bash
+
+    ```powershell
     Get-PSDrive | Where-Object {$_.Free -ne $null} | Select-Object Name, Used, Free
     ```
-    
-    Isso mostrará o espaço de disco utilizado e disponível.
-    
+
+    O espaço em disco utilizado e o espaço em disco disponível são apresentados.
 
     </details>
   </Tab>
-  <Tab label="Em Linux">
+  <Tab label="Para Linux">
     <details>
-    <summary>Utilizando o comando "df"</summary>
+    <summary>Utilização do comando 'df'</summary>
 
-    
-    Para verificar a utilização geral do disco, execute:
-    
+    Para verificar a utilização global do disco, execute o comando
+
     ```bash
     df -h
     ```
-    
-    Isso exibirá o uso do disco em um formato legível por humanos.
-    
+
+    Esta função apresenta a utilização do disco num formato legível por humanos.
 
     </details>
-    
-    <details>
-    <summary>Utilizando o comando "lsblk"</summary>
 
-    
-    Para visualizar as partições de disco e os respetivos tamanhos:
-    
+    <details>
+    <summary>Utilização do comando 'lsblk'</summary>
+
+    Para visualizar as partições do disco e o seu tamanho:
+
     ```bash
     lsblk
     ```
-    
 
     </details>
   </Tab>
 </Tabs>
 
+:::warning
+Antes de redimensionar, recomendamos que crie uma snapshot do seu volume para proteger os seus dados. Em caso de problema durante o redimensionamento ou a extensão da partição, poderá restaurar a partir dessa snapshot. Consulte [Criar uma snapshot de um volume](/guides/public-cloud/compute/storage-create-volume-snapshot) para obter instruções.
+:::
 
 ### Modificar o tamanho do disco
 
-Ligue-se à sua <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> e abra o seu projeto <code className="action">Public Cloud</code>. A seguir, clique em <code className="action">Block Storage</code> no menu à esquerda em **Backup Storage**.
+No seu projeto Public Cloud, clique em <code className="action">Block Storage</code> no menu à esquerda, sob **Storage & Backup**.
 
-Se o volume está associado a uma **instância Windows**, clique no botão <code className="action">...</code> à direita do volume em causa e selecione <code className="action">Desassociar a instância</code>.
+Se o volume estiver associado a uma **instância Windows**, clique no botão <code className="action">...</code> à direita do volume em questão e selecione <code className="action">Desassociar da instância</code>.
 
-Clique no botão <code className="action">...</code> à direita do volume em causa e selecione <code className="action">Editar</code>.
+Clique no botão <code className="action">...</code> à direita do volume em questão e selecione <code className="action">Editar</code>.
 
 <img className="thumbnail" alt="painel de controlo" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-02.png" loading="lazy" />
 
-Na nova janela, indique o novo tamanho do volume e clique em <code className="action">Modificar o volume</code>.
+:::warning
+O redimensionamento de um volume é irreversível. Só pode aumentar o tamanho de um volume, nunca diminuí-lo. Verifique se o novo tamanho está correto antes de confirmar.
+:::
+
+Na janela que aparece, indique o novo tamanho do volume e clique em <code className="action">Modificar o volume</code>.
 
 <img className="thumbnail" alt="painel de controlo" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/increase-disk-03.png" loading="lazy" />
 
@@ -132,42 +126,104 @@ Na nova janela, indique o novo tamanho do volume e clique em <code className="ac
 
 Abra uma ligação SSH à sua instância para ajustar a partição ao disco redimensionado.
 
-Desmonte primeiro o disco utilizando este comando:
+Verifique primeiro o tipo de sistema de ficheiros:
+
+```bash
+admin@server:~$ lsblk -f /dev/vdb1
+```
+
+```console
+NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
+vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+Os passos abaixo aplicam-se aos sistemas de ficheiros **ext2/ext3/ext4**. Ao contrário do ext4, o XFS não pode ser redimensionado enquanto estiver desmontado — a ferramenta `xfs_growfs` exige que o sistema de ficheiros esteja montado. Se o seu sistema de ficheiros for **XFS**, desmonte o disco e recrie a partição conforme indicado a seguir, mas ignore os passos `e2fsck` e `resize2fs`: volte a montar o disco e execute `sudo xfs_growfs /mnt/disk`.
+
+Antes de desmontar, verifique a disposição atual da partição:
+
+```bash
+admin@server:~$ sudo fdisk -l /dev/vdb
+```
+
+```console
+Disk /dev/vdb: 70 GiB, 75161927680 bytes, 146800640 sectors
+Units: sectors of 1 * 512 = 512 bytes
+Sector size (logical/physical): 512 bytes / 512 bytes
+I/O size (minimum/optimal): 512 bytes / 512 bytes
+Disklabel type: dos
+Disk identifier: 0x00000001
+
+Device     Boot  Start       End   Sectors  Size Id Type
+/dev/vdb1        2048  104857599 104855552   50G 83 Linux
+```
+
+:::warning
+Anote o valor do setor `Start` (neste exemplo, `2048`). Deve introduzir este valor exato ao recriar a partição no passo seguinte. A utilização de um setor de início diferente provocará um desalinhamento do sistema de ficheiros e causará corrupção ou perda de dados.
+:::
+
+Desmonte primeiro o disco:
 
 ```bash
 admin@server:~$ sudo umount /mnt/disk
 ```
 
-Recrie a partição:
+Recrie a partição utilizando o comando seguinte. Este processo reescreve apenas a tabela de partições — os seus dados não são afetados e serão preservados, desde que introduza o mesmo setor de início quando solicitado.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
 ```
+
 ```console
 Welcome to fdisk (util-linux 2.25.2).
 Changes will remain in memory only, until you decide to write them.
 Be careful before using the write command
 ```
+
+Introduza `d` para eliminar a partição:
+
 ```console
 Command (m for help): d
 
 Selected partition 1
 Partition 1 has been deleted.
 ```
+
+Introduza `n` para recriar a partição:
+
 ```console
 Command (m for help): n
 
 Partition type
 p primary (0 primary, 0 extended, 4 free)
 e extended (container for logical partitions)
+```
+
+Introduza `p` para selecionar o tipo de partição principal:
+
+```console
 Select (default p):
 Using default response p.
-Partition number (1-4, default 1):
-First sector (2048-146800639, default 2048):
+```
+
+Introduza o número da partição, no nosso exemplo `1`:
+
+```console
+Partition number (1-4, default 1): 1
+```
+
+Introduza o valor do primeiro setor anotado anteriormente (2048) e, em seguida, aceite o último setor predefinido para estender a partição a todo o espaço disponível no disco:
+
+```console
+First sector (2048-146800639, default 2048): 2048
 Last sector, +sectors or +size{K,M,G,T,P} (2048-146800639, default 146800639):
 
 Created a new partition 1 of type 'Linux' and of size 70 GiB.
 ```
+
+Para listar as alterações efetuadas, introduza novamente `p`.
+
+Em seguida, introduza `w` para guardar as alterações:
+
 ```console
 Command (m for help): w
 
@@ -176,18 +232,18 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Verifique a partição:
+Verifique e valide a partição (para os sistemas de ficheiros **ext2/ext3/ext4**):
 
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
 
-e2fsck 1.42.12 (29-Aug-2014)
+e2fsck 1.42.12 (29-août-2014)
 Pass 1: Checking inodes, blocks, and sizes
 Pass 2: Checking directory structure
 Pass 3: Checking directory connectivity
 Pass 4: Checking reference counts
 Pass 5: Checking group summary information
-/dev/vdb: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
+/dev/vdb1: 12/3276800 files (0.0% non-contiguous), 251700/13107200 blocks
 ```
 
 ```bash
@@ -198,7 +254,7 @@ Resizing the filesystem on /dev/vdb to 18350080 (4k) blocks.
 The filesystem on /dev/vdb is now 18350080 (4k) blocks long.
 ```
 
-Por fim, volte e verifique o disco:
+Por fim, volte a montar e verifique o disco:
 
 ```bash
 admin@server:~$ sudo mount /dev/vdb1 /mnt/disk/
@@ -216,46 +272,50 @@ tmpfs 982M 0 982M 0% /sys/fs/cgroup
 /dev/vdb1 69G 52M 66G 1% /mnt/disk
 ```
 
-Assim que esta operação estiver concluída, desligue o volume da instância e ligue-o novamente para se certificar de que as definições QoS atualizadas (IOPS e largura de banda) estão corretamente aplicadas.
+Depois de concluída esta operação, desassocie o volume da instância e volte a associá-lo para garantir que as definições QoS atualizadas (IOPS e largura de banda) são corretamente aplicadas.
+
+Depois de o associar novamente, pode verificar a configuração atualizada do volume no seu projeto Public Cloud em <code className="action">Block Storage</code>.
 
 ### Estender a partição (instância Windows)
 
-Antes de continuar, ligue o volume à instância. Clique em <code className="action">...</code> na linha do volume e selecione <code className="action">Associar a instância</code>.
+Antes de continuar, volte a associar o volume à instância. Clique em <code className="action">...</code> na linha do volume e selecione <code className="action">Associar à instância</code>.
 
-Crie uma ligação RDP (Remote Desktop) na sua instância Windows.
+Estabeleça uma ligação RDP (Remote Desktop) à sua instância Windows.
 
-Uma vez ligado, clique com o botão <code className="action">Iniciar</code> e abra a <code className="action">Gestão dos discos</code>.
+Depois de ligado, clique com o botão direito no botão <code className="action">Iniciar</code> e abra a <code className="action">Gestão de Discos</code>.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-01.png" loading="lazy" />
 
-O disco ampliado apresenta agora a capacidade suplementar sob a forma de espaço não atribuído.
+O disco expandido apresenta agora a capacidade suplementar sob a forma de espaço não alocado.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-02.png" loading="lazy" />
 
-Faça um clique direito no volume e selecione <code className="action">Expandir o volume</code> no menu contextual.
+Clique com o botão direito no volume e selecione <code className="action">Estender Volume</code> no menu de contexto.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-03.png" loading="lazy" />
 
-No assistente de extensão de volume, clique em <code className="action">Seguinte</code> para continuar.
+No assistente de extensão de volume, clique em <code className="action">Seguinte</code>.
 
-Pode alterar o espaço de disco nesta etapa se deseja adicionar uma capacidade inferior à totalidade da partição.
+Pode alterar o espaço em disco nesta fase se pretender adicionar uma capacidade inferior à totalidade da partição.
 
 Clique em <code className="action">Seguinte</code>.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-04.png" loading="lazy" />
 
-Clique em <code className="action">Terminar</code> para terminar o processo.
+Clique em <code className="action">Concluir</code> para concluir o processo.
 
-O volume redimensionado inclui agora o espaço de disco suplementar.
+O volume redimensionado inclui agora o espaço em disco suplementar.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-05.png" loading="lazy" />
 
-Assim que esta operação estiver concluída, desligue o volume da instância e ligue-o novamente para se certificar de que as definições QoS atualizadas (IOPS e largura de banda) estão corretamente aplicadas.
+Depois de concluída esta operação, desassocie o volume da instância e volte a associá-lo para garantir que as definições QoS atualizadas (IOPS e largura de banda) são corretamente aplicadas.
+
+Depois de o associar novamente, abra outra vez a <code className="action">Gestão de Discos</code> para confirmar que o volume apresenta o tamanho total correto. Também pode verificar a configuração atualizada do volume no seu projeto Public Cloud em <code className="action">Block Storage</code>.
 
 ## Quer saber mais?
 
 [Criar e configurar um disco suplementar numa instância](/guides/public-cloud/compute/create-and-configure-an-additional-disk-on-an-instance)
 
-[Alterar o tipo de volume do seu Block Storage](/guides/public-cloud/compute/switch-volume-type)
+[Modificar um Volume Block Storage](/guides/public-cloud/compute/switch-volume-type)
 
-Fale com nossa [comunidade de utilizadores](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).


### PR DESCRIPTION
## Context

Following customer feedback in #347, the guide **Increasing the size of an
additional disk** was missing a critical step: it never told users to note the
partition's **First sector** (Start) value before deleting and recreating the
partition with `fdisk`.

Because `fdisk` defaults may not match the original start sector, following the
guide as written could realign the filesystem and cause **data corruption or
loss** — the exact risk the customer flagged
("*C'est un gros risque de corruption et de perte de donnée !*").

## Changes

Revised `increase-the-size-of-an-additional-disk` across all 7 locales
(en, fr, de, es, it, pl, pt):

**Fixes the reported issue**
- Added a step to inspect the current partition layout with `sudo fdisk -l /dev/vdb`
  and **note the `Start` sector value** before making changes.
- Added a warning to **re-enter the exact same start sector** when recreating the
  partition, explaining that a different value misaligns the filesystem and
  corrupts data.
- Annotated each `fdisk` sub-command (`d`, `n`, `p`, partition number, first/last
  sector, `w`) so users know exactly what to type at each prompt.

**Supporting improvements**
- Added a recommendation to **create a volume snapshot before resizing** so users
  can restore if something goes wrong.
- Added filesystem-type detection (`lsblk -f`) and **XFS-specific guidance**
  (`xfs_growfs` requires the filesystem mounted; skip `e2fsck`/`resize2fs`).
- Added a warning that **volume resizing is irreversible** (increase-only).
- Fixed the `e2fsck` output to reference `/dev/vdb1` (the partition) rather than
  `/dev/vdb` (the disk).
- Marked the Windows code blocks as `cmd` / `powershell` instead of `bash`.
- Replaced the hardcoded product URL with the internal `/links/public-cloud/compute` link.
- Minor wording clarifications and post-resize verification steps.

## Related

- Closes #347
