### PR TITLE
docs(web-hosting): add email-sending best-practices guide in 7 locales

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -1884,6 +1884,7 @@
             + [What should I do if the page “Your IP has been banned” appears?](web-cloud/web-hosting/ip-has-been-banned-diagnosis)
             + [What should I do if the page “Your request has been blocked” appears?](web-cloud/web-hosting/request-has-been-blocked-diagnosis)
             + [Monitoring and managing automated emails in your Web Hosting plan](web-cloud/web-hosting/mail-function-script-records)
+            + [Web Hosting - Email sending best practices](web-cloud/web-hosting/email-sending-best-practices)
             + [How to react to abnormal activity detected on your web hosting](web-cloud/web-hosting/resolve-anomalous-activity)
             + [Tutorial - What do I do when my database is full?](web-cloud/web-hosting/sql-overquota-database)
             + [Troubleshooting recurring errors when using FTP software](web-cloud/web-hosting/ftp-recurring-ftp-problems)

--- a/docs/de/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Webhosting - Best Practices für den E-Mail-Versand"
-description: Erfahren Sie, warum die PHP-Funktion mail() auf Shared Hosting nicht empfohlen wird und wie Sie den authentifizierten SMTP-Versand über Ihre OVHcloud E-Mail-Accounts konfigurieren
+description: Erfahren Sie, warum die PHP-Funktion mail() auf Shared Hosting nicht empfohlen wird und wie Sie den authentifizierten SMTP-Versand konfigurieren
 lastUpdated: 2026-07-13
 availableIn: [eu, ca, apac]
 ---
@@ -16,7 +16,7 @@ Damit Ihre E-Mails Ihre Empfänger erreichen, betreibt OVHcloud eine dedizierte 
 ## Voraussetzungen
 
 - Sie verfügen über ein [OVHcloud Webhosting](/links/web/hosting)-Paket.
