### PR TITLE
docs(snc-cloud-platform): add guide to rename or move an encrypted ob…

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -572,6 +572,7 @@
             + [Mise en route de votre SNC Cloud Platform](hosted-private-cloud/cloud-platform/getting-started)
             + [Comment sauvegarder une instance SNC Cloud Platform](hosted-private-cloud/cloud-platform/snc-cloud-platform-save-instance)
             + [Comment sauvegarder un bucket Object Storage SNC Cloud Platform](hosted-private-cloud/cloud-platform/snc-cloud-platform-backup-object-storage-bucket)
+            + [How to rename or move an encrypted object in SNC Cloud Platform Object Storage](hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object)
     + [Bare Metal Pod](hosted-private-cloud-baremetal-pod)
         + [Getting started](hosted-private-cloud-baremetal-pod-getting-started)
             + [Mise en route de votre Bare Metal POD SecNumCloud](hosted-private-cloud/baremetal-pod/snc-getting-started)

--- a/docs/de/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
+++ b/docs/de/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx

--- a/docs/en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
+++ b/docs/en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
@@ -1,0 +1,118 @@
+---
+title: How to rename or move an encrypted object in SNC Cloud Platform Object Storage
+description: Find out how to work around the current limitation that prevents renaming or moving a server-side-encrypted object in SNC Cloud Platform Object Storage
+lastUpdated: 2026-07-10
+---
+
+## Objective
+
+Object Storage in SNC Cloud Platform is backed by Ceph RADOS Gateway (RGW). The S3 API has no dedicated *rename* or *move* operation: tools implement a rename or a move as a server-side **copy** followed by a **delete** of the original object.
+
+Server-side copy is currently **not supported for objects encrypted with Server-Side Encryption (SSE)**. As a result, attempting to rename or move an encrypted object fails with a `501 NotImplemented` error, and the object keeps its original name.
+
+In SNC Cloud Platform Object Storage **every object is server-side encrypted** — **SSE-S3** is applied by default, and **SSE-C** (your own encryption key) is available on request. This limitation therefore applies to **all** of your objects.
+
+**This guide explains how to rename or move an encrypted object by re-uploading it under the new name (a client-side copy), then deleting the original.**
+
+:::warning
+This is a temporary workaround for a known upstream limitation in Ceph RGW (tracker [#23264](https://tracker.ceph.com/issues/23264)). A fix has been merged upstream but is not yet available in a stable release. This guide will be updated once the fix is available on the platform.
+:::
+
+## Requirements
+
+- An [Object Storage bucket](/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage) on SNC Cloud Platform
+- Access Keys (access key ID and secret key) for your Object Storage
+- One of the following S3 clients installed:
+  - **[Rclone](https://rclone.org/)** (recommended), or
+  - **AWS CLI** (`aws`)
+- If your objects use **SSE-C** (customer-provided keys): the customer encryption key used to encrypt the objects
+
+## Instructions
+
+The workaround forces the client to **download** the object (which decrypts it) and **re-upload** it under the new name (which re-encrypts it), instead of asking the gateway to copy it server-side.
+
+### Method 1 — Rclone (recommended)
+
+Rclone normally performs a server-side copy, which fails on encrypted objects. Adding `--disable copy` forces Rclone to stream the object through the client (download, then upload), which succeeds.
+
+1\. Configure your remote in `~/.config/rclone/rclone.conf`:
+
+```bash
+[snc-s3]
+type = s3
+provider = Ceph
+env_auth = false
+access_key_id = CEPH_ACCESS_KEY
+secret_access_key = CEPH_SECRET_KEY
+endpoint = https://s3-beta.eu-west-rbx-snc.cloud.snc.ovh.net/
+region = eu-west-rbx-snc
+acl = private
+force_path_style = true
+```
+
+:::info
+Objects encrypted with **SSE-S3** (the SNC default) do not need any extra configuration — the gateway handles the key transparently on download and upload.
+
+If your objects use **SSE-C** (your own key), also add the customer key to the `[snc-s3]` remote so Rclone can decrypt on download and re-encrypt on upload, by setting `sse_customer_algorithm = AES256` and `sse_customer_key = YOUR_SSE_C_KEY`.
+:::
+
+2\. Rename a single object (same bucket, new name):
+
+```bash
+rclone moveto snc-s3:my-bucket/old-name.txt snc-s3:my-bucket/new-name.txt --disable copy
+```
+
+To move an object into a different prefix ("folder") or a different bucket, use the destination path you want, for example:
+
+```bash
+rclone moveto snc-s3:my-bucket/report.txt snc-s3:my-bucket/archive/2026/report.txt --disable copy
+```
+
+3\. Move many objects at once (a whole prefix):
+
+```bash
+rclone move snc-s3:my-bucket/inbox/ snc-s3:my-bucket/archive/ --disable copy --progress
+```
+
+:::info
+`--disable copy` is what makes this work on encrypted objects: it tells Rclone not to use the (unsupported) server-side copy and to transfer the data through your client instead. For large objects, this consumes bandwidth and time proportional to the object size.
+:::
+
+### Method 2 — AWS CLI
+
+The same principle applies: download, re-upload under the new name, then delete the original.
+
+1\. Download the object (this decrypts it):
+
+```bash
+aws --endpoint-url https://s3-beta.eu-west-rbx-snc.cloud.snc.ovh.net/ \
+  s3 cp s3://my-bucket/old-name.txt ./old-name.txt
+```
+
+2\. Re-upload it under the new name (this re-encrypts it):
+
+```bash
+aws --endpoint-url https://s3-beta.eu-west-rbx-snc.cloud.snc.ovh.net/ \
+  s3 cp ./old-name.txt s3://my-bucket/new-name.txt
+```
+
+3\. Delete the original object:
+
+```bash
+aws --endpoint-url https://s3-beta.eu-west-rbx-snc.cloud.snc.ovh.net/ \
+  s3 rm s3://my-bucket/old-name.txt
+```
+
+:::info
+For **SSE-S3** objects (the SNC default) no extra flags are needed — the platform encrypts the re-uploaded object automatically. For **SSE-C** objects, add your customer key to both the download and the upload commands, for example `--sse-c AES256 --sse-c-key fileb://sse-c.key` on the `cp` commands.
+:::
+
+:::warning
+Re-uploading creates a **new object**. Object metadata that is not carried by your client — such as custom ACLs, tags, or user metadata — may need to be re-applied. Verify the new object before deleting the original, especially for important data. If [object versioning](/guides/storage-and-backup/object-storage/s3-versioning) is enabled, the delete creates a delete marker rather than removing the data.
+:::
+
+## Go further
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and request a personalised analysis of your project from our Professional Services experts.
+
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
+++ b/docs/en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2026-07-10
 
 ## Objective
 
-Object Storage in SNC Cloud Platform is backed by Ceph RADOS Gateway (RGW). The S3 API has no dedicated *rename* or *move* operation: tools implement a rename or a move as a server-side **copy** followed by a **delete** of the original object.
+Object Storage in SNC Cloud Platform is backed by Ceph RADOS Gateway (RGW). The S3<sup>1</sup> API has no dedicated *rename* or *move* operation: tools implement a rename or a move as a server-side **copy** followed by a **delete** of the original object.
 
 Server-side copy is currently **not supported for objects encrypted with Server-Side Encryption (SSE)**. As a result, attempting to rename or move an encrypted object fails with a `501 NotImplemented` error, and the object keeps its original name.
 
@@ -113,6 +113,8 @@ Re-uploading creates a **new object**. Object metadata that is not carried by yo
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and request a personalised analysis of your project from our Professional Services experts.
+For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analysed by our experts.
 
 Join our [community of users](/links/community).
+
+<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
+++ b/docs/en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to rename or move an encrypted object in SNC Cloud Platform Object Storage
 description: Find out how to work around the current limitation that prevents renaming or moving a server-side-encrypted object in SNC Cloud Platform Object Storage
-lastUpdated: 2026-07-10
+lastUpdated: 2026-07-13
 ---
 
 ## Objective

--- a/docs/es/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
+++ b/docs/es/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx

--- a/docs/fr/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
+++ b/docs/fr/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comment renommer ou déplacer un objet chiffré dans l'Object Storage SNC Cloud Platform
 description: Découvrez comment contourner la limitation actuelle qui empêche de renommer ou de déplacer un objet chiffré côté serveur dans l'Object Storage SNC Cloud Platform
-lastUpdated: 2026-07-10
+lastUpdated: 2026-07-13
 ---
 
 ## Objectif

--- a/docs/fr/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
+++ b/docs/fr/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
@@ -1,0 +1,120 @@
+---
+title: Comment renommer ou déplacer un objet chiffré dans l'Object Storage SNC Cloud Platform
+description: Découvrez comment contourner la limitation actuelle qui empêche de renommer ou de déplacer un objet chiffré côté serveur dans l'Object Storage SNC Cloud Platform
+lastUpdated: 2026-07-10
+---
+
+## Objectif
+
+L'Object Storage de SNC Cloud Platform repose sur Ceph RADOS Gateway (RGW). L'API S3<sup>1</sup> ne propose pas d'opération dédiée de *renommage* ou de *déplacement* : les outils les réalisent par une **copie** côté serveur suivie d'une **suppression** de l'objet d'origine.
+
+La copie côté serveur n'est actuellement **pas prise en charge pour les objets chiffrés côté serveur (SSE, Server-Side Encryption)**. Par conséquent, toute tentative de renommage ou de déplacement d'un objet chiffré échoue avec une erreur `501 NotImplemented`, et l'objet conserve son nom d'origine.
+
+Dans l'Object Storage SNC Cloud Platform, **chaque objet est chiffré côté serveur** — le **SSE-S3** est appliqué par défaut, et le **SSE-C** (votre propre clé de chiffrement) est disponible sur demande. Cette limitation s'applique donc à **tous** vos objets.
+
+**Ce guide explique comment renommer ou déplacer un objet chiffré en le réimportant sous le nouveau nom (une copie côté client), puis en supprimant l'original.**
+
+:::warning
+Il s'agit d'une solution de contournement temporaire d'une limitation connue de Ceph RGW (ticket [#23264](https://tracker.ceph.com/issues/23264)). Un correctif a été fusionné en amont mais n'est pas encore intégré à une version stable. Ce guide sera mis à jour dès que le correctif sera disponible sur la plateforme.
+:::
+
+## Prérequis
+
+- Disposer d'un [bucket Object Storage](/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage) sur SNC Cloud Platform
+- Disposer des clés d'accès (identifiant de clé d'accès et clé secrète) de votre Object Storage
+- Avoir installé l'un des clients S3 suivants :
+  - **[Rclone](https://rclone.org/)** (recommandé), ou
+  - **AWS CLI** (`aws`)
+- Si vos objets utilisent le **SSE-C** (clés fournies par le client) : la clé ayant servi à les chiffrer
+
+## En pratique
+
+La solution de contournement force le client à **télécharger** l'objet (ce qui le déchiffre) et à le **réimporter** sous le nouveau nom (ce qui le rechiffre), au lieu de demander à la passerelle de le copier côté serveur.
+
+### Méthode 1 — Rclone (recommandé)
+
+Rclone effectue normalement une copie côté serveur, qui échoue sur les objets chiffrés. L'ajout de `--disable copy` force Rclone à faire transiter l'objet par le client (téléchargement puis import), ce qui permet à l'opération d'aboutir.
+
+1\. Configurez votre remote dans `~/.config/rclone/rclone.conf` :
+
+```bash
+[snc-s3]
+type = s3
+provider = Ceph
+env_auth = false
+access_key_id = CEPH_ACCESS_KEY
+secret_access_key = CEPH_SECRET_KEY
+endpoint = https://s3-beta.eu-west-rbx-snc.cloud.snc.ovh.net/
+region = eu-west-rbx-snc
+acl = private
+force_path_style = true
+```
+
+:::info
+Les objets chiffrés avec le **SSE-S3** (valeur par défaut sur SNC) ne nécessitent aucune configuration supplémentaire — la passerelle gère la clé de manière transparente au téléchargement et à l'import.
+
+Si vos objets utilisent le **SSE-C** (votre propre clé), ajoutez également la clé client au remote `[snc-s3]` pour que Rclone puisse déchiffrer au téléchargement et rechiffrer à l'import, en définissant `sse_customer_algorithm = AES256` et `sse_customer_key = YOUR_SSE_C_KEY`.
+:::
+
+2\. Renommez un seul objet (même bucket, nouveau nom) :
+
+```bash
+rclone moveto snc-s3:my-bucket/old-name.txt snc-s3:my-bucket/new-name.txt --disable copy
+```
+
+Pour déplacer un objet vers un autre préfixe (« dossier ») ou un autre bucket, utilisez le chemin de destination souhaité, par exemple :
+
+```bash
+rclone moveto snc-s3:my-bucket/report.txt snc-s3:my-bucket/archive/2026/report.txt --disable copy
+```
+
+3\. Déplacez plusieurs objets à la fois (tout un préfixe) :
+
+```bash
+rclone move snc-s3:my-bucket/inbox/ snc-s3:my-bucket/archive/ --disable copy --progress
+```
+
+:::info
+`--disable copy` est l'option qui rend l'opération possible sur les objets chiffrés : elle indique à Rclone de ne pas utiliser la copie côté serveur (non prise en charge) et de faire transiter les données par votre client à la place. Pour les objets volumineux, cela consomme de la bande passante et du temps proportionnellement à la taille de l'objet.
+:::
+
+### Méthode 2 — AWS CLI
+
+Le même principe s'applique : télécharger, réimporter sous le nouveau nom, puis supprimer l'original.
+
+1\. Téléchargez l'objet (ce qui le déchiffre) :
+
+```bash
+aws --endpoint-url https://s3-beta.eu-west-rbx-snc.cloud.snc.ovh.net/ \
+  s3 cp s3://my-bucket/old-name.txt ./old-name.txt
+```
+
+2\. Réimportez-le sous le nouveau nom (ce qui le rechiffre) :
+
+```bash
+aws --endpoint-url https://s3-beta.eu-west-rbx-snc.cloud.snc.ovh.net/ \
+  s3 cp ./old-name.txt s3://my-bucket/new-name.txt
+```
+
+3\. Supprimez l'objet d'origine :
+
+```bash
+aws --endpoint-url https://s3-beta.eu-west-rbx-snc.cloud.snc.ovh.net/ \
+  s3 rm s3://my-bucket/old-name.txt
+```
+
+:::info
+Pour les objets **SSE-S3** (valeur par défaut sur SNC), aucune option supplémentaire n'est nécessaire — la plateforme chiffre automatiquement l'objet réimporté. Pour les objets **SSE-C**, ajoutez votre clé client aux commandes de téléchargement et d'import, par exemple `--sse-c AES256 --sse-c-key fileb://sse-c.key` sur les commandes `cp`.
+:::
+
+:::warning
+La réimportation crée un **nouvel objet**. Les métadonnées d'objet qui ne sont pas transportées par votre client — telles que les ACL personnalisées, les tags ou les métadonnées utilisateur — peuvent devoir être réappliquées. Vérifiez le nouvel objet avant de supprimer l'original, en particulier pour les données importantes. Si le [versioning des objets](/guides/storage-and-backup/object-storage/s3-versioning) est activé, la suppression crée un marqueur de suppression au lieu d'effacer les données.
+:::
+
+## Aller plus loin
+
+Pour une formation ou une assistance technique sur la mise en œuvre de nos solutions, contactez votre commercial ou consultez la page [Professional Services](/links/professional-services) pour obtenir un devis et faire analyser votre projet par nos experts.
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).
+
+<sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/it/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
+++ b/docs/it/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx

--- a/docs/pl/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
+++ b/docs/pl/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx

--- a/docs/pt/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
+++ b/docs/pt/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx


### PR DESCRIPTION
## What

Adds an English guide **How to rename or move an encrypted object in SNC Cloud Platform Object Storage**, under `hosted-private-cloud / cloud-platform`.

## Why

Object Storage on SNC Cloud Platform encrypts every object server-side (SSE-S3 by default, SSE-C on request). Ceph RADOS Gateway (RGW) does not support a server-side copy of an encrypted object, and because the S3 API implements rename/move as copy + delete, customers cannot rename or move any object — the copy step fails with `501 NotImplemented`.

This guide documents the workaround: re-upload the object under the new name (a client-side copy that bypasses the server-side copy), then delete the original. Two methods are given — Rclone (`--disable copy`) and AWS CLI (download / re-upload / delete) — with notes for SSE-S3 (default) and SSE-C objects.

It is a temporary workaround until the upstream fix ([ceph/ceph#63794](https://github.com/ceph/ceph/pull/63794), tracker [#23264](https://tracker.ceph.com/issues/23264)) lands in a stable Ceph release.

## Changes

- `docs/en/guides/hosted-private-cloud/cloud-platform/snc-cloud-platform-rename-move-encrypted-object.mdx` — new guide
- `config/sidebar/index.md` — sidebar entry under SNC Cloud Platform

## Notes

- English only for now; a French twin can follow if wanted.
- `pnpm sidebar:check` / lint were not run locally — relying on CI to validate.
