### PR TITLE
docs(opcp): add guide to access the NetBox API with a token

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -593,6 +593,7 @@
             + [How to see node inventory](hosted-private-cloud/opcp/how-to-see-node-inventory)
             + [How to handle the NetBox rack elevation](hosted-private-cloud/opcp/how-to-handle-rack-elevation)
             + [How the Ironic to NetBox synchronisation works](hosted-private-cloud/opcp/netbox-ironic-synchronisation)
+            + [How to access the NetBox API with a token](hosted-private-cloud/opcp/netbox-api-access)
             + [How to use Terraform](hosted-private-cloud/opcp/use-terraform)
             + [How to update the backup S3 buckets](hosted-private-cloud/opcp/how-to-update-backup-s3-buckets)
         + [Security](hosted-private-cloud-hosted-private-cloud-opcp-security)

--- a/docs/de/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/de/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx

--- a/docs/en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,97 @@
+---
+title: How to access the NetBox API with a token
+description: How to use the NetBox REST API
+lastUpdated: 2026-07-15
+---
+
+## Objective
+
+On an **OVHcloud On-Prem Cloud Platform (OPCP)**, the NetBox web interface is protected by Keycloak SSO. To let an external system — for example your own CMDB or a helpdesk integration — query the NetBox inventory automatically, a dedicated API endpoint is available. This endpoint authenticates directly with a NetBox API token and does **not** go through Keycloak.
+
+**This guide explains how to enable the dedicated endpoint, create a NetBox API token, and reach the NetBox API through that endpoint.**
+
+:::info
+This feature is available from **OPCP Core 3.0.7**.
+:::
+
+## Requirements
+
+- The dedicated API endpoint must be enabled on your platform. It is **disabled by default**; enabling it is the first step below.
+- Access to the NetBox web interface (`netbox.<your-platform-domain>`), reachable through Keycloak SSO.
+- A NetBox user allowed to create API tokens.
+
+## Instructions
+
+### 1. Enable the dedicated API endpoint
+
+The dedicated endpoint is **disabled by default**. To enable it, set the following flag in your OPCP configuration:
+
+```yaml
+netbox_api:
+  enabled: true
+```
+
+Then apply the configuration by running, from a controller:
+
+```bash
+opcp-cli deploy --system
+```
+
+:::info
+In OVHcloud-managed mode, ask your OVHcloud contact to enable this endpoint if you are not able to run the deployment yourself.
+:::
+
+### 2. Create a NetBox API token
+
+1. Log in to the NetBox web interface at `https://netbox.<your-platform-domain>` with your usual Keycloak credentials or SSO.
+2. Open the user menu (top right), go to your profile, then to the **API Tokens** section.
+3. Click <code className="action">Add a token</code>, adjust the options if needed (expiry, allowed IP ranges, read-only or write access), then save.
+4. Copy the generated token and store it in a safe place. It grants access to the NetBox API with your own permissions.
+
+For the full description of tokens and their options, see the official NetBox documentation: [NetBox REST API — Tokens](https://netboxlabs.com/docs/netbox/integrations/rest-api/#tokens).
+
+### 3. Call the API through the dedicated endpoint
+
+The dedicated endpoint exposes the NetBox API at the following URL:
+
+```console
+https://netbox-api.<your-platform-domain>/api
+```
+
+Unlike the web interface, this endpoint does not use Keycloak: authentication relies entirely on your NetBox token, passed in the `Authorization` header of every request.
+
+To verify that your token and the endpoint work, query the NetBox status. A valid token returns an HTTP `200` response with a JSON payload:
+
+```bash
+curl -sS -H "Authorization: Token YOUR_TOKEN" \
+  https://netbox-api.<your-platform-domain>/api/status/
+```
+
+Once the connection is confirmed, you can query any NetBox resource, for example the list of devices:
+
+```bash
+curl -sS -H "Authorization: Token YOUR_TOKEN" \
+  https://netbox-api.<your-platform-domain>/api/dcim/devices/
+```
+
+A request sent without a valid token is rejected. The web interface remains available only on `https://netbox.<your-platform-domain>`, behind Keycloak.
+
+:::tip
+This endpoint is meant for programmatic access. To browse the API interactively (the browsable API, or the Swagger and ReDoc pages), use the main NetBox interface at `https://netbox.<your-platform-domain>/api/`, which is served through Keycloak.
+:::
+
+:::warning
+A token carries the permissions of the user who created it. Keep it secret, prefer a token with the narrowest scope required (read-only whenever possible), and rotate it regularly.
+:::
+
+### References
+
+- [NetBox REST API](https://netboxlabs.com/docs/netbox/integrations/rest-api/)
+- [NetBox REST API — Tokens](https://netboxlabs.com/docs/netbox/integrations/rest-api/#tokens)
+- [How to see the node inventory](/guides/hosted-private-cloud/opcp/how-to-see-node-inventory)
+
+## Go further
+
+For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analysed by our experts.
+
+Join our [community of users](/links/community).

--- a/docs/es/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/es/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx

--- a/docs/fr/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,97 @@
+---
+title: Comment accéder à l'API NetBox avec un token
+description: Comment utiliser l'API REST de NetBox
+lastUpdated: 2026-07-15
+---
+
+## Objectif
+
+Sur une plateforme **OVHcloud On-Prem Cloud Platform (OPCP)**, l'interface web de NetBox est protégée par l'authentification unique (SSO) Keycloak. Pour permettre à un système externe — par exemple votre propre CMDB ou une intégration avec votre outil de support — d'interroger automatiquement l'inventaire NetBox, un point d'accès API dédié est disponible. Ce point d'accès s'authentifie directement avec un token API NetBox et ne passe **pas** par Keycloak.
+
+**Ce guide explique comment activer le point d'accès dédié, créer un token API NetBox et joindre l'API NetBox via ce point d'accès.**
+
+:::info
+Cette fonctionnalité est disponible à partir d'**OPCP Core 3.0.7**.
+:::
+
+## Prérequis
+
+- Le point d'accès API dédié doit être activé sur votre plateforme. Il est **désactivé par défaut** ; son activation constitue la première étape ci-dessous.
+- Avoir accès à l'interface web de NetBox (`netbox.<votre-domaine-de-plateforme>`), accessible via le SSO Keycloak.
+- Disposer d'un utilisateur NetBox autorisé à créer des tokens API.
+
+## En pratique
+
+### 1. Activer le point d'accès dédié
+
+Le point d'accès dédié est **désactivé par défaut**. Pour l'activer, positionnez le flag suivant dans la configuration de votre OPCP :
+
+```yaml
+netbox_api:
+  enabled: true
+```
+
+Appliquez ensuite la configuration en exécutant, depuis un contrôleur :
+
+```bash
+opcp-cli deploy --system
+```
+
+:::info
+En mode managé par OVHcloud, demandez à votre interlocuteur OVHcloud d'activer ce point d'accès si vous ne pouvez pas lancer le déploiement vous-même.
+:::
+
+### 2. Créer un token API NetBox
+
+1. Connectez-vous à l'interface web de NetBox à l'adresse `https://netbox.<votre-domaine-de-plateforme>` avec vos identifiants Keycloak habituels ou votre SSO.
+2. Ouvrez le menu utilisateur (en haut à droite), accédez à votre profil, puis à la section **API Tokens**.
+3. Cliquez sur <code className="action">Add a token</code>, ajustez les options si nécessaire (expiration, plages d'adresses IP autorisées, accès en lecture seule ou en écriture), puis enregistrez.
+4. Copiez le token généré et conservez-le en lieu sûr. Il donne accès à l'API NetBox avec vos propres permissions.
+
+Pour la description complète des tokens et de leurs options, consultez la documentation officielle de NetBox : [NetBox REST API — Tokens](https://netboxlabs.com/docs/netbox/integrations/rest-api/#tokens).
+
+### 3. Appeler l'API via le point d'accès dédié
+
+Le point d'accès dédié expose l'API NetBox à l'URL suivante :
+
+```console
+https://netbox-api.<votre-domaine-de-plateforme>/api
+```
+
+Contrairement à l'interface web, ce point d'accès n'utilise pas Keycloak : l'authentification repose entièrement sur votre token NetBox, transmis dans l'en-tête `Authorization` de chaque requête.
+
+Pour vérifier que votre token et le point d'accès fonctionnent, interrogez le statut de NetBox. Un token valide renvoie une réponse HTTP `200` accompagnée d'une charge utile JSON :
+
+```bash
+curl -sS -H "Authorization: Token YOUR_TOKEN" \
+  https://netbox-api.<votre-domaine-de-plateforme>/api/status/
+```
+
+Une fois la connexion confirmée, vous pouvez interroger n'importe quelle ressource NetBox, par exemple la liste des équipements :
+
+```bash
+curl -sS -H "Authorization: Token YOUR_TOKEN" \
+  https://netbox-api.<votre-domaine-de-plateforme>/api/dcim/devices/
+```
+
+Une requête envoyée sans token valide est rejetée. L'interface web reste accessible uniquement sur `https://netbox.<votre-domaine-de-plateforme>`, derrière Keycloak.
+
+:::tip
+Ce point d'accès est destiné à un usage programmatique. Pour explorer l'API de manière interactive (interface browsable, ou pages Swagger et ReDoc), utilisez l'interface principale de NetBox sur `https://netbox.<votre-domaine-de-plateforme>/api/`, servie via Keycloak.
+:::
+
+:::warning
+Un token porte les permissions de l'utilisateur qui l'a créé. Gardez-le secret, privilégiez un token au périmètre le plus restreint possible (en lecture seule autant que possible) et renouvelez-le régulièrement.
+:::
+
+### Références
+
+- [NetBox REST API](https://netboxlabs.com/docs/netbox/integrations/rest-api/)
+- [NetBox REST API — Tokens](https://netboxlabs.com/docs/netbox/integrations/rest-api/#tokens)
+- [Comment consulter l'inventaire des nœuds](/guides/hosted-private-cloud/opcp/how-to-see-node-inventory)
+
+## Aller plus loin
+
+Pour une formation ou une assistance technique à la mise en place de nos solutions, contactez votre commercial ou rendez-vous sur notre page [Professional Services](/links/professional-services) pour demander un devis et faire analyser votre projet par nos experts.
+
+Rejoignez notre [communauté d'utilisateurs](/links/community).

--- a/docs/it/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/it/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx

--- a/docs/pl/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/pl/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx

--- a/docs/pt/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/pt/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx


### PR DESCRIPTION
## Summary

Adds an OPCP guide documenting the dedicated `netbox-api.<base>` endpoint that bypasses Keycloak and authenticates with a NetBox token (companion to irobox SOV-875).

The guide covers:
- Enabling the endpoint (`netbox_api.enabled` flag + `opcp-cli deploy --system`), available from OPCP Core 3.0.7
- Creating a NetBox API token (links to the official NetBox REST API docs)
- A `curl` connectivity check (`/api/status/`) and a sample query
- A note that the interactive API contract (browsable API / Swagger / ReDoc) is consulted on the main host `netbox.<base>/api/` via Keycloak

Added under `hosted-private-cloud/opcp/`, wired into the sidebar. English source, French translation, English placeholders for de/es/it/pl/pt (matching the existing opcp translation practice).

## Notes
- Run `pnpm sidebar:check` and `pnpm check` in CI/locally with deps installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)