### PR TITLE
feat(search): signal that universe filters unfold product sub-filters

### DIFF
--- a/theme/components/PagefindSearch/index.css
+++ b/theme/components/PagefindSearch/index.css
@@ -210,6 +210,53 @@
   font-size: 11.5px;
 }
 
+/* Universe pills carrying a chevron lay out label + caret inline. */
+.pagefind-pill--universe {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+/* Chevron signals "click to reveal products". Points right when collapsed,
+   rotates down (90°) when the universe is expanded. */
+.pagefind-pill__chevron {
+  display: inline-block;
+  font-size: 13px;
+  line-height: 1;
+  opacity: 0.7;
+  transition: transform 0.15s ease;
+}
+
+.pagefind-pill--active .pagefind-pill__chevron {
+  transform: rotate(90deg);
+  opacity: 1;
+}
+
+/* Product row fades + slides in when a universe is expanded, so the unfold
+   reads as a consequence of the click rather than a static jump. */
+.pagefind-filter-row--products {
+  animation: pagefind-products-in 0.18s ease;
+}
+
+@keyframes pagefind-products-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pagefind-pill__chevron,
+  .pagefind-filter-row--products {
+    transition: none;
+    animation: none;
+  }
+}
+
 /* ── Results ───────────────────────────────────────────────────────────── */
 
 .pagefind-results {

--- a/theme/components/PagefindSearch/index.tsx
+++ b/theme/components/PagefindSearch/index.tsx
@@ -1043,25 +1043,40 @@ export function PagefindSearch() {
                   >
                     {t.allDocumentation}
                   </button>
-                  {taxonomy.universes.map((u) => (
-                    <button
-                      key={u.slug}
-                      type="button"
-                      className={`pagefind-pill${universe === u.slug ? ' pagefind-pill--active' : ''}`}
-                      aria-pressed={universe === u.slug}
-                      onClick={() => {
-                        if (universe === u.slug) {
-                          setUniverse('');
-                          setProduct('');
-                        } else {
-                          setUniverse(u.slug);
-                          setProduct('');
-                        }
-                      }}
-                    >
-                      {u.label}
-                    </button>
-                  ))}
+                  {taxonomy.universes.map((u) => {
+                    const hasProducts =
+                      (taxonomy.products[u.slug]?.length ?? 0) > 0;
+                    const isActive = universe === u.slug;
+                    return (
+                      <button
+                        key={u.slug}
+                        type="button"
+                        className={`pagefind-pill pagefind-pill--universe${isActive ? ' pagefind-pill--active' : ''}`}
+                        aria-pressed={isActive}
+                        // Announce that this pill expands a product sub-filter.
+                        aria-expanded={hasProducts ? isActive : undefined}
+                        onClick={() => {
+                          if (isActive) {
+                            setUniverse('');
+                            setProduct('');
+                          } else {
+                            setUniverse(u.slug);
+                            setProduct('');
+                          }
+                        }}
+                      >
+                        {u.label}
+                        {hasProducts && (
+                          <span
+                            className="pagefind-pill__chevron"
+                            aria-hidden="true"
+                          >
+                            ›
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
                 </div>
                 {productOptions.length > 0 && (
                   <div


### PR DESCRIPTION
Users didn't realise clicking a universe filter reveals product sub-filters, so product filtering looked absent. Add a chevron on each universe pill that has products (rotates when expanded) and animate the product row's reveal, keeping the universe > product progressive disclosure. Respects prefers-reduced-motion.