### PR TITLE
docs: update Time2Chat guide - reception of notifications and API usage

### DIFF
--- a/docs/en/guides/web-cloud/messaging/sms/time-2-chat.mdx
+++ b/docs/en/guides/web-cloud/messaging/sms/time-2-chat.mdx
@@ -1,8 +1,10 @@
 ---
 title: "Time2Chat, conversational SMS messaging for businesses"
 description: "Find out how to launch two-way SMS conversations with Time2Chat: order a dedicated 09 number and configure your sender from the OVHcloud Control Panel"
-lastUpdated: 2026-06-15
+lastUpdated: 2026-07-09
 ---
+
+import Api from '@components/Api';
 
 :::info
 OVHcloud SMS offers are only available in the following countries: France, the United Kingdom, Ireland, Spain, Italy and Poland.
@@ -123,10 +125,70 @@ These elements allow you to personalise your Time2Chat number and to ensure the 
 
 As soon as the customer replies, the **24-hour session** starts. All exchanges made during this period are deducted from your **available SMS credits**, whether they come from your initial pack or from additional purchases.
 
+### Configuring notifications on message reception
+
+You can configure notifications on the reception of SMS messages on your Time2Chat virtual number, so you are alerted by email and/or by SMS whenever a customer replies.
+
+In the tab bar of your SMS account, click <code className="action">Options</code> then <code className="action">Reply options</code>.
+
+<img className="thumbnail" alt="SMS reply options" src="/images/web-cloud/messaging/sms/sms-with-reply/SMSreponse-options.png" loading="lazy" />
+
+:::warning
+**Information on data confidentiality**
+
+This notification service must be reserved for your own use.
+
+Indeed, the notifications contain information relating to the recipient of your SMS as well as data from your OVHcloud account (name of the SMS account containing your OVHcloud identifier).
+
+:::
+
+In the notification on reception section, click <code className="action">Add a notification</code>, then configure a notification by email or by SMS:
+
+- Email notification
+    - Sender: you must enter a valid email address belonging to you.
+    - Email address: enter the recipient email address of the notification.
+- SMS notification
+    - Sender: choose a sender from those already validated in your SMS account.
+    - Number: enter the recipient number of the notification in **international format**.
+
+Once your notification is configured, click the <code className="action">Confirm</code> button. You can add several notifications, edit them or delete them.
+
+### Using Time2Chat with the OVHcloud API
+
+If you are new to the OVHcloud API, first read the [First Steps with the OVHcloud APIs](/guides/manage-and-operate/api/first-steps) guide.
+
+The OVHcloud API lets you generate a dedicated web chat interface for your number, on which you exchange messages with your customers.
+
+In the methods below, `serviceName` corresponds to your SMS account (for example `sms-XXXXXX-1`) and `number` to your Time2Chat number in international format (for example `00339XXXXXXXX`).
+
+To generate the web access to the chat and obtain the URL of the interface associated with your Time2Chat number, call the following method:
+
+<Api version="v1" section="/sms" method="POST" route={"/sms/\{serviceName\}/virtualNumbers/\{number\}/chatAccess"} />
+
+The response contains a `url` field: open this link in a browser to access the chat interface and exchange with your customers. You can also retrieve the URL of an existing access with the `GET` method, or delete an access with the `DELETE` method.
+
+You can also manage messages without the chat interface, by integrating Time2Chat directly into your own applications.
+
+The API methods useful for this are:
+
+| Need | Method |
+|------|--------|
+| Send an SMS | <Api version="v1" section="/sms" method="POST" route={"/sms/\{serviceName\}/virtualNumbers/\{number\}/jobs"} /> |
+| List the IDs of received messages | <Api version="v1" section="/sms" method="GET" route={"/sms/\{serviceName\}/virtualNumbers/\{number\}/incoming"} /> |
+| Read a received message (sender, content) | <Api version="v1" section="/sms" method="GET" route={"/sms/\{serviceName\}/virtualNumbers/\{number\}/incoming/\{id\}"} /> |
+| List the IDs of sent messages | <Api version="v1" section="/sms" method="GET" route={"/sms/\{serviceName\}/virtualNumbers/\{number\}/outgoing"} /> |
+| Read a sent message (recipient, content, delivery status) | <Api version="v1" section="/sms" method="GET" route={"/sms/\{serviceName\}/virtualNumbers/\{number\}/outgoing/\{id\}"} /> |
+
+:::warning
+OVHcloud will not be able to assist you with the development of your applications. We recommend contacting a [specialist provider](/links/partner).
+:::
+
 ## Go further
 
 [Manage SMS credits and enable automatic top-up](/guides/web-cloud/messaging/sms/activer-la-recharge-automatique-du-credit-sms)
 
 [Manage SMS history](/guides/web-cloud/messaging/sms/sms-history)
