### PR TITLE
fix(occ): add missing temp 301 for logs-forwarding

### DIFF
--- a/docs/public/301.map
+++ b/docs/public/301.map
@@ -240,6 +240,13 @@
 /it/guides/network/ovhcloud-connect/introduction /it/guides/network/ovhcloud-connect/ovhcloud-connect-overview;
 /pl/guides/network/ovhcloud-connect/introduction /pl/guides/network/ovhcloud-connect/ovhcloud-connect-overview;
 /pt/guides/network/ovhcloud-connect/introduction /pt/guides/network/ovhcloud-connect/ovhcloud-connect-overview;
+/en/guides/network/ovhcloud-connect/logs-forwarding /en/guides/network/ovhcloud-connect/logs-to-customers;
+/fr/guides/network/ovhcloud-connect/logs-forwarding /fr/guides/network/ovhcloud-connect/logs-to-customers;
+/de/guides/network/ovhcloud-connect/logs-forwarding /de/guides/network/ovhcloud-connect/logs-to-customers;
+/es/guides/network/ovhcloud-connect/logs-forwarding /es/guides/network/ovhcloud-connect/logs-to-customers;
+/it/guides/network/ovhcloud-connect/logs-forwarding /it/guides/network/ovhcloud-connect/logs-to-customers;
+/pl/guides/network/ovhcloud-connect/logs-forwarding /pl/guides/network/ovhcloud-connect/logs-to-customers;
+/pt/guides/network/ovhcloud-connect/logs-forwarding /pt/guides/network/ovhcloud-connect/logs-to-customers;
 # Revamp-only guides (no old equivalent) -> product overview:
 /en/guides/network/ovhcloud-connect/glossary /en/guides/network/ovhcloud-connect/overview;
 /fr/guides/network/ovhcloud-connect/glossary /fr/guides/network/ovhcloud-connect/overview;


### PR DESCRIPTION
The OCC revert recorded logs-forwarding -> logs-to-customers as a git rename, so it was missed by the delete-only slug scan in the first temp-301 batch (#341 follow-up). Its published URL (/{locale}/guides/network/ovhcloud-connect/ logs-forwarding) still 404s. Add the 7 locale redirects to logs-to-customers, inside the existing TEMP OCC-revert block.

TEMP: delete with the rest of the block when the next OCC revamp lands.