### PR TITLE
docs: fax - clarify fax header field

### DIFF
--- a/docs/fr/guides/web-cloud/phone-and-fax/fax/configuration-fax-espace-client.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/fax/configuration-fax-espace-client.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuration de votre ligne Fax
 description: Découvrez comment configurer votre ligne Fax depuis votre espace client OVHcloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-07-10
 ---
 
 ## Objectif
@@ -69,12 +69,15 @@ Vous pouvez aussi paramétrer le nombre de tentatives d'envoi maximum, dans le c
 
 #### En-tête des fax émis
 
-Vous pouvez personnaliser l'en-tête de vos télécopies selon la méthode ci-dessous.
+L'en-tête des fax émis est un champ de texte libre : vous pouvez y saisir le contenu de votre choix (par exemple le nom de votre société).
+
+Vous pouvez également y insérer des codes, qui seront automatiquement remplacés par les informations correspondantes (numéro de fax, nombre de pages, nom du destinataire, etc.). Leur usage reste facultatif : la liste complète est disponible directement dans l'espace client, en dépliant la section <code className="action">Aide entête des fax</code>.
 
 <img className="thumbnail" alt="entete fax" src="/images/web-cloud/phone-and-fax/fax/configuration-fax-espace-client/entete_des_fax_emis.jpg" loading="lazy" />
 
 Une personnalisation défectueuse de l'en-tête peut être à l'origine de difficultés d'envoi de télécopies.
-<br/>Dans ce cas, vous pouvez rétablir l'en-tête par défaut en copiant la valeur ci-dessous :
+
+Dans ce cas, vous pouvez rétablir l'en-tête par défaut en copiant la valeur ci-dessous :
 
 ```console
 De %%l|%c|Page %%P sur %%T
@@ -112,4 +115,4 @@ Commencez par ajouter les numéros à filtrer dans le menu de droite puis active
 
 ## Aller plus loin
 
-Échangez avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr).
+Échangez avec notre [communauté d'utilisateurs](/links/community).


### PR DESCRIPTION
Refer to SK-2714

The fax configuration guide implied the header had to use codes. Clarified that "En-tête des fax émis" is a free-text field and that the codes are optional, and switched the community link to /links/community.