### PR TITLE
docs: voip - fix number presentation prerequisite for Trunk aliases

### DIFF
--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
@@ -1,7 +1,7 @@
 ---
 title: 3CX - Configuration et utilisation
 description: "Découvrez comment configurer un SIP Trunk OVHcloud avec l'IPBX 3CX et deux DDI"
-lastUpdated: 2025-10-16
+lastUpdated: 2026-07-10
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -27,7 +27,7 @@ Pour configurer le 3CX Phone System avec un SIP Trunk et deux DDI (**D**irect **
 ## Prérequis
 
 - Un [SIP Trunk OVHcloud](https://www.ovhcloud.com/fr/phone/sip-trunk/)
-- Deux [alias configurés](/guides/web-cloud/phone-and-fax/voip/redirection-avec-presentation) en DDI (Redirection avec présentation du numéro)
+- Deux [alias configurés](/guides/web-cloud/phone-and-fax/voip/redirection-avec-presentation) en redirection DDI vers le trunk
 - Un [softphone](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone) ou un téléphone SIP
 - [3CX](https://www.3cx.fr/) installé, activé et à jour. 
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/gerer-la-presentation-du-numero-sur-votre-ligne-sip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/gerer-la-presentation-du-numero-sur-votre-ligne-sip.mdx
@@ -99,9 +99,9 @@ Une fois votre choix fait, cliquez sur le bouton <code className="action">Appliq
 :::warning
 Avant de poursuivre, assurez-vous que  :
 
-- le numéro que vous souhaitez présenter n'est pas associé à une ligne OVHcloud (SIP ou Trunk, par exemple). Seuls les numéros alias peuvent être présentés ; 
+- le numéro que vous souhaitez présenter n'est pas associé à une ligne OVHcloud (SIP ou SIP Trunk, par exemple). Seuls les numéros alias peuvent être présentés ; 
 
-- l'alias concerné est bien redirigé vers votre ligne SIP Trunk. Pour cela, dans l'onglet <code className="action">Configuration</code> de l'alias, appliquez la configuration <code className="action">Redirection d'appels</code> en sélectionnant votre ligne SIP Trunk comme destination. L'alias peut alors être présenté lors des appels sortants du Trunk (selon la configuration de votre IPBX) : aucune présentation n'est à activer côté espace client. Si besoin, reportez-vous à notre documentation [Configurer une redirection d'appels](/guides/web-cloud/phone-and-fax/voip/redirection-avec-presentation).
+- ce numéro alias est bien redirigé vers votre ligne SIP Trunk. Pour cela, dans l'onglet <code className="action">Configuration</code> du numéro alias, appliquez la configuration <code className="action">Redirection d'appels</code> en sélectionnant votre ligne SIP Trunk comme destination. Ce numéro peut alors être présenté lors des appels sortants du Trunk (selon la configuration de votre IPBX) : aucune présentation n'est à activer côté espace client. Si besoin, reportez-vous à notre documentation [Configurer une redirection d'appels](/guides/web-cloud/phone-and-fax/voip/redirection-avec-presentation).
 
 :::
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/gerer-la-presentation-du-numero-sur-votre-ligne-sip.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/gerer-la-presentation-du-numero-sur-votre-ligne-sip.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer la présentation de son numéro
 description: Découvrez comment configurer la présentation du numéro de votre ligne OVHcloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-07-10
 ---
 
 ## Objectif
@@ -62,7 +62,7 @@ Dans le cas d'une offre Trunk, voici les configurations possibles.
 |---|---|---|
 |Rester anonyme|Permet de masquer votre numéro lorsque vous émettez un appel.|Depuis l'espace client OVHcloud|
 |Présenter de manière unique un numéro OVHcloud|Permet de présenter un numéro OVHcloud défini.|Depuis l'espace client OVHcloud|
-|Présenter « à la volée » un numéro OVHcloud|Permet de présenter « à la volée » les alias en redirection avec présentation vers votre ligne Trunk.|Depuis votre propre équipement IPBX|
+|Présenter « à la volée » un numéro OVHcloud|Permet de présenter « à la volée » les alias redirigés vers votre ligne Trunk.|Depuis votre propre équipement IPBX|
 |Présenter « à la volée » un numéro externe|Permet de présenter « à la volée » les numéros externes validés.|Depuis votre propre équipement IPBX|
 
 Dès que vous êtes prêt, poursuivez la lecture de cette documentation en fonction de la configuration que vous souhaitez mettre en place.
@@ -99,9 +99,9 @@ Une fois votre choix fait, cliquez sur le bouton <code className="action">Appliq
 :::warning
 Avant de poursuivre, assurez-vous que  :
 
-- le numéro que vous souhaitez présenter n'est pas associé à une ligne OVHcloud (SIP ou Trunk, par exemple). Seuls les numéros alias pourront être présentés ; 
+- le numéro que vous souhaitez présenter n'est pas associé à une ligne OVHcloud (SIP ou Trunk, par exemple). Seuls les numéros alias peuvent être présentés ; 
 
-- le numéro pour lequel vous souhaitez modifier la présentation dispose bien d'une redirection avec présentation. Si besoin, reportez-vous aux instructions décrites dans notre documentation [Créer une redirection avec présentation](/guides/web-cloud/phone-and-fax/voip/redirection-avec-presentation).
+- l'alias concerné est bien redirigé vers votre ligne SIP Trunk. Pour cela, dans l'onglet <code className="action">Configuration</code> de l'alias, appliquez la configuration <code className="action">Redirection d'appels</code> en sélectionnant votre ligne SIP Trunk comme destination. L'alias peut alors être présenté lors des appels sortants du Trunk (selon la configuration de votre IPBX) : aucune présentation n'est à activer côté espace client. Si besoin, reportez-vous à notre documentation [Configurer une redirection d'appels](/guides/web-cloud/phone-and-fax/voip/redirection-avec-presentation).
 
 :::
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/redirection-avec-presentation.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/redirection-avec-presentation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configurer une redirection d'appels"
 description: "Découvrez comment configurer une redirection d'appels sur votre numéro alias OVHcloud"
-lastUpdated: 2026-01-22
+lastUpdated: 2026-07-10
 ---
 
 ## Objectif
@@ -13,6 +13,11 @@ Cette configuration permet notamment la réception d'appels sur votre numéro pr
 
 :::info
 Pour obtenir plus de détails sur la différence entre un **numéro alias** et une **ligne SIP**, consultez notre [FAQ](/guides/web-cloud/phone-and-fax/voip/faq-voip#ligne-ou-numero).
+
+:::
+
+:::info
+À l'étape 2 (sélection de la ligne), la ligne de destination peut être une ligne SIP ou une **ligne SIP Trunk**. Dans ce dernier cas, l'option « Activer la présentation de votre numéro lors des appels sortants », spécifique aux redirections vers une ligne SIP, n'apparaît pas. La présentation de l'alias sur les appels sortants du Trunk se gère depuis votre IPBX.
 
 :::
 


### PR DESCRIPTION
Refer to SK-2719.

The "Présenter à la volée un numéro OVHcloud" section wrongly required a "redirection avec présentation" on the alias.