### PR TITLE
[SK2635]-WEB-Emails-replace webmail-technology image with identification tiles

### DIFF
--- a/components/LinkCard/LinkCard.css
+++ b/components/LinkCard/LinkCard.css
@@ -20,6 +20,12 @@
   gap: 1.25rem;
 }
 
+/* Icon on top instead of beside — for three-column grids. */
+.link-card--with-icon.link-card--stacked {
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
 .link-card__content {
   display: flex;
   flex-direction: column;
@@ -65,4 +71,22 @@
   font-size: 0.9rem;
   color: var(--rp-c-text-2);
   line-height: 1.5;
+}
+
+/* Small "value to match" chip under the description. */
+.link-card__tag {
+  align-self: flex-start;
+  margin-top: 0.15rem;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: var(--rp-c-text-2);
+  background: var(--rp-c-bg-soft);
+  border: 1px solid var(--rp-c-divider);
+  border-radius: 6px;
+  padding: 0.2rem 0.55rem;
+}
+
+.link-card__tag strong {
+  color: #6696e7;
+  font-weight: 700;
 }

--- a/components/LinkCard/LinkCard.tsx
+++ b/components/LinkCard/LinkCard.tsx
@@ -20,6 +20,17 @@ interface LinkCardProps {
    */
   icon?: React.ReactNode;
   /**
+   * Stack the icon on top of the content instead of beside it. Useful for
+   * three-column grids where the beside layout gets cramped. No effect without
+   * an `icon`.
+   */
+  stacked?: boolean;
+  /**
+   * Optional small chip rendered under the description — e.g. a value to match
+   * ("Webmail: Roundcube"). Use it to turn a card into a recognizable choice.
+   */
+  tag?: React.ReactNode;
+  /**
    * The style of the link card.
    */
   style?: React.CSSProperties;
@@ -30,16 +41,26 @@ export function LinkCard({
   title,
   description,
   icon,
+  stacked,
+  tag,
   style,
 }: LinkCardProps) {
   const localizeHref = useLocalizeHref();
   const isExternal = href.startsWith('http://') || href.startsWith('https://');
   const resolvedHref = isExternal ? href : localizeHref(href);
 
+  const className = [
+    'link-card',
+    icon && 'link-card--with-icon',
+    icon && stacked && 'link-card--stacked',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <a
       href={resolvedHref}
-      className={icon ? 'link-card link-card--with-icon' : 'link-card'}
+      className={className}
       style={style}
       {...(isExternal && { target: '_blank', rel: 'noopener noreferrer' })}
     >
@@ -54,6 +75,7 @@ export function LinkCard({
           <span className="link-card__arrow">→</span>
         </h3>
         {description && <p className="link-card__description">{description}</p>}
+        {tag && <span className="link-card__tag">{tag}</span>}
       </div>
     </a>
   );

--- a/components/Panel/Panel.css
+++ b/components/Panel/Panel.css
@@ -1,0 +1,20 @@
+.doc-panel {
+  margin: 1.5rem 0;
+  padding: 1.25rem 1.4rem 1.45rem;
+  border: 1px solid var(--rp-c-divider);
+  border-radius: 12px;
+}
+
+.doc-panel > :first-child {
+  margin-top: 0;
+}
+
+.doc-panel > :last-child {
+  margin-bottom: 0;
+}
+
+/* Accent edge on the left of each tile so they read as cards without a fill.
+   Scoped to the panel so other pages' cards are untouched. */
+.doc-panel .link-card {
+  border-left: 3px solid #6696e7;
+}

--- a/components/Panel/Panel.tsx
+++ b/components/Panel/Panel.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import './Panel.css';
+
+interface PanelProps {
+  children: ReactNode;
+}
+
+/**
+ * A lightly shaded, rounded container that visually delimits a self-contained
+ * block of content (e.g. the "Identify your email technology" zone). Uses
+ * Rspress CSS variables so it adapts to the light/dark theme. Inner cards get
+ * an opaque background so they stand out against the panel's tint.
+ */
+export function Panel({ children }: PanelProps) {
+  return <section className="doc-panel">{children}</section>;
+}
+
+export default Panel;

--- a/components/Panel/index.ts
+++ b/components/Panel/index.ts
@@ -1,0 +1,1 @@
+export { Panel, Panel as default } from './Panel';

--- a/components/WebmailIcon/WebmailIcon.tsx
+++ b/components/WebmailIcon/WebmailIcon.tsx
@@ -1,0 +1,113 @@
+import type { CSSProperties } from 'react';
+
+export type Webmail = 'roundcube' | 'zimbra' | 'owa';
+
+interface WebmailIconProps {
+  /** Which MX Plan webmail technology this tile is about. */
+  name: Webmail;
+  /** Square size in px. Defaults to 34. */
+  size?: number;
+  style?: CSSProperties;
+}
+
+/**
+ * Monochrome brand glyphs for the three MX Plan webmail technologies, used by
+ * the "Identify your email technology" tiles of the troubleshooting guides.
+ * Each SVG uses `currentColor` (fill or stroke) so it inherits the surrounding
+ * color and adapts to the light/dark theme automatically — same approach as
+ * <ClientLink> and <ProblemIcon>, unlike a coloured <img> that renders in
+ * isolation.
+ *
+ * - `roundcube`: the Roundcube cube mark (Simple Icons, CC0).
+ * - `owa`: the Microsoft Outlook mark (Material Design Icons) — same glyph as
+ *   <ClientLink client="outlook" />.
+ * - `zimbra`: Zimbra has no glyph in any open icon set (Simple Icons, Iconify…),
+ *   so this is a trademark-neutral recreation of its mark — two mirrored,
+ *   interlaced speech bubbles (one lighter than the other) with a smiley in the
+ *   middle.
+ */
+export function WebmailIcon({ name, size = 34, style }: WebmailIconProps) {
+  if (name === 'roundcube') {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        aria-hidden="true"
+        focusable="false"
+        style={style}
+      >
+        <path d="M12.002.072a8.302 8.302 0 0 0-8.266 7.512L.498 9.454l4.682 2.704A7.8 7.8 0 0 1 12.002.572a7.802 7.802 0 0 1 6.824 11.582l4.676-2.7-3.236-1.87A8.302 8.302 0 0 0 12.002.072zM0 9.742v7.399l11.75 6.787v-7.399L0 9.742zm24 0l-5.777 3.338-5.248 3.031h-.002l-.108.063-.615.355v7.399L24 17.14V9.744z" />
+      </svg>
+    );
+  }
+
+  if (name === 'zimbra') {
+    // Two mirrored speech bubbles + a centred smiley. `currentColor`, with the
+    // right-hand bubble dimmed so the pair reads as interlaced in monochrome.
+    const bubble =
+      'M8.5 4.5 A5.3 4.5 0 0 1 8.5 13.5 A5.3 4.5 0 0 1 5.4 12.85 Q4.6 14.8 3.6 16.1 Q4.1 13.6 3.4 11.2 A5.3 4.5 0 0 1 8.5 4.5 Z';
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.9}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        aria-hidden="true"
+        focusable="false"
+        style={style}
+      >
+        <g vectorEffect="non-scaling-stroke">
+          <path
+            opacity={0.45}
+            transform="translate(24,0) scale(-1,1)"
+            d={bubble}
+          />
+          <path d={bubble} />
+        </g>
+        <circle
+          cx="10.75"
+          cy="8.3"
+          r="0.95"
+          fill="currentColor"
+          stroke="none"
+        />
+        <circle
+          cx="13.25"
+          cy="8.3"
+          r="0.95"
+          fill="currentColor"
+          stroke="none"
+        />
+        <path
+          d="M10.3 9.95 Q12 12.2 13.7 9.95"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.45}
+        />
+      </svg>
+    );
+  }
+
+  // owa — Microsoft Outlook (Material Design Icons), same glyph as <ClientLink>.
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      style={style}
+    >
+      <path d="M8.56 12.03q0 .38-.06.73q-.11.34-.3.62q-.2.27-.49.43q-.3.16-.71.16q-.42 0-.71-.17t-.48-.45t-.27-.63q-.09-.35-.09-.72q0-.36.09-.72q.08-.35.27-.63t.5-.45q.3-.17.72-.17q.43 0 .72.17q.3.18.48.46q.18.29.27.64q.06.36.06.73M22 12v7.81q0 .39-.27.69q-.28.25-.67.25H7.94q-.39 0-.67-.25q-.27-.3-.27-.69V17H2.83q-.33 0-.59-.24Q2 16.5 2 16.17V7.83q0-.33.24-.59Q2.5 7 2.83 7h5.42V4.13q0-.37.25-.63q.26-.25.63-.25h10.74q.37 0 .63.25q.25.26.25.63v6.91l1.04.6h.01q.08.06.14.16q.06.09.06.2m-5-6.87v2.5h2.5v-2.5M17 8.88v2.5h2.5v-2.5M17 12.63v1.52l2.54-1.52m-6.91-7.5v2.5h3.12v-2.5m-3.12 3.75v2.5h3.12v-2.5m-3.12 3.75v1.69l2.01 1.24l1.11-.66v-2.27M9.5 5.13V7h1.77q.06 0 .11.04V5.12M7 15.32q.73 0 1.32-.26q.58-.26.99-.71q.4-.45.6-1.07q.21-.62.22-1.34q0-.69-.21-1.29q-.2-.59-.6-1.03q-.39-.44-.95-.69q-.57-.25-1.29-.25q-.77 0-1.37.25q-.59.25-1 .7q-.41.46-.62 1.08q-.21.63-.21 1.37q0 .7.21 1.3q.22.59.62 1.02t.97.68q.58.24 1.32.24m1.25 4.18h10.32L12 15.4v.77q0 .33-.24.59q-.26.24-.59.24H8.25m12.5 2.39v-6.03l-4.92 2.95Z" />
+    </svg>
+  );
+}
+
+export default WebmailIcon;

