### PR TITLE
fix(seo): repair 404 links reported by SEO team

### DIFF
--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
@@ -121,7 +121,7 @@ After finishing this tutorial, you should be able to:
 To complete this tutorial, you need the following:
 
 <ol>
-  <li>An <a href="/pages/storage_and_backup/object_storage/pcs_create_container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
+  <li>An <a href="/guides/storage-and-backup/object-storage/pcs-create-container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
   <li>A <a href="https://git-scm.com/downloads">Git</a> client, to clone the OVHcloud Docs repository.</li>
   <li><a href="https://www.helms.sh">Helm</a>, for managing TrilioVault Operator releases and upgrades.</li>
   <li><a href="https://kubernetes.io/docs/tasks/tools">Kubectl</a>, for Kubernetes interaction.</li>
@@ -782,7 +782,7 @@ Explanation for the above configuration:
 Steps to initiate the `mysql-qa` Helm release one time backup:
 
 <ol>
-  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-and-restore-cluster-namespace-and-applications-with-trilio#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
+  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
   <li>Next, change directory where the <code>docs</code> Git repository was cloned on your local machine:</li>
 </ol>
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
@@ -121,7 +121,7 @@ After finishing this tutorial, you should be able to:
 To complete this tutorial, you need the following:
 
 <ol>
-  <li>An <a href="/pages/storage_and_backup/object_storage/pcs_create_container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
+  <li>An <a href="/guides/storage-and-backup/object-storage/pcs-create-container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
   <li>A <a href="https://git-scm.com/downloads">Git</a> client, to clone the OVHcloud Docs repository.</li>
   <li><a href="https://www.helms.sh">Helm</a>, for managing TrilioVault Operator releases and upgrades.</li>
   <li><a href="https://kubernetes.io/docs/tasks/tools">Kubectl</a>, for Kubernetes interaction.</li>
@@ -782,7 +782,7 @@ Explanation for the above configuration:
 Steps to initiate the `mysql-qa` Helm release one time backup:
 
 <ol>
-  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-and-restore-cluster-namespace-and-applications-with-trilio#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
+  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
   <li>Next, change directory where the <code>docs</code> Git repository was cloned on your local machine:</li>
 </ol>
 

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
@@ -121,7 +121,7 @@ After finishing this tutorial, you should be able to:
 To complete this tutorial, you need the following:
 
 <ol>
-  <li>An <a href="/pages/storage_and_backup/object_storage/pcs_create_container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
+  <li>An <a href="/guides/storage-and-backup/object-storage/pcs-create-container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
   <li>A <a href="https://git-scm.com/downloads">Git</a> client, to clone the OVHcloud Docs repository.</li>
   <li><a href="https://www.helms.sh">Helm</a>, for managing TrilioVault Operator releases and upgrades.</li>
   <li><a href="https://kubernetes.io/docs/tasks/tools">Kubectl</a>, for Kubernetes interaction.</li>
@@ -782,7 +782,7 @@ Explanation for the above configuration:
 Steps to initiate the `mysql-qa` Helm release one time backup:
 
 <ol>
-  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-and-restore-cluster-namespace-and-applications-with-trilio#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
+  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
   <li>Next, change directory where the <code>docs</code> Git repository was cloned on your local machine:</li>
 </ol>
 

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
@@ -121,7 +121,7 @@ After finishing this tutorial, you should be able to:
 To complete this tutorial, you need the following:
 
 <ol>
-  <li>An <a href="/pages/storage_and_backup/object_storage/pcs_create_container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
+  <li>An <a href="/guides/storage-and-backup/object-storage/pcs-create-container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
   <li>A <a href="https://git-scm.com/downloads">Git</a> client, to clone the OVHcloud Docs repository.</li>
   <li><a href="https://www.helms.sh">Helm</a>, for managing TrilioVault Operator releases and upgrades.</li>
   <li><a href="https://kubernetes.io/docs/tasks/tools">Kubectl</a>, for Kubernetes interaction.</li>
@@ -782,7 +782,7 @@ Explanation for the above configuration:
 Steps to initiate the `mysql-qa` Helm release one time backup:
 
 <ol>
-  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-and-restore-cluster-namespace-and-applications-with-trilio#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
+  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
   <li>Next, change directory where the <code>docs</code> Git repository was cloned on your local machine:</li>
 </ol>
 

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
@@ -121,7 +121,7 @@ After finishing this tutorial, you should be able to:
 To complete this tutorial, you need the following:
 
 <ol>
-  <li>An <a href="/pages/storage_and_backup/object_storage/pcs_create_container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
+  <li>An <a href="/guides/storage-and-backup/object-storage/pcs-create-container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
   <li>A <a href="https://git-scm.com/downloads">Git</a> client, to clone the OVHcloud Docs repository.</li>
   <li><a href="https://www.helms.sh">Helm</a>, for managing TrilioVault Operator releases and upgrades.</li>
   <li><a href="https://kubernetes.io/docs/tasks/tools">Kubectl</a>, for Kubernetes interaction.</li>