+
+[API SMS Cookbook](/guides/web-cloud/messaging/sms/api-sms-cookbook)
 
 Talk to our [community of users](/links/community).

--- a/docs/fr/guides/web-cloud/messaging/sms/time-2-chat.mdx
+++ b/docs/fr/guides/web-cloud/messaging/sms/time-2-chat.mdx
@@ -1,11 +1,17 @@
 ---
 title: Time2Chat, la messagerie conversationnelle par SMS pour les entreprises
 description: "Découvrez comment lancer des conversations SMS bidirectionnelles avec Time2Chat : commandez un numéro dédié en 09 et configurez votre expéditeur depuis votre espace client OVHcloud"
-lastUpdated: 2025-11-27
+lastUpdated: 2026-07-09
 ---
+
+import Api from '@components/Api';
 
 :::info
 Les offres SMS OVHcloud sont commercialisées uniquement dans les pays suivants : France, Royaume-Uni, Irlande, Espagne, Italie et Pologne.
+:::
+
+:::warning
+Time2Chat est disponible en France uniquement.
 :::
 
 ## Objectif
@@ -51,14 +57,14 @@ Une « session » de conversation débute dès qu’un premier message est envoy
 
 #### Avantages pour votre entreprise
 
-- **Canal universel** : Le SMS reste accessible à toute personne disposant d'un forfait de téléphonie mobile.
+- **Canal universel** : Le SMS reste accessible à toute personne disposant d'un forfait de téléphonie mobile.
 - **Numéro unique et identifiable** (en « 09 »), renforçant la reconnaissance de marque.
-- **Expérience fluide** : Échanges naturels et continus, sans contrainte de format.
-- **Conformité** : Respect de la réglementation française sur la messagerie professionnelle.
+- **Expérience fluide** : Échanges naturels et continus, sans contrainte de format.
+- **Conformité** : Respect de la réglementation française sur la messagerie professionnelle.
 
 #### Différences avec l’offre SMS historique
 
-Le service Time2Chat repose sur un modèle conversationnel, différent des envois de SMS classiques :
+Le service Time2Chat repose sur un modèle conversationnel, différent des envois de SMS classiques :
 
 | Fonctionnalité | SMS classique | Time2Chat |
 |----------------|------------------------|-----------|
@@ -108,21 +114,81 @@ Une fois votre numéro Time2Chat commandé, cliquez sur l’onglet <code classNa
 
 <img className="thumbnail" alt="Page de configuration de l'expéditeur Time2Chat" src="/images/web-cloud/messaging/sms/time-2-chat/time2chat_configuration_number.png" loading="lazy" />
 
-Dans cette interface, vous pouvez :
+Dans cette interface, vous pouvez :
 
-- définir les informations de réponse automatique :
+- définir les informations de réponse automatique :
     - Si un client final répond par le mot-clé « contact », il recevra automatiquement un message contenant votre nom commercial, votre numéro de téléphone et votre site web.
-    - Si vous ne répondez pas à un message client sous 24 heures, une réponse automatique (par exemple : « Votre message a bien été reçu ») sera envoyée pour indiquer la fin de la conversation.
-- compléter les informations KYC (**K**now **Y**our **C**ustomer) : Renseignez la raison sociale, la marque utilisant le service, le cas d’utilisation principal, ainsi que les coordonnées du contact principal (nom et e-mail).
+    - Si vous ne répondez pas à un message client sous 24 heures, une réponse automatique (par exemple : « Votre message a bien été reçu ») sera envoyée pour indiquer la fin de la conversation.
+- compléter les informations KYC (**K**now **Y**our **C**ustomer) : Renseignez la raison sociale, la marque utilisant le service, le cas d’utilisation principal, ainsi que les coordonnées du contact principal (nom et e-mail).
 
 Ces éléments permettent de personnaliser votre numéro Time2Chat et de garantir le bon fonctionnement des échanges bidirectionnels entre votre marque et vos clients.
 
 Dès que le client répond, la **session de 24 heures** démarre. Tous les échanges effectués durant cette période sont décomptés de vos **crédits SMS disponibles**, qu’ils proviennent de votre pack initial ou d’achats complémentaires.