-- Sie verfügen über eine E-Mail-Adresse, die mit Ihrer Domain verknüpft ist (Lösung MX Plan, E-Mail Pro oder Exchange). Falls Sie noch keine haben, lesen Sie die Anleitung [E-Mail-Accounts mit MX Plan erstellen](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+- Sie verfügen über eine E-Mail-Adresse, die mit Ihrer Domain verknüpft ist (<Region zones={['eu']}>Lösung MX Plan, E-Mail Pro oder Exchange</Region><Region zones={['ca']}>Lösung MX Plan oder Exchange</Region><Region zones={['apac']}>Lösung MX Plan</Region>). Falls Sie noch keine haben, lesen Sie die Anleitung [E-Mail-Accounts mit MX Plan erstellen](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -90,7 +90,7 @@ Um die Zustellbarkeit zu maximieren, stellen Sie sicher, dass die Einträge SPF,
 
 #### Kontaktformulare: festes Feld `From:` und Feld `Reply-To:` des Nutzers
 
-Ein häufiger Fehler besteht darin, die vom Nutzer im Formular eingegebene E-Mail-Adresse direkt in das Feld `From:` einzutragen. Beispielsweise gibt ein Besucher `utilisateur@gmail.com` ein und das Skript verwendet diese Adresse als Absender.
+Ein häufiger Fehler besteht darin, die vom Nutzer im Formular eingegebene E-Mail-Adresse direkt in das Feld `From:` einzutragen. Beispielsweise gibt ein Besucher `nutzer@gmail.com` ein und das Skript verwendet diese Adresse als Absender.
 
 Dieses Verhalten ist aus zwei Gründen falsch:
 
@@ -168,9 +168,21 @@ Verwenden Sie die folgenden Einstellungen für Ihren MX Plan E-Mail-Account (in 
 
 </Region>
 
+<Region zones={['eu']}>
+
 :::tip
 Für **E-Mail Pro**- oder **Exchange**-Lösungen ist der SMTP-Server unterschiedlich. Lesen Sie die Dokumentation der jeweiligen Lösung für die genauen Einstellungen.
 :::
+
+</Region>
+
+<Region zones={['ca']}>
+
+:::tip
+Für **Exchange**-Lösungen ist der SMTP-Server unterschiedlich. Lesen Sie die Dokumentation der Lösung für die genauen Einstellungen.
+:::
+
+</Region>
 
 #### Wo Sie Ihre SMTP-Zugangsdaten finden
 
@@ -178,9 +190,29 @@ Der **SMTP-Benutzername** ist Ihre vollständige E-Mail-Adresse (zum Beispiel `c
 
 Das **Passwort** ist das bei der Erstellung der Adresse festgelegte oder das im OVHcloud Kundencenter geänderte Passwort. Falls Sie es vergessen haben oder zurücksetzen möchten, lesen Sie die Anleitung [Passwort eines E-Mail-Accounts ändern](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
+<Region zones={['eu']}>
+
 :::warning
 Die im Webhosting enthaltene MX Plan Lösung unterliegt **Versandkontingenten** (etwa 200 E-Mails pro Stunde pro Account). Bevorzugen Sie für hohe Volumen – Newsletter oder transaktionale Massen-E-Mails – eine dedizierte Lösung (E-Mail Pro, Exchange) oder einen externen Dienst für transaktionalen Versand.
 :::
+
+</Region>
+
+<Region zones={['ca']}>
+
+:::warning
+Die im Webhosting enthaltene MX Plan Lösung unterliegt **Versandkontingenten** (etwa 200 E-Mails pro Stunde pro Account). Bevorzugen Sie für hohe Volumen – Newsletter oder transaktionale Massen-E-Mails – eine dedizierte Lösung wie Exchange oder einen externen Dienst für transaktionalen Versand.
+:::
+
+</Region>
+
+<Region zones={['apac']}>
+
+:::warning
+Die im Webhosting enthaltene MX Plan Lösung unterliegt **Versandkontingenten** (etwa 200 E-Mails pro Stunde pro Account). Bevorzugen Sie für hohe Volumen – Newsletter oder transaktionale Massen-E-Mails – einen externen Dienst für transaktionalen Versand.
+:::
+
+</Region>
 
 #### PHP-Codebeispiel mit PHPMailer
 

--- a/docs/de/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Webhosting - Best Practices für den E-Mail-Versand"
 description: Erfahren Sie, warum die PHP-Funktion mail() auf Shared Hosting nicht empfohlen wird und wie Sie den authentifizierten SMTP-Versand konfigurieren
-lastUpdated: 2026-07-13
+lastUpdated: 2026-07-15
 availableIn: [eu, ca, apac]
 ---
 
@@ -144,7 +144,7 @@ Verwenden Sie die folgenden Einstellungen für Ihren MX Plan E-Mail-Account (in 
 
 | Einstellung | Wert |
 |---|---|
-| **SMTP-Server** | `ssl0.ovh.net` |
+| **SMTP-Server** | `smtp.mail.ovh.net` |
 | **Port (SSL/TLS)** | `465` *(empfohlen)* |
 | **Port (STARTTLS)** | `587` |
 | **Verschlüsselung** | `SSL/TLS` (Port 465) oder `STARTTLS` (Port 587) |
@@ -190,29 +190,9 @@ Der **SMTP-Benutzername** ist Ihre vollständige E-Mail-Adresse (zum Beispiel `c
 
 Das **Passwort** ist das bei der Erstellung der Adresse festgelegte oder das im OVHcloud Kundencenter geänderte Passwort. Falls Sie es vergessen haben oder zurücksetzen möchten, lesen Sie die Anleitung [Passwort eines E-Mail-Accounts ändern](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
-<Region zones={['eu']}>
-
 :::warning
-Die im Webhosting enthaltene MX Plan Lösung unterliegt **Versandkontingenten** (etwa 200 E-Mails pro Stunde pro Account). Bevorzugen Sie für hohe Volumen – Newsletter oder transaktionale Massen-E-Mails – eine dedizierte Lösung (E-Mail Pro, Exchange) oder einen externen Dienst für transaktionalen Versand.
+Die im Webhosting enthaltene MX Plan Lösung unterliegt **Versandkontingenten** (etwa 200 E-Mails pro Stunde pro Account). E-Mail-Lösungen sind nicht für den Massenversand ausgelegt: Verwenden Sie für hohe Volumen – Newsletter oder transaktionale Massen-E-Mails – einen externen Dienst für transaktionalen Versand, der für diesen Zweck ausgelegt ist.
 :::
-
-</Region>
-
-<Region zones={['ca']}>
-
-:::warning
-Die im Webhosting enthaltene MX Plan Lösung unterliegt **Versandkontingenten** (etwa 200 E-Mails pro Stunde pro Account). Bevorzugen Sie für hohe Volumen – Newsletter oder transaktionale Massen-E-Mails – eine dedizierte Lösung wie Exchange oder einen externen Dienst für transaktionalen Versand.
-:::
-
-</Region>
-
-<Region zones={['apac']}>
-
-:::warning
-Die im Webhosting enthaltene MX Plan Lösung unterliegt **Versandkontingenten** (etwa 200 E-Mails pro Stunde pro Account). Bevorzugen Sie für hohe Volumen – Newsletter oder transaktionale Massen-E-Mails – einen externen Dienst für transaktionalen Versand.
-:::
-
-</Region>
 
 #### PHP-Codebeispiel mit PHPMailer
 
@@ -237,7 +217,7 @@ $mail = new PHPMailer(true);
 try {
     // Einstellungen des OVHcloud SMTP-Servers
     $mail->isSMTP();
-    $mail->Host       = 'ssl0.ovh.net';
+    $mail->Host       = 'smtp.mail.ovh.net';
     $mail->SMTPAuth   = true;
     $mail->Username   = 'contact@mydomain.ovh'; // Ihre OVHcloud E-Mail-Adresse
     $mail->Password   = 'your_password';         // Passwort des E-Mail-Accounts
@@ -267,7 +247,7 @@ try {
 <Region zones={['ca', 'apac']}>
 
 :::warning
-Das obige Beispiel verwendet den SMTP-Server `ssl0.ovh.net`, der nur in der Zone Europa verfügbar ist. Ersetzen Sie in Kanada oder in der Zone Asien-Pazifik den Wert von `$mail->Host` durch `smtp.mail.ovh.ca`.
+Das obige Beispiel verwendet den SMTP-Server `smtp.mail.ovh.net`, der nur in der Zone Europa verfügbar ist. Ersetzen Sie in Kanada oder in der Zone Asien-Pazifik den Wert von `$mail->Host` durch `smtp.mail.ovh.ca`.
 :::
 
 </Region>
@@ -319,7 +299,7 @@ Die Lösung besteht darin, ein **SMTP-Plugin** zu installieren, das `wp_mail()` 
 
 | Feld | Wert |
 |---|---|
-| **SMTP Host** | `ssl0.ovh.net` |
+| **SMTP Host** | `smtp.mail.ovh.net` |
 | **Encryption** | `SSL/TLS` |
 | **SMTP Port** | `465` |
 | **Authentication** | Aktiviert |
@@ -367,7 +347,7 @@ Aktivieren Sie die Option **Force From Email**, damit alle ausgehenden E-Mails d
 
 | Feld | Wert |
 |---|---|
-| **Host** | `ssl0.ovh.net` |
+| **Host** | `smtp.mail.ovh.net` |
 | **Port** | `465` |
 | **Encryption** | `SSL/TLS` |
 | **Authentication** | Ja |
@@ -405,7 +385,7 @@ Das Prinzip ist für jedes CMS oder Framework dasselbe: Ersetzen Sie die native 
 
 <Region zones={['eu']}>
 
-In allen Fällen sind die zu verwendenden SMTP-Einstellungen dieselben: Server `ssl0.ovh.net`, Port `465` (SSL/TLS) oder `587` (STARTTLS), mit Authentifizierung über die vollständige E-Mail-Adresse und deren Passwort.
+In allen Fällen sind die zu verwendenden SMTP-Einstellungen dieselben: Server `smtp.mail.ovh.net`, Port `465` (SSL/TLS) oder `587` (STARTTLS), mit Authentifizierung über die vollständige E-Mail-Adresse und deren Passwort.
 
 </Region>
 

--- a/docs/de/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,0 +1,400 @@
+---
+title: "Webhosting - Best Practices für den E-Mail-Versand"
+description: Erfahren Sie, warum die PHP-Funktion mail() auf Shared Hosting nicht empfohlen wird und wie Sie den authentifizierten SMTP-Versand über Ihre OVHcloud E-Mail-Accounts konfigurieren
+lastUpdated: 2026-07-13
+availableIn: [eu, ca, apac]
+---
+
+import { Region } from '@components/Zone';
+
+## Ziel
+
+Damit Ihre E-Mails Ihre Empfänger erreichen, betreibt OVHcloud eine dedizierte Infrastruktur für den ausgehenden Versand mit automatischer Anti-Spam-Filterung und kontinuierlicher Überwachung der Server-Reputation. Um diese optimal zu nutzen, empfehlen wir, Ihre E-Mails über **authentifizierten SMTP** anstatt über die native PHP-Funktion `mail()` zu versenden. Dieser Ansatz stellt sicher, dass jede E-Mail mit einer überprüfbaren Identität versendet wird, was die Zustellbarkeit deutlich verbessert und das Risiko verringert, als Spam eingestuft zu werden.
+
+**Diese Anleitung erläutert die Best Practices und Empfehlungen von OVHcloud, um E-Mails zuverlässig und sicher von einem Shared-Hosting-Paket aus zu versenden, egal ob Sie eine WordPress-Website, ein anderes CMS oder eine PHP-Anwendung verwalten.**
+
+## Voraussetzungen
+
+- Sie verfügen über ein [OVHcloud Webhosting](/links/web/hosting)-Paket.
+- Sie verfügen über eine E-Mail-Adresse, die mit Ihrer gehosteten Domain verknüpft ist (Lösung MX Plan, Email Pro oder Exchange). Falls Sie noch keine haben, lesen Sie die Anleitung [E-Mail-Accounts mit MX Plan erstellen](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+
+{/* CP-NAV-START:web-hosting */}
+---
+
+### Zugriff auf das OVHcloud Kundencenter
+
+- **Direkter Link:** <ManagerLink to="/#/web/hosting">Hosting-Pakete</ManagerLink>
+- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">Hosting-Pakete</code> > Wählen Sie Ihr Webhosting aus
+
+---
+{/* CP-NAV-END:web-hosting */}
+
+## In der praktischen Anwendung
+
+### 1. `mail()` oder authentifizierter SMTP: Welchen Unterschied macht das für Sie?
+
+#### Was OVHcloud unternimmt, um Ihren Versand zu schützen
+
+OVHcloud überwacht kontinuierlich die Reputation seiner Versandserver und filtert automatisch verdächtige Nachrichten heraus, damit Ihre legitimen E-Mails nicht darunter leiden. Dieser Schutz hat jedoch eine Grenze: Die PHP-Funktion `mail()` führt keinerlei Prüfung der in der E-Mail angegebenen Absenderidentität (das Feld `From:`) durch. Eine über `mail()` versendete E-Mail kann daher scheinbar von jeder beliebigen Adresse stammen, was ausreicht, um die Filter der Empfängerserver (Gmail, Outlook usw.) auszulösen und die Zustellbarkeit **Ihrer eigenen E-Mails** zu beeinträchtigen.
+
+#### E-Mails ohne zuverlässige Signatur
+
+Die Funktion `mail()` versendet E-Mails, ohne die Identität des Absenders zu garantieren. Empfängerserver (Gmail, Outlook usw.) prüfen anhand der **SPF**- und **DKIM**-Einträge, ob die E-Mail tatsächlich von einem für Ihre Domain autorisierten Server stammt. Mit `mail()` schlägt diese Prüfung häufig fehl: Die Nachricht landet dann möglicherweise im Spam oder wird abgewiesen.
+
+Der Versand über authentifizierten SMTP löst dieses Problem: Die E-Mail wird von dem für Ihre Domain autorisierten OVHcloud Server mit der korrekten Signatur versendet.
+
+:::warning
+Ein missbräuchlicher Einsatz der Funktion `mail()` kann zur automatischen Sperrung der ausgehenden E-Mails Ihres Hostings führen. Falls Sie feststellen, dass Ihre E-Mails nicht mehr versendet werden, lesen Sie die Anleitung [Automatische E-Mails eines Webhostings verwalten](/guides/web-cloud/web-hosting/mail-function-script-records).
+:::
+
+#### Offene Formulare: ein zusätzlicher Angriffsvektor für Missbrauch
+
+Ein öffentlich zugängliches Kontaktformular ohne Schutzmechanismus ist ein bevorzugtes Ziel für Bots. Sie nutzen es aus, um innerhalb weniger Minuten den Versand von Tausenden E-Mails über Ihr Hosting auszulösen, wodurch die geteilte IP-Adresse gesperrt wird und alle Kunden auf dem Cluster beeinträchtigt werden.
+
+Richten Sie die folgenden Schutzmaßnahmen für jedes Formular ein, das einen E-Mail-Versand auslöst:
+
+- **Captcha**: Integrieren Sie ein Überprüfungssystem (Google reCAPTCHA v3, hCaptcha oder eine einfache Rechenaufgabe), um automatisierte Übermittlungen zu blockieren.
+- **Rate Limiting**: Begrenzen Sie serverseitig die Anzahl der Sendevorgänge pro IP-Adresse, um Missbrauch durch Massenversand zu verhindern.
+- **Strenge Eingabevalidierung**: Prüfen und bereinigen Sie jedes Formularfeld, bevor Sie es in einer E-Mail verwenden. Vertrauen Sie niemals den von Nutzern übermittelten Daten.
+
+:::warning
+Das Fehlen eines Captchas bei einem offenen Versandformular ist eine der häufigsten Ursachen dafür, dass Shared Hosting wegen Spam gesperrt wird. Dieser Schutz ist unabhängig von der verwendeten Versandmethode unerlässlich.
+:::
+
+### 2. Die Best Practice: Verwenden Sie einen OVHcloud E-Mail-Account mit authentifiziertem SMTP
+
+#### Prinzip
+
+Versenden Sie Ihre E-Mails über eine **authentifizierte SMTP**-Verbindung zum OVHcloud Mailserver, indem Sie einen E-Mail-Account verwenden, der mit Ihrer gehosteten Domain verknüpft ist (zum Beispiel `contact@mydomain.ovh`).
+
+Dieser Ansatz bietet drei wesentliche Vorteile:
+
+- **Garantierte Authentifizierung**: Der OVHcloud Server überprüft Ihre Identität, bevor er die E-Mail annimmt.
+- **Funktionierende SPF- und DKIM-Einträge**: Die E-Mail wird von einem für Ihre Domain autorisierten Server versendet und korrekt signiert.
+- **Nachverfolgbarkeit**: Jeder Versand ist mit einem identifizierten Account verknüpft, was ein schnelles Eingreifen im Missbrauchsfall ermöglicht.
+
+#### Warum das Feld `From:` zu Ihrer Domain gehören muss
+
+Das Feld `From:` Ihrer E-Mail muss **zwingend** eine Adresse enthalten, die zu Ihrer Domain gehört (z. B. `contact@mydomain.ovh`), und diese Adresse muss mit dem für die Authentifizierung verwendeten SMTP-Account übereinstimmen.
+
+Wenn das Feld `From:` nicht mit der im SPF-Eintrag autorisierten Domain übereinstimmt oder wenn die DKIM-Signatur nicht passt, können die Empfängerserver (Gmail, Outlook usw.) die E-Mail abweisen oder als Spam einstufen.
+
+:::tip
+Um die Zustellbarkeit zu maximieren, stellen Sie sicher, dass die Einträge SPF, DKIM und DMARC in Ihrer DNS-Zone korrekt konfiguriert sind. Gmail und Yahoo Mail setzen sie mittlerweile für Massenversender voraus. Lesen Sie unsere Anleitungen:
+
+- [E-Mail-Sicherheit durch SPF-Eintrag verbessern](/guides/web-cloud/domains/dns-zone-spf)
+- [E-Mail-Sicherheit durch DKIM-Eintrag verbessern](/guides/web-cloud/domains/dns-zone-dkim)
+- [E-Mail-Sicherheit durch DMARC-Eintrag verbessern](/guides/web-cloud/domains/dns-zone-dmarc)
+
+:::
+
+#### Kontaktformulare: festes Feld `From:` und Feld `Reply-To:` des Nutzers
+
+Ein häufiger Fehler besteht darin, die vom Nutzer im Formular eingegebene E-Mail-Adresse direkt in das Feld `From:` einzutragen. Beispielsweise gibt ein Besucher `utilisateur@gmail.com` ein und das Skript verwendet diese Adresse als Absender.
+
+Dieses Verhalten ist aus zwei Gründen falsch:
+
+- Der SPF-Eintrag Ihrer Domain autorisiert die Gmail-Server (oder die eines anderen Drittanbieters) nicht, in Ihrem Namen zu versenden → Fehlschlagen der SPF-Prüfung.
+- Sie versenden "im Namen" einer Adresse, die Ihnen nicht gehört → hohes Risiko, als Spam eingestuft oder abgewiesen zu werden.
+
+**Das korrekte Muster für ein Kontaktformular:**
+
+| E-Mail-Feld | Wert | Rolle |
+|---|---|---|
+| `From:` | `contact@mydomain.ovh` (feste Adresse der Website) | Authentifizierter Absender – ändert sich nie |
+| `Reply-To:` | Vom Nutzer im Formular eingegebene Adresse | Ermöglicht es Ihnen, direkt dem Nutzer zu antworten |
+| `Subject:` | Betreff der Nachricht, mit Präfix (z. B. `[Contact] ...`) | Macht Formularnachrichten leicht erkennbar |
+
+Auf diese Weise sendet Ihr Mailprogramm, wenn Sie auf die empfangene E-Mail antworten, die Antwort über das Feld `Reply-To:` an die Adresse des Nutzers, ohne die SPF/DKIM-Authentifizierung zu beeinträchtigen.
+
+So passen Sie das PHPMailer-Beispiel für ein Kontaktformular an:
+
+```php
+// User-supplied data (validate and sanitise before use)
+$userEmail = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
+$userName  = htmlspecialchars(strip_tags($_POST['name']));
+$message   = htmlspecialchars(strip_tags($_POST['message']));
+
+if (!$userEmail) {
+    die('Invalid email address.');
+}
+
+// From: always fixed — your site's address, never the user's
+$mail->setFrom('contact@mydomain.ovh', 'My Website');
+
+// Reply-To: the user's address, so you can reply to them directly
+$mail->addReplyTo($userEmail, $userName);
+
+// Recipient: yourself (you receive the form message)
+$mail->addAddress('contact@mydomain.ovh', 'My Website');
+
+$mail->Subject = '[Contact] ' . $userName;
+$mail->Body    = "Name: $userName\nEmail: $userEmail\n\nMessage:\n$message";
+```
+
+:::tip
+Übergeben Sie Formulardaten niemals ohne vorherige Validierung direkt an PHPMailer. Verwenden Sie `filter_var()` für die E-Mail-Adresse und `htmlspecialchars()` + `strip_tags()` für Textfelder, um E-Mail-Header-Injection zu verhindern.
+:::
+
+#### OVHcloud SMTP-Einstellungen
+
+Verwenden Sie die folgenden Einstellungen für Ihren MX Plan E-Mail-Account (in Ihrem Webhosting enthalten):
+
+<Region zones={['eu']}>
+
+| Einstellung | Wert |
+|---|---|
+| **SMTP-Server** | `ssl0.ovh.net` |
+| **Port (SSL/TLS)** | `465` *(empfohlen)* |
+| **Port (STARTTLS)** | `587` |
+| **Verschlüsselung** | `SSL/TLS` (Port 465) oder `STARTTLS` (Port 587) |
+| **Authentifizierung** | Erforderlich |
+| **Benutzername** | Vollständige E-Mail-Adresse (z. B. `contact@mydomain.ovh`) |
+| **Passwort** | Passwort des OVHcloud E-Mail-Accounts |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Einstellung | Wert |
+|---|---|
+| **SMTP-Server** | `smtp.mail.ovh.ca` |
+| **Port (SSL/TLS)** | `465` *(empfohlen)* |
+| **Port (STARTTLS)** | `587` |
+| **Verschlüsselung** | `SSL/TLS` (Port 465) oder `STARTTLS` (Port 587) |
+| **Authentifizierung** | Erforderlich |
+| **Benutzername** | Vollständige E-Mail-Adresse (z. B. `contact@mydomain.ovh`) |
+| **Passwort** | Passwort des OVHcloud E-Mail-Accounts |
+
+</Region>
+
+:::tip
+Für **Email Pro**- oder **Exchange**-Lösungen ist der SMTP-Server unterschiedlich. Lesen Sie die Dokumentation der jeweiligen Lösung für die genauen Einstellungen.
+:::
+
+#### Wo Sie Ihre SMTP-Zugangsdaten finden
+
+Der **SMTP-Benutzername** ist Ihre vollständige E-Mail-Adresse (z. B. `contact@mydomain.ovh`).
+
+Das **Passwort** ist das bei der Erstellung der Adresse festgelegte oder das im OVHcloud Kundencenter geänderte Passwort. Falls Sie es vergessen haben oder zurücksetzen möchten, lesen Sie die Anleitung [Passwort eines E-Mail-Accounts ändern](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
+
+:::warning
+Die im Webhosting enthaltene MX Plan Lösung unterliegt **Versandkontingenten** (etwa 200 E-Mails pro Stunde pro Account). Bevorzugen Sie für hohe Volumen – Newsletter oder transaktionale Massen-E-Mails – eine dedizierte Lösung (Email Pro, Exchange) oder einen externen Dienst für transaktionalen Versand.
+:::
+
+#### PHP-Codebeispiel mit PHPMailer
+
+[PHPMailer](https://github.com/PHPMailer/PHPMailer) ist die Referenz-PHP-Bibliothek für den E-Mail-Versand über SMTP. Installieren Sie sie über Composer:
+
+```bash
+composer require phpmailer/phpmailer
+```
+
+Hier ein vollständiges Beispiel für den authentifizierten SMTP-Versand:
+
+```php
+<?php
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
+use PHPMailer\PHPMailer\Exception;
+
+require 'vendor/autoload.php';
+
+$mail = new PHPMailer(true);
+
+try {
+    // OVHcloud SMTP server settings
+    $mail->isSMTP();
+    $mail->Host       = 'ssl0.ovh.net';
+    $mail->SMTPAuth   = true;
+    $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
+    $mail->Password   = 'your_password';         // Password of the email account
+    $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
+    $mail->Port       = 465;
+
+    // Sender: must belong to your hosted domain
+    $mail->setFrom('contact@mydomain.ovh', 'My Website');
+    $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
+
+    // Recipient
+    $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
+
+    // Content
+    $mail->isHTML(true);
+    $mail->Subject = 'Your email subject';
+    $mail->Body    = 'Email body in <b>HTML</b>';
+    $mail->AltBody = 'Email body in plain text (fallback)';
+
+    $mail->send();
+    echo 'Email sent successfully.';
+} catch (Exception $e) {
+    echo "Error while sending: {$mail->ErrorInfo}";
+}
+```
+
+<Region zones={['ca', 'apac']}>
+
+:::warning
+Das obige Beispiel verwendet den SMTP-Server `ssl0.ovh.net`, der nur in der Zone Europa verfügbar ist. Ersetzen Sie in Kanada oder in der Zone Asien-Pazifik den Wert von `$mail->Host` durch `smtp.mail.ovh.ca`.
+:::
+
+</Region>
+
+:::warning
+Speichern Sie das Passwort Ihres E-Mail-Accounts niemals im Klartext in einer versionierten PHP-Datei. Verwenden Sie eine Konfigurationsdatei, die von Ihrem Git-Repository ausgeschlossen ist (`.gitignore`).
+:::
+
+:::info
+Mit dieser Konfiguration ist jede von Ihrer Website versendete E-Mail:
+
+- **authentifiziert** über den OVHcloud Server,
+- **signiert** mit den SPF- und DKIM-Einträgen Ihrer Domain,
+- **nachverfolgbar** im Fall von Missbrauch oder eines Zustellbarkeitsproblems.
+
+:::
+
+### 3. WordPress und andere CMS: Verwenden Sie ein SMTP-Plugin
+
+#### 3.1 Das Problem mit WordPress in der Standardkonfiguration
+
+Die Funktion `wp_mail()` in WordPress verwendet im Hintergrund die PHP-Funktion `mail()`. Sie erbt daher alle im vorherigen Abschnitt beschriebenen Probleme: keine Authentifizierung, unkontrolliertes Feld `From:`, Spam-Risiko.
+
+Die Lösung besteht darin, ein **SMTP-Plugin** zu installieren, das `wp_mail()` durch eine authentifizierte SMTP-Verbindung zu Ihrem OVHcloud Mailserver ersetzt.
+
+#### 3.2 WP Mail SMTP konfigurieren
+
+[WP Mail SMTP](https://wordpress.org/plugins/wp-mail-smtp/) ist das am häufigsten verwendete Plugin für diese Konfiguration.
+
+**Installation:**
+
+1. Gehen Sie in Ihrer WordPress-Administration zu **Plugins** > **Neues Plugin hinzufügen**.
+2. Suchen Sie nach `WP Mail SMTP` und klicken Sie auf **Jetzt installieren** und anschließend auf **Aktivieren**.
+
+**Konfiguration:**
+
+1. Gehen Sie im Administrationsmenü zu **WP Mail SMTP** > **Einstellungen**.
+2. Füllen Sie im Bereich **From** die folgenden Felder aus:
+
+| Feld | Wert |
+|---|---|
+| **From Email** | `contact@mydomain.ovh` (Adresse, die zu Ihrer Domain gehört) |
+| **From Name** | Anzeigename für Ihre Website (z. B. `My Website`) |
+
+3. Wählen Sie im Bereich **Mailer** die Option **Other SMTP**.
+4. Füllen Sie die SMTP-Einstellungen aus:
+
+<Region zones={['eu']}>
+
+| Feld | Wert |
+|---|---|
+| **SMTP Host** | `ssl0.ovh.net` |
+| **Encryption** | `SSL/TLS` |
+| **SMTP Port** | `465` |
+| **Authentication** | Aktiviert |
+| **SMTP Username** | `contact@mydomain.ovh` |
+| **SMTP Password** | Passwort Ihres OVHcloud E-Mail-Accounts |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Feld | Wert |
+|---|---|
+| **SMTP Host** | `smtp.mail.ovh.ca` |
+| **Encryption** | `SSL/TLS` |
+| **SMTP Port** | `465` |
+| **Authentication** | Aktiviert |
+| **SMTP Username** | `contact@mydomain.ovh` |
+| **SMTP Password** | Passwort Ihres OVHcloud E-Mail-Accounts |
+
+</Region>
+
+5. Klicken Sie auf **Einstellungen speichern**.
+6. Verwenden Sie im Tab **Tools** die Funktion **Email Test**, um die Konfiguration zu überprüfen.
+
+:::tip
+Aktivieren Sie die Option **Force From Email**, damit alle ausgehenden E-Mails die konfigurierte Adresse verwenden, selbst wenn ein Drittanbieter-Plugin versucht, eine andere zu verwenden.
+:::
+
+#### 3.3 Alternative: FluentSMTP
+
+[FluentSMTP](https://wordpress.org/plugins/fluent-smtp/) ist eine schlanke, kostenlose Alternative ohne Begrenzung des Versandvolumens.
+
+**Installation:**
+
+1. Gehen Sie in Ihrer WordPress-Administration zu **Plugins** > **Neues Plugin hinzufügen**.
+2. Suchen Sie nach `FluentSMTP` und klicken Sie auf **Jetzt installieren** und anschließend auf **Aktivieren**.
+
+**Konfiguration:**
+
+1. Gehen Sie zu **FluentSMTP** > **Einstellungen**.
+2. Klicken Sie auf **Add Connection** und wählen Sie **Other SMTP**.
+3. Füllen Sie dieselben Einstellungen wie bei WP Mail SMTP aus:
+
+<Region zones={['eu']}>
+
+| Feld | Wert |
+|---|---|
+| **Host** | `ssl0.ovh.net` |
+| **Port** | `465` |
+| **Encryption** | `SSL/TLS` |
+| **Authentication** | Ja |
+| **Username** | `contact@mydomain.ovh` |
+| **Password** | Passwort Ihres OVHcloud E-Mail-Accounts |
+| **From Email** | `contact@mydomain.ovh` |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Feld | Wert |
+|---|---|
+| **Host** | `smtp.mail.ovh.ca` |
+| **Port** | `465` |
+| **Encryption** | `SSL/TLS` |
+| **Authentication** | Ja |
+| **Username** | `contact@mydomain.ovh` |
+| **Password** | Passwort Ihres OVHcloud E-Mail-Accounts |
+| **From Email** | `contact@mydomain.ovh` |
+
+</Region>
+
+4. Klicken Sie auf **Save Connection** und senden Sie anschließend eine Test-E-Mail.
+
+#### 3.4 Andere CMS (Drupal, Joomla, PrestaShop)
+
+Das Prinzip ist für jedes CMS oder Framework dasselbe: Ersetzen Sie die native Versandfunktion durch ein Modul oder eine authentifizierte SMTP-Konfiguration.
+
+| CMS | Empfohlenes Modul |
+|---|---|
+| **Drupal** | [SMTP Authentication Support](https://www.drupal.org/project/smtp) |
+| **Joomla** | Native Konfiguration: **System** > **Globale Konfiguration** > Tab **Server** > Bereich **Mail-Einstellungen** |
+| **PrestaShop** | **Erweiterte Parameter** > **E-Mail** – wählen Sie **Eigene SMTP-Parameter festlegen** |
+
+<Region zones={['eu']}>
+
+In allen Fällen sind die zu verwendenden SMTP-Einstellungen dieselben: Server `ssl0.ovh.net`, Port `465` (SSL/TLS) oder `587` (STARTTLS), mit Authentifizierung über die vollständige E-Mail-Adresse und deren Passwort.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+In allen Fällen sind die zu verwendenden SMTP-Einstellungen dieselben: Server `smtp.mail.ovh.ca`, Port `465` (SSL/TLS) oder `587` (STARTTLS), mit Authentifizierung über die vollständige E-Mail-Adresse und deren Passwort.
+
+</Region>
+
+## Weiterführende Informationen
+
+[Automatische E-Mails eines Webhostings verwalten](/guides/web-cloud/web-hosting/mail-function-script-records)
+
+[E-Mail-Sicherheit durch SPF-Eintrag verbessern](/guides/web-cloud/domains/dns-zone-spf)
+
+[E-Mail-Sicherheit durch DKIM-Eintrag verbessern](/guides/web-cloud/domains/dns-zone-dkim)
+
+[E-Mail-Sicherheit durch DMARC-Eintrag verbessern](/guides/web-cloud/domains/dns-zone-dmarc)
+
+Für spezialisierte Leistungen (Referenzierung, Entwicklung usw.) wenden Sie sich an die [OVHcloud Partner](/links/partner).
+
+Wenn Sie Unterstützung bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, sehen Sie sich unsere verschiedenen [Support-Angebote](/links/support) an.
+
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -16,7 +16,7 @@ Damit Ihre E-Mails Ihre Empfänger erreichen, betreibt OVHcloud eine dedizierte 
 ## Voraussetzungen
 
 - Sie verfügen über ein [OVHcloud Webhosting](/links/web/hosting)-Paket.
-- Sie verfügen über eine E-Mail-Adresse, die mit Ihrer gehosteten Domain verknüpft ist (Lösung MX Plan, Email Pro oder Exchange). Falls Sie noch keine haben, lesen Sie die Anleitung [E-Mail-Accounts mit MX Plan erstellen](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+- Sie verfügen über eine E-Mail-Adresse, die mit Ihrer Domain verknüpft ist (Lösung MX Plan, E-Mail Pro oder Exchange). Falls Sie noch keine haben, lesen Sie die Anleitung [E-Mail-Accounts mit MX Plan erstellen](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -65,7 +65,7 @@ Das Fehlen eines Captchas bei einem offenen Versandformular ist eine der häufig
 
 #### Prinzip
 
-Versenden Sie Ihre E-Mails über eine **authentifizierte SMTP**-Verbindung zum OVHcloud Mailserver, indem Sie einen E-Mail-Account verwenden, der mit Ihrer gehosteten Domain verknüpft ist (zum Beispiel `contact@mydomain.ovh`).
+Versenden Sie Ihre E-Mails über eine **authentifizierte SMTP**-Verbindung zum OVHcloud Mailserver, indem Sie einen E-Mail-Account verwenden, der mit Ihrer Domain verknüpft ist (zum Beispiel `contact@mydomain.ovh`).
 
 Dieser Ansatz bietet drei wesentliche Vorteile:
 
@@ -75,7 +75,7 @@ Dieser Ansatz bietet drei wesentliche Vorteile:
 
 #### Warum das Feld `From:` zu Ihrer Domain gehören muss
 
-Das Feld `From:` Ihrer E-Mail muss **zwingend** eine Adresse enthalten, die zu Ihrer Domain gehört (z. B. `contact@mydomain.ovh`), und diese Adresse muss mit dem für die Authentifizierung verwendeten SMTP-Account übereinstimmen.
+Das Feld `From:` Ihrer E-Mail muss **zwingend** eine Adresse enthalten, die zu Ihrer Domain gehört (zum Beispiel `contact@mydomain.ovh`), und diese Adresse muss mit dem für die Authentifizierung verwendeten SMTP-Account übereinstimmen.
 
 Wenn das Feld `From:` nicht mit der im SPF-Eintrag autorisierten Domain übereinstimmt oder wenn die DKIM-Signatur nicht passt, können die Empfängerserver (Gmail, Outlook usw.) die E-Mail abweisen oder als Spam einstufen.
 
@@ -103,14 +103,14 @@ Dieses Verhalten ist aus zwei Gründen falsch:
 |---|---|---|
 | `From:` | `contact@mydomain.ovh` (feste Adresse der Website) | Authentifizierter Absender – ändert sich nie |
 | `Reply-To:` | Vom Nutzer im Formular eingegebene Adresse | Ermöglicht es Ihnen, direkt dem Nutzer zu antworten |
-| `Subject:` | Betreff der Nachricht, mit Präfix (z. B. `[Contact] ...`) | Macht Formularnachrichten leicht erkennbar |
+| `Subject:` | Betreff der Nachricht, mit Präfix (zum Beispiel `[Contact]`) | Macht Formularnachrichten leicht erkennbar |
 
 Auf diese Weise sendet Ihr Mailprogramm, wenn Sie auf die empfangene E-Mail antworten, die Antwort über das Feld `Reply-To:` an die Adresse des Nutzers, ohne die SPF/DKIM-Authentifizierung zu beeinträchtigen.
 
 So passen Sie das PHPMailer-Beispiel für ein Kontaktformular an:
 
 ```php
-// User-supplied data (validate and sanitise before use)
+// Vom Benutzer bereitgestellte Daten (vor Verwendung validieren und bereinigen)
 $userEmail = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
 $userName  = htmlspecialchars(strip_tags($_POST['name']));
 $message   = htmlspecialchars(strip_tags($_POST['message']));
@@ -119,13 +119,13 @@ if (!$userEmail) {
     die('Invalid email address.');
 }
 
-// From: always fixed — your site's address, never the user's
+// From: immer fest — die Adresse Ihrer Website, niemals die des Benutzers
 $mail->setFrom('contact@mydomain.ovh', 'My Website');
 
-// Reply-To: the user's address, so you can reply to them directly
+// Reply-To: die Adresse des Benutzers, damit Sie ihm direkt antworten können
 $mail->addReplyTo($userEmail, $userName);
 
-// Recipient: yourself (you receive the form message)
+// Empfänger: Sie selbst (Sie erhalten die Formularnachricht)
 $mail->addAddress('contact@mydomain.ovh', 'My Website');
 
 $mail->Subject = '[Contact] ' . $userName;
@@ -149,7 +149,7 @@ Verwenden Sie die folgenden Einstellungen für Ihren MX Plan E-Mail-Account (in 
 | **Port (STARTTLS)** | `587` |
 | **Verschlüsselung** | `SSL/TLS` (Port 465) oder `STARTTLS` (Port 587) |
 | **Authentifizierung** | Erforderlich |
-| **Benutzername** | Vollständige E-Mail-Adresse (z. B. `contact@mydomain.ovh`) |
+| **Benutzername** | Vollständige E-Mail-Adresse (zum Beispiel `contact@mydomain.ovh`) |
 | **Passwort** | Passwort des OVHcloud E-Mail-Accounts |
 
 </Region>
@@ -163,23 +163,23 @@ Verwenden Sie die folgenden Einstellungen für Ihren MX Plan E-Mail-Account (in 
 | **Port (STARTTLS)** | `587` |
 | **Verschlüsselung** | `SSL/TLS` (Port 465) oder `STARTTLS` (Port 587) |
 | **Authentifizierung** | Erforderlich |
-| **Benutzername** | Vollständige E-Mail-Adresse (z. B. `contact@mydomain.ovh`) |
+| **Benutzername** | Vollständige E-Mail-Adresse (zum Beispiel `contact@mydomain.ovh`) |
 | **Passwort** | Passwort des OVHcloud E-Mail-Accounts |
 
 </Region>
 
 :::tip
-Für **Email Pro**- oder **Exchange**-Lösungen ist der SMTP-Server unterschiedlich. Lesen Sie die Dokumentation der jeweiligen Lösung für die genauen Einstellungen.
+Für **E-Mail Pro**- oder **Exchange**-Lösungen ist der SMTP-Server unterschiedlich. Lesen Sie die Dokumentation der jeweiligen Lösung für die genauen Einstellungen.
 :::
 
 #### Wo Sie Ihre SMTP-Zugangsdaten finden
 
-Der **SMTP-Benutzername** ist Ihre vollständige E-Mail-Adresse (z. B. `contact@mydomain.ovh`).
+Der **SMTP-Benutzername** ist Ihre vollständige E-Mail-Adresse (zum Beispiel `contact@mydomain.ovh`).
 
 Das **Passwort** ist das bei der Erstellung der Adresse festgelegte oder das im OVHcloud Kundencenter geänderte Passwort. Falls Sie es vergessen haben oder zurücksetzen möchten, lesen Sie die Anleitung [Passwort eines E-Mail-Accounts ändern](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
 :::warning
-Die im Webhosting enthaltene MX Plan Lösung unterliegt **Versandkontingenten** (etwa 200 E-Mails pro Stunde pro Account). Bevorzugen Sie für hohe Volumen – Newsletter oder transaktionale Massen-E-Mails – eine dedizierte Lösung (Email Pro, Exchange) oder einen externen Dienst für transaktionalen Versand.
+Die im Webhosting enthaltene MX Plan Lösung unterliegt **Versandkontingenten** (etwa 200 E-Mails pro Stunde pro Account). Bevorzugen Sie für hohe Volumen – Newsletter oder transaktionale Massen-E-Mails – eine dedizierte Lösung (E-Mail Pro, Exchange) oder einen externen Dienst für transaktionalen Versand.
 :::
 
 #### PHP-Codebeispiel mit PHPMailer
@@ -203,23 +203,23 @@ require 'vendor/autoload.php';
 $mail = new PHPMailer(true);
 
 try {
-    // OVHcloud SMTP server settings
+    // Einstellungen des OVHcloud SMTP-Servers
     $mail->isSMTP();
     $mail->Host       = 'ssl0.ovh.net';
     $mail->SMTPAuth   = true;
-    $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
-    $mail->Password   = 'your_password';         // Password of the email account
+    $mail->Username   = 'contact@mydomain.ovh'; // Ihre OVHcloud E-Mail-Adresse
+    $mail->Password   = 'your_password';         // Passwort des E-Mail-Accounts
     $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
     $mail->Port       = 465;
 
-    // Sender: must belong to your hosted domain
+    // Absender: muss zu Ihrer Domain gehören
     $mail->setFrom('contact@mydomain.ovh', 'My Website');
     $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
 
-    // Recipient
+    // Empfänger
     $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
 
-    // Content
+    // Inhalt
     $mail->isHTML(true);
     $mail->Subject = 'Your email subject';
     $mail->Body    = 'Email body in <b>HTML</b>';
@@ -263,7 +263,7 @@ Die Lösung besteht darin, ein **SMTP-Plugin** zu installieren, das `wp_mail()` 
 
 #### 3.2 WP Mail SMTP konfigurieren
 
-[WP Mail SMTP](https://wordpress.org/plugins/wp-mail-smtp/) ist das am häufigsten verwendete Plugin für diese Konfiguration.
+[WP Mail SMTP](https://de.wordpress.org/plugins/wp-mail-smtp/) ist das am häufigsten verwendete Plugin für diese Konfiguration.
 
 **Installation:**
 
@@ -278,7 +278,7 @@ Die Lösung besteht darin, ein **SMTP-Plugin** zu installieren, das `wp_mail()` 
 | Feld | Wert |
 |---|---|
 | **From Email** | `contact@mydomain.ovh` (Adresse, die zu Ihrer Domain gehört) |
-| **From Name** | Anzeigename für Ihre Website (z. B. `My Website`) |
+| **From Name** | Anzeigename für Ihre Website (zum Beispiel `My Website`) |
 
 3. Wählen Sie im Bereich **Mailer** die Option **Other SMTP**.
 4. Füllen Sie die SMTP-Einstellungen aus:
@@ -318,7 +318,7 @@ Aktivieren Sie die Option **Force From Email**, damit alle ausgehenden E-Mails d
 
 #### 3.3 Alternative: FluentSMTP
 
-[FluentSMTP](https://wordpress.org/plugins/fluent-smtp/) ist eine schlanke, kostenlose Alternative ohne Begrenzung des Versandvolumens.
+[FluentSMTP](https://de.wordpress.org/plugins/fluent-smtp/) ist eine schlanke, kostenlose Alternative ohne Begrenzung des Versandvolumens.
 
 **Installation:**
 

--- a/docs/de/guides/web-cloud/web-hosting/landing-page-configuration.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/landing-page-configuration.mdx
@@ -75,6 +75,7 @@ Um die passende Anleitung für Ihren Bedarf zu finden:
         { title: 'Git konfigurieren und verwenden', link: '/guides/web-cloud/web-hosting/git-integration-webhosting' },
         { title: 'Automatische Aufgaben (CRON) erstellen', link: '/guides/web-cloud/web-hosting/cron-tasks' },
         { title: 'Automatische E-Mails nachverfolgen', link: '/guides/web-cloud/web-hosting/mail-function-script-records' },
+        { title: 'Best Practices für den E-Mail-Versand', link: '/guides/web-cloud/web-hosting/email-sending-best-practices' },
         { title: 'Eine Webanwendung über die API verwalten', link: '/guides/web-cloud/web-hosting/api-webhosting' },
         { title: 'Ihren Tarif anpassen', link: '/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer' },
         { title: 'Das Backup des FTP-Speichers abrufen (Cloud Web)', link: '/guides/web-cloud/web-hosting/backup-ftp', zones: ['eu'] },

--- a/docs/en/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -15,8 +15,8 @@ To ensure your emails reach your recipients, OVHcloud maintains a dedicated outb
 
 ## Requirements
 
-- A [OVHcloud Web Hosting](/links/web/hosting) plan.
-- An email address attached to your hosted domain name (MX Plan, Email Pro, or Exchange solution). If you do not have one yet, refer to the guide [Creating an email address with an MX Plan solution](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+- An [OVHcloud Web Hosting](/links/web/hosting) plan.
+- An email address attached to your domain name (MX Plan, Email Pro, or Exchange solution). If you do not have one yet, refer to the guide [Creating an email address with an MX Plan solution](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -65,7 +65,7 @@ The absence of a captcha on an open sending form is one of the most frequent cau
 
 #### Principle
 
-Send your emails through an **authenticated SMTP** connection to the OVHcloud mail server, using an email account attached to your hosted domain (for example `contact@mydomain.ovh`).
+Send your emails through an **authenticated SMTP** connection to the OVHcloud mail server, using an email account attached to your domain (for example `contact@mydomain.ovh`).
 
 This approach offers three major benefits:
 
@@ -75,7 +75,7 @@ This approach offers three major benefits:
 
 #### Why the `From:` field must belong to your domain
 
-The `From:` field of your email must **necessarily** contain an address belonging to your domain (e.g. `contact@mydomain.ovh`), and this address must match the SMTP account used for authentication.
+The `From:` field of your email must **necessarily** contain an address belonging to your domain (for example `contact@mydomain.ovh`), and this address must match the SMTP account used for authentication.
 
 If the `From:` does not match the domain authorised in the SPF record, or if the DKIM signature does not match, the recipient mail servers (Gmail, Outlook, etc.) may reject the email or classify it as spam.
 
@@ -103,7 +103,7 @@ This behaviour is incorrect for two reasons:
 |---|---|---|
 | `From:` | `contact@mydomain.ovh` (fixed address of the site) | Authenticated sender — never changes |
 | `Reply-To:` | Address entered by the user in the form | Allows you to reply directly to the user |
-| `Subject:` | Message subject, prefixed (e.g. `[Contact] ...`) | Makes form messages easy to identify |
+| `Subject:` | Message subject, prefixed (for example `[Contact]`) | Makes form messages easy to identify |
 
 This way, when you reply to the email received, your mail client sends the reply to the user's address via the `Reply-To:` field, without compromising SPF/DKIM authentication.
 
@@ -149,7 +149,7 @@ Use the following settings for your MX Plan email account (included with your we
 | **Port (STARTTLS)** | `587` |
 | **Encryption** | `SSL/TLS` (port 465) or `STARTTLS` (port 587) |
 | **Authentication** | Required |
-| **Username** | Full email address (e.g. `contact@mydomain.ovh`) |
+| **Username** | Full email address (for example `contact@mydomain.ovh`) |
 | **Password** | Password of the OVHcloud email account |
 
 </Region>
@@ -163,7 +163,7 @@ Use the following settings for your MX Plan email account (included with your we
 | **Port (STARTTLS)** | `587` |
 | **Encryption** | `SSL/TLS` (port 465) or `STARTTLS` (port 587) |
 | **Authentication** | Required |
-| **Username** | Full email address (e.g. `contact@mydomain.ovh`) |
+| **Username** | Full email address (for example `contact@mydomain.ovh`) |
 | **Password** | Password of the OVHcloud email account |
 
 </Region>
@@ -174,7 +174,7 @@ For **Email Pro** or **Exchange** solutions, the SMTP server is different. Refer
 
 #### Where to find your SMTP credentials
 
-The **SMTP username** is your full email address (e.g. `contact@mydomain.ovh`).
+The **SMTP username** is your full email address (for example `contact@mydomain.ovh`).
 
 The **password** is the one set when the address was created, or changed from the OVHcloud Control Panel. If you have forgotten it or want to reset it, refer to the guide [Changing the password of an email account](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
@@ -212,7 +212,7 @@ try {
     $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
     $mail->Port       = 465;
 
-    // Sender: must belong to your hosted domain
+    // Sender: must belong to your domain
     $mail->setFrom('contact@mydomain.ovh', 'My Website');
     $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
 
@@ -278,7 +278,7 @@ The solution is to install an **SMTP plugin** that replaces `wp_mail()` with an 
 | Field | Value |
 |---|---|
 | **From Email** | `contact@mydomain.ovh` (address belonging to your domain) |
-| **From Name** | Display name for your site (e.g. `My Website`) |
+| **From Name** | Display name for your site (for example `My Website`) |
 
 3. In the **Mailer** section, select **Other SMTP**.
 4. Fill in the SMTP settings:

--- a/docs/en/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -9,14 +9,14 @@ import { Region } from '@components/Zone';
 
 ## Objective
 
-To ensure your emails reach your recipients, OVHcloud maintains a dedicated outbound infrastructure, with automatic anti-spam filtering and continuous monitoring of server reputation. To make the most of it, we recommend sending your emails through **authenticated SMTP** rather than the native PHP `mail()` function. This approach ensures that every email is issued with a verifiable identity, which significantly improves deliverability and reduces the risk of being classified as spam.
+To ensure your emails reach your recipients, OVHcloud maintains a dedicated outbound infrastructure, with automatic anti-spam filtering and continuous monitoring of server reputation. To make the most of it, we recommend sending your emails through **authenticated SMTP** rather than the native PHP `mail()` function. This approach gives every email a verifiable identity, which significantly improves deliverability and reduces the risk of being classified as spam.
 
 **This guide explains OVHcloud's best practices and recommendations for sending emails reliably and securely from a shared hosting plan, whether you manage a WordPress site, another CMS, or a PHP application.**
 
 ## Requirements
 
 - An [OVHcloud Web Hosting](/links/web/hosting) plan.
-- An email address attached to your domain name (MX Plan, Email Pro, or Exchange solution). If you do not have one yet, refer to the guide [Creating an email address with an MX Plan solution](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+- An email address attached to your domain name (<Region zones={['eu']}>MX Plan, Email Pro, or Exchange solution</Region><Region zones={['ca']}>MX Plan or Exchange solution</Region><Region zones={['apac']}>MX Plan solution</Region>). If you do not have one yet, refer to the guide [Creating an email address with an MX Plan solution](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -35,7 +35,7 @@ To ensure your emails reach your recipients, OVHcloud maintains a dedicated outb
 
 #### What OVHcloud does to protect your sending
 
-OVHcloud continuously monitors the reputation of its sending servers and automatically filters suspicious messages — so your legitimate emails do not suffer. But this protection has a limit: the PHP `mail()` function performs no check on the sender identity declared in the email (the `From:` field). An email sent through `mail()` can therefore appear to come from any address, which is enough to trigger the filters of recipient servers (Gmail, Outlook, etc.) and compromise the deliverability of **your own emails**.
+OVHcloud continuously monitors the reputation of its sending servers and automatically filters suspicious messages — so your legitimate emails do not suffer. But this protection has a limit: the PHP `mail()` function does not check the sender identity declared in the email (the `From:` field). An email sent through `mail()` can therefore appear to come from any address, which is enough to trigger the filters of recipient servers (Gmail, Outlook, etc.) and compromise the deliverability of **your own emails**.
 
 #### Emails without a reliable signature
 
@@ -49,7 +49,7 @@ Abusive use of the `mail()` function can lead to automatic blocking of your host
 
 #### Open forms: an additional abuse vector
 
-A contact form that is publicly accessible, with no protection mechanism, is a prime target for bots. They exploit it to trigger the sending of thousands of emails within minutes through your hosting, causing the shared IP address to be blocked and harming every client on the cluster.
+A publicly accessible contact form with no protection mechanism is a prime target for bots. They exploit it to send thousands of emails within minutes through your hosting, causing the shared IP address to be blocked and harming every client on the cluster.
 
 Set up the following protections on any form that triggers an email:
 
@@ -71,11 +71,11 @@ This approach offers three major benefits:
 
 - **Guaranteed authentication**: the OVHcloud server verifies your identity before accepting the email.
 - **Working SPF and DKIM**: the email is issued by a server authorised for your domain and signed correctly.
-- **Traceability**: every send is associated with an identified account, which makes it possible to act quickly in case of abuse.
+- **Traceability**: every send is tied to an identified account, so you can act quickly in case of abuse.
 
 #### Why the `From:` field must belong to your domain
 
-The `From:` field of your email must **necessarily** contain an address belonging to your domain (for example `contact@mydomain.ovh`), and this address must match the SMTP account used for authentication.
+The `From:` field of your email **must contain** an address belonging to your domain (for example `contact@mydomain.ovh`), and this address must match the SMTP account used for authentication.
 
 If the `From:` does not match the domain authorised in the SPF record, or if the DKIM signature does not match, the recipient mail servers (Gmail, Outlook, etc.) may reject the email or classify it as spam.
 
@@ -90,7 +90,7 @@ To maximise deliverability, make sure the SPF, DKIM, and DMARC records are corre
 
 #### Contact forms: fixed `From:` field and user `Reply-To:`
 
-A common mistake is to place the email address entered by the user in the form directly in the `From:` field. For example, a visitor enters `utilisateur@gmail.com` and the script uses this address as the sender.
+A common mistake is to place the email address entered by the user in the form directly in the `From:` field. For example, a visitor enters `user@gmail.com` and the script uses this address as the sender.
 
 This behaviour is incorrect for two reasons:
 
@@ -105,7 +105,7 @@ This behaviour is incorrect for two reasons:
 | `Reply-To:` | Address entered by the user in the form | Allows you to reply directly to the user |
 | `Subject:` | Message subject, prefixed (for example `[Contact]`) | Makes form messages easy to identify |
 
-This way, when you reply to the email received, your mail client sends the reply to the user's address via the `Reply-To:` field, without compromising SPF/DKIM authentication.
+This way, when you reply to the email you received, your mail client sends the reply to the user's address via the `Reply-To:` field, without compromising SPF/DKIM authentication.
 
 Here is how to adapt the PHPMailer example for a contact form:
 
@@ -168,9 +168,21 @@ Use the following settings for your MX Plan email account (included with your we
 
 </Region>
 
+<Region zones={['eu']}>
+
 :::tip
 For **Email Pro** or **Exchange** solutions, the SMTP server is different. Refer to the documentation for each solution for the exact settings.
 :::
+
+</Region>
+
+<Region zones={['ca']}>
+
+:::tip
+For **Exchange** solutions, the SMTP server is different. Refer to the documentation for the exact settings.
+:::
+
+</Region>
 
 #### Where to find your SMTP credentials
 
@@ -178,9 +190,29 @@ The **SMTP username** is your full email address (for example `contact@mydomain.
 
 The **password** is the one set when the address was created, or changed from the OVHcloud Control Panel. If you have forgotten it or want to reset it, refer to the guide [Changing the password of an email account](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
+<Region zones={['eu']}>
+
 :::warning
 The MX Plan solution included with web hosting is subject to **sending quotas** (around 200 emails per hour per account). For high volumes — newsletters or bulk transactional emails — favour a dedicated solution (Email Pro, Exchange) or a third-party transactional sending service.
 :::
+
+</Region>
+
+<Region zones={['ca']}>
+
+:::warning
+The MX Plan solution included with web hosting is subject to **sending quotas** (around 200 emails per hour per account). For high volumes — newsletters or bulk transactional emails — favour a dedicated solution such as Exchange, or a third-party transactional sending service.
+:::
+
+</Region>
+
+<Region zones={['apac']}>
+
+:::warning
+The MX Plan solution included with web hosting is subject to **sending quotas** (around 200 emails per hour per account). For high volumes — newsletters or bulk transactional emails — favour a third-party transactional sending service.
+:::
+
+</Region>
 
 #### PHP code example with PHPMailer
 
@@ -373,13 +405,13 @@ The principle is the same for any CMS or framework: replace the native sending f
 
 <Region zones={['eu']}>
 
-In all cases, the SMTP settings to use are the same: server `ssl0.ovh.net`, port `465` (SSL/TLS) or `587` (STARTTLS), with authentication using the full email address and its password.
+In all cases, the SMTP settings are the same: server `ssl0.ovh.net`, port `465` (SSL/TLS) or `587` (STARTTLS), with authentication using the full email address and its password.
 
 </Region>
 
 <Region zones={['ca', 'apac']}>
 
-In all cases, the SMTP settings to use are the same: server `smtp.mail.ovh.ca`, port `465` (SSL/TLS) or `587` (STARTTLS), with authentication using the full email address and its password.
+In all cases, the SMTP settings are the same: server `smtp.mail.ovh.ca`, port `465` (SSL/TLS) or `587` (STARTTLS), with authentication using the full email address and its password.
 
 </Region>
 

--- a/docs/en/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,0 +1,400 @@
+---
+title: "Web Hosting - Email sending best practices"
+description: Learn why the PHP mail() function is discouraged on shared hosting and how to configure authenticated SMTP sending through your OVHcloud email accounts
+lastUpdated: 2026-07-13
+availableIn: [eu, ca, apac]
+---
+
+import { Region } from '@components/Zone';
+
+## Objective
+
+To ensure your emails reach your recipients, OVHcloud maintains a dedicated outbound infrastructure, with automatic anti-spam filtering and continuous monitoring of server reputation. To make the most of it, we recommend sending your emails through **authenticated SMTP** rather than the native PHP `mail()` function. This approach ensures that every email is issued with a verifiable identity, which significantly improves deliverability and reduces the risk of being classified as spam.
+
+**This guide explains OVHcloud's best practices and recommendations for sending emails reliably and securely from a shared hosting plan, whether you manage a WordPress site, another CMS, or a PHP application.**
+
+## Requirements
+
+- A [OVHcloud Web Hosting](/links/web/hosting) plan.
+- An email address attached to your hosted domain name (MX Plan, Email Pro, or Exchange solution). If you do not have one yet, refer to the guide [Creating an email address with an MX Plan solution](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+
+{/* CP-NAV-START:web-hosting */}
+---
+
+### OVHcloud Control Panel Access
+
+- **Direct link:** <ManagerLink to="/#/web/hosting">Hosting plans</ManagerLink>
+- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Hosting plans</code> > Select your web hosting plan
+
+---
+{/* CP-NAV-END:web-hosting */}
+
+## Instructions
+
+### 1. `mail()` or authenticated SMTP: what difference does it make for you?
+
+#### What OVHcloud does to protect your sending
+
+OVHcloud continuously monitors the reputation of its sending servers and automatically filters suspicious messages — so your legitimate emails do not suffer. But this protection has a limit: the PHP `mail()` function performs no check on the sender identity declared in the email (the `From:` field). An email sent through `mail()` can therefore appear to come from any address, which is enough to trigger the filters of recipient servers (Gmail, Outlook, etc.) and compromise the deliverability of **your own emails**.
+
+#### Emails without a reliable signature
+
+The `mail()` function sends emails without guaranteeing the sender's identity. Recipient servers (Gmail, Outlook, etc.) verify that the email genuinely comes from a server authorised by your domain, using the **SPF** and **DKIM** records. With `mail()`, this verification often fails: the message may then land in spam or be rejected.
+
+Sending through authenticated SMTP solves this problem: the email is issued by the OVHcloud server authorised for your domain, with the correct signature.
+
+:::warning
+Abusive use of the `mail()` function can lead to automatic blocking of your hosting's outbound emails. If you notice that your emails are no longer being sent, refer to the guide [Monitoring and managing automated emails in your web hosting plan](/guides/web-cloud/web-hosting/mail-function-script-records).
+:::
+
+#### Open forms: an additional abuse vector
+
+A contact form that is publicly accessible, with no protection mechanism, is a prime target for bots. They exploit it to trigger the sending of thousands of emails within minutes through your hosting, causing the shared IP address to be blocked and harming every client on the cluster.
+
+Set up the following protections on any form that triggers an email:
+
+- **Captcha**: integrate a verification system (Google reCAPTCHA v3, hCaptcha, or a simple arithmetic challenge) to block automated submissions.
+- **Rate limiting**: limit the number of sends per IP address on the server side to prevent burst abuse.
+- **Strict input validation**: check and sanitise every form field before using it in an email — never trust user-supplied data.
+
+:::warning
+The absence of a captcha on an open sending form is one of the most frequent causes of shared hosting being blocked for spam. This protection is essential regardless of the sending method used.
+:::
+
+### 2. The best practice: use an OVHcloud email account with authenticated SMTP
+
+#### Principle
+
+Send your emails through an **authenticated SMTP** connection to the OVHcloud mail server, using an email account attached to your hosted domain (for example `contact@mydomain.ovh`).
+
+This approach offers three major benefits:
+
+- **Guaranteed authentication**: the OVHcloud server verifies your identity before accepting the email.
+- **Working SPF and DKIM**: the email is issued by a server authorised for your domain and signed correctly.
+- **Traceability**: every send is associated with an identified account, which makes it possible to act quickly in case of abuse.
+
+#### Why the `From:` field must belong to your domain
+
+The `From:` field of your email must **necessarily** contain an address belonging to your domain (e.g. `contact@mydomain.ovh`), and this address must match the SMTP account used for authentication.
+
+If the `From:` does not match the domain authorised in the SPF record, or if the DKIM signature does not match, the recipient mail servers (Gmail, Outlook, etc.) may reject the email or classify it as spam.
+
+:::tip
+To maximise deliverability, make sure the SPF, DKIM, and DMARC records are correctly configured in your DNS zone. Gmail and Yahoo Mail now require them for bulk senders. Refer to our guides:
+
+- [How to improve email security with an SPF record](/guides/web-cloud/domains/dns-zone-spf)
+- [How to improve email security with a DKIM record](/guides/web-cloud/domains/dns-zone-dkim)
+- [How to improve email security with a DMARC record](/guides/web-cloud/domains/dns-zone-dmarc)
+
+:::
+
+#### Contact forms: fixed `From:` field and user `Reply-To:`
+
+A common mistake is to place the email address entered by the user in the form directly in the `From:` field. For example, a visitor enters `utilisateur@gmail.com` and the script uses this address as the sender.
+
+This behaviour is incorrect for two reasons:
+
+- Your domain's SPF record does not authorise Gmail servers (or any other third-party provider) to send on your behalf → SPF check failure.
+- You are sending "on behalf of" an address that does not belong to you → high risk of being classified as spam or rejected.
+
+**The correct pattern for a contact form:**
+
+| Email field | Value | Role |
+|---|---|---|
+| `From:` | `contact@mydomain.ovh` (fixed address of the site) | Authenticated sender — never changes |
+| `Reply-To:` | Address entered by the user in the form | Allows you to reply directly to the user |
+| `Subject:` | Message subject, prefixed (e.g. `[Contact] ...`) | Makes form messages easy to identify |
+
+This way, when you reply to the email received, your mail client sends the reply to the user's address via the `Reply-To:` field, without compromising SPF/DKIM authentication.
+
+Here is how to adapt the PHPMailer example for a contact form:
+
+```php
+// User-supplied data (validate and sanitise before use)
+$userEmail = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
+$userName  = htmlspecialchars(strip_tags($_POST['name']));
+$message   = htmlspecialchars(strip_tags($_POST['message']));
+
+if (!$userEmail) {
+    die('Invalid email address.');
+}
+
+// From: always fixed — your site's address, never the user's
+$mail->setFrom('contact@mydomain.ovh', 'My Website');
+
+// Reply-To: the user's address, so you can reply to them directly
+$mail->addReplyTo($userEmail, $userName);
+
+// Recipient: yourself (you receive the form message)
+$mail->addAddress('contact@mydomain.ovh', 'My Website');
+
+$mail->Subject = '[Contact] ' . $userName;
+$mail->Body    = "Name: $userName\nEmail: $userEmail\n\nMessage:\n$message";
+```
+
+:::tip
+Never pass form data directly into PHPMailer without prior validation. Use `filter_var()` for the email address and `htmlspecialchars()` + `strip_tags()` for text fields to prevent email header injection.
+:::
+
+#### OVHcloud SMTP settings
+
+Use the following settings for your MX Plan email account (included with your web hosting):
+
+<Region zones={['eu']}>
+
+| Setting | Value |
+|---|---|
+| **SMTP server** | `ssl0.ovh.net` |
+| **Port (SSL/TLS)** | `465` *(recommended)* |
+| **Port (STARTTLS)** | `587` |
+| **Encryption** | `SSL/TLS` (port 465) or `STARTTLS` (port 587) |
+| **Authentication** | Required |
+| **Username** | Full email address (e.g. `contact@mydomain.ovh`) |
+| **Password** | Password of the OVHcloud email account |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Setting | Value |
+|---|---|
+| **SMTP server** | `smtp.mail.ovh.ca` |
+| **Port (SSL/TLS)** | `465` *(recommended)* |
+| **Port (STARTTLS)** | `587` |
+| **Encryption** | `SSL/TLS` (port 465) or `STARTTLS` (port 587) |
+| **Authentication** | Required |
+| **Username** | Full email address (e.g. `contact@mydomain.ovh`) |
+| **Password** | Password of the OVHcloud email account |
+
+</Region>
+
+:::tip
+For **Email Pro** or **Exchange** solutions, the SMTP server is different. Refer to the documentation for each solution for the exact settings.
+:::
+
+#### Where to find your SMTP credentials
+
+The **SMTP username** is your full email address (e.g. `contact@mydomain.ovh`).
+
+The **password** is the one set when the address was created, or changed from the OVHcloud Control Panel. If you have forgotten it or want to reset it, refer to the guide [Changing the password of an email account](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
+
+:::warning
+The MX Plan solution included with web hosting is subject to **sending quotas** (around 200 emails per hour per account). For high volumes — newsletters or bulk transactional emails — favour a dedicated solution (Email Pro, Exchange) or a third-party transactional sending service.
+:::
+
+#### PHP code example with PHPMailer
+
+[PHPMailer](https://github.com/PHPMailer/PHPMailer) is the reference PHP library for sending emails through SMTP. Install it via Composer:
+
+```bash
+composer require phpmailer/phpmailer
+```
+
+Here is a complete example of authenticated SMTP sending:
+
+```php
+<?php
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
+use PHPMailer\PHPMailer\Exception;
+
+require 'vendor/autoload.php';
+
+$mail = new PHPMailer(true);
+
+try {
+    // OVHcloud SMTP server settings
+    $mail->isSMTP();
+    $mail->Host       = 'ssl0.ovh.net';
+    $mail->SMTPAuth   = true;
+    $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
+    $mail->Password   = 'your_password';         // Password of the email account
+    $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
+    $mail->Port       = 465;
+
+    // Sender: must belong to your hosted domain
+    $mail->setFrom('contact@mydomain.ovh', 'My Website');
+    $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
+
+    // Recipient
+    $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
+
+    // Content
+    $mail->isHTML(true);
+    $mail->Subject = 'Your email subject';
+    $mail->Body    = 'Email body in <b>HTML</b>';
+    $mail->AltBody = 'Email body in plain text (fallback)';
+
+    $mail->send();
+    echo 'Email sent successfully.';
+} catch (Exception $e) {
+    echo "Error while sending: {$mail->ErrorInfo}";
+}
+```
+
+<Region zones={['ca', 'apac']}>
+
+:::warning
+The example above uses the SMTP server `ssl0.ovh.net`, available only in the Europe zone. From Canada or the Asia-Pacific zone, replace the value of `$mail->Host` with `smtp.mail.ovh.ca`.
+:::
+
+</Region>
+
+:::warning
+Never store your email account password in plain text in a versioned PHP file. Use a configuration file excluded from your Git repository (`.gitignore`).
+:::
+
+:::info
+With this configuration, every email sent from your site is:
+
+- **authenticated** with the OVHcloud server,
+- **signed** with your domain's SPF and DKIM records,
+- **traceable** in case of abuse or a deliverability issue.
+
+:::
+
+### 3. WordPress and other CMSs: use an SMTP plugin
+
+#### 3.1 The problem with WordPress by default
+
+The `wp_mail()` function in WordPress uses the PHP `mail()` function behind the scenes. It therefore inherits all the problems described in the previous section: no authentication, uncontrolled `From:`, spam risk.
+
+The solution is to install an **SMTP plugin** that replaces `wp_mail()` with an authenticated SMTP connection to your OVHcloud mail server.
+
+#### 3.2 Configuring WP Mail SMTP
+
+[WP Mail SMTP](https://wordpress.org/plugins/wp-mail-smtp/) is the most widely used plugin for this configuration.
+
+**Installation:**
+
+1. In your WordPress administration, go to **Plugins** > **Add New Plugin**.
+2. Search for `WP Mail SMTP` and click **Install Now**, then **Activate**.
+
+**Configuration:**
+
+1. Go to **WP Mail SMTP** > **Settings** in the administration menu.
+2. In the **From** section, fill in the following fields:
+
+| Field | Value |
+|---|---|
+| **From Email** | `contact@mydomain.ovh` (address belonging to your domain) |
+| **From Name** | Display name for your site (e.g. `My Website`) |
+
+3. In the **Mailer** section, select **Other SMTP**.
+4. Fill in the SMTP settings:
+
+<Region zones={['eu']}>
+
+| Field | Value |
+|---|---|
+| **SMTP Host** | `ssl0.ovh.net` |
+| **Encryption** | `SSL/TLS` |
+| **SMTP Port** | `465` |
+| **Authentication** | Enabled |
+| **SMTP Username** | `contact@mydomain.ovh` |
+| **SMTP Password** | Password of your OVHcloud email account |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Field | Value |
+|---|---|
+| **SMTP Host** | `smtp.mail.ovh.ca` |
+| **Encryption** | `SSL/TLS` |
+| **SMTP Port** | `465` |
+| **Authentication** | Enabled |
+| **SMTP Username** | `contact@mydomain.ovh` |
+| **SMTP Password** | Password of your OVHcloud email account |
+
+</Region>
+
+5. Click **Save Settings**.
+6. In the **Tools** tab, use **Email Test** to check the configuration.
+
+:::tip
+Enable the **Force From Email** option so that all outgoing emails use the configured address, even if a third-party plugin tries to use another one.
+:::
+
+#### 3.3 Alternative: FluentSMTP
+
+[FluentSMTP](https://wordpress.org/plugins/fluent-smtp/) is a lightweight, free alternative with no limit on sending volume.
+
+**Installation:**
+
+1. In your WordPress administration, go to **Plugins** > **Add New Plugin**.
+2. Search for `FluentSMTP` and click **Install Now**, then **Activate**.
+
+**Configuration:**
+
+1. Go to **FluentSMTP** > **Settings**.
+2. Click **Add Connection** and select **Other SMTP**.
+3. Fill in the same settings as for WP Mail SMTP:
+
+<Region zones={['eu']}>
+
+| Field | Value |
+|---|---|
+| **Host** | `ssl0.ovh.net` |
+| **Port** | `465` |
+| **Encryption** | `SSL/TLS` |
+| **Authentication** | Yes |
+| **Username** | `contact@mydomain.ovh` |
+| **Password** | Password of your OVHcloud email account |
+| **From Email** | `contact@mydomain.ovh` |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Field | Value |
+|---|---|
+| **Host** | `smtp.mail.ovh.ca` |
+| **Port** | `465` |
+| **Encryption** | `SSL/TLS` |
+| **Authentication** | Yes |
+| **Username** | `contact@mydomain.ovh` |
+| **Password** | Password of your OVHcloud email account |
+| **From Email** | `contact@mydomain.ovh` |
+
+</Region>
+
+4. Click **Save Connection**, then send a test email.
+
+#### 3.4 Other CMSs (Drupal, Joomla, PrestaShop)
+
+The principle is the same for any CMS or framework: replace the native sending function with a module or an authenticated SMTP configuration.
+
+| CMS | Recommended module |
+|---|---|
+| **Drupal** | [SMTP Authentication Support](https://www.drupal.org/project/smtp) |
+| **Joomla** | Native configuration: **System** > **Global Configuration** > **Server** tab > **Mail Settings** section |
+| **PrestaShop** | **Advanced Parameters** > **E-mail** — choose **Set my own SMTP parameters** |
+
+<Region zones={['eu']}>
+
+In all cases, the SMTP settings to use are the same: server `ssl0.ovh.net`, port `465` (SSL/TLS) or `587` (STARTTLS), with authentication using the full email address and its password.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+In all cases, the SMTP settings to use are the same: server `smtp.mail.ovh.ca`, port `465` (SSL/TLS) or `587` (STARTTLS), with authentication using the full email address and its password.
+
+</Region>
+
+## Go further
+
+[Monitoring and managing automated emails in your web hosting plan](/guides/web-cloud/web-hosting/mail-function-script-records)
+
+[How to improve email security with an SPF record](/guides/web-cloud/domains/dns-zone-spf)
+
+[How to improve email security with a DKIM record](/guides/web-cloud/domains/dns-zone-dkim)
+
+[How to improve email security with a DMARC record](/guides/web-cloud/domains/dns-zone-dmarc)
+
+For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+
+If you would like assistance using and configuring your OVHcloud solutions, please take a look at our [support offers](/links/support).
+
+Join our [community of users](/links/community).

--- a/docs/en/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - Email sending best practices"
 description: Learn why the PHP mail() function is discouraged on shared hosting and how to configure authenticated SMTP sending through your OVHcloud email accounts
-lastUpdated: 2026-07-13
+lastUpdated: 2026-07-15
 availableIn: [eu, ca, apac]
 ---
 
@@ -144,7 +144,7 @@ Use the following settings for your MX Plan email account (included with your we
 
 | Setting | Value |
 |---|---|
-| **SMTP server** | `ssl0.ovh.net` |
+| **SMTP server** | `smtp.mail.ovh.net` |
 | **Port (SSL/TLS)** | `465` *(recommended)* |
 | **Port (STARTTLS)** | `587` |
 | **Encryption** | `SSL/TLS` (port 465) or `STARTTLS` (port 587) |
@@ -190,29 +190,9 @@ The **SMTP username** is your full email address (for example `contact@mydomain.
 
 The **password** is the one set when the address was created, or changed from the OVHcloud Control Panel. If you have forgotten it or want to reset it, refer to the guide [Changing the password of an email account](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
-<Region zones={['eu']}>
-
 :::warning
-The MX Plan solution included with web hosting is subject to **sending quotas** (around 200 emails per hour per account). For high volumes — newsletters or bulk transactional emails — favour a dedicated solution (Email Pro, Exchange) or a third-party transactional sending service.
+The MX Plan solution included with web hosting is subject to **sending quotas** (around 200 emails per hour per account). Standard mailbox solutions are not designed for bulk sending: for high volumes — newsletters or bulk transactional emails — use a dedicated third-party transactional email service, which is built for this purpose.
 :::
-
-</Region>
-
-<Region zones={['ca']}>
-
-:::warning
-The MX Plan solution included with web hosting is subject to **sending quotas** (around 200 emails per hour per account). For high volumes — newsletters or bulk transactional emails — favour a dedicated solution such as Exchange, or a third-party transactional sending service.
-:::
-
-</Region>
-
-<Region zones={['apac']}>
-
-:::warning
-The MX Plan solution included with web hosting is subject to **sending quotas** (around 200 emails per hour per account). For high volumes — newsletters or bulk transactional emails — favour a third-party transactional sending service.
-:::
-
-</Region>
 
 #### PHP code example with PHPMailer
 
@@ -237,7 +217,7 @@ $mail = new PHPMailer(true);
 try {
     // OVHcloud SMTP server settings
     $mail->isSMTP();
-    $mail->Host       = 'ssl0.ovh.net';
+    $mail->Host       = 'smtp.mail.ovh.net';
     $mail->SMTPAuth   = true;
     $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
     $mail->Password   = 'your_password';         // Password of the email account
@@ -267,7 +247,7 @@ try {
 <Region zones={['ca', 'apac']}>
 
 :::warning
-The example above uses the SMTP server `ssl0.ovh.net`, available only in the Europe zone. From Canada or the Asia-Pacific zone, replace the value of `$mail->Host` with `smtp.mail.ovh.ca`.
+The example above uses the SMTP server `smtp.mail.ovh.net`, available only in the Europe zone. From Canada or the Asia-Pacific zone, replace the value of `$mail->Host` with `smtp.mail.ovh.ca`.
 :::
 
 </Region>
@@ -319,7 +299,7 @@ The solution is to install an **SMTP plugin** that replaces `wp_mail()` with an 
 
 | Field | Value |
 |---|---|
-| **SMTP Host** | `ssl0.ovh.net` |
+| **SMTP Host** | `smtp.mail.ovh.net` |
 | **Encryption** | `SSL/TLS` |
 | **SMTP Port** | `465` |
 | **Authentication** | Enabled |
@@ -367,7 +347,7 @@ Enable the **Force From Email** option so that all outgoing emails use the confi
 
 | Field | Value |
 |---|---|
-| **Host** | `ssl0.ovh.net` |
+| **Host** | `smtp.mail.ovh.net` |
 | **Port** | `465` |
 | **Encryption** | `SSL/TLS` |
 | **Authentication** | Yes |
@@ -405,7 +385,7 @@ The principle is the same for any CMS or framework: replace the native sending f
 
 <Region zones={['eu']}>
 
-In all cases, the SMTP settings are the same: server `ssl0.ovh.net`, port `465` (SSL/TLS) or `587` (STARTTLS), with authentication using the full email address and its password.
+In all cases, the SMTP settings are the same: server `smtp.mail.ovh.net`, port `465` (SSL/TLS) or `587` (STARTTLS), with authentication using the full email address and its password.
 
 </Region>
 

--- a/docs/en/guides/web-cloud/web-hosting/landing-page-configuration.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/landing-page-configuration.mdx
@@ -75,6 +75,7 @@ To find the right guide for your needs:
         { title: 'Configure and use Git', link: '/guides/web-cloud/web-hosting/git-integration-webhosting' },
         { title: 'Create automated tasks (CRON)', link: '/guides/web-cloud/web-hosting/cron-tasks' },
         { title: 'Track automated emails', link: '/guides/web-cloud/web-hosting/mail-function-script-records' },
+        { title: 'Email sending best practices', link: '/guides/web-cloud/web-hosting/email-sending-best-practices' },
         { title: 'Manage a web application via the API', link: '/guides/web-cloud/web-hosting/api-webhosting' },
         { title: 'Upgrade your plan', link: '/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer' },
         { title: 'Retrieve the backup of the FTP space (Cloud Web)', link: '/guides/web-cloud/web-hosting/backup-ftp', zones: ['eu'] },

--- a/docs/es/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,0 +1,400 @@
+---
+title: "Web hosting - Buenas prácticas de envío de correo electrónico"
+description: Descubra por qué la función PHP mail() no es recomendable en un alojamiento compartido y cómo configurar un envío SMTP autenticado a través de sus cuentas de correo electrónico OVHcloud
+lastUpdated: 2026-07-13
+availableIn: [eu, ca, apac]
+---
+
+import { Region } from '@components/Zone';
+
+## Objetivo
+
+Para que sus correos electrónicos lleguen correctamente a sus destinatarios, OVHcloud dispone de una infraestructura dedicada al envío saliente, con filtrado antispam automático y supervisión continua de la reputación de los servidores. Para aprovecharla al máximo, se recomienda enviar sus correos electrónicos mediante **SMTP autenticado** en lugar de la función PHP `mail()` nativa. Este enfoque garantiza que cada correo electrónico se emita con una identidad verificable, lo que mejora significativamente la entregabilidad y reduce el riesgo de clasificación como spam.
+
+**Esta guía le presenta las buenas prácticas y recomendaciones de OVHcloud para enviar correos electrónicos de forma fiable y segura desde un alojamiento compartido, ya sea que gestione un sitio WordPress, otro CMS o una aplicación PHP.**
+
+## Requisitos
+
+- Disponer de una oferta de [alojamiento web OVHcloud](/links/web/hosting).
+- Disponer de una dirección de correo electrónico asociada a su nombre de dominio alojado (oferta MX Plan, Email Pro o Exchange). Si todavía no dispone de una, consulte la guía [Crear una dirección de correo electrónico en un MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+
+{/* CP-NAV-START:web-hosting */}
+---
+
+### Acceso al área de cliente de OVHcloud
+
+- **Enlace directo:** <ManagerLink to="/#/web/hosting">Alojamientos</ManagerLink>
+- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Alojamientos</code> > Seleccione su alojamiento web
+
+---
+{/* CP-NAV-END:web-hosting */}
+
+## Procedimiento
+
+### 1. `mail()` o SMTP autenticado: ¿qué diferencia hay para usted?
+
+#### Lo que OVHcloud hace para proteger sus envíos
+
+OVHcloud supervisa de forma permanente la reputación de sus servidores de envío y filtra automáticamente los mensajes sospechosos, para que sus correos electrónicos legítimos no se vean afectados. Pero esta protección tiene un límite: la función PHP `mail()` no realiza ningún control sobre la identidad del remitente declarado en el correo electrónico (campo `From:`). Por tanto, un correo electrónico enviado mediante `mail()` puede parecer que procede de cualquier dirección, lo que basta para activar los filtros de los servidores destinatarios (Gmail, Outlook…) y comprometer la entregabilidad de **sus propios envíos**.
+
+#### Correos electrónicos sin firma fiable
+
+La función `mail()` envía correos electrónicos sin garantizar la identidad del remitente. Sin embargo, los servidores destinatarios (Gmail, Outlook…) verifican que el correo electrónico proceda efectivamente de un servidor autorizado por su dominio, gracias a los registros **SPF** y **DKIM**. Con `mail()`, esta verificación falla a menudo: el mensaje puede entonces acabar en la carpeta de spam o ser rechazado.
+
+El envío mediante SMTP autenticado resuelve este problema: el correo electrónico es emitido por el servidor OVHcloud autorizado para su dominio, con la firma correcta.
+
+:::warning
+Un uso abusivo de la función `mail()` puede provocar el bloqueo automático de los envíos de su alojamiento. Si observa que sus correos electrónicos ya no se envían, consulte la guía [Gestionar los mensajes de correo automatizados](/guides/web-cloud/web-hosting/mail-function-script-records).
+:::
+
+#### Formularios abiertos: un vector de abuso adicional
+
+Un formulario de contacto accesible públicamente, sin mecanismo de protección, es un objetivo preferente para los robots. Estos lo aprovechan para desencadenar el envío de miles de correos electrónicos en pocos minutos a través de su alojamiento, provocando el bloqueo de la IP compartida y perjudicando a todos los clientes del clúster.
+
+Implemente las siguientes protecciones en cualquier formulario que desencadene un envío de correo electrónico:
+
+- **Captcha**: integre un sistema de verificación (Google reCAPTCHA v3, hCaptcha o un cálculo aritmético sencillo) para bloquear los envíos automatizados.
+- **Limitación de la tasa**: limite el número de envíos por dirección IP en el servidor para evitar los abusos en ráfaga.
+- **Validación estricta de las entradas**: verifique y depure todos los campos del formulario antes de utilizarlos en un correo electrónico; nunca confíe en los datos introducidos por el usuario.
+
+:::warning
+La ausencia de captcha en un formulario de envío abierto es una de las causas más frecuentes de bloqueo de los alojamientos compartidos por envío de spam. Esta protección es indispensable independientemente del método de envío utilizado.
+:::
+
+### 2. La buena práctica: utilizar una cuenta de correo electrónico OVHcloud con SMTP autenticado
+
+#### Principio
+
+Envíe sus correos electrónicos mediante una conexión **SMTP autenticada** al servidor de mensajería de OVHcloud, utilizando una cuenta de correo electrónico asociada a su dominio alojado (por ejemplo, `contact@mydomain.ovh`).
+
+Este enfoque presenta tres ventajas principales:
+
+- **Autenticación garantizada**: el servidor OVHcloud verifica su identidad antes de aceptar el correo electrónico.
+- **SPF y DKIM funcionales**: el correo electrónico es emitido por un servidor autorizado para su dominio y firmado correctamente.
+- **Trazabilidad**: cada envío está asociado a una cuenta identificada, lo que permite intervenir rápidamente en caso de abuso.
+
+#### Por qué el campo `From:` debe pertenecer a su dominio
+
+El campo `From:` de su correo electrónico debe **obligatoriamente** contener una dirección que pertenezca a su dominio (por ejemplo, `contact@mydomain.ovh`), y esta dirección debe corresponder a la cuenta SMTP utilizada para la autenticación.
+
+Si el campo `From:` no corresponde al dominio autorizado en el registro SPF, o si la firma DKIM no coincide, los servidores de mensajería destinatarios (Gmail, Outlook, etc.) pueden rechazar o clasificar el correo electrónico como spam.
+
+:::tip
+Para maximizar la entregabilidad, compruebe que los registros SPF, DKIM y DMARC estén correctamente configurados en su zona DNS. Gmail y Yahoo Mail los exigen ahora para los remitentes de gran volumen. Consulte nuestras guías:
+
+- [Mejorar la seguridad del correo electrónico mediante el registro SPF](/guides/web-cloud/domains/dns-zone-spf)
+- [Mejorar la seguridad del correo electrónico mediante un registro DKIM](/guides/web-cloud/domains/dns-zone-dkim)
+- [Mejorar la seguridad del correo electrónico mediante el registro DMARC](/guides/web-cloud/domains/dns-zone-dmarc)
+
+:::
+
+#### Formularios de contacto: campo `From:` fijo y `Reply-To:` del usuario
+
+Un error frecuente consiste en colocar la dirección de correo electrónico introducida por el usuario en el formulario directamente en el campo `From:`. Por ejemplo, un visitante introduce `utilisateur@gmail.com` y el script utiliza esta dirección como remitente.
+
+Este comportamiento es incorrecto por dos razones:
+
+- El registro SPF de su dominio no autoriza a los servidores de Gmail (o de cualquier otro proveedor externo) a enviar en su nombre → fallo del control SPF.
+- Está enviando "en nombre de" una dirección que no le pertenece → alto riesgo de clasificación como spam o de rechazo.
+
+**El esquema correcto para un formulario de contacto:**
+
+| Campo de correo electrónico | Valor | Función |
+|---|---|---|
+| `From:` | `contact@mydomain.ovh` (dirección fija del sitio) | Remitente autenticado, nunca cambia |
+| `Reply-To:` | Dirección introducida por el usuario en el formulario | Permite responder directamente al usuario |
+| `Subject:` | Asunto del mensaje, con prefijo (por ejemplo, `[Contact] ...`) | Identifica fácilmente los mensajes del formulario |
+
+Así, cuando responda al correo electrónico recibido, su cliente de mensajería envía la respuesta a la dirección del usuario a través del campo `Reply-To:`, sin comprometer la autenticación SPF/DKIM.
+
+A continuación se muestra cómo adaptar el ejemplo de PHPMailer para un formulario de contacto:
+
+```php
+// User-supplied data (validate and sanitise before use)
+$userEmail = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
+$userName  = htmlspecialchars(strip_tags($_POST['name']));
+$message   = htmlspecialchars(strip_tags($_POST['message']));
+
+if (!$userEmail) {
+    die('Invalid email address.');
+}
+
+// From: always fixed — your site's address, never the user's
+$mail->setFrom('contact@mydomain.ovh', 'My Website');
+
+// Reply-To: the user's address, so you can reply to them directly
+$mail->addReplyTo($userEmail, $userName);
+
+// Recipient: yourself (you receive the form message)
+$mail->addAddress('contact@mydomain.ovh', 'My Website');
+
+$mail->Subject = '[Contact] ' . $userName;
+$mail->Body    = "Name: $userName\nEmail: $userEmail\n\nMessage:\n$message";
+```
+
+:::tip
+Nunca pase directamente los datos de un formulario a PHPMailer sin validación previa. Utilice `filter_var()` para la dirección de correo electrónico y `htmlspecialchars()` + `strip_tags()` para los campos de texto, con el fin de evitar las inyecciones de encabezados de correo electrónico.
+:::
+
+#### Parámetros SMTP de OVHcloud
+
+Utilice los siguientes parámetros para su cuenta de correo electrónico MX Plan (incluida con el alojamiento web):
+
+<Region zones={['eu']}>
+
+| Parámetro | Valor |
+|---|---|
+| **Servidor SMTP** | `ssl0.ovh.net` |
+| **Puerto (SSL/TLS)** | `465` *(recomendado)* |
+| **Puerto (STARTTLS)** | `587` |
+| **Cifrado** | `SSL/TLS` (puerto 465) o `STARTTLS` (puerto 587) |
+| **Autenticación** | Obligatoria |
+| **Nombre de usuario** | Dirección de correo electrónico completa (por ejemplo, `contact@mydomain.ovh`) |
+| **Contraseña** | Contraseña de la cuenta de correo electrónico OVHcloud |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Parámetro | Valor |
+|---|---|
+| **Servidor SMTP** | `smtp.mail.ovh.ca` |
+| **Puerto (SSL/TLS)** | `465` *(recomendado)* |
+| **Puerto (STARTTLS)** | `587` |
+| **Cifrado** | `SSL/TLS` (puerto 465) o `STARTTLS` (puerto 587) |
+| **Autenticación** | Obligatoria |
+| **Nombre de usuario** | Dirección de correo electrónico completa (por ejemplo, `contact@mydomain.ovh`) |
+| **Contraseña** | Contraseña de la cuenta de correo electrónico OVHcloud |
+
+</Region>
+
+:::tip
+Para las ofertas **Email Pro** o **Exchange**, el servidor SMTP es diferente. Consulte la documentación de cada oferta para conocer los parámetros exactos.
+:::
+
+#### Dónde encontrar sus credenciales SMTP
+
+El **nombre de usuario SMTP** es su dirección de correo electrónico completa (por ejemplo, `contact@mydomain.ovh`).
+
+La **contraseña** es la que definió al crear la dirección, o la que modificó desde el área de cliente de OVHcloud. Si la ha olvidado o desea restablecerla, consulte la guía [Cambiar la contraseña de una dirección de correo](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
+
+:::warning
+La oferta MX Plan incluida con el alojamiento web está sujeta a **cuotas de envío** (aproximadamente 200 correos electrónicos por hora y por cuenta). Para volúmenes importantes, como newsletters o correos electrónicos transaccionales masivos, opte por una solución dedicada (Email Pro, Exchange) o por un servicio de envío transaccional externo.
+:::
+
+#### Ejemplo de código PHP con PHPMailer
+
+[PHPMailer](https://github.com/PHPMailer/PHPMailer) es la biblioteca PHP de referencia para el envío de correos electrónicos mediante SMTP. Instálela a través de Composer:
+
+```bash
+composer require phpmailer/phpmailer
+```
+
+A continuación se muestra un ejemplo completo de envío SMTP autenticado:
+
+```php
+<?php
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
+use PHPMailer\PHPMailer\Exception;
+
+require 'vendor/autoload.php';
+
+$mail = new PHPMailer(true);
+
+try {
+    // OVHcloud SMTP server settings
+    $mail->isSMTP();
+    $mail->Host       = 'ssl0.ovh.net';
+    $mail->SMTPAuth   = true;
+    $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
+    $mail->Password   = 'your_password';         // Password of the email account
+    $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
+    $mail->Port       = 465;
+
+    // Sender: must belong to your hosted domain
+    $mail->setFrom('contact@mydomain.ovh', 'My Website');
+    $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
+
+    // Recipient
+    $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
+
+    // Content
+    $mail->isHTML(true);
+    $mail->Subject = 'Your email subject';
+    $mail->Body    = 'Email body in <b>HTML</b>';
+    $mail->AltBody = 'Email body in plain text (fallback)';
+
+    $mail->send();
+    echo 'Email sent successfully.';
+} catch (Exception $e) {
+    echo "Error while sending: {$mail->ErrorInfo}";
+}
+```
+
+<Region zones={['ca', 'apac']}>
+
+:::warning
+El ejemplo anterior utiliza el servidor SMTP `ssl0.ovh.net`, disponible únicamente en la zona de Europa. Desde Canadá o la zona Asia-Pacífico, sustituya el valor de `$mail->Host` por `smtp.mail.ovh.ca`.
+:::
+
+</Region>
+
+:::warning
+Nunca almacene la contraseña de su cuenta de correo electrónico en texto plano en un archivo PHP versionado. Utilice un archivo de configuración excluido de su repositorio Git (`.gitignore`).
+:::
+
+:::info
+Con esta configuración, cada correo electrónico enviado desde su sitio es:
+
+- **autenticado** ante el servidor OVHcloud,
+- **firmado** con los registros SPF y DKIM de su dominio,
+- **trazable** en caso de abuso o de problema de entregabilidad.
+
+:::
+
+### 3. WordPress y otros CMS: utilizar un plugin SMTP
+
+#### 3.1 El problema con WordPress por defecto
+
+La función `wp_mail()` de WordPress utiliza en segundo plano la función PHP `mail()`. Por tanto, hereda todos los problemas descritos en la sección anterior: ausencia de autenticación, `From:` no controlado, riesgo de spam.
+
+La solución consiste en instalar un **plugin SMTP** que sustituya `wp_mail()` por una conexión SMTP autenticada a su servidor de mensajería OVHcloud.
+
+#### 3.2 Configurar WP Mail SMTP
+
+[WP Mail SMTP](https://es.wordpress.org/plugins/wp-mail-smtp/) es el plugin más utilizado para esta configuración.
+
+**Instalación:**
+
+1. En su administración de WordPress, acceda a **Plugins** > **Añadir nuevo plugin**.
+2. Busque `WP Mail SMTP` y haga clic en **Instalar ahora** y, a continuación, en **Activar**.
+
+**Configuración:**
+
+1. Acceda a **WP Mail SMTP** > **Ajustes** en el menú de administración.
+2. En la sección **Remitente**, rellene los siguientes campos:
+
+| Campo | Valor |
+|---|---|
+| **Correo electrónico del remitente** | `contact@mydomain.ovh` (dirección que pertenece a su dominio) |
+| **Nombre del remitente** | Nombre mostrado para su sitio (por ejemplo, `Mi sitio web`) |
+
+3. En la sección **Mailer**, seleccione **Otro SMTP**.
+4. Rellene los parámetros SMTP:
+
+<Region zones={['eu']}>
+
+| Campo | Valor |
+|---|---|
+| **Host SMTP** | `ssl0.ovh.net` |
+| **Cifrado** | `SSL/TLS` |
+| **Puerto SMTP** | `465` |
+| **Autenticación** | Activada |
+| **Nombre de usuario SMTP** | `contact@mydomain.ovh` |
+| **Contraseña SMTP** | Contraseña de su cuenta de correo electrónico OVHcloud |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Campo | Valor |
+|---|---|
+| **Host SMTP** | `smtp.mail.ovh.ca` |
+| **Cifrado** | `SSL/TLS` |
+| **Puerto SMTP** | `465` |
+| **Autenticación** | Activada |
+| **Nombre de usuario SMTP** | `contact@mydomain.ovh` |
+| **Contraseña SMTP** | Contraseña de su cuenta de correo electrónico OVHcloud |
+
+</Region>
+
+5. Haga clic en **Guardar ajustes**.
+6. En la pestaña **Herramientas**, utilice **Prueba de envío de correo electrónico** para verificar la configuración.
+
+:::tip
+Active la opción **Forzar el correo electrónico del remitente** para que todos los correos electrónicos salientes utilicen la dirección configurada, incluso si un plugin externo intenta usar otra.
+:::
+
+#### 3.3 Alternativa: FluentSMTP
+
+[FluentSMTP](https://es.wordpress.org/plugins/fluent-smtp/) es una alternativa ligera y gratuita, sin limitación en el volumen de envío.
+
+**Instalación:**
+
+1. En su administración de WordPress, acceda a **Plugins** > **Añadir nuevo plugin**.
+2. Busque `FluentSMTP` y haga clic en **Instalar ahora** y, a continuación, en **Activar**.
+
+**Configuración:**
+
+1. Acceda a **FluentSMTP** > **Ajustes**.
+2. Haga clic en **Añadir conexión** y seleccione **Otro SMTP**.
+3. Rellene los mismos parámetros que para WP Mail SMTP:
+
+<Region zones={['eu']}>
+
+| Campo | Valor |
+|---|---|
+| **Host** | `ssl0.ovh.net` |
+| **Puerto** | `465` |
+| **Cifrado** | `SSL/TLS` |
+| **Autenticación** | Sí |
+| **Nombre de usuario** | `contact@mydomain.ovh` |
+| **Contraseña** | Contraseña de su cuenta de correo electrónico OVHcloud |
+| **Correo electrónico del remitente** | `contact@mydomain.ovh` |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Campo | Valor |
+|---|---|
+| **Host** | `smtp.mail.ovh.ca` |
+| **Puerto** | `465` |
+| **Cifrado** | `SSL/TLS` |
+| **Autenticación** | Sí |
+| **Nombre de usuario** | `contact@mydomain.ovh` |
+| **Contraseña** | Contraseña de su cuenta de correo electrónico OVHcloud |
+| **Correo electrónico del remitente** | `contact@mydomain.ovh` |
+
+</Region>
+
+4. Haga clic en **Guardar conexión** y, a continuación, envíe un correo electrónico de prueba.
+
+#### 3.4 Otros CMS (Drupal, Joomla, PrestaShop)
+
+El principio es idéntico para cualquier CMS o framework: sustituir la función de envío nativa por un módulo o una configuración SMTP autenticada.
+
+| CMS | Módulo recomendado |
+|---|---|
+| **Drupal** | [SMTP Authentication Support](https://www.drupal.org/project/smtp) |
+| **Joomla** | Configuración nativa: **Sistema** > **Configuración global** > pestaña **Servidor** > sección **Ajustes de correo** |
+| **PrestaShop** | **Parámetros avanzados** > **Correo electrónico** — seleccionar **Utilizar mis propios parámetros SMTP** |
+
+<Region zones={['eu']}>
+
+En todos los casos, los parámetros SMTP que se deben utilizar son idénticos: servidor `ssl0.ovh.net`, puerto `465` (SSL/TLS) o `587` (STARTTLS), con autenticación mediante la dirección de correo electrónico completa y su contraseña.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+En todos los casos, los parámetros SMTP que se deben utilizar son idénticos: servidor `smtp.mail.ovh.ca`, puerto `465` (SSL/TLS) o `587` (STARTTLS), con autenticación mediante la dirección de correo electrónico completa y su contraseña.
+
+</Region>
+
+## Más información
+
+[Gestionar los mensajes de correo automatizados](/guides/web-cloud/web-hosting/mail-function-script-records)
+
+[Mejorar la seguridad del correo electrónico mediante el registro SPF](/guides/web-cloud/domains/dns-zone-spf)
+
+[Mejorar la seguridad del correo electrónico mediante un registro DKIM](/guides/web-cloud/domains/dns-zone-dkim)
+
+[Mejorar la seguridad del correo electrónico mediante el registro DMARC](/guides/web-cloud/domains/dns-zone-dmarc)
+
+Para prestaciones especializadas (posicionamiento, desarrollo, etc.), contacte con los [partners de OVHcloud](/links/partner).
+
+Si desea asistencia para el uso y configuración de sus soluciones OVHcloud, le proponemos que consulte nuestras diferentes [ofertas de soporte](/links/support).
+
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Web hosting - Buenas prácticas de envío de correo electrónico"
-description: Descubra por qué la función PHP mail() no es recomendable en un alojamiento compartido y cómo configurar un envío SMTP autenticado a través de sus cuentas de correo electrónico OVHcloud
+description: Descubra por qué la función PHP mail() no es recomendable en un alojamiento compartido y cómo configurar un envío SMTP autenticado
 lastUpdated: 2026-07-13
 availableIn: [eu, ca, apac]
 ---
@@ -16,7 +16,7 @@ Para que sus correos electrónicos lleguen correctamente a sus destinatarios, OV
 ## Requisitos
 
 - Disponer de una oferta de [alojamiento web OVHcloud](/links/web/hosting).
-- Disponer de una dirección de correo electrónico asociada a su nombre de dominio (oferta MX Plan, Email Pro o Exchange). Si todavía no dispone de una, consulte la guía [Crear una dirección de correo electrónico en un MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+- Disponer de una dirección de correo electrónico asociada a su nombre de dominio (<Region zones={['eu']}>oferta MX Plan, Email Pro o Exchange</Region><Region zones={['ca']}>oferta MX Plan o Exchange</Region><Region zones={['apac']}>oferta MX Plan</Region>). Si todavía no dispone de una, consulte la guía [Crear una dirección de correo electrónico en un MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -90,7 +90,7 @@ Para maximizar la entregabilidad, compruebe que los registros SPF, DKIM y DMARC 
 
 #### Formularios de contacto: campo `From:` fijo y `Reply-To:` del usuario
 
-Un error frecuente consiste en colocar la dirección de correo electrónico introducida por el usuario en el formulario directamente en el campo `From:`. Por ejemplo, un visitante introduce `utilisateur@gmail.com` y el script utiliza esta dirección como remitente.
+Un error frecuente consiste en colocar la dirección de correo electrónico introducida por el usuario en el formulario directamente en el campo `From:`. Por ejemplo, un visitante introduce `usuario@gmail.com` y el script utiliza esta dirección como remitente.
 
 Este comportamiento es incorrecto por dos razones:
 
@@ -168,9 +168,21 @@ Utilice los siguientes parámetros para su cuenta de correo electrónico MX Plan
 
 </Region>
 
+<Region zones={['eu']}>
+
 :::tip
 Para las ofertas **Email Pro** o **Exchange**, el servidor SMTP es diferente. Consulte la documentación de cada oferta para conocer los parámetros exactos.
 :::
+
+</Region>
+
+<Region zones={['ca']}>
+
+:::tip
+Para la oferta **Exchange**, el servidor SMTP es diferente. Consulte la documentación de esta oferta para conocer los parámetros exactos.
+:::
+
+</Region>
 
 #### Dónde encontrar sus credenciales SMTP
 
@@ -178,9 +190,29 @@ El **nombre de usuario SMTP** es su dirección de correo electrónico completa (
 
 La **contraseña** es la que definió al crear la dirección, o la que modificó desde el área de cliente de OVHcloud. Si la ha olvidado o desea restablecerla, consulte la guía [Cambiar la contraseña de una dirección de correo](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
+<Region zones={['eu']}>
+
 :::warning
 La oferta MX Plan incluida con el alojamiento web está sujeta a **cuotas de envío** (aproximadamente 200 correos electrónicos por hora y por cuenta). Para volúmenes importantes, como newsletters o correos electrónicos transaccionales masivos, opte por una solución dedicada (Email Pro, Exchange) o por un servicio de envío transaccional externo.
 :::
+
+</Region>
+
+<Region zones={['ca']}>
+
+:::warning
+La oferta MX Plan incluida con el alojamiento web está sujeta a **cuotas de envío** (aproximadamente 200 correos electrónicos por hora y por cuenta). Para volúmenes importantes, como newsletters o correos electrónicos transaccionales masivos, opte por una solución dedicada como Exchange o por un servicio de envío transaccional externo.
+:::
+
+</Region>
+
+<Region zones={['apac']}>
+
+:::warning
+La oferta MX Plan incluida con el alojamiento web está sujeta a **cuotas de envío** (aproximadamente 200 correos electrónicos por hora y por cuenta). Para volúmenes importantes, como newsletters o correos electrónicos transaccionales masivos, opte por un servicio de envío transaccional externo.
+:::
+
+</Region>
 
 #### Ejemplo de código PHP con PHPMailer
 

--- a/docs/es/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web hosting - Buenas prácticas de envío de correo electrónico"
 description: Descubra por qué la función PHP mail() no es recomendable en un alojamiento compartido y cómo configurar un envío SMTP autenticado
-lastUpdated: 2026-07-13
+lastUpdated: 2026-07-15
 availableIn: [eu, ca, apac]
 ---
 
@@ -144,7 +144,7 @@ Utilice los siguientes parámetros para su cuenta de correo electrónico MX Plan
 
 | Parámetro | Valor |
 |---|---|
-| **Servidor SMTP** | `ssl0.ovh.net` |
+| **Servidor SMTP** | `smtp.mail.ovh.net` |
 | **Puerto (SSL/TLS)** | `465` *(recomendado)* |
 | **Puerto (STARTTLS)** | `587` |
 | **Cifrado** | `SSL/TLS` (puerto 465) o `STARTTLS` (puerto 587) |
@@ -190,29 +190,9 @@ El **nombre de usuario SMTP** es su dirección de correo electrónico completa (
 
 La **contraseña** es la que definió al crear la dirección, o la que modificó desde el área de cliente de OVHcloud. Si la ha olvidado o desea restablecerla, consulte la guía [Cambiar la contraseña de una dirección de correo](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
-<Region zones={['eu']}>
-
 :::warning
-La oferta MX Plan incluida con el alojamiento web está sujeta a **cuotas de envío** (aproximadamente 200 correos electrónicos por hora y por cuenta). Para volúmenes importantes, como newsletters o correos electrónicos transaccionales masivos, opte por una solución dedicada (Email Pro, Exchange) o por un servicio de envío transaccional externo.
+La oferta MX Plan incluida con el alojamiento web está sujeta a **cuotas de envío** (aproximadamente 200 correos electrónicos por hora y por cuenta). Las soluciones de mensajería no están diseñadas para el envío masivo: para volúmenes importantes, como newsletters o correos electrónicos transaccionales masivos, utilice un servicio de envío transaccional externo, diseñado para este uso.
 :::
-
-</Region>
-
-<Region zones={['ca']}>
-
-:::warning
-La oferta MX Plan incluida con el alojamiento web está sujeta a **cuotas de envío** (aproximadamente 200 correos electrónicos por hora y por cuenta). Para volúmenes importantes, como newsletters o correos electrónicos transaccionales masivos, opte por una solución dedicada como Exchange o por un servicio de envío transaccional externo.
-:::
-
-</Region>
-
-<Region zones={['apac']}>
-
-:::warning
-La oferta MX Plan incluida con el alojamiento web está sujeta a **cuotas de envío** (aproximadamente 200 correos electrónicos por hora y por cuenta). Para volúmenes importantes, como newsletters o correos electrónicos transaccionales masivos, opte por un servicio de envío transaccional externo.
-:::
-
-</Region>
 
 #### Ejemplo de código PHP con PHPMailer
 
@@ -237,7 +217,7 @@ $mail = new PHPMailer(true);
 try {
     // Parámetros del servidor SMTP de OVHcloud
     $mail->isSMTP();
-    $mail->Host       = 'ssl0.ovh.net';
+    $mail->Host       = 'smtp.mail.ovh.net';
     $mail->SMTPAuth   = true;
     $mail->Username   = 'contact@mydomain.ovh'; // Su dirección de correo electrónico de OVHcloud
     $mail->Password   = 'your_password';         // Contraseña de la cuenta de correo electrónico
@@ -267,7 +247,7 @@ try {
 <Region zones={['ca', 'apac']}>
 
 :::warning
-El ejemplo anterior utiliza el servidor SMTP `ssl0.ovh.net`, disponible únicamente en la zona de Europa. Desde Canadá o la zona Asia-Pacífico, sustituya el valor de `$mail->Host` por `smtp.mail.ovh.ca`.
+El ejemplo anterior utiliza el servidor SMTP `smtp.mail.ovh.net`, disponible únicamente en la zona de Europa. Desde Canadá o la zona Asia-Pacífico, sustituya el valor de `$mail->Host` por `smtp.mail.ovh.ca`.
 :::
 
 </Region>
@@ -319,7 +299,7 @@ La solución consiste en instalar un **plugin SMTP** que sustituya `wp_mail()` p
 
 | Campo | Valor |
 |---|---|
-| **Host SMTP** | `ssl0.ovh.net` |
+| **Host SMTP** | `smtp.mail.ovh.net` |
 | **Cifrado** | `SSL/TLS` |
 | **Puerto SMTP** | `465` |
 | **Autenticación** | Activada |
@@ -367,7 +347,7 @@ Active la opción **Forzar el correo electrónico del remitente** para que todos
 
 | Campo | Valor |
 |---|---|
-| **Host** | `ssl0.ovh.net` |
+| **Host** | `smtp.mail.ovh.net` |
 | **Puerto** | `465` |
 | **Cifrado** | `SSL/TLS` |
 | **Autenticación** | Sí |
@@ -405,7 +385,7 @@ El principio es idéntico para cualquier CMS o framework: sustituir la función 
 
 <Region zones={['eu']}>
 
-En todos los casos, los parámetros SMTP que se deben utilizar son idénticos: servidor `ssl0.ovh.net`, puerto `465` (SSL/TLS) o `587` (STARTTLS), con autenticación mediante la dirección de correo electrónico completa y su contraseña.
+En todos los casos, los parámetros SMTP que se deben utilizar son idénticos: servidor `smtp.mail.ovh.net`, puerto `465` (SSL/TLS) o `587` (STARTTLS), con autenticación mediante la dirección de correo electrónico completa y su contraseña.
 
 </Region>
 

--- a/docs/es/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -16,7 +16,7 @@ Para que sus correos electrónicos lleguen correctamente a sus destinatarios, OV
 ## Requisitos
 
 - Disponer de una oferta de [alojamiento web OVHcloud](/links/web/hosting).
-- Disponer de una dirección de correo electrónico asociada a su nombre de dominio alojado (oferta MX Plan, Email Pro o Exchange). Si todavía no dispone de una, consulte la guía [Crear una dirección de correo electrónico en un MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+- Disponer de una dirección de correo electrónico asociada a su nombre de dominio (oferta MX Plan, Email Pro o Exchange). Si todavía no dispone de una, consulte la guía [Crear una dirección de correo electrónico en un MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -35,11 +35,11 @@ Para que sus correos electrónicos lleguen correctamente a sus destinatarios, OV
 
 #### Lo que OVHcloud hace para proteger sus envíos
 
-OVHcloud supervisa de forma permanente la reputación de sus servidores de envío y filtra automáticamente los mensajes sospechosos, para que sus correos electrónicos legítimos no se vean afectados. Pero esta protección tiene un límite: la función PHP `mail()` no realiza ningún control sobre la identidad del remitente declarado en el correo electrónico (campo `From:`). Por tanto, un correo electrónico enviado mediante `mail()` puede parecer que procede de cualquier dirección, lo que basta para activar los filtros de los servidores destinatarios (Gmail, Outlook…) y comprometer la entregabilidad de **sus propios envíos**.
+OVHcloud supervisa de forma permanente la reputación de sus servidores de envío y filtra automáticamente los mensajes sospechosos, para que sus correos electrónicos legítimos no se vean afectados. Pero esta protección tiene un límite: la función PHP `mail()` no realiza ningún control sobre la identidad del remitente declarado en el correo electrónico (campo `From:`). Por tanto, un correo electrónico enviado mediante `mail()` puede parecer que procede de cualquier dirección, lo que basta para activar los filtros de los servidores destinatarios (Gmail, Outlook, etc.) y comprometer la entregabilidad de **sus propios envíos**.
 
 #### Correos electrónicos sin firma fiable
 
-La función `mail()` envía correos electrónicos sin garantizar la identidad del remitente. Sin embargo, los servidores destinatarios (Gmail, Outlook…) verifican que el correo electrónico proceda efectivamente de un servidor autorizado por su dominio, gracias a los registros **SPF** y **DKIM**. Con `mail()`, esta verificación falla a menudo: el mensaje puede entonces acabar en la carpeta de spam o ser rechazado.
+La función `mail()` envía correos electrónicos sin garantizar la identidad del remitente. Sin embargo, los servidores destinatarios (Gmail, Outlook, etc.) verifican que el correo electrónico proceda efectivamente de un servidor autorizado por su dominio, gracias a los registros **SPF** y **DKIM**. Con `mail()`, esta verificación falla a menudo: el mensaje puede entonces acabar en la carpeta de spam o ser rechazado.
 
 El envío mediante SMTP autenticado resuelve este problema: el correo electrónico es emitido por el servidor OVHcloud autorizado para su dominio, con la firma correcta.
 
@@ -65,7 +65,7 @@ La ausencia de captcha en un formulario de envío abierto es una de las causas m
 
 #### Principio
 
-Envíe sus correos electrónicos mediante una conexión **SMTP autenticada** al servidor de mensajería de OVHcloud, utilizando una cuenta de correo electrónico asociada a su dominio alojado (por ejemplo, `contact@mydomain.ovh`).
+Envíe sus correos electrónicos mediante una conexión **SMTP autenticada** al servidor de mensajería de OVHcloud, utilizando una cuenta de correo electrónico asociada a su dominio (por ejemplo, `contact@mydomain.ovh`).
 
 Este enfoque presenta tres ventajas principales:
 
@@ -103,14 +103,14 @@ Este comportamiento es incorrecto por dos razones:
 |---|---|---|
 | `From:` | `contact@mydomain.ovh` (dirección fija del sitio) | Remitente autenticado, nunca cambia |
 | `Reply-To:` | Dirección introducida por el usuario en el formulario | Permite responder directamente al usuario |
-| `Subject:` | Asunto del mensaje, con prefijo (por ejemplo, `[Contact] ...`) | Identifica fácilmente los mensajes del formulario |
+| `Subject:` | Asunto del mensaje, con prefijo (por ejemplo, `[Contact]`) | Identifica fácilmente los mensajes del formulario |
 
 Así, cuando responda al correo electrónico recibido, su cliente de mensajería envía la respuesta a la dirección del usuario a través del campo `Reply-To:`, sin comprometer la autenticación SPF/DKIM.
 
 A continuación se muestra cómo adaptar el ejemplo de PHPMailer para un formulario de contacto:
 
 ```php
-// User-supplied data (validate and sanitise before use)
+// Datos proporcionados por el usuario (validar y depurar antes de usarlos)
 $userEmail = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
 $userName  = htmlspecialchars(strip_tags($_POST['name']));
 $message   = htmlspecialchars(strip_tags($_POST['message']));
@@ -119,13 +119,13 @@ if (!$userEmail) {
     die('Invalid email address.');
 }
 
-// From: always fixed — your site's address, never the user's
+// From: siempre fijo — la dirección de su sitio, nunca la del usuario
 $mail->setFrom('contact@mydomain.ovh', 'My Website');
 
-// Reply-To: the user's address, so you can reply to them directly
+// Reply-To: la dirección del usuario, para poder responderle directamente
 $mail->addReplyTo($userEmail, $userName);
 
-// Recipient: yourself (you receive the form message)
+// Destinatario: usted mismo (recibe el mensaje del formulario)
 $mail->addAddress('contact@mydomain.ovh', 'My Website');
 
 $mail->Subject = '[Contact] ' . $userName;
@@ -203,23 +203,23 @@ require 'vendor/autoload.php';
 $mail = new PHPMailer(true);
 
 try {
-    // OVHcloud SMTP server settings
+    // Parámetros del servidor SMTP de OVHcloud
     $mail->isSMTP();
     $mail->Host       = 'ssl0.ovh.net';
     $mail->SMTPAuth   = true;
-    $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
-    $mail->Password   = 'your_password';         // Password of the email account
+    $mail->Username   = 'contact@mydomain.ovh'; // Su dirección de correo electrónico de OVHcloud
+    $mail->Password   = 'your_password';         // Contraseña de la cuenta de correo electrónico
     $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
     $mail->Port       = 465;
 
-    // Sender: must belong to your hosted domain
+    // Remitente: debe pertenecer a su dominio
     $mail->setFrom('contact@mydomain.ovh', 'My Website');
     $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
 
-    // Recipient
+    // Destinatario
     $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
 
-    // Content
+    // Contenido
     $mail->isHTML(true);
     $mail->Subject = 'Your email subject';
     $mail->Body    = 'Email body in <b>HTML</b>';

--- a/docs/es/guides/web-cloud/web-hosting/landing-page-configuration.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/landing-page-configuration.mdx
@@ -75,6 +75,7 @@ Para orientarse según su necesidad:
         { title: 'Configurar y utilizar Git', link: '/guides/web-cloud/web-hosting/git-integration-webhosting' },
         { title: 'Crear tareas automatizadas (CRON)', link: '/guides/web-cloud/web-hosting/cron-tasks' },
         { title: 'Hacer un seguimiento de los e-mails automatizados', link: '/guides/web-cloud/web-hosting/mail-function-script-records' },
+        { title: 'Buenas prácticas de envío de e-mails', link: '/guides/web-cloud/web-hosting/email-sending-best-practices' },
         { title: 'Gestionar una aplicación web mediante la API', link: '/guides/web-cloud/web-hosting/api-webhosting' },
         { title: 'Hacer evolucionar su plan', link: '/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer' },
         { title: 'Recuperar la copia de seguridad del espacio FTP (Cloud Web)', link: '/guides/web-cloud/web-hosting/backup-ftp', zones: ['eu'] },

--- a/docs/fr/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Hébergement web - Bonnes pratiques d'envoi d'e-mail"
 description: Découvrez pourquoi la fonction PHP mail() est déconseillée sur un hébergement mutualisé et comment configurer un envoi SMTP authentifié
-lastUpdated: 2026-07-13
+lastUpdated: 2026-07-15
 availableIn: [eu, ca, apac]
 ---
 
@@ -144,7 +144,7 @@ Utilisez les paramètres suivants pour votre compte e-mail MX Plan (inclus avec 
 
 | Paramètre | Valeur |
 |---|---|
-| **Serveur SMTP** | `ssl0.ovh.net` |
+| **Serveur SMTP** | `smtp.mail.ovh.net` |
 | **Port (SSL/TLS)** | `465` *(recommandé)* |
 | **Port (STARTTLS)** | `587` |
 | **Chiffrement** | `SSL/TLS` (port 465) ou `STARTTLS` (port 587) |
@@ -190,29 +190,9 @@ Le **nom d’utilisateur SMTP** est votre adresse e-mail complète (par exemple 
 
 Le **mot de passe** est celui défini lors de la création de l’adresse, ou modifié depuis l’espace client OVHcloud. Si vous l’avez oublié ou souhaitez le réinitialiser, consultez le guide « [Modifier le mot de passe d’une adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password) ».
 
-<Region zones={['eu']}>
-
 :::warning
-L’offre MX Plan incluse avec l’hébergement web est soumise à des **quotas d’envoi** (environ 200 e-mails par heure par compte). Pour des volumes importants — newsletters ou e-mails transactionnels en masse — privilégiez une solution dédiée (E-mail Pro, Exchange) ou un service d’envoi transactionnel tiers.
+L’offre MX Plan incluse avec l’hébergement web est soumise à des **quotas d’envoi** (environ 200 e-mails par heure par compte). Les solutions de messagerie ne sont pas conçues pour l’envoi en masse : pour des volumes importants — newsletters ou e-mails transactionnels en masse — utilisez un service d’envoi transactionnel tiers, dédié à cet usage.
 :::
-
-</Region>
-
-<Region zones={['ca']}>
-
-:::warning
-L’offre MX Plan incluse avec l’hébergement web est soumise à des **quotas d’envoi** (environ 200 e-mails par heure par compte). Pour des volumes importants — newsletters ou e-mails transactionnels en masse — privilégiez une solution dédiée telle qu’Exchange ou un service d’envoi transactionnel tiers.
-:::
-
-</Region>
-
-<Region zones={['apac']}>
-
-:::warning
-L’offre MX Plan incluse avec l’hébergement web est soumise à des **quotas d’envoi** (environ 200 e-mails par heure par compte). Pour des volumes importants — newsletters ou e-mails transactionnels en masse — privilégiez un service d’envoi transactionnel tiers.
-:::
-
-</Region>
 
 #### Exemple de code PHP avec PHPMailer
 
@@ -237,7 +217,7 @@ $mail = new PHPMailer(true);
 try {
     // Paramètres du serveur SMTP OVHcloud
     $mail->isSMTP();
-    $mail->Host       = 'ssl0.ovh.net';
+    $mail->Host       = 'smtp.mail.ovh.net';
     $mail->SMTPAuth   = true;
     $mail->Username   = 'contact@mydomain.ovh'; // Votre adresse e-mail OVHcloud
     $mail->Password   = 'your_password';         // Mot de passe du compte e-mail
@@ -267,7 +247,7 @@ try {
 <Region zones={['ca', 'apac']}>
 
 :::warning
-L’exemple ci-dessus utilise le serveur SMTP `ssl0.ovh.net`, disponible uniquement en zone Europe. Depuis le Canada ou la zone Asie-Pacifique, remplacez la valeur de `$mail->Host` par `smtp.mail.ovh.ca`.
+L’exemple ci-dessus utilise le serveur SMTP `smtp.mail.ovh.net`, disponible uniquement en zone Europe. Depuis le Canada ou la zone Asie-Pacifique, remplacez la valeur de `$mail->Host` par `smtp.mail.ovh.ca`.
 :::
 
 </Region>
@@ -319,7 +299,7 @@ La solution consiste à installer un **plugin SMTP** qui remplace `wp_mail()` pa
 
 | Champ | Valeur |
 |---|---|
-| **Hôte SMTP** | `ssl0.ovh.net` |
+| **Hôte SMTP** | `smtp.mail.ovh.net` |
 | **Chiffrement** | `SSL/TLS` |
 | **Port SMTP** | `465` |
 | **Authentification** | Activée |
@@ -367,7 +347,7 @@ Activez l’option **Forcer l’e-mail de l’expéditeur** pour que tous les e-
 
 | Champ | Valeur |
 |---|---|
-| **Hôte** | `ssl0.ovh.net` |
+| **Hôte** | `smtp.mail.ovh.net` |
 | **Port** | `465` |
 | **Chiffrement** | `SSL/TLS` |
 | **Authentification** | Oui |
@@ -405,7 +385,7 @@ Le principe est identique pour tout CMS ou framework : remplacer la fonction d�
 
 <Region zones={['eu']}>
 
-Dans tous les cas, les paramètres SMTP à utiliser sont identiques : serveur `ssl0.ovh.net`, port `465` (SSL/TLS) ou `587` (STARTTLS), avec authentification par l’adresse e-mail complète et son mot de passe.
+Dans tous les cas, les paramètres SMTP à utiliser sont identiques : serveur `smtp.mail.ovh.net`, port `465` (SSL/TLS) ou `587` (STARTTLS), avec authentification par l’adresse e-mail complète et son mot de passe.
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,0 +1,400 @@
+---
+title: "Hébergement web - Bonnes pratiques d'envoi d'e-mail"
+description: Découvrez pourquoi la fonction PHP mail() est déconseillée sur un hébergement mutualisé et comment configurer un envoi SMTP authentifié via vos comptes e-mail OVHcloud
+lastUpdated: 2026-07-13
+availableIn: [eu, ca, apac]
+---
+
+import { Region } from '@components/Zone';
+
+## Objectif
+
+Pour que vos e-mails arrivent bien chez vos destinataires, OVHcloud met en place une infrastructure dédiée à l’envoi sortant, avec filtrage anti-spam automatique et surveillance continue de la réputation des serveurs. Pour en tirer pleinement parti, il est recommandé d’envoyer vos e-mails via **SMTP authentifié** plutôt que via la fonction PHP `mail()` native. Cette approche garantit que chaque e-mail est émis avec une identité vérifiable, ce qui améliore significativement la délivrabilité et réduit le risque de classement en spam.
+
+**Ce guide vous présente les bonnes pratiques et recommandations OVHcloud pour envoyer des e-mails de façon fiable et sécurisée depuis un hébergement mutualisé, que vous gériez un site WordPress, un autre CMS ou une application PHP.**
+
+## Prérequis
+
+- Disposer d’une offre d’[hébergement web OVHcloud](/links/web/hosting).
+- Disposer d’une adresse e-mail attachée à votre nom de domaine hébergé (offre MX Plan, Email Pro ou Exchange). Si vous n’en avez pas encore, consultez le guide « [Créer une adresse e-mail avec son offre MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation) ».
+
+{/* CP-NAV-START:web-hosting */}
+---
+
+### Accès à l’espace client OVHcloud
+
+- **Lien direct :** <ManagerLink to="/#/web/hosting">Hébergements</ManagerLink>
+- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Hébergements</code> > Sélectionnez votre hébergement web
+
+---
+{/* CP-NAV-END:web-hosting */}
+
+## En pratique
+
+### 1. `mail()` ou SMTP authentifié : quelle différence pour vous ?
+
+#### Ce qu’OVHcloud fait pour protéger vos envois
+
+OVHcloud surveille en permanence la réputation de ses serveurs d’envoi et filtre automatiquement les messages suspects — pour que vos e-mails légitimes n’en pâtissent pas. Mais cette protection a une limite : la fonction PHP `mail()` n’effectue aucun contrôle sur l’identité de l’expéditeur déclaré dans l’e-mail (champ `From:`). Un e-mail envoyé via `mail()` peut donc sembler provenir de n’importe quelle adresse, ce qui suffit à déclencher les filtres des serveurs destinataires (Gmail, Outlook…) et compromettre la délivrabilité de **vos propres envois**.
+
+#### Des e-mails sans signature fiable
+
+La fonction `mail()` envoie des e-mails sans garantir l’identité de l’expéditeur. Or les serveurs destinataires (Gmail, Outlook…) vérifient que l’e-mail provient bien d’un serveur autorisé par votre domaine, grâce aux enregistrements **SPF** et **DKIM**. Avec `mail()`, cette vérification échoue souvent : le message risque alors d’atterrir en spam ou d’être rejeté.
+
+L’envoi via SMTP authentifié résout ce problème : l’e-mail est émis par le serveur OVHcloud autorisé pour votre domaine, avec la bonne signature.
+
+:::warning
+Un usage abusif de la fonction `mail()` peut entraîner le blocage automatique des envois pour votre hébergement. Si vous constatez que vos e-mails ne partent plus, consultez le guide « [Suivre et gérer les e-mails automatisés de son hébergement web](/guides/web-cloud/web-hosting/mail-function-script-records) ».
+:::
+
+#### Formulaires ouverts : un vecteur d’abus supplémentaire
+
+Un formulaire de contact accessible publiquement, sans mécanisme de protection, est une cible privilégiée pour les robots. Ces derniers l’exploitent pour déclencher l’envoi de milliers d’e-mails en quelques minutes via votre hébergement, provoquant le blocage de l’IP partagée et nuisant à tous les clients du cluster.
+
+Mettez en place les protections suivantes sur tout formulaire qui déclenche un envoi d’e-mail :
+
+- **Captcha** : intégrez un système de vérification (Google reCAPTCHA v3, hCaptcha, ou un calcul arithmétique simple) pour bloquer les soumissions automatisées.
+- **Limitation du débit** : limitez le nombre d’envois par adresse IP côté serveur pour éviter les abus en rafale.
+- **Validation stricte des entrées** : vérifiez et nettoyez tous les champs du formulaire avant de les utiliser dans un e-mail — ne faites jamais confiance aux données saisies par l’utilisateur.
+
+:::warning
+L’absence de captcha sur un formulaire d’envoi ouvert est l’une des causes les plus fréquentes de blocage des hébergements mutualisés pour envoi de spam. Cette protection est indispensable quelle que soit la méthode d’envoi utilisée.
+:::
+
+### 2. La bonne pratique : utiliser un compte e-mail OVHcloud avec SMTP authentifié
+
+#### Principe
+
+Envoyez vos e-mails via une connexion **SMTP authentifiée** vers le serveur de messagerie OVHcloud, à l’aide d’un compte e-mail attaché à votre domaine hébergé (par exemple `contact@mydomain.ovh`).
+
+Cette approche présente trois avantages majeurs :
+
+- **Authentification garantie** : le serveur OVHcloud vérifie votre identité avant d’accepter l’e-mail.
+- **SPF et DKIM fonctionnels** : l’e-mail est émis par un serveur autorisé pour votre domaine et signé correctement.
+- **Traçabilité** : chaque envoi est associé à un compte identifié, ce qui permet d’intervenir rapidement en cas d’abus.
+
+#### Pourquoi le champ `From:` doit appartenir à votre domaine
+
+Le champ `From:` de votre e-mail doit **obligatoirement** contenir une adresse appartenant à votre domaine (ex. `contact@mydomain.ovh`), et cette adresse doit correspondre au compte SMTP utilisé pour l’authentification.
+
+Si le `From:` ne correspond pas au domaine autorisé dans l’enregistrement SPF, ou si la signature DKIM ne correspond pas, les serveurs de messagerie destinataires (Gmail, Outlook, etc.) peuvent rejeter ou classer l’e-mail en spam.
+
+:::tip
+Pour maximiser la délivrabilité, vérifiez que les enregistrements SPF, DKIM et DMARC sont bien configurés dans votre zone DNS. Gmail et Yahoo Mail les exigent désormais pour les expéditeurs en volume. Consultez nos guides :
+
+- [Améliorer la sécurité des e-mails via un enregistrement SPF](/guides/web-cloud/domains/dns-zone-spf)
+- [Améliorer la sécurité des e-mails via un enregistrement DKIM](/guides/web-cloud/domains/dns-zone-dkim)
+- [Améliorer la sécurité des e-mails via un enregistrement DMARC](/guides/web-cloud/domains/dns-zone-dmarc)
+
+:::
+
+#### Formulaires de contact : champ `From:` fixe et `Reply-To:` utilisateur
+
+Une erreur fréquente consiste à placer l’adresse e-mail saisie par l’utilisateur dans le formulaire directement en champ `From:`. Par exemple, un visiteur saisit `utilisateur@gmail.com` et le script utilise cette adresse comme expéditeur.
+
+Ce comportement est incorrect pour deux raisons :
+
+- L’enregistrement SPF de votre domaine n’autorise pas les serveurs Gmail (ou tout autre fournisseur tiers) à envoyer en votre nom → échec du contrôle SPF.
+- Vous envoyez « au nom de » une adresse qui ne vous appartient pas → risque élevé de classification en spam ou de rejet.
+
+**Le bon schéma pour un formulaire de contact :**
+
+| Champ e-mail | Valeur | Rôle |
+|---|---|---|
+| `From:` | `contact@mydomain.ovh` (adresse fixe du site) | Expéditeur authentifié — ne change jamais |
+| `Reply-To:` | Adresse saisie par l’utilisateur dans le formulaire | Permet de répondre directement à l’utilisateur |
+| `Subject:` | Objet du message, préfixé (ex. `[Contact] ...`) | Identifie facilement les messages du formulaire |
+
+Ainsi, quand vous répondez à l’e-mail reçu, votre client de messagerie envoie la réponse à l’adresse de l’utilisateur via le champ `Reply-To:`, sans compromettre l’authentification SPF/DKIM.
+
+Voici comment adapter l’exemple PHPMailer pour un formulaire de contact :
+
+```php
+// User-supplied data (validate and sanitise before use)
+$userEmail = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
+$userName  = htmlspecialchars(strip_tags($_POST['name']));
+$message   = htmlspecialchars(strip_tags($_POST['message']));
+
+if (!$userEmail) {
+    die('Invalid email address.');
+}
+
+// From: always fixed — your site's address, never the user's
+$mail->setFrom('contact@mydomain.ovh', 'My Website');
+
+// Reply-To: the user's address, so you can reply to them directly
+$mail->addReplyTo($userEmail, $userName);
+
+// Recipient: yourself (you receive the form message)
+$mail->addAddress('contact@mydomain.ovh', 'My Website');
+
+$mail->Subject = '[Contact] ' . $userName;
+$mail->Body    = "Name: $userName\nEmail: $userEmail\n\nMessage:\n$message";
+```
+
+:::tip
+Ne passez jamais directement les données d’un formulaire dans PHPMailer sans validation préalable. Utilisez `filter_var()` pour l’adresse e-mail et `htmlspecialchars()` + `strip_tags()` pour les champs texte afin d’éviter les injections d’en-têtes e-mail.
+:::
+
+#### Paramètres SMTP OVHcloud
+
+Utilisez les paramètres suivants pour votre compte e-mail MX Plan (inclus avec l’hébergement web) :
+
+<Region zones={['eu']}>
+
+| Paramètre | Valeur |
+|---|---|
+| **Serveur SMTP** | `ssl0.ovh.net` |
+| **Port (SSL/TLS)** | `465` *(recommandé)* |
+| **Port (STARTTLS)** | `587` |
+| **Chiffrement** | `SSL/TLS` (port 465) ou `STARTTLS` (port 587) |
+| **Authentification** | Obligatoire |
+| **Nom d’utilisateur** | Adresse e-mail complète (ex. `contact@mydomain.ovh`) |
+| **Mot de passe** | Mot de passe du compte e-mail OVHcloud |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Paramètre | Valeur |
+|---|---|
+| **Serveur SMTP** | `smtp.mail.ovh.ca` |
+| **Port (SSL/TLS)** | `465` *(recommandé)* |
+| **Port (STARTTLS)** | `587` |
+| **Chiffrement** | `SSL/TLS` (port 465) ou `STARTTLS` (port 587) |
+| **Authentification** | Obligatoire |
+| **Nom d’utilisateur** | Adresse e-mail complète (ex. `contact@mydomain.ovh`) |
+| **Mot de passe** | Mot de passe du compte e-mail OVHcloud |
+
+</Region>
+
+:::tip
+Pour les offres **Email Pro** ou **Exchange**, le serveur SMTP est différent. Consultez la documentation de chaque offre pour les paramètres exacts.
+:::
+
+#### Où trouver vos identifiants SMTP
+
+Le **nom d’utilisateur SMTP** est votre adresse e-mail complète (ex. `contact@mydomain.ovh`).
+
+Le **mot de passe** est celui défini lors de la création de l’adresse, ou modifié depuis l’espace client OVHcloud. Si vous l’avez oublié ou souhaitez le réinitialiser, consultez le guide « [Modifier le mot de passe d’une adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password) ».
+
+:::warning
+L’offre MX Plan incluse avec l’hébergement web est soumise à des **quotas d’envoi** (environ 200 e-mails par heure par compte). Pour des volumes importants — newsletters ou e-mails transactionnels en masse — privilégiez une solution dédiée (Email Pro, Exchange) ou un service d’envoi transactionnel tiers.
+:::
+
+#### Exemple de code PHP avec PHPMailer
+
+[PHPMailer](https://github.com/PHPMailer/PHPMailer) est la bibliothèque PHP de référence pour l’envoi d’e-mails via SMTP. Installez-la via Composer :
+
+```bash
+composer require phpmailer/phpmailer
+```
+
+Voici un exemple complet d’envoi SMTP authentifié :
+
+```php
+<?php
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
+use PHPMailer\PHPMailer\Exception;
+
+require 'vendor/autoload.php';
+
+$mail = new PHPMailer(true);
+
+try {
+    // OVHcloud SMTP server settings
+    $mail->isSMTP();
+    $mail->Host       = 'ssl0.ovh.net';
+    $mail->SMTPAuth   = true;
+    $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
+    $mail->Password   = 'your_password';         // Password of the email account
+    $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
+    $mail->Port       = 465;
+
+    // Sender: must belong to your hosted domain
+    $mail->setFrom('contact@mydomain.ovh', 'My Website');
+    $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
+
+    // Recipient
+    $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
+
+    // Content
+    $mail->isHTML(true);
+    $mail->Subject = 'Your email subject';
+    $mail->Body    = 'Email body in <b>HTML</b>';
+    $mail->AltBody = 'Email body in plain text (fallback)';
+
+    $mail->send();
+    echo 'Email sent successfully.';
+} catch (Exception $e) {
+    echo "Error while sending: {$mail->ErrorInfo}";
+}
+```
+
+<Region zones={['ca', 'apac']}>
+
+:::warning
+L’exemple ci-dessus utilise le serveur SMTP `ssl0.ovh.net`, disponible uniquement en zone Europe. Depuis le Canada ou la zone Asie-Pacifique, remplacez la valeur de `$mail->Host` par `smtp.mail.ovh.ca`.
+:::
+
+</Region>
+
+:::warning
+Ne stockez jamais le mot de passe de votre compte e-mail en clair dans un fichier PHP versionné. Utilisez un fichier de configuration exclu de votre dépôt Git (`.gitignore`).
+:::
+
+:::info
+Avec cette configuration, chaque e-mail envoyé depuis votre site est :
+
+- **authentifié** auprès du serveur OVHcloud,
+- **signé** avec les enregistrements SPF et DKIM de votre domaine,
+- **traçable** en cas d’abus ou de problème de délivrabilité.
+
+:::
+
+### 3. WordPress et autres CMS : utiliser un plugin SMTP
+
+#### 3.1 Le problème avec WordPress par défaut
+
+La fonction `wp_mail()` de WordPress utilise en arrière-plan la fonction PHP `mail()`. Elle hérite donc de tous les problèmes décrits dans la section précédente : absence d’authentification, `From:` non contrôlé, risque de spam.
+
+La solution consiste à installer un **plugin SMTP** qui remplace `wp_mail()` par une connexion SMTP authentifiée vers votre serveur de messagerie OVHcloud.
+
+#### 3.2 Configurer WP Mail SMTP
+
+[WP Mail SMTP](https://fr.wordpress.org/plugins/wp-mail-smtp/) est le plugin le plus utilisé pour cette configuration.
+
+**Installation :**
+
+1. Dans votre administration WordPress, accédez à **Extensions** > **Ajouter une extension**.
+2. Recherchez `WP Mail SMTP` et cliquez sur **Installer maintenant**, puis **Activer**.
+
+**Configuration :**
+
+1. Accédez à **WP Mail SMTP** > **Paramètres** dans le menu d’administration.
+2. Dans la section **Expéditeur**, renseignez les champs suivants :
+
+| Champ | Valeur |
+|---|---|
+| **E-mail de l’expéditeur** | `contact@mydomain.ovh` (adresse appartenant à votre domaine) |
+| **Nom de l’expéditeur** | Nom affiché pour votre site (ex. `Mon Site Web`) |
+
+3. Dans la section **Mailer**, sélectionnez **Autre SMTP**.
+4. Renseignez les paramètres SMTP :
+
+<Region zones={['eu']}>
+
+| Champ | Valeur |
+|---|---|
+| **Hôte SMTP** | `ssl0.ovh.net` |
+| **Chiffrement** | `SSL/TLS` |
+| **Port SMTP** | `465` |
+| **Authentification** | Activée |
+| **Nom d’utilisateur SMTP** | `contact@mydomain.ovh` |
+| **Mot de passe SMTP** | Mot de passe de votre compte e-mail OVHcloud |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Champ | Valeur |
+|---|---|
+| **Hôte SMTP** | `smtp.mail.ovh.ca` |
+| **Chiffrement** | `SSL/TLS` |
+| **Port SMTP** | `465` |
+| **Authentification** | Activée |
+| **Nom d’utilisateur SMTP** | `contact@mydomain.ovh` |
+| **Mot de passe SMTP** | Mot de passe de votre compte e-mail OVHcloud |
+
+</Region>
+
+5. Cliquez sur **Enregistrer les paramètres**.
+6. Dans l’onglet **Outils**, utilisez **Test d’envoi d’e-mail** pour vérifier la configuration.
+
+:::tip
+Activez l’option **Forcer l’e-mail de l’expéditeur** pour que tous les e-mails sortants utilisent l’adresse configurée, même si un plugin tiers tente d’en utiliser une autre.
+:::
+
+#### 3.3 Alternative : FluentSMTP
+
+[FluentSMTP](https://fr.wordpress.org/plugins/fluent-smtp/) est une alternative légère et gratuite, sans limitation sur le volume d’envoi.
+
+**Installation :**
+
+1. Dans votre administration WordPress, accédez à **Extensions** > **Ajouter une extension**.
+2. Recherchez `FluentSMTP` et cliquez sur **Installer maintenant**, puis **Activer**.
+
+**Configuration :**
+
+1. Accédez à **FluentSMTP** > **Paramètres**.
+2. Cliquez sur **Ajouter une connexion** et sélectionnez **Autre SMTP**.
+3. Renseignez les mêmes paramètres que pour WP Mail SMTP :
+
+<Region zones={['eu']}>
+
+| Champ | Valeur |
+|---|---|
+| **Hôte** | `ssl0.ovh.net` |
+| **Port** | `465` |
+| **Chiffrement** | `SSL/TLS` |
+| **Authentification** | Oui |
+| **Nom d’utilisateur** | `contact@mydomain.ovh` |
+| **Mot de passe** | Mot de passe de votre compte e-mail OVHcloud |
+| **E-mail expéditeur** | `contact@mydomain.ovh` |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Champ | Valeur |
+|---|---|
+| **Hôte** | `smtp.mail.ovh.ca` |
+| **Port** | `465` |
+| **Chiffrement** | `SSL/TLS` |
+| **Authentification** | Oui |
+| **Nom d’utilisateur** | `contact@mydomain.ovh` |
+| **Mot de passe** | Mot de passe de votre compte e-mail OVHcloud |
+| **E-mail expéditeur** | `contact@mydomain.ovh` |
+
+</Region>
+
+4. Cliquez sur **Enregistrer la connexion** puis envoyez un e-mail de test.
+
+#### 3.4 Autres CMS (Drupal, Joomla, PrestaShop)
+
+Le principe est identique pour tout CMS ou framework : remplacer la fonction d’envoi native par un module ou une configuration SMTP authentifiée.
+
+| CMS | Module recommandé |
+|---|---|
+| **Drupal** | [SMTP Authentication Support](https://www.drupal.org/project/smtp) |
+| **Joomla** | Configuration native : **Système** > **Configuration globale** > onglet **Serveur** > section **Paramètres mail** |
+| **PrestaShop** | **Paramètres avancés** > **E-mail** — choisir **Utiliser mes propres paramètres SMTP** |
+
+<Region zones={['eu']}>
+
+Dans tous les cas, les paramètres SMTP à utiliser sont identiques : serveur `ssl0.ovh.net`, port `465` (SSL/TLS) ou `587` (STARTTLS), avec authentification par l’adresse e-mail complète et son mot de passe.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Dans tous les cas, les paramètres SMTP à utiliser sont identiques : serveur `smtp.mail.ovh.ca`, port `465` (SSL/TLS) ou `587` (STARTTLS), avec authentification par l’adresse e-mail complète et son mot de passe.
+
+</Region>
+
+## Aller plus loin
+
+[Suivre et gérer les e-mails automatisés de son hébergement web](/guides/web-cloud/web-hosting/mail-function-script-records)
+
+[Améliorer la sécurité des e-mails via un enregistrement SPF](/guides/web-cloud/domains/dns-zone-spf)
+
+[Configurer un enregistrement DKIM](/guides/web-cloud/domains/dns-zone-dkim)
+
+[Améliorer la sécurité des e-mails via un enregistrement DMARC](/guides/web-cloud/domains/dns-zone-dmarc)
+
+Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](/links/partner).
+
+Si vous souhaitez bénéficier d’une assistance à l’usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).
+
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Hébergement web - Bonnes pratiques d'envoi d'e-mail"
-description: Découvrez pourquoi la fonction PHP mail() est déconseillée sur un hébergement mutualisé et comment configurer un envoi SMTP authentifié via vos comptes e-mail OVHcloud
+description: Découvrez pourquoi la fonction PHP mail() est déconseillée sur un hébergement mutualisé et comment configurer un envoi SMTP authentifié
 lastUpdated: 2026-07-13
 availableIn: [eu, ca, apac]
 ---
@@ -9,14 +9,14 @@ import { Region } from '@components/Zone';
 
 ## Objectif
 
-Pour que vos e-mails arrivent bien chez vos destinataires, OVHcloud met en place une infrastructure dédiée à l’envoi sortant, avec filtrage anti-spam automatique et surveillance continue de la réputation des serveurs. Pour en tirer pleinement parti, il est recommandé d’envoyer vos e-mails via **SMTP authentifié** plutôt que via la fonction PHP `mail()` native. Cette approche garantit que chaque e-mail est émis avec une identité vérifiable, ce qui améliore significativement la délivrabilité et réduit le risque de classement en spam.
+Pour que vos e-mails arrivent bien chez vos destinataires, OVHcloud met en place une infrastructure dédiée à l’envoi sortant, avec filtrage anti-spam automatique et surveillance continue de la réputation des serveurs. Pour en tirer pleinement parti, il est recommandé d’envoyer vos e-mails via **SMTP authentifié** plutôt que via la fonction PHP `mail()` native. Cette approche garantit que chaque e-mail est émis avec une identité vérifiable, ce qui améliore nettement la délivrabilité et réduit le risque de classement en spam.
 
 **Ce guide vous présente les bonnes pratiques et recommandations OVHcloud pour envoyer des e-mails de façon fiable et sécurisée depuis un hébergement mutualisé, que vous gériez un site WordPress, un autre CMS ou une application PHP.**
 
 ## Prérequis
 
 - Disposer d’une offre d’[hébergement web OVHcloud](/links/web/hosting).
-- Disposer d’une adresse e-mail attachée à votre nom de domaine (offre MX Plan, E-mail Pro ou Exchange). Si vous n’en avez pas encore, consultez le guide « [Créer une adresse e-mail avec son offre MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation) ».
+- Disposer d’une adresse e-mail attachée à votre nom de domaine (<Region zones={['eu']}>offre MX Plan, E-mail Pro ou Exchange</Region><Region zones={['ca']}>offre MX Plan ou Exchange</Region><Region zones={['apac']}>offre MX Plan</Region>). Si vous n’en avez pas encore, consultez le guide « [Créer une adresse e-mail avec son offre MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation) ».
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -31,47 +31,47 @@ Pour que vos e-mails arrivent bien chez vos destinataires, OVHcloud met en place
 
 ## En pratique
 
-### 1. `mail()` ou SMTP authentifié : quelle différence pour vous ?
+### 1. `mail()` ou SMTP authentifié : quelle différence pour vous ?
 
 #### Ce qu’OVHcloud fait pour protéger vos envois
 
-OVHcloud surveille en permanence la réputation de ses serveurs d’envoi et filtre automatiquement les messages suspects — pour que vos e-mails légitimes n’en pâtissent pas. Mais cette protection a une limite : la fonction PHP `mail()` n’effectue aucun contrôle sur l’identité de l’expéditeur déclaré dans l’e-mail (champ `From:`). Un e-mail envoyé via `mail()` peut donc sembler provenir de n’importe quelle adresse, ce qui suffit à déclencher les filtres des serveurs destinataires (Gmail, Outlook, etc.) et à compromettre la délivrabilité de **vos propres envois**.
+OVHcloud surveille en permanence la réputation de ses serveurs d’envoi et filtre automatiquement les messages suspects — pour que vos e-mails légitimes n’en pâtissent pas. Mais cette protection a une limite : la fonction PHP `mail()` n’effectue aucun contrôle sur l’identité de l’expéditeur déclaré dans l’e-mail (champ `From:`). Un e-mail envoyé via `mail()` peut donc sembler provenir de n’importe quelle adresse, ce qui suffit à déclencher les filtres des serveurs destinataires (Gmail, Outlook, etc.) et à compromettre la délivrabilité de **vos propres envois**.
 
 #### Des e-mails sans signature fiable
 
-La fonction `mail()` envoie des e-mails sans garantir l’identité de l’expéditeur. Or les serveurs destinataires (Gmail, Outlook, etc.) vérifient que l’e-mail provient bien d’un serveur autorisé par votre domaine, grâce aux enregistrements **SPF** et **DKIM**. Avec `mail()`, cette vérification échoue souvent : le message risque alors d’être classé en spam ou rejeté.
+La fonction `mail()` envoie des e-mails sans garantir l’identité de l’expéditeur. Or les serveurs destinataires (Gmail, Outlook, etc.) vérifient que l’e-mail provient bien d’un serveur autorisé par votre domaine, grâce aux enregistrements **SPF** et **DKIM**. Avec `mail()`, cette vérification échoue souvent : le message risque alors d’être classé en spam ou rejeté.
 
-L’envoi via SMTP authentifié résout ce problème : l’e-mail est émis par le serveur OVHcloud autorisé pour votre domaine, avec la bonne signature.
+L’envoi via SMTP authentifié résout ce problème : l’e-mail est émis par le serveur OVHcloud autorisé pour votre domaine, avec la bonne signature.
 
 :::warning
 Un usage abusif de la fonction `mail()` peut entraîner le blocage automatique des envois pour votre hébergement. Si vous constatez que vos e-mails ne partent plus, consultez le guide « [Suivre et gérer les e-mails automatisés de son hébergement web](/guides/web-cloud/web-hosting/mail-function-script-records) ».
 :::
 
-#### Formulaires ouverts : un vecteur d’abus supplémentaire
+#### Formulaires ouverts : un vecteur d’abus supplémentaire
 
-Un formulaire de contact accessible publiquement, sans mécanisme de protection, est une cible privilégiée pour les robots. Ces derniers l’exploitent pour déclencher l’envoi de milliers d’e-mails en quelques minutes via votre hébergement, provoquant le blocage de l’IP partagée et nuisant à tous les clients du cluster.
+Un formulaire de contact accessible publiquement, sans mécanisme de protection, est une cible privilégiée pour les robots. Ces derniers l’exploitent pour déclencher l’envoi de milliers d’e-mails en quelques minutes via votre hébergement, provoquant le blocage de l’IP partagée et nuisant à tous les clients hébergés sur le même serveur.
 
-Mettez en place les protections suivantes sur tout formulaire qui déclenche un envoi d’e-mail :
+Mettez en place les protections suivantes sur tout formulaire qui déclenche un envoi d’e-mail :
 
-- **Captcha** : intégrez un système de vérification (Google reCAPTCHA v3, hCaptcha, ou un calcul arithmétique simple) pour bloquer les soumissions automatisées.
-- **Limitation du débit** : limitez le nombre d’envois par adresse IP côté serveur pour éviter les abus en rafale.
-- **Validation stricte des entrées** : vérifiez et nettoyez tous les champs du formulaire avant de les utiliser dans un e-mail — ne faites jamais confiance aux données saisies par l’utilisateur.
+- **Captcha** : intégrez un système de vérification (Google reCAPTCHA v3, hCaptcha, ou un calcul arithmétique simple) pour bloquer les soumissions automatisées.
+- **Limitation du débit** : limitez le nombre d’envois par adresse IP côté serveur pour éviter les abus en rafale.
+- **Validation stricte des entrées** : vérifiez et nettoyez tous les champs du formulaire avant de les utiliser dans un e-mail — ne faites jamais confiance aux données saisies par l’utilisateur.
 
 :::warning
-L’absence de captcha sur un formulaire d’envoi ouvert est l’une des causes les plus fréquentes de blocage des hébergements mutualisés pour envoi de spam. Cette protection est indispensable quelle que soit la méthode d’envoi utilisée.
+L’absence de captcha sur un formulaire d’envoi ouvert est l’une des causes les plus fréquentes de blocage des hébergements mutualisés pour envoi de spam. Cette protection est indispensable quelle que soit la méthode d’envoi.
 :::
 
-### 2. La bonne pratique : utiliser un compte e-mail OVHcloud avec SMTP authentifié
+### 2. La bonne pratique : utiliser un compte e-mail OVHcloud avec SMTP authentifié
 
 #### Principe
 
 Envoyez vos e-mails via une connexion **SMTP authentifiée** vers le serveur de messagerie OVHcloud, à l’aide d’un compte e-mail attaché à votre domaine (par exemple `contact@mydomain.ovh`).
 
-Cette approche présente trois avantages majeurs :
+Cette approche présente trois avantages majeurs :
 
-- **Authentification garantie** : le serveur OVHcloud vérifie votre identité avant d’accepter l’e-mail.
-- **SPF et DKIM fonctionnels** : l’e-mail est émis par un serveur autorisé pour votre domaine et signé correctement.
-- **Traçabilité** : chaque envoi est associé à un compte identifié, ce qui permet d’intervenir rapidement en cas d’abus.
+- **Authentification garantie** : le serveur OVHcloud vérifie votre identité avant d’accepter l’e-mail.
+- **SPF et DKIM fonctionnels** : l’e-mail est émis par un serveur autorisé pour votre domaine et signé correctement.
+- **Traçabilité** : chaque envoi est associé à un compte identifié, ce qui permet d’intervenir rapidement en cas d’abus.
 
 #### Pourquoi le champ `From:` doit appartenir à votre domaine
 
@@ -80,7 +80,7 @@ Le champ `From:` de votre e-mail doit **obligatoirement** contenir une adresse a
 Si le `From:` ne correspond pas au domaine autorisé dans l’enregistrement SPF, ou si la signature DKIM ne correspond pas, les serveurs de messagerie destinataires (Gmail, Outlook, etc.) peuvent rejeter ou classer l’e-mail en spam.
 
 :::tip
-Pour maximiser la délivrabilité, vérifiez que les enregistrements SPF, DKIM et DMARC sont bien configurés dans votre zone DNS. Gmail et Yahoo Mail les exigent désormais pour les expéditeurs en volume. Consultez nos guides :
+Pour maximiser la délivrabilité, vérifiez que les enregistrements SPF, DKIM et DMARC sont bien configurés dans votre zone DNS. Gmail et Yahoo Mail les exigent désormais pour les expéditeurs à fort volume. Consultez nos guides :
 
 - [Améliorer la sécurité des e-mails via un enregistrement SPF](/guides/web-cloud/domains/dns-zone-spf)
 - [Améliorer la sécurité des e-mails via un enregistrement DKIM](/guides/web-cloud/domains/dns-zone-dkim)
@@ -88,16 +88,16 @@ Pour maximiser la délivrabilité, vérifiez que les enregistrements SPF, DKIM e
 
 :::
 
-#### Formulaires de contact : champ `From:` fixe et `Reply-To:` utilisateur
+#### Formulaires de contact : champ `From:` fixe et `Reply-To:` utilisateur
 
-Une erreur fréquente consiste à placer l’adresse e-mail saisie par l’utilisateur dans le formulaire directement en champ `From:`. Par exemple, un visiteur saisit `utilisateur@gmail.com` et le script utilise cette adresse comme expéditeur.
+Une erreur fréquente consiste à placer directement l’adresse e-mail saisie par l’utilisateur dans le champ `From:`. Par exemple, un visiteur saisit `utilisateur@gmail.com` et le script utilise cette adresse comme expéditeur.
 
-Ce comportement est incorrect pour deux raisons :
+Ce comportement est incorrect pour deux raisons :
 
 - L’enregistrement SPF de votre domaine n’autorise pas les serveurs Gmail (ou tout autre fournisseur tiers) à envoyer en votre nom → échec du contrôle SPF.
 - Vous envoyez au nom d’une adresse qui ne vous appartient pas → risque élevé de classification en spam ou de rejet.
 
-**Le bon schéma pour un formulaire de contact :**
+**Le bon schéma pour un formulaire de contact :**
 
 | Champ e-mail | Valeur | Rôle |
 |---|---|---|
@@ -107,7 +107,7 @@ Ce comportement est incorrect pour deux raisons :
 
 Ainsi, quand vous répondez à l’e-mail reçu, votre client de messagerie envoie la réponse à l’adresse de l’utilisateur via le champ `Reply-To:`, sans compromettre l’authentification SPF/DKIM.
 
-Voici comment adapter l’exemple PHPMailer pour un formulaire de contact :
+Voici comment adapter l’exemple PHPMailer pour un formulaire de contact :
 
 ```php
 // Données fournies par l'utilisateur (à valider et nettoyer avant utilisation)
@@ -138,7 +138,7 @@ Ne passez jamais directement les données d’un formulaire dans PHPMailer sans 
 
 #### Paramètres SMTP OVHcloud
 
-Utilisez les paramètres suivants pour votre compte e-mail MX Plan (inclus avec l’hébergement web) :
+Utilisez les paramètres suivants pour votre compte e-mail MX Plan (inclus avec l’hébergement web) :
 
 <Region zones={['eu']}>
 
@@ -168,9 +168,21 @@ Utilisez les paramètres suivants pour votre compte e-mail MX Plan (inclus avec 
 
 </Region>
 
+<Region zones={['eu']}>
+
 :::tip
 Pour les offres **E-mail Pro** ou **Exchange**, le serveur SMTP est différent. Consultez la documentation de chaque offre pour les paramètres exacts.
 :::
+
+</Region>
+
+<Region zones={['ca']}>
+
+:::tip
+Pour l’offre **Exchange**, le serveur SMTP est différent. Consultez la documentation de cette offre pour les paramètres exacts.
+:::
+
+</Region>
 
 #### Où trouver vos identifiants SMTP
 
@@ -178,19 +190,39 @@ Le **nom d’utilisateur SMTP** est votre adresse e-mail complète (par exemple 
 
 Le **mot de passe** est celui défini lors de la création de l’adresse, ou modifié depuis l’espace client OVHcloud. Si vous l’avez oublié ou souhaitez le réinitialiser, consultez le guide « [Modifier le mot de passe d’une adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password) ».
 
+<Region zones={['eu']}>
+
 :::warning
 L’offre MX Plan incluse avec l’hébergement web est soumise à des **quotas d’envoi** (environ 200 e-mails par heure par compte). Pour des volumes importants — newsletters ou e-mails transactionnels en masse — privilégiez une solution dédiée (E-mail Pro, Exchange) ou un service d’envoi transactionnel tiers.
 :::
 
+</Region>
+
+<Region zones={['ca']}>
+
+:::warning
+L’offre MX Plan incluse avec l’hébergement web est soumise à des **quotas d’envoi** (environ 200 e-mails par heure par compte). Pour des volumes importants — newsletters ou e-mails transactionnels en masse — privilégiez une solution dédiée telle qu’Exchange ou un service d’envoi transactionnel tiers.
+:::
+
+</Region>
+
+<Region zones={['apac']}>
+
+:::warning
+L’offre MX Plan incluse avec l’hébergement web est soumise à des **quotas d’envoi** (environ 200 e-mails par heure par compte). Pour des volumes importants — newsletters ou e-mails transactionnels en masse — privilégiez un service d’envoi transactionnel tiers.
+:::
+
+</Region>
+
 #### Exemple de code PHP avec PHPMailer
 
-[PHPMailer](https://github.com/PHPMailer/PHPMailer) est la bibliothèque PHP de référence pour l’envoi d’e-mails via SMTP. Installez-la via Composer :
+[PHPMailer](https://github.com/PHPMailer/PHPMailer) est la bibliothèque PHP de référence pour l’envoi d’e-mails via SMTP. Installez-la via Composer :
 
 ```bash
 composer require phpmailer/phpmailer
 ```
 
-Voici un exemple complet d’envoi SMTP authentifié :
+Voici un exemple complet d’envoi SMTP authentifié :
 
 ```php
 <?php
@@ -245,7 +277,7 @@ Ne stockez jamais le mot de passe de votre compte e-mail en clair dans un fichie
 :::
 
 :::info
-Avec cette configuration, chaque e-mail envoyé depuis votre site est :
+Avec cette configuration, chaque e-mail envoyé depuis votre site est :
 
 - **authentifié** auprès du serveur OVHcloud,
 - **signé** avec les enregistrements SPF et DKIM de votre domaine,
@@ -253,11 +285,11 @@ Avec cette configuration, chaque e-mail envoyé depuis votre site est :
 
 :::
 
-### 3. WordPress et autres CMS : utiliser un plugin SMTP
+### 3. WordPress et autres CMS : utiliser un plugin SMTP
 
 #### 3.1 Le problème avec WordPress par défaut
 
-La fonction `wp_mail()` de WordPress utilise en arrière-plan la fonction PHP `mail()`. Elle hérite donc de tous les problèmes décrits dans la section précédente : absence d’authentification, `From:` non contrôlé, risque de spam.
+La fonction `wp_mail()` de WordPress utilise en arrière-plan la fonction PHP `mail()`. Elle hérite donc de tous les problèmes décrits dans la section précédente : absence d’authentification, `From:` non contrôlé, risque de spam.
 
 La solution consiste à installer un **plugin SMTP** qui remplace `wp_mail()` par une connexion SMTP authentifiée vers votre serveur de messagerie OVHcloud.
 
@@ -265,15 +297,15 @@ La solution consiste à installer un **plugin SMTP** qui remplace `wp_mail()` pa
 
 [WP Mail SMTP](https://fr.wordpress.org/plugins/wp-mail-smtp/) est le plugin le plus utilisé pour cette configuration.
 
-**Installation :**
+**Installation :**
 
 1. Dans votre administration WordPress, accédez à **Extensions** > **Ajouter une extension**.
 2. Recherchez `WP Mail SMTP` et cliquez sur **Installer maintenant**, puis sur **Activer**.
 
-**Configuration :**
+**Configuration :**
 
 1. Accédez à **WP Mail SMTP** > **Paramètres** dans le menu d’administration.
-2. Dans la section **Expéditeur**, renseignez les champs suivants :
+2. Dans la section **Expéditeur**, renseignez les champs suivants :
 
 | Champ | Valeur |
 |---|---|
@@ -281,7 +313,7 @@ La solution consiste à installer un **plugin SMTP** qui remplace `wp_mail()` pa
 | **Nom de l’expéditeur** | Nom affiché pour votre site (par exemple `Mon Site Web`) |
 
 3. Dans la section **Mailer**, sélectionnez **Autre SMTP**.
-4. Renseignez les paramètres SMTP :
+4. Renseignez les paramètres SMTP :
 
 <Region zones={['eu']}>
 
@@ -316,20 +348,20 @@ La solution consiste à installer un **plugin SMTP** qui remplace `wp_mail()` pa
 Activez l’option **Forcer l’e-mail de l’expéditeur** pour que tous les e-mails sortants utilisent l’adresse configurée, même si un plugin tiers tente d’en utiliser une autre.
 :::
 
-#### 3.3 Alternative : FluentSMTP
+#### 3.3 Alternative : FluentSMTP
 
 [FluentSMTP](https://fr.wordpress.org/plugins/fluent-smtp/) est une alternative légère et gratuite, sans limitation sur le volume d’envoi.
 
-**Installation :**
+**Installation :**
 
 1. Dans votre administration WordPress, accédez à **Extensions** > **Ajouter une extension**.
 2. Recherchez `FluentSMTP` et cliquez sur **Installer maintenant**, puis sur **Activer**.
 
-**Configuration :**
+**Configuration :**
 
 1. Accédez à **FluentSMTP** > **Paramètres**.
 2. Cliquez sur **Ajouter une connexion** et sélectionnez **Autre SMTP**.
-3. Renseignez les mêmes paramètres que pour WP Mail SMTP :
+3. Renseignez les mêmes paramètres que pour WP Mail SMTP :
 
 <Region zones={['eu']}>
 
@@ -363,23 +395,23 @@ Activez l’option **Forcer l’e-mail de l’expéditeur** pour que tous les e-
 
 #### 3.4 Autres CMS (Drupal, Joomla, PrestaShop)
 
-Le principe est identique pour tout CMS ou framework : remplacer la fonction d’envoi native par un module ou une configuration SMTP authentifiée.
+Le principe est identique pour tout CMS ou framework : remplacer la fonction d’envoi native par un module ou une configuration SMTP authentifiée.
 
 | CMS | Module recommandé |
 |---|---|
 | **Drupal** | [SMTP Authentication Support](https://www.drupal.org/project/smtp) |
-| **Joomla** | Configuration native : **Système** > **Configuration globale** > onglet **Serveur** > section **Paramètres mail** |
+| **Joomla** | Configuration native : **Système** > **Configuration globale** > onglet **Serveur** > section **Paramètres mail** |
 | **PrestaShop** | **Paramètres avancés** > **E-mail** — choisir **Utiliser mes propres paramètres SMTP** |
 
 <Region zones={['eu']}>
 
-Dans tous les cas, les paramètres SMTP à utiliser sont identiques : serveur `ssl0.ovh.net`, port `465` (SSL/TLS) ou `587` (STARTTLS), avec authentification par l’adresse e-mail complète et son mot de passe.
+Dans tous les cas, les paramètres SMTP à utiliser sont identiques : serveur `ssl0.ovh.net`, port `465` (SSL/TLS) ou `587` (STARTTLS), avec authentification par l’adresse e-mail complète et son mot de passe.
 
 </Region>
 
 <Region zones={['ca', 'apac']}>
 
-Dans tous les cas, les paramètres SMTP à utiliser sont identiques : serveur `smtp.mail.ovh.ca`, port `465` (SSL/TLS) ou `587` (STARTTLS), avec authentification par l’adresse e-mail complète et son mot de passe.
+Dans tous les cas, les paramètres SMTP à utiliser sont identiques : serveur `smtp.mail.ovh.ca`, port `465` (SSL/TLS) ou `587` (STARTTLS), avec authentification par l’adresse e-mail complète et son mot de passe.
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -16,7 +16,7 @@ Pour que vos e-mails arrivent bien chez vos destinataires, OVHcloud met en place
 ## Prérequis
 
 - Disposer d’une offre d’[hébergement web OVHcloud](/links/web/hosting).
-- Disposer d’une adresse e-mail attachée à votre nom de domaine hébergé (offre MX Plan, Email Pro ou Exchange). Si vous n’en avez pas encore, consultez le guide « [Créer une adresse e-mail avec son offre MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation) ».
+- Disposer d’une adresse e-mail attachée à votre nom de domaine (offre MX Plan, E-mail Pro ou Exchange). Si vous n’en avez pas encore, consultez le guide « [Créer une adresse e-mail avec son offre MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation) ».
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -35,11 +35,11 @@ Pour que vos e-mails arrivent bien chez vos destinataires, OVHcloud met en place
 
 #### Ce qu’OVHcloud fait pour protéger vos envois
 
-OVHcloud surveille en permanence la réputation de ses serveurs d’envoi et filtre automatiquement les messages suspects — pour que vos e-mails légitimes n’en pâtissent pas. Mais cette protection a une limite : la fonction PHP `mail()` n’effectue aucun contrôle sur l’identité de l’expéditeur déclaré dans l’e-mail (champ `From:`). Un e-mail envoyé via `mail()` peut donc sembler provenir de n’importe quelle adresse, ce qui suffit à déclencher les filtres des serveurs destinataires (Gmail, Outlook…) et compromettre la délivrabilité de **vos propres envois**.
+OVHcloud surveille en permanence la réputation de ses serveurs d’envoi et filtre automatiquement les messages suspects — pour que vos e-mails légitimes n’en pâtissent pas. Mais cette protection a une limite : la fonction PHP `mail()` n’effectue aucun contrôle sur l’identité de l’expéditeur déclaré dans l’e-mail (champ `From:`). Un e-mail envoyé via `mail()` peut donc sembler provenir de n’importe quelle adresse, ce qui suffit à déclencher les filtres des serveurs destinataires (Gmail, Outlook, etc.) et à compromettre la délivrabilité de **vos propres envois**.
 
 #### Des e-mails sans signature fiable
 
-La fonction `mail()` envoie des e-mails sans garantir l’identité de l’expéditeur. Or les serveurs destinataires (Gmail, Outlook…) vérifient que l’e-mail provient bien d’un serveur autorisé par votre domaine, grâce aux enregistrements **SPF** et **DKIM**. Avec `mail()`, cette vérification échoue souvent : le message risque alors d’atterrir en spam ou d’être rejeté.
+La fonction `mail()` envoie des e-mails sans garantir l’identité de l’expéditeur. Or les serveurs destinataires (Gmail, Outlook, etc.) vérifient que l’e-mail provient bien d’un serveur autorisé par votre domaine, grâce aux enregistrements **SPF** et **DKIM**. Avec `mail()`, cette vérification échoue souvent : le message risque alors d’être classé en spam ou rejeté.
 
 L’envoi via SMTP authentifié résout ce problème : l’e-mail est émis par le serveur OVHcloud autorisé pour votre domaine, avec la bonne signature.
 
@@ -65,7 +65,7 @@ L’absence de captcha sur un formulaire d’envoi ouvert est l’une des causes
 
 #### Principe
 
-Envoyez vos e-mails via une connexion **SMTP authentifiée** vers le serveur de messagerie OVHcloud, à l’aide d’un compte e-mail attaché à votre domaine hébergé (par exemple `contact@mydomain.ovh`).
+Envoyez vos e-mails via une connexion **SMTP authentifiée** vers le serveur de messagerie OVHcloud, à l’aide d’un compte e-mail attaché à votre domaine (par exemple `contact@mydomain.ovh`).
 
 Cette approche présente trois avantages majeurs :
 
@@ -75,7 +75,7 @@ Cette approche présente trois avantages majeurs :
 
 #### Pourquoi le champ `From:` doit appartenir à votre domaine
 
-Le champ `From:` de votre e-mail doit **obligatoirement** contenir une adresse appartenant à votre domaine (ex. `contact@mydomain.ovh`), et cette adresse doit correspondre au compte SMTP utilisé pour l’authentification.
+Le champ `From:` de votre e-mail doit **obligatoirement** contenir une adresse appartenant à votre domaine (par exemple `contact@mydomain.ovh`), et cette adresse doit correspondre au compte SMTP utilisé pour l’authentification.
 
 Si le `From:` ne correspond pas au domaine autorisé dans l’enregistrement SPF, ou si la signature DKIM ne correspond pas, les serveurs de messagerie destinataires (Gmail, Outlook, etc.) peuvent rejeter ou classer l’e-mail en spam.
 
@@ -95,7 +95,7 @@ Une erreur fréquente consiste à placer l’adresse e-mail saisie par l’utili
 Ce comportement est incorrect pour deux raisons :
 
 - L’enregistrement SPF de votre domaine n’autorise pas les serveurs Gmail (ou tout autre fournisseur tiers) à envoyer en votre nom → échec du contrôle SPF.
-- Vous envoyez « au nom de » une adresse qui ne vous appartient pas → risque élevé de classification en spam ou de rejet.
+- Vous envoyez au nom d’une adresse qui ne vous appartient pas → risque élevé de classification en spam ou de rejet.
 
 **Le bon schéma pour un formulaire de contact :**
 
@@ -103,14 +103,14 @@ Ce comportement est incorrect pour deux raisons :
 |---|---|---|
 | `From:` | `contact@mydomain.ovh` (adresse fixe du site) | Expéditeur authentifié — ne change jamais |
 | `Reply-To:` | Adresse saisie par l’utilisateur dans le formulaire | Permet de répondre directement à l’utilisateur |
-| `Subject:` | Objet du message, préfixé (ex. `[Contact] ...`) | Identifie facilement les messages du formulaire |
+| `Subject:` | Objet du message, préfixé (par exemple `[Contact]`) | Identifie facilement les messages du formulaire |
 
 Ainsi, quand vous répondez à l’e-mail reçu, votre client de messagerie envoie la réponse à l’adresse de l’utilisateur via le champ `Reply-To:`, sans compromettre l’authentification SPF/DKIM.
 
 Voici comment adapter l’exemple PHPMailer pour un formulaire de contact :
 
 ```php
-// User-supplied data (validate and sanitise before use)
+// Données fournies par l'utilisateur (à valider et nettoyer avant utilisation)
 $userEmail = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
 $userName  = htmlspecialchars(strip_tags($_POST['name']));
 $message   = htmlspecialchars(strip_tags($_POST['message']));
@@ -119,13 +119,13 @@ if (!$userEmail) {
     die('Invalid email address.');
 }
 
-// From: always fixed — your site's address, never the user's
+// From : toujours fixe — l'adresse de votre site, jamais celle de l'utilisateur
 $mail->setFrom('contact@mydomain.ovh', 'My Website');
 
-// Reply-To: the user's address, so you can reply to them directly
+// Reply-To : l'adresse de l'utilisateur, pour pouvoir lui répondre directement
 $mail->addReplyTo($userEmail, $userName);
 
-// Recipient: yourself (you receive the form message)
+// Destinataire : vous-même (vous recevez le message du formulaire)
 $mail->addAddress('contact@mydomain.ovh', 'My Website');
 
 $mail->Subject = '[Contact] ' . $userName;
@@ -149,7 +149,7 @@ Utilisez les paramètres suivants pour votre compte e-mail MX Plan (inclus avec 
 | **Port (STARTTLS)** | `587` |
 | **Chiffrement** | `SSL/TLS` (port 465) ou `STARTTLS` (port 587) |
 | **Authentification** | Obligatoire |
-| **Nom d’utilisateur** | Adresse e-mail complète (ex. `contact@mydomain.ovh`) |
+| **Nom d’utilisateur** | Adresse e-mail complète (par exemple `contact@mydomain.ovh`) |
 | **Mot de passe** | Mot de passe du compte e-mail OVHcloud |
 
 </Region>
@@ -163,23 +163,23 @@ Utilisez les paramètres suivants pour votre compte e-mail MX Plan (inclus avec 
 | **Port (STARTTLS)** | `587` |
 | **Chiffrement** | `SSL/TLS` (port 465) ou `STARTTLS` (port 587) |
 | **Authentification** | Obligatoire |
-| **Nom d’utilisateur** | Adresse e-mail complète (ex. `contact@mydomain.ovh`) |
+| **Nom d’utilisateur** | Adresse e-mail complète (par exemple `contact@mydomain.ovh`) |
 | **Mot de passe** | Mot de passe du compte e-mail OVHcloud |
 
 </Region>
 
 :::tip
-Pour les offres **Email Pro** ou **Exchange**, le serveur SMTP est différent. Consultez la documentation de chaque offre pour les paramètres exacts.
+Pour les offres **E-mail Pro** ou **Exchange**, le serveur SMTP est différent. Consultez la documentation de chaque offre pour les paramètres exacts.
 :::
 
 #### Où trouver vos identifiants SMTP
 
-Le **nom d’utilisateur SMTP** est votre adresse e-mail complète (ex. `contact@mydomain.ovh`).
+Le **nom d’utilisateur SMTP** est votre adresse e-mail complète (par exemple `contact@mydomain.ovh`).
 
 Le **mot de passe** est celui défini lors de la création de l’adresse, ou modifié depuis l’espace client OVHcloud. Si vous l’avez oublié ou souhaitez le réinitialiser, consultez le guide « [Modifier le mot de passe d’une adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password) ».
 
 :::warning
-L’offre MX Plan incluse avec l’hébergement web est soumise à des **quotas d’envoi** (environ 200 e-mails par heure par compte). Pour des volumes importants — newsletters ou e-mails transactionnels en masse — privilégiez une solution dédiée (Email Pro, Exchange) ou un service d’envoi transactionnel tiers.
+L’offre MX Plan incluse avec l’hébergement web est soumise à des **quotas d’envoi** (environ 200 e-mails par heure par compte). Pour des volumes importants — newsletters ou e-mails transactionnels en masse — privilégiez une solution dédiée (E-mail Pro, Exchange) ou un service d’envoi transactionnel tiers.
 :::
 
 #### Exemple de code PHP avec PHPMailer
@@ -203,23 +203,23 @@ require 'vendor/autoload.php';
 $mail = new PHPMailer(true);
 
 try {
-    // OVHcloud SMTP server settings
+    // Paramètres du serveur SMTP OVHcloud
     $mail->isSMTP();
     $mail->Host       = 'ssl0.ovh.net';
     $mail->SMTPAuth   = true;
-    $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
-    $mail->Password   = 'your_password';         // Password of the email account
+    $mail->Username   = 'contact@mydomain.ovh'; // Votre adresse e-mail OVHcloud
+    $mail->Password   = 'your_password';         // Mot de passe du compte e-mail
     $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
     $mail->Port       = 465;
 
-    // Sender: must belong to your hosted domain
+    // Expéditeur : doit appartenir à votre domaine
     $mail->setFrom('contact@mydomain.ovh', 'My Website');
     $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
 
-    // Recipient
+    // Destinataire
     $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
 
-    // Content
+    // Contenu
     $mail->isHTML(true);
     $mail->Subject = 'Your email subject';
     $mail->Body    = 'Email body in <b>HTML</b>';
@@ -268,7 +268,7 @@ La solution consiste à installer un **plugin SMTP** qui remplace `wp_mail()` pa
 **Installation :**
 
 1. Dans votre administration WordPress, accédez à **Extensions** > **Ajouter une extension**.
-2. Recherchez `WP Mail SMTP` et cliquez sur **Installer maintenant**, puis **Activer**.
+2. Recherchez `WP Mail SMTP` et cliquez sur **Installer maintenant**, puis sur **Activer**.
 
 **Configuration :**
 
@@ -278,7 +278,7 @@ La solution consiste à installer un **plugin SMTP** qui remplace `wp_mail()` pa
 | Champ | Valeur |
 |---|---|
 | **E-mail de l’expéditeur** | `contact@mydomain.ovh` (adresse appartenant à votre domaine) |
-| **Nom de l’expéditeur** | Nom affiché pour votre site (ex. `Mon Site Web`) |
+| **Nom de l’expéditeur** | Nom affiché pour votre site (par exemple `Mon Site Web`) |
 
 3. Dans la section **Mailer**, sélectionnez **Autre SMTP**.
 4. Renseignez les paramètres SMTP :
@@ -323,7 +323,7 @@ Activez l’option **Forcer l’e-mail de l’expéditeur** pour que tous les e-
 **Installation :**
 
 1. Dans votre administration WordPress, accédez à **Extensions** > **Ajouter une extension**.
-2. Recherchez `FluentSMTP` et cliquez sur **Installer maintenant**, puis **Activer**.
+2. Recherchez `FluentSMTP` et cliquez sur **Installer maintenant**, puis sur **Activer**.
 
 **Configuration :**
 
@@ -389,7 +389,7 @@ Dans tous les cas, les paramètres SMTP à utiliser sont identiques : serveur `s
 
 [Améliorer la sécurité des e-mails via un enregistrement SPF](/guides/web-cloud/domains/dns-zone-spf)
 
-[Configurer un enregistrement DKIM](/guides/web-cloud/domains/dns-zone-dkim)
+[Améliorer la sécurité des e-mails via un enregistrement DKIM](/guides/web-cloud/domains/dns-zone-dkim)
 
 [Améliorer la sécurité des e-mails via un enregistrement DMARC](/guides/web-cloud/domains/dns-zone-dmarc)
 

--- a/docs/fr/guides/web-cloud/web-hosting/landing-page-configuration.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/landing-page-configuration.mdx
@@ -75,6 +75,7 @@ Pour vous orienter selon votre besoin :
         { title: 'Configurer et utiliser Git', link: '/guides/web-cloud/web-hosting/git-integration-webhosting' },
         { title: 'Créer des tâches automatisées (CRON)', link: '/guides/web-cloud/web-hosting/cron-tasks' },
         { title: 'Suivre les e-mails automatisés', link: '/guides/web-cloud/web-hosting/mail-function-script-records' },
+        { title: "Bonnes pratiques d'envoi d'e-mail", link: '/guides/web-cloud/web-hosting/email-sending-best-practices' },
         { title: "Gérer une application web via l'API", link: '/guides/web-cloud/web-hosting/api-webhosting' },
         { title: 'Faire évoluer son offre', link: '/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer' },
         { title: "Récupérer la sauvegarde de l'espace FTP (Cloud Web)", link: '/guides/web-cloud/web-hosting/backup-ftp', zones: ['eu'] },

--- a/docs/it/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Hosting Web - Buone pratiche per l'invio delle email"
-description: Scopri perché la funzione PHP mail() è sconsigliata su un hosting condiviso e come configurare un invio SMTP autenticato tramite i tuoi account email OVHcloud
+description: Scopri perché la funzione PHP mail() è sconsigliata su un hosting condiviso e come configurare un invio SMTP autenticato
 lastUpdated: 2026-07-13
 availableIn: [eu, ca, apac]
 ---
@@ -15,8 +15,8 @@ Affinché le tue email arrivino correttamente ai destinatari, OVHcloud mette a d
 
 ## Prerequisiti
 
-- Disporre di un’offerta di [hosting web OVHcloud](/links/web/hosting).
-- Disporre di un indirizzo email associato al tuo nome a dominio (offerta MX Plan, Email Pro o Exchange). Se non ne hai ancora uno, consulta la guida [Creare un account email con MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+- Disporre di un’offerta di [Hosting Web OVHcloud](/links/web/hosting).
+- Disporre di un indirizzo email associato al tuo nome a dominio (<Region zones={['eu']}>offerta MX Plan, Email Pro o Exchange</Region><Region zones={['ca']}>offerta MX Plan o Exchange</Region><Region zones={['apac']}>offerta MX Plan</Region>). Se non ne hai ancora uno, consulta la guida [Creare un account email con MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -95,7 +95,7 @@ Un errore frequente consiste nell’inserire l’indirizzo email digitato dall�
 Questo comportamento è errato per due motivi:
 
 - Il record SPF del tuo dominio non autorizza i server Gmail (o qualsiasi altro fornitore terzo) a inviare a tuo nome → errore del controllo SPF.
-- Invii «a nome di» un indirizzo che non ti appartiene → alto rischio di classificazione come spam o di rifiuto.
+- Invii "a nome di" un indirizzo che non ti appartiene → alto rischio di classificazione come spam o di rifiuto.
 
 **Lo schema corretto per un modulo di contatto:**
 
@@ -168,9 +168,21 @@ Utilizza i seguenti parametri per il tuo account email MX Plan (incluso con l’
 
 </Region>
 
+<Region zones={['eu']}>
+
 :::tip
 Per le offerte **Email Pro** o **Exchange**, il server SMTP è diverso. Consulta la documentazione di ciascuna offerta per i parametri esatti.
 :::
+
+</Region>
+
+<Region zones={['ca']}>
+
+:::tip
+Per l’offerta **Exchange**, il server SMTP è diverso. Consulta la documentazione di questa offerta per i parametri esatti.
+:::
+
+</Region>
 
 #### Dove trovare le tue credenziali SMTP
 
@@ -178,9 +190,29 @@ Il **nome utente SMTP** è il tuo indirizzo email completo (ad esempio `contact@
 
 La **password** è quella definita durante la creazione dell’indirizzo, o modificata dallo Spazio Cliente OVHcloud. Se l’hai dimenticata o desideri reimpostarla, consulta la guida [Modifica la password di un indirizzo email](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
+<Region zones={['eu']}>
+
 :::warning
 L’offerta MX Plan inclusa con l’hosting web è soggetta a **quote di invio** (circa 200 email all’ora per account). Per volumi elevati — newsletter o email transazionali in grande quantità — privilegia una soluzione dedicata (Email Pro, Exchange) o un servizio di invio transazionale di terze parti.
 :::
+
+</Region>
+
+<Region zones={['ca']}>
+
+:::warning
+L’offerta MX Plan inclusa con l’hosting web è soggetta a **quote di invio** (circa 200 email all’ora per account). Per volumi elevati — newsletter o email transazionali in grande quantità — privilegia una soluzione dedicata come Exchange o un servizio di invio transazionale di terze parti.
+:::
+
+</Region>
+
+<Region zones={['apac']}>
+
+:::warning
+L’offerta MX Plan inclusa con l’hosting web è soggetta a **quote di invio** (circa 200 email all’ora per account). Per volumi elevati — newsletter o email transazionali in grande quantità — privilegia un servizio di invio transazionale di terze parti.
+:::
+
+</Region>
 
 #### Esempio di codice PHP con PHPMailer
 

--- a/docs/it/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,0 +1,400 @@
+---
+title: "Hosting Web - Buone pratiche per l'invio delle email"
+description: Scopri perché la funzione PHP mail() è sconsigliata su un hosting condiviso e come configurare un invio SMTP autenticato tramite i tuoi account email OVHcloud
+lastUpdated: 2026-07-13
+availableIn: [eu, ca, apac]
+---
+
+import { Region } from '@components/Zone';
+
+## Obiettivo
+
+Affinché le tue email arrivino correttamente ai destinatari, OVHcloud mette a disposizione un’infrastruttura dedicata all’invio in uscita, con filtraggio anti-spam automatico e monitoraggio continuo della reputazione dei server. Per sfruttarla pienamente, è consigliato inviare le tue email tramite **SMTP autenticato** anziché tramite la funzione PHP `mail()` nativa. Questo approccio garantisce che ogni email venga inviata con un’identità verificabile, migliorando in modo significativo la recapitabilità e riducendo il rischio di finire nello spam.
+
+**Questa guida ti presenta le buone pratiche e le raccomandazioni OVHcloud per inviare email in modo affidabile e sicuro da un hosting condiviso, sia che tu gestisca un sito WordPress, un altro CMS o un’applicazione PHP.**
+
+## Prerequisiti
+
+- Disporre di un’offerta di [hosting web OVHcloud](/links/web/hosting).
+- Disporre di un indirizzo email associato al tuo nome a dominio ospitato (offerta MX Plan, Email Pro o Exchange). Se non ne hai ancora uno, consulta la guida [Creare un account email con MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+
+{/* CP-NAV-START:web-hosting */}
+---
+
+### Accesso allo Spazio Cliente OVHcloud
+
+- **Link diretto:** <ManagerLink to="/#/web/hosting">Hosting</ManagerLink>
+- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Hosting</code> > Seleziona il tuo hosting web
+
+---
+{/* CP-NAV-END:web-hosting */}
+
+## Procedura
+
+### 1. `mail()` o SMTP autenticato: qual è la differenza per te?
+
+#### Cosa fa OVHcloud per proteggere i tuoi invii
+
+OVHcloud monitora costantemente la reputazione dei suoi server di invio e filtra automaticamente i messaggi sospetti, affinché le tue email legittime non ne risentano. Ma questa protezione ha un limite: la funzione PHP `mail()` non effettua alcun controllo sull’identità del mittente dichiarato nell’email (campo `From:`). Un’email inviata tramite `mail()` può quindi sembrare provenire da qualsiasi indirizzo, e questo è sufficiente ad attivare i filtri dei server destinatari (Gmail, Outlook…) e a compromettere la recapitabilità dei **tuoi stessi invii**.
+
+#### Email senza una firma affidabile
+
+La funzione `mail()` invia email senza garantire l’identità del mittente. I server destinatari (Gmail, Outlook…) verificano invece che l’email provenga effettivamente da un server autorizzato dal tuo dominio, grazie ai record **SPF** e **DKIM**. Con `mail()`, questa verifica spesso fallisce: il messaggio rischia allora di finire nello spam o di essere rifiutato.
+
+L’invio tramite SMTP autenticato risolve questo problema: l’email viene inviata dal server OVHcloud autorizzato per il tuo dominio, con la firma corretta.
+
+:::warning
+Un uso abusivo della funzione `mail()` può comportare il blocco automatico degli invii per il tuo hosting. Se noti che le tue email non partono più, consulta la guida [Gestire l’invio delle email automatiche](/guides/web-cloud/web-hosting/mail-function-script-records).
+:::
+
+#### Moduli aperti: un ulteriore vettore di abuso
+
+Un modulo di contatto accessibile pubblicamente, senza alcun meccanismo di protezione, è un bersaglio privilegiato per i bot. Questi lo sfruttano per generare l’invio di migliaia di email in pochi minuti tramite il tuo hosting, provocando il blocco dell’IP condiviso e danneggiando tutti i clienti del cluster.
+
+Metti in atto le seguenti protezioni su qualsiasi modulo che generi un invio di email:
+
+- **Captcha**: integra un sistema di verifica (Google reCAPTCHA v3, hCaptcha o un semplice calcolo aritmetico) per bloccare gli invii automatizzati.
+- **Limitazione della frequenza**: limita il numero di invii per indirizzo IP lato server per evitare abusi a raffica.
+- **Validazione rigorosa degli input**: verifica e ripulisci tutti i campi del modulo prima di utilizzarli in un’email, non fidarti mai dei dati inseriti dall’utente.
+
+:::warning
+L’assenza di un captcha su un modulo di invio aperto è una delle cause più frequenti di blocco degli hosting condivisi per invio di spam. Questa protezione è indispensabile qualunque sia il metodo di invio utilizzato.
+:::
+
+### 2. La buona pratica: utilizzare un account email OVHcloud con SMTP autenticato
+
+#### Principio
+
+Invia le tue email tramite una connessione **SMTP autenticata** verso il server di posta OVHcloud, utilizzando un account email associato al tuo dominio ospitato (ad esempio `contact@mydomain.ovh`).
+
+Questo approccio presenta tre vantaggi principali:
+
+- **Autenticazione garantita**: il server OVHcloud verifica la tua identità prima di accettare l’email.
+- **SPF e DKIM funzionanti**: l’email viene inviata da un server autorizzato per il tuo dominio e firmata correttamente.
+- **Tracciabilità**: ogni invio è associato a un account identificato, il che consente di intervenire rapidamente in caso di abuso.
+
+#### Perché il campo `From:` deve appartenere al tuo dominio
+
+Il campo `From:` della tua email deve **obbligatoriamente** contenere un indirizzo appartenente al tuo dominio (es. `contact@mydomain.ovh`), e questo indirizzo deve corrispondere all’account SMTP utilizzato per l’autenticazione.
+
+Se il `From:` non corrisponde al dominio autorizzato nel record SPF, o se la firma DKIM non corrisponde, i server di posta destinatari (Gmail, Outlook, ecc.) possono rifiutare l’email o classificarla come spam.
+
+:::tip
+Per massimizzare la recapitabilità, verifica che i record SPF, DKIM e DMARC siano configurati correttamente nella tua zona DNS. Gmail e Yahoo Mail li richiedono ormai per i mittenti che inviano grandi volumi. Consulta le nostre guide:
+
+- [Migliora la sicurezza delle email con un record SPF](/guides/web-cloud/domains/dns-zone-spf)
+- [Migliora la sicurezza delle email con un record DKIM](/guides/web-cloud/domains/dns-zone-dkim)
+- [Migliora la sicurezza delle email con un record DMARC](/guides/web-cloud/domains/dns-zone-dmarc)
+
+:::
+
+#### Moduli di contatto: campo `From:` fisso e `Reply-To:` dell’utente
+
+Un errore frequente consiste nell’inserire l’indirizzo email digitato dall’utente nel modulo direttamente nel campo `From:`. Ad esempio, un visitatore inserisce `utente@gmail.com` e lo script utilizza questo indirizzo come mittente.
+
+Questo comportamento è errato per due motivi:
+
+- Il record SPF del tuo dominio non autorizza i server Gmail (o qualsiasi altro fornitore terzo) a inviare a tuo nome → errore del controllo SPF.
+- Invii «a nome di» un indirizzo che non ti appartiene → alto rischio di classificazione come spam o di rifiuto.
+
+**Lo schema corretto per un modulo di contatto:**
+
+| Campo email | Valore | Ruolo |
+|---|---|---|
+| `From:` | `contact@mydomain.ovh` (indirizzo fisso del sito) | Mittente autenticato — non cambia mai |
+| `Reply-To:` | Indirizzo inserito dall’utente nel modulo | Consente di rispondere direttamente all’utente |
+| `Subject:` | Oggetto del messaggio, con prefisso (es. `[Contact] ...`) | Identifica facilmente i messaggi del modulo |
+
+In questo modo, quando rispondi all’email ricevuta, il tuo client di posta invia la risposta all’indirizzo dell’utente tramite il campo `Reply-To:`, senza compromettere l’autenticazione SPF/DKIM.
+
+Ecco come adattare l’esempio PHPMailer per un modulo di contatto:
+
+```php
+// User-supplied data (validate and sanitise before use)
+$userEmail = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
+$userName  = htmlspecialchars(strip_tags($_POST['name']));
+$message   = htmlspecialchars(strip_tags($_POST['message']));
+
+if (!$userEmail) {
+    die('Invalid email address.');
+}
+
+// From: always fixed — your site's address, never the user's
+$mail->setFrom('contact@mydomain.ovh', 'My Website');
+
+// Reply-To: the user's address, so you can reply to them directly
+$mail->addReplyTo($userEmail, $userName);
+
+// Recipient: yourself (you receive the form message)
+$mail->addAddress('contact@mydomain.ovh', 'My Website');
+
+$mail->Subject = '[Contact] ' . $userName;
+$mail->Body    = "Name: $userName\nEmail: $userEmail\n\nMessage:\n$message";
+```
+
+:::tip
+Non passare mai direttamente i dati di un modulo a PHPMailer senza una validazione preventiva. Utilizza `filter_var()` per l’indirizzo email e `htmlspecialchars()` + `strip_tags()` per i campi di testo, in modo da evitare le iniezioni di intestazioni email.
+:::
+
+#### Parametri SMTP OVHcloud
+
+Utilizza i seguenti parametri per il tuo account email MX Plan (incluso con l’hosting web):
+
+<Region zones={['eu']}>
+
+| Parametro | Valore |
+|---|---|
+| **Server SMTP** | `ssl0.ovh.net` |
+| **Porta (SSL/TLS)** | `465` *(consigliata)* |
+| **Porta (STARTTLS)** | `587` |
+| **Crittografia** | `SSL/TLS` (porta 465) o `STARTTLS` (porta 587) |
+| **Autenticazione** | Obbligatoria |
+| **Nome utente** | Indirizzo email completo (es. `contact@mydomain.ovh`) |
+| **Password** | Password dell’account email OVHcloud |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Parametro | Valore |
+|---|---|
+| **Server SMTP** | `smtp.mail.ovh.ca` |
+| **Porta (SSL/TLS)** | `465` *(consigliata)* |
+| **Porta (STARTTLS)** | `587` |
+| **Crittografia** | `SSL/TLS` (porta 465) o `STARTTLS` (porta 587) |
+| **Autenticazione** | Obbligatoria |
+| **Nome utente** | Indirizzo email completo (es. `contact@mydomain.ovh`) |
+| **Password** | Password dell’account email OVHcloud |
+
+</Region>
+
+:::tip
+Per le offerte **Email Pro** o **Exchange**, il server SMTP è diverso. Consulta la documentazione di ciascuna offerta per i parametri esatti.
+:::
+
+#### Dove trovare le tue credenziali SMTP
+
+Il **nome utente SMTP** è il tuo indirizzo email completo (es. `contact@mydomain.ovh`).
+
+La **password** è quella definita durante la creazione dell’indirizzo, o modificata dallo Spazio Cliente OVHcloud. Se l’hai dimenticata o desideri reimpostarla, consulta la guida [Modifica la password di un indirizzo email](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
+
+:::warning
+L’offerta MX Plan inclusa con l’hosting web è soggetta a **quote di invio** (circa 200 email all’ora per account). Per volumi elevati — newsletter o email transazionali in grande quantità — privilegia una soluzione dedicata (Email Pro, Exchange) o un servizio di invio transazionale di terze parti.
+:::
+
+#### Esempio di codice PHP con PHPMailer
+
+[PHPMailer](https://github.com/PHPMailer/PHPMailer) è la libreria PHP di riferimento per l’invio di email tramite SMTP. Installala tramite Composer:
+
+```bash
+composer require phpmailer/phpmailer
+```
+
+Ecco un esempio completo di invio SMTP autenticato:
+
+```php
+<?php
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
+use PHPMailer\PHPMailer\Exception;
+
+require 'vendor/autoload.php';
+
+$mail = new PHPMailer(true);
+
+try {
+    // OVHcloud SMTP server settings
+    $mail->isSMTP();
+    $mail->Host       = 'ssl0.ovh.net';
+    $mail->SMTPAuth   = true;
+    $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
+    $mail->Password   = 'your_password';         // Password of the email account
+    $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
+    $mail->Port       = 465;
+
+    // Sender: must belong to your hosted domain
+    $mail->setFrom('contact@mydomain.ovh', 'My Website');
+    $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
+
+    // Recipient
+    $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
+
+    // Content
+    $mail->isHTML(true);
+    $mail->Subject = 'Your email subject';
+    $mail->Body    = 'Email body in <b>HTML</b>';
+    $mail->AltBody = 'Email body in plain text (fallback)';
+
+    $mail->send();
+    echo 'Email sent successfully.';
+} catch (Exception $e) {
+    echo "Error while sending: {$mail->ErrorInfo}";
+}
+```
+
+<Region zones={['ca', 'apac']}>
+
+:::warning
+L’esempio qui sopra utilizza il server SMTP `ssl0.ovh.net`, disponibile solo nella zona Europa. Dal Canada o dalla zona Asia-Pacifico, sostituisci il valore di `$mail->Host` con `smtp.mail.ovh.ca`.
+:::
+
+</Region>
+
+:::warning
+Non memorizzare mai la password del tuo account email in chiaro in un file PHP versionato. Utilizza un file di configurazione escluso dal tuo repository Git (`.gitignore`).
+:::
+
+:::info
+Con questa configurazione, ogni email inviata dal tuo sito è:
+
+- **autenticata** presso il server OVHcloud,
+- **firmata** con i record SPF e DKIM del tuo dominio,
+- **tracciabile** in caso di abuso o problema di recapitabilità.
+
+:::
+
+### 3. WordPress e altri CMS: utilizzare un plugin SMTP
+
+#### 3.1 Il problema con WordPress di default
+
+La funzione `wp_mail()` di WordPress utilizza in background la funzione PHP `mail()`. Eredita quindi tutti i problemi descritti nella sezione precedente: assenza di autenticazione, `From:` non controllato, rischio di spam.
+
+La soluzione consiste nell’installare un **plugin SMTP** che sostituisce `wp_mail()` con una connessione SMTP autenticata verso il tuo server di posta OVHcloud.
+
+#### 3.2 Configurare WP Mail SMTP
+
+[WP Mail SMTP](https://it.wordpress.org/plugins/wp-mail-smtp/) è il plugin più utilizzato per questa configurazione.
+
+**Installazione:**
+
+1. Nella tua amministrazione WordPress, accedi a **Plugin** > **Aggiungi nuovo plugin**.
+2. Cerca `WP Mail SMTP` e clicca su **Installa ora**, quindi su **Attiva**.
+
+**Configurazione:**
+
+1. Accedi a **WP Mail SMTP** > **Impostazioni** nel menu di amministrazione.
+2. Nella sezione **Mittente**, compila i seguenti campi:
+
+| Campo | Valore |
+|---|---|
+| **Email del mittente** | `contact@mydomain.ovh` (indirizzo appartenente al tuo dominio) |
+| **Nome del mittente** | Nome visualizzato per il tuo sito (es. `Il mio sito web`) |
+
+3. Nella sezione **Mailer**, seleziona **Altro SMTP**.
+4. Compila i parametri SMTP:
+
+<Region zones={['eu']}>
+
+| Campo | Valore |
+|---|---|
+| **Host SMTP** | `ssl0.ovh.net` |
+| **Crittografia** | `SSL/TLS` |
+| **Porta SMTP** | `465` |
+| **Autenticazione** | Attivata |
+| **Nome utente SMTP** | `contact@mydomain.ovh` |
+| **Password SMTP** | Password del tuo account email OVHcloud |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Campo | Valore |
+|---|---|
+| **Host SMTP** | `smtp.mail.ovh.ca` |
+| **Crittografia** | `SSL/TLS` |
+| **Porta SMTP** | `465` |
+| **Autenticazione** | Attivata |
+| **Nome utente SMTP** | `contact@mydomain.ovh` |
+| **Password SMTP** | Password del tuo account email OVHcloud |
+
+</Region>
+
+5. Clicca su **Salva impostazioni**.
+6. Nella scheda **Strumenti**, utilizza **Test invio email** per verificare la configurazione.
+
+:::tip
+Attiva l’opzione **Forza email del mittente** affinché tutte le email in uscita utilizzino l’indirizzo configurato, anche se un plugin di terze parti tenta di utilizzarne un altro.
+:::
+
+#### 3.3 Alternativa: FluentSMTP
+
+[FluentSMTP](https://it.wordpress.org/plugins/fluent-smtp/) è un’alternativa leggera e gratuita, senza limitazioni sul volume di invio.
+
+**Installazione:**
+
+1. Nella tua amministrazione WordPress, accedi a **Plugin** > **Aggiungi nuovo plugin**.
+2. Cerca `FluentSMTP` e clicca su **Installa ora**, quindi su **Attiva**.
+
+**Configurazione:**
+
+1. Accedi a **FluentSMTP** > **Impostazioni**.
+2. Clicca su **Aggiungi connessione** e seleziona **Altro SMTP**.
+3. Compila gli stessi parametri di WP Mail SMTP:
+
+<Region zones={['eu']}>
+
+| Campo | Valore |
+|---|---|
+| **Host** | `ssl0.ovh.net` |
+| **Porta** | `465` |
+| **Crittografia** | `SSL/TLS` |
+| **Autenticazione** | Sì |
+| **Nome utente** | `contact@mydomain.ovh` |
+| **Password** | Password del tuo account email OVHcloud |
+| **Email mittente** | `contact@mydomain.ovh` |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Campo | Valore |
+|---|---|
+| **Host** | `smtp.mail.ovh.ca` |
+| **Porta** | `465` |
+| **Crittografia** | `SSL/TLS` |
+| **Autenticazione** | Sì |
+| **Nome utente** | `contact@mydomain.ovh` |
+| **Password** | Password del tuo account email OVHcloud |
+| **Email mittente** | `contact@mydomain.ovh` |
+
+</Region>
+
+4. Clicca su **Salva connessione**, quindi invia un’email di test.
+
+#### 3.4 Altri CMS (Drupal, Joomla, PrestaShop)
+
+Il principio è identico per qualsiasi CMS o framework: sostituire la funzione di invio nativa con un modulo o una configurazione SMTP autenticata.
+
+| CMS | Modulo consigliato |
+|---|---|
+| **Drupal** | [SMTP Authentication Support](https://www.drupal.org/project/smtp) |
+| **Joomla** | Configurazione nativa: **Sistema** > **Configurazione globale** > scheda **Server** > sezione **Impostazioni mail** |
+| **PrestaShop** | **Parametri avanzati** > **Email** — scegliere **Utilizza i miei parametri SMTP** |
+
+<Region zones={['eu']}>
+
+In tutti i casi, i parametri SMTP da utilizzare sono identici: server `ssl0.ovh.net`, porta `465` (SSL/TLS) o `587` (STARTTLS), con autenticazione tramite l’indirizzo email completo e la relativa password.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+In tutti i casi, i parametri SMTP da utilizzare sono identici: server `smtp.mail.ovh.ca`, porta `465` (SSL/TLS) o `587` (STARTTLS), con autenticazione tramite l’indirizzo email completo e la relativa password.
+
+</Region>
+
+## Per saperne di più
+
+[Gestire l’invio delle email automatiche](/guides/web-cloud/web-hosting/mail-function-script-records)
+
+[Migliora la sicurezza delle email con un record SPF](/guides/web-cloud/domains/dns-zone-spf)
+
+[Migliora la sicurezza delle email con un record DKIM](/guides/web-cloud/domains/dns-zone-dkim)
+
+[Migliora la sicurezza delle email con un record DMARC](/guides/web-cloud/domains/dns-zone-dmarc)
+
+Per prestazioni specializzate (posizionamento, sviluppo, ecc.) contatta i [partner di OVHcloud](/links/partner).
+
+Se desideri ricevere assistenza sull’utilizzo e la configurazione delle tue soluzioni OVHcloud, ti invitiamo a consultare le nostre diverse [offerte di supporto](/links/support).
+
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -16,7 +16,7 @@ Affinché le tue email arrivino correttamente ai destinatari, OVHcloud mette a d
 ## Prerequisiti
 
 - Disporre di un’offerta di [hosting web OVHcloud](/links/web/hosting).
-- Disporre di un indirizzo email associato al tuo nome a dominio ospitato (offerta MX Plan, Email Pro o Exchange). Se non ne hai ancora uno, consulta la guida [Creare un account email con MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+- Disporre di un indirizzo email associato al tuo nome a dominio (offerta MX Plan, Email Pro o Exchange). Se non ne hai ancora uno, consulta la guida [Creare un account email con MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -35,11 +35,11 @@ Affinché le tue email arrivino correttamente ai destinatari, OVHcloud mette a d
 
 #### Cosa fa OVHcloud per proteggere i tuoi invii
 
-OVHcloud monitora costantemente la reputazione dei suoi server di invio e filtra automaticamente i messaggi sospetti, affinché le tue email legittime non ne risentano. Ma questa protezione ha un limite: la funzione PHP `mail()` non effettua alcun controllo sull’identità del mittente dichiarato nell’email (campo `From:`). Un’email inviata tramite `mail()` può quindi sembrare provenire da qualsiasi indirizzo, e questo è sufficiente ad attivare i filtri dei server destinatari (Gmail, Outlook…) e a compromettere la recapitabilità dei **tuoi stessi invii**.
+OVHcloud monitora costantemente la reputazione dei suoi server di invio e filtra automaticamente i messaggi sospetti, affinché le tue email legittime non ne risentano. Ma questa protezione ha un limite: la funzione PHP `mail()` non effettua alcun controllo sull’identità del mittente dichiarato nell’email (campo `From:`). Un’email inviata tramite `mail()` può quindi sembrare provenire da qualsiasi indirizzo, e questo è sufficiente ad attivare i filtri dei server destinatari (Gmail, Outlook, ecc.) e a compromettere la recapitabilità dei **tuoi stessi invii**.
 
 #### Email senza una firma affidabile
 
-La funzione `mail()` invia email senza garantire l’identità del mittente. I server destinatari (Gmail, Outlook…) verificano invece che l’email provenga effettivamente da un server autorizzato dal tuo dominio, grazie ai record **SPF** e **DKIM**. Con `mail()`, questa verifica spesso fallisce: il messaggio rischia allora di finire nello spam o di essere rifiutato.
+La funzione `mail()` invia email senza garantire l’identità del mittente. I server destinatari (Gmail, Outlook, ecc.) verificano invece che l’email provenga effettivamente da un server autorizzato dal tuo dominio, grazie ai record **SPF** e **DKIM**. Con `mail()`, questa verifica spesso fallisce: il messaggio rischia allora di finire nello spam o di essere rifiutato.
 
 L’invio tramite SMTP autenticato risolve questo problema: l’email viene inviata dal server OVHcloud autorizzato per il tuo dominio, con la firma corretta.
 
@@ -65,7 +65,7 @@ L’assenza di un captcha su un modulo di invio aperto è una delle cause più f
 
 #### Principio
 
-Invia le tue email tramite una connessione **SMTP autenticata** verso il server di posta OVHcloud, utilizzando un account email associato al tuo dominio ospitato (ad esempio `contact@mydomain.ovh`).
+Invia le tue email tramite una connessione **SMTP autenticata** verso il server di posta OVHcloud, utilizzando un account email associato al tuo dominio (ad esempio `contact@mydomain.ovh`).
 
 Questo approccio presenta tre vantaggi principali:
 
@@ -75,7 +75,7 @@ Questo approccio presenta tre vantaggi principali:
 
 #### Perché il campo `From:` deve appartenere al tuo dominio
 
-Il campo `From:` della tua email deve **obbligatoriamente** contenere un indirizzo appartenente al tuo dominio (es. `contact@mydomain.ovh`), e questo indirizzo deve corrispondere all’account SMTP utilizzato per l’autenticazione.
+Il campo `From:` della tua email deve **obbligatoriamente** contenere un indirizzo appartenente al tuo dominio (ad esempio `contact@mydomain.ovh`), e questo indirizzo deve corrispondere all’account SMTP utilizzato per l’autenticazione.
 
 Se il `From:` non corrisponde al dominio autorizzato nel record SPF, o se la firma DKIM non corrisponde, i server di posta destinatari (Gmail, Outlook, ecc.) possono rifiutare l’email o classificarla come spam.
 
@@ -103,14 +103,14 @@ Questo comportamento è errato per due motivi:
 |---|---|---|
 | `From:` | `contact@mydomain.ovh` (indirizzo fisso del sito) | Mittente autenticato — non cambia mai |
 | `Reply-To:` | Indirizzo inserito dall’utente nel modulo | Consente di rispondere direttamente all’utente |
-| `Subject:` | Oggetto del messaggio, con prefisso (es. `[Contact] ...`) | Identifica facilmente i messaggi del modulo |
+| `Subject:` | Oggetto del messaggio, con prefisso (ad esempio `[Contact]`) | Identifica facilmente i messaggi del modulo |
 
 In questo modo, quando rispondi all’email ricevuta, il tuo client di posta invia la risposta all’indirizzo dell’utente tramite il campo `Reply-To:`, senza compromettere l’autenticazione SPF/DKIM.
 
 Ecco come adattare l’esempio PHPMailer per un modulo di contatto:
 
 ```php
-// User-supplied data (validate and sanitise before use)
+// Dati forniti dall'utente (validare e sanificare prima dell'uso)
 $userEmail = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
 $userName  = htmlspecialchars(strip_tags($_POST['name']));
 $message   = htmlspecialchars(strip_tags($_POST['message']));
@@ -119,13 +119,13 @@ if (!$userEmail) {
     die('Invalid email address.');
 }
 
-// From: always fixed — your site's address, never the user's
+// From: sempre fisso — l'indirizzo del tuo sito, mai quello dell'utente
 $mail->setFrom('contact@mydomain.ovh', 'My Website');
 
-// Reply-To: the user's address, so you can reply to them directly
+// Reply-To: l'indirizzo dell'utente, per potergli rispondere direttamente
 $mail->addReplyTo($userEmail, $userName);
 
-// Recipient: yourself (you receive the form message)
+// Destinatario: te stesso (ricevi il messaggio del modulo)
 $mail->addAddress('contact@mydomain.ovh', 'My Website');
 
 $mail->Subject = '[Contact] ' . $userName;
@@ -149,7 +149,7 @@ Utilizza i seguenti parametri per il tuo account email MX Plan (incluso con l’
 | **Porta (STARTTLS)** | `587` |
 | **Crittografia** | `SSL/TLS` (porta 465) o `STARTTLS` (porta 587) |
 | **Autenticazione** | Obbligatoria |
-| **Nome utente** | Indirizzo email completo (es. `contact@mydomain.ovh`) |
+| **Nome utente** | Indirizzo email completo (ad esempio `contact@mydomain.ovh`) |
 | **Password** | Password dell’account email OVHcloud |
 
 </Region>
@@ -163,7 +163,7 @@ Utilizza i seguenti parametri per il tuo account email MX Plan (incluso con l’
 | **Porta (STARTTLS)** | `587` |
 | **Crittografia** | `SSL/TLS` (porta 465) o `STARTTLS` (porta 587) |
 | **Autenticazione** | Obbligatoria |
-| **Nome utente** | Indirizzo email completo (es. `contact@mydomain.ovh`) |
+| **Nome utente** | Indirizzo email completo (ad esempio `contact@mydomain.ovh`) |
 | **Password** | Password dell’account email OVHcloud |
 
 </Region>
@@ -174,7 +174,7 @@ Per le offerte **Email Pro** o **Exchange**, il server SMTP è diverso. Consulta
 
 #### Dove trovare le tue credenziali SMTP
 
-Il **nome utente SMTP** è il tuo indirizzo email completo (es. `contact@mydomain.ovh`).
+Il **nome utente SMTP** è il tuo indirizzo email completo (ad esempio `contact@mydomain.ovh`).
 
 La **password** è quella definita durante la creazione dell’indirizzo, o modificata dallo Spazio Cliente OVHcloud. Se l’hai dimenticata o desideri reimpostarla, consulta la guida [Modifica la password di un indirizzo email](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
@@ -203,23 +203,23 @@ require 'vendor/autoload.php';
 $mail = new PHPMailer(true);
 
 try {
-    // OVHcloud SMTP server settings
+    // Impostazioni del server SMTP OVHcloud
     $mail->isSMTP();
     $mail->Host       = 'ssl0.ovh.net';
     $mail->SMTPAuth   = true;
-    $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
-    $mail->Password   = 'your_password';         // Password of the email account
+    $mail->Username   = 'contact@mydomain.ovh'; // Il tuo indirizzo email OVHcloud
+    $mail->Password   = 'your_password';         // Password dell'account email
     $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
     $mail->Port       = 465;
 
-    // Sender: must belong to your hosted domain
+    // Mittente: deve appartenere al tuo dominio
     $mail->setFrom('contact@mydomain.ovh', 'My Website');
     $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
 
-    // Recipient
+    // Destinatario
     $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
 
-    // Content
+    // Contenuto
     $mail->isHTML(true);
     $mail->Subject = 'Your email subject';
     $mail->Body    = 'Email body in <b>HTML</b>';
@@ -278,7 +278,7 @@ La soluzione consiste nell’installare un **plugin SMTP** che sostituisce `wp_m
 | Campo | Valore |
 |---|---|
 | **Email del mittente** | `contact@mydomain.ovh` (indirizzo appartenente al tuo dominio) |
-| **Nome del mittente** | Nome visualizzato per il tuo sito (es. `Il mio sito web`) |
+| **Nome del mittente** | Nome visualizzato per il tuo sito (ad esempio `Il mio sito web`) |
 
 3. Nella sezione **Mailer**, seleziona **Altro SMTP**.
 4. Compila i parametri SMTP:

--- a/docs/it/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Hosting Web - Buone pratiche per l'invio delle email"
 description: Scopri perché la funzione PHP mail() è sconsigliata su un hosting condiviso e come configurare un invio SMTP autenticato
-lastUpdated: 2026-07-13
+lastUpdated: 2026-07-15
 availableIn: [eu, ca, apac]
 ---
 
@@ -144,7 +144,7 @@ Utilizza i seguenti parametri per il tuo account email MX Plan (incluso con l’
 
 | Parametro | Valore |
 |---|---|
-| **Server SMTP** | `ssl0.ovh.net` |
+| **Server SMTP** | `smtp.mail.ovh.net` |
 | **Porta (SSL/TLS)** | `465` *(consigliata)* |
 | **Porta (STARTTLS)** | `587` |
 | **Crittografia** | `SSL/TLS` (porta 465) o `STARTTLS` (porta 587) |
@@ -190,29 +190,9 @@ Il **nome utente SMTP** è il tuo indirizzo email completo (ad esempio `contact@
 
 La **password** è quella definita durante la creazione dell’indirizzo, o modificata dallo Spazio Cliente OVHcloud. Se l’hai dimenticata o desideri reimpostarla, consulta la guida [Modifica la password di un indirizzo email](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
-<Region zones={['eu']}>
-
 :::warning
-L’offerta MX Plan inclusa con l’hosting web è soggetta a **quote di invio** (circa 200 email all’ora per account). Per volumi elevati — newsletter o email transazionali in grande quantità — privilegia una soluzione dedicata (Email Pro, Exchange) o un servizio di invio transazionale di terze parti.
+L’offerta MX Plan inclusa con l’hosting web è soggetta a **quote di invio** (circa 200 email all’ora per account). Le soluzioni di posta non sono progettate per l’invio in grande quantità: per volumi elevati — newsletter o email transazionali in grande quantità — utilizza un servizio di invio transazionale di terze parti, dedicato a questo scopo.
 :::
-
-</Region>
-
-<Region zones={['ca']}>
-
-:::warning
-L’offerta MX Plan inclusa con l’hosting web è soggetta a **quote di invio** (circa 200 email all’ora per account). Per volumi elevati — newsletter o email transazionali in grande quantità — privilegia una soluzione dedicata come Exchange o un servizio di invio transazionale di terze parti.
-:::
-
-</Region>
-
-<Region zones={['apac']}>
-
-:::warning
-L’offerta MX Plan inclusa con l’hosting web è soggetta a **quote di invio** (circa 200 email all’ora per account). Per volumi elevati — newsletter o email transazionali in grande quantità — privilegia un servizio di invio transazionale di terze parti.
-:::
-
-</Region>
 
 #### Esempio di codice PHP con PHPMailer
 
@@ -237,7 +217,7 @@ $mail = new PHPMailer(true);
 try {
     // Impostazioni del server SMTP OVHcloud
     $mail->isSMTP();
-    $mail->Host       = 'ssl0.ovh.net';
+    $mail->Host       = 'smtp.mail.ovh.net';
     $mail->SMTPAuth   = true;
     $mail->Username   = 'contact@mydomain.ovh'; // Il tuo indirizzo email OVHcloud
     $mail->Password   = 'your_password';         // Password dell'account email
@@ -267,7 +247,7 @@ try {
 <Region zones={['ca', 'apac']}>
 
 :::warning
-L’esempio qui sopra utilizza il server SMTP `ssl0.ovh.net`, disponibile solo nella zona Europa. Dal Canada o dalla zona Asia-Pacifico, sostituisci il valore di `$mail->Host` con `smtp.mail.ovh.ca`.
+L’esempio qui sopra utilizza il server SMTP `smtp.mail.ovh.net`, disponibile solo nella zona Europa. Dal Canada o dalla zona Asia-Pacifico, sostituisci il valore di `$mail->Host` con `smtp.mail.ovh.ca`.
 :::
 
 </Region>
@@ -319,7 +299,7 @@ La soluzione consiste nell’installare un **plugin SMTP** che sostituisce `wp_m
 
 | Campo | Valore |
 |---|---|
-| **Host SMTP** | `ssl0.ovh.net` |
+| **Host SMTP** | `smtp.mail.ovh.net` |
 | **Crittografia** | `SSL/TLS` |
 | **Porta SMTP** | `465` |
 | **Autenticazione** | Attivata |
@@ -367,7 +347,7 @@ Attiva l’opzione **Forza email del mittente** affinché tutte le email in usci
 
 | Campo | Valore |
 |---|---|
-| **Host** | `ssl0.ovh.net` |
+| **Host** | `smtp.mail.ovh.net` |
 | **Porta** | `465` |
 | **Crittografia** | `SSL/TLS` |
 | **Autenticazione** | Sì |
@@ -405,7 +385,7 @@ Il principio è identico per qualsiasi CMS o framework: sostituire la funzione d
 
 <Region zones={['eu']}>
 
-In tutti i casi, i parametri SMTP da utilizzare sono identici: server `ssl0.ovh.net`, porta `465` (SSL/TLS) o `587` (STARTTLS), con autenticazione tramite l’indirizzo email completo e la relativa password.
+In tutti i casi, i parametri SMTP da utilizzare sono identici: server `smtp.mail.ovh.net`, porta `465` (SSL/TLS) o `587` (STARTTLS), con autenticazione tramite l’indirizzo email completo e la relativa password.
 
 </Region>
 

--- a/docs/it/guides/web-cloud/web-hosting/landing-page-configuration.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/landing-page-configuration.mdx
@@ -75,6 +75,7 @@ Per orientarti in base alla tua esigenza:
         { title: 'Configurare e utilizzare Git', link: '/guides/web-cloud/web-hosting/git-integration-webhosting' },
         { title: 'Creare operazioni automatizzate (CRON)', link: '/guides/web-cloud/web-hosting/cron-tasks' },
         { title: 'Monitorare le email automatizzate', link: '/guides/web-cloud/web-hosting/mail-function-script-records' },
+        { title: "Buone pratiche per l'invio di email", link: '/guides/web-cloud/web-hosting/email-sending-best-practices' },
         { title: "Gestire un'applicazione web tramite l'API", link: '/guides/web-cloud/web-hosting/api-webhosting' },
         { title: 'Far evolvere la tua offerta', link: '/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer' },
         { title: 'Recuperare il backup dello spazio FTP (Cloud Web)', link: '/guides/web-cloud/web-hosting/backup-ftp', zones: ['eu'] },

--- a/docs/pl/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -16,7 +16,7 @@ Aby zapewnić dotarcie Twoich wiadomości e-mail do odbiorców, OVHcloud utrzymu
 ## Wymagania początkowe
 
 - Usługa [Hosting WWW OVHcloud](/links/web/hosting).
-- Adres e-mail powiązany z Twoją nazwą domeny (rozwiązanie MX Plan, E-mail Pro lub Exchange). Jeżeli jeszcze go nie posiadasz, zapoznaj się z przewodnikiem [Tworzenie konta e-mail w ramach usługi MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+- Adres e-mail powiązany z Twoją nazwą domeny (<Region zones={['eu']}>rozwiązanie MX Plan, E-mail Pro lub Exchange</Region><Region zones={['ca']}>rozwiązanie MX Plan lub Exchange</Region><Region zones={['apac']}>rozwiązanie MX Plan</Region>). Jeżeli jeszcze go nie posiadasz, zapoznaj się z przewodnikiem [Tworzenie konta e-mail w ramach usługi MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -90,7 +90,7 @@ Aby zmaksymalizować dostarczalność, upewnij się, że rekordy SPF, DKIM i DMA
 
 #### Formularze kontaktowe: stałe pole `From:` i pole `Reply-To:` użytkownika
 
-Częstym błędem jest umieszczanie adresu e-mail wprowadzonego przez użytkownika w formularzu bezpośrednio w polu `From:`. Na przykład odwiedzający wprowadza `utilisateur@gmail.com`, a skrypt używa tego adresu jako nadawcy.
+Częstym błędem jest umieszczanie adresu e-mail wprowadzonego przez użytkownika w formularzu bezpośrednio w polu `From:`. Na przykład odwiedzający wprowadza `uzytkownik@gmail.com`, a skrypt używa tego adresu jako nadawcy.
 
 Takie postępowanie jest nieprawidłowe z dwóch powodów:
 
@@ -168,9 +168,21 @@ Użyj następujących ustawień dla swojego konta e-mail MX Plan (dołączonego 
 
 </Region>
 
+<Region zones={['eu']}>
+
 :::tip
 W przypadku rozwiązań **E-mail Pro** lub **Exchange** serwer SMTP jest inny. Zapoznaj się z dokumentacją każdego rozwiązania, aby poznać dokładne ustawienia.
 :::
+
+</Region>
+
+<Region zones={['ca']}>
+
+:::tip
+W przypadku rozwiązania **Exchange** serwer SMTP jest inny. Zapoznaj się z dokumentacją tego rozwiązania, aby poznać dokładne ustawienia.
+:::
+
+</Region>
 
 #### Gdzie znaleźć swoje dane uwierzytelniające SMTP
 
@@ -178,9 +190,29 @@ W przypadku rozwiązań **E-mail Pro** lub **Exchange** serwer SMTP jest inny. Z
 
 **Hasło** to hasło ustawione podczas tworzenia adresu lub zmienione w Panelu klienta OVHcloud. Jeżeli je zapomniałeś lub chcesz je zresetować, zapoznaj się z przewodnikiem [Zmiana hasła do konta e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
+<Region zones={['eu']}>
+
 :::warning
 Rozwiązanie MX Plan dołączone do hostingu WWW podlega **limitom wysyłki** (około 200 wiadomości e-mail na godzinę na konto). W przypadku dużych wolumenów — newsletterów lub masowych transakcyjnych wiadomości e-mail — preferuj dedykowane rozwiązanie (E-mail Pro, Exchange) lub zewnętrzną usługę wysyłki transakcyjnej.
 :::
+
+</Region>
+
+<Region zones={['ca']}>
+
+:::warning
+Rozwiązanie MX Plan dołączone do hostingu WWW podlega **limitom wysyłki** (około 200 wiadomości e-mail na godzinę na konto). W przypadku dużych wolumenów — newsletterów lub masowych transakcyjnych wiadomości e-mail — preferuj dedykowane rozwiązanie takie jak Exchange lub zewnętrzną usługę wysyłki transakcyjnej.
+:::
+
+</Region>
+
+<Region zones={['apac']}>
+
+:::warning
+Rozwiązanie MX Plan dołączone do hostingu WWW podlega **limitom wysyłki** (około 200 wiadomości e-mail na godzinę na konto). W przypadku dużych wolumenów — newsletterów lub masowych transakcyjnych wiadomości e-mail — preferuj zewnętrzną usługę wysyłki transakcyjnej.
+:::
+
+</Region>
 
 #### Przykład kodu PHP z PHPMailer
 

--- a/docs/pl/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,0 +1,400 @@
+---
+title: "Hosting WWW - Najlepsze praktyki dotyczące wysyłania wiadomości e-mail"
+description: Dowiedz się, dlaczego funkcja PHP mail() jest odradzana na hostingu współdzielonym oraz jak skonfigurować uwierzytelnione wysyłanie SMTP za pośrednictwem kont e-mail OVHcloud
+lastUpdated: 2026-07-13
+availableIn: [eu, ca, apac]
+---
+
+import { Region } from '@components/Zone';
+
+## Wprowadzenie
+
+Aby zapewnić dotarcie Twoich wiadomości e-mail do odbiorców, OVHcloud utrzymuje dedykowaną infrastrukturę wychodzącą z automatycznym filtrowaniem antyspamowym oraz ciągłym monitorowaniem reputacji serwerów. Aby w pełni z niej skorzystać, zalecamy wysyłanie wiadomości e-mail za pośrednictwem **uwierzytelnionego SMTP**, a nie natywnej funkcji PHP `mail()`. Takie podejście zapewnia, że każda wiadomość e-mail jest wysyłana ze zweryfikowaną tożsamością, co znacznie poprawia dostarczalność i zmniejsza ryzyko zaklasyfikowania jako spam.
+
+**Ten przewodnik wyjaśnia najlepsze praktyki i zalecenia OVHcloud dotyczące niezawodnego i bezpiecznego wysyłania wiadomości e-mail z hostingu współdzielonego, niezależnie od tego, czy zarządzasz witryną WordPress, innym CMS, czy aplikacją PHP.**
+
+## Wymagania początkowe
+
+- Usługa [Hosting WWW OVHcloud](/links/web/hosting).
+- Adres e-mail powiązany z Twoją hostowaną nazwą domeny (rozwiązanie MX Plan, Email Pro lub Exchange). Jeżeli jeszcze go nie posiadasz, zapoznaj się z przewodnikiem [Tworzenie konta e-mail w ramach usługi MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+
+{/* CP-NAV-START:web-hosting */}
+---
+
+### Dostęp do Panelu klienta OVHcloud
+
+- **Link bezpośredni:** <ManagerLink to="/#/web/hosting">Hosting</ManagerLink>
+- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">Hosting</code> > Wybierz Twój hosting WWW
+
+---
+{/* CP-NAV-END:web-hosting */}
+
+## W praktyce
+
+### 1. `mail()` czy uwierzytelnione SMTP: jaka jest dla Ciebie różnica?
+
+#### Co robi OVHcloud, aby chronić Twoje wysyłki
+
+OVHcloud stale monitoruje reputację swoich serwerów wysyłkowych i automatycznie filtruje podejrzane wiadomości — dzięki czemu Twoje prawidłowe wiadomości e-mail nie są narażone na problemy. Ta ochrona ma jednak swoje ograniczenie: funkcja PHP `mail()` nie przeprowadza żadnej weryfikacji tożsamości nadawcy zadeklarowanej w wiadomości (pole `From:`). Wiadomość e-mail wysłana za pomocą `mail()` może zatem wydawać się pochodzić z dowolnego adresu, co wystarczy, aby uruchomić filtry serwerów odbiorców (Gmail, Outlook itp.) i pogorszyć dostarczalność **Twoich własnych wiadomości e-mail**.
+
+#### Wiadomości e-mail bez wiarygodnego podpisu
+
+Funkcja `mail()` wysyła wiadomości e-mail bez zagwarantowania tożsamości nadawcy. Serwery odbiorców (Gmail, Outlook itp.) sprawdzają, czy wiadomość e-mail rzeczywiście pochodzi z serwera autoryzowanego przez Twoją domenę, korzystając z rekordów **SPF** i **DKIM**. W przypadku `mail()` ta weryfikacja często kończy się niepowodzeniem: wiadomość może wówczas trafić do spamu lub zostać odrzucona.
+
+Wysyłanie za pośrednictwem uwierzytelnionego SMTP rozwiązuje ten problem: wiadomość e-mail jest wysyłana przez serwer OVHcloud autoryzowany dla Twojej domeny, z prawidłowym podpisem.
+
+:::warning
+Nadużywanie funkcji `mail()` może prowadzić do automatycznego zablokowania wychodzących wiadomości e-mail z Twojego hostingu. Jeżeli zauważysz, że Twoje wiadomości e-mail nie są już wysyłane, zapoznaj się z przewodnikiem [Monitoring i zarządzanie automatycznymi wiadomościami e-mail na Twoim hostingu](/guides/web-cloud/web-hosting/mail-function-script-records).
+:::
+
+#### Otwarte formularze: dodatkowy wektor nadużyć
+
+Formularz kontaktowy dostępny publicznie, bez żadnego mechanizmu ochrony, jest głównym celem botów. Wykorzystują go one do wywołania wysyłki tysięcy wiadomości e-mail w ciągu kilku minut za pośrednictwem Twojego hostingu, powodując zablokowanie współdzielonego adresu IP i szkodząc wszystkim klientom w klastrze.
+
+Skonfiguruj następujące zabezpieczenia dla każdego formularza, który wywołuje wysyłkę wiadomości e-mail:
+
+- **Captcha**: zintegruj system weryfikacji (Google reCAPTCHA v3, hCaptcha lub proste zadanie arytmetyczne), aby blokować automatyczne przesyłanie formularzy.
+- **Ograniczanie liczby wysyłek (rate limiting)**: ogranicz liczbę wysyłek na adres IP po stronie serwera, aby zapobiec nagłym nadużyciom.
+- **Ścisła walidacja danych wejściowych**: sprawdzaj i oczyszczaj każde pole formularza przed użyciem go w wiadomości e-mail — nigdy nie ufaj danym dostarczonym przez użytkownika.
+
+:::warning
+Brak captchy w otwartym formularzu wysyłkowym jest jedną z najczęstszych przyczyn blokowania hostingu współdzielonego za spam. To zabezpieczenie jest niezbędne niezależnie od zastosowanej metody wysyłki.
+:::
+
+### 2. Najlepsza praktyka: korzystaj z konta e-mail OVHcloud z uwierzytelnionym SMTP
+
+#### Zasada
+
+Wysyłaj swoje wiadomości e-mail za pośrednictwem połączenia **uwierzytelnionego SMTP** z serwerem pocztowym OVHcloud, korzystając z konta e-mail powiązanego z Twoją hostowaną domeną (na przykład `contact@mydomain.ovh`).
+
+Takie podejście oferuje trzy główne korzyści:
+
+- **Gwarantowane uwierzytelnianie**: serwer OVHcloud weryfikuje Twoją tożsamość przed przyjęciem wiadomości e-mail.
+- **Działające SPF i DKIM**: wiadomość e-mail jest wysyłana przez serwer autoryzowany dla Twojej domeny i prawidłowo podpisana.
+- **Możliwość śledzenia**: każda wysyłka jest powiązana ze zidentyfikowanym kontem, co pozwala szybko zareagować w razie nadużycia.
+
+#### Dlaczego pole `From:` musi należeć do Twojej domeny
+
+Pole `From:` Twojej wiadomości e-mail musi **koniecznie** zawierać adres należący do Twojej domeny (np. `contact@mydomain.ovh`), a adres ten musi być zgodny z kontem SMTP użytym do uwierzytelniania.
+
+Jeżeli pole `From:` nie jest zgodne z domeną autoryzowaną w rekordzie SPF lub jeżeli podpis DKIM nie jest zgodny, serwery pocztowe odbiorców (Gmail, Outlook itp.) mogą odrzucić wiadomość e-mail lub zaklasyfikować ją jako spam.
+
+:::tip
+Aby zmaksymalizować dostarczalność, upewnij się, że rekordy SPF, DKIM i DMARC są prawidłowo skonfigurowane w Twojej strefie DNS. Gmail i Yahoo Mail wymagają ich teraz od nadawców masowych. Zapoznaj się z naszymi przewodnikami:
+
+- [Poprawa bezpieczeństwa e-maili poprzez rekord SPF](/guides/web-cloud/domains/dns-zone-spf)
+- [Poprawa bezpieczeństwa e-maili dzięki rejestracji DKIM](/guides/web-cloud/domains/dns-zone-dkim)
+- [Poprawa bezpieczeństwa e-maili dzięki rejestracji DMARC](/guides/web-cloud/domains/dns-zone-dmarc)
+
+:::
+
+#### Formularze kontaktowe: stałe pole `From:` i pole `Reply-To:` użytkownika
+
+Częstym błędem jest umieszczanie adresu e-mail wprowadzonego przez użytkownika w formularzu bezpośrednio w polu `From:`. Na przykład odwiedzający wprowadza `utilisateur@gmail.com`, a skrypt używa tego adresu jako nadawcy.
+
+Takie postępowanie jest nieprawidłowe z dwóch powodów:
+
+- Rekord SPF Twojej domeny nie autoryzuje serwerów Gmail (ani żadnego innego zewnętrznego dostawcy) do wysyłania w Twoim imieniu → niepowodzenie weryfikacji SPF.
+- Wysyłasz "w imieniu" adresu, który do Ciebie nie należy → wysokie ryzyko zaklasyfikowania jako spam lub odrzucenia.
+
+**Prawidłowy schemat dla formularza kontaktowego:**
+
+| Pole wiadomości e-mail | Wartość | Rola |
+|---|---|---|
+| `From:` | `contact@mydomain.ovh` (stały adres witryny) | Uwierzytelniony nadawca — nigdy się nie zmienia |
+| `Reply-To:` | Adres wprowadzony przez użytkownika w formularzu | Umożliwia bezpośrednią odpowiedź użytkownikowi |
+| `Subject:` | Temat wiadomości, z prefiksem (np. `[Contact] ...`) | Ułatwia identyfikację wiadomości z formularza |
+
+W ten sposób, gdy odpowiadasz na otrzymaną wiadomość e-mail, Twój klient poczty wysyła odpowiedź na adres użytkownika za pośrednictwem pola `Reply-To:`, nie naruszając uwierzytelniania SPF/DKIM.
+
+Oto jak dostosować przykład PHPMailer do formularza kontaktowego:
+
+```php
+// User-supplied data (validate and sanitise before use)
+$userEmail = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
+$userName  = htmlspecialchars(strip_tags($_POST['name']));
+$message   = htmlspecialchars(strip_tags($_POST['message']));
+
+if (!$userEmail) {
+    die('Invalid email address.');
+}
+
+// From: always fixed — your site's address, never the user's
+$mail->setFrom('contact@mydomain.ovh', 'My Website');
+
+// Reply-To: the user's address, so you can reply to them directly
+$mail->addReplyTo($userEmail, $userName);
+
+// Recipient: yourself (you receive the form message)
+$mail->addAddress('contact@mydomain.ovh', 'My Website');
+
+$mail->Subject = '[Contact] ' . $userName;
+$mail->Body    = "Name: $userName\nEmail: $userEmail\n\nMessage:\n$message";
+```
+
+:::tip
+Nigdy nie przekazuj danych z formularza bezpośrednio do PHPMailer bez wcześniejszej walidacji. Użyj `filter_var()` dla adresu e-mail oraz `htmlspecialchars()` + `strip_tags()` dla pól tekstowych, aby zapobiec wstrzykiwaniu nagłówków wiadomości e-mail.
+:::
+
+#### Ustawienia SMTP OVHcloud
+
+Użyj następujących ustawień dla swojego konta e-mail MX Plan (dołączonego do Twojego hostingu WWW):
+
+<Region zones={['eu']}>
+
+| Ustawienie | Wartość |
+|---|---|
+| **Serwer SMTP** | `ssl0.ovh.net` |
+| **Port (SSL/TLS)** | `465` *(zalecany)* |
+| **Port (STARTTLS)** | `587` |
+| **Szyfrowanie** | `SSL/TLS` (port 465) lub `STARTTLS` (port 587) |
+| **Uwierzytelnianie** | Wymagane |
+| **Nazwa użytkownika** | Pełny adres e-mail (np. `contact@mydomain.ovh`) |
+| **Hasło** | Hasło do konta e-mail OVHcloud |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Ustawienie | Wartość |
+|---|---|
+| **Serwer SMTP** | `smtp.mail.ovh.ca` |
+| **Port (SSL/TLS)** | `465` *(zalecany)* |
+| **Port (STARTTLS)** | `587` |
+| **Szyfrowanie** | `SSL/TLS` (port 465) lub `STARTTLS` (port 587) |
+| **Uwierzytelnianie** | Wymagane |
+| **Nazwa użytkownika** | Pełny adres e-mail (np. `contact@mydomain.ovh`) |
+| **Hasło** | Hasło do konta e-mail OVHcloud |
+
+</Region>
+
+:::tip
+W przypadku rozwiązań **Email Pro** lub **Exchange** serwer SMTP jest inny. Zapoznaj się z dokumentacją każdego rozwiązania, aby poznać dokładne ustawienia.
+:::
+
+#### Gdzie znaleźć swoje dane uwierzytelniające SMTP
+
+**Nazwa użytkownika SMTP** to Twój pełny adres e-mail (np. `contact@mydomain.ovh`).
+
+**Hasło** to hasło ustawione podczas tworzenia adresu lub zmienione w Panelu klienta OVHcloud. Jeżeli je zapomniałeś lub chcesz je zresetować, zapoznaj się z przewodnikiem [Zmiana hasła do konta e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
+
+:::warning
+Rozwiązanie MX Plan dołączone do hostingu WWW podlega **limitom wysyłki** (około 200 wiadomości e-mail na godzinę na konto). W przypadku dużych wolumenów — newsletterów lub masowych transakcyjnych wiadomości e-mail — preferuj dedykowane rozwiązanie (Email Pro, Exchange) lub zewnętrzną usługę wysyłki transakcyjnej.
+:::
+
+#### Przykład kodu PHP z PHPMailer
+
+[PHPMailer](https://github.com/PHPMailer/PHPMailer) to referencyjna biblioteka PHP do wysyłania wiadomości e-mail za pośrednictwem SMTP. Zainstaluj ją za pomocą Composer:
+
+```bash
+composer require phpmailer/phpmailer
+```
+
+Oto kompletny przykład uwierzytelnionego wysyłania SMTP:
+
+```php
+<?php
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
+use PHPMailer\PHPMailer\Exception;
+
+require 'vendor/autoload.php';
+
+$mail = new PHPMailer(true);
+
+try {
+    // OVHcloud SMTP server settings
+    $mail->isSMTP();
+    $mail->Host       = 'ssl0.ovh.net';
+    $mail->SMTPAuth   = true;
+    $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
+    $mail->Password   = 'your_password';         // Password of the email account
+    $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
+    $mail->Port       = 465;
+
+    // Sender: must belong to your hosted domain
+    $mail->setFrom('contact@mydomain.ovh', 'My Website');
+    $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
+
+    // Recipient
+    $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
+
+    // Content
+    $mail->isHTML(true);
+    $mail->Subject = 'Your email subject';
+    $mail->Body    = 'Email body in <b>HTML</b>';
+    $mail->AltBody = 'Email body in plain text (fallback)';
+
+    $mail->send();
+    echo 'Email sent successfully.';
+} catch (Exception $e) {
+    echo "Error while sending: {$mail->ErrorInfo}";
+}
+```
+
+<Region zones={['ca', 'apac']}>
+
+:::warning
+Powyższy przykład używa serwera SMTP `ssl0.ovh.net`, dostępnego wyłącznie w strefie Europa. Z Kanady lub strefy Azja-Pacyfik zastąp wartość `$mail->Host` wartością `smtp.mail.ovh.ca`.
+:::
+
+</Region>
+
+:::warning
+Nigdy nie przechowuj hasła do konta e-mail jako zwykłego tekstu w wersjonowanym pliku PHP. Użyj pliku konfiguracyjnego wykluczonego z Twojego repozytorium Git (`.gitignore`).
+:::
+
+:::info
+Przy tej konfiguracji każda wiadomość e-mail wysłana z Twojej witryny jest:
+
+- **uwierzytelniona** za pomocą serwera OVHcloud,
+- **podpisana** rekordami SPF i DKIM Twojej domeny,
+- **możliwa do śledzenia** w razie nadużycia lub problemu z dostarczalnością.
+
+:::
+
+### 3. WordPress i inne systemy CMS: użyj wtyczki SMTP
+
+#### 3.1 Problem z domyślnym WordPress
+
+Funkcja `wp_mail()` w WordPress korzysta w tle z funkcji PHP `mail()`. Dziedziczy zatem wszystkie problemy opisane w poprzedniej sekcji: brak uwierzytelniania, niekontrolowane pole `From:`, ryzyko spamu.
+
+Rozwiązaniem jest zainstalowanie **wtyczki SMTP**, która zastępuje `wp_mail()` uwierzytelnionym połączeniem SMTP z Twoim serwerem pocztowym OVHcloud.
+
+#### 3.2 Konfiguracja WP Mail SMTP
+
+[WP Mail SMTP](https://wordpress.org/plugins/wp-mail-smtp/) to najczęściej używana wtyczka do tej konfiguracji.
+
+**Instalacja:**
+
+1. W panelu administracyjnym WordPress przejdź do **Wtyczki** > **Dodaj nową wtyczkę**.
+2. Wyszukaj `WP Mail SMTP` i kliknij **Zainstaluj teraz**, a następnie **Włącz**.
+
+**Konfiguracja:**
+
+1. Przejdź do **WP Mail SMTP** > **Ustawienia** w menu administracyjnym.
+2. W sekcji **From** wypełnij następujące pola:
+
+| Pole | Wartość |
+|---|---|
+| **From Email** | `contact@mydomain.ovh` (adres należący do Twojej domeny) |
+| **From Name** | Wyświetlana nazwa Twojej witryny (np. `My Website`) |
+
+3. W sekcji **Mailer** wybierz **Other SMTP**.
+4. Wypełnij ustawienia SMTP:
+
+<Region zones={['eu']}>
+
+| Pole | Wartość |
+|---|---|
+| **SMTP Host** | `ssl0.ovh.net` |
+| **Encryption** | `SSL/TLS` |
+| **SMTP Port** | `465` |
+| **Authentication** | Włączone |
+| **SMTP Username** | `contact@mydomain.ovh` |
+| **SMTP Password** | Hasło do Twojego konta e-mail OVHcloud |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Pole | Wartość |
+|---|---|
+| **SMTP Host** | `smtp.mail.ovh.ca` |
+| **Encryption** | `SSL/TLS` |
+| **SMTP Port** | `465` |
+| **Authentication** | Włączone |
+| **SMTP Username** | `contact@mydomain.ovh` |
+| **SMTP Password** | Hasło do Twojego konta e-mail OVHcloud |
+
+</Region>
+
+5. Kliknij **Save Settings**.
+6. W zakładce **Tools** użyj opcji **Email Test**, aby sprawdzić konfigurację.
+
+:::tip
+Włącz opcję **Force From Email**, aby wszystkie wychodzące wiadomości e-mail używały skonfigurowanego adresu, nawet jeżeli zewnętrzna wtyczka próbuje użyć innego.
+:::
+
+#### 3.3 Alternatywa: FluentSMTP
+
+[FluentSMTP](https://wordpress.org/plugins/fluent-smtp/) to lekka, bezpłatna alternatywa bez ograniczeń wolumenu wysyłki.
+
+**Instalacja:**
+
+1. W panelu administracyjnym WordPress przejdź do **Wtyczki** > **Dodaj nową wtyczkę**.
+2. Wyszukaj `FluentSMTP` i kliknij **Zainstaluj teraz**, a następnie **Włącz**.
+
+**Konfiguracja:**
+
+1. Przejdź do **FluentSMTP** > **Settings**.
+2. Kliknij **Add Connection** i wybierz **Other SMTP**.
+3. Wypełnij te same ustawienia co dla WP Mail SMTP:
+
+<Region zones={['eu']}>
+
+| Pole | Wartość |
+|---|---|
+| **Host** | `ssl0.ovh.net` |
+| **Port** | `465` |
+| **Encryption** | `SSL/TLS` |
+| **Authentication** | Tak |
+| **Username** | `contact@mydomain.ovh` |
+| **Password** | Hasło do Twojego konta e-mail OVHcloud |
+| **From Email** | `contact@mydomain.ovh` |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Pole | Wartość |
+|---|---|
+| **Host** | `smtp.mail.ovh.ca` |
+| **Port** | `465` |
+| **Encryption** | `SSL/TLS` |
+| **Authentication** | Tak |
+| **Username** | `contact@mydomain.ovh` |
+| **Password** | Hasło do Twojego konta e-mail OVHcloud |
+| **From Email** | `contact@mydomain.ovh` |
+
+</Region>
+
+4. Kliknij **Save Connection**, a następnie wyślij testową wiadomość e-mail.
+
+#### 3.4 Inne systemy CMS (Drupal, Joomla, PrestaShop)
+
+Zasada jest taka sama dla każdego CMS lub frameworka: zastąp natywną funkcję wysyłki modułem lub konfiguracją uwierzytelnionego SMTP.
+
+| CMS | Zalecany moduł |
+|---|---|
+| **Drupal** | [SMTP Authentication Support](https://www.drupal.org/project/smtp) |
+| **Joomla** | Konfiguracja natywna: **System** > **Global Configuration** > zakładka **Server** > sekcja **Mail Settings** |
+| **PrestaShop** | **Advanced Parameters** > **E-mail** — wybierz **Set my own SMTP parameters** |
+
+<Region zones={['eu']}>
+
+We wszystkich przypadkach ustawienia SMTP do użycia są takie same: serwer `ssl0.ovh.net`, port `465` (SSL/TLS) lub `587` (STARTTLS), z uwierzytelnianiem przy użyciu pełnego adresu e-mail i jego hasła.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+We wszystkich przypadkach ustawienia SMTP do użycia są takie same: serwer `smtp.mail.ovh.ca`, port `465` (SSL/TLS) lub `587` (STARTTLS), z uwierzytelnianiem przy użyciu pełnego adresu e-mail i jego hasła.
+
+</Region>
+
+## Sprawdź również
+
+[Monitoring i zarządzanie automatycznymi wiadomościami e-mail na Twoim hostingu](/guides/web-cloud/web-hosting/mail-function-script-records)
+
+[Poprawa bezpieczeństwa e-maili poprzez rekord SPF](/guides/web-cloud/domains/dns-zone-spf)
+
+[Poprawa bezpieczeństwa e-maili dzięki rejestracji DKIM](/guides/web-cloud/domains/dns-zone-dkim)
+
+[Poprawa bezpieczeństwa e-maili dzięki rejestracji DMARC](/guides/web-cloud/domains/dns-zone-dmarc)
+
+W celu uzyskania specjalistycznych usług (pozycjonowanie, rozwój itp.) skontaktuj się z [partnerami OVHcloud](/links/partner).
+
+Jeżeli chcesz skorzystać z pomocy w zakresie użytkowania i konfiguracji rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami wsparcia](/links/support).
+
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Hosting WWW - Najlepsze praktyki dotyczące wysyłania wiadomości e-mail"
 description: Dowiedz się, dlaczego funkcja PHP mail() jest odradzana na hostingu współdzielonym oraz jak skonfigurować uwierzytelnione wysyłanie SMTP za pośrednictwem kont e-mail OVHcloud
-lastUpdated: 2026-07-13
+lastUpdated: 2026-07-15
 availableIn: [eu, ca, apac]
 ---
 
@@ -144,7 +144,7 @@ Użyj następujących ustawień dla swojego konta e-mail MX Plan (dołączonego 
 
 | Ustawienie | Wartość |
 |---|---|
-| **Serwer SMTP** | `ssl0.ovh.net` |
+| **Serwer SMTP** | `smtp.mail.ovh.net` |
 | **Port (SSL/TLS)** | `465` *(zalecany)* |
 | **Port (STARTTLS)** | `587` |
 | **Szyfrowanie** | `SSL/TLS` (port 465) lub `STARTTLS` (port 587) |
@@ -190,29 +190,9 @@ W przypadku rozwiązania **Exchange** serwer SMTP jest inny. Zapoznaj się z dok
 
 **Hasło** to hasło ustawione podczas tworzenia adresu lub zmienione w Panelu klienta OVHcloud. Jeżeli je zapomniałeś lub chcesz je zresetować, zapoznaj się z przewodnikiem [Zmiana hasła do konta e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
-<Region zones={['eu']}>
-
 :::warning
-Rozwiązanie MX Plan dołączone do hostingu WWW podlega **limitom wysyłki** (około 200 wiadomości e-mail na godzinę na konto). W przypadku dużych wolumenów — newsletterów lub masowych transakcyjnych wiadomości e-mail — preferuj dedykowane rozwiązanie (E-mail Pro, Exchange) lub zewnętrzną usługę wysyłki transakcyjnej.
+Rozwiązanie MX Plan dołączone do hostingu WWW podlega **limitom wysyłki** (około 200 wiadomości e-mail na godzinę na konto). Rozwiązania pocztowe nie są przeznaczone do masowej wysyłki: w przypadku dużych wolumenów — newsletterów lub masowych transakcyjnych wiadomości e-mail — użyj zewnętrznej usługi wysyłki transakcyjnej przeznaczonej do tego celu.
 :::
-
-</Region>
-
-<Region zones={['ca']}>
-
-:::warning
-Rozwiązanie MX Plan dołączone do hostingu WWW podlega **limitom wysyłki** (około 200 wiadomości e-mail na godzinę na konto). W przypadku dużych wolumenów — newsletterów lub masowych transakcyjnych wiadomości e-mail — preferuj dedykowane rozwiązanie takie jak Exchange lub zewnętrzną usługę wysyłki transakcyjnej.
-:::
-
-</Region>
-
-<Region zones={['apac']}>
-
-:::warning
-Rozwiązanie MX Plan dołączone do hostingu WWW podlega **limitom wysyłki** (około 200 wiadomości e-mail na godzinę na konto). W przypadku dużych wolumenów — newsletterów lub masowych transakcyjnych wiadomości e-mail — preferuj zewnętrzną usługę wysyłki transakcyjnej.
-:::
-
-</Region>
 
 #### Przykład kodu PHP z PHPMailer
 
@@ -237,7 +217,7 @@ $mail = new PHPMailer(true);
 try {
     // Ustawienia serwera SMTP OVHcloud
     $mail->isSMTP();
-    $mail->Host       = 'ssl0.ovh.net';
+    $mail->Host       = 'smtp.mail.ovh.net';
     $mail->SMTPAuth   = true;
     $mail->Username   = 'contact@mydomain.ovh'; // Twój adres e-mail OVHcloud
     $mail->Password   = 'your_password';         // Hasło konta e-mail
@@ -267,7 +247,7 @@ try {
 <Region zones={['ca', 'apac']}>
 
 :::warning
-Powyższy przykład używa serwera SMTP `ssl0.ovh.net`, dostępnego wyłącznie w strefie Europa. Z Kanady lub strefy Azja-Pacyfik zastąp wartość `$mail->Host` wartością `smtp.mail.ovh.ca`.
+Powyższy przykład używa serwera SMTP `smtp.mail.ovh.net`, dostępnego wyłącznie w strefie Europa. Z Kanady lub strefy Azja-Pacyfik zastąp wartość `$mail->Host` wartością `smtp.mail.ovh.ca`.
 :::
 
 </Region>
@@ -319,7 +299,7 @@ Rozwiązaniem jest zainstalowanie **wtyczki SMTP**, która zastępuje `wp_mail()
 
 | Pole | Wartość |
 |---|---|
-| **SMTP Host** | `ssl0.ovh.net` |
+| **SMTP Host** | `smtp.mail.ovh.net` |
 | **Encryption** | `SSL/TLS` |
 | **SMTP Port** | `465` |
 | **Authentication** | Włączone |
@@ -367,7 +347,7 @@ Włącz opcję **Force From Email**, aby wszystkie wychodzące wiadomości e-mai
 
 | Pole | Wartość |
 |---|---|
-| **Host** | `ssl0.ovh.net` |
+| **Host** | `smtp.mail.ovh.net` |
 | **Port** | `465` |
 | **Encryption** | `SSL/TLS` |
 | **Authentication** | Tak |
@@ -405,7 +385,7 @@ Zasada jest taka sama dla każdego CMS lub frameworka: zastąp natywną funkcję
 
 <Region zones={['eu']}>
 
-We wszystkich przypadkach ustawienia SMTP do użycia są takie same: serwer `ssl0.ovh.net`, port `465` (SSL/TLS) lub `587` (STARTTLS), z uwierzytelnianiem przy użyciu pełnego adresu e-mail i jego hasła.
+We wszystkich przypadkach ustawienia SMTP do użycia są takie same: serwer `smtp.mail.ovh.net`, port `465` (SSL/TLS) lub `587` (STARTTLS), z uwierzytelnianiem przy użyciu pełnego adresu e-mail i jego hasła.
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -16,7 +16,7 @@ Aby zapewnić dotarcie Twoich wiadomości e-mail do odbiorców, OVHcloud utrzymu
 ## Wymagania początkowe
 
 - Usługa [Hosting WWW OVHcloud](/links/web/hosting).
-- Adres e-mail powiązany z Twoją hostowaną nazwą domeny (rozwiązanie MX Plan, Email Pro lub Exchange). Jeżeli jeszcze go nie posiadasz, zapoznaj się z przewodnikiem [Tworzenie konta e-mail w ramach usługi MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+- Adres e-mail powiązany z Twoją nazwą domeny (rozwiązanie MX Plan, E-mail Pro lub Exchange). Jeżeli jeszcze go nie posiadasz, zapoznaj się z przewodnikiem [Tworzenie konta e-mail w ramach usługi MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -65,7 +65,7 @@ Brak captchy w otwartym formularzu wysyłkowym jest jedną z najczęstszych przy
 
 #### Zasada
 
-Wysyłaj swoje wiadomości e-mail za pośrednictwem połączenia **uwierzytelnionego SMTP** z serwerem pocztowym OVHcloud, korzystając z konta e-mail powiązanego z Twoją hostowaną domeną (na przykład `contact@mydomain.ovh`).
+Wysyłaj swoje wiadomości e-mail za pośrednictwem połączenia **uwierzytelnionego SMTP** z serwerem pocztowym OVHcloud, korzystając z konta e-mail powiązanego z Twoją domeną (na przykład `contact@mydomain.ovh`).
 
 Takie podejście oferuje trzy główne korzyści:
 
@@ -75,7 +75,7 @@ Takie podejście oferuje trzy główne korzyści:
 
 #### Dlaczego pole `From:` musi należeć do Twojej domeny
 
-Pole `From:` Twojej wiadomości e-mail musi **koniecznie** zawierać adres należący do Twojej domeny (np. `contact@mydomain.ovh`), a adres ten musi być zgodny z kontem SMTP użytym do uwierzytelniania.
+Pole `From:` Twojej wiadomości e-mail musi **koniecznie** zawierać adres należący do Twojej domeny (na przykład `contact@mydomain.ovh`), a adres ten musi być zgodny z kontem SMTP użytym do uwierzytelniania.
 
 Jeżeli pole `From:` nie jest zgodne z domeną autoryzowaną w rekordzie SPF lub jeżeli podpis DKIM nie jest zgodny, serwery pocztowe odbiorców (Gmail, Outlook itp.) mogą odrzucić wiadomość e-mail lub zaklasyfikować ją jako spam.
 
@@ -103,14 +103,14 @@ Takie postępowanie jest nieprawidłowe z dwóch powodów:
 |---|---|---|
 | `From:` | `contact@mydomain.ovh` (stały adres witryny) | Uwierzytelniony nadawca — nigdy się nie zmienia |
 | `Reply-To:` | Adres wprowadzony przez użytkownika w formularzu | Umożliwia bezpośrednią odpowiedź użytkownikowi |
-| `Subject:` | Temat wiadomości, z prefiksem (np. `[Contact] ...`) | Ułatwia identyfikację wiadomości z formularza |
+| `Subject:` | Temat wiadomości, z prefiksem (na przykład `[Contact]`) | Ułatwia identyfikację wiadomości z formularza |
 
 W ten sposób, gdy odpowiadasz na otrzymaną wiadomość e-mail, Twój klient poczty wysyła odpowiedź na adres użytkownika za pośrednictwem pola `Reply-To:`, nie naruszając uwierzytelniania SPF/DKIM.
 
 Oto jak dostosować przykład PHPMailer do formularza kontaktowego:
 
 ```php
-// User-supplied data (validate and sanitise before use)
+// Dane dostarczone przez użytkownika (zweryfikuj i oczyść przed użyciem)
 $userEmail = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
 $userName  = htmlspecialchars(strip_tags($_POST['name']));
 $message   = htmlspecialchars(strip_tags($_POST['message']));
@@ -119,13 +119,13 @@ if (!$userEmail) {
     die('Invalid email address.');
 }
 
-// From: always fixed — your site's address, never the user's
+// From: zawsze stały — adres Twojej witryny, nigdy użytkownika
 $mail->setFrom('contact@mydomain.ovh', 'My Website');
 
-// Reply-To: the user's address, so you can reply to them directly
+// Reply-To: adres użytkownika, aby móc odpowiedzieć mu bezpośrednio
 $mail->addReplyTo($userEmail, $userName);
 
-// Recipient: yourself (you receive the form message)
+// Odbiorca: Ty sam (otrzymujesz wiadomość z formularza)
 $mail->addAddress('contact@mydomain.ovh', 'My Website');
 
 $mail->Subject = '[Contact] ' . $userName;
@@ -149,7 +149,7 @@ Użyj następujących ustawień dla swojego konta e-mail MX Plan (dołączonego 
 | **Port (STARTTLS)** | `587` |
 | **Szyfrowanie** | `SSL/TLS` (port 465) lub `STARTTLS` (port 587) |
 | **Uwierzytelnianie** | Wymagane |
-| **Nazwa użytkownika** | Pełny adres e-mail (np. `contact@mydomain.ovh`) |
+| **Nazwa użytkownika** | Pełny adres e-mail (na przykład `contact@mydomain.ovh`) |
 | **Hasło** | Hasło do konta e-mail OVHcloud |
 
 </Region>
@@ -163,23 +163,23 @@ Użyj następujących ustawień dla swojego konta e-mail MX Plan (dołączonego 
 | **Port (STARTTLS)** | `587` |
 | **Szyfrowanie** | `SSL/TLS` (port 465) lub `STARTTLS` (port 587) |
 | **Uwierzytelnianie** | Wymagane |
-| **Nazwa użytkownika** | Pełny adres e-mail (np. `contact@mydomain.ovh`) |
+| **Nazwa użytkownika** | Pełny adres e-mail (na przykład `contact@mydomain.ovh`) |
 | **Hasło** | Hasło do konta e-mail OVHcloud |
 
 </Region>
 
 :::tip
-W przypadku rozwiązań **Email Pro** lub **Exchange** serwer SMTP jest inny. Zapoznaj się z dokumentacją każdego rozwiązania, aby poznać dokładne ustawienia.
+W przypadku rozwiązań **E-mail Pro** lub **Exchange** serwer SMTP jest inny. Zapoznaj się z dokumentacją każdego rozwiązania, aby poznać dokładne ustawienia.
 :::
 
 #### Gdzie znaleźć swoje dane uwierzytelniające SMTP
 
-**Nazwa użytkownika SMTP** to Twój pełny adres e-mail (np. `contact@mydomain.ovh`).
+**Nazwa użytkownika SMTP** to Twój pełny adres e-mail (na przykład `contact@mydomain.ovh`).
 
 **Hasło** to hasło ustawione podczas tworzenia adresu lub zmienione w Panelu klienta OVHcloud. Jeżeli je zapomniałeś lub chcesz je zresetować, zapoznaj się z przewodnikiem [Zmiana hasła do konta e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
 :::warning
-Rozwiązanie MX Plan dołączone do hostingu WWW podlega **limitom wysyłki** (około 200 wiadomości e-mail na godzinę na konto). W przypadku dużych wolumenów — newsletterów lub masowych transakcyjnych wiadomości e-mail — preferuj dedykowane rozwiązanie (Email Pro, Exchange) lub zewnętrzną usługę wysyłki transakcyjnej.
+Rozwiązanie MX Plan dołączone do hostingu WWW podlega **limitom wysyłki** (około 200 wiadomości e-mail na godzinę na konto). W przypadku dużych wolumenów — newsletterów lub masowych transakcyjnych wiadomości e-mail — preferuj dedykowane rozwiązanie (E-mail Pro, Exchange) lub zewnętrzną usługę wysyłki transakcyjnej.
 :::
 
 #### Przykład kodu PHP z PHPMailer
@@ -203,23 +203,23 @@ require 'vendor/autoload.php';
 $mail = new PHPMailer(true);
 
 try {
-    // OVHcloud SMTP server settings
+    // Ustawienia serwera SMTP OVHcloud
     $mail->isSMTP();
     $mail->Host       = 'ssl0.ovh.net';
     $mail->SMTPAuth   = true;
-    $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
-    $mail->Password   = 'your_password';         // Password of the email account
+    $mail->Username   = 'contact@mydomain.ovh'; // Twój adres e-mail OVHcloud
+    $mail->Password   = 'your_password';         // Hasło konta e-mail
     $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
     $mail->Port       = 465;
 
-    // Sender: must belong to your hosted domain
+    // Nadawca: musi należeć do Twojej domeny
     $mail->setFrom('contact@mydomain.ovh', 'My Website');
     $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
 
-    // Recipient
+    // Odbiorca
     $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
 
-    // Content
+    // Treść
     $mail->isHTML(true);
     $mail->Subject = 'Your email subject';
     $mail->Body    = 'Email body in <b>HTML</b>';
@@ -263,7 +263,7 @@ Rozwiązaniem jest zainstalowanie **wtyczki SMTP**, która zastępuje `wp_mail()
 
 #### 3.2 Konfiguracja WP Mail SMTP
 
-[WP Mail SMTP](https://wordpress.org/plugins/wp-mail-smtp/) to najczęściej używana wtyczka do tej konfiguracji.
+[WP Mail SMTP](https://pl.wordpress.org/plugins/wp-mail-smtp/) to najczęściej używana wtyczka do tej konfiguracji.
 
 **Instalacja:**
 
@@ -278,7 +278,7 @@ Rozwiązaniem jest zainstalowanie **wtyczki SMTP**, która zastępuje `wp_mail()
 | Pole | Wartość |
 |---|---|
 | **From Email** | `contact@mydomain.ovh` (adres należący do Twojej domeny) |
-| **From Name** | Wyświetlana nazwa Twojej witryny (np. `My Website`) |
+| **From Name** | Wyświetlana nazwa Twojej witryny (na przykład `My Website`) |
 
 3. W sekcji **Mailer** wybierz **Other SMTP**.
 4. Wypełnij ustawienia SMTP:
@@ -318,7 +318,7 @@ Włącz opcję **Force From Email**, aby wszystkie wychodzące wiadomości e-mai
 
 #### 3.3 Alternatywa: FluentSMTP
 
-[FluentSMTP](https://wordpress.org/plugins/fluent-smtp/) to lekka, bezpłatna alternatywa bez ograniczeń wolumenu wysyłki.
+[FluentSMTP](https://pl.wordpress.org/plugins/fluent-smtp/) to lekka, bezpłatna alternatywa bez ograniczeń wolumenu wysyłki.
 
 **Instalacja:**
 

--- a/docs/pl/guides/web-cloud/web-hosting/landing-page-configuration.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/landing-page-configuration.mdx
@@ -75,6 +75,7 @@ Aby znaleźć odpowiedni przewodnik dla swoich potrzeb:
         { title: 'Skonfiguruj i używaj Git', link: '/guides/web-cloud/web-hosting/git-integration-webhosting' },
         { title: 'Twórz zadania automatyczne (CRON)', link: '/guides/web-cloud/web-hosting/cron-tasks' },
         { title: 'Śledź automatyczne e-maile', link: '/guides/web-cloud/web-hosting/mail-function-script-records' },
+        { title: 'Dobre praktyki wysyłania e-maili', link: '/guides/web-cloud/web-hosting/email-sending-best-practices' },
         { title: 'Zarządzaj aplikacją webową przez API', link: '/guides/web-cloud/web-hosting/api-webhosting' },
         { title: 'Rozwijaj swoją ofertę', link: '/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer' },
         { title: 'Pobierz kopię zapasową przestrzeni FTP (Cloud Web)', link: '/guides/web-cloud/web-hosting/backup-ftp', zones: ['eu'] },

--- a/docs/pt/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Alojamento web - Boas práticas de envio de e-mail"
 description: Saiba porque a função PHP mail() é desaconselhada num alojamento partilhado e como configurar um envio SMTP autenticado através das suas contas de e-mail OVHcloud
-lastUpdated: 2026-07-13
+lastUpdated: 2026-07-15
 availableIn: [eu, ca, apac]
 ---
 
@@ -144,7 +144,7 @@ Utilize os seguintes parâmetros para a sua conta de e-mail MX Plan (incluída n
 
 | Parâmetro | Valor |
 |---|---|
-| **Servidor SMTP** | `ssl0.ovh.net` |
+| **Servidor SMTP** | `smtp.mail.ovh.net` |
 | **Porta (SSL/TLS)** | `465` *(recomendada)* |
 | **Porta (STARTTLS)** | `587` |
 | **Encriptação** | `SSL/TLS` (porta 465) ou `STARTTLS` (porta 587) |
@@ -190,29 +190,9 @@ O **nome de utilizador SMTP** é o seu endereço de e-mail completo (por exemplo
 
 A **palavra-passe** é a definida durante a criação do endereço, ou alterada a partir da Área de Cliente OVHcloud. Se a esqueceu ou pretende reiniciá-la, consulte o guia [Alterar a palavra-passe de um endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
-<Region zones={['eu']}>
-
 :::warning
-A oferta MX Plan incluída no alojamento web está sujeita a **quotas de envio** (cerca de 200 e-mails por hora por conta). Para volumes importantes — newsletters ou e-mails transacionais em massa — privilegie uma solução dedicada (E-mail Pro, Exchange) ou um serviço de envio transacional terceiro.
+A oferta MX Plan incluída no alojamento web está sujeita a **quotas de envio** (cerca de 200 e-mails por hora por conta). As soluções de correio não foram concebidas para o envio em massa: para volumes importantes — newsletters ou e-mails transacionais em massa — utilize um serviço de envio transacional terceiro, concebido para este fim.
 :::
-
-</Region>
-
-<Region zones={['ca']}>
-
-:::warning
-A oferta MX Plan incluída no alojamento web está sujeita a **quotas de envio** (cerca de 200 e-mails por hora por conta). Para volumes importantes — newsletters ou e-mails transacionais em massa — privilegie uma solução dedicada como o Exchange ou um serviço de envio transacional terceiro.
-:::
-
-</Region>
-
-<Region zones={['apac']}>
-
-:::warning
-A oferta MX Plan incluída no alojamento web está sujeita a **quotas de envio** (cerca de 200 e-mails por hora por conta). Para volumes importantes — newsletters ou e-mails transacionais em massa — privilegie um serviço de envio transacional terceiro.
-:::
-
-</Region>
 
 #### Exemplo de código PHP com PHPMailer
 
@@ -237,7 +217,7 @@ $mail = new PHPMailer(true);
 try {
     // Parâmetros do servidor SMTP OVHcloud
     $mail->isSMTP();
-    $mail->Host       = 'ssl0.ovh.net';
+    $mail->Host       = 'smtp.mail.ovh.net';
     $mail->SMTPAuth   = true;
     $mail->Username   = 'contact@mydomain.ovh'; // O seu endereço de e-mail OVHcloud
     $mail->Password   = 'your_password';         // Palavra-passe da conta de e-mail
@@ -267,7 +247,7 @@ try {
 <Region zones={['ca', 'apac']}>
 
 :::warning
-O exemplo acima utiliza o servidor SMTP `ssl0.ovh.net`, disponível apenas na zona Europa. A partir do Canadá ou da zona Ásia-Pacífico, substitua o valor de `$mail->Host` por `smtp.mail.ovh.ca`.
+O exemplo acima utiliza o servidor SMTP `smtp.mail.ovh.net`, disponível apenas na zona Europa. A partir do Canadá ou da zona Ásia-Pacífico, substitua o valor de `$mail->Host` por `smtp.mail.ovh.ca`.
 :::
 
 </Region>
@@ -319,7 +299,7 @@ O [WP Mail SMTP](https://pt.wordpress.org/plugins/wp-mail-smtp/) é o plugin mai
 
 | Campo | Valor |
 |---|---|
-| **Host SMTP** | `ssl0.ovh.net` |
+| **Host SMTP** | `smtp.mail.ovh.net` |
 | **Encriptação** | `SSL/TLS` |
 | **Porta SMTP** | `465` |
 | **Autenticação** | Ativada |
@@ -367,7 +347,7 @@ O [FluentSMTP](https://pt.wordpress.org/plugins/fluent-smtp/) é uma alternativa
 
 | Campo | Valor |
 |---|---|
-| **Host** | `ssl0.ovh.net` |
+| **Host** | `smtp.mail.ovh.net` |
 | **Porta** | `465` |
 | **Encriptação** | `SSL/TLS` |
 | **Autenticação** | Sim |
@@ -405,7 +385,7 @@ O princípio é idêntico para qualquer CMS ou framework: substituir a função 
 
 <Region zones={['eu']}>
 
-Em todos os casos, os parâmetros SMTP a utilizar são idênticos: servidor `ssl0.ovh.net`, porta `465` (SSL/TLS) ou `587` (STARTTLS), com autenticação pelo endereço de e-mail completo e a respetiva palavra-passe.
+Em todos os casos, os parâmetros SMTP a utilizar são idênticos: servidor `smtp.mail.ovh.net`, porta `465` (SSL/TLS) ou `587` (STARTTLS), com autenticação pelo endereço de e-mail completo e a respetiva palavra-passe.
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -1,0 +1,400 @@
+---
+title: "Alojamento web - Boas práticas de envio de e-mail"
+description: Saiba porque a função PHP mail() é desaconselhada num alojamento partilhado e como configurar um envio SMTP autenticado através das suas contas de e-mail OVHcloud
+lastUpdated: 2026-07-13
+availableIn: [eu, ca, apac]
+---
+
+import { Region } from '@components/Zone';
+
+## Objetivo
+
+Para que os seus e-mails cheguem corretamente aos seus destinatários, a OVHcloud implementa uma infraestrutura dedicada ao envio de saída, com filtragem anti-spam automática e vigilância contínua da reputação dos servidores. Para tirar pleno partido disto, é recomendado enviar os seus e-mails através de **SMTP autenticado** em vez da função PHP `mail()` nativa. Esta abordagem garante que cada e-mail é emitido com uma identidade verificável, o que melhora significativamente a entregabilidade e reduz o risco de classificação como spam.
+
+**Este guia apresenta-lhe as boas práticas e recomendações OVHcloud para enviar e-mails de forma fiável e segura a partir de um alojamento partilhado, quer gira um site WordPress, outro CMS ou uma aplicação PHP.**
+
+## Requisitos
+
+- Dispor de uma oferta de [alojamento web OVHcloud](/links/web/hosting).
+- Dispor de um endereço de e-mail associado ao seu nome de domínio alojado (oferta MX Plan, Email Pro ou Exchange). Se ainda não tiver nenhum, consulte o guia [Criar um endereço de e-mail com a oferta MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+
+{/* CP-NAV-START:web-hosting */}
+---
+
+### Acesso à Área de Cliente OVHcloud
+
+- **Link direto:** <ManagerLink to="/#/web/hosting">Alojamentos</ManagerLink>
+- **Percurso de navegação:** <code className="action">Web Cloud</code> > <code className="action">Alojamentos</code> > Selecione o seu alojamento web
+
+---
+{/* CP-NAV-END:web-hosting */}
+
+## Instruções
+
+### 1. `mail()` ou SMTP autenticado: qual a diferença para si?
+
+#### O que a OVHcloud faz para proteger os seus envios
+
+A OVHcloud monitoriza permanentemente a reputação dos seus servidores de envio e filtra automaticamente as mensagens suspeitas — para que os seus e-mails legítimos não sejam prejudicados. Mas esta proteção tem um limite: a função PHP `mail()` não efetua qualquer controlo sobre a identidade do remetente declarado no e-mail (campo `From:`). Um e-mail enviado através de `mail()` pode, por isso, parecer provir de qualquer endereço, o que basta para acionar os filtros dos servidores de destino (Gmail, Outlook…) e comprometer a entregabilidade dos **seus próprios envios**.
+
+#### E-mails sem assinatura fiável
+
+A função `mail()` envia e-mails sem garantir a identidade do remetente. Ora os servidores de destino (Gmail, Outlook…) verificam se o e-mail provém realmente de um servidor autorizado pelo seu domínio, graças aos registos **SPF** e **DKIM**. Com `mail()`, esta verificação falha frequentemente: a mensagem corre então o risco de acabar no spam ou de ser rejeitada.
+
+O envio através de SMTP autenticado resolve este problema: o e-mail é emitido pelo servidor OVHcloud autorizado para o seu domínio, com a assinatura correta.
+
+:::warning
+Uma utilização abusiva da função `mail()` pode provocar o bloqueio automático dos envios do seu alojamento. Se verificar que os seus e-mails já não são enviados, consulte o guia [Seguimento dos emails automatizados](/guides/web-cloud/web-hosting/mail-function-script-records).
+:::
+
+#### Formulários abertos: mais um vetor de abuso
+
+Um formulário de contacto acessível publicamente, sem mecanismo de proteção, é um alvo privilegiado para os robôs. Estes exploram-no para desencadear o envio de milhares de e-mails em poucos minutos através do seu alojamento, provocando o bloqueio do IP partilhado e prejudicando todos os clientes do cluster.
+
+Implemente as seguintes proteções em qualquer formulário que desencadeie um envio de e-mail:
+
+- **Captcha**: integre um sistema de verificação (Google reCAPTCHA v3, hCaptcha, ou um cálculo aritmético simples) para bloquear as submissões automatizadas.
+- **Limitação do débito**: limite o número de envios por endereço IP do lado do servidor para evitar os abusos em rajada.
+- **Validação rigorosa das entradas**: verifique e limpe todos os campos do formulário antes de os utilizar num e-mail — nunca confie nos dados introduzidos pelo utilizador.
+
+:::warning
+A ausência de captcha num formulário de envio aberto é uma das causas mais frequentes de bloqueio dos alojamentos partilhados por envio de spam. Esta proteção é indispensável independentemente do método de envio utilizado.
+:::
+
+### 2. A boa prática: utilizar uma conta de e-mail OVHcloud com SMTP autenticado
+
+#### Princípio
+
+Envie os seus e-mails através de uma ligação **SMTP autenticada** para o servidor de correio OVHcloud, utilizando uma conta de e-mail associada ao seu domínio alojado (por exemplo `contact@mydomain.ovh`).
+
+Esta abordagem apresenta três vantagens principais:
+
+- **Autenticação garantida**: o servidor OVHcloud verifica a sua identidade antes de aceitar o e-mail.
+- **SPF e DKIM funcionais**: o e-mail é emitido por um servidor autorizado para o seu domínio e assinado corretamente.
+- **Rastreabilidade**: cada envio está associado a uma conta identificada, o que permite intervir rapidamente em caso de abuso.
+
+#### Porque é que o campo `From:` deve pertencer ao seu domínio
+
+O campo `From:` do seu e-mail deve **obrigatoriamente** conter um endereço pertencente ao seu domínio (ex. `contact@mydomain.ovh`), e este endereço deve corresponder à conta SMTP utilizada para a autenticação.
+
+Se o `From:` não corresponder ao domínio autorizado no registo SPF, ou se a assinatura DKIM não corresponder, os servidores de correio de destino (Gmail, Outlook, etc.) podem rejeitar ou classificar o e-mail como spam.
+
+:::tip
+Para maximizar a entregabilidade, verifique se os registos SPF, DKIM e DMARC estão bem configurados na sua zona DNS. O Gmail e o Yahoo Mail exigem-nos agora para os remetentes em volume. Consulte os nossos guias:
+
+- [Melhorar a segurança dos e-mails através do registo SPF](/guides/web-cloud/domains/dns-zone-spf)
+- [Melhorar a segurança dos e-mails através do registo DKIM](/guides/web-cloud/domains/dns-zone-dkim)
+- [Melhorar a segurança dos e-mails através do registo DMARC](/guides/web-cloud/domains/dns-zone-dmarc)
+
+:::
+
+#### Formulários de contacto: campo `From:` fixo e `Reply-To:` do utilizador
+
+Um erro frequente consiste em colocar o endereço de e-mail introduzido pelo utilizador no formulário diretamente no campo `From:`. Por exemplo, um visitante introduz `utilizador@gmail.com` e o script utiliza este endereço como remetente.
+
+Este comportamento é incorreto por duas razões:
+
+- O registo SPF do seu domínio não autoriza os servidores Gmail (ou qualquer outro fornecedor terceiro) a enviar em seu nome → falha do controlo SPF.
+- Está a enviar "em nome de" um endereço que não lhe pertence → risco elevado de classificação como spam ou de rejeição.
+
+**O esquema correto para um formulário de contacto:**
+
+| Campo de e-mail | Valor | Função |
+|---|---|---|
+| `From:` | `contact@mydomain.ovh` (endereço fixo do site) | Remetente autenticado — nunca muda |
+| `Reply-To:` | Endereço introduzido pelo utilizador no formulário | Permite responder diretamente ao utilizador |
+| `Subject:` | Assunto da mensagem, prefixado (ex. `[Contact] ...`) | Identifica facilmente as mensagens do formulário |
+
+Assim, quando responde ao e-mail recebido, o seu cliente de correio envia a resposta para o endereço do utilizador através do campo `Reply-To:`, sem comprometer a autenticação SPF/DKIM.
+
+Eis como adaptar o exemplo PHPMailer para um formulário de contacto:
+
+```php
+// User-supplied data (validate and sanitise before use)
+$userEmail = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
+$userName  = htmlspecialchars(strip_tags($_POST['name']));
+$message   = htmlspecialchars(strip_tags($_POST['message']));
+
+if (!$userEmail) {
+    die('Invalid email address.');
+}
+
+// From: always fixed — your site's address, never the user's
+$mail->setFrom('contact@mydomain.ovh', 'My Website');
+
+// Reply-To: the user's address, so you can reply to them directly
+$mail->addReplyTo($userEmail, $userName);
+
+// Recipient: yourself (you receive the form message)
+$mail->addAddress('contact@mydomain.ovh', 'My Website');
+
+$mail->Subject = '[Contact] ' . $userName;
+$mail->Body    = "Name: $userName\nEmail: $userEmail\n\nMessage:\n$message";
+```
+
+:::tip
+Nunca passe diretamente os dados de um formulário para o PHPMailer sem validação prévia. Utilize `filter_var()` para o endereço de e-mail e `htmlspecialchars()` + `strip_tags()` para os campos de texto, de forma a evitar as injeções de cabeçalhos de e-mail.
+:::
+
+#### Parâmetros SMTP OVHcloud
+
+Utilize os seguintes parâmetros para a sua conta de e-mail MX Plan (incluída no alojamento web):
+
+<Region zones={['eu']}>
+
+| Parâmetro | Valor |
+|---|---|
+| **Servidor SMTP** | `ssl0.ovh.net` |
+| **Porta (SSL/TLS)** | `465` *(recomendada)* |
+| **Porta (STARTTLS)** | `587` |
+| **Encriptação** | `SSL/TLS` (porta 465) ou `STARTTLS` (porta 587) |
+| **Autenticação** | Obrigatória |
+| **Nome de utilizador** | Endereço de e-mail completo (ex. `contact@mydomain.ovh`) |
+| **Palavra-passe** | Palavra-passe da conta de e-mail OVHcloud |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Parâmetro | Valor |
+|---|---|
+| **Servidor SMTP** | `smtp.mail.ovh.ca` |
+| **Porta (SSL/TLS)** | `465` *(recomendada)* |
+| **Porta (STARTTLS)** | `587` |
+| **Encriptação** | `SSL/TLS` (porta 465) ou `STARTTLS` (porta 587) |
+| **Autenticação** | Obrigatória |
+| **Nome de utilizador** | Endereço de e-mail completo (ex. `contact@mydomain.ovh`) |
+| **Palavra-passe** | Palavra-passe da conta de e-mail OVHcloud |
+
+</Region>
+
+:::tip
+Para as ofertas **Email Pro** ou **Exchange**, o servidor SMTP é diferente. Consulte a documentação de cada oferta para os parâmetros exatos.
+:::
+
+#### Onde encontrar as suas credenciais SMTP
+
+O **nome de utilizador SMTP** é o seu endereço de e-mail completo (ex. `contact@mydomain.ovh`).
+
+A **palavra-passe** é a definida durante a criação do endereço, ou alterada a partir da Área de Cliente OVHcloud. Se a esqueceu ou pretende reiniciá-la, consulte o guia [Alterar a palavra-passe de um endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
+
+:::warning
+A oferta MX Plan incluída no alojamento web está sujeita a **quotas de envio** (cerca de 200 e-mails por hora por conta). Para volumes importantes — newsletters ou e-mails transacionais em massa — privilegie uma solução dedicada (Email Pro, Exchange) ou um serviço de envio transacional terceiro.
+:::
+
+#### Exemplo de código PHP com PHPMailer
+
+O [PHPMailer](https://github.com/PHPMailer/PHPMailer) é a biblioteca PHP de referência para o envio de e-mails através de SMTP. Instale-a através do Composer:
+
+```bash
+composer require phpmailer/phpmailer
+```
+
+Eis um exemplo completo de envio SMTP autenticado:
+
+```php
+<?php
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
+use PHPMailer\PHPMailer\Exception;
+
+require 'vendor/autoload.php';
+
+$mail = new PHPMailer(true);
+
+try {
+    // OVHcloud SMTP server settings
+    $mail->isSMTP();
+    $mail->Host       = 'ssl0.ovh.net';
+    $mail->SMTPAuth   = true;
+    $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
+    $mail->Password   = 'your_password';         // Password of the email account
+    $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
+    $mail->Port       = 465;
+
+    // Sender: must belong to your hosted domain
+    $mail->setFrom('contact@mydomain.ovh', 'My Website');
+    $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
+
+    // Recipient
+    $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
+
+    // Content
+    $mail->isHTML(true);
+    $mail->Subject = 'Your email subject';
+    $mail->Body    = 'Email body in <b>HTML</b>';
+    $mail->AltBody = 'Email body in plain text (fallback)';
+
+    $mail->send();
+    echo 'Email sent successfully.';
+} catch (Exception $e) {
+    echo "Error while sending: {$mail->ErrorInfo}";
+}
+```
+
+<Region zones={['ca', 'apac']}>
+
+:::warning
+O exemplo acima utiliza o servidor SMTP `ssl0.ovh.net`, disponível apenas na zona Europa. A partir do Canadá ou da zona Ásia-Pacífico, substitua o valor de `$mail->Host` por `smtp.mail.ovh.ca`.
+:::
+
+</Region>
+
+:::warning
+Nunca armazene a palavra-passe da sua conta de e-mail em texto simples num ficheiro PHP versionado. Utilize um ficheiro de configuração excluído do seu repositório Git (`.gitignore`).
+:::
+
+:::info
+Com esta configuração, cada e-mail enviado a partir do seu site é:
+
+- **autenticado** junto do servidor OVHcloud,
+- **assinado** com os registos SPF e DKIM do seu domínio,
+- **rastreável** em caso de abuso ou de problema de entregabilidade.
+
+:::
+
+### 3. WordPress e outros CMS: utilizar um plugin SMTP
+
+#### 3.1 O problema com o WordPress por predefinição
+
+A função `wp_mail()` do WordPress utiliza em segundo plano a função PHP `mail()`. Herda, por isso, todos os problemas descritos na secção anterior: ausência de autenticação, `From:` não controlado, risco de spam.
+
+A solução consiste em instalar um **plugin SMTP** que substitui `wp_mail()` por uma ligação SMTP autenticada para o seu servidor de correio OVHcloud.
+
+#### 3.2 Configurar o WP Mail SMTP
+
+O [WP Mail SMTP](https://pt.wordpress.org/plugins/wp-mail-smtp/) é o plugin mais utilizado para esta configuração.
+
+**Instalação:**
+
+1. Na sua administração WordPress, aceda a **Plugins** > **Adicionar novo plugin**.
+2. Procure `WP Mail SMTP` e clique em **Instalar agora**, depois em **Ativar**.
+
+**Configuração:**
+
+1. Aceda a **WP Mail SMTP** > **Definições** no menu de administração.
+2. Na secção **Remetente**, preencha os seguintes campos:
+
+| Campo | Valor |
+|---|---|
+| **E-mail do remetente** | `contact@mydomain.ovh` (endereço pertencente ao seu domínio) |
+| **Nome do remetente** | Nome apresentado para o seu site (ex. `O Meu Site Web`) |
+
+3. Na secção **Mailer**, selecione **Outro SMTP**.
+4. Preencha os parâmetros SMTP:
+
+<Region zones={['eu']}>
+
+| Campo | Valor |
+|---|---|
+| **Host SMTP** | `ssl0.ovh.net` |
+| **Encriptação** | `SSL/TLS` |
+| **Porta SMTP** | `465` |
+| **Autenticação** | Ativada |
+| **Nome de utilizador SMTP** | `contact@mydomain.ovh` |
+| **Palavra-passe SMTP** | Palavra-passe da sua conta de e-mail OVHcloud |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Campo | Valor |
+|---|---|
+| **Host SMTP** | `smtp.mail.ovh.ca` |
+| **Encriptação** | `SSL/TLS` |
+| **Porta SMTP** | `465` |
+| **Autenticação** | Ativada |
+| **Nome de utilizador SMTP** | `contact@mydomain.ovh` |
+| **Palavra-passe SMTP** | Palavra-passe da sua conta de e-mail OVHcloud |
+
+</Region>
+
+5. Clique em **Guardar definições**.
+6. No separador **Ferramentas**, utilize **Teste de envio de e-mail** para verificar a configuração.
+
+:::tip
+Ative a opção **Forçar o e-mail do remetente** para que todos os e-mails de saída utilizem o endereço configurado, mesmo que um plugin terceiro tente utilizar outro.
+:::
+
+#### 3.3 Alternativa: FluentSMTP
+
+O [FluentSMTP](https://pt.wordpress.org/plugins/fluent-smtp/) é uma alternativa leve e gratuita, sem limitação no volume de envio.
+
+**Instalação:**
+
+1. Na sua administração WordPress, aceda a **Plugins** > **Adicionar novo plugin**.
+2. Procure `FluentSMTP` e clique em **Instalar agora**, depois em **Ativar**.
+
+**Configuração:**
+
+1. Aceda a **FluentSMTP** > **Definições**.
+2. Clique em **Adicionar uma ligação** e selecione **Outro SMTP**.
+3. Preencha os mesmos parâmetros que para o WP Mail SMTP:
+
+<Region zones={['eu']}>
+
+| Campo | Valor |
+|---|---|
+| **Host** | `ssl0.ovh.net` |
+| **Porta** | `465` |
+| **Encriptação** | `SSL/TLS` |
+| **Autenticação** | Sim |
+| **Nome de utilizador** | `contact@mydomain.ovh` |
+| **Palavra-passe** | Palavra-passe da sua conta de e-mail OVHcloud |
+| **E-mail do remetente** | `contact@mydomain.ovh` |
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+| Campo | Valor |
+|---|---|
+| **Host** | `smtp.mail.ovh.ca` |
+| **Porta** | `465` |
+| **Encriptação** | `SSL/TLS` |
+| **Autenticação** | Sim |
+| **Nome de utilizador** | `contact@mydomain.ovh` |
+| **Palavra-passe** | Palavra-passe da sua conta de e-mail OVHcloud |
+| **E-mail do remetente** | `contact@mydomain.ovh` |
+
+</Region>
+
+4. Clique em **Guardar a ligação** e envie um e-mail de teste.
+
+#### 3.4 Outros CMS (Drupal, Joomla, PrestaShop)
+
+O princípio é idêntico para qualquer CMS ou framework: substituir a função de envio nativa por um módulo ou uma configuração SMTP autenticada.
+
+| CMS | Módulo recomendado |
+|---|---|
+| **Drupal** | [SMTP Authentication Support](https://www.drupal.org/project/smtp) |
+| **Joomla** | Configuração nativa: **Sistema** > **Configuração global** > separador **Servidor** > secção **Definições de correio** |
+| **PrestaShop** | **Parâmetros avançados** > **E-mail** — escolher **Utilizar os meus próprios parâmetros SMTP** |
+
+<Region zones={['eu']}>
+
+Em todos os casos, os parâmetros SMTP a utilizar são idênticos: servidor `ssl0.ovh.net`, porta `465` (SSL/TLS) ou `587` (STARTTLS), com autenticação pelo endereço de e-mail completo e a respetiva palavra-passe.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Em todos os casos, os parâmetros SMTP a utilizar são idênticos: servidor `smtp.mail.ovh.ca`, porta `465` (SSL/TLS) ou `587` (STARTTLS), com autenticação pelo endereço de e-mail completo e a respetiva palavra-passe.
+
+</Region>
+
+## Quer saber mais?
+
+[Seguimento dos emails automatizados](/guides/web-cloud/web-hosting/mail-function-script-records)
+
+[Melhorar a segurança dos e-mails através do registo SPF](/guides/web-cloud/domains/dns-zone-spf)
+
+[Melhorar a segurança dos e-mails através do registo DKIM](/guides/web-cloud/domains/dns-zone-dkim)
+
+[Melhorar a segurança dos e-mails através do registo DMARC](/guides/web-cloud/domains/dns-zone-dmarc)
+
+Para prestações especializadas (referenciamento, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
+
+Se pretender obter assistência na utilização e configuração das suas soluções OVHcloud, sugerimos que consulte as nossas diferentes [ofertas de suporte](/links/support).
+
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -16,7 +16,7 @@ Para que os seus e-mails cheguem corretamente aos seus destinatários, a OVHclou
 ## Requisitos
 
 - Dispor de uma oferta de [alojamento web OVHcloud](/links/web/hosting).
-- Dispor de um endereço de e-mail associado ao seu nome de domínio alojado (oferta MX Plan, Email Pro ou Exchange). Se ainda não tiver nenhum, consulte o guia [Criar um endereço de e-mail com a oferta MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+- Dispor de um endereço de e-mail associado ao seu nome de domínio (oferta MX Plan, E-mail Pro ou Exchange). Se ainda não tiver nenhum, consulte o guia [Criar um endereço de e-mail com a oferta MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -35,16 +35,16 @@ Para que os seus e-mails cheguem corretamente aos seus destinatários, a OVHclou
 
 #### O que a OVHcloud faz para proteger os seus envios
 
-A OVHcloud monitoriza permanentemente a reputação dos seus servidores de envio e filtra automaticamente as mensagens suspeitas — para que os seus e-mails legítimos não sejam prejudicados. Mas esta proteção tem um limite: a função PHP `mail()` não efetua qualquer controlo sobre a identidade do remetente declarado no e-mail (campo `From:`). Um e-mail enviado através de `mail()` pode, por isso, parecer provir de qualquer endereço, o que basta para acionar os filtros dos servidores de destino (Gmail, Outlook…) e comprometer a entregabilidade dos **seus próprios envios**.
+A OVHcloud monitoriza permanentemente a reputação dos seus servidores de envio e filtra automaticamente as mensagens suspeitas — para que os seus e-mails legítimos não sejam prejudicados. Mas esta proteção tem um limite: a função PHP `mail()` não efetua qualquer controlo sobre a identidade do remetente declarado no e-mail (campo `From:`). Um e-mail enviado através de `mail()` pode, por isso, parecer provir de qualquer endereço, o que basta para acionar os filtros dos servidores de destino (Gmail, Outlook, etc.) e comprometer a entregabilidade dos **seus próprios envios**.
 
 #### E-mails sem assinatura fiável
 
-A função `mail()` envia e-mails sem garantir a identidade do remetente. Ora os servidores de destino (Gmail, Outlook…) verificam se o e-mail provém realmente de um servidor autorizado pelo seu domínio, graças aos registos **SPF** e **DKIM**. Com `mail()`, esta verificação falha frequentemente: a mensagem corre então o risco de acabar no spam ou de ser rejeitada.
+A função `mail()` envia e-mails sem garantir a identidade do remetente. Ora os servidores de destino (Gmail, Outlook, etc.) verificam se o e-mail provém realmente de um servidor autorizado pelo seu domínio, graças aos registos **SPF** e **DKIM**. Com `mail()`, esta verificação falha frequentemente: a mensagem corre então o risco de acabar no spam ou de ser rejeitada.
 
 O envio através de SMTP autenticado resolve este problema: o e-mail é emitido pelo servidor OVHcloud autorizado para o seu domínio, com a assinatura correta.
 
 :::warning
-Uma utilização abusiva da função `mail()` pode provocar o bloqueio automático dos envios do seu alojamento. Se verificar que os seus e-mails já não são enviados, consulte o guia [Seguimento dos emails automatizados](/guides/web-cloud/web-hosting/mail-function-script-records).
+Uma utilização abusiva da função `mail()` pode provocar o bloqueio automático dos envios do seu alojamento. Se verificar que os seus e-mails já não são enviados, consulte o guia [Seguimento dos e-mails automatizados](/guides/web-cloud/web-hosting/mail-function-script-records).
 :::
 
 #### Formulários abertos: mais um vetor de abuso
@@ -65,7 +65,7 @@ A ausência de captcha num formulário de envio aberto é uma das causas mais fr
 
 #### Princípio
 
-Envie os seus e-mails através de uma ligação **SMTP autenticada** para o servidor de correio OVHcloud, utilizando uma conta de e-mail associada ao seu domínio alojado (por exemplo `contact@mydomain.ovh`).
+Envie os seus e-mails através de uma ligação **SMTP autenticada** para o servidor de correio OVHcloud, utilizando uma conta de e-mail associada ao seu domínio (por exemplo `contact@mydomain.ovh`).
 
 Esta abordagem apresenta três vantagens principais:
 
@@ -75,7 +75,7 @@ Esta abordagem apresenta três vantagens principais:
 
 #### Porque é que o campo `From:` deve pertencer ao seu domínio
 
-O campo `From:` do seu e-mail deve **obrigatoriamente** conter um endereço pertencente ao seu domínio (ex. `contact@mydomain.ovh`), e este endereço deve corresponder à conta SMTP utilizada para a autenticação.
+O campo `From:` do seu e-mail deve **obrigatoriamente** conter um endereço pertencente ao seu domínio (por exemplo `contact@mydomain.ovh`), e este endereço deve corresponder à conta SMTP utilizada para a autenticação.
 
 Se o `From:` não corresponder ao domínio autorizado no registo SPF, ou se a assinatura DKIM não corresponder, os servidores de correio de destino (Gmail, Outlook, etc.) podem rejeitar ou classificar o e-mail como spam.
 
@@ -103,14 +103,14 @@ Este comportamento é incorreto por duas razões:
 |---|---|---|
 | `From:` | `contact@mydomain.ovh` (endereço fixo do site) | Remetente autenticado — nunca muda |
 | `Reply-To:` | Endereço introduzido pelo utilizador no formulário | Permite responder diretamente ao utilizador |
-| `Subject:` | Assunto da mensagem, prefixado (ex. `[Contact] ...`) | Identifica facilmente as mensagens do formulário |
+| `Subject:` | Assunto da mensagem, prefixado (por exemplo `[Contact]`) | Identifica facilmente as mensagens do formulário |
 
 Assim, quando responde ao e-mail recebido, o seu cliente de correio envia a resposta para o endereço do utilizador através do campo `Reply-To:`, sem comprometer a autenticação SPF/DKIM.
 
 Eis como adaptar o exemplo PHPMailer para um formulário de contacto:
 
 ```php
-// User-supplied data (validate and sanitise before use)
+// Dados fornecidos pelo utilizador (validar e limpar antes de utilizar)
 $userEmail = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
 $userName  = htmlspecialchars(strip_tags($_POST['name']));
 $message   = htmlspecialchars(strip_tags($_POST['message']));
@@ -119,13 +119,13 @@ if (!$userEmail) {
     die('Invalid email address.');
 }
 
-// From: always fixed — your site's address, never the user's
+// From: sempre fixo — o endereço do seu site, nunca o do utilizador
 $mail->setFrom('contact@mydomain.ovh', 'My Website');
 
-// Reply-To: the user's address, so you can reply to them directly
+// Reply-To: o endereço do utilizador, para poder responder-lhe diretamente
 $mail->addReplyTo($userEmail, $userName);
 
-// Recipient: yourself (you receive the form message)
+// Destinatário: o próprio (recebe a mensagem do formulário)
 $mail->addAddress('contact@mydomain.ovh', 'My Website');
 
 $mail->Subject = '[Contact] ' . $userName;
@@ -149,7 +149,7 @@ Utilize os seguintes parâmetros para a sua conta de e-mail MX Plan (incluída n
 | **Porta (STARTTLS)** | `587` |
 | **Encriptação** | `SSL/TLS` (porta 465) ou `STARTTLS` (porta 587) |
 | **Autenticação** | Obrigatória |
-| **Nome de utilizador** | Endereço de e-mail completo (ex. `contact@mydomain.ovh`) |
+| **Nome de utilizador** | Endereço de e-mail completo (por exemplo `contact@mydomain.ovh`) |
 | **Palavra-passe** | Palavra-passe da conta de e-mail OVHcloud |
 
 </Region>
@@ -163,23 +163,23 @@ Utilize os seguintes parâmetros para a sua conta de e-mail MX Plan (incluída n
 | **Porta (STARTTLS)** | `587` |
 | **Encriptação** | `SSL/TLS` (porta 465) ou `STARTTLS` (porta 587) |
 | **Autenticação** | Obrigatória |
-| **Nome de utilizador** | Endereço de e-mail completo (ex. `contact@mydomain.ovh`) |
+| **Nome de utilizador** | Endereço de e-mail completo (por exemplo `contact@mydomain.ovh`) |
 | **Palavra-passe** | Palavra-passe da conta de e-mail OVHcloud |
 
 </Region>
 
 :::tip
-Para as ofertas **Email Pro** ou **Exchange**, o servidor SMTP é diferente. Consulte a documentação de cada oferta para os parâmetros exatos.
+Para as ofertas **E-mail Pro** ou **Exchange**, o servidor SMTP é diferente. Consulte a documentação de cada oferta para os parâmetros exatos.
 :::
 
 #### Onde encontrar as suas credenciais SMTP
 
-O **nome de utilizador SMTP** é o seu endereço de e-mail completo (ex. `contact@mydomain.ovh`).
+O **nome de utilizador SMTP** é o seu endereço de e-mail completo (por exemplo `contact@mydomain.ovh`).
 
 A **palavra-passe** é a definida durante a criação do endereço, ou alterada a partir da Área de Cliente OVHcloud. Se a esqueceu ou pretende reiniciá-la, consulte o guia [Alterar a palavra-passe de um endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
 :::warning
-A oferta MX Plan incluída no alojamento web está sujeita a **quotas de envio** (cerca de 200 e-mails por hora por conta). Para volumes importantes — newsletters ou e-mails transacionais em massa — privilegie uma solução dedicada (Email Pro, Exchange) ou um serviço de envio transacional terceiro.
+A oferta MX Plan incluída no alojamento web está sujeita a **quotas de envio** (cerca de 200 e-mails por hora por conta). Para volumes importantes — newsletters ou e-mails transacionais em massa — privilegie uma solução dedicada (E-mail Pro, Exchange) ou um serviço de envio transacional terceiro.
 :::
 
 #### Exemplo de código PHP com PHPMailer
@@ -203,23 +203,23 @@ require 'vendor/autoload.php';
 $mail = new PHPMailer(true);
 
 try {
-    // OVHcloud SMTP server settings
+    // Parâmetros do servidor SMTP OVHcloud
     $mail->isSMTP();
     $mail->Host       = 'ssl0.ovh.net';
     $mail->SMTPAuth   = true;
-    $mail->Username   = 'contact@mydomain.ovh'; // Your OVHcloud email address
-    $mail->Password   = 'your_password';         // Password of the email account
+    $mail->Username   = 'contact@mydomain.ovh'; // O seu endereço de e-mail OVHcloud
+    $mail->Password   = 'your_password';         // Palavra-passe da conta de e-mail
     $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // SSL/TLS
     $mail->Port       = 465;
 
-    // Sender: must belong to your hosted domain
+    // Remetente: deve pertencer ao seu domínio
     $mail->setFrom('contact@mydomain.ovh', 'My Website');
     $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
 
-    // Recipient
+    // Destinatário
     $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
 
-    // Content
+    // Conteúdo
     $mail->isHTML(true);
     $mail->Subject = 'Your email subject';
     $mail->Body    = 'Email body in <b>HTML</b>';
@@ -278,7 +278,7 @@ O [WP Mail SMTP](https://pt.wordpress.org/plugins/wp-mail-smtp/) é o plugin mai
 | Campo | Valor |
 |---|---|
 | **E-mail do remetente** | `contact@mydomain.ovh` (endereço pertencente ao seu domínio) |
-| **Nome do remetente** | Nome apresentado para o seu site (ex. `O Meu Site Web`) |
+| **Nome do remetente** | Nome apresentado para o seu site (por exemplo `O Meu Site Web`) |
 
 3. Na secção **Mailer**, selecione **Outro SMTP**.
 4. Preencha os parâmetros SMTP:
@@ -385,7 +385,7 @@ Em todos os casos, os parâmetros SMTP a utilizar são idênticos: servidor `smt
 
 ## Quer saber mais?
 
-[Seguimento dos emails automatizados](/guides/web-cloud/web-hosting/mail-function-script-records)
+[Seguimento dos e-mails automatizados](/guides/web-cloud/web-hosting/mail-function-script-records)
 
 [Melhorar a segurança dos e-mails através do registo SPF](/guides/web-cloud/domains/dns-zone-spf)
 

--- a/docs/pt/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/email-sending-best-practices.mdx
@@ -15,8 +15,8 @@ Para que os seus e-mails cheguem corretamente aos seus destinatários, a OVHclou
 
 ## Requisitos
 
-- Dispor de uma oferta de [alojamento web OVHcloud](/links/web/hosting).
-- Dispor de um endereço de e-mail associado ao seu nome de domínio (oferta MX Plan, E-mail Pro ou Exchange). Se ainda não tiver nenhum, consulte o guia [Criar um endereço de e-mail com a oferta MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
+- Dispor de uma oferta de [Alojamento web OVHcloud](/links/web/hosting).
+- Dispor de um endereço de e-mail associado ao seu nome de domínio (<Region zones={['eu']}>oferta MX Plan, E-mail Pro ou Exchange</Region><Region zones={['ca']}>oferta MX Plan ou Exchange</Region><Region zones={['apac']}>oferta MX Plan</Region>). Se ainda não tiver nenhum, consulte o guia [Criar um endereço de e-mail com a oferta MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation).
 
 {/* CP-NAV-START:web-hosting */}
 ---
@@ -120,13 +120,13 @@ if (!$userEmail) {
 }
 
 // From: sempre fixo — o endereço do seu site, nunca o do utilizador
-$mail->setFrom('contact@mydomain.ovh', 'My Website');
+$mail->setFrom('contact@mydomain.ovh', 'O Meu Site Web');
 
 // Reply-To: o endereço do utilizador, para poder responder-lhe diretamente
 $mail->addReplyTo($userEmail, $userName);
 
 // Destinatário: o próprio (recebe a mensagem do formulário)
-$mail->addAddress('contact@mydomain.ovh', 'My Website');
+$mail->addAddress('contact@mydomain.ovh', 'O Meu Site Web');
 
 $mail->Subject = '[Contact] ' . $userName;
 $mail->Body    = "Name: $userName\nEmail: $userEmail\n\nMessage:\n$message";
@@ -168,9 +168,21 @@ Utilize os seguintes parâmetros para a sua conta de e-mail MX Plan (incluída n
 
 </Region>
 
+<Region zones={['eu']}>
+
 :::tip
 Para as ofertas **E-mail Pro** ou **Exchange**, o servidor SMTP é diferente. Consulte a documentação de cada oferta para os parâmetros exatos.
 :::
+
+</Region>
+
+<Region zones={['ca']}>
+
+:::tip
+Para a oferta **Exchange**, o servidor SMTP é diferente. Consulte a documentação desta oferta para os parâmetros exatos.
+:::
+
+</Region>
 
 #### Onde encontrar as suas credenciais SMTP
 
@@ -178,9 +190,29 @@ O **nome de utilizador SMTP** é o seu endereço de e-mail completo (por exemplo
 
 A **palavra-passe** é a definida durante a criação do endereço, ou alterada a partir da Área de Cliente OVHcloud. Se a esqueceu ou pretende reiniciá-la, consulte o guia [Alterar a palavra-passe de um endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password).
 
+<Region zones={['eu']}>
+
 :::warning
 A oferta MX Plan incluída no alojamento web está sujeita a **quotas de envio** (cerca de 200 e-mails por hora por conta). Para volumes importantes — newsletters ou e-mails transacionais em massa — privilegie uma solução dedicada (E-mail Pro, Exchange) ou um serviço de envio transacional terceiro.
 :::
+
+</Region>
+
+<Region zones={['ca']}>
+
+:::warning
+A oferta MX Plan incluída no alojamento web está sujeita a **quotas de envio** (cerca de 200 e-mails por hora por conta). Para volumes importantes — newsletters ou e-mails transacionais em massa — privilegie uma solução dedicada como o Exchange ou um serviço de envio transacional terceiro.
+:::
+
+</Region>
+
+<Region zones={['apac']}>
+
+:::warning
+A oferta MX Plan incluída no alojamento web está sujeita a **quotas de envio** (cerca de 200 e-mails por hora por conta). Para volumes importantes — newsletters ou e-mails transacionais em massa — privilegie um serviço de envio transacional terceiro.
+:::
+
+</Region>
 
 #### Exemplo de código PHP com PHPMailer
 
@@ -213,8 +245,8 @@ try {
     $mail->Port       = 465;
 
     // Remetente: deve pertencer ao seu domínio
-    $mail->setFrom('contact@mydomain.ovh', 'My Website');
-    $mail->addReplyTo('contact@mydomain.ovh', 'My Website');
+    $mail->setFrom('contact@mydomain.ovh', 'O Meu Site Web');
+    $mail->addReplyTo('contact@mydomain.ovh', 'O Meu Site Web');
 
     // Destinatário
     $mail->addAddress('mary.johnson@example.com', 'Recipient Name');
@@ -393,7 +425,7 @@ Em todos os casos, os parâmetros SMTP a utilizar são idênticos: servidor `smt
 
 [Melhorar a segurança dos e-mails através do registo DMARC](/guides/web-cloud/domains/dns-zone-dmarc)
 
-Para prestações especializadas (referenciamento, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
+Para prestações especializadas (SEO, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
 
 Se pretender obter assistência na utilização e configuração das suas soluções OVHcloud, sugerimos que consulte as nossas diferentes [ofertas de suporte](/links/support).
 

--- a/docs/pt/guides/web-cloud/web-hosting/landing-page-configuration.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/landing-page-configuration.mdx
@@ -75,6 +75,7 @@ Para se orientar consoante a sua necessidade:
         { title: 'Configurar e utilizar o Git', link: '/guides/web-cloud/web-hosting/git-integration-webhosting' },
         { title: 'Criar tarefas automatizadas (CRON)', link: '/guides/web-cloud/web-hosting/cron-tasks' },
         { title: 'Acompanhar os e-mails automatizados', link: '/guides/web-cloud/web-hosting/mail-function-script-records' },
+        { title: 'Boas práticas de envio de e-mail', link: '/guides/web-cloud/web-hosting/email-sending-best-practices' },
         { title: 'Gerir uma aplicação web através da API', link: '/guides/web-cloud/web-hosting/api-webhosting' },
         { title: 'Evoluir a sua oferta', link: '/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer' },
         { title: 'Recuperar a cópia de segurança do espaço FTP (Cloud Web)', link: '/guides/web-cloud/web-hosting/backup-ftp', zones: ['eu'] },


### PR DESCRIPTION
New guide "Email sending best practices" for Web Hosting, covering authenticated SMTP vs the PHP mail() function, contact-form From/Reply-To handling, PHPMailer, and SMTP plugins for WordPress and other CMSs. Added in all 7 locales (en/fr/de/ es/it/pl/pt), registered in the sidebar and in landing-page-configuration.

Author: @GuiF008 

Commercial-zone gating (EU / CA / APAC):
The guide is availableIn [eu, ca, apac] and the SMTP server host is zone-specific, so the settings are wrapped in <Region> blocks. This impacts every place a mail server is shown:
- EU readers see ssl0.ovh.net (EU-only submission relay; ssl0.ovh.ca does not exist / NXDOMAIN).
- CA and APAC readers see smtp.mail.ovh.ca instead, since ssl0 has no CA twin.
- Affected spots: the OVHcloud SMTP settings table, the WP Mail SMTP config table, the FluentSMTP config table, and the "other CMS" summary sentence — each split into an EU block and a CA/APAC block.
- The PHPMailer code block cannot be zone-gated, so it keeps ssl0.ovh.net (EU) and a CA/APAC-only warning tells those readers to replace $mail->Host with smtp.mail.ovh.ca. Ports (465/587), encryption and auth are identical across zones.