### PR TITLE
docs(public-cloud): editorial review of compute guides (nova, security group, packer)

### DIFF
--- a/docs/de/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/de/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: Eine Sicherheitsgruppe in Horizon erstellen und konfigurieren
 description: Erfahren Sie hier, wie Sie eine Sicherheitsgruppe erstellen und auf einer Public Cloud Instanz konfigurieren
-lastUpdated: 2026-06-24
+lastUpdated: 2026-07-08
 ---
 
 :::info

--- a/docs/de/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/de/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: Eine Sicherheitsgruppe in Horizon erstellen und konfigurieren
 description: Erfahren Sie hier, wie Sie eine Sicherheitsgruppe erstellen und auf einer Public Cloud Instanz konfigurieren
-lastUpdated: 2023-07-24
+lastUpdated: 2026-06-24
 ---
 
 :::info
@@ -17,7 +17,7 @@ Zur Erhöhung der Sicherheit können Filterregeln konfiguriert und verwendet wer
 
 ## Voraussetzungen
 
-- Sie haben ein [Public Cloud Projekt](https://www.ovhcloud.com/de/public-cloud/) in Ihrem Kunden-Account.
+- Sie haben ein [Public Cloud Projekt](/links/public-cloud/public-cloud) in Ihrem Kunden-Account.
 - Sie haben Zugriff auf das [Horizon-Interface](/guides/public-cloud/cross-functional/create-and-delete-a-user).
 
 ## In der praktischen Anwendung

--- a/docs/de/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/de/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Erste Schritte mit der OpenStack API
 description: Erfahren Sie hier, wie Sie Ihre Instanzen mithilfe des OpenStack Python Clients verwalten
-lastUpdated: 2026-06-23
+lastUpdated: 2026-07-08
 ---
 
 :::info

--- a/docs/de/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/de/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Erste Schritte mit der OpenStack API
 description: Erfahren Sie hier, wie Sie Ihre Instanzen mithilfe des OpenStack Python Clients verwalten
-lastUpdated: 2022-10-13
+lastUpdated: 2026-06-23
 ---
 
 :::info
@@ -14,11 +14,11 @@ Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In 
 Um Ihre Operationen in der Public Cloud zu automatisieren, können Sie die OpenStack API verwenden, mit der verschiedene Skripte erstellt werden können. 
 
 :::info
-Der Nova Client wurde bislang für die Verwaltung Ihrer Instanzen und deren Disks verwendet. Dieser Client wird nicht mehr weiterentwickelt und die Funktionen wurden in den Python Client von OpenStack integriert.
+Der Nova Client wurde bislang für die Verwaltung Ihrer Instanzen und deren Disks verwendet. Dieser Client wird nicht mehr weiterentwickelt und die Befehle wurden in den Python Client von OpenStack integriert.
 :::
 
 
-Sie können zum Beispiel die Erstellung zusätzlicher Instanzen starten, wenn Ihre Monitoring-Tools Lastspitzen erkennen, um eine Überlastung Ihrer Infrastruktur zu vermeiden. Die regelmßige Erstellung von Snapshots kann ebenfalls eingerichtet werden.
+Sie können zum Beispiel die Erstellung zusätzlicher Instanzen starten, wenn Ihre Monitoring-Tools Lastspitzen erkennen, um eine Überlastung Ihrer Infrastruktur zu vermeiden. Die regelmäßige Erstellung von Snapshots kann ebenfalls eingerichtet werden.
 
 **Diese Anleitung hilft Ihnen dabei, die OpenStack API zu verwenden, um Ihre Instanzen mithilfe des OpenStack Python Clients zu verwalten.**
 
@@ -127,14 +127,17 @@ admin@server-1:~$ openstack image list
 +--------------------------------------+-----------------------------------------------+--------+
 | ID                                   | Name                                          | Status |
 +--------------------------------------+-----------------------------------------------+--------+
-| 8990fbbb-bd7e-4c57-8b19-a162e12c5195 | AlmaLinux 8                                   | active |
-| f1d2e56e-faec-4fd4-8493-dcf4c4201b40 | AlmaLinux 8 - UEFI                            | active |
-| a243240a-ca1f-4a53-a3bd-30c4f96b241f | AlmaLinux 8 - cPanel                          | active |
-| 1be04371-252f-48be-81fb-1cb89ea55778 | AlmaLinux 9                                   | active |
-| df89529f-8b4f-4534-9ddc-0092e30bcc97 | AlmaLinux 9 - UEFI                            | active |
-| 81c5ebbc-04fd-40f8-83aa-9b2bae8769f2 | Centos 7                                      | active |
-| b753f820-37cd-437a-b301-3423caf27637 | Centos 7 - Analytics - Ambari pre-warmed      | active |
-| 81ddd059-41b0-493e-a1e2-a278139b7bbb | Centos 7 - Analytics - Base image             | active |
+| 814f0f1d-5c06-40c6-b582-842fbf4995d2 | AlmaLinux 10                                  | active |
+| 2d1914bb-266b-4049-b4bd-c195d9e920bd | AlmaLinux 10 - UEFI                           | active |
+| b442e71d-2ce4-43ad-a9c6-03d0ee2359ee | AlmaLinux 8                                   | active |
+| 268b6be2-68f7-42c1-8d12-ba5fab40a84b | AlmaLinux 8 - UEFI                            | active |
+| f9170d19-919e-49a0-b1a3-f217fe48ab0b | AlmaLinux 8 - cPanel                          | active |
+| dbb258c0-a4ff-4b97-a695-6cd99763132c | AlmaLinux 9                                   | active |
+| 57659466-a19d-418e-8d98-4cb74fe1d717 | AlmaLinux 9 - UEFI                            | active |
+| 326ba25a-644c-4e6f-867a-f4fbc60b9c9b | AlmaLinux 9 - cPanel                          | active |
+| bc6eb0f9-2a59-4ea6-86b8-8f6a2befba5c | Baremetal - Debian 11                         | active |
+| 67b90767-19bc-4f4e-8982-77c227810f02 | Baremetal - Debian 12                         | active |
+| fee70d7e-e32a-44ec-af2d-20201eeeaf6d | Baremetal - Debian 13                         | active |
 | ...                                  | ...                                           | ...    |
 +--------------------------------------+-----------------------------------------------+--------+
 ```

--- a/docs/en/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/en/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -29,14 +29,14 @@ Packer can be downloaded from the official website (currently [here](https://www
 
 For Linux 64bits
 
-```shell
+```bash
 wget https://releases.hashicorp.com/packer/1.11.2/packer_1.11.2_linux_amd64.zip
 unzip packer_1.11.2_linux_amd64.zip
 ```
 
 ### Install the OpenStack plugin for Packer
 
-```shell
+```bash
 packer plugins install github.com/hashicorp/openstack
 ```
 
@@ -44,7 +44,7 @@ packer plugins install github.com/hashicorp/openstack
 
 `jq` is a command line tool for [parsing JSON document](https://stedolan.github.io/jq/manual/). It'll be used to automate the configuration file creation.
 
-```shell
+```bash
 apt-get install jq
 ```
 
@@ -54,9 +54,9 @@ From <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, fetch your `openr
 
 ### Install openstack command line client
 
-The easier way is to use a python virtual environment
+The easier way is to use a Python virtual environment
 
-```shell
+```bash
 python3 -m venv venv3 # creates a virtualenv named venv3
 . ./venv3/bin/activate # enter the virtualenv
 pip install --upgrade pip
@@ -67,9 +67,9 @@ or install your distribution package `apt-get install python-openstackclient`
 
 #### Verification
 
-Sourcing the `openrc.sh` configuration file retrieved before, try your local setup with
+After sourcing the `openrc.sh` file, test your local setup with
 
-```shell
+```bash
 . ./openrc.sh
 openstack token issue
 ```
@@ -78,23 +78,23 @@ openstack token issue
 
 First, source your `openrc.sh` file with
 
-```shell
+```bash
 . ./openrc.sh
 ```
 
-Next, let's find some needed ID. You'll need the ID of the image, flavor and network. We'll build our image from `Ubuntu 24.04` on a `b2-7` hardware, with a interface connected on public network `Ext-Net`
+Next, find the required IDs. You'll need the ID of the image, flavor and network. We'll build our image from `Ubuntu 24.04` on a `b2-7` hardware, with an interface connected on public network `Ext-Net`.
 
-```shell
+```bash
 export SOURCE_ID=`openstack image list -f json | jq -r '.[] | select(.Name == "Ubuntu 24.04") | .ID'`
 export FLAVOR_ID=`openstack flavor list -f json | jq -r '.[] | select(.Name == "b2-7") | .ID'`
 export NETWORK_ID=`openstack network list -f json | jq -r '.[] | select(.Name == "Ext-Net") | .ID'`
 ```
 
-**INFO**: for `FLAVOR_ID`, you can directly use the name, ie `b2-7`
+**INFO**: for `FLAVOR_ID`, you can directly use the name, i.e., `b2-7`
 
 Finally, create a `packer.json` file
 
-```shell
+```bash
 cat > packer.json <<EOF
 {
     "variables": {
@@ -129,7 +129,7 @@ cat > packer.json <<EOF
 EOF
 ```
 
-In the last selection of the configuration file, we specify a `setup_vm.sh` shell script to be run.
+In the last section of the configuration file, we specify a `setup_vm.sh` shell script to be run.
 
 ```sh
 #!/bin/sh
@@ -149,16 +149,16 @@ git clone ...
 
 ## Building the image
 
-Using the configuration file created above, check it and build the image with
+Using the configuration file above, validate and build the image:
 
-```shell
+```bash
 packer validate packer.json
 packer build packer.json
 ```
 
-If all went ok, you should have a new image available. You can check with
+If all went OK, you should have a new image available. You can check with
 
-```shell
+```bash
 openstack image list | grep 'My Custom Image'
 ```
 

--- a/docs/en/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/en/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,18 +1,18 @@
 ---
 title: Creating and configuring a security group in Horizon
 description: Find out how to create a security group and configure it on a Public Cloud instance
-lastUpdated: 2023-07-24
+lastUpdated: 2026-06-24
 ---
 
 ## Objective
 
-For security reasons, you can configure and use filtering rules that will define access to your instances. You can allow or block certain incoming or outgoing connections using security groups. These rules can be applied for traffic from certain IP addresses, or even for instances configured on particular security groups.
+For security reasons, you can configure and use filtering rules that define access to your instances. You can allow or block certain incoming or outgoing connections using security groups. You can apply these rules to traffic from specific IP addresses or to instances in particular security groups.
 
-**Find out how to create a security group, and configure it on a Public Cloud instance.**
+**This guide explains how to create a security group in Horizon and configure it on a Public Cloud instance.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/).
+- A [Public Cloud project](/links/public-cloud/public-cloud).
 - Access to the [Horizon interface](/guides/public-cloud/cross-functional/create-and-delete-a-user)
 
 ## Instructions
@@ -30,7 +30,7 @@ If a security group is to be used in several regions, you must create it for eac
 
 Now expand the <code className="action">Network</code> menu and click <code className="action">Security Groups</code>. 
 
-A table lists the security groups created. The default group is already listed here. This will allow all incoming and outgoing traffic to pass through.
+A table lists the security groups created. The default group is listed here and allows all traffic through.
 
 :::danger
 **Please do not modify or delete the "default" group. You will need to create a new security group and configure your rules in it.**
@@ -49,9 +49,9 @@ On the page that appears, give a name and description to the group you are about
 
 <img className="thumbnail" alt="create security group" src="/images/public-cloud/compute/setup-security-group/security-group2.png" loading="lazy" />
 
-Returning to the <code className="action">Security Groups</code> tab, the table now displays the newly created group. Rules are configured by default. These allow only outgoing traffic to pass.
+Returning to the <code className="action">Security Groups</code> tab, the table now displays the newly created group. Default rules allow only outgoing traffic.
 
-If you would like to modify these, go to the next step.
+To modify them, go to the next step.
 
 If you are satisfied with these rules, go to Step 3: [Configure a security group on your instance](#instance-security-group).
 
@@ -61,7 +61,7 @@ Click the <code className="action">Manage Rules</code> button.
 
 <img className="thumbnail" alt="manage rules" src="/images/public-cloud/compute/setup-security-group/security-group3.png" loading="lazy" />
 
-If you have left the default rules on your security group, they will only let outgoing traffic pass through.
+If you kept the default rules, they only allow outgoing traffic.
 
 ```bash
 root@server:~$ ssh admin@149.xxx.xxx.177
@@ -71,12 +71,12 @@ ssh connect to host 149.xxx.xxx.177 port 22: Connection timed out
 
 On the rules management page, you can:
 
-- delete an existing rule: Use the <code className="action">Delete Rule</code> button.
+- delete an existing rule: use the <code className="action">Delete Rule</code> button.
 - add a new rule: use the <code className="action">+ Add Rule</code> button.
 
-When you add a rule, you will need to fill in the information requested, then click <code className="action">Add</code>.
+When you add a rule, fill in the required information, then click <code className="action">Add</code>.
 
-In our example, we will authorise the SSH connection to the instance.
+In this example, we authorise an SSH connection to the instance.
 
 <img className="thumbnail" alt="add a rule" src="/images/public-cloud/compute/setup-security-group/security-group4.png" loading="lazy" />
 
@@ -97,7 +97,7 @@ When you create your instance, you can choose the new security group created in 
 
 <img className="thumbnail" alt="assign security group" src="/images/public-cloud/compute/setup-security-group/security-group5.png" loading="lazy" />
 
-You can apply a new security group to an instance that has already been created by clicking <code className="action">Edit Security Groups</code> to the right of the instance.
+You can apply a new security group to an existing instance by clicking <code className="action">Edit Security Groups</code> to the right of the instance.
 
 <img className="thumbnail" alt="edit security group" src="/images/public-cloud/compute/setup-security-group/security-group6.png" loading="lazy" />
 

--- a/docs/en/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/en/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creating and configuring a security group in Horizon
 description: Find out how to create a security group and configure it on a Public Cloud instance
-lastUpdated: 2026-06-24
+lastUpdated: 2026-07-08
 ---
 
 ## Objective

--- a/docs/en/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/en/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting started with the OpenStack API
 description: Find out how to manage your instances using the Python OpenStack client
-lastUpdated: 2026-06-23
+lastUpdated: 2026-07-08
 ---
 
 ## Objective

--- a/docs/en/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/en/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting started with the OpenStack API
 description: Find out how to manage your instances using the Python OpenStack client
-lastUpdated: 2022-10-13
+lastUpdated: 2026-06-23
 ---
 
 ## Objective
@@ -13,9 +13,9 @@ The Nova client was previously used to manage your instances and their disks. It
 :::
 
 
-For example, you can start creating an additional instance when your monitoring tools detect a peak load in order to avoid saturation on your infrastructure. It is also possible to schedule snapshot creation on a regular basis at the same time.
+For example, you can create an additional instance when your monitoring tools detect a peak load to avoid saturation on your infrastructure. It is also possible to schedule snapshot creation on a regular basis at the same time.
 
-**This guide will help you take the OpenStack APIs into your hands to manage your instances using the Python OpenStack client.**
+**This guide explains how to manage your instances using the Python OpenStack client.**
 
 ## Requirements
 
@@ -38,7 +38,7 @@ You can filter the commands displayed by indicating the group.
 admin@server-1:~$ openstack command list --group compute
 ```
 
-It is also possible to get information about a command by adding "help" in front of it:
+You can also get information about a command by adding `help` before it:
 
 ```bash
 admin@server-1:~$ openstack help flavor list 
@@ -53,7 +53,7 @@ List flavors ...
 ```
 
 :::tip
-You can obtain the Python Client documentation from the [OpenStack Website](https://docs.openstack.org/python-openstackclient/latest/cli/index.html).
+You can obtain the Python Client documentation from the [Python OpenStack Client documentation](https://docs.openstack.org/python-openstackclient/latest/cli/index.html).
 :::
 
 
@@ -61,9 +61,9 @@ You can obtain the Python Client documentation from the [OpenStack Website](http
 
 #### Adding an SSH Public Key
 
-As a first step, it is necessary to add a Public SSH key to connect to the instances.
+As a first step, it is necessary to add a public SSH key to connect to the instances.
 
-- List commands associated with SSH keys
+- List commands associated with SSH keys.
 
 ```bash
 admin@server-1:~$ openstack help | grep keypair         
@@ -73,13 +73,13 @@ admin@server-1:~$ openstack help | grep keypair
   keypair show    Display key details
 ```
 
-- Add a Public SSH key
+- Add a public SSH key.
 
 ```bash
 admin@server-1:~$ openstack keypair create --public-key ~/.ssh/id_rsa.pub SSHKEY
 ```
 
-- List available SSH Keys:
+- List available SSH keys:
 
 ```bash
 admin@server-1:~$ openstack keypair list
@@ -92,7 +92,7 @@ admin@server-1:~$ openstack keypair list
 
 #### Listing the instance models
 
-Next, you will need to obtain the ID of the model that you would like to use:
+Next, obtain the ID of the model you want to use:
 
 ```bash
 admin@server-1:~$ openstack flavor list
@@ -114,21 +114,24 @@ admin@server-1:~$ openstack flavor list
 
 #### Listing available images
 
-Finally, you need to obtain the ID of the image you want to use on the instance:
+Finally, obtain the ID of the image you want to use:
 
 ```bash
 admin@server-1:~$ openstack image list 
 +--------------------------------------+-----------------------------------------------+--------+
 | ID                                   | Name                                          | Status |
 +--------------------------------------+-----------------------------------------------+--------+
-| 8990fbbb-bd7e-4c57-8b19-a162e12c5195 | AlmaLinux 8                                   | active |
-| f1d2e56e-faec-4fd4-8493-dcf4c4201b40 | AlmaLinux 8 - UEFI                            | active |
-| a243240a-ca1f-4a53-a3bd-30c4f96b241f | AlmaLinux 8 - cPanel                          | active |
-| 1be04371-252f-48be-81fb-1cb89ea55778 | AlmaLinux 9                                   | active |
-| df89529f-8b4f-4534-9ddc-0092e30bcc97 | AlmaLinux 9 - UEFI                            | active |
-| 81c5ebbc-04fd-40f8-83aa-9b2bae8769f2 | Centos 7                                      | active |
-| b753f820-37cd-437a-b301-3423caf27637 | Centos 7 - Analytics - Ambari pre-warmed      | active |
-| 81ddd059-41b0-493e-a1e2-a278139b7bbb | Centos 7 - Analytics - Base image             | active |
+| 814f0f1d-5c06-40c6-b582-842fbf4995d2 | AlmaLinux 10                                  | active |
+| 2d1914bb-266b-4049-b4bd-c195d9e920bd | AlmaLinux 10 - UEFI                           | active |
+| b442e71d-2ce4-43ad-a9c6-03d0ee2359ee | AlmaLinux 8                                   | active |
+| 268b6be2-68f7-42c1-8d12-ba5fab40a84b | AlmaLinux 8 - UEFI                            | active |
+| f9170d19-919e-49a0-b1a3-f217fe48ab0b | AlmaLinux 8 - cPanel                          | active |
+| dbb258c0-a4ff-4b97-a695-6cd99763132c | AlmaLinux 9                                   | active |
+| 57659466-a19d-418e-8d98-4cb74fe1d717 | AlmaLinux 9 - UEFI                            | active |
+| 326ba25a-644c-4e6f-867a-f4fbc60b9c9b | AlmaLinux 9 - cPanel                          | active |
+| bc6eb0f9-2a59-4ea6-86b8-8f6a2befba5c | Baremetal - Debian 11                         | active |
+| 67b90767-19bc-4f4e-8982-77c227810f02 | Baremetal - Debian 12                         | active |
+| fee70d7e-e32a-44ec-af2d-20201eeeaf6d | Baremetal - Debian 13                         | active |
 | ...                                  | ...                                           | ...    |
 +--------------------------------------+-----------------------------------------------+--------+
 ```
@@ -172,7 +175,7 @@ admin@server-1:~$ openstack server create --key-name SSHKEY --flavor d2-2 --imag
 +-----------------------------+-----------------------------------------------------+
 ```
 
-After a few moments, you can verify the list of instances to find the newly created instance:
+After a few moments, verify the instance list to confirm the new instance appears:
 
 ```bash
 admin@server-1:~$ openstack server list                                                                 

--- a/docs/es/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/es/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: Crear y configurar un grupo de seguridad en Horizon
 description: Cómo crear un grupo de seguridad y configurarlo en una instancia de Public Cloud
-lastUpdated: 2026-06-24
+lastUpdated: 2026-07-08
 ---
 
 :::info

--- a/docs/es/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/es/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: Crear y configurar un grupo de seguridad en Horizon
 description: Cómo crear un grupo de seguridad y configurarlo en una instancia de Public Cloud
-lastUpdated: 2023-07-24
+lastUpdated: 2026-06-24
 ---
 
 :::info
@@ -17,7 +17,7 @@ Por motivos de seguridad, es posible configurar y utilizar reglas de filtrado qu
 
 ## Requisitos
 
-- Un [proyecto de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/)
+- Un [proyecto de Public Cloud](/links/public-cloud/public-cloud)
 - [Estar conectado a Horizon](/guides/public-cloud/cross-functional/create-and-delete-a-user)
 
 ## Procedimiento
@@ -74,7 +74,7 @@ ssh: connect to host 149.xxx.xxx.177 port 22: Connection timed out
 
 A continuación, en la página de gestión de las reglas, podrá:
 
-- eliminar una regla existente: Para ello, utilice el botón <code className="action">Delete Rule</code>.
+- eliminar una regla existente: para ello, utilice el botón <code className="action">Delete Rule</code>.
 - añadir una nueva regla: para ello, utilice el botón <code className="action">+ Add Rule</code>.
 
 Al añadir una regla, deberá completar la información solicitada y hacer clic en <code className="action">Add</code>.

--- a/docs/es/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/es/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Empezar con la API de OpenStack
 description: Cómo gestionar sus instancias con ayuda del cliente Python OpenStack
-lastUpdated: 2026-06-23
+lastUpdated: 2026-07-08
 ---
 
 :::info

--- a/docs/es/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/es/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Empezar con la API de OpenStack
 description: Cómo gestionar sus instancias con ayuda del cliente Python OpenStack
-lastUpdated: 2022-10-13
+lastUpdated: 2026-06-23
 ---
 
 :::info
@@ -14,13 +14,13 @@ Esta traducción ha sido generada de forma automática por nuestro partner SYSTR
 Para automatizar las operaciones en el Public Cloud, puede utilizar las API de OpenStack para generar diferentes scripts. 
 
 :::info
-El cliente Nova se utilizaba anteriormente para gestionar sus instancias y discos. Este cliente se ha deteriorado y los pedidos se han integrado en el cliente Python OpenStack.
+El cliente Nova se utilizaba anteriormente para gestionar sus instancias y discos. Este cliente está ahora obsoleto y los comandos se han integrado en el cliente Python OpenStack.
 :::
 
 
 Por ejemplo, podrá crear instancias adicionales cuando sus herramientas de monitorización detecten un pico de carga para evitar la saturación de su infraestructura. También es posible programar regularmente la creación de snapshots.
 
-Esta guía explica cómo utilizar las API de OpenStack para gestionar sus instancias utilizando el cliente Python OpenStack.
+**Esta guía explica cómo utilizar las API de OpenStack para gestionar sus instancias utilizando el cliente Python OpenStack.**
 
 ## Requisitos
 
@@ -29,7 +29,7 @@ Esta guía explica cómo utilizar las API de OpenStack para gestionar sus instan
 
 ## Procedimiento
 
-Puede consultar la lista de posibles pedidos en la documentación del cliente:
+Puede consultar la lista de posibles comandos en la documentación del cliente:
 
 ```bash
 admin@server-1:~$ openstack command list
@@ -38,10 +38,10 @@ admin@server-1:~$ openstack command list
 Puede filtrar los comandos mostrados indicando el grupo: 
 
 ```bash
-admin@server-1:~$ openstack command list —group compute
+admin@server-1:~$ openstack command list --group compute
 ```
 
-También puede consultar la información relativa a un pedido añadiendo `help` delante del pedido:
+También puede consultar la información relativa a un comando añadiendo `help` delante del comando:
 
 ```bash
 admin@server-1:~$ openstack help flavor list 
@@ -56,7 +56,7 @@ List flavors ...
 ```
 
 :::tip
-Consulte la documentación del cliente directamente en el [sitio web de OpenStack.](https://docs.openstack.org/python-openstackclient/latest/cli/index.html)
+Consulte la documentación del cliente directamente en el [sitio web de OpenStack](https://docs.openstack.org/python-openstackclient/latest/cli/index.html).
 :::
 
 
@@ -124,14 +124,17 @@ admin@server-1:~$ openstack image list
 +--------------------------------------+-----------------------------------------------+--------+
 | ID                                   | Name                                          | Status |
 +--------------------------------------+-----------------------------------------------+--------+
-| 8990fbbb-bd7e-4c57-8b19-a162e12c5195 | AlmaLinux 8                                   | active |
-| f1d2e56e-faec-4fd4-8493-dcf4c4201b40 | AlmaLinux 8 - UEFI                            | active |
-| a243240a-ca1f-4a53-a3bd-30c4f96b241f | AlmaLinux 8 - cPanel                          | active |
-| 1be04371-252f-48be-81fb-1cb89ea55778 | AlmaLinux 9                                   | active |
-| df89529f-8b4f-4534-9ddc-0092e30bcc97 | AlmaLinux 9 - UEFI                            | active |
-| 81c5ebbc-04fd-40f8-83aa-9b2bae8769f2 | Centos 7                                      | active |
-| b753f820-37cd-437a-b301-3423caf27637 | Centos 7 - Analytics - Ambari pre-warmed      | active |
-| 81ddd059-41b0-493e-a1e2-a278139b7bbb | Centos 7 - Analytics - Base image             | active |
+| 814f0f1d-5c06-40c6-b582-842fbf4995d2 | AlmaLinux 10                                  | active |
+| 2d1914bb-266b-4049-b4bd-c195d9e920bd | AlmaLinux 10 - UEFI                           | active |
+| b442e71d-2ce4-43ad-a9c6-03d0ee2359ee | AlmaLinux 8                                   | active |
+| 268b6be2-68f7-42c1-8d12-ba5fab40a84b | AlmaLinux 8 - UEFI                            | active |
+| f9170d19-919e-49a0-b1a3-f217fe48ab0b | AlmaLinux 8 - cPanel                          | active |
+| dbb258c0-a4ff-4b97-a695-6cd99763132c | AlmaLinux 9                                   | active |
+| 57659466-a19d-418e-8d98-4cb74fe1d717 | AlmaLinux 9 - UEFI                            | active |
+| 326ba25a-644c-4e6f-867a-f4fbc60b9c9b | AlmaLinux 9 - cPanel                          | active |
+| bc6eb0f9-2a59-4ea6-86b8-8f6a2befba5c | Baremetal - Debian 11                         | active |
+| 67b90767-19bc-4f4e-8982-77c227810f02 | Baremetal - Debian 12                         | active |
+| fee70d7e-e32a-44ec-af2d-20201eeeaf6d | Baremetal - Debian 13                         | active |
 | ...                                  | ...                                           | ...    |
 +--------------------------------------+-----------------------------------------------+--------+
 ```

--- a/docs/fr/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
+++ b/docs/fr/guides/public-cloud/compute/create-image-from-existing-image-with-packer.mdx
@@ -32,14 +32,14 @@ Packer peut être téléchargé depuis le site officiel [ici](https://www.packer
 
 Pour Linux 64bits :
 
-```shell
+```bash
 wget https://releases.hashicorp.com/packer/1.11.2/packer_1.11.2_linux_amd64.zip
 unzip packer_1.11.2_linux_amd64.zip
 ```
 
 ### Installer le plugin OpenStack pour Packer
 
-```shell
+```bash
 packer plugins install github.com/hashicorp/openstack
 ```
 
@@ -49,7 +49,7 @@ packer plugins install github.com/hashicorp/openstack
 
 Il sera utilisé pour automatiser la création du fichier de configuration.
 
-```shell
+```bash
 apt-get install jq
 ```
 
@@ -63,22 +63,22 @@ La [création d'un utilisateur OpenStack](/guides/public-cloud/cross-functional/
 
 ### Installer le client de ligne de commande OpenStack
 
-La méthode la plus simple est  d'utiliser un environnement virtuel python.
+La méthode la plus simple est d'utiliser un environnement virtuel Python.
 
-```shell
+```bash
 python3 -m venv venv3 # crée un environnement virtuel nommé venv3
 . ./venv3/bin/activate # renseignez l’environnement virtuel
 pip install --upgrade pip
 pip install python-openstackclient
 ```
 
-ou d'installer votre package de distribution  `apt-get install python-openstackclient`.
+ou d'installer votre package de distribution `apt-get install python-openstackclient`.
 
 #### Vérification
 
 En utilisant le fichier de configuration `openrc.sh` récupéré précédemment, essayez votre installation locale avec :
 
-```shell
+```bash
 . ./openrc.sh
 openstack token issue
 ```
@@ -87,13 +87,13 @@ openstack token issue
 
 D'abord, chargez votre fichier `openrc.sh` avec
 
-```shell
+```bash
 . ./openrc.sh
 ```
 
-Il faut à présent trouver les ID nécessaires. Vous aurez besoin des ID de l’image, de la flavor et du réseau. Nous construirons notre image à partir de `Ubuntu 24.04` sur un matériel `b2-7`, avec une interface connectée au réseau public `Ext-Net`
+Il faut à présent trouver les ID nécessaires. Vous aurez besoin des ID de l’image, de la flavor et du réseau. Nous construirons notre image à partir de `Ubuntu 24.04` sur un matériel `b2-7`, avec une interface connectée au réseau public `Ext-Net`.
 
-```shell
+```bash
 export SOURCE_ID=`openstack image list -f json | jq -r '.[] | select(.Name == "Ubuntu 24.04") | .ID'`
 export FLAVOR_ID=`openstack flavor list -f json | jq -r '.[] | select(.Name == "b2-7") | .ID'`
 export NETWORK_ID=`openstack network list -f json | jq -r '.[] | select(.Name == "Ext-Net") | .ID'`
@@ -103,7 +103,7 @@ export NETWORK_ID=`openstack network list -f json | jq -r '.[] | select(.Name ==
 
 Enfin, créez un fichier `packer.json`
 
-```shell
+```bash
 cat > packer.json <<EOF
 {
     "variables": {
@@ -138,7 +138,7 @@ cat > packer.json <<EOF
 EOF
 ```
 
-Dans la dernière sélection du fichier de configuration, nous spécifions un script shell `setup_vm.sh` à exécuter.
+Dans la dernière section du fichier de configuration, nous spécifions un script shell `setup_vm.sh` à exécuter.
 
 ```sh
 #!/bin/sh
@@ -159,14 +159,14 @@ git clone ...
 
 À l'aide du fichier de configuration créé ci-dessus, vérifiez-le et créez l'image avec :
 
-```shell
+```bash
 packer validate packer.json
 packer build packer.json
 ```
 
 Si tout s'est bien passé, vous devriez obtenir une nouvelle image disponible. Vous pouvez le vérifier avec :
 
-```shell
+```bash
 openstack image list | grep 'My Custom Image'
 ```
 

--- a/docs/fr/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/fr/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: Créer et configurer un groupe de sécurité dans Horizon
 description: Apprenez à créer un groupe de sécurité et à le configurer sur une instance Public Cloud
-lastUpdated: 2026-06-24
+lastUpdated: 2026-07-08
 ---
 
 ## Objectif

--- a/docs/fr/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/fr/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,18 +1,18 @@
 ---
 title: Créer et configurer un groupe de sécurité dans Horizon
 description: Apprenez à créer un groupe de sécurité et à le configurer sur une instance Public Cloud
-lastUpdated: 2023-07-24
+lastUpdated: 2026-06-24
 ---
 
 ## Objectif
 
-Pour des raisons de sécurité, il est possible de configurer et d'utiliser des règles de filtrage qui définiront les accès à vos instances. Vous pouvez y autoriser ou bloquer certaines connexions entrantes ou sortantes à l'aide de groupes de sécurité. Ces règles peuvent être appliquées pour du trafic provenant de certaines adresses IP, ou même pour des instances configurées sur des groupes de sécurité en particulier.
+Pour des raisons de sécurité, il est possible de configurer et d'utiliser des règles de filtrage qui définissent les accès à vos instances. Vous pouvez y autoriser ou bloquer certaines connexions entrantes ou sortantes à l'aide de groupes de sécurité. Vous pouvez appliquer ces règles au trafic provenant d'adresses IP spécifiques ou à des instances configurées dans des groupes de sécurité en particulier.
 
-**Apprenez à créer un groupe de sécurité et à le configurer sur une instance Public Cloud.**
+**Ce guide vous explique comment créer un groupe de sécurité et le configurer sur une instance Public Cloud.**
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/).
+- Un [projet Public Cloud](/links/public-cloud/public-cloud).
 - [Être connecté à l'interface Horizon](/guides/public-cloud/cross-functional/create-and-delete-a-user).
 
 ## En pratique
@@ -28,11 +28,11 @@ Si un groupe de sécurité doit être utilisé dans plusieurs régions, vous dev
 :::
 
 
-A présent, dépliez le menu <code className="action">Network</code> et cliquez sur <code className="action">Security Groups</code>. 
+Dépliez le menu <code className="action">Network</code> et cliquez sur <code className="action">Security Groups</code>.
 
 Un tableau liste les groupes de sécurité créés. 
 
-Le groupe « default » y est déjà listé. Celui-ci laisse passer tout le trafic entrant et sortant.
+Le groupe « default » est listé ici et laisse passer tout le trafic entrant et sortant.
 
 :::danger
 **Veuillez ne pas modifier ou supprimer le groupe « default ». Vous devez impérativement créer un nouveau groupe de sécurité et y configurer vos règles.**
@@ -51,7 +51,7 @@ Sur la page qui apparaît, donnez un nom et une description au groupe que vous �
 
 <img className="thumbnail" alt="créer un groupe de sécurité" src="/images/public-cloud/compute/setup-security-group/security-group2.png" loading="lazy" />
 
-De retour sur l'onglet <code className="action">Security Groups</code>, le tableau affiche désormais le groupe nouvellement créé. Des règles y sont configurées par défaut. Ces dernières laissent passer uniquement le trafic sortant. Poursuivez vers l'étape suivante si vous souhaitez modifier ces dernières.
+De retour sur l'onglet <code className="action">Security Groups</code>, le tableau affiche désormais le groupe nouvellement créé. Les règles par défaut laissent passer uniquement le trafic sortant. Pour les modifier, passez à l'étape suivante.
 
 Si ces règles vous conviennent, poursuivez la lecture de ce guide à l'étape 3 « [configurer un groupe de sécurité sur son instance](#instance-security-group) ».
 
@@ -61,7 +61,7 @@ Cliquez sur le bouton <code className="action">Manage Rules</code>.
 
 <img className="thumbnail" alt="gérer les règles" src="/images/public-cloud/compute/setup-security-group/security-group3.png" loading="lazy" />
 
-Si vous avez laissé les règles par défaut sur votre groupe de sécurité, celles-ci ne laissent passer que le trafic sortant.
+Si vous avez conservé les règles par défaut, elles ne laissent passer que le trafic sortant.
 
 ```bash
 root@serveur:~$ ssh admin@149.xxx.xxx.177
@@ -74,13 +74,13 @@ Dès lors, sur la page de gestion des règles, vous avez la possibilité de :
 - supprimer une règle existante : utilisez pour cela le bouton <code className="action">Delete Rule</code> ;
 - ajouter une nouvelle règle : utilisez pour cela le bouton <code className="action">+ Add Rule</code>.
 
-Lors de l'ajout d'une règle, vous devrez compléter les informations demandées puis cliquer sur <code className="action">Add</code>.
+Lors de l'ajout d'une règle, complétez les informations demandées, puis cliquez sur <code className="action">Add</code>.
 
-Dans notre exemple, nous allons autoriser la connexion SSH à l'instance.
+Dans cet exemple, nous autorisons la connexion SSH à l'instance.
 
 <img className="thumbnail" alt="ajouter une règle" src="/images/public-cloud/compute/setup-security-group/security-group4.png" loading="lazy" />
 
-Une fois la nouvelle règle ajoutée, patientez quelques minutes le temps que celle-ci soit prise en compte.
+Une fois la nouvelle règle ajoutée, attendez quelques minutes qu'elle soit prise en compte.
 
 ```bash
 root@serveur:~$ ssh admin@149.xxx.xxx.177
@@ -97,7 +97,7 @@ Lors de la création de votre instance, vous pourrez choisir, via le menu <code 
 
 <img className="thumbnail" alt="affecter groupe de sécurité" src="/images/public-cloud/compute/setup-security-group/security-group5.png" loading="lazy" />
 
-Vous pouvez appliquer un nouveau groupe de sécurité sur une instance déjà créée en cliquant sur <code className="action">Edit Security Groups</code> à droite de l'instance.
+Vous pouvez appliquer un nouveau groupe de sécurité sur une instance existante en cliquant sur <code className="action">Edit Security Groups</code> à droite de l'instance.
 
 <img className="thumbnail" alt="modifier groupe de sécurité" src="/images/public-cloud/compute/setup-security-group/security-group6.png" loading="lazy" />
 

--- a/docs/fr/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/fr/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Débuter avec l’API OpenStack
 description: "Découvrez comment gérer vos instances à l'aide du client Python OpenStack"
-lastUpdated: 2026-06-23
+lastUpdated: 2026-07-08
 ---
 
 ## Objectif

--- a/docs/fr/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/fr/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Débuter avec l’API OpenStack
 description: "Découvrez comment gérer vos instances à l'aide du client Python OpenStack"
-lastUpdated: 2022-10-13
+lastUpdated: 2026-06-23
 ---
 
 ## Objectif
@@ -15,7 +15,7 @@ Le client Nova était précédemment utilisé pour gérer vos instances ainsi qu
 
 Vous pourrez par exemple lancer la création d'instances supplémentaires lorsque vos outils de monitoring détectent un pic de charge, afin d'éviter une saturation sur votre infrastructure. Il est aussi possible de programmer la création de snapshots de manière régulière.
 
-Ce guide vous aidera à prendre en main les API OpenStack afin de gérer vos instances à l'aide du client Python OpenStack.
+**Ce guide vous aidera à prendre en main les API OpenStack afin de gérer vos instances à l'aide du client Python OpenStack.**
 
 ## Prérequis
 
@@ -24,7 +24,7 @@ Ce guide vous aidera à prendre en main les API OpenStack afin de gérer vos ins
 
 ## En pratique
 
-Vous pouvez obtenir la liste des commandes possible en lisant la documentation du client :
+Vous pouvez obtenir la liste des commandes possibles en lisant la documentation du client :
 
 ```bash
 admin@serveur-1:~$ openstack command list
@@ -36,7 +36,7 @@ Vous pouvez filtrer les commandes affichées en indiquant le groupe :
 admin@serveur-1:~$ openstack command list --group compute
 ```
 
-Il est aussi possible d'avoir des informations concernant une commande en ajoutant `help` devant celle ci :
+Il est aussi possible d'avoir des informations concernant une commande en ajoutant `help` devant celle-ci :
 
 ```bash
 admin@serveur-1:~$ openstack help flavor list 
@@ -53,7 +53,7 @@ List flavors ...
 ```
 
 :::tip
-Consultez la documentation du client directement sur le [site OpenStack](https://docs.openstack.org/python-openstackclient/latest/cli/index.html)
+Consultez la documentation du client directement sur le [site OpenStack](https://docs.openstack.org/python-openstackclient/latest/cli/index.html).
 :::
 
 
@@ -118,23 +118,26 @@ admin@serveur-1:~$ openstack flavor list
 Pour finir, il suffit de récupérer l'ID de l'image qui sera utilisée pour l'instance :
 
 ```bash
-admin@serveur-1:~$ openstack image list 
+admin@server-1:~$ openstack image list 
 +--------------------------------------+-----------------------------------------------+--------+
 | ID                                   | Name                                          | Status |
 +--------------------------------------+-----------------------------------------------+--------+
-| 8990fbbb-bd7e-4c57-8b19-a162e12c5195 | AlmaLinux 8                                   | active |
-| f1d2e56e-faec-4fd4-8493-dcf4c4201b40 | AlmaLinux 8 - UEFI                            | active |
-| a243240a-ca1f-4a53-a3bd-30c4f96b241f | AlmaLinux 8 - cPanel                          | active |
-| 1be04371-252f-48be-81fb-1cb89ea55778 | AlmaLinux 9                                   | active |
-| df89529f-8b4f-4534-9ddc-0092e30bcc97 | AlmaLinux 9 - UEFI                            | active |
-| 81c5ebbc-04fd-40f8-83aa-9b2bae8769f2 | Centos 7                                      | active |
-| b753f820-37cd-437a-b301-3423caf27637 | Centos 7 - Analytics - Ambari pre-warmed      | active |
-| 81ddd059-41b0-493e-a1e2-a278139b7bbb | Centos 7 - Analytics - Base image             | active |
+| 814f0f1d-5c06-40c6-b582-842fbf4995d2 | AlmaLinux 10                                  | active |
+| 2d1914bb-266b-4049-b4bd-c195d9e920bd | AlmaLinux 10 - UEFI                           | active |
+| b442e71d-2ce4-43ad-a9c6-03d0ee2359ee | AlmaLinux 8                                   | active |
+| 268b6be2-68f7-42c1-8d12-ba5fab40a84b | AlmaLinux 8 - UEFI                            | active |
+| f9170d19-919e-49a0-b1a3-f217fe48ab0b | AlmaLinux 8 - cPanel                          | active |
+| dbb258c0-a4ff-4b97-a695-6cd99763132c | AlmaLinux 9                                   | active |
+| 57659466-a19d-418e-8d98-4cb74fe1d717 | AlmaLinux 9 - UEFI                            | active |
+| 326ba25a-644c-4e6f-867a-f4fbc60b9c9b | AlmaLinux 9 - cPanel                          | active |
+| bc6eb0f9-2a59-4ea6-86b8-8f6a2befba5c | Baremetal - Debian 11                         | active |
+| 67b90767-19bc-4f4e-8982-77c227810f02 | Baremetal - Debian 12                         | active |
+| fee70d7e-e32a-44ec-af2d-20201eeeaf6d | Baremetal - Debian 13                         | active |
 | ...                                  | ...                                           | ...    |
 +--------------------------------------+-----------------------------------------------+--------+
 ```
 
-#### Creation d'une instance
+#### Création d'une instance
 
 Avec les éléments récupérés précédemment, vous pouvez créer une instance :
 

--- a/docs/it/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/it/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creare e configurare un gruppo di sicurezza su Horizon
 description: "Come creare un gruppo di sicurezza e configurarlo su un'istanza Public Cloud"
-lastUpdated: 2023-07-24
+lastUpdated: 2026-06-24
 ---
 
 :::info
@@ -17,7 +17,7 @@ Per motivi di sicurezza, è possibile configurare e utilizzare regole di filtrag
 
 ## Prerequisiti
 
-- Un [progetto Public Cloud](https://www.ovhcloud.com/it/public-cloud/)
+- Un [progetto Public Cloud](/links/public-cloud/public-cloud)
 - [Essere connesso all'interfaccia Horizon](/guides/public-cloud/cross-functional/create-and-delete-a-user)
 
 ## Procedura

--- a/docs/it/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/it/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creare e configurare un gruppo di sicurezza su Horizon
 description: "Come creare un gruppo di sicurezza e configurarlo su un'istanza Public Cloud"
-lastUpdated: 2026-06-24
+lastUpdated: 2026-07-08
 ---
 
 :::info

--- a/docs/it/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/it/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Come utilizzare l’API OpenStack
 description: Come gestire le tue istanze con il client Python OpenStack
-lastUpdated: 2026-06-23
+lastUpdated: 2026-07-08
 ---
 
 :::info

--- a/docs/it/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/it/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Come utilizzare l’API OpenStack
 description: Come gestire le tue istanze con il client Python OpenStack
-lastUpdated: 2022-10-13
+lastUpdated: 2026-06-23
 ---
 
 :::info
@@ -14,13 +14,13 @@ Questa traduzione è stata generata automaticamente dal nostro partner SYSTRAN. 
 Se vuoi automatizzare le tue operazioni sul Public Cloud, puoi utilizzare le API di OpenStack per creare diversi script.
 
 :::info
-Il client Nova era stato utilizzato in precedenza per gestire le istanze e i dischi. Questo cliente ha subito una riduzione di valore e gli ordini sono stati integrati nel client Python OpenStack.
+Il client Nova era stato utilizzato in precedenza per gestire le istanze e i dischi. Questo cliente non è più supportato e i comandi sono stati integrati nel client Python OpenStack.
 :::
 
 
-Ad esempio, puoi craere istanze aggiuntive per evitare un sovraccarico della tua infrastruttura quando i tuoi sistemi di monitoring rilevano picchi di carico, oppure pianificare la creazione di Snapshot.
+Ad esempio, puoi creare istanze aggiuntive per evitare un sovraccarico della tua infrastruttura quando i tuoi sistemi di monitoring rilevano picchi di carico, oppure pianificare la creazione di Snapshot.
 
-Questa guida ti mostra come utilizzare le API OpenStack per gestire le tue istanze con il client Python OpenStack.
+**Questa guida ti mostra come utilizzare le API OpenStack per gestire le tue istanze con il client Python OpenStack.**
 
 ## Prerequisiti
 
@@ -38,7 +38,7 @@ admin@server-1:~$ openstack command list
 Puoi filtrare i comandi visualizzati indicando il gruppo: 
 
 ```bash
-admin@server-1:~$ openstack command list —group compute
+admin@server-1:~$ openstack command list --group compute
 ```
 
 Per maggiori informazioni su un comando, aggiungi `help` davanti al comando:
@@ -56,7 +56,7 @@ List flavors ...
 ```
 
 :::tip
-Consulta la documentazione del cliente direttamente sul [sito OpenStack](https://docs.openstack.org/python-openstackclient/latest/cli/index.html)
+Consulta la documentazione del cliente direttamente sul [sito OpenStack](https://docs.openstack.org/python-openstackclient/latest/cli/index.html).
 :::
 
 
@@ -66,7 +66,7 @@ Consulta la documentazione del cliente direttamente sul [sito OpenStack](https:/
 
 Per prima cosa, è necessario aggiungere una chiave SSH pubblica che permetterà di connettersi alle istanze.
 
-- Lista gli ordini associati alle chiavi SSH:
+- Lista i comandi associati alle chiavi SSH:
 
 ```bash
 admin@server-1:~$ openstack help | grep keypair         
@@ -120,25 +120,28 @@ admin@server-1:~$ openstack flavor list
 Infine, è sufficiente recuperare l'ID dell'immagine che verrà utilizzata per l'istanza:
 
 ```bash
-admin@serveur-1:~$ openstack image list 
+admin@server-1:~$ openstack image list 
 +--------------------------------------+-----------------------------------------------+--------+
 | ID                                   | Name                                          | Status |
 +--------------------------------------+-----------------------------------------------+--------+
-| 8990fbb-bd7e-4c57-8b19-a162e12c5195 | AlmaLinux 8                                   | active |
-| f1d2e56e-faec-4fd4-8493-dcf4c4201b40 | AlmaLinux 8 - UEFI                            | active |
-| a243240a-ca1f-4a53-a3bd-30c4f96b241f | AlmaLinux 8 - cPanel                          | active |
-| 1be04371-252f-48be-81fb-1cb89ea55778 | AlmaLinux 9                                   | active |
-| df89529f-8b4f-4534-9ddc-0092e30bcc97 | AlmaLinux 9 - UEFI                            | active |
-| 81c5ebbc-04fd-40f8-83aa-9b2bae8769f2 | Centos 7                                      | active |
-| b753f820-37cd-437a-b301-3423caf27637 | Centos 7 - Analytics - Ambari pre-warmed      | active |
-| 81ddd059-41b0-493e-a1e2-a278139b7bbb | Centos 7 - Analytics - Base image             | active |
+| 814f0f1d-5c06-40c6-b582-842fbf4995d2 | AlmaLinux 10                                  | active |
+| 2d1914bb-266b-4049-b4bd-c195d9e920bd | AlmaLinux 10 - UEFI                           | active |
+| b442e71d-2ce4-43ad-a9c6-03d0ee2359ee | AlmaLinux 8                                   | active |
+| 268b6be2-68f7-42c1-8d12-ba5fab40a84b | AlmaLinux 8 - UEFI                            | active |
+| f9170d19-919e-49a0-b1a3-f217fe48ab0b | AlmaLinux 8 - cPanel                          | active |
+| dbb258c0-a4ff-4b97-a695-6cd99763132c | AlmaLinux 9                                   | active |
+| 57659466-a19d-418e-8d98-4cb74fe1d717 | AlmaLinux 9 - UEFI                            | active |
+| 326ba25a-644c-4e6f-867a-f4fbc60b9c9b | AlmaLinux 9 - cPanel                          | active |
+| bc6eb0f9-2a59-4ea6-86b8-8f6a2befba5c | Baremetal - Debian 11                         | active |
+| 67b90767-19bc-4f4e-8982-77c227810f02 | Baremetal - Debian 12                         | active |
+| fee70d7e-e32a-44ec-af2d-20201eeeaf6d | Baremetal - Debian 13                         | active |
 | ...                                  | ...                                           | ...    |
 +--------------------------------------+-----------------------------------------------+--------+
 ```
 
 #### Crea un'istanza
 
-Con gli elementi recuperati precedentemente, potete creare un'istanza:
+Con gli elementi recuperati precedentemente, puoi creare un'istanza:
 
 ```bash
 admin@server-1:~$ openstack server create --key-name SSHKEY --flavor d2-2 --image "Ubuntu 22.04" InstanceTest

--- a/docs/pl/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/pl/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tworzenie i konfigurowanie grupy zabezpieczeń w interfejsie Horizon
 description: Dowiedz się, jak utworzyć grupę zabezpieczeń i skonfigurować ją na instancji Public Cloud
-lastUpdated: 2026-06-24
+lastUpdated: 2026-07-08
 ---
 
 :::info

--- a/docs/pl/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/pl/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tworzenie i konfigurowanie grupy zabezpieczeń w interfejsie Horizon
 description: Dowiedz się, jak utworzyć grupę zabezpieczeń i skonfigurować ją na instancji Public Cloud
-lastUpdated: 2023-07-24
+lastUpdated: 2026-06-24
 ---
 
 :::info
@@ -13,11 +13,11 @@ Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera S
 
 Ze względów bezpieczeństwa możesz konfigurować i używać reguł filtrowania, które zdefiniują dostęp do instancji. Możesz zezwolić lub zablokować niektóre połączenia przychodzące lub wychodzące za pomocą grup zabezpieczeń. Reguły te mogą być stosowane w przypadku ruchu pochodzącego z niektórych adresów IP lub nawet w przypadku instancji skonfigurowanych w grupach zabezpieczeń.
 
-**Dowiedz się, jak utworzyć grupę zabezpieczeń i skonfigurować ją na instancji Public Cloud.**
+**Ten przewodnik wyjaśnia, jak utworzyć grupę zabezpieczeń i skonfigurować ją na instancji Public Cloud.**
 
 ## Wymagania początkowe
 
-- Projekt [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/)
+- Projekt [Public Cloud](/links/public-cloud/public-cloud)
 - [Dostęp do interfejsu Horizon](/guides/public-cloud/cross-functional/create-and-delete-a-user)
 
 ## W praktyce
@@ -75,7 +75,7 @@ ssh: connect to host 149.xxx.xxx.177 port 22: Connection timed out
 Teraz na stronie zarządzania regułami możesz:
 
 - usuń istniejącą regułę: w tym celu użyj przycisku <code className="action">Delete Rule</code>;
-- dodaj nową regułę: Użyj przycisku <code className="action">+ Add Rule</code>.
+- dodaj nową regułę: użyj przycisku <code className="action">+ Add Rule</code>.
 
 Podczas dodawania reguły należy uzupełnić wymagane informacje, a następnie kliknąć <code className="action">Add</code>.
 

--- a/docs/pl/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/pl/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pierwsze kroki z API OpenStack
 description: Dowiedz się, jak zarządzać instancjami za pomocą klienta Python OpenStack
-lastUpdated: 2022-10-13
+lastUpdated: 2026-06-23
 ---
 
 :::info
@@ -14,13 +14,13 @@ Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera S
 Aby móc zautomatyzować operacje dotyczące usługi Public Cloud, można korzystać z API OpenStack do generowania poszczególnych skryptów. 
 
 :::info
-Klient Nova był wcześniej używany do zarządzania instancjami i ich dyskami. Klient ten jest teraz zdeprecjowany, a zamówienia zostały zintegrowane z klientem Python OpenStack.
+Klient Nova był wcześniej używany do zarządzania instancjami i ich dyskami. Klient ten jest teraz zdeprecjowany, a polecenia zostały zintegrowane z klientem Python OpenStack.
 :::
 
 
 Będziesz mógł na przykład uruchomić tworzenie dodatkowych instancji, gdy Twoje narzędzia monitoringu wykryją wzrost obciążenia, aby uniknąć przeciążenia infrastruktury. Możesz również regularnie programować tworzenie snapshotów.
 
-Niniejszy przewodnik pomoże Ci w korzystaniu z API OpenStack w zarządzaniu instancjami za pomocą klienta Python OpenStack.
+**Niniejszy przewodnik pomoże Ci w korzystaniu z API OpenStack w zarządzaniu instancjami za pomocą klienta Python OpenStack.**
 
 ## Wymagania początkowe
 
@@ -29,7 +29,7 @@ Niniejszy przewodnik pomoże Ci w korzystaniu z API OpenStack w zarządzaniu ins
 
 ## W praktyce
 
-Możesz uzyskać listę zamówień, które możesz wykonać, czytając dokumentację klienta:
+Możesz uzyskać listę poleceń, które możesz wykonać, czytając dokumentację klienta:
 
 ```bash
 admin@server-1:~$ openstack command list
@@ -38,10 +38,10 @@ admin@server-1:~$ openstack command list
 Możesz filtrować wyświetlane polecenia, wskazując grupę:
 
 ```bash
-admin@server-1:~$ openstack command list —group compute
+admin@server-1:~$ openstack command list --group compute
 ```
 
-Możesz również uzyskać informacje dotyczące zamówienia, dodając `help` przed komendą:
+Możesz również uzyskać informacje dotyczące polecenia, dodając `help` przed poleceniem:
 
 ```bash
 admin@server-1:~$ openstack help flavor list 
@@ -56,7 +56,7 @@ List flavors ...
 ```
 
 :::tip
-Zapoznaj się z dokumentacją klienta bezpośrednio na [stronie OpenStack](https://docs.openstack.org/python-openstackclient/latest/cli/index.html)
+Zapoznaj się z dokumentacją klienta bezpośrednio na [stronie OpenStack](https://docs.openstack.org/python-openstackclient/latest/cli/index.html).
 :::
 
 
@@ -64,7 +64,7 @@ Zapoznaj się z dokumentacją klienta bezpośrednio na [stronie OpenStack](https
 
 #### Dodanie publicznego klucza SSH
 
-W pierwszej kolejności należy dodać publiczny klucz SSH, który pozwoli na logowanie sie na instancje. 
+W pierwszej kolejności należy dodać publiczny klucz SSH, który pozwoli na logowanie się na instancje. 
 
 - Wyświetl listę poleceń związanych z kluczami SSH:
 
@@ -124,14 +124,17 @@ admin@server-1:~$ openstack image list
 +--------------------------------------+-----------------------------------------------+--------+
 | ID                                   | Name                                          | Status |
 +--------------------------------------+-----------------------------------------------+--------+
-| 8990fbbb-bd7e-4c57-8b19-a162e12c5195 | AlmaLinux 8                                   | active |
-| f1d2e56e-faec-4fd4-8493-dcf4c4201b40 | AlmaLinux 8 - UEFI                            | active |
-| a243240a-ca1f-4a53-a3bd-30c4f96b241f | AlmaLinux 8 - cPanel                          | active |
-| 1be04371-252f-48be-81fb-1cb89ea55778 | AlmaLinux 9                                   | active |
-| df89529f-8b4f-4534-9ddc-0092e30bcc97 | AlmaLinux 9 - UEFI                            | active |
-| 81c5ebbc-04fd-40f8-83aa-9b2bae8769f2 | Centos 7                                      | active |
-| b753f820-37cd-437a-b301-3423caf27637 | Centos 7 - Analytics - Ambari pre-warmed      | active |
-| 81ddd059-41b0-493e-a1e2-a278139b7bbb | Centos 7 - Analytics - Base image             | active |
+| 814f0f1d-5c06-40c6-b582-842fbf4995d2 | AlmaLinux 10                                  | active |
+| 2d1914bb-266b-4049-b4bd-c195d9e920bd | AlmaLinux 10 - UEFI                           | active |
+| b442e71d-2ce4-43ad-a9c6-03d0ee2359ee | AlmaLinux 8                                   | active |
+| 268b6be2-68f7-42c1-8d12-ba5fab40a84b | AlmaLinux 8 - UEFI                            | active |
+| f9170d19-919e-49a0-b1a3-f217fe48ab0b | AlmaLinux 8 - cPanel                          | active |
+| dbb258c0-a4ff-4b97-a695-6cd99763132c | AlmaLinux 9                                   | active |
+| 57659466-a19d-418e-8d98-4cb74fe1d717 | AlmaLinux 9 - UEFI                            | active |
+| 326ba25a-644c-4e6f-867a-f4fbc60b9c9b | AlmaLinux 9 - cPanel                          | active |
+| bc6eb0f9-2a59-4ea6-86b8-8f6a2befba5c | Baremetal - Debian 11                         | active |
+| 67b90767-19bc-4f4e-8982-77c227810f02 | Baremetal - Debian 12                         | active |
+| fee70d7e-e32a-44ec-af2d-20201eeeaf6d | Baremetal - Debian 13                         | active |
 | ...                                  | ...                                           | ...    |
 +--------------------------------------+-----------------------------------------------+--------+
 ```

--- a/docs/pl/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/pl/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pierwsze kroki z API OpenStack
 description: Dowiedz się, jak zarządzać instancjami za pomocą klienta Python OpenStack
-lastUpdated: 2026-06-23
+lastUpdated: 2026-07-08
 ---
 
 :::info

--- a/docs/pt/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/pt/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: Criar e configurar um grupo de segurança no Horizon
 description: Saiba como criar um grupo de segurança e configurá-lo numa instância Public Cloud
-lastUpdated: 2026-06-24
+lastUpdated: 2026-07-08
 ---
 
 :::info

--- a/docs/pt/guides/public-cloud/compute/setup-security-group.mdx
+++ b/docs/pt/guides/public-cloud/compute/setup-security-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: Criar e configurar um grupo de segurança no Horizon
 description: Saiba como criar um grupo de segurança e configurá-lo numa instância Public Cloud
-lastUpdated: 2023-07-24
+lastUpdated: 2026-06-24
 ---
 
 :::info
@@ -13,11 +13,11 @@ Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certo
 
 Por razões de segurança, é possível configurar e utilizar regras de filtragem que irão definir os acessos às suas instâncias. Pode autorizar ou bloquear certas ligações de entrada ou de saída através de grupos de segurança. Estas regras podem ser aplicadas para o tráfego proveniente de certos endereços IP, ou mesmo para as instâncias configuradas em grupos de segurança em particular.
 
-**Saiba como criar um grupo de segurança e configurá-lo numa instância Public Cloud.**
+**Este guia explica como criar um grupo de segurança e configurá-lo numa instância Public Cloud.**
 
 ## Requisitos
 
-- Um [projeto Public Cloud](https://www.ovhcloud.com/pt/public-cloud/)
+- Um [projeto Public Cloud](/links/public-cloud/public-cloud)
 - [Ter acesso à interface Horizon](/guides/public-cloud/cross-functional/create-and-delete-a-user)
 
 ## Instruções

--- a/docs/pt/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/pt/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Primeiros passos com a API OpenStack
 description: Descubra como gerir as suas instâncias com a ajuda do cliente Python OpenStack
-lastUpdated: 2026-06-23
+lastUpdated: 2026-07-08
 ---
 
 :::info

--- a/docs/pt/guides/public-cloud/compute/starting-with-nova.mdx
+++ b/docs/pt/guides/public-cloud/compute/starting-with-nova.mdx
@@ -1,7 +1,7 @@
 ---
 title: Primeiros passos com a API OpenStack
 description: Descubra como gerir as suas instâncias com a ajuda do cliente Python OpenStack
-lastUpdated: 2022-10-13
+lastUpdated: 2026-06-23
 ---
 
 :::info
@@ -14,14 +14,14 @@ Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certo
 Com o objetivo de automatizar as suas operações no Public Cloud é possível utilizar as APIs OpenStack de forma a gerar diferentes scripts.
 
 :::info
-O cliente Nova era anteriormente utilizado para gerir as suas instâncias bem como os seus discos. Este cliente está agora com imparidade e as encomendas foram integradas no seio do cliente Python OpenStack.
+O cliente Nova era anteriormente utilizado para gerir as suas instâncias bem como os seus discos. Este cliente está agora obsoleto e os comandos foram integrados no cliente Python OpenStack.
 :::
 
 
 Poderá, por exemplo, lançar a criação de uma instância suplementar assim que as ferramentas de monitorização detetarem um pico de carga para evitar uma saturação na sua infraestrutura.
-É igualmente possível programar a criação instantânea de foram regular pelo mesmo motivo.
+É igualmente possível programar a criação de snapshots de forma regular.
 
-Este guia ajudá-lo-á a gerir as suas instâncias com a ajuda do cliente Python OpenStack.
+**Este guia ajudá-lo-á a gerir as suas instâncias com a ajuda do cliente Python OpenStack.**
 
 ## Requisitos
 
@@ -30,7 +30,7 @@ Este guia ajudá-lo-á a gerir as suas instâncias com a ajuda do cliente Python
 
 ## Instruções
 
-Pode obter a lista dos comandos possível lendo a documentação do cliente:
+Pode obter a lista dos comandos possíveis lendo a documentação do cliente:
 
 ```bash
 admin@server-1:~$ openstack command list
@@ -39,10 +39,10 @@ admin@server-1:~$ openstack command list
 Pode filtrar os comandos indicados indicando o grupo: 
 
 ```bash
-admin@server-1:~$ openstack command list —group compute
+admin@server-1:~$ openstack command list --group compute
 ```
 
-Também é possível obter informações sobre uma encomenda adicionando `help` a esta:
+Também é possível obter informações sobre um comando adicionando `help` a este:
 
 ```bash
 admin@server-1:~$ openstack help flavor list 
@@ -57,7 +57,7 @@ List flavors ...
 ```
 
 :::tip
-Consulte a documentação do cliente diretamente no [site OpenStack](https://docs.openstack.org/python-openstackclient/latest/cli/index.html)
+Consulte a documentação do cliente diretamente no [site OpenStack](https://docs.openstack.org/python-openstackclient/latest/cli/index.html).
 :::
 
 
@@ -83,7 +83,7 @@ admin@server-1:~$ openstack help | grep keypair
 admin@server-1:~$ openstack keypair create --public-key ~/.ssh/id_rsa.pub SSHKEY
 ```
 
-- Lista as chaves SSH disponíveis:
+- Listar as chaves SSH disponíveis:
 
 ```bash
 admin@server-1:~$ openstack keypair list
@@ -121,23 +121,26 @@ admin@server-1:~$ openstack flavor list
 Basta recuperar o ID da imagem que será utilizada pela instância:
 
 ```bash
-admin@serveur-1:~$ openstack image list 
+admin@server-1:~$ openstack image list 
 +--------------------------------------+-----------------------------------------------+--------+
 | ID                                   | Name                                          | Status |
 +--------------------------------------+-----------------------------------------------+--------+
-| 8990fbb-bd7e-4c57-8b19-a162e12c5195 | AlmaLinux 8                                   | active |
-| f1d2e56e-faec-4fd4-8493-dcf4c4201b40 | AlmaLinux 8 - UEFI                            | active |
-| a243240a-ca1f-4a53-a3bd-30c4f96b241f | AlmaLinux 8 - cPanel                          | active |
-| 1be04371-252f-48be-81fb-1cb89ea55778 | AlmaLinux 9                                   | active |
-| df89529f-8b4f-4534-9ddc-0092e30bcc97 | AlmaLinux 9 - UEFI                            | active |
-| 81c5ebbc-04fd-40f8-83aa-9b2bae8769f2 | Centos 7                                      | active |
-| b753f820-37cd-437a-b301-3423caf27637 | Centos 7 - Analytics - Ambari pre-warmed      | active |
-| 81ddd059-41b0-493e-a1e2-a278139b7bbb | Centos 7 - Analytics - Base image             | active |
+| 814f0f1d-5c06-40c6-b582-842fbf4995d2 | AlmaLinux 10                                  | active |
+| 2d1914bb-266b-4049-b4bd-c195d9e920bd | AlmaLinux 10 - UEFI                           | active |
+| b442e71d-2ce4-43ad-a9c6-03d0ee2359ee | AlmaLinux 8                                   | active |
+| 268b6be2-68f7-42c1-8d12-ba5fab40a84b | AlmaLinux 8 - UEFI                            | active |
+| f9170d19-919e-49a0-b1a3-f217fe48ab0b | AlmaLinux 8 - cPanel                          | active |
+| dbb258c0-a4ff-4b97-a695-6cd99763132c | AlmaLinux 9                                   | active |
+| 57659466-a19d-418e-8d98-4cb74fe1d717 | AlmaLinux 9 - UEFI                            | active |
+| 326ba25a-644c-4e6f-867a-f4fbc60b9c9b | AlmaLinux 9 - cPanel                          | active |
+| bc6eb0f9-2a59-4ea6-86b8-8f6a2befba5c | Baremetal - Debian 11                         | active |
+| 67b90767-19bc-4f4e-8982-77c227810f02 | Baremetal - Debian 12                         | active |
+| fee70d7e-e32a-44ec-af2d-20201eeeaf6d | Baremetal - Debian 13                         | active |
 | ...                                  | ...                                           | ...    |
 +--------------------------------------+-----------------------------------------------+--------+
 ```
 
-## Criação de uma instância
+#### Criação de uma instância
 
 Com os elementos obtidos anteriormente, é possível criar uma instância:
 
@@ -176,7 +179,7 @@ admin@server-1:~$ openstack server create --key-name SSHKEY --flavor d2-2 --imag
 +-----------------------------+-----------------------------------------------------+
 ```
 
-Dopo pochi minuti, puoi verificare la lista delle istanze esistenti per trovare l'istanza appena creata:
+Após alguns instantes, pode verificar a lista de instâncias existentes para encontrar a instância recém-criada:
 
 ```bash
 admin@server-1:~$ openstack server list                                                                 


### PR DESCRIPTION
## Change context

Editorial review pass over three Public Cloud › Compute guides, applied
consistently across all locales.

## What changed

- **starting-with-nova**: tightened wording throughout; refreshed the
  `openstack image list` sample output (AlmaLinux 10, AlmaLinux 9 - cPanel,
  Baremetal Debian 11/12/13); clarified the Python OpenStack Client doc link.
- **setup-security-group**: tightened wording; replaced the hardcoded
  `ovhcloud.com/en-gb/public-cloud/` URL with the `/links/public-cloud/public-cloud`
  internal link; condensed rule/traffic descriptions.
- **create-image-from-existing-image-with-packer**: normalised code fences
  from ` ```shell ` to ` ```bash `; wording and typo fixes
  ("python" → "Python", "ie" → "i.e.,", "selection" → "section").

Locale coverage:
- nova + security-group: all 7 locales (en, fr, de, es, it, pl, pt), with the
  same editorial care applied per language; `lastUpdated` bumped to 2026-07-08.
- packer: en + fr only (language-agnostic code-fence/wording fixes).

No structural, procedural, or factual changes — copy-editing, one internal-link
fix, and a sample-output refresh only.