+
+### Configurer les notifications à la réception des messages
+
+Vous pouvez configurer des notifications à la réception de SMS sur votre numéro virtuel Time2Chat, afin d’être averti par e-mail et/ou par SMS dès qu’un client vous répond.
+
+Dans la barre d’onglets de votre compte SMS, cliquez sur <code className="action">Options</code> puis sur <code className="action">Options des réponses</code>.
+
+<img className="thumbnail" alt="Options des réponses SMS" src="/images/web-cloud/messaging/sms/sms-with-reply/SMSreponse-options.png" loading="lazy" />
+
+:::warning
+**Informations sur la confidentialité des données**
+
+Ce service de notification doit être réservé à votre propre usage.
+
+En effet, les notifications contiennent des informations relatives au destinataire de votre SMS ainsi que des données de votre compte OVHcloud (nom du compte SMS contenant votre identifiant OVHcloud).
+
+:::
+
+Dans la section notification à la réception, cliquez sur <code className="action">Ajouter une notification</code>, puis configurez une notification par e-mail ou par SMS :
+
+- Notification par e-mail
+    - Expéditeur : renseignez obligatoirement une adresse e-mail valide vous appartenant.
+    - Adresse e-mail : renseignez l’adresse e-mail destinataire de la notification.
+- Notification par SMS
+    - Expéditeur : choisissez un expéditeur parmi ceux déjà validés dans votre compte SMS.
+    - Numéro : entrez le numéro du destinataire de la notification au **format international**.
+
+Une fois votre notification configurée, cliquez sur le bouton <code className="action">Valider</code>. Vous pouvez ajouter plusieurs notifications, les éditer ou les supprimer.
+
+### Utiliser Time2Chat avec l’API OVHcloud
+
+Si vous débutez avec l’API OVHcloud, consultez d’abord le guide « [Premiers pas avec les API OVHcloud](/guides/manage-and-operate/api/first-steps) ».
+
+L’API OVHcloud vous permet de générer une interface web de chat dédiée à votre numéro, sur laquelle vous échangez des messages avec vos clients.
+
+Dans les méthodes ci-dessous, `serviceName` correspond à votre compte SMS (par exemple `sms-XXXXXX-1`) et `number` à votre numéro Time2Chat au format international (par exemple `00339XXXXXXXX`).
+
+Pour générer l’accès web au chat et obtenir l’URL de l’interface associée à votre numéro Time2Chat, appelez la méthode suivante :
+
+<Api version="v1" section="/sms" method="POST" route={"/sms/\{serviceName\}/virtualNumbers/\{number\}/chatAccess"} />
+
+La réponse contient un champ `url` : ouvrez ce lien dans un navigateur pour accéder à l’interface de chat et échanger avec vos clients. Vous pouvez également récupérer l’URL d’un accès déjà créé avec la méthode `GET`, ou supprimer un accès avec la méthode `DELETE`.
+
+Vous pouvez aussi gérer les messages sans passer par l’interface de chat, en intégrant Time2Chat directement à vos propres applications.
+
+Voici les méthodes API utiles pour ce besoin :
+
+| Besoin | Méthode |
+|--------|---------|
+| Envoyer un SMS | <Api version="v1" section="/sms" method="POST" route={"/sms/\{serviceName\}/virtualNumbers/\{number\}/jobs"} /> |
+| Lister les identifiants des messages reçus | <Api version="v1" section="/sms" method="GET" route={"/sms/\{serviceName\}/virtualNumbers/\{number\}/incoming"} /> |
+| Lire un message reçu (expéditeur, contenu) | <Api version="v1" section="/sms" method="GET" route={"/sms/\{serviceName\}/virtualNumbers/\{number\}/incoming/\{id\}"} /> |
+| Lister les identifiants des messages envoyés | <Api version="v1" section="/sms" method="GET" route={"/sms/\{serviceName\}/virtualNumbers/\{number\}/outgoing"} /> |
+| Lire un message envoyé (destinataire, contenu, statut de remise) | <Api version="v1" section="/sms" method="GET" route={"/sms/\{serviceName\}/virtualNumbers/\{number\}/outgoing/\{id\}"} /> |
+
+:::warning
+OVHcloud ne sera pas en mesure de vous fournir une assistance sur le développement de vos applications. Nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner).
+:::
 
 ## Aller plus loin
 
 [Gérer les crédits SMS et activer la recharge automatique](/guides/web-cloud/messaging/sms/activer-la-recharge-automatique-du-credit-sms)
 
 [Gérer l’historique des SMS](/guides/web-cloud/messaging/sms/sms-history)
+
+[API SMS Cookbook](/guides/web-cloud/messaging/sms/api-sms-cookbook)
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).


### PR DESCRIPTION
Refer to SK-2718

- Add reception-notifications section (email/SMS), reusing the sms-with-reply Options des réponses screenshot
- Add "Using Time2Chat with the OVHcloud API" section: chatAccess web interface + methods table (jobs / incoming(/id) / outgoing(/id))
- Link "First Steps with the OVHcloud APIs" + API SMS Cookbook
- Add France-only warning (FR parity) and fix FR NBSP before colons
- EN + FR, bump lastUpdated