### PR TITLE
fix(home): render hero title as h1 and add meta description

### DIFF
--- a/docs/de/index.mdx
+++ b/docs/de/index.mdx
@@ -1,5 +1,9 @@
 ---
 pageType: home
+description: >-
+  Willkommen in der OVHcloud Dokumentation. Hier finden Sie alle technischen
+  Anleitungen, Schritt-für-Schritt-Tutorials und Ressourcen, um Ihre
+  Cloud-Dienste sicher bereitzustellen, zu konfigurieren und zu verwalten.
 
 hero:
   name: OVHcloud documentation

--- a/docs/en/index.mdx
+++ b/docs/en/index.mdx
@@ -1,5 +1,9 @@
 ---
 pageType: home
+description: >-
+  Welcome to OVHcloud documentation. Find all our technical guides,
+  step-by-step tutorials and resources to deploy, configure and manage your
+  cloud services with confidence.
 
 hero:
   name: OVHcloud documentation

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -1,5 +1,9 @@
 ---
 pageType: home
+description: >-
+  Bienvenido a la documentación de OVHcloud. Encuentre todas nuestras guías
+  técnicas, tutoriales paso a paso y recursos para desplegar, configurar y
+  gestionar sus servicios cloud con total confianza.
 
 hero:
   name: OVHcloud documentation

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -1,5 +1,9 @@
 ---
 pageType: home
+description: >-
+  Bienvenue sur la documentation OVHcloud. Retrouvez tous nos guides techniques,
+  tutoriels pas à pas et ressources pour déployer, configurer et gérer vos
+  services cloud en toute sérénité.
 
 hero:
   name: OVHcloud documentation

--- a/docs/it/index.mdx
+++ b/docs/it/index.mdx
@@ -1,5 +1,9 @@
 ---
 pageType: home
+description: >-
+  Benvenuto nella documentazione OVHcloud. Trova tutte le nostre guide
+  tecniche, i tutorial passo dopo passo e le risorse per distribuire,
+  configurare e gestire i tuoi servizi cloud in tutta sicurezza.
 
 hero:
   name: OVHcloud documentation

--- a/docs/pl/index.mdx
+++ b/docs/pl/index.mdx
@@ -1,5 +1,9 @@
 ---
 pageType: home
+description: >-
+  Witamy w dokumentacji OVHcloud. Znajdź wszystkie nasze przewodniki
+  techniczne, samouczki krok po kroku i zasoby do wdrażania, konfigurowania
+  i zarządzania usługami cloud z pełnym zaufaniem.
 
 hero:
   name: OVHcloud documentation

--- a/docs/pt/index.mdx
+++ b/docs/pt/index.mdx
@@ -1,5 +1,9 @@
 ---
 pageType: home
+description: >-
+  Bem-vindo à documentação OVHcloud. Encontre todos os nossos guias técnicos,
+  tutoriais passo a passo e recursos para implementar, configurar e gerir os
+  seus serviços cloud com total confiança.
 
 hero:
   name: OVHcloud documentation

--- a/theme/components/HomeHero/index.scss
+++ b/theme/components/HomeHero/index.scss
@@ -88,6 +88,7 @@
   }
 
   &__title {
+    margin: 0;
     font-size: 1.8rem;
     line-height: 1.2em;
     font-weight: 700;

--- a/theme/components/HomeHero/index.tsx
+++ b/theme/components/HomeHero/index.tsx
@@ -43,12 +43,12 @@ function HomeHero({ beforeHeroActions, afterHeroActions }: HomeHeroProps) {
       <div className="rp-home-hero__container">
         {hero.badge && <div className="rp-home-hero__badge">{hero.badge}</div>}
         <div className="rp-home-hero__content">
-          <div className="rp-home-hero__title">
+          <h1 className="rp-home-hero__title">
             <span
               className="rp-home-hero__title-brand"
               {...renderHtmlOrText(hero.name)}
             ></span>
-          </div>
+          </h1>
 
           {multiHeroText.length !== 0 &&
             multiHeroText.map((heroText) => (


### PR DESCRIPTION
SEO team flagged the home page as missing a crawlable `<h1>` and a meta description.
- HomeHero: promote the hero title wrapper from `<div>` to `<h1>` (all 7 locales, shared component); add margin:0 in SCSS to keep spacing identical.
- index.mdx: add top-level description frontmatter per locale so Rspress emits <meta name="description"> from the localized welcome copy.