--- a/components/WebmailIcon/index.ts
+++ b/components/WebmailIcon/index.ts
@@ -1,0 +1,5 @@
+export {
+  type Webmail,
+  WebmailIcon,
+  WebmailIcon as default,
+} from './WebmailIcon';

--- a/components/WebmailLookup/WebmailLookup.css
+++ b/components/WebmailLookup/WebmailLookup.css
@@ -1,0 +1,63 @@
+/* Mirrors the always-light OVHcloud Control Panel, so every colour is fixed
+   (no theme tokens): it reads as an embedded screenshot in both doc themes.
+   Colours are the Manager/ODS values — blue #0050D7, navy #000E9C. */
+.webmail-lookup {
+  max-width: 360px;
+  margin: 1.25rem auto;
+  border: 1px solid #b9c0cc;
+  border-radius: 10px;
+  background: #ffffff;
+  box-shadow: 0 2px 10px rgba(0, 14, 156, 0.1);
+  overflow: hidden;
+}
+
+.webmail-lookup__tabs {
+  padding: 0 1.1rem;
+  border-bottom: 1px solid #e4e7ec;
+}
+
+.webmail-lookup__tab {
+  display: inline-block;
+  padding: 0.7rem 0;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #0050d7;
+  border-bottom: 2px solid #0050d7;
+}
+
+.webmail-lookup__body {
+  padding: 1rem 1.1rem 1.15rem;
+}
+
+.webmail-lookup__card-title {
+  margin: 0 0 0.6rem;
+  padding-bottom: 0.55rem;
+  border-bottom: 1px solid #e4e7ec;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #000e9c;
+}
+
+.webmail-lookup__label {
+  margin: 0 0 0.3rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #000e9c;
+}
+
+/* The information to look up — highlighted like a marker pen. */
+.webmail-lookup__value {
+  display: inline-block;
+  background: #ffd88a;
+  border-radius: 3px;
+  padding: 0.12rem 0.4rem;
+}
+
+.webmail-lookup__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #0050d7;
+}

--- a/components/WebmailLookup/WebmailLookup.tsx
+++ b/components/WebmailLookup/WebmailLookup.tsx
@@ -1,0 +1,76 @@
+import { useLang } from '@rspress/core/runtime';
+import './WebmailLookup.css';
+
+// Exact Control Panel strings (source: Manager `emailpro` dashboard
+// translations). Falls back to English.
+const TAB_LABEL: Record<string, string> = {
+  fr: 'Informations générales',
+  en: 'General information',
+  de: 'Allgemeine Informationen',
+  es: 'Información general',
+  it: 'Informazioni generali',
+  pl: 'Informacje ogólne',
+  pt: 'Informações gerais',
+};
+
+const CONNEXION_LABEL: Record<string, string> = {
+  fr: 'Connexion',
+  en: 'Connection',
+  de: 'Verbindung',
+  es: 'Conexión',
+  it: 'Connessione',
+  pl: 'Logowanie',
+  pt: 'Ligação',
+};
+
+/**
+ * Reproduction of the Control Panel's "General information" tab + "Connexion"
+ * card, where the webmail technology is read. Uses the Manager's real strings
+ * (localized) and colours (ODS blue #0050D7, navy #000E9C). Deliberately
+ * rendered with a fixed light palette — like the always-light Control Panel it
+ * mirrors — so it reads as an embedded screenshot in both doc themes. The
+ * Webmail value is highlighted to point at the information to look up.
+ */
+export function WebmailLookup() {
+  const lang = useLang();
+  const tab = TAB_LABEL[lang] ?? TAB_LABEL.en;
+  const connexion = CONNEXION_LABEL[lang] ?? CONNEXION_LABEL.en;
+  return (
+    <div
+      className="webmail-lookup"
+      role="img"
+      aria-label={`${tab} — ${connexion} — Webmail`}
+    >
+      <div className="webmail-lookup__tabs">
+        <span className="webmail-lookup__tab">{tab}</span>
+      </div>
+      <div className="webmail-lookup__body">
+        <p className="webmail-lookup__card-title">{connexion}</p>
+        <p className="webmail-lookup__label">Webmail</p>
+        <span className="webmail-lookup__value">
+          <span className="webmail-lookup__link">
+            Zimbra
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path d="M14 4h6v6" />
+              <path d="M20 4 11 13" />
+              <path d="M18 13v5a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h5" />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default WebmailLookup;

--- a/components/WebmailLookup/index.ts
+++ b/components/WebmailLookup/index.ts
@@ -1,0 +1,1 @@
+export { WebmailLookup, WebmailLookup as default } from './WebmailLookup';

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Ziel
 
@@ -78,21 +82,25 @@ Sie möchten:
 
 <a name="whichmxplan"></a>
 
-**Identifizierung der E-Mail-Technologie Ihres MX Plan Angebots**
-
 <Region zones={['eu']}>
 
-Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
+<Panel>
 
-- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
-- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
-- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+**Identifizierung der E-Mail-Technologie Ihres MX Plan Angebots**
 
 Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
 
-Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Das klassische Webmail, leichtgewichtig und einfach zu bedienen." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Das Webmail auf Basis der Microsoft Exchange-Technologie." />
+</CardGrid>
+
+</Panel>
+
+Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
 
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Ziel
 
@@ -91,21 +95,25 @@ Aus Sicherheitsgründen empfehlen wir, Passwörter nicht mehrfach zu verwenden, 
 
 <a name="whichmxplan"></a>
 
-**E-Mail-Technologie Ihres MX Plan Angebots identifizieren**
-
 <Region zones={['eu']}>
 
-Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
+<Panel>
 
-- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
-- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
-- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+**E-Mail-Technologie Ihres MX Plan Angebots identifizieren**
 
 Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
 
-Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Das klassische Webmail, leichtgewichtig und einfach zu bedienen." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Das Webmail auf Basis der Microsoft Exchange-Technologie." />
+</CardGrid>
+
+</Panel>
+
+Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
 
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Ziel
 
@@ -54,21 +58,25 @@ Sie haben gerade eine MX Plan E-Mail-Lösung erworben. Diese bietet Ihnen E-Mail
 
 **Fahren Sie mit der von Ihrem MX Plan Dienst verwendeten E-Mail Technologie fort**.
 
-**E-Mail-Technologie Ihres MX Plan Angebots identifizieren**
-
 <Region zones={['eu']}>
 
-Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
+<Panel>
 
-- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
-- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
-- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+**E-Mail-Technologie Ihres MX Plan Angebots identifizieren**
 
 Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
 
-Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Das klassische Webmail, leichtgewichtig und einfach zu bedienen." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Das Webmail auf Basis der Microsoft Exchange-Technologie." />
+</CardGrid>
+
+</Panel>
+
+Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
 
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { ZoneTabs, Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Ziel
 
@@ -52,21 +56,25 @@ Bei MX Plan ist es nicht möglich, von einer E-Mail-Technologie zu einer anderen
 
 **Fahren Sie mit der von Ihrem MX Plan Dienst verwendeten E-Mail Technologie fort.**
 
-**E-Mail-Technologie Ihres MX Plan Angebots identifizieren**
-
 <Region zones={['eu']}>
 
-Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
+<Panel>
 
-- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
-- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
-- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+**E-Mail-Technologie Ihres MX Plan Angebots identifizieren**
 
 Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
 
-Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Das klassische Webmail, leichtgewichtig und einfach zu bedienen." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Das Webmail auf Basis der Microsoft Exchange-Technologie." />
+</CardGrid>
+
+</Panel>
+
+Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
 
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -5,6 +5,10 @@ availableIn: [eu]
 ---
 
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Ziel
 
@@ -18,21 +22,25 @@ Mit der OVHcloud MX Plan Lösung können Sie E-Mails über eine Drittanbieter-So
 - Sie verfügen über die Logindaten der MX Plan E-Mail-Adresse, die Sie verwenden möchten. Weitere Informationen finden Sie in unserer Anleitung [Erste Schritte mit der MX Plan Lösung](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Ihre OVHcloud E-Mail-Lösung **MX Plan** muss die Webmail-Technologie **Roundcube** verwenden. Folgen Sie den nachstehenden Anweisungen, um dies zu identifizieren.
 
-**Die E-Mail-Technologie Ihres MX Plan-Angebots ermitteln**
-
 <Region zones={['eu']}>
 
-Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
+<Panel>
 
-- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
-- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
-- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+**Die E-Mail-Technologie Ihres MX Plan-Angebots ermitteln**
 
 Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
 
-Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Das klassische Webmail, leichtgewichtig und einfach zu bedienen." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Das Webmail auf Basis der Microsoft Exchange-Technologie." />
+</CardGrid>
+
+</Panel>
+
+Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
 
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## E-Mail FAQ
 
@@ -105,15 +109,19 @@ Im Folgenden finden Sie eine Tabelle mit einer Zusammenfassung der wichtigsten E
 
 <Region zones={['eu']}>
 
-Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
-
-- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
-- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
-- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+<Panel>
 
 Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
 
-<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Das klassische Webmail, leichtgewichtig und einfach zu bedienen." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Das Webmail auf Basis der Microsoft Exchange-Technologie." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -29,6 +29,9 @@ import { LinkCard } from '@components/LinkCard';
 import { OsIcon } from '@components/OsIcon';
 import { ClientLink } from '@components/ClientLink';
 import { Region } from '@components/Zone';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Was ist MX Plan?
 
@@ -54,21 +57,19 @@ Mit einem MX Plan-Angebot können Sie:
 
 <Region zones={['eu']}>
 
-Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
-
-- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
-- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
-- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+<Panel>
 
 Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
 
-<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
 
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Webmail Roundcube" description="Rufen Sie Ihre E-Mails über die Roundcube-Webmail-Oberfläche ab." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Webmail Zimbra" description="Rufen Sie Ihre E-Mails über die Zimbra-Webmail-Oberfläche ab." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Nutzen Sie Ihre E-Mail-Adresse über das Outlook Web App Webmail." />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Das klassische Webmail, leichtgewichtig und einfach zu bedienen." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Das Webmail auf Basis der Microsoft Exchange-Technologie." />
 </CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Ziel
 
@@ -75,21 +79,25 @@ Jeder OVHcloud E-Mail-Account verfügt über einen dedizierten Speicherplatz. Ei
 :::
 
 
-**E-Mail-Technologie Ihres MX Plan Angebots identifizieren**
-
 <Region zones={['eu']}>
 
-Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
+<Panel>
 
-- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
-- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
-- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+**E-Mail-Technologie Ihres MX Plan Angebots identifizieren**
 
 Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
 
-Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Das klassische Webmail, leichtgewichtig und einfach zu bedienen." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Das Webmail auf Basis der Microsoft Exchange-Technologie." />
+</CardGrid>
+
+</Panel>
+
+Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
 
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -9,6 +9,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 
 ## Ziel
@@ -66,21 +70,25 @@ Für die Lösungen **Zimbra Starter** und **Zimbra Pro** wechseln Sie direkt zum
 
 </Region>
 
-**Identifizieren Sie die E-Mail-Technologie Ihrer MX Plan Lösung**
-
 <Region zones={['eu']}>
 
-Je nach Angebot (und einer eventuellen Migration) basiert Ihr MX Plan E-Mail-Dienst auf einer dieser drei Webmail-Technologien, mit jeweils unterschiedlicher Oberfläche und Funktionen:
+<Panel>
 
-- **Roundcube**: das klassische Webmail, leichtgewichtig und einfach zu bedienen.
-- **Zimbra**: ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen.
-- **Outlook Web App (OWA)**: das Webmail auf Basis der Microsoft Exchange-Technologie.
+**Identifizieren Sie die E-Mail-Technologie Ihrer MX Plan Lösung**
 
 Um die Technologie Ihres Dienstes zu ermitteln, melden Sie sich in Ihrem OVHcloud Kundencenter an und gehen Sie zum Tab **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie finden die Information unter **Webmail**.
 
-Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan-Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Das klassische Webmail, leichtgewichtig und einfach zu bedienen." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Das Webmail auf Basis der Microsoft Exchange-Technologie." />
+</CardGrid>
+
+</Panel>
+
+Unabhängig von der Technologie kann die Anmeldung beim Webmail eine zweifache Anmeldung erfordern: zunächst auf der Webmail-Anmeldeseite und anschließend im Anmeldefenster der jeweiligen Technologie (Roundcube, Zimbra oder OWA).
 
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
@@ -25,6 +25,10 @@ cta:
 
 import { WebmailOffers } from '@components/WebmailOffers';
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Was ist ein Webmail?
 
@@ -68,15 +72,19 @@ In Ihrer Zone basieren die OVHcloud E-Mail-Angebote auf dem Webmail **Outlook We
 
 ## Welches Webmail für Ihr MX Plan Angebot?
 
-Bei einem **MX Plan** Angebot basiert Ihr Postfach — je nach Angebot und eventueller Migration — auf einer dieser drei Webmail-Technologien:
-
-- **Outlook Web App (OWA)**: das auf der Microsoft Exchange-Technologie basierende Webmail.
-- **Zimbra**: ein modernes kollaboratives Webmail mit geteiltem Kalender, Kontakten und Aufgaben.
-- **Roundcube**: das historische, leichtgewichtige und einfach zu bedienende Webmail.
+<Panel>
 
 Um die Technologie Ihres Dienstes zu ermitteln, rufen Sie Ihr OVHcloud Kundencenter auf, im Reiter **Allgemeine Informationen** Ihres E-Mail-Dienstes: Sie wird unter **Webmail** angezeigt.
 
-<img className="thumbnail" alt="Die Webmail-Technologie Ihres MX Plan Angebots im OVHcloud Kundencenter ermitteln" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Das klassische Webmail, leichtgewichtig und einfach zu bedienen." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Ein modernes kollaboratives Webmail mit gemeinsamen Kalender-, Kontakt- und Aufgabenfunktionen." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Das Webmail auf Basis der Microsoft Exchange-Technologie." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objective
 
@@ -78,21 +82,25 @@ You want to:
 
 <a name="whichmxplan"></a>
 
-**Identifying the email technology of your MX Plan solution**
-
 <Region zones={['eu']}>
 
-Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
+<Panel>
 
-- **Roundcube**: the original webmail, lightweight and easy to use.
-- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
-- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
+**Identifying the email technology of your MX Plan solution**
 
 To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
 
-Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="The original webmail, lightweight and easy to use." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="A modern collaborative webmail, with shared calendar, contacts and tasks." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="The webmail based on Microsoft Exchange technology." />
+</CardGrid>
+
+</Panel>
+
+Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objective
 
@@ -92,21 +96,25 @@ For security reasons, we recommend not using the same password twice, and choosi
 
 <a name="whichmxplan"></a>
 
-**Identify the email technology for your MX Plan solution**
-
 <Region zones={['eu']}>
 
-Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
+<Panel>
 
-- **Roundcube**: the original webmail, lightweight and easy to use.
-- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
-- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
+**Identify the email technology for your MX Plan solution**
 
 To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
 
-Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="The original webmail, lightweight and easy to use." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="A modern collaborative webmail, with shared calendar, contacts and tasks." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="The webmail based on Microsoft Exchange technology." />
+</CardGrid>
+
+</Panel>
+
+Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objective
 
@@ -54,21 +58,25 @@ You have just purchased an MX Plan email solution. It allows you to benefit from
 
 **Continue with the email technology used by your MX Plan service**.
 
-**Identify the email technology for your MX Plan solution**
-
 <Region zones={['eu']}>
 
-Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
+<Panel>
 
-- **Roundcube**: the original webmail, lightweight and easy to use.
-- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
-- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
+**Identify the email technology for your MX Plan solution**
 
 To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
 
-Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="The original webmail, lightweight and easy to use." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="A modern collaborative webmail, with shared calendar, contacts and tasks." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="The webmail based on Microsoft Exchange technology." />
+</CardGrid>
+
+</Panel>
+
+Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { ZoneTabs, Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objective
 
@@ -52,21 +56,25 @@ On MX Plan, it is not possible to switch from one email technology to another (f
 
 **Continue with the email technology used by your MX Plan service**.
 
-**Identify the email technology for your MX Plan solution**
-
 <Region zones={['eu']}>
 
-Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
+<Panel>
 
-- **Roundcube**: the original webmail, lightweight and easy to use.
-- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
-- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
+**Identify the email technology for your MX Plan solution**
 
 To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
 
-Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="The original webmail, lightweight and easy to use." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="A modern collaborative webmail, with shared calendar, contacts and tasks." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="The webmail based on Microsoft Exchange technology." />
+</CardGrid>
+
+</Panel>
+
+Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -6,6 +6,10 @@ availableIn: [eu]
 
 
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objective
 
@@ -19,21 +23,25 @@ With the OVHcloud MX Plan solution, you can send and receive emails from third-p
 - Access to the login details for the MX Plan email address you want to consult. For more information, see our guide [Getting started with the MX Plan solution](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Your OVHcloud **MX Plan** email solution must use the **Roundcube** webmail technology. To identify it, follow the instructions below.
 
-**Identify the email technology of your MX Plan offer**
-
 <Region zones={['eu']}>
 
-Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
+<Panel>
 
-- **Roundcube**: the original webmail, lightweight and easy to use.
-- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
-- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
+**Identify the email technology of your MX Plan offer**
 
 To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
 
-Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="The original webmail, lightweight and easy to use." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="A modern collaborative webmail, with shared calendar, contacts and tasks." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="The webmail based on Microsoft Exchange technology." />
+</CardGrid>
+
+</Panel>
+
+Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Email FAQ
 
@@ -105,15 +109,19 @@ Below is a summary table of key email features, sorted by technology and configu
 
 <Region zones={['eu']}>
 
-Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
-
-- **Roundcube**: the original webmail, lightweight and easy to use.
-- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
-- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
+<Panel>
 
 To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
 
-<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="The original webmail, lightweight and easy to use." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="A modern collaborative webmail, with shared calendar, contacts and tasks." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="The webmail based on Microsoft Exchange technology." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -29,6 +29,9 @@ import { LinkCard } from '@components/LinkCard';
 import { OsIcon } from '@components/OsIcon';
 import { ClientLink } from '@components/ClientLink';
 import { Region } from '@components/Zone';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## What is MX Plan?
 
@@ -54,21 +57,19 @@ With an MX Plan offer, you can:
 
 <Region zones={['eu']}>
 
-Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
-
-- **Roundcube**: the original webmail, lightweight and easy to use.
-- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
-- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
+<Panel>
 
 To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
 
-<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
 
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube webmail" description="Access your email from the Roundcube webmail interface." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra webmail" description="Access your email from the Zimbra webmail interface." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Use your email address from the Outlook Web App webmail." />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="The original webmail, lightweight and easy to use." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="A modern collaborative webmail, with shared calendar, contacts and tasks." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="The webmail based on Microsoft Exchange technology." />
 </CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objective
 
@@ -75,21 +79,25 @@ Every OVHcloud email account has a dedicated storage space. By managing your sto
 :::
 
 
-**Identify the email technology for your MX Plan solution**
-
 <Region zones={['eu']}>
 
-Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
+<Panel>
 
-- **Roundcube**: the original webmail, lightweight and easy to use.
-- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
-- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
+**Identify the email technology for your MX Plan solution**
 
 To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
 
-Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="The original webmail, lightweight and easy to use." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="A modern collaborative webmail, with shared calendar, contacts and tasks." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="The webmail based on Microsoft Exchange technology." />
+</CardGrid>
+
+</Panel>
+
+Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -9,6 +9,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 
 ## Objective
@@ -66,21 +70,25 @@ For **Zimbra Starter** and **Zimbra Pro** solutions, go directly to the **Zimbra
 
 </Region>
 
-**Identify the email technology of your MX Plan solution**
-
 <Region zones={['eu']}>
 
-Depending on your offer (and any migration it may have undergone), your MX Plan email service is based on one of these three webmail technologies, each with a different interface and features:
+<Panel>
 
-- **Roundcube**: the original webmail, lightweight and easy to use.
-- **Zimbra**: a modern collaborative webmail, with shared calendar, contacts and tasks.
-- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
+**Identify the email technology of your MX Plan solution**
 
 To identify your service's technology, log in to your OVHcloud Control Panel, go to the **General information** tab of your email service: it is shown under **Webmail**.
 
-Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identify the webmail technology of your MX Plan offer in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="The original webmail, lightweight and easy to use." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="A modern collaborative webmail, with shared calendar, contacts and tasks." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="The webmail based on Microsoft Exchange technology." />
+</CardGrid>
+
+</Panel>
+
+Whatever the technology, signing in to the webmail may require a two-step sign-in: first on the webmail login page, then on the login window specific to your technology (Roundcube, Zimbra or OWA).
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
@@ -25,6 +25,10 @@ cta:
 
 import { WebmailOffers } from '@components/WebmailOffers';
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## What is a webmail?
 
@@ -78,15 +82,19 @@ In your region, OVHcloud email plans rely on the [Outlook Web App (OWA)](/guides
 
 ## Which webmail for your MX Plan solution?
 
-With an **MX Plan** solution, your mailbox runs — depending on your plan and any migration it may have undergone — on one of these three webmail technologies:
-
-- **Outlook Web App (OWA)**: the webmail based on Microsoft Exchange technology.
-- **Zimbra**: a modern collaborative webmail with shared calendar, contacts and tasks.
-- **Roundcube**: the original webmail, lightweight and easy to use.
+<Panel>
 
 To identify the technology used by your service, go to your OVHcloud Control Panel, in the **General information** tab of your email service: it is shown under **Webmail**.
 
-<img className="thumbnail" alt="Identifying your MX Plan webmail technology in the OVHcloud Control Panel" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="The original webmail, lightweight and easy to use." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="A modern collaborative webmail, with shared calendar, contacts and tasks." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="The webmail based on Microsoft Exchange technology." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objetivo
 
@@ -78,21 +82,25 @@ Quiere:
 
 <a name="whichmxplan"></a>
 
-**Identificar la tecnología de correo de su solución MX Plan**
-
 <Region zones={['eu']}>
 
-Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: el webmail original, ligero y fácil de usar.
-- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
-- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
+**Identificar la tecnología de correo de su solución MX Plan**
 
 Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
 
-Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="El webmail original, ligero y fácil de usar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail colaborativo moderno, con calendario, contactos y tareas compartidos." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="El webmail basado en la tecnología Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objetivo
 
@@ -91,21 +95,25 @@ Por motivos de seguridad, le recomendamos que no utilice dos veces la misma cont
 
 <a name="whichmxplan"></a>
 
-**Identificar la tecnología de correo electrónico de su solución MX Plan**
-
 <Region zones={['eu']}>
 
-Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: el webmail original, ligero y fácil de usar.
-- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
-- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
+**Identificar la tecnología de correo electrónico de su solución MX Plan**
 
 Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
 
-Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="El webmail original, ligero y fácil de usar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail colaborativo moderno, con calendario, contactos y tareas compartidos." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="El webmail basado en la tecnología Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objetivo
 
@@ -54,21 +58,25 @@ La solución MX Plan le permite disfrutar de direcciones de correo asociadas a u
 
 **Prosiga con la tecnología de correo electrónico que utiliza su servicio MX Plan**.
 
-**Identificar la tecnología de correo electrónico de su solución MX Plan**
-
 <Region zones={['eu']}>
 
-Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: el webmail original, ligero y fácil de usar.
-- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
-- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
+**Identificar la tecnología de correo electrónico de su solución MX Plan**
 
 Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
 
-Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="El webmail original, ligero y fácil de usar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail colaborativo moderno, con calendario, contactos y tareas compartidos." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="El webmail basado en la tecnología Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { ZoneTabs, Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objetivo
 
@@ -52,21 +56,25 @@ En MX Plan no es posible cambiar de una tecnología de correo a otra (por ejempl
 
 **Prosiga con la tecnología de correo electrónico que utiliza su servicio MX Plan**.
 
-**Identificar la tecnología de correo electrónico de su solución MX Plan**
-
 <Region zones={['eu']}>
 
-Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: el webmail original, ligero y fácil de usar.
-- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
-- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
+**Identificar la tecnología de correo electrónico de su solución MX Plan**
 
 Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
 
-Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="El webmail original, ligero y fácil de usar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail colaborativo moderno, con calendario, contactos y tareas compartidos." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="El webmail basado en la tecnología Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -5,6 +5,10 @@ availableIn: [eu]
 ---
 
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objetivo
 
@@ -18,21 +22,25 @@ Con la solución MX Plan de OVHcloud, puede enviar y recibir correos electrónic
 - Disponer de los datos de conexión a la dirección de correo electrónico MX Plan que desea consultar. Para más información, consulte nuestra guía [Primeros pasos con la solución MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Su solución de correo electrónico **MX Plan** de OVHcloud debe utilizar la tecnología de webmail **Roundcube**. Para identificarla, siga las siguientes instrucciones.
 
-**Identificar la tecnología de correo electrónico de su solución MX Plan**
-
 <Region zones={['eu']}>
 
-Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: el webmail original, ligero y fácil de usar.
-- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
-- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
+**Identificar la tecnología de correo electrónico de su solución MX Plan**
 
 Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
 
-Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="El webmail original, ligero y fácil de usar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail colaborativo moderno, con calendario, contactos y tareas compartidos." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="El webmail basado en la tecnología Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## FAQ e-mail
 
@@ -106,15 +110,19 @@ A continuación, se ofrece un resumen de las principales funcionalidades de corr
 
 <Region zones={['eu']}>
 
-Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
-
-- **Roundcube**: el webmail original, ligero y fácil de usar.
-- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
-- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
+<Panel>
 
 Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
 
-<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="El webmail original, ligero y fácil de usar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail colaborativo moderno, con calendario, contactos y tareas compartidos." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="El webmail basado en la tecnología Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -29,6 +29,9 @@ import { LinkCard } from '@components/LinkCard';
 import { OsIcon } from '@components/OsIcon';
 import { ClientLink } from '@components/ClientLink';
 import { Region } from '@components/Zone';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## ¿Qué es MX Plan?
 
@@ -54,21 +57,19 @@ Con una solución MX Plan, puede:
 
 <Region zones={['eu']}>
 
-Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
-
-- **Roundcube**: el webmail original, ligero y fácil de usar.
-- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
-- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
+<Panel>
 
 Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
 
-<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
 
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Webmail Roundcube" description="Consulte su correo desde la interfaz webmail Roundcube." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Webmail Zimbra" description="Consulte su correo desde la interfaz webmail Zimbra." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Utilice su dirección de correo electrónico desde el webmail Outlook Web App." />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="El webmail original, ligero y fácil de usar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail colaborativo moderno, con calendario, contactos y tareas compartidos." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="El webmail basado en la tecnología Microsoft Exchange." />
 </CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objetivo
 
@@ -75,21 +79,25 @@ Cada cuenta de correo de OVHcloud dispone de un espacio de almacenamiento dedica
 :::
 
 
-**Identificar la tecnología de correo electrónico de su solución MX Plan**
-
 <Region zones={['eu']}>
 
-Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: el webmail original, ligero y fácil de usar.
-- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
-- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
+**Identificar la tecnología de correo electrónico de su solución MX Plan**
 
 Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
 
-Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="El webmail original, ligero y fácil de usar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail colaborativo moderno, con calendario, contactos y tareas compartidos." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="El webmail basado en la tecnología Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -9,6 +9,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 
 ## Objetivo
@@ -66,21 +70,25 @@ Para los planes **Zimbra Starter** y **Zimbra Pro**, vaya directamente a la pest
 
 </Region>
 
-**Identificar la tecnología de correo electrónico de su plan MX Plan.**
-
 <Region zones={['eu']}>
 
-Según su solución (y su posible migración), su servicio de correo electrónico MX Plan se basa en una de estas tres tecnologías de webmail, con interfaces y funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: el webmail original, ligero y fácil de usar.
-- **Zimbra**: un webmail colaborativo moderno, con calendario, contactos y tareas compartidos.
-- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
+**Identificar la tecnología de correo electrónico de su plan MX Plan.**
 
 Para identificar la tecnología de su servicio, acceda a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo electrónico: aparece bajo **Webmail**.
 
-Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar la tecnología de webmail de su solución MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="El webmail original, ligero y fácil de usar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail colaborativo moderno, con calendario, contactos y tareas compartidos." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="El webmail basado en la tecnología Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Sea cual sea la tecnología, la conexión al webmail puede requerir una doble identificación: primero en la página de inicio de sesión del webmail y, después, en la ventana de conexión propia de la tecnología (Roundcube, Zimbra u OWA).
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
@@ -25,6 +25,10 @@ cta:
 
 import { WebmailOffers } from '@components/WebmailOffers';
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## ¿Qué es un webmail?
 
@@ -68,15 +72,19 @@ En su zona, las ofertas de correo de OVHcloud se basan en el webmail **Outlook W
 
 ## ¿Qué webmail para su oferta MX Plan?
 
-Con una solución **MX Plan**, su mensajería se basa —según su oferta y su posible migración— en una de estas tres tecnologías de webmail:
-
-- **Outlook Web App (OWA)**: el webmail basado en la tecnología Microsoft Exchange.
-- **Zimbra**: un webmail colaborativo moderno con calendario, contactos y tareas compartidos.
-- **Roundcube**: el webmail histórico, ligero y fácil de usar.
+<Panel>
 
 Para identificar la tecnología de su servicio, vaya a su área de cliente de OVHcloud, en la pestaña **Información general** de su servicio de correo: aparece indicada en **Webmail**.
 
-<img className="thumbnail" alt="Identificar la tecnología de webmail de su oferta MX Plan en el área de cliente de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="El webmail original, ligero y fácil de usar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail colaborativo moderno, con calendario, contactos y tareas compartidos." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="El webmail basado en la tecnología Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objectif
 
@@ -78,21 +82,25 @@ Vous souhaitez :
 
 <a name="whichmxplan"></a>
 
-**Identifier la technologie e-mail de votre offre MX Plan**
-
 <Region zones={['eu']}>
 
-Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
+<Panel>
 
-- **Roundcube** : le webmail historique, léger et simple d'utilisation.
-- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
-- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
+**Identifier la technologie e-mail de votre offre MX Plan**
 
 Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
-Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Le webmail historique, léger et simple d'utilisation." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail collaboratif moderne, avec agenda, contacts et tâches partagés." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Le webmail basé sur la technologie Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -88,7 +88,7 @@ Vous souhaitez :
 
 **Identifier la technologie e-mail de votre offre MX Plan**
 
-Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
 <WebmailLookup />
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -102,7 +102,7 @@ Pour des raisons de sécurité, nous vous recommandons de ne pas utiliser deux f
 
 **Identifier la technologie e-mail de votre offre MX Plan**
 
-Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
 <WebmailLookup />
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objectif
 
@@ -92,21 +96,25 @@ Pour des raisons de sécurité, nous vous recommandons de ne pas utiliser deux f
 
 <a name="whichmxplan"></a>
 
-**Identifier la technologie e-mail de votre offre MX Plan**
-
 <Region zones={['eu']}>
 
-Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
+<Panel>
 
-- **Roundcube** : le webmail historique, léger et simple d'utilisation.
-- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
-- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
+**Identifier la technologie e-mail de votre offre MX Plan**
 
 Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
-Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Le webmail historique, léger et simple d'utilisation." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail collaboratif moderne, avec agenda, contacts et tâches partagés." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Le webmail basé sur la technologie Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -64,7 +64,7 @@ Vous venez d'acquérir une solution e-mail MX Plan. Celle-ci vous permet de bén
 
 **Identifier la technologie e-mail de votre offre MX Plan**
 
-Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
 <WebmailLookup />
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objectif
 
@@ -54,21 +58,25 @@ Vous venez d'acquérir une solution e-mail MX Plan. Celle-ci vous permet de bén
 
 **Poursuivez selon la technologie e-mail utilisée par votre service MX Plan**.
 
-**Identifier la technologie e-mail de votre offre MX Plan**
-
 <Region zones={['eu']}>
 
-Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
+<Panel>
 
-- **Roundcube** : le webmail historique, léger et simple d'utilisation.
-- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
-- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
+**Identifier la technologie e-mail de votre offre MX Plan**
 
 Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
-Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Le webmail historique, léger et simple d'utilisation." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail collaboratif moderne, avec agenda, contacts et tâches partagés." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Le webmail basé sur la technologie Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { ZoneTabs, Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objectif
 
@@ -52,21 +56,25 @@ Sur MX Plan, il n'est pas possible de passer d'une technologie e-mail à une aut
 
 **Poursuivez selon la technologie e-mail utilisée par votre service MX Plan**.
 
-**Identifier la technologie e-mail de votre offre MX Plan**
-
 <Region zones={['eu']}>
 
-Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
+<Panel>
 
-- **Roundcube** : le webmail historique, léger et simple d'utilisation.
-- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
-- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
+**Identifier la technologie e-mail de votre offre MX Plan**
 
 Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
-Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Le webmail historique, léger et simple d'utilisation." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail collaboratif moderne, avec agenda, contacts et tâches partagés." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Le webmail basé sur la technologie Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -62,7 +62,7 @@ Sur MX Plan, il n'est pas possible de passer d'une technologie e-mail à une aut
 
 **Identifier la technologie e-mail de votre offre MX Plan**
 
-Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
 <WebmailLookup />
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -28,7 +28,7 @@ Avec l'offre MX Plan OVHcloud, vous pouvez envoyer et recevoir des e-mails depui
 
 **Identifier la technologie e-mail de votre offre MX Plan**
 
-Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
 <WebmailLookup />
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -5,6 +5,10 @@ availableIn: [eu]
 ---
 
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objectif
 
@@ -18,21 +22,25 @@ Avec l'offre MX Plan OVHcloud, vous pouvez envoyer et recevoir des e-mails depui
 - Disposer des informations de connexion à l'adresse e-mail MX Plan que vous souhaitez consulter. Pour plus d'informations, consultez notre guide [Premiers pas avec l'offre MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Votre solution e-mail OVHcloud **MX Plan** doit utiliser la technologie webmail **Roundcube**. Pour l'identifier, suivez les instructions ci-dessous.
 
-**Identifier la technologie e-mail de votre offre MX Plan**
-
 <Region zones={['eu']}>
 
-Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
+<Panel>
 
-- **Roundcube** : le webmail historique, léger et simple d'utilisation.
-- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
-- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
+**Identifier la technologie e-mail de votre offre MX Plan**
 
 Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
-Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Le webmail historique, léger et simple d'utilisation." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail collaboratif moderne, avec agenda, contacts et tâches partagés." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Le webmail basé sur la technologie Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## FAQ e-mail
 
@@ -106,15 +110,19 @@ Ci-dessous, vous trouverez un tableau récapitulatif des principales fonctionnal
 
 <Region zones={['eu']}>
 
-Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
-
-- **Roundcube** : le webmail historique, léger et simple d'utilisation.
-- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
-- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
+<Panel>
 
 Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
-<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Le webmail historique, léger et simple d'utilisation." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail collaboratif moderne, avec agenda, contacts et tâches partagés." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Le webmail basé sur la technologie Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -112,7 +112,7 @@ Ci-dessous, vous trouverez un tableau récapitulatif des principales fonctionnal
 
 <Panel>
 
-Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
 <WebmailLookup />
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -29,6 +29,9 @@ import { LinkCard } from '@components/LinkCard';
 import { OsIcon } from '@components/OsIcon';
 import { ClientLink } from '@components/ClientLink';
 import { Region } from '@components/Zone';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Qu'est-ce que l'offre MX Plan ?
 
@@ -54,21 +57,19 @@ Avec une offre MX Plan, vous pouvez :
 
 <Region zones={['eu']}>
 
-Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
-
-- **Roundcube** : le webmail historique, léger et simple d'utilisation.
-- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
-- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
+<Panel>
 
 Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
-<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
 
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Webmail Roundcube" description="Consultez votre messagerie depuis l'interface webmail Roundcube." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Webmail Zimbra" description="Consultez votre messagerie depuis l'interface webmail Zimbra." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Utilisez votre adresse e-mail depuis le webmail Outlook Web App." />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Le webmail historique, léger et simple d'utilisation." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail collaboratif moderne, avec agenda, contacts et tâches partagés." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Le webmail basé sur la technologie Microsoft Exchange." />
 </CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -85,7 +85,7 @@ Chaque compte e-mail OVHcloud dispose d'un espace de stockage dédié. Bien gér
 
 **Identifier la technologie e-mail de votre offre MX Plan**
 
-Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
+Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
 <WebmailLookup />
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objectif
 
@@ -75,21 +79,25 @@ Chaque compte e-mail OVHcloud dispose d'un espace de stockage dédié. Bien gér
 :::
 
 
-**Identifier la technologie e-mail de votre offre MX Plan**
-
 <Region zones={['eu']}>
 
-Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
+<Panel>
 
-- **Roundcube** : le webmail historique, léger et simple d'utilisation.
-- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
-- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
+**Identifier la technologie e-mail de votre offre MX Plan**
 
 Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
-Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Le webmail historique, léger et simple d'utilisation." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail collaboratif moderne, avec agenda, contacts et tâches partagés." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Le webmail basé sur la technologie Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -9,6 +9,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 
 ## Objectif
@@ -66,21 +70,25 @@ Pour les offres **Zimbra Starter** et **Zimbra Pro**, rendez-vous directement à
 
 </Region>
 
-**Identifier la technologie e-mail de votre offre MX Plan**
-
 <Region zones={['eu']}>
 
-Selon votre offre (et son éventuelle migration), votre messagerie MX Plan repose sur l'une de ces trois technologies de webmail, aux interfaces et fonctionnalités différentes :
+<Panel>
 
-- **Roundcube** : le webmail historique, léger et simple d'utilisation.
-- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
-- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
+**Identifier la technologie e-mail de votre offre MX Plan**
 
 Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
-Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Le webmail historique, léger et simple d'utilisation." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail collaboratif moderne, avec agenda, contacts et tâches partagés." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Le webmail basé sur la technologie Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Quelle que soit la technologie, la connexion au webmail peut nécessiter une **double identification** : une première fois sur la page de connexion au webmail, puis une seconde fois dans la fenêtre de connexion propre à la technologie (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
@@ -25,6 +25,10 @@ cta:
 
 import { Region } from '@components/Zone';
 import { WebmailOffers } from '@components/WebmailOffers';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Qu'est-ce qu'un webmail ?
 
@@ -78,15 +82,19 @@ Dans votre zone, les offres e-mail OVHcloud s'appuient sur le webmail [Outlook W
 
 ## Quel webmail pour votre offre MX Plan ?
 
-Avec une offre **MX Plan**, votre messagerie repose — selon votre offre et son éventuelle migration — sur l'une de ces trois technologies de webmail :
-
-- **Outlook Web App (OWA)** : le webmail basé sur la technologie Microsoft Exchange.
-- **Zimbra** : un webmail collaboratif moderne, avec agenda, contacts et tâches partagés.
-- **Roundcube** : le webmail historique, léger et simple d'utilisation.
+<Panel>
 
 Pour identifier la technologie de votre service, rendez-vous dans votre espace client OVHcloud, dans l'onglet **Informations générales** de votre service e-mail : elle est indiquée sous **Webmail**.
 
-<img className="thumbnail" alt="Identifier la technologie de webmail de votre offre MX Plan dans l'espace client OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Le webmail historique, léger et simple d'utilisation." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Un webmail collaboratif moderne, avec agenda, contacts et tâches partagés." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Le webmail basé sur la technologie Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Obiettivo
 
@@ -78,21 +82,25 @@ Vuoi:
 
 <a name="whichmxplan"></a>
 
-**Identificare la tecnologia email della tua offerta MX Plan**
-
 <Region zones={['eu']}>
 
-In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
+<Panel>
 
-- **Roundcube**: la webmail storica, leggera e semplice da usare.
-- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
-- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
+**Identificare la tecnologia email della tua offerta MX Plan**
 
 Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
 
-Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="La webmail storica, leggera e semplice da usare." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Una webmail collaborativa moderna, con calendario, contatti e attività condivisi." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="La webmail basata sulla tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Obiettivo
 
@@ -91,21 +95,25 @@ Per motivi di sicurezza, ti consigliamo di non utilizzare due volte la stessa pa
 
 <a name="whichmxplan"></a>
 
-**Identificare la tecnologia di posta elettronica della soluzione MX Plan**
-
 <Region zones={['eu']}>
 
-In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
+<Panel>
 
-- **Roundcube**: la webmail storica, leggera e semplice da usare.
-- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
-- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
+**Identificare la tecnologia di posta elettronica della soluzione MX Plan**
 
 Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
 
-Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="La webmail storica, leggera e semplice da usare." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Una webmail collaborativa moderna, con calendario, contatti e attività condivisi." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="La webmail basata sulla tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Obiettivo
 
@@ -54,21 +58,25 @@ Una soluzione email MX Plan è stata appena creata per usufruire di indirizzi em
 
 **Prosegui nella lettura di questa guida in base alla tecnologia utilizzata dal tuo servizio MX Plan**.
 
-**Identificare la tecnologia di posta elettronica della soluzione MX Plan**
-
 <Region zones={['eu']}>
 
-In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
+<Panel>
 
-- **Roundcube**: la webmail storica, leggera e semplice da usare.
-- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
-- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
+**Identificare la tecnologia di posta elettronica della soluzione MX Plan**
 
 Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
 
-Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="La webmail storica, leggera e semplice da usare." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Una webmail collaborativa moderna, con calendario, contatti e attività condivisi." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="La webmail basata sulla tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { ZoneTabs, Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Obiettivo
 
@@ -52,21 +56,25 @@ Su MX Plan non è possibile passare da una tecnologia email a un'altra (ad esemp
 
 **Prosegui nella lettura di questa guida in base alla tecnologia utilizzata dal tuo servizio MX Plan**.
 
-**Identificare la tecnologia di posta elettronica della soluzione MX Plan**
-
 <Region zones={['eu']}>
 
-In base alla tua offerta (e a un'eventuale migrazione), il tuo servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
+<Panel>
 
-- **Roundcube**: la webmail storica, leggera e semplice da usare.
-- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
-- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
+**Identificare la tecnologia di posta elettronica della soluzione MX Plan**
 
 Per identificare la tecnologia del tuo servizio, accedi al tuo Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del tuo servizio email: è indicata sotto **Webmail**.
 
-Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificare la tecnologia webmail della tua offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="La webmail storica, leggera e semplice da usare." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Una webmail collaborativa moderna, con calendario, contatti e attività condivisi." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="La webmail basata sulla tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -5,6 +5,10 @@ availableIn: [eu]
 ---
 
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Obiettivo
 
@@ -18,21 +22,25 @@ Con la soluzione MX Plan OVHcloud, puoi inviare e ricevere e-mail da un software
 - Disporre delle informazioni di connessione all'indirizzo e-mail MX Plan che desideri consultare. Per maggiori informazioni, consulta la nostra guida [Iniziare a utilizzare la soluzione MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - La tua soluzione e-mail OVHcloud **MX Plan** deve utilizzare la tecnologia webmail **Roundcube**. Per identificarla, segui le istruzioni riportate di seguito.
 
-**Identificare la tecnologia email della vostra offerta MX Plan**
-
 <Region zones={['eu']}>
 
-In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
+<Panel>
 
-- **Roundcube**: la webmail storica, leggera e semplice da usare.
-- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
-- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
+**Identificare la tecnologia email della vostra offerta MX Plan**
 
 Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
 
-Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="La webmail storica, leggera e semplice da usare." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Una webmail collaborativa moderna, con calendario, contatti e attività condivisi." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="La webmail basata sulla tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## FAQ e-mail
 
@@ -106,15 +110,19 @@ Di seguito trovi una tabella riassuntiva delle principali funzionalità email, o
 
 <Region zones={['eu']}>
 
-In base alla tua offerta (e a un'eventuale migrazione), il tuo servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
-
-- **Roundcube**: la webmail storica, leggera e semplice da usare.
-- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
-- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
+<Panel>
 
 Per identificare la tecnologia del tuo servizio, accedi al tuo Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del tuo servizio email: è indicata sotto **Webmail**.
 
-<img className="thumbnail" alt="Identificare la tecnologia webmail della tua offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="La webmail storica, leggera e semplice da usare." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Una webmail collaborativa moderna, con calendario, contatti e attività condivisi." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="La webmail basata sulla tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -29,6 +29,9 @@ import { LinkCard } from '@components/LinkCard';
 import { OsIcon } from '@components/OsIcon';
 import { ClientLink } from '@components/ClientLink';
 import { Region } from '@components/Zone';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Cos'è MX Plan?
 
@@ -54,21 +57,19 @@ Con un'offerta MX Plan, potete:
 
 <Region zones={['eu']}>
 
-In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
-
-- **Roundcube**: la webmail storica, leggera e semplice da usare.
-- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
-- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
+<Panel>
 
 Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
 
-<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
 
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Webmail Roundcube" description="Consultate la posta elettronica dall'interfaccia webmail Roundcube." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Webmail Zimbra" description="Consultate la posta elettronica dall'interfaccia webmail Zimbra." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Utilizzate il vostro indirizzo email dalla webmail Outlook Web App." />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="La webmail storica, leggera e semplice da usare." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Una webmail collaborativa moderna, con calendario, contatti e attività condivisi." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="La webmail basata sulla tecnologia Microsoft Exchange." />
 </CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Obiettivo
 
@@ -75,21 +79,25 @@ Ogni account email OVHcloud dispone di uno spazio di storage dedicato. Gestire c
 :::
 
 
-**Identificare la tecnologia di posta elettronica della soluzione MX Plan**
-
 <Region zones={['eu']}>
 
-In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
+<Panel>
 
-- **Roundcube**: la webmail storica, leggera e semplice da usare.
-- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
-- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
+**Identificare la tecnologia di posta elettronica della soluzione MX Plan**
 
 Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
 
-Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="La webmail storica, leggera e semplice da usare." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Una webmail collaborativa moderna, con calendario, contatti e attività condivisi." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="La webmail basata sulla tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -9,6 +9,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 
 ## Obiettivo
@@ -66,21 +70,25 @@ Per le offerte **Zimbra Starter** e **Zimbra Pro**, vai direttamente alla scheda
 
 </Region>
 
-**Individuare la tecnologia e-mail della tua offerta MX Plan**
-
 <Region zones={['eu']}>
 
-In base alla vostra offerta (e a un'eventuale migrazione), il vostro servizio email MX Plan si basa su una di queste tre tecnologie webmail, con interfacce e funzionalità diverse:
+<Panel>
 
-- **Roundcube**: la webmail storica, leggera e semplice da usare.
-- **Zimbra**: una webmail collaborativa moderna, con calendario, contatti e attività condivisi.
-- **Outlook Web App (OWA)**: la webmail basata sulla tecnologia Microsoft Exchange.
+**Individuare la tecnologia e-mail della tua offerta MX Plan**
 
 Per identificare la tecnologia del vostro servizio, accedete al vostro Spazio Cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio email: è indicata sotto **Webmail**.
 
-Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificare la tecnologia webmail della vostra offerta MX Plan nello Spazio Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="La webmail storica, leggera e semplice da usare." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Una webmail collaborativa moderna, con calendario, contatti e attività condivisi." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="La webmail basata sulla tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Indipendentemente dalla tecnologia, l'accesso alla webmail può richiedere una doppia identificazione: prima sulla pagina di accesso alla webmail, poi nella finestra di accesso specifica della tecnologia (Roundcube, Zimbra o OWA).
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
@@ -25,6 +25,10 @@ cta:
 
 import { WebmailOffers } from '@components/WebmailOffers';
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Cos'è una webmail?
 
@@ -68,15 +72,19 @@ Nella vostra zona, le offerte e-mail OVHcloud si basano sul webmail **Outlook We
 
 ## Quale webmail per la vostra offerta MX Plan?
 
-Con una soluzione **MX Plan**, la vostra messaggistica si basa — in base alla vostra offerta e all'eventuale migrazione — su una di queste tre tecnologie di webmail:
-
-- **Outlook Web App (OWA)**: il webmail basato sulla tecnologia Microsoft Exchange.
-- **Zimbra**: un webmail collaborativo moderno con calendario, contatti e attività condivisi.
-- **Roundcube**: il webmail storico, leggero e semplice da usare.
+<Panel>
 
 Per identificare la tecnologia del vostro servizio, accedete al vostro spazio cliente OVHcloud, nella scheda **Informazioni generali** del vostro servizio e-mail: è indicata sotto **Webmail**.
 
-<img className="thumbnail" alt="Identificare la tecnologia di webmail della vostra offerta MX Plan nello spazio cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="La webmail storica, leggera e semplice da usare." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Una webmail collaborativa moderna, con calendario, contatti e attività condivisi." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="La webmail basata sulla tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Wprowadzenie
 
@@ -78,21 +82,25 @@ Chcesz:
 
 <a name="whichmxplan"></a>
 
-**Identyfikacja technologii e-mail Twojej oferty MX Plan**
-
 <Region zones={['eu']}>
 
-W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
+<Panel>
 
-- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
-- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
-- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
+**Identyfikacja technologii e-mail Twojej oferty MX Plan**
 
 Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
 
-Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Klasyczny webmail, lekki i prosty w obsłudze." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Webmail oparty na technologii Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Wprowadzenie
 
@@ -91,21 +95,25 @@ Ze względów bezpieczeństwa zalecamy nie używać dwa razy tego samego hasła.
 
 <a name="whichmxplan"></a>
 
-**Sprawdzenie konfiguracji usługi MX Plan**
-
 <Region zones={['eu']}>
 
-W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
+<Panel>
 
-- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
-- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
-- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
+**Sprawdzenie konfiguracji usługi MX Plan**
 
 Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
 
-Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Klasyczny webmail, lekki i prosty w obsłudze." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Webmail oparty na technologii Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Wprowadzenie
 
@@ -54,21 +58,25 @@ Właśnie zakupiłeś usługę e-mail MX Plan. Umożliwia ona korzystanie z kont
 
 **Następnie postępuj zgodnie z technologią poczty elektronicznej używaną przez Twoją usługę MX Plan**.
 
-**Sprawdzenie poprawności technologii poczty e-mail w usłudze MX Plan**
-
 <Region zones={['eu']}>
 
-W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
+<Panel>
 
-- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
-- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
-- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
+**Sprawdzenie poprawności technologii poczty e-mail w usłudze MX Plan**
 
 Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
 
-Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Klasyczny webmail, lekki i prosty w obsłudze." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Webmail oparty na technologii Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { ZoneTabs, Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Wprowadzenie
 
@@ -53,21 +57,25 @@ W MX Plan nie można przełączać się między technologiami poczty (na przykł
 1. Kliknij opcję <code className="action">MX Plan</code>.
 1. **Następnie postępuj zgodnie z technologią poczty elektronicznej używaną przez Twoją usługę MX Plan**.
 
-**Sprawdzenie konfiguracji usługi MX Plan**
-
 <Region zones={['eu']}>
 
-W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
+<Panel>
 
-- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
-- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
-- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
+**Sprawdzenie konfiguracji usługi MX Plan**
 
 Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
 
-Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Klasyczny webmail, lekki i prosty w obsłudze." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Webmail oparty na technologii Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -5,6 +5,10 @@ availableIn: [eu]
 ---
 
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Wprowadzenie
 
@@ -18,21 +22,25 @@ Dzięki rozwiązaniu OVHcloud MX Plan możesz wysyłać i odbierać e-maile za p
 - Posiadanie danych logowania do adresu e-mail MX Plan, który chcesz sprawdzić. Więcej informacji znajdziesz w naszym przewodniku [Pierwsze kroki z rozwiązaniem MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - Twoje rozwiązanie pocztowe OVHcloud **MX Plan** musi korzystać z technologii webmail **Roundcube**. Aby to sprawdzić, postępuj zgodnie z poniższymi wskazówkami.
 
-**Identyfikacja technologii e-mail oferty MX Plan**
-
 <Region zones={['eu']}>
 
-W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
+<Panel>
 
-- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
-- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
-- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
+**Identyfikacja technologii e-mail oferty MX Plan**
 
 Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
 
-Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Klasyczny webmail, lekki i prosty w obsłudze." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Webmail oparty na technologii Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## FAQ e-mail
 
@@ -106,15 +110,19 @@ Poniżej znajduje się tabela podsumowująca najważniejsze funkcje poczty elekt
 
 <Region zones={['eu']}>
 
-W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
-
-- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
-- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
-- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
+<Panel>
 
 Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
 
-<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Klasyczny webmail, lekki i prosty w obsłudze." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Webmail oparty na technologii Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -29,6 +29,9 @@ import { LinkCard } from '@components/LinkCard';
 import { OsIcon } from '@components/OsIcon';
 import { ClientLink } from '@components/ClientLink';
 import { Region } from '@components/Zone';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Co to jest MX Plan?
 
@@ -54,21 +57,19 @@ Z ofertą MX Plan możesz:
 
 <Region zones={['eu']}>
 
-W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
-
-- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
-- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
-- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
+<Panel>
 
 Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
 
-<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
 
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Webmail Roundcube" description="Sprawdzaj pocztę w interfejsie webmail Roundcube." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Webmail Zimbra" description="Sprawdzaj pocztę w interfejsie webmail Zimbra." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Korzystaj z adresu e-mail przez webmail Outlook Web App." />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Klasyczny webmail, lekki i prosty w obsłudze." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Webmail oparty na technologii Microsoft Exchange." />
 </CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Wprowadzenie
 
@@ -75,21 +79,25 @@ Każde konto e-mail OVHcloud dysponuje dedykowaną przestrzenią dyskową. Zarz�
 :::
 
 
-**Identyfikacja technologii e-mail oferty MX Plan**
-
 <Region zones={['eu']}>
 
-W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
+<Panel>
 
-- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
-- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
-- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
+**Identyfikacja technologii e-mail oferty MX Plan**
 
 Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
 
-Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Klasyczny webmail, lekki i prosty w obsłudze." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Webmail oparty na technologii Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -9,6 +9,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 
 ## Wprowadzenie
@@ -66,21 +70,25 @@ W przypadku usług **Zimbra Starter** i **Zimbra Pro** przejdź bezpośrednio do
 
 </Region>
 
-**Zidentyfikuj technologię e-mail Twojej usługi MX Plan**
-
 <Region zones={['eu']}>
 
-W zależności od oferty (i ewentualnej migracji) usługa e-mail MX Plan opiera się na jednej z trzech technologii webmail, z różnymi interfejsami i funkcjami:
+<Panel>
 
-- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
-- **Zimbra**: nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami.
-- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
+**Zidentyfikuj technologię e-mail Twojej usługi MX Plan**
 
 Aby zidentyfikować technologię swojej usługi, zaloguj się do Panelu klienta OVHcloud, przejdź do karty **Informacje ogólne** swojej usługi e-mail: jest ona wskazana pod **Webmail**.
 
-Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Klasyczny webmail, lekki i prosty w obsłudze." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Webmail oparty na technologii Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Niezależnie od technologii połączenie z pocztą webmail może wymagać dwukrotnego logowania: najpierw na stronie logowania do interfejsu webmail, a następnie w oknie logowania właściwym dla danej technologii (Roundcube, Zimbra lub OWA).
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
@@ -25,6 +25,10 @@ cta:
 
 import { WebmailOffers } from '@components/WebmailOffers';
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Czym jest webmail?
 
@@ -68,15 +72,19 @@ W Twojej strefie oferty e-mail OVHcloud opierają się na usłudze webmail **Out
 
 ## Który webmail dla Twojej oferty MX Plan?
 
-W przypadku oferty **MX Plan** Twoja poczta opiera się — w zależności od oferty i ewentualnej migracji — na jednej z tych trzech technologii webmail:
-
-- **Outlook Web App (OWA)**: webmail oparty na technologii Microsoft Exchange.
-- **Zimbra**: nowoczesny webmail do pracy zespołowej z udostępnianym kalendarzem, kontaktami i zadaniami.
-- **Roundcube**: klasyczny webmail, lekki i prosty w obsłudze.
+<Panel>
 
 Aby zidentyfikować technologię swojej usługi, przejdź do Panelu klienta OVHcloud, do zakładki **Informacje ogólne** swojej usługi e-mail: technologia jest wskazana w polu **Webmail**.
 
-<img className="thumbnail" alt="Identyfikacja technologii webmail oferty MX Plan w Panelu klienta OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="Klasyczny webmail, lekki i prosty w obsłudze." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Nowoczesny, współpracujący webmail z udostępnionym kalendarzem, kontaktami i zadaniami." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Webmail oparty na technologii Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objetivo
 
@@ -78,21 +82,25 @@ Deseja:
 
 <a name="whichmxplan"></a>
 
-**Identificar a tecnologia de e-mail da sua oferta MX Plan**
-
 <Region zones={['eu']}>
 
-Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: o webmail original, leve e simples de utilizar.
-- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
-- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
+**Identificar a tecnologia de e-mail da sua oferta MX Plan**
 
 Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
 
-Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="O webmail original, leve e simples de utilizar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="O webmail baseado na tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objetivo
 
@@ -91,21 +95,25 @@ Por razões de segurança, recomendamos que não utilize duas vezes a mesma pala
 
 <a name="whichmxplan"></a>
 
-**Identificar a tecnologia de e-mail da oferta MX Plan**
-
 <Region zones={['eu']}>
 
-Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: o webmail original, leve e simples de utilizar.
-- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
-- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
+**Identificar a tecnologia de e-mail da oferta MX Plan**
 
 Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
 
-Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="O webmail original, leve e simples de utilizar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="O webmail baseado na tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-creation.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objetivo
 
@@ -54,21 +58,25 @@ Adquiriu um serviço de e-mail MX Plan. que lhe permite beneficiar de endereços
 
 **Continuar com base na tecnologia de e-mail utilizada pelo serviço MX Plan**.
 
-**Identificar a tecnologia de e-mail da oferta MX Plan**
-
 <Region zones={['eu']}>
 
-Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: o webmail original, leve e simples de utilizar.
-- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
-- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
+**Identificar a tecnologia de e-mail da oferta MX Plan**
 
 Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
 
-Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="O webmail original, leve e simples de utilizar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="O webmail baseado na tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { ZoneTabs, Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objetivo
 
@@ -52,21 +56,25 @@ No MX Plan, não é possível mudar de uma tecnologia de e-mail para outra (por 
 
 **Continuar com base na tecnologia de e-mail utilizada pelo serviço MX Plan**.
 
-**Identificar a tecnologia de e-mail da oferta MX Plan**
-
 <Region zones={['eu']}>
 
-Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: o webmail original, leve e simples de utilizar.
-- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
-- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
+**Identificar a tecnologia de e-mail da oferta MX Plan**
 
 Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
 
-Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="O webmail original, leve e simples de utilizar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="O webmail baseado na tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube.mdx
@@ -5,6 +5,10 @@ availableIn: [eu]
 ---
 
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objetivo
 
@@ -18,21 +22,25 @@ Com a oferta MX Plan da OVHcloud, pode enviar e receber e-mails a partir de um s
 - Dispor das informações de ligação ao endereço de e-mail MX Plan que pretende consultar. Para mais informações, consulte o nosso guia [Primeiros passos com a oferta MX Plan](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-generalities).
 - A sua solução de e-mail OVHcloud **MX Plan** deve utilizar a tecnologia de webmail **Roundcube**. Para a identificar, siga as instruções abaixo.
 
-**Identificar a tecnologia de e-mail da sua oferta MX Plan**
-
 <Region zones={['eu']}>
 
-Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: o webmail original, leve e simples de utilizar.
-- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
-- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
+**Identificar a tecnologia de e-mail da sua oferta MX Plan**
 
 Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
 
-Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="O webmail original, leve e simples de utilizar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="O webmail baseado na tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -12,6 +12,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## FAQ de e-mail
 
@@ -106,15 +110,19 @@ Pode encontrar em seguida um quadro recapitulativo das principais funcionalidade
 
 <Region zones={['eu']}>
 
-Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
-
-- **Roundcube**: o webmail original, leve e simples de utilizar.
-- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
-- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
+<Panel>
 
 Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
 
-<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="O webmail original, leve e simples de utilizar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="O webmail baseado na tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan.mdx
@@ -29,6 +29,9 @@ import { LinkCard } from '@components/LinkCard';
 import { OsIcon } from '@components/OsIcon';
 import { ClientLink } from '@components/ClientLink';
 import { Region } from '@components/Zone';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## O que é o MX Plan?
 
@@ -54,21 +57,19 @@ Com uma oferta MX Plan, pode:
 
 <Region zones={['eu']}>
 
-Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
-
-- **Roundcube**: o webmail original, leve e simples de utilizar.
-- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
-- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
+<Panel>
 
 Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
 
-<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
 
-<CardGrid>
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Webmail Roundcube" description="Consulte o seu e-mail a partir da interface webmail Roundcube." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Webmail Zimbra" description="Consulte o seu e-mail a partir da interface webmail Zimbra." />
-  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="Utilize o seu endereço de e-mail a partir do webmail Outlook Web App." />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="O webmail original, leve e simples de utilizar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="O webmail baseado na tecnologia Microsoft Exchange." />
 </CardGrid>
+
+</Panel>
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota.mdx
@@ -10,6 +10,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 
 import { Region, ZoneTabs } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## Objetivo
 
@@ -75,21 +79,25 @@ Cada conta de e-mail da OVHcloud dispõe de um espaço de armazenamento dedicado
 :::
 
 
-**Identificar a tecnologia de e-mail da oferta MX Plan**
-
 <Region zones={['eu']}>
 
-Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: o webmail original, leve e simples de utilizar.
-- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
-- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
+**Identificar a tecnologia de e-mail da oferta MX Plan**
 
 Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
 
-Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="O webmail original, leve e simples de utilizar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="O webmail baseado na tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -9,6 +9,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 import { ZoneTabs } from '@components/Zone';
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 
 ## Objetivo
@@ -66,21 +70,25 @@ Para as ofertas **Zimbra Starter** e **Zimbra Pro**, dirija-se diretamente ao se
 
 </Region>
 
-**Identificar a tecnologia de e-mail da sua oferta MX Plan**
-
 <Region zones={['eu']}>
 
-Consoante a sua oferta (e a eventual migração), o seu serviço de e-mail MX Plan baseia-se numa das seguintes três tecnologias de webmail, com interfaces e funcionalidades diferentes:
+<Panel>
 
-- **Roundcube**: o webmail original, leve e simples de utilizar.
-- **Zimbra**: um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados.
-- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
+**Identificar a tecnologia de e-mail da sua oferta MX Plan**
 
 Para identificar a tecnologia do seu serviço, aceda à sua área de cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
 
-Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
+<WebmailLookup />
 
-<img className="thumbnail" alt="Identificar a tecnologia webmail da sua oferta MX Plan na área de cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="O webmail original, leve e simples de utilizar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="O webmail baseado na tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
+
+Independentemente da tecnologia, a ligação ao webmail pode exigir uma dupla identificação: primeiro na página de acesso ao webmail e, em seguida, na janela de início de sessão própria da tecnologia (Roundcube, Zimbra ou OWA).
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/landing-page-webmail.mdx
@@ -25,6 +25,10 @@ cta:
 
 import { WebmailOffers } from '@components/WebmailOffers';
 import { Region } from '@components/Zone';
+import { LinkCard } from '@components/LinkCard';
+import { WebmailIcon } from '@components/WebmailIcon';
+import { WebmailLookup } from '@components/WebmailLookup';
+import { Panel } from '@components/Panel';
 
 ## O que é um webmail?
 
@@ -68,15 +72,19 @@ Na sua zona, as ofertas de e-mail OVHcloud assentam no webmail **Outlook Web App
 
 ## Que webmail para a sua oferta MX Plan?
 
-Com uma solução **MX Plan**, o seu serviço de e-mail assenta — consoante a sua oferta e a eventual migração — numa destas três tecnologias de webmail:
-
-- **Outlook Web App (OWA)**: o webmail baseado na tecnologia Microsoft Exchange.
-- **Zimbra**: um webmail colaborativo moderno com calendário, contactos e tarefas partilhados.
-- **Roundcube**: o webmail histórico, leve e simples de utilizar.
+<Panel>
 
 Para identificar a tecnologia do seu serviço, aceda à sua Área de Cliente OVHcloud, no separador **Informações gerais** do seu serviço de e-mail: está indicada em **Webmail**.
 
-<img className="thumbnail" alt="Identificar a tecnologia de webmail da sua oferta MX Plan na Área de Cliente OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/overview/mxplan-webmail-technologies.png" loading="lazy" />
+<WebmailLookup />
+
+<CardGrid columns={3}>
+  <LinkCard icon={<WebmailIcon name="roundcube" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube" title="Roundcube" description="O webmail original, leve e simples de utilizar." />
+  <LinkCard icon={<WebmailIcon name="zimbra" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra" title="Zimbra" description="Um webmail colaborativo moderno, com calendário, contactos e tarefas partilhados." />
+  <LinkCard icon={<WebmailIcon name="owa" size={34} />} href="/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa" title="Outlook Web App (OWA)" description="O webmail baseado na tecnologia Microsoft Exchange." />
+</CardGrid>
+
+</Panel>
 
 </Region>
 


### PR DESCRIPTION
## What & why

Across the OVHcloud email guides, the "Identify your email technology" step relied on a single shared PNG infographic (`mxplan-webmail-technologies.png`): not translatable, not clickable, unreadable in dark mode, and showing `example.com` instead of the canonical example domain.

This PR replaces it, in **every guide that includes that step**, with a theme-aware, localized, delimited zone: a Control Panel lookup panel + three clickable technology tiles.

## Changes

### Guides — 10 guides × 7 EU locales (fr/en/de/es/it/pl/pt)
Inside the EU `<Region>`, the image + bullet list + intro are replaced by a bordered `<Panel>` zone containing the instruction, a `<WebmailLookup>` panel, and three `<LinkCard>` tiles (Roundcube / Zimbra / OWA) linking to each webmail guide.

- `troubleshooting/locked-for-spam`
- `troubleshooting/email-manage-quota`
- `common-email-features/delete-email-account`
- `mx-plan/email-change-password`, `email-creation`, `email-generalities`, `email-roundcube`, `faq-emails`
- `mx-plan/landing-page-mx-plan` (its now-redundant webmail-link grid is replaced by the identification tiles)
- `using-the-outlook-web-app-webmail/landing-page-webmail`

CA/APAC wording is unchanged (OWA only). The image asset is left in place — it is still referenced by other guides.

### New components
- **`WebmailIcon`** — monochrome brand glyphs (Roundcube: Simple Icons/CC0, OWA: Material Design Icons, Zimbra: recreated as no icon set provides it). `currentColor`, so they adapt to the theme.
- **`WebmailLookup`** — faithful reproduction of the Control Panel *General information* tab + *Connexion* card, with the **Webmail** field highlighted. Strings are localized from the Manager (`emailpro`) translations; colours match the ODS palette (`#0050D7` / `#000E9C`). Rendered with a fixed light palette on purpose — it mirrors the always-light Control Panel and reads as an embedded screenshot in both doc themes.
- **`Panel`** — bordered container that delimits the identification zone.

### `LinkCard`
Added optional `stacked` (icon on top) and `tag` props. Backwards-compatible; existing usages are unaffected.

## Verification
- `pnpm build:en` and `pnpm build:fr` — both succeed, no errors, no dead links (`checkDeadLinks` is on).
- `content:lint` — all checks pass. `biome ci` — clean on the touched components.
- Tile link targets verified present in all 7 locales.
- Rendered in the dev server (light + dark); tab/card labels localize per locale.
