### PR TITLE
[SK-2707] WEB - Emails - note that MX Plan email technology cannot be changed (EU)

### DIFF
--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Erste Schritte mit MX Plan
 description: Erfahren Sie hier, wie Sie Ihr MX Plan Angebot verwenden
-lastUpdated: 2026-06-08
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -18,6 +18,14 @@ import { ZoneTabs, Region } from '@components/Zone';
 Mit der MX Plan Lösung verfügen Sie über E-Mail-Adressen, mit denen Sie Nachrichten von einem Gerät Ihrer Wahl aus versenden und empfangen können.
 
 **Diese Anleitung erklärt, wie Sie Ihr MX Plan Angebot verwenden.**
+
+<Region zones={['eu']}>
+
+:::warning
+Bei MX Plan ist es nicht möglich, von einer E-Mail-Technologie zu einer anderen zu wechseln (zum Beispiel zwischen Roundcube, OWA und Zimbra). Die Ihrem Service zugewiesene E-Mail-Technologie ist festgelegt und kann nicht geändert werden.
+:::
+
+</Region>
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ OVHcloud E-Mails
 description: Hier finden Sie die am häufigsten gestellten Fragen zu E-Mails
-lastUpdated: 2026-03-24
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -104,6 +104,14 @@ OVHcloud bietet derzeit 4 E-Mail-Angebote an. Um mehr über die Eigenschaften zu
     3. Dieses Angebot verwendet das Webmail-Interface **OWA** (Outlook Web App).
   </Tab>
 </ZoneTabs>
+
+<Region zones={['eu']}>
+
+:::warning
+Bei MX Plan ist es nicht möglich, von einer E-Mail-Technologie zu einer anderen zu wechseln (zum Beispiel zwischen Roundcube, OWA und Zimbra). Die Ihrem Service zugewiesene E-Mail-Technologie ist festgelegt und kann nicht geändert werden.
+:::
+
+</Region>
 
 
 :::tip

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ OVHcloud E-Mails
 description: Hier finden Sie die am häufigsten gestellten Fragen zu E-Mails
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -12,52 +12,6 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
-
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### Zugriff auf das OVHcloud Kundencenter
-
-**MX Plan:**
-
-- **Direkter Link:** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
-- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Wählen Sie Ihren MX Plan Dienst aus
-
-<Region zones={['eu']}>
-
-**Zimbra:**
-
-- **Direkter Link:** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
-- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Wählen Sie Ihren Zimbra Dienst aus
-
-</Region>
-
-<Region zones={['eu']}>
-
-**E-Mail Pro:**
-
-- **Direkter Link:** <ManagerLink to="/#/web/email_pro">E-Mail Pro</ManagerLink>
-- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">E-Mail Pro</code> > Wählen Sie Ihre Plattform aus
-
-</Region>
-
-<Region zones={['eu', 'ca']}>
-
-**Exchange:**
-
-- **Direkter Link:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Wählen Sie Ihre Plattform aus
-
-</Region>
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
 
 ## E-Mail FAQ
 
@@ -70,7 +24,7 @@ OVHcloud bietet derzeit 4 E-Mail-Angebote an. Um mehr über die Eigenschaften zu
   <Tab label="E-Mails / MX Plan">
     <img className="thumbnail" alt="MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/mxplan01.png" loading="lazy" />
     
-    1. Das älteste E-Mail-Angebot von OVHcloud, das die wesentlichen Funktionen eines E-Mail-Dienstes mit 5 GB Speicherplatz pro E-Mail-Account enthält.
+    1. Das ursprüngliche E-Mail-Angebot von OVHcloud, das die wesentlichen Funktionen eines E-Mail-Dienstes mit 5 GB Speicherplatz pro E-Mail-Account enthält.
     2. Es ist in den Webhosting-Angeboten inklusive und kann über das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> bestellt werden.
     3. Dieses Angebot ist mit folgenden Webmail-Technologien verfügbar:
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -43,11 +43,11 @@ OVHcloud bietet derzeit 4 E-Mail-Angebote an. Um mehr über die Eigenschaften zu
     2. Sie können einen Zimbra-Account über das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> oder direkt über [ovhcloud.com](https://www.ovhcloud.com/de/mail/) bestellen.
     3. Sie verwendet das **Zimbra**-Interface.
   </Tab>
-  <Tab label="E-Mails Pro" availableIn={['eu']}>
-    <img className="thumbnail" alt="E-Mail Pro" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/emailpro01.png" loading="lazy" />
+  <Tab label="Email Pro" availableIn={['eu']}>
+    <img className="thumbnail" alt="Email Pro" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/emailpro01.png" loading="lazy" />
     
     1. E-Mail-Angebot auf Basis von Exchange mit grundlegenden Funktionen und 10 GB Speicherplatz.
-    2. Sie können einen E-Mail Pro Account über das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> oder direkt über [ovhcloud.com](https://www.ovhcloud.com/de/mail/) bestellen.
+    2. Sie können einen Email Pro Account über das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> oder direkt über [ovhcloud.com](https://www.ovhcloud.com/de/mail/) bestellen.
     3. Dieses Angebot verwendet das Webmail-Interface **OWA** (Outlook Web App).
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
@@ -235,7 +235,7 @@ Hierzu stellen wir Ihnen Anleitungen zur Einrichtung Ihrer E-Mail-Adresse zur Ve
     **Android Smartphone oder Tablet**
     - [Google Mail für Android](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-android)
   </Tab>
-  <Tab label="E-Mails Pro" availableIn={['eu']}>
+  <Tab label="Email Pro" availableIn={['eu']}>
     **Windows**
     - [Outlook für Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/outlook-windows-configuration)
     - [Thunderbird für Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/how-to-configure-thunderbird)
@@ -370,7 +370,7 @@ Sie möchten zu einem anderen [E-Mail-Angebot](https://www.ovhcloud.com/de/email
 
 <Region zones={['eu']}>
 
-[MX Plan E-Mail-Account auf E-Mail Pro oder Exchange Account migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+[MX Plan E-Mail-Account auf Email Pro oder Exchange Account migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting started with the MX Plan solution
 description: Find out how to get started with an MX Plan solution
-lastUpdated: 2026-06-08
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -18,6 +18,14 @@ import { ZoneTabs, Region } from '@components/Zone';
 If you have just purchased an MX Plan solution, this means you have email addresses that you can use to send and receive messages from a device of your choice.
 
 **Find out how to get started with an MX Plan solution.**
+
+<Region zones={['eu']}>
+
+:::warning
+On MX Plan, it is not possible to switch from one email technology to another (for example, between Roundcube, OWA and Zimbra). The email technology assigned to your service is fixed and cannot be changed.
+:::
+
+</Region>
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ OVHcloud emails
 description: Find the most frequently asked questions about emails
-lastUpdated: 2026-03-24
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -106,6 +106,13 @@ OVHcloud currently offers 4 email solutions. To understand their specifics, navi
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
+
+:::warning
+On MX Plan, it is not possible to switch from one email technology to another (for example, between Roundcube, OWA and Zimbra). The email technology assigned to your service is fixed and cannot be changed.
+:::
+
+</Region>
 
 :::tip
 Unless specified, the questions listed below concern all OVHcloud email solutions.

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ OVHcloud emails
 description: Find the most frequently asked questions about emails
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -12,52 +12,6 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
-
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### OVHcloud Control Panel Access
-
-**MX Plan:**
-
-- **Direct link:** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Select your MX Plan service
-
-<Region zones={['eu']}>
-
-**Zimbra:**
-
-- **Direct link:** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Select your Zimbra service
-
-</Region>
-
-<Region zones={['eu']}>
-
-**Email Pro:**
-
-- **Direct link:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Select your platform
-
-</Region>
-
-<Region zones={['eu', 'ca']}>
-
-**Exchange:**
-
-- **Direct link:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Select your platform
-
-</Region>
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
 
 ## Email FAQ
 
@@ -71,7 +25,7 @@ OVHcloud currently offers 4 email solutions. To understand their specifics, navi
   <Tab label="Emails/MX Plan">
     <img className="thumbnail" alt="MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/mxplan01.png" loading="lazy" />
     
-    1. OVHcloud's oldest email solution, which includes the essential features of an email service with 5GB of storage space per email account.
+    1. OVHcloud's original email solution, which includes the essential features of an email service with 5GB of storage space per email account.
     2. Included with web hosting plans and can be ordered via the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
     3. This offer is available in the following webmail technologies:
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Primeros pasos con la solución MX Plan
 description: Cómo empezar a utilizar la solución de correo electrónico MX Plan
-lastUpdated: 2026-06-08
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -18,6 +18,14 @@ import { ZoneTabs, Region } from '@components/Zone';
 Usted acaba de adquirir una solución MX Plan que permite disfrutar de direcciones de correo electrónico para enviar y recibir mensajes desde cualquier dispositivo.
 
 **Esta guía explica cómo empezar a utilizar la solución MX Plan.**
+
+<Region zones={['eu']}>
+
+:::warning
+En MX Plan no es posible cambiar de una tecnología de correo a otra (por ejemplo, entre Roundcube, OWA y Zimbra). La tecnología de correo asignada a su servicio es fija y no puede modificarse.
+:::
+
+</Region>
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ soluciones de correo electrónico de OVHcloud
 description: Encuentre las preguntas más frecuentes sobre el correo electrónico
-lastUpdated: 2026-03-24
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -105,6 +105,14 @@ OVHcloud ofrece actualmente 4 soluciones de correo. Para entender sus especifica
     3. Esta oferta utiliza la interfaz webmail **OWA** (Outlook Web Access).
   </Tab>
 </ZoneTabs>
+
+<Region zones={['eu']}>
+
+:::warning
+En MX Plan no es posible cambiar de una tecnología de correo a otra (por ejemplo, entre Roundcube, OWA y Zimbra). La tecnología de correo asignada a su servicio es fija y no puede modificarse.
+:::
+
+</Region>
 
 
 :::tip

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ soluciones de correo electrónico de OVHcloud
 description: Encuentre las preguntas más frecuentes sobre el correo electrónico
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -12,52 +12,6 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
-
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### Acceso al área de cliente de OVHcloud
-
-**MX Plan:**
-
-- **Enlace directo:** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Seleccione su servicio MX Plan
-
-<Region zones={['eu']}>
-
-**Zimbra:**
-
-- **Enlace directo:** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Seleccione su servicio Zimbra
-
-</Region>
-
-<Region zones={['eu']}>
-
-**Email Pro:**
-
-- **Enlace directo:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Seleccione su plataforma
-
-</Region>
-
-<Region zones={['eu', 'ca']}>
-
-**Exchange:**
-
-- **Enlace directo:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Seleccione su plataforma
-
-</Region>
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
 
 ## FAQ e-mail
 
@@ -71,7 +25,7 @@ OVHcloud ofrece actualmente 4 soluciones de correo. Para entender sus especifica
   <Tab label="Correo electrónico / MX Plan">
     <img className="thumbnail" alt="MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/mxplan01.png" loading="lazy" />
     
-    1. La solución de correo electrónico más antigua de OVHcloud, que incluye las funciones esenciales de un servicio de correo con 5 GB de espacio de almacenamiento por cuenta de correo.
+    1. La solución de correo electrónico histórica de OVHcloud, que incluye las funciones esenciales de un servicio de correo con 5 GB de espacio de almacenamiento por cuenta de correo.
     2. Incluido con los planes de hosting, puede contratarlo desde el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>.
     3. Esta oferta está disponible en las siguientes tecnologías de webmail:
 
@@ -90,7 +44,7 @@ OVHcloud ofrece actualmente 4 soluciones de correo. Para entender sus especifica
     2. Puede contratar una cuenta Zimbra desde el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink> o directamente en [ovhcloud.com](https://www.ovhcloud.com/es-es/mail/).
     3. Como su nombre indica, utiliza la interfaz **Zimbra**.
   </Tab>
-  <Tab label="Emails Pro" availableIn={['eu']}>
+  <Tab label="Email Pro" availableIn={['eu']}>
     <img className="thumbnail" alt="Email Pro" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/emailpro01.png" loading="lazy" />
     
     1. Solución de correo basada en la tecnología Exchange, que ofrece funcionalidades esenciales con un espacio de almacenamiento de 10 GB.
@@ -282,7 +236,7 @@ Puede consultar nuestras guías en [este página](/guides/web-cloud/email-and-co
     **Smartphone o tableta Android**
     - [Gmail para Android](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-android).
   </Tab>
-  <Tab label="Emails Pro" availableIn={['eu']}>
+  <Tab label="Email Pro" availableIn={['eu']}>
     **Equipo Windows**
     - [Outlook para Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/outlook-windows-configuration).
     - [Thunderbird para Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/how-to-configure-thunderbird).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Premiers pas avec l'offre MX Plan"
 description: Découvrez comment bien débuter avec votre offre MX Plan
-lastUpdated: 2026-06-08
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -18,6 +18,14 @@ import { ZoneTabs, Region } from '@components/Zone';
 Vous venez d'acquérir une solution MX Plan. Celle-ci vous permet de bénéficier d'adresses e-mail, avec lesquelles vous pourrez envoyer et recevoir des messages depuis l’appareil de votre choix.
 
 **Découvrez comment débuter avec votre offre MX Plan.**
+
+<Region zones={['eu']}>
+
+:::warning
+Sur MX Plan, il n'est pas possible de passer d'une technologie e-mail à une autre (par exemple entre Roundcube, OWA et Zimbra). La technologie e-mail attribuée à votre service est figée et ne peut pas être modifiée.
+:::
+
+</Region>
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -44,7 +44,7 @@ OVHcloud propose actuellement 4 offres e-mail. Pour comprendre leurs spécificit
     2. Vous pouvez commander un compte Zimbra via l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> ou directement sur [ovhcloud.com](https://www.ovhcloud.com/fr/mail/).
     3. Comme son nom l'indique, elle utilise l'interface **Zimbra**.
   </Tab>
-  <Tab label="E-mails Pro" availableIn={['eu']}>
+  <Tab label="Email Pro" availableIn={['eu']}>
     <img className="thumbnail" alt="Email Pro" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/emailpro01_fr.png" loading="lazy" />
     
     1. Offre e-mail basée sur la technologie Exchange, offrant des fonctionnalités essentielles avec un espace de stockage de 10 Go.
@@ -239,7 +239,7 @@ Pour ce faire nous vous mettons à disposition des guides afin d'effectuer la mi
     **Smartphone ou tablette Android**
     - [Gmail pour Android](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-android).
   </Tab>
-  <Tab label="E-mails Pro" availableIn={['eu']}>
+  <Tab label="Email Pro" availableIn={['eu']}>
     **Ordinateur Windows**
     - [Outlook pour Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/outlook-windows-configuration).
     - [Thunderbird pour Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/how-to-configure-thunderbird).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ e-mails OVHcloud
 description: Retrouvez les questions les plus fréquemment posées sur les e-mails
-lastUpdated: 2026-06-19
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -105,6 +105,14 @@ OVHcloud propose actuellement 4 offres e-mail. Pour comprendre leurs spécificit
     3. Cette offre utilise l'interface webmail **OWA** (Outlook Web Access).
   </Tab>
 </ZoneTabs>
+
+<Region zones={['eu']}>
+
+:::warning
+Sur MX Plan, il n'est pas possible de passer d'une technologie e-mail à une autre (par exemple entre Roundcube, OWA et Zimbra). La technologie e-mail attribuée à votre service est figée et ne peut pas être modifiée.
+:::
+
+</Region>
 
 
 :::tip

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ e-mails OVHcloud
 description: Retrouvez les questions les plus fréquemment posées sur les e-mails
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -12,52 +12,6 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
-
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### Accès à l'espace client OVHcloud
-
-**MX Plan :**
-
-- **Lien direct :** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Sélectionnez votre service MX Plan
-
-<Region zones={['eu']}>
-
-**Zimbra :**
-
-- **Lien direct :** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Sélectionnez votre service Zimbra
-
-</Region>
-
-<Region zones={['eu']}>
-
-**Email Pro :**
-
-- **Lien direct :** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Sélectionnez votre plateforme
-
-</Region>
-
-<Region zones={['eu', 'ca']}>
-
-**Exchange :**
-
-- **Lien direct :** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Sélectionnez votre plateforme
-
-</Region>
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
 
 ## FAQ e-mail
 
@@ -71,7 +25,7 @@ OVHcloud propose actuellement 4 offres e-mail. Pour comprendre leurs spécificit
   <Tab label="E-mails / MX Plan">
     <img className="thumbnail" alt="MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/mxplan01_fr.png" loading="lazy" />
     
-    1. L'offre e-mail la plus ancienne d'OVHcloud, qui comprend les fonctions essentielles d'un service e-mail avec 5 Go d'espace de stockage par compte e-mail.
+    1. L'offre e-mail historique d'OVHcloud, qui comprend les fonctions essentielles d'un service e-mail avec 5 Go d'espace de stockage par compte e-mail.
     2. Incluse avec les offres d'hébergement web et peut être commandée via l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>.
     3. Cette offre est disponible dans les technologies de webmail suivantes :
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Iniziare a utilizzare la soluzione MX Plan
 description: Come eseguire le prime operazioni sul servizio MX Plan
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,7 +22,7 @@ La soluzione MX Plan di OVHcloud con cui potrai inviare e ricevere messaggi dal 
 <Region zones={['eu']}>
 
 :::warning
-Su MX Plan non è possibile passare da una tecnologia email a un'altra (ad esempio tra Roundcube, OWA e Zimbra). La tecnologia email assegnata al vostro servizio è fissa e non può essere modificata.
+Su MX Plan non è possibile passare da una tecnologia email a un'altra (ad esempio tra Roundcube, OWA e Zimbra). La tecnologia email assegnata al tuo servizio è fissa e non può essere modificata.
 :::
 
 </Region>
@@ -56,23 +56,23 @@ Su MX Plan non è possibile passare da una tecnologia email a un'altra (ad esemp
 
 <Region zones={['eu']}>
 
-In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
+In base alla tua offerta (e a un'eventuale migrazione), il tuo servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
 
 - **Roundcube**: la webmail storica, leggera e semplice da usare.
 - **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
 - **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
 
-Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
+Per identificare la tecnologia del tuo servizio, accedi al tuo Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del tuo servizio email: è indicata sotto **Webmail**.
 
 Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
 
-<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<img className="thumbnail" alt="Identificare la tecnologia webmail della tua offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
 
 </Region>
 
 <Region zones={['ca', 'apac']}>
 
-Consultate la posta elettronica online, senza installazione, tramite la webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+Consulta la posta elettronica online, senza installazione, tramite la webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
 
 </Region>
 
@@ -103,7 +103,7 @@ Nella nuova finestra, inserisci le informazioni richieste:
     - **Nome account**: inserisci il tuo nuovo indirizzo email (ad esempio nome.cognome). Il dominio che compone l’indirizzo email è già preselezionato nella lista.
     - **Descrizione dell’account**: Informazione sull’indirizzo email, disponibile nella tabella disponibile nella scheda <code className="action">Email</code> del tuo servizio di posta.
     - **Dimensione account**: determina la dimensione che vuoi attribuire all’account email.
-    - **Password**: [Definisci una password](/guides/account-and-service-management/account-information/manage-ovh-password) e confermala. Per motivi di sicurezza, vi consigliamo di non utilizzare due volte la stessa password, sceglierne una che non abbia alcun rapporto con le vostre informazioni personali (ad esempio, evitate di inserire il vostro cognome, nome e data di nascita) e di rinnovarla regolarmente.
+    - **Password**: [Definisci una password](/guides/account-and-service-management/account-information/manage-ovh-password) e confermala. Per motivi di sicurezza, ti consigliamo di non utilizzare due volte la stessa password, sceglierne una che non abbia alcun rapporto con le tue informazioni personali (ad esempio, evita di inserire il tuo cognome, nome e data di nascita) e di rinnovarla regolarmente.
     
     Una volta completati i campi clicca su <code className="action">Seguente</code> e verifica le informazioni mostrate nel riepilogo. Se sono corrette, clicca su <code className="action">Conferma</code>. Ripeti questa operazione per tutti gli account che vuoi creare, in base al numero a tua disposizione.
     
@@ -120,7 +120,7 @@ Nella nuova finestra, inserisci le informazioni richieste:
     - **Nome**: Inserisci un nome.
     - **Cognome**: Inserisci un cognome.
     - **Nome da visualizzare**: indica il nome che comparirà come mittente delle email inviate da questo indirizzo.
-    - **Password**: [Definisci una password](/guides/account-and-service-management/account-information/manage-ovh-password) e confermala. Per motivi di sicurezza, vi consigliamo di non utilizzare due volte la stessa password, sceglierne una che non abbia alcun rapporto con le vostre informazioni personali (ad esempio, evitate di inserire il vostro cognome, nome e data di nascita) e di rinnovarla regolarmente.
+    - **Password**: [Definisci una password](/guides/account-and-service-management/account-information/manage-ovh-password) e confermala. Per motivi di sicurezza, ti consigliamo di non utilizzare due volte la stessa password, sceglierne una che non abbia alcun rapporto con le tue informazioni personali (ad esempio, evita di inserire il tuo cognome, nome e data di nascita) e di rinnovarla regolarmente.
     - **Quota**: determina la dimensione che vuoi attribuire all’account email.
     
     Una volta completati i campi clicca su <code className="action">Seguente</code> e verifica le informazioni mostrate nel riepilogo. Se sono corrette, clicca su <code className="action">Conferma</code>. Ripeti questa operazione per tutti gli account che vuoi creare, in base al numero a tua disposizione.

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Iniziare a utilizzare la soluzione MX Plan
 description: Come eseguire le prime operazioni sul servizio MX Plan
-lastUpdated: 2026-06-08
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -18,6 +18,14 @@ import { ZoneTabs, Region } from '@components/Zone';
 La soluzione MX Plan di OVHcloud con cui potrai inviare e ricevere messaggi dal dispositivo che preferisci.
 
 **Questa guida ti mostra le operazioni di base da effettuare sul tuo servizio di posta elettronica MX Plan.**
+
+<Region zones={['eu']}>
+
+:::warning
+Su MX Plan non è possibile passare da una tecnologia email a un'altra (ad esempio tra Roundcube, OWA e Zimbra). La tecnologia email assegnata al vostro servizio è fissa e non può essere modificata.
+:::
+
+</Region>
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ email OVHcloud
 description: Rileggi le domande più frequenti sulle email
-lastUpdated: 2026-03-24
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -105,6 +105,14 @@ OVHcloud propone attualmente 4 offerte email. Per comprenderne le specificità, 
     3. Questa soluzione utilizza l’interfaccia Webmail **OWA** (Outlook Web Access).
   </Tab>
 </ZoneTabs>
+
+<Region zones={['eu']}>
+
+:::warning
+Su MX Plan non è possibile passare da una tecnologia email a un'altra (ad esempio tra Roundcube, OWA e Zimbra). La tecnologia email assegnata al vostro servizio è fissa e non può essere modificata.
+:::
+
+</Region>
 
 
 :::tip

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ email OVHcloud
 description: Rileggi le domande più frequenti sulle email
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -12,52 +12,6 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
-
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### Accesso allo Spazio Cliente OVHcloud
-
-**MX Plan:**
-
-- **Link diretto:** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Seleziona il tuo servizio MX Plan
-
-<Region zones={['eu']}>
-
-**Zimbra:**
-
-- **Link diretto:** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Seleziona il tuo servizio Zimbra
-
-</Region>
-
-<Region zones={['eu']}>
-
-**Email Pro:**
-
-- **Link diretto:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Seleziona la tua piattaforma
-
-</Region>
-
-<Region zones={['eu', 'ca']}>
-
-**Exchange:**
-
-- **Link diretto:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Seleziona la tua piattaforma
-
-</Region>
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
 
 ## FAQ e-mail
 
@@ -71,7 +25,7 @@ OVHcloud propone attualmente 4 offerte email. Per comprenderne le specificità, 
   <Tab label="Email/MX Plan">
     <img className="thumbnail" alt="MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/mxplan01.png" loading="lazy" />
     
-    1. Il servizio email più datato di OVHcloud, che include le funzioni essenziali di un servizio di posta con 5 GB di spazio di storage per ogni account email.
+    1. Il servizio email storico di OVHcloud, che include le funzioni essenziali di un servizio di posta con 5 GB di spazio di storage per ogni account email.
     2. Incluso nelle offerte di hosting Web e può essere ordinato dallo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>.
     3. Questa soluzione è disponibile con le seguenti tecnologie di Webmail:
 
@@ -109,7 +63,7 @@ OVHcloud propone attualmente 4 offerte email. Per comprenderne le specificità, 
 <Region zones={['eu']}>
 
 :::warning
-Su MX Plan non è possibile passare da una tecnologia email a un'altra (ad esempio tra Roundcube, OWA e Zimbra). La tecnologia email assegnata al vostro servizio è fissa e non può essere modificata.
+Su MX Plan non è possibile passare da una tecnologia email a un'altra (ad esempio tra Roundcube, OWA e Zimbra). La tecnologia email assegnata al tuo servizio è fissa e non può essere modificata.
 :::
 
 </Region>
@@ -152,21 +106,21 @@ Di seguito trovi una tabella riassuntiva delle principali funzionalità email, o
 
 <Region zones={['eu']}>
 
-In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
+In base alla tua offerta (e a un'eventuale migrazione), il tuo servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
 
 - **Roundcube**: la webmail storica, leggera e semplice da usare.
 - **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
 - **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
 
-Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
+Per identificare la tecnologia del tuo servizio, accedi al tuo Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del tuo servizio email: è indicata sotto **Webmail**.
 
-<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<img className="thumbnail" alt="Identificare la tecnologia webmail della tua offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
 
 </Region>
 
 <Region zones={['ca', 'apac']}>
 
-Consultate la posta elettronica online, senza installazione, tramite la webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+Consulta la posta elettronica online, senza installazione, tramite la webmail [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pierwsze kroki z usługą MX Plan
 description: Dowiedz się, jak rozpocząć korzystanie z usługi MX Plan
-lastUpdated: 2026-06-08
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -18,6 +18,14 @@ import { ZoneTabs, Region } from '@components/Zone';
 Właśnie zakupiłeś usługę MX Plan. Pozwala ona na korzystanie z kont e-mail, dzięki którym możesz wysyłać i odbierać wiadomości, korzystając z dowolnego urządzenia.
 
 **Dowiedz się, jak rozpocząć korzystanie z usługi MX Plan.**
+
+<Region zones={['eu']}>
+
+:::warning
+W MX Plan nie można przełączać się między technologiami poczty (na przykład między Roundcube, OWA i Zimbra). Technologia poczty przypisana do Twojej usługi jest stała i nie można jej zmienić.
+:::
+
+</Region>
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ e-mail OVHcloud
 description: Znajdź najczęściej zadawane pytania dotyczące kont e-mail
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -12,52 +12,6 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
-
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### Dostęp do Panelu klienta OVHcloud
-
-**MX Plan:**
-
-- **Link bezpośredni:** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Wybierz usługę MX Plan
-
-<Region zones={['eu']}>
-
-**Zimbra:**
-
-- **Link bezpośredni:** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Wybierz usługę Zimbra
-
-</Region>
-
-<Region zones={['eu']}>
-
-**E-mail Pro:**
-
-- **Link bezpośredni:** <ManagerLink to="/#/web/email_pro">E-mail Pro</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">E-mail Pro</code> > Wybierz platformę
-
-</Region>
-
-<Region zones={['eu', 'ca']}>
-
-**Exchange:**
-
-- **Link bezpośredni:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Wybierz platformę
-
-</Region>
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
 
 ## FAQ e-mail
 
@@ -71,7 +25,7 @@ OVHcloud oferuje aktualnie 4 oferty e-mail. Poznaj ich funkcje, przechodząc prz
   <Tab label="E-maile / MX Plan">
     <img className="thumbnail" alt="MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/mxplan01.png" loading="lazy" />
     
-    1. Najstarsza oferta e-mail od OVHcloud, zawierająca kluczowe funkcje usługi e-mail z przestrzenią dyskową 5 GB na konto e-mail.
+    1. Historyczna oferta e-mail od OVHcloud, zawierająca kluczowe funkcje usługi e-mail z przestrzenią dyskową 5 GB na konto e-mail.
     2. Zawarty w ofercie hostingu www i może być zamówiony za pośrednictwem <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>.
     3. Ta oferta jest dostępna w następujących technologiach webmail:
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -45,10 +45,10 @@ OVHcloud oferuje aktualnie 4 oferty e-mail. Poznaj ich funkcje, przechodząc prz
     3. Interfejs **Zimbra** jest obsługiwany przez aplikację.
   </Tab>
   <Tab label="E-maile Pro" availableIn={['eu']}>
-    <img className="thumbnail" alt="E-mail Pro" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/emailpro01.png" loading="lazy" />
+    <img className="thumbnail" alt="Email Pro" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/emailpro01.png" loading="lazy" />
     
     1. Oferta e-mail oparta na technologii Exchange, oferująca podstawowe funkcje z przestrzenią dyskową 10 GB.
-    2. Możesz zamówić konto E-mail Pro w Panelu klienta <ManagerLink to="/">OVHcloud</ManagerLink> lub bezpośrednio w [ovhcloud.com](https://www.ovhcloud.com/pl/mail/).
+    2. Możesz zamówić konto Email Pro w Panelu klienta <ManagerLink to="/">OVHcloud</ManagerLink> lub bezpośrednio w [ovhcloud.com](https://www.ovhcloud.com/pl/mail/).
     3. W tej ofercie zastosowano interfejs webmail **OWA** (Outlook Web Access).
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
@@ -371,7 +371,7 @@ Chcesz zmienić [ofertę e-mail](https://www.ovhcloud.com/pl/emails/) na większ
 
 <Region zones={['eu']}>
 
-[Przeniesienie adresu e-mail MX Plan na konto E-mail Pro lub Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+[Przeniesienie adresu e-mail MX Plan na konto Email Pro lub Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ e-mail OVHcloud
 description: Znajdź najczęściej zadawane pytania dotyczące kont e-mail
-lastUpdated: 2026-03-24
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -105,6 +105,14 @@ OVHcloud oferuje aktualnie 4 oferty e-mail. Poznaj ich funkcje, przechodząc prz
     3. W tej ofercie zastosowano interfejs webmail **OWA** (Outlook Web Access).
   </Tab>
 </ZoneTabs>
+
+<Region zones={['eu']}>
+
+:::warning
+W MX Plan nie można przełączać się między technologiami poczty (na przykład między Roundcube, OWA i Zimbra). Technologia poczty przypisana do Twojej usługi jest stała i nie można jej zmienić.
+:::
+
+</Region>
 
 
 :::tip

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Introdução à oferta MX Plan
 description: Saiba como começar a usar a oferta MX Plan
-lastUpdated: 2026-06-08
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -18,6 +18,14 @@ import { ZoneTabs, Region } from '@components/Zone';
 Adquiriu um serviço MX Plan, que lhe permite beneficiar de endereços de e-mail, com os quais poderá enviar e receber mensagens no dispositivo que preferir.
 
 **Saiba como começar a usar a oferta MX Plan.**
+
+<Region zones={['eu']}>
+
+:::warning
+No MX Plan, não é possível mudar de uma tecnologia de e-mail para outra (por exemplo, entre o Roundcube, o OWA e o Zimbra). A tecnologia de e-mail atribuída ao seu serviço é fixa e não pode ser alterada.
+:::
+
+</Region>
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ e-mails OVHcloud
 description: Consulte as perguntas mais frequentes sobre os e-mails
-lastUpdated: 2026-03-24
+lastUpdated: 2026-07-07
 availableIn: [eu, ca, apac]
 ---
 
@@ -105,6 +105,14 @@ A OVHcloud oferece atualmente 4 ofertas de e-mail. Para compreender as suas espe
     3. Esta oferta utiliza a interface webmail **OWA** (Outlook Web Access).
   </Tab>
 </ZoneTabs>
+
+<Region zones={['eu']}>
+
+:::warning
+No MX Plan, não é possível mudar de uma tecnologia de e-mail para outra (por exemplo, entre o Roundcube, o OWA e o Zimbra). A tecnologia de e-mail atribuída ao seu serviço é fixa e não pode ser alterada.
+:::
+
+</Region>
 
 
 :::tip

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ e-mails OVHcloud
 description: Consulte as perguntas mais frequentes sobre os e-mails
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 availableIn: [eu, ca, apac]
 ---
 
@@ -12,52 +12,6 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
-
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### Acesso à Área de Cliente OVHcloud
-
-**MX Plan:**
-
-- **Ligação direta:** <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Selecione o seu serviço MX Plan
-
-<Region zones={['eu']}>
-
-**Zimbra:**
-
-- **Ligação direta:** <ManagerLink to="/#/web/zimbra">Zimbra</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Selecione o seu serviço Zimbra
-
-</Region>
-
-<Region zones={['eu']}>
-
-**E-mail Pro:**
-
-- **Ligação direta:** <ManagerLink to="/#/web/email_pro">E-mail Pro</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">E-mail Pro</code> > Selecione a sua plataforma
-
-</Region>
-
-<Region zones={['eu', 'ca']}>
-
-**Exchange:**
-
-- **Ligação direta:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Selecione a sua plataforma
-
-</Region>
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
 
 ## FAQ de e-mail
 
@@ -71,7 +25,7 @@ A OVHcloud oferece atualmente 4 ofertas de e-mail. Para compreender as suas espe
   <Tab label="E-mails / MX Plan">
     <img className="thumbnail" alt="MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/mxplan01.png" loading="lazy" />
     
-    1. A oferta de e-mail mais antiga da OVHcloud, que inclui as funções essenciais de um serviço de e-mail com 5 GB de espaço de armazenamento por conta de e-mail.
+    1. A oferta de e-mail histórica da OVHcloud, que inclui as funções essenciais de um serviço de e-mail com 5 GB de espaço de armazenamento por conta de e-mail.
     2. Incluída com as ofertas de alojamento web e pode ser encomendada através da <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>.
     3. Esta oferta está disponível nas seguintes tecnologias de webmail:
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -44,11 +44,11 @@ A OVHcloud oferece atualmente 4 ofertas de e-mail. Para compreender as suas espe
     2. Pode encomendar uma conta Zimbra através da <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> ou diretamente em [ovhcloud.com](https://www.ovhcloud.com/pt/mail/).
     3. Como o nome indica, utiliza a interface **Zimbra**.
   </Tab>
-  <Tab label="E-mails Pro" availableIn={['eu']}>
-    <img className="thumbnail" alt="E-mail Pro" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/emailpro01.png" loading="lazy" />
+  <Tab label="Email Pro" availableIn={['eu']}>
+    <img className="thumbnail" alt="Email Pro" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails/emailpro01.png" loading="lazy" />
     
     1. Oferta de e-mail baseada na tecnologia Exchange, com funcionalidades essenciais e um espaço de armazenamento de 10 GB.
-    2. Pode encomendar uma conta E-mail Pro através da <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> ou diretamente através de [ovhcloud.com](https://www.ovhcloud.com/pt/mail/).
+    2. Pode encomendar uma conta Email Pro através da <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> ou diretamente através de [ovhcloud.com](https://www.ovhcloud.com/pt/mail/).
     3. Esta oferta utiliza a interface webmail **OWA** (Outlook Web Access).
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
@@ -236,7 +236,7 @@ Disponibilizamos guias que o ajudarão nesse processo. Aceda a eles [aqui](/guid
     **Smartphone ou tablet Android**
     - [Gmail para Android](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-android).
   </Tab>
-  <Tab label="E-mails Pro" availableIn={['eu']}>
+  <Tab label="Email Pro" availableIn={['eu']}>
     **Computador com Windows**
     - [Outlook para Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/outlook-windows-configuration).
     - [Thunderbird para Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/how-to-configure-thunderbird).
@@ -370,7 +370,7 @@ Deseja mudar [de oferta de e-mail](https://www.ovhcloud.com/pt/emails/) para ben
 
 <Region zones={['eu']}>
 
-[Migrar um endereço de e-mail MX Plan para uma conta E-mail Pro ou Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+[Migrar um endereço de e-mail MX Plan para uma conta Email Pro ou Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
 
 </Region>
 


### PR DESCRIPTION
## Problem
On MX Plan (EU), a service runs on one of three webmail technologies — Roundcube,
OWA or Zimbra — depending on the offer and the transition it went through. Two
recurring misunderstandings need to be addressed in the docs:

1. Customers/support think an existing service can be **switched from one technology
   to another** (e.g. Roundcube → Zimbra). It cannot — the technology is fixed.
2. The historical "old vs new MX Plan" framing is **obsolete**: that migration path
   no longer exists, so wording around choosing/migrating between versions only adds
   confusion.

This concerns the **EU zone only** — the only zone that went through the
multi-technology transition (CA/APAC MX Plan is OWA-only).

## Changes
**1. MX Plan email-technology note** (commit 1)
- EU-gated `:::warning` note added to `mx-plan/email-generalities` (Getting started,
  Objective section) and `mx-plan/faq-emails` (after the offers block), all 7 locales,
  wrapped in `<Region zones={['eu']}>`. The "old/new version" wording is dropped.

**2. Emails FAQ cleanup** (commit 2)
- Reworded the MX Plan description from "oldest" to "original/historical" (7 locales).
- Fixed the ES tab label "Emails Pro" → "Email Pro" (product-name typo).
- Removed the redundant Control Panel access (CP-NAV) block from the FAQ.
- Normalized the Italian register to informal "tu" in the two edited guides (they were
  mixed tu/voi; the guides' dominant register is tu).
- Bumped `lastUpdated`.

## Out of scope (intentionally not touched)
- Cross-solution migration guides (`migrating/*`, `zimbra/migrate-mxplan-to-zimbra`):
  migrating an MX Plan account to **another solution** is supported — the note must not
  contradict this.
- A full IT tu/voi register sweep across the rest of the email tree (~193 `voi`
  occurrences in 25 files) — belongs in a dedicated PR.

## Testing
- `pnpm dev` (fr/en/es/de): both guides compile (HTTP 200), no MDX error.
- Warning renders as a callout in the EU zone and is absent in CA/APAC.
- `sidebar:validate` unaffected; register conversion is prose-only (no markup change).

## Source (feedback)
- https://help.ovhcloud.com/csm/fr-mx-plan-getting-started
- https://help.ovhcloud.com/csm/fr-mx-plan-emails-faq
