### PR TITLE
[SK-2737] WEB -Emaisl - Locked for spam - state mail solutions are not for transactional/bulk mailing

### DIFF
--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,6 +1,6 @@
 ---
-title: Was tun, wenn Ihre E-Mail-Adresse wegen Spamversands gesperrt wurde
-description: "Eine wegen Spamversands gesperrte E-Mail-Adresse entsperren: Ursache der verdächtigen Aktivität identifizieren, beheben und den OVHcloud Support kontaktieren."
+title: "E-Mail-Adresse wegen Spam gesperrt: Was tun?"
+description: "Eine wegen Spam gesperrte E-Mail-Adresse entsperren: Ursache der verdächtigen Aktivität identifizieren, beheben und den OVHcloud Support kontaktieren."
 lastUpdated: 2026-07-09
 availableIn: [eu, ca, apac]
 ---
@@ -19,7 +19,7 @@ Wenn Ihre E-Mail-Adresse wegen Spamversands gesperrt ist, bedeutet dies, dass be
 
 ## Voraussetzungen
 
-- Sie verfügen über eine [OVHcloud E-Mail-Lösung](https://www.ovhcloud.com/de/emails/).
+- Sie verfügen über eine [OVHcloud E-Mail-Lösung](/links/web/emails).
 - Sie sind in Ihrem <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> angemeldet.
 
 {/* CP-NAV-START:web-mx-plan */}
@@ -262,8 +262,8 @@ Informationen zur Verwaltung von Aliassen und Weiterleitungen Ihrer E-Mail-Adres
 
 Informationen dazu, wie Sie Ihre Filter und Abwesenheitsbenachrichtigungen über das Webmail einsehen können, finden Sie in den Anleitungen [E-Mail-Adresse über das Roundcube Webmail nutzen](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) und [Das Zimbra Webmail nutzen](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
 
-Für spezialisierte Dienstleistungen (SEO, Entwicklung usw.) wenden Sie sich an die [OVHcloud Partner](https://partner.ovhcloud.com/de/directory/).
+Für spezialisierte Dienstleistungen (SEO, Entwicklung usw.) wenden Sie sich an die [OVHcloud Partner](/links/partner).
 
-Wenn Sie Unterstützung bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen wünschen, lesen Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
+Wenn Sie Unterstützung bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen wünschen, lesen Sie unsere [Support-Angebote](/links/support).
 
-Treten Sie unserer [User Community](https://community.ovhcloud.com/community/de) bei.
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -58,7 +58,13 @@ Wenn Ihre E-Mail-Adresse wegen Spamversands gesperrt ist, bedeutet dies, dass be
 
 ## In der praktischen Anwendung <a name="instructions"></a>
 
-Bevor Sie fortfahren: Falls die Sperrung eine MX Plan E-Mail-Adresse betrifft, identifizieren Sie zunächst die von Ihrer Lösung verwendete E-Mail-Technologie, um den richtigen Entsperrvorgang zu befolgen. Für die Lösungen **Zimbra Starter** und **Zimbra Pro** wechseln Sie direkt zum Tab **Zimbra** in Schritt 2, ohne dabei die Prüfungen aus Schritt 1 zu überspringen.
+Bevor Sie fortfahren: Falls die Sperrung eine MX Plan E-Mail-Adresse betrifft, identifizieren Sie zunächst die von Ihrer Lösung verwendete E-Mail-Technologie, um den richtigen Entsperrvorgang zu befolgen.
+
+<Region zones={['eu']}>
+
+Für die Lösungen **Zimbra Starter** und **Zimbra Pro** wechseln Sie direkt zum Tab **Zimbra** in Schritt 2, ohne dabei die Prüfungen aus Schritt 1 zu überspringen.
+
+</Region>
 
 **Identifizieren Sie die E-Mail-Technologie Ihrer MX Plan Lösung**
 
@@ -119,15 +125,32 @@ Wurde die vom Anti-Spam-System erkannte verdächtige Aktivität nicht von den re
 
 - Überprüfen Sie die auf der wegen Spamversands gesperrten E-Mail-Adresse konfigurierten Abwesenheitsbenachrichtigungen über einen E-Mail-Client oder das Webmail.
 
+<Region zones={['eu']}>
+
 :::info
 Filter, Weiterleitungen und Abwesenheitsbenachrichtigungen, die direkt im Webmail (Zimbra, OWA) oder in Ihrem E-Mail-Client konfiguriert wurden, sind für den OVHcloud Support nicht zugänglich: Der Support kann sie nicht für Sie überprüfen. Diese Prüfungen müssen Sie selbst durchführen, entweder über das Webmail oder über ein bereits mit der Adresse konfiguriertes Gerät.
 
 :::
 
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+:::info
+Filter, Weiterleitungen und Abwesenheitsbenachrichtigungen, die direkt im Webmail (OWA) oder in Ihrem E-Mail-Client konfiguriert wurden, sind für den OVHcloud Support nicht zugänglich: Der Support kann sie nicht für Sie überprüfen. Diese Prüfungen müssen Sie selbst durchführen, entweder über das Webmail oder über ein bereits mit der Adresse konfiguriertes Gerät.
+
+:::
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 Wenn die Sperrung eine Adresse mit der Technologie **Zimbra** betrifft (MX Plan - Zimbra, Zimbra Starter oder Zimbra Pro), ist die Adresse **nicht mehr zugänglich**: Zusätzlich zum E-Mail-Versand wird auch die Anmeldung am Zimbra-Webmail gesperrt. Filter, Weiterleitungen und Abwesenheitsbenachrichtigungen können daher nicht mehr über das Webmail eingesehen werden.
 
 :::
+
+</Region>
 
 #### Einen Filter einrichten, um SPAM- / DCE-Nachrichten zu isolieren
 
@@ -260,7 +283,17 @@ Wenn ein neues Passwort erforderlich ist, achten Sie darauf, dass es ausreichend
 
 Informationen zur Verwaltung von Aliassen und Weiterleitungen Ihrer E-Mail-Adresse finden Sie in der Anleitung [E-Mail-Aliasse und Weiterleitungen verwenden](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 Informationen dazu, wie Sie Ihre Filter und Abwesenheitsbenachrichtigungen über das Webmail einsehen können, finden Sie in den Anleitungen [E-Mail-Adresse über das Roundcube Webmail nutzen](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) und [Das Zimbra Webmail nutzen](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Informationen dazu, wie Sie Ihre Filter und Abwesenheitsbenachrichtigungen über das Webmail einsehen können, finden Sie in der Anleitung [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 Für spezialisierte Dienstleistungen (SEO, Entwicklung usw.) wenden Sie sich an die [OVHcloud Partner](/links/partner).
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E-Mail-Adresse wegen Spam gesperrt: Was tun?"
 description: "Eine wegen Spam gesperrte E-Mail-Adresse entsperren: Ursache der verdächtigen Aktivität identifizieren, beheben und den OVHcloud Support kontaktieren."
-lastUpdated: 2026-07-09
+lastUpdated: 2026-07-10
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: Was tun, wenn Ihre E-Mail-Adresse wegen Spamversands gesperrt wurde
 description: "Eine wegen Spamversands gesperrte E-Mail-Adresse entsperren: Ursache der verdächtigen Aktivität identifizieren, beheben und den OVHcloud Support kontaktieren."
-lastUpdated: 2026-05-28
+lastUpdated: 2026-07-09
 availableIn: [eu, ca, apac]
 ---
 
@@ -100,7 +100,7 @@ Die genauen Gründe für eine Sperrung können nicht offengelegt werden, um zu v
 :::
 
 :::warning
-**Unsere E-Mail-Lösungen (MX Plan, Email Pro, Exchange, Zimbra) sind nicht für den Versand von Transaktions- oder Massen-E-Mails ausgelegt** (automatische Benachrichtigungen, Bestellbestätigungen, Passwort-Zurücksetzungen, E-Mail-Kampagnen usw.). Verwenden Sie für diese Zwecke einen dedizierten Dienst (einen Mailinglisten-Dienst oder eine Plattform für Transaktions-E-Mails). Die Nutzung einer Standard-E-Mail-Adresse für solche Versendungen erhöht das Risiko einer Sperrung wegen verdächtiger Aktivitäten erheblich.
+**Unsere E-Mail-Lösungen sind nicht für den Versand von Transaktions- oder Massen-E-Mails ausgelegt** (automatische Benachrichtigungen, Bestellbestätigungen, Passwort-Zurücksetzungen, E-Mail-Kampagnen usw.). Verwenden Sie für diese Zwecke einen dedizierten Dienst (einen Mailinglisten-Dienst oder eine Plattform für Transaktions-E-Mails). Die Nutzung einer Standard-E-Mail-Adresse für solche Versendungen erhöht das Risiko einer Sperrung wegen verdächtiger Aktivitäten erheblich.
 
 :::
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -99,6 +99,11 @@ Die genauen Gründe für eine Sperrung können nicht offengelegt werden, um zu v
 
 :::
 
+:::warning
+**Unsere E-Mail-Lösungen (MX Plan, Email Pro, Exchange, Zimbra) sind nicht für den Versand von Transaktions- oder Massen-E-Mails ausgelegt** (automatische Benachrichtigungen, Bestellbestätigungen, Passwort-Zurücksetzungen, E-Mail-Kampagnen usw.). Verwenden Sie für diese Zwecke einen dedizierten Dienst (einen Mailinglisten-Dienst oder eine Plattform für Transaktions-E-Mails). Die Nutzung einer Standard-E-Mail-Adresse für solche Versendungen erhöht das Risiko einer Sperrung wegen verdächtiger Aktivitäten erheblich.
+
+:::
+
 
 Prüfen Sie zunächst mit den Nutzern der gesperrten E-Mail-Adresse, ob diese nicht selbst für die Sperrung verantwortlich sind, etwa durch eine ungewöhnliche Nutzung der E-Mail-Adresse (zum Beispiel Massenversand von E-Mails). Sollte dies der Fall sein, müssen Sie die Situation bereinigen, bevor Sie die Adresse entsperren lassen.
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -19,7 +19,7 @@ When your email address is blocked for spam, this means that suspicious activity
 
 ## Requirements
 
-- An [OVHcloud email solution](https://www.ovhcloud.com/en/emails/).
+- An [OVHcloud email solution](/links/web/emails).
 - You are logged in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
 
 {/* CP-NAV-START:web-mx-plan */}
@@ -262,8 +262,8 @@ To manage the aliases and redirections of your email address, see the guide [Usi
 
 To view your filters and auto-replies from the webmail, see the guides [Using your email address from the Roundcube webmail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) and [Using the Zimbra webmail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en/support-levels/).
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
-Join our [community of users](https://community.ovhcloud.com/community/en).
+Join our [community of users](/links/community).

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: What to do if your email address is blocked for spam
 description: "Unblock an email address blocked for spam: identify the cause of the suspicious activity, fix it and contact OVHcloud support."
-lastUpdated: 2026-07-09
+lastUpdated: 2026-07-10
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: What to do if your email address is blocked for spam
 description: "Unblock an email address blocked for spam: identify the cause of the suspicious activity, fix it and contact OVHcloud support."
-lastUpdated: 2026-05-28
+lastUpdated: 2026-07-09
 availableIn: [eu, ca, apac]
 ---
 
@@ -100,7 +100,7 @@ The precise reasons for a block cannot be disclosed, in order to prevent any att
 :::
 
 :::warning
-**Our email solutions (MX Plan, Email Pro, Exchange, Zimbra) are not designed for sending transactional or bulk email** (automated notifications, order confirmations, password resets, email marketing campaigns, etc.). For this type of use, rely on a dedicated service (a mailing list service or a transactional email platform). Using a standard email address for such sending greatly increases the risk of a block for suspicious activity.
+**Our email solutions are not designed for sending transactional or bulk email** (automated notifications, order confirmations, password resets, email marketing campaigns, etc.). For this type of use, rely on a dedicated service (a mailing list service or a transactional email platform). Using a standard email address for such use greatly increases the risk of a block for suspicious activity.
 
 :::
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -99,6 +99,11 @@ The precise reasons for a block cannot be disclosed, in order to prevent any att
 
 :::
 
+:::warning
+**Our email solutions (MX Plan, Email Pro, Exchange, Zimbra) are not designed for sending transactional or bulk email** (automated notifications, order confirmations, password resets, email marketing campaigns, etc.). For this type of use, rely on a dedicated service (a mailing list service or a transactional email platform). Using a standard email address for such sending greatly increases the risk of a block for suspicious activity.
+
+:::
+
 
 First of all, check with the user(s) of the blocked email address that they are not directly responsible for the block, following an unusual use of the email address (for example, mass email sending). If this is the case, you must rectify the situation before unblocking the address.
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -58,7 +58,13 @@ When your email address is blocked for spam, this means that suspicious activity
 
 ## Instructions <a name="instructions"></a>
 
-Before continuing, if the block concerns an MX Plan email address, identify the email technology used by your solution in order to follow the correct unblocking process. For **Zimbra Starter** and **Zimbra Pro** solutions, go directly to the **Zimbra** tab in step 2, without skipping the checks in step 1.
+Before continuing, if the block concerns an MX Plan email address, identify the email technology used by your solution in order to follow the correct unblocking process.
+
+<Region zones={['eu']}>
+
+For **Zimbra Starter** and **Zimbra Pro** solutions, go directly to the **Zimbra** tab in step 2, without skipping the checks in step 1.
+
+</Region>
 
 **Identify the email technology of your MX Plan solution**
 
@@ -119,15 +125,32 @@ If the suspicious activity detected by the anti-spam system was not initiated by
 
 - Check the auto-replies configured on the email address blocked for spam, via an email client or webmail.
 
+<Region zones={['eu']}>
+
 :::info
 Filters, redirections and auto-replies configured directly on the webmail (Zimbra, OWA) or in your email client are not accessible to OVHcloud support: support cannot check them on your behalf. These checks must be carried out by you, from the webmail or from a device already configured with the address.
 
 :::
 
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+:::info
+Filters, redirections and auto-replies configured directly on the webmail (OWA) or in your email client are not accessible to OVHcloud support: support cannot check them on your behalf. These checks must be carried out by you, from the webmail or from a device already configured with the address.
+
+:::
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 If the block concerns an address using the **Zimbra** technology (MX Plan - Zimbra, Zimbra Starter or Zimbra Pro), the address is **no longer accessible**: the Zimbra webmail login is suspended in addition to email sending. Filters, redirections and auto-replies can therefore no longer be consulted from the webmail.
 
 :::
+
+</Region>
 
 #### Set up a filter to isolate SPAM / DCE messages
 
@@ -260,7 +283,17 @@ If a new password is needed, make sure it is sufficiently strong. Use a reputabl
 
 To manage the aliases and redirections of your email address, see the guide [Using email aliases and redirections](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 To view your filters and auto-replies from the webmail, see the guides [Using your email address from the Roundcube webmail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) and [Using the Zimbra webmail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+To view your filters and auto-replies from the webmail, see the guide [Using the Outlook Web App (OWA) webmail](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -99,6 +99,11 @@ Las razones concretas de un bloqueo no pueden ser divulgadas para evitar cualqui
 
 :::
 
+:::warning
+**Nuestras soluciones de correo (MX Plan, Email Pro, Exchange, Zimbra) no están diseñadas para el envío de correos transaccionales o masivos** (notificaciones automáticas, confirmaciones de pedido, restablecimientos de contraseña, campañas de emailing, etc.). Para este tipo de uso, utilice un servicio dedicado (un servicio de listas de correo o una plataforma de correo transaccional). Utilizar una dirección de correo estándar para estos envíos aumenta considerablemente el riesgo de bloqueo por actividad sospechosa.
+
+:::
+
 
 En primer lugar, asegúrese, con el o los usuarios de la dirección de correo electrónico bloqueada, de que no son los causantes directos del bloqueo debido a un uso inusual de la dirección (por ejemplo, tras envíos masivos de correos electrónicos). Si es así, debe corregir la situación antes de desbloquear la dirección.
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: ¿Qué hacer si una dirección de correo electrónico está bloqueada por spam?
 description: "Desbloquee una dirección de correo electrónico bloqueada por spam: identifique la causa de la actividad sospechosa, corríjala y contacte con el soporte de OVHcloud."
-lastUpdated: 2026-05-28
+lastUpdated: 2026-07-09
 availableIn: [eu, ca, apac]
 ---
 
@@ -100,7 +100,7 @@ Las razones concretas de un bloqueo no pueden ser divulgadas para evitar cualqui
 :::
 
 :::warning
-**Nuestras soluciones de correo (MX Plan, Email Pro, Exchange, Zimbra) no están diseñadas para el envío de correos transaccionales o masivos** (notificaciones automáticas, confirmaciones de pedido, restablecimientos de contraseña, campañas de emailing, etc.). Para este tipo de uso, utilice un servicio dedicado (un servicio de listas de correo o una plataforma de correo transaccional). Utilizar una dirección de correo estándar para estos envíos aumenta considerablemente el riesgo de bloqueo por actividad sospechosa.
+**Nuestras soluciones de correo no están diseñadas para el envío de correos transaccionales o masivos** (notificaciones automáticas, confirmaciones de pedido, restablecimientos de contraseña, campañas de emailing, etc.). Para este tipo de uso, utilice un servicio dedicado (un servicio de listas de correo o una plataforma de correo transaccional). Utilizar una dirección de correo estándar para estos envíos aumenta considerablemente el riesgo de bloqueo por actividad sospechosa.
 
 :::
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -58,7 +58,13 @@ Cuando su dirección de correo electrónico está bloqueada por spam, significa 
 
 ## Procedimiento <a name="instructions"></a>
 
-Antes de continuar, y si el bloqueo afecta a una dirección de correo electrónico de tipo MX Plan, identifique la tecnología de correo electrónico utilizada por su plan para seguir el proceso de desbloqueo adecuado. Para los planes **Zimbra Starter** y **Zimbra Pro**, vaya directamente a la pestaña **Zimbra** de la etapa 2, sin omitir las comprobaciones de la etapa 1.
+Antes de continuar, y si el bloqueo afecta a una dirección de correo electrónico de tipo MX Plan, identifique la tecnología de correo electrónico utilizada por su plan para seguir el proceso de desbloqueo adecuado.
+
+<Region zones={['eu']}>
+
+Para los planes **Zimbra Starter** y **Zimbra Pro**, vaya directamente a la pestaña **Zimbra** de la etapa 2, sin omitir las comprobaciones de la etapa 1.
+
+</Region>
 
 **Identificar la tecnología de correo electrónico de su plan MX Plan.**
 
@@ -119,15 +125,32 @@ Si la actividad sospechosa detectada por el antispam no ha sido iniciada por los
 
 - Compruebe las respuestas automáticas configuradas en la dirección de correo electrónico bloqueada por spam, mediante un software de mensajería o el webmail.
 
+<Region zones={['eu']}>
+
 :::info
 Los filtros, redirecciones y respuestas automáticas configurados directamente en el webmail (Zimbra, OWA) o en su software de mensajería no son accesibles para el soporte de OVHcloud: no puede verificarlos en su lugar. Estas comprobaciones deben realizarse por su cuenta, desde el webmail o un equipo ya configurado con la dirección.
 
 :::
 
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+:::info
+Los filtros, redirecciones y respuestas automáticas configurados directamente en el webmail (OWA) o en su software de mensajería no son accesibles para el soporte de OVHcloud: no puede verificarlos en su lugar. Estas comprobaciones deben realizarse por su cuenta, desde el webmail o un equipo ya configurado con la dirección.
+
+:::
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 Si el bloqueo afecta a una dirección que utiliza la tecnología **Zimbra** (MX Plan - Zimbra, Zimbra Starter o Zimbra Pro), la dirección **deja de ser accesible**: además del envío, se suspende la conexión al webmail Zimbra. Los filtros, redirecciones y respuestas automáticas dejan de ser consultables desde el webmail.
 
 :::
+
+</Region>
 
 #### Configurar un filtro para aislar los mensajes SPAM / DCE
 
@@ -260,7 +283,17 @@ Si es necesario establecer una nueva contraseña, asegúrese de que sea lo sufic
 
 Para gestionar los alias y las redirecciones de su dirección de correo electrónico, consulte la guía [Utilizar alias y redirecciones de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 Para consultar sus filtros y respuestas automáticas desde el webmail, consulte las guías [Utilizar su dirección de correo electrónico desde el webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) y [Utilizar el webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Para consultar sus filtros y respuestas automáticas desde el webmail, consulte la guía [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 Para prestaciones especializadas (posicionamiento web, desarrollo, etc.), contacte con los [partners de OVHcloud](/links/partner).
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,6 +1,6 @@
 ---
-title: ¿Qué hacer si una dirección de correo electrónico está bloqueada por spam?
-description: "Desbloquee una dirección de correo electrónico bloqueada por spam: identifique la causa de la actividad sospechosa, corríjala y contacte con el soporte de OVHcloud."
+title: "Correo electrónico bloqueado por spam: ¿qué hacer?"
+description: "Desbloquee una dirección de correo bloqueada por spam: identifique la causa de la actividad sospechosa, corríjala y contacte con el soporte OVHcloud."
 lastUpdated: 2026-07-09
 availableIn: [eu, ca, apac]
 ---
@@ -19,7 +19,7 @@ Cuando su dirección de correo electrónico está bloqueada por spam, significa 
 
 ## Requisitos
 
-- Disponer de un [plan de correo electrónico de OVHcloud](https://www.ovhcloud.com/es-es/emails/).
+- Disponer de un [plan de correo electrónico de OVHcloud](/links/web/emails).
 - Haber iniciado sesión en su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>.
 
 {/* CP-NAV-START:web-mx-plan */}
@@ -262,8 +262,8 @@ Para gestionar los alias y las redirecciones de su dirección de correo electró
 
 Para consultar sus filtros y respuestas automáticas desde el webmail, consulte las guías [Utilizar su dirección de correo electrónico desde el webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) y [Utilizar el webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
 
-Para prestaciones especializadas (posicionamiento web, desarrollo, etc.), contacte con los [partners de OVHcloud](https://partner.ovhcloud.com/es/directory/).
+Para prestaciones especializadas (posicionamiento web, desarrollo, etc.), contacte con los [partners de OVHcloud](/links/partner).
 
-Para recibir asistencia en el uso y la configuración de sus soluciones de OVHcloud, consulte nuestras [ofertas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
+Para recibir asistencia en el uso y la configuración de sus soluciones de OVHcloud, consulte nuestras [ofertas de soporte](/links/support).
 
-Interactúe con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/es).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Correo electrónico bloqueado por spam: ¿qué hacer?"
 description: "Desbloquee una dirección de correo bloqueada por spam: identifique la causa de la actividad sospechosa, corríjala y contacte con el soporte OVHcloud."
-lastUpdated: 2026-07-09
+lastUpdated: 2026-07-10
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -19,7 +19,7 @@ Lorsque votre adresse e-mail est bloquée pour spam, cela signifie qu'une activi
 
 ## Prérequis
 
-- Disposer d'une [offre e-mail OVHcloud](https://www.ovhcloud.com/fr/emails/).
+- Disposer d'une [offre e-mail OVHcloud](/links/web/emails).
 - Être connecté à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
 
 {/* CP-NAV-START:web-mx-plan */}
@@ -262,9 +262,9 @@ Pour gérer les alias et redirections de votre adresse e-mail, consultez le guid
 
 Pour consulter vos filtres et réponses automatiques depuis le webmail, consultez les guides [Utiliser son adresse e-mail depuis le webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) et [Utiliser le webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
 
-Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/).
+Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](/links/partner).
 
-Pour une assistance à l'usage et à la configuration de vos solutions OVHcloud, consultez nos [offres de support](https://www.ovhcloud.com/fr/support-levels/).
+Pour une assistance à l'usage et à la configuration de vos solutions OVHcloud, consultez nos [offres de support](/links/support).
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -99,6 +99,11 @@ Les raisons précises d'un blocage ne peuvent pas être divulguées pour éviter
 
 :::
 
+:::warning
+**Nos solutions e-mail (MX Plan, Email Pro, Exchange, Zimbra) ne sont pas conçues pour l'envoi de courriers transactionnels ou massifs** (notifications automatiques, confirmations de commande, réinitialisations de mot de passe, campagnes d'e-mailing, etc.). Pour ce type d'usage, utilisez un service dédié (service de mailing list ou plateforme d'e-mailing transactionnel). Recourir à une adresse e-mail standard pour ces envois augmente fortement le risque de blocage pour activité suspecte.
+
+:::
+
 
 Tout d'abord, assurez-vous, auprès du (des) utilisateur(s) de l'adresse e-mail bloquée, qu'il(s) n'est (ne sont) pas directement à l'origine du blocage, suite à une utilisation inhabituelle de l'adresse e-mail (par exemple, suite à des envois massifs d'e-mails). Si c'est le cas, vous devez corriger la situation avant de débloquer l'adresse.
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -58,7 +58,13 @@ Lorsque votre adresse e-mail est bloquée pour spam, cela signifie qu'une activi
 
 ## En pratique <a name="instructions"></a>
 
-Avant de poursuivre et si le blocage concerne une adresse e-mail de type MX Plan, identifiez la technologie e-mail utilisée par votre offre pour suivre le bon processus de déblocage. Pour les offres **Zimbra Starter** et **Zimbra Pro**, rendez-vous directement à l'onglet **Zimbra** de l'étape 2, sans omettre les vérifications de l'étape 1.
+Avant de poursuivre et si le blocage concerne une adresse e-mail de type MX Plan, identifiez la technologie e-mail utilisée par votre offre pour suivre le bon processus de déblocage.
+
+<Region zones={['eu']}>
+
+Pour les offres **Zimbra Starter** et **Zimbra Pro**, rendez-vous directement à l'onglet **Zimbra** de l'étape 2, sans omettre les vérifications de l'étape 1.
+
+</Region>
 
 **Identifier la technologie e-mail de votre offre MX Plan**
 
@@ -119,15 +125,32 @@ Si l'activité suspecte détectée par l'anti-spam n'a pas été initiée par le
 
 - Vérifiez les réponses automatiques configurées sur l'adresse e-mail bloquée pour spam, via un logiciel de messagerie ou le webmail.
 
+<Region zones={['eu']}>
+
 :::info
 Les filtres, redirections et réponses automatiques qui sont configurés directement sur le webmail (Zimbra, OWA) ou dans votre logiciel de messagerie ne sont pas accessibles au support OVHcloud : il ne peut pas les vérifier à votre place. Ces vérifications doivent être réalisées par vos soins, depuis le webmail ou un poste déjà configuré avec l'adresse.
 
 :::
 
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+:::info
+Les filtres, redirections et réponses automatiques qui sont configurés directement sur le webmail (OWA) ou dans votre logiciel de messagerie ne sont pas accessibles au support OVHcloud : il ne peut pas les vérifier à votre place. Ces vérifications doivent être réalisées par vos soins, depuis le webmail ou un poste déjà configuré avec l'adresse.
+
+:::
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 Si le blocage concerne une adresse utilisant la technologie **Zimbra** (MX Plan - Zimbra, Zimbra Starter ou Zimbra Pro), l'adresse n'est **plus accessible** : la connexion au webmail Zimbra est suspendue en plus de l'envoi. Les filtres, redirections et réponses automatiques ne sont alors plus consultables depuis le webmail.
 
 :::
+
+</Region>
 
 #### Mettre en place un filtre pour isoler les messages SPAM / DCE
 
@@ -260,7 +283,17 @@ Si un nouveau mot de passe est nécessaire, veillez à ce qu'il soit suffisammen
 
 Pour gérer les alias et redirections de votre adresse e-mail, consultez le guide [Utiliser les alias et redirections e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 Pour consulter vos filtres et réponses automatiques depuis le webmail, consultez les guides [Utiliser son adresse e-mail depuis le webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) et [Utiliser le webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Pour consulter vos filtres et réponses automatiques depuis le webmail, consultez le guide [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](/links/partner).
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: Que faire en cas d'adresse e-mail bloquée pour spam ?
 description: "Débloquez une adresse e-mail bloquée pour spam : identifiez la cause de l'activité suspecte, corrigez-la et contactez le support OVHcloud."
-lastUpdated: 2026-05-28
+lastUpdated: 2026-07-09
 availableIn: [eu, ca, apac]
 ---
 
@@ -100,7 +100,7 @@ Les raisons précises d'un blocage ne peuvent pas être divulguées pour éviter
 :::
 
 :::warning
-**Nos solutions e-mail (MX Plan, Email Pro, Exchange, Zimbra) ne sont pas conçues pour l'envoi de courriers transactionnels ou massifs** (notifications automatiques, confirmations de commande, réinitialisations de mot de passe, campagnes d'e-mailing, etc.). Pour ce type d'usage, utilisez un service dédié (service de mailing list ou plateforme d'e-mailing transactionnel). Recourir à une adresse e-mail standard pour ces envois augmente fortement le risque de blocage pour activité suspecte.
+**Nos solutions e-mail ne sont pas conçues pour l'envoi de courriers transactionnels ou massifs** (notifications automatiques, confirmations de commande, réinitialisations de mot de passe, campagnes d'e-mailing, etc.). Pour ce type d'usage, utilisez un service dédié (service de mailing list ou plateforme d'e-mailing transactionnel). Recourir à une adresse e-mail standard pour ces envois augmente fortement le risque de blocage pour activité suspecte.
 
 :::
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: Que faire en cas d'adresse e-mail bloquée pour spam ?
 description: "Débloquez une adresse e-mail bloquée pour spam : identifiez la cause de l'activité suspecte, corrigez-la et contactez le support OVHcloud."
-lastUpdated: 2026-07-09
+lastUpdated: 2026-07-10
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -19,7 +19,7 @@ Quando il tuo indirizzo e-mail viene bloccato per spam, significa che è stata r
 
 ## Prerequisiti
 
-- Disporre di un'[offerta e-mail OVHcloud](https://www.ovhcloud.com/it/emails/).
+- Disporre di un'[offerta e-mail OVHcloud](/links/web/emails).
 - Aver effettuato l'accesso allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>.
 
 {/* CP-NAV-START:web-mx-plan */}
@@ -262,8 +262,8 @@ Per gestire gli alias e i reindirizzamenti del tuo indirizzo e-mail, consulta la
 
 Per consultare i tuoi filtri e le tue risposte automatiche dal webmail, consulta le guide [Utilizzare il proprio indirizzo e-mail dal webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) e [Utilizzare il webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
 
-Per servizi specializzati (posizionamento sui motori di ricerca, sviluppo, ecc.), contatta i [partner OVHcloud](https://partner.ovhcloud.com/it/directory/).
+Per servizi specializzati (posizionamento sui motori di ricerca, sviluppo, ecc.), contatta i [partner OVHcloud](/links/partner).
 
-Per assistenza nell'utilizzo e nella configurazione delle tue soluzioni OVHcloud, consulta le nostre [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
+Per assistenza nell'utilizzo e nella configurazione delle tue soluzioni OVHcloud, consulta le nostre [offerte di supporto](/links/support).
 
-Contatta la nostra [Community di utenti](https://community.ovhcloud.com/community/it).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cosa fare se un indirizzo e-mail è bloccato per spam?
 description: "Sblocca un indirizzo e-mail bloccato per spam: individua la causa dell'attività sospetta, correggila e contatta il supporto OVHcloud."
-lastUpdated: 2026-05-28
+lastUpdated: 2026-07-09
 availableIn: [eu, ca, apac]
 ---
 
@@ -100,7 +100,7 @@ I motivi precisi di un blocco non possono essere divulgati per evitare qualsiasi
 :::
 
 :::warning
-**Le nostre soluzioni email (MX Plan, Email Pro, Exchange, Zimbra) non sono progettate per l'invio di email transazionali o massive** (notifiche automatiche, conferme d'ordine, reimpostazioni della password, campagne di emailing, ecc.). Per questo tipo di utilizzo, utilizza un servizio dedicato (un servizio di mailing list o una piattaforma di email transazionali). Utilizzare un indirizzo email standard per questi invii aumenta notevolmente il rischio di blocco per attività sospetta.
+**Le nostre soluzioni email non sono progettate per l'invio di email transazionali o massive** (notifiche automatiche, conferme d'ordine, reimpostazioni della password, campagne di emailing, ecc.). Per questo tipo di utilizzo, utilizza un servizio dedicato (un servizio di mailing list o una piattaforma di email transazionali). Utilizzare un indirizzo email standard per questi invii aumenta notevolmente il rischio di blocco per attività sospetta.
 
 :::
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cosa fare se un indirizzo e-mail è bloccato per spam?
 description: "Sblocca un indirizzo e-mail bloccato per spam: individua la causa dell'attività sospetta, correggila e contatta il supporto OVHcloud."
-lastUpdated: 2026-07-09
+lastUpdated: 2026-07-10
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -58,7 +58,13 @@ Quando il tuo indirizzo e-mail viene bloccato per spam, significa che è stata r
 
 ## Procedura <a name="instructions"></a>
 
-Prima di proseguire, se il blocco riguarda un indirizzo e-mail di tipo MX Plan, individua la tecnologia e-mail utilizzata dalla tua offerta per seguire la procedura di sblocco corretta. Per le offerte **Zimbra Starter** e **Zimbra Pro**, vai direttamente alla scheda **Zimbra** della fase 2, senza tralasciare le verifiche della fase 1.
+Prima di proseguire, se il blocco riguarda un indirizzo e-mail di tipo MX Plan, individua la tecnologia e-mail utilizzata dalla tua offerta per seguire la procedura di sblocco corretta.
+
+<Region zones={['eu']}>
+
+Per le offerte **Zimbra Starter** e **Zimbra Pro**, vai direttamente alla scheda **Zimbra** della fase 2, senza tralasciare le verifiche della fase 1.
+
+</Region>
 
 **Individuare la tecnologia e-mail della tua offerta MX Plan**
 
@@ -119,15 +125,32 @@ Se l'attività sospetta rilevata dall'antispam non è stata avviata dall'utente 
 
 - Verifica le risposte automatiche configurate sull'indirizzo e-mail bloccato per spam, tramite un client di posta o il webmail.
 
+<Region zones={['eu']}>
+
 :::info
 I filtri, i reindirizzamenti e le risposte automatiche configurati direttamente nel webmail (Zimbra, OWA) o nel tuo client di posta non sono accessibili al supporto OVHcloud: non può verificarli al posto tuo. Queste verifiche devono essere effettuate da te, dal webmail o da una postazione già configurata con l'indirizzo.
 
 :::
 
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+:::info
+I filtri, i reindirizzamenti e le risposte automatiche configurati direttamente nel webmail (OWA) o nel tuo client di posta non sono accessibili al supporto OVHcloud: non può verificarli al posto tuo. Queste verifiche devono essere effettuate da te, dal webmail o da una postazione già configurata con l'indirizzo.
+
+:::
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 Se il blocco riguarda un indirizzo che utilizza la tecnologia **Zimbra** (MX Plan - Zimbra, Zimbra Starter o Zimbra Pro), l'indirizzo **non è più accessibile**: la connessione al webmail Zimbra è sospesa oltre all'invio. I filtri, i reindirizzamenti e le risposte automatiche non sono quindi più consultabili dal webmail.
 
 :::
+
+</Region>
 
 #### Impostare un filtro per isolare i messaggi SPAM / DCE
 
@@ -260,7 +283,17 @@ Se è necessaria una nuova password, assicurati che sia sufficientemente robusta
 
 Per gestire gli alias e i reindirizzamenti del tuo indirizzo e-mail, consulta la guida [Utilizzare gli alias e i reindirizzamenti e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 Per consultare i tuoi filtri e le tue risposte automatiche dal webmail, consulta le guide [Utilizzare il proprio indirizzo e-mail dal webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) e [Utilizzare il webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Per consultare i tuoi filtri e le tue risposte automatiche dal webmail, consulta la guida [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 Per servizi specializzati (posizionamento sui motori di ricerca, sviluppo, ecc.), contatta i [partner OVHcloud](/links/partner).
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -99,6 +99,11 @@ I motivi precisi di un blocco non possono essere divulgati per evitare qualsiasi
 
 :::
 
+:::warning
+**Le nostre soluzioni email (MX Plan, Email Pro, Exchange, Zimbra) non sono progettate per l'invio di email transazionali o massive** (notifiche automatiche, conferme d'ordine, reimpostazioni della password, campagne di emailing, ecc.). Per questo tipo di utilizzo, utilizza un servizio dedicato (un servizio di mailing list o una piattaforma di email transazionali). Utilizzare un indirizzo email standard per questi invii aumenta notevolmente il rischio di blocco per attività sospetta.
+
+:::
+
 
 Innanzitutto, verifica con l'utente (o gli utenti) dell'indirizzo e-mail bloccato che non sia stato lui stesso a causare direttamente il blocco, a seguito di un utilizzo insolito dell'indirizzo e-mail (ad esempio, dopo invii massivi di e-mail). Se è questo il caso, devi correggere la situazione prima di sbloccare l'indirizzo.
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,5 +1,5 @@
 ---
-title: Co zrobić, gdy Twój adres e-mail jest zablokowany z powodu spamu
+title: "Adres e-mail zablokowany z powodu spamu: co zrobić?"
 description: "Odblokuj adres e-mail zablokowany z powodu spamu: zidentyfikuj przyczynę podejrzanej aktywności, usuń ją i skontaktuj się z pomocą techniczną OVHcloud."
 lastUpdated: 2026-07-09
 availableIn: [eu, ca, apac]
@@ -19,7 +19,7 @@ Gdy Twój adres e-mail zostaje zablokowany z powodu spamu, oznacza to, że podcz
 
 ## Wymagania początkowe
 
-- Posiadanie [usługi e-mail OVHcloud](https://www.ovhcloud.com/pl/emails/).
+- Posiadanie [usługi e-mail OVHcloud](/links/web/emails).
 - Zalogowanie się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>.
 
 {/* CP-NAV-START:web-mx-plan */}
@@ -262,8 +262,8 @@ Aby zarządzać aliasami i przekierowaniami Twojego adresu e-mail, zapoznaj się
 
 Aby wyświetlić filtry i autorespondery z poziomu webmail, zapoznaj się z przewodnikami [Korzystanie z adresu e-mail w webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) oraz [Korzystanie z webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
 
-W przypadku usług specjalistycznych (SEO, programowanie itd.) skontaktuj się z [partnerami OVHcloud](https://partner.ovhcloud.com/pl/directory/).
+W przypadku usług specjalistycznych (SEO, programowanie itd.) skontaktuj się z [partnerami OVHcloud](/links/partner).
 
-Aby uzyskać pomoc w korzystaniu i konfigurowaniu rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami wsparcia](https://www.ovhcloud.com/pl/support-levels/).
+Aby uzyskać pomoc w korzystaniu i konfigurowaniu rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami wsparcia](/links/support).
 
-Dołącz do [grona naszych użytkowników](https://community.ovhcloud.com/community/pl).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adres e-mail zablokowany z powodu spamu: co zrobić?"
 description: "Odblokuj adres e-mail zablokowany z powodu spamu: zidentyfikuj przyczynę podejrzanej aktywności, usuń ją i skontaktuj się z pomocą techniczną OVHcloud."
-lastUpdated: 2026-07-09
+lastUpdated: 2026-07-10
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: Co zrobić, gdy Twój adres e-mail jest zablokowany z powodu spamu
 description: "Odblokuj adres e-mail zablokowany z powodu spamu: zidentyfikuj przyczynę podejrzanej aktywności, usuń ją i skontaktuj się z pomocą techniczną OVHcloud."
-lastUpdated: 2026-05-28
+lastUpdated: 2026-07-09
 availableIn: [eu, ca, apac]
 ---
 
@@ -100,7 +100,7 @@ Dokładne przyczyny blokady nie mogą zostać ujawnione, aby zapobiec próbom ob
 :::
 
 :::warning
-**Nasze rozwiązania e-mail (MX Plan, Email Pro, Exchange, Zimbra) nie są przeznaczone do wysyłania wiadomości transakcyjnych ani masowych** (automatyczne powiadomienia, potwierdzenia zamówień, resetowanie haseł, kampanie e-mailowe itp.). W przypadku takiego zastosowania skorzystaj z dedykowanej usługi (usługi list mailingowych lub platformy do wysyłki wiadomości transakcyjnych). Używanie standardowego adresu e-mail do takich wysyłek znacznie zwiększa ryzyko blokady za podejrzaną aktywność.
+**Nasze rozwiązania e-mail nie są przeznaczone do wysyłania wiadomości transakcyjnych ani masowych** (automatyczne powiadomienia, potwierdzenia zamówień, resetowanie haseł, kampanie e-mailowe itp.). W przypadku takiego zastosowania skorzystaj z dedykowanej usługi (usługi list mailingowych lub platformy do wysyłki wiadomości transakcyjnych). Używanie standardowego adresu e-mail do takich wysyłek znacznie zwiększa ryzyko blokady za podejrzaną aktywność.
 
 :::
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -99,6 +99,11 @@ Dokładne przyczyny blokady nie mogą zostać ujawnione, aby zapobiec próbom ob
 
 :::
 
+:::warning
+**Nasze rozwiązania e-mail (MX Plan, Email Pro, Exchange, Zimbra) nie są przeznaczone do wysyłania wiadomości transakcyjnych ani masowych** (automatyczne powiadomienia, potwierdzenia zamówień, resetowanie haseł, kampanie e-mailowe itp.). W przypadku takiego zastosowania skorzystaj z dedykowanej usługi (usługi list mailingowych lub platformy do wysyłki wiadomości transakcyjnych). Używanie standardowego adresu e-mail do takich wysyłek znacznie zwiększa ryzyko blokady za podejrzaną aktywność.
+
+:::
+
 
 Przede wszystkim sprawdź wraz z użytkownikiem (lub użytkownikami) zablokowanego adresu e-mail, czy nie są oni bezpośrednio odpowiedzialni za blokadę w wyniku nietypowego korzystania z adresu e-mail (na przykład masowa wysyłka wiadomości). Jeśli tak jest, musisz naprawić sytuację przed odblokowaniem adresu.
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -58,7 +58,13 @@ Gdy Twój adres e-mail zostaje zablokowany z powodu spamu, oznacza to, że podcz
 
 ## W praktyce <a name="instructions"></a>
 
-Zanim przejdziesz dalej, jeśli blokada dotyczy adresu e-mail w usłudze MX Plan, zidentyfikuj technologię e-mail wykorzystywaną przez Twoją usługę, aby postępować zgodnie z właściwą procedurą odblokowania. W przypadku usług **Zimbra Starter** i **Zimbra Pro** przejdź bezpośrednio do zakładki **Zimbra** w kroku 2, nie pomijając kontroli wymienionych w kroku 1.
+Zanim przejdziesz dalej, jeśli blokada dotyczy adresu e-mail w usłudze MX Plan, zidentyfikuj technologię e-mail wykorzystywaną przez Twoją usługę, aby postępować zgodnie z właściwą procedurą odblokowania.
+
+<Region zones={['eu']}>
+
+W przypadku usług **Zimbra Starter** i **Zimbra Pro** przejdź bezpośrednio do zakładki **Zimbra** w kroku 2, nie pomijając kontroli wymienionych w kroku 1.
+
+</Region>
 
 **Zidentyfikuj technologię e-mail Twojej usługi MX Plan**
 
@@ -119,15 +125,32 @@ Jeśli podejrzana aktywność wykryta przez system antyspamowy nie została zain
 
 - Sprawdź autorespondery skonfigurowane dla adresu e-mail zablokowanego z powodu spamu, w kliencie poczty lub w webmail.
 
+<Region zones={['eu']}>
+
 :::info
 Filtry, przekierowania i autorespondery skonfigurowane bezpośrednio w webmail (Zimbra, OWA) lub w Twoim kliencie poczty nie są dostępne dla pomocy technicznej OVHcloud: pomoc techniczna nie może ich sprawdzić w Twoim imieniu. Te kontrole musisz wykonać samodzielnie z poziomu webmail lub urządzenia już skonfigurowanego z danym adresem.
 
 :::
 
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+:::info
+Filtry, przekierowania i autorespondery skonfigurowane bezpośrednio w webmail (OWA) lub w Twoim kliencie poczty nie są dostępne dla pomocy technicznej OVHcloud: pomoc techniczna nie może ich sprawdzić w Twoim imieniu. Te kontrole musisz wykonać samodzielnie z poziomu webmail lub urządzenia już skonfigurowanego z danym adresem.
+
+:::
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 Jeśli blokada dotyczy adresu wykorzystującego technologię **Zimbra** (MX Plan - Zimbra, Zimbra Starter lub Zimbra Pro), adres **nie jest już dostępny**: logowanie do webmail Zimbra zostaje zawieszone razem z wysyłaniem e-maili. Filtrów, przekierowań i autoresponderów nie można już zatem sprawdzić z poziomu webmail.
 
 :::
+
+</Region>
 
 #### Skonfiguruj filtr izolujący wiadomości SPAM / DCE
 
@@ -260,7 +283,17 @@ Jeśli nowe hasło jest potrzebne, upewnij się, że jest ono wystarczająco sil
 
 Aby zarządzać aliasami i przekierowaniami Twojego adresu e-mail, zapoznaj się z przewodnikiem [Korzystanie z aliasów i przekierowań e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 Aby wyświetlić filtry i autorespondery z poziomu webmail, zapoznaj się z przewodnikami [Korzystanie z adresu e-mail w webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) oraz [Korzystanie z webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Aby wyświetlić filtry i autorespondery z poziomu webmail, zapoznaj się z przewodnikiem [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 W przypadku usług specjalistycznych (SEO, programowanie itd.) skontaktuj się z [partnerami OVHcloud](/links/partner).
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -99,6 +99,11 @@ Os motivos específicos de um bloqueio não podem ser divulgados para evitar qua
 
 :::
 
+:::warning
+**As nossas soluções de email (MX Plan, Email Pro, Exchange, Zimbra) não foram concebidas para o envio de emails transacionais ou em massa** (notificações automáticas, confirmações de encomenda, redefinições de palavra-passe, campanhas de emailing, etc.). Para este tipo de utilização, recorra a um serviço dedicado (um serviço de mailing list ou uma plataforma de email transacional). Utilizar um endereço de email padrão para estes envios aumenta consideravelmente o risco de bloqueio por atividade suspeita.
+
+:::
+
 
 Antes de mais, certifique-se, junto do(s) utilizador(es) do endereço de e-mail bloqueado, de que este(s) não está(ão) diretamente na origem do bloqueio, na sequência de uma utilização invulgar do endereço de e-mail (por exemplo, após envios massivos de e-mails). Se for o caso, deverá corrigir a situação antes de desbloquear o endereço.
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,5 +1,5 @@
 ---
-title: O que fazer no caso de um endereço de e-mail bloqueado por spam?
+title: "Endereço de e-mail bloqueado por spam: o que fazer?"
 description: "Desbloqueie um endereço de e-mail bloqueado por spam: identifique a causa da atividade suspeita, corrija-a e contacte o suporte da OVHcloud."
 lastUpdated: 2026-07-09
 availableIn: [eu, ca, apac]
@@ -19,7 +19,7 @@ Quando o seu endereço de e-mail é bloqueado por spam, isto significa que foi d
 
 ## Requisitos
 
-- Dispor de uma [solução de e-mail OVHcloud](https://www.ovhcloud.com/pt/emails/).
+- Dispor de uma [solução de e-mail OVHcloud](/links/web/emails).
 - Ter sessão iniciada na sua <ManagerLink to="/">área de cliente OVHcloud</ManagerLink>.
 
 {/* CP-NAV-START:web-mx-plan */}
@@ -262,8 +262,8 @@ Para gerir os aliases e reencaminhamentos do seu endereço de e-mail, consulte o
 
 Para consultar os seus filtros e respostas automáticas a partir do webmail, consulte os guias [Utilizar o seu endereço de e-mail a partir do webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) e [Utilizar o webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
 
-Para serviços especializados (referenciamento, desenvolvimento, etc.), contacte os [parceiros OVHcloud](https://partner.ovhcloud.com/pt/directory/).
+Para serviços especializados (referenciamento, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
 
-Para obter assistência na utilização e configuração das suas soluções OVHcloud, consulte as nossas [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
+Para obter assistência na utilização e configuração das suas soluções OVHcloud, consulte as nossas [ofertas de suporte](/links/support).
 
-Fale com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/pt).
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -58,7 +58,13 @@ Quando o seu endereço de e-mail é bloqueado por spam, isto significa que foi d
 
 ## Instruções <a name="instructions"></a>
 
-Antes de prosseguir, e se o bloqueio disser respeito a um endereço de e-mail do tipo MX Plan, identifique a tecnologia de e-mail utilizada pela sua oferta para seguir o processo de desbloqueio correto. Para as ofertas **Zimbra Starter** e **Zimbra Pro**, dirija-se diretamente ao separador **Zimbra** da etapa 2, sem omitir as verificações da etapa 1.
+Antes de prosseguir, e se o bloqueio disser respeito a um endereço de e-mail do tipo MX Plan, identifique a tecnologia de e-mail utilizada pela sua oferta para seguir o processo de desbloqueio correto.
+
+<Region zones={['eu']}>
+
+Para as ofertas **Zimbra Starter** e **Zimbra Pro**, dirija-se diretamente ao separador **Zimbra** da etapa 2, sem omitir as verificações da etapa 1.
+
+</Region>
 
 **Identificar a tecnologia de e-mail da sua oferta MX Plan**
 
@@ -119,15 +125,32 @@ Se a atividade suspeita detetada pelo antispam não tiver sido iniciada pelo(s) 
 
 - Verifique as respostas automáticas configuradas no endereço de e-mail bloqueado por spam, através de um software de correio eletrónico ou do webmail.
 
+<Region zones={['eu']}>
+
 :::info
 Os filtros, reencaminhamentos e respostas automáticas configurados diretamente no webmail (Zimbra, OWA) ou no seu software de correio eletrónico não são acessíveis ao suporte da OVHcloud: este não os pode verificar em sua substituição. Estas verificações devem ser realizadas por si, a partir do webmail ou de um posto já configurado com o endereço.
 
 :::
 
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+:::info
+Os filtros, reencaminhamentos e respostas automáticas configurados diretamente no webmail (OWA) ou no seu software de correio eletrónico não são acessíveis ao suporte da OVHcloud: este não os pode verificar em sua substituição. Estas verificações devem ser realizadas por si, a partir do webmail ou de um posto já configurado com o endereço.
+
+:::
+
+</Region>
+
+<Region zones={['eu']}>
+
 :::warning
 Se o bloqueio disser respeito a um endereço que utiliza a tecnologia **Zimbra** (MX Plan - Zimbra, Zimbra Starter ou Zimbra Pro), o endereço **deixa de estar acessível**: a ligação ao webmail Zimbra é suspensa, para além do envio. Os filtros, reencaminhamentos e respostas automáticas deixam então de ser consultáveis a partir do webmail.
 
 :::
+
+</Region>
 
 #### Configurar um filtro para isolar as mensagens SPAM / DCE
 
@@ -260,7 +283,17 @@ Se for necessária uma nova palavra-passe, certifique-se de que esta é suficien
 
 Para gerir os aliases e reencaminhamentos do seu endereço de e-mail, consulte o guia [Utilizar os aliases e reencaminhamentos de e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 Para consultar os seus filtros e respostas automáticas a partir do webmail, consulte os guias [Utilizar o seu endereço de e-mail a partir do webmail Roundcube](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube) e [Utilizar o webmail Zimbra](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra).
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Para consultar os seus filtros e respostas automáticas a partir do webmail, consulte o guia [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+
+</Region>
 
 Para serviços especializados (referenciamento, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: O que fazer no caso de um endereço de e-mail bloqueado por spam?
 description: "Desbloqueie um endereço de e-mail bloqueado por spam: identifique a causa da atividade suspeita, corrija-a e contacte o suporte da OVHcloud."
-lastUpdated: 2026-05-28
+lastUpdated: 2026-07-09
 availableIn: [eu, ca, apac]
 ---
 
@@ -100,7 +100,7 @@ Os motivos específicos de um bloqueio não podem ser divulgados para evitar qua
 :::
 
 :::warning
-**As nossas soluções de email (MX Plan, Email Pro, Exchange, Zimbra) não foram concebidas para o envio de emails transacionais ou em massa** (notificações automáticas, confirmações de encomenda, redefinições de palavra-passe, campanhas de emailing, etc.). Para este tipo de utilização, recorra a um serviço dedicado (um serviço de mailing list ou uma plataforma de email transacional). Utilizar um endereço de email padrão para estes envios aumenta consideravelmente o risco de bloqueio por atividade suspeita.
+**As nossas soluções de e-mail não foram concebidas para o envio de e-mails transacionais ou em massa** (notificações automáticas, confirmações de encomenda, redefinições de palavra-passe, campanhas de e-mailing, etc.). Para este tipo de utilização, recorra a um serviço dedicado (um serviço de mailing list ou uma plataforma de e-mail transacional). Utilizar um endereço de e-mail padrão para estes envios aumenta consideravelmente o risco de bloqueio por atividade suspeita.
 
 :::
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Endereço de e-mail bloqueado por spam: o que fazer?"
 description: "Desbloqueie um endereço de e-mail bloqueado por spam: identifique a causa da atividade suspeita, corrija-a e contacte o suporte da OVHcloud."
-lastUpdated: 2026-07-09
+lastUpdated: 2026-07-10
 availableIn: [eu, ca, apac]
 ---
 


### PR DESCRIPTION
## Context

Following support feedback on a case where a customer's mailbox was blocked
after being used for **transactional mailing**, we were asked to explicitly
state, in the locked-for-spam guide, that OVHcloud email solutions are not
dedicated to transactional mailing.

> Customer's mailbox is used for transactional mailing and got blocked.
> Blocking is not directly linked to transactional mailing, but transactional
> mailing is not recommended/allowed.

Ref: **SK-2737**

## What this PR does

Adds a warning note in **Step 1 – understand and address the cause of the block**
of the [locked-for-spam guide](https://docs.ovhcloud.com/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam), in all 7 locales.

> Our email solutions (MX Plan, Email Pro, Exchange, Zimbra) are not designed for
> sending transactional or bulk email (automated notifications, order confirmations,
> password resets, email marketing campaigns, etc.). For this type of use, rely on
> a dedicated service (a mailing list service or a transactional email platform).
> Using a standard email address for such sending greatly increases the risk of a
> block for suspicious activity.

## Editorial choices

- **Framed as best-practice guidance ("not designed for"), not a contractual prohibition.** A troubleshooting guide should not create a contractual commitment. If transactional mailing is contractually *forbidden*, the wording should instead link to the Terms (Conditions Particulières E-mail / AUP) — see follow-up.
- **Transactional ≠ bulk.** Transactional email can be low-volume but automated; the existing guide only covered mass mailing. This note closes that gap.

## Scope

| Locale | File |
|--------|------|
| fr, en, de, es, it, pl, pt | `docs/<locale>/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx` |

- Plain-text `:::warning` block — no new components, links, buttons or API references.
- `:::` fences balanced in all 7 files; renders live in `fr`/`en` (dev server only serves those two).