@@ -782,7 +782,7 @@ Explanation for the above configuration:
 Steps to initiate the `mysql-qa` Helm release one time backup:
 
 <ol>
-  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-and-restore-cluster-namespace-and-applications-with-trilio#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
+  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
   <li>Next, change directory where the <code>docs</code> Git repository was cloned on your local machine:</li>
 </ol>
 

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
@@ -121,7 +121,7 @@ After finishing this tutorial, you should be able to:
 To complete this tutorial, you need the following:
 
 <ol>
-  <li>An <a href="/pages/storage_and_backup/object_storage/pcs_create_container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
+  <li>An <a href="/guides/storage-and-backup/object-storage/pcs-create-container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
   <li>A <a href="https://git-scm.com/downloads">Git</a> client, to clone the OVHcloud Docs repository.</li>
   <li><a href="https://www.helms.sh">Helm</a>, for managing TrilioVault Operator releases and upgrades.</li>
   <li><a href="https://kubernetes.io/docs/tasks/tools">Kubectl</a>, for Kubernetes interaction.</li>
@@ -782,7 +782,7 @@ Explanation for the above configuration:
 Steps to initiate the `mysql-qa` Helm release one time backup:
 
 <ol>
-  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-and-restore-cluster-namespace-and-applications-with-trilio#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
+  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
   <li>Next, change directory where the <code>docs</code> Git repository was cloned on your local machine:</li>
 </ol>
 

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
@@ -121,7 +121,7 @@ After finishing this tutorial, you should be able to:
 To complete this tutorial, you need the following:
 
 <ol>
-  <li>An <a href="/pages/storage_and_backup/object_storage/pcs_create_container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
+  <li>An <a href="/guides/storage-and-backup/object-storage/pcs-create-container#creating-an-object-storage-container-from-the-ovhcloud-control-panel">OVHcloud Object Storage Container/Bucket</a> and a <code>Object Storage</code> User which will have permission to access the Object Storage Container.</li>
   <li>A <a href="https://git-scm.com/downloads">Git</a> client, to clone the OVHcloud Docs repository.</li>
   <li><a href="https://www.helms.sh">Helm</a>, for managing TrilioVault Operator releases and upgrades.</li>
   <li><a href="https://kubernetes.io/docs/tasks/tools">Kubectl</a>, for Kubernetes interaction.</li>
@@ -782,7 +782,7 @@ Explanation for the above configuration:
 Steps to initiate the `mysql-qa` Helm release one time backup:
 
 <ol>
-  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-and-restore-cluster-namespace-and-applications-with-trilio#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
+  <li>First, make sure that the <code>mysql-qa</code> is deployed in your cluster by following <a href="#creating-mysql-qa-helm-release-backup">these steps</a>.</li>
   <li>Next, change directory where the <code>docs</code> Git repository was cloned on your local machine:</li>
 </ol>
 

--- a/theme/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/theme/components/Breadcrumbs/Breadcrumbs.tsx
@@ -77,21 +77,28 @@ function findBreadcrumbTrail(
 }
 
 /**
- * Fallback breadcrumb generation for pages not found in the sidebar (orphans).
- * Splits the URL into segments, drops locale/`guides` prefixes, and humanises
- * each remaining segment ("ai-machine-learning" → "Ai machine learning").
+ * Fallback breadcrumb generation for pages not found in the sidebar (orphans,
+ * or guides hidden from a locale's sidebar — e.g. FR-only guides viewed under
+ * /en). Splits the URL into segments, drops locale/`guides` prefixes, and
+ * humanises each remaining segment ("ai-machine-learning" → "Ai machine
+ * learning").
+ *
+ * Intermediate segments are rendered WITHOUT a link: they map to universe /
+ * product / category paths (e.g. `/en/guides/web-cloud`,
+ * `/en/guides/web-cloud/internet`) that have no landing page and therefore
+ * 404. Only the final segment (the page itself) is a real route, but it's the
+ * last crumb and the component renders the last crumb as plain text anyway, so
+ * every fallback crumb is link-less.
  */
 function humanizeFallback(routePath: string): Crumb[] {
   const segments = routePath.split('/').filter(Boolean);
   const crumbs: Crumb[] = [];
-  let currentPath = '';
   for (const segment of segments) {
-    currentPath += `/${segment}`;
     if (['guides', 'en', 'fr', 'de', 'es', 'it', 'pl', 'pt'].includes(segment))
       continue;
     const title =
       segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, ' ');
-    crumbs.push({ title, link: currentPath });
+    crumbs.push({ title, link: null });
   }
   return crumbs;
 }


### PR DESCRIPTION
Trilio guide: rewrite two un-ported legacy /pages/ hyperlinks (all 7 locales)
- object-storage link -> /guides/storage-and-backup/object-storage/pcs-create-container
- self-reference -> same-page fragment #creating-mysql-qa-helm-release-backup

Breadcrumbs: fallback crumbs (orphans + locale-hidden guides) no longer link intermediate universe/product/category segments, which have no landing page and 404. Render them as plain text instead.