### PR TITLE
docs(game-panel): add <message> argument to Palworld announce command

### DIFF
--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
@@ -79,7 +79,7 @@ Bei einem Palworld-Server können Sie verschiedene Befehle direkt über das Eing
 
 | Befehl | Argumente | Beschreibung |
 |--------|-----------|--------------|
-| `announce` | - | Sendet eine Ankündigung, die für alle verbundenen Spieler sichtbar ist. |
+| `announce` | `<message>` | Sendet eine Ankündigung, die für alle verbundenen Spieler sichtbar ist. |
 | `players` | - | Zeigt die Liste der aktuell mit dem Server verbundenen Spieler an. |
 | `info` | - | Gibt allgemeine Informationen über den Server zurück. |
 | `settings` | - | Gibt die aktuelle Serverkonfiguration zurück. |

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
@@ -79,7 +79,7 @@ With a Palworld server, you can run various commands directly from the input fie
 
 | Command | Arguments | Description |
 |---------|-----------|-------------|
-| `announce` | - | Sends an announcement message visible to all connected players. |
+| `announce` | `<message>` | Sends an announcement message visible to all connected players. |
 | `players` | - | Displays the list of players currently connected to the server. |
 | `info` | - | Returns general information about the server. |
 | `settings` | - | Returns the current server configuration. |

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
@@ -79,7 +79,7 @@ Con un servidor Palworld, puede ejecutar distintos comandos directamente desde e
 
 | Comando | Argumentos | Descripción |
 |---------|------------|-------------|
-| `announce` | - | Envía un mensaje de anuncio visible para todos los jugadores conectados. |
+| `announce` | `<message>` | Envía un mensaje de anuncio visible para todos los jugadores conectados. |
 | `players` | - | Muestra la lista de los jugadores conectados actualmente al servidor. |
 | `info` | - | Devuelve la información general del servidor. |
 | `settings` | - | Devuelve la configuración actual del servidor. |

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
@@ -79,7 +79,7 @@ Avec un serveur Palworld, vous pouvez exécuter différentes commandes directeme
 
 | Commande | Arguments | Description |
 |----------|-----------|-------------|
-| `announce` | - | Envoie un message d'annonce visible par tous les joueurs connectés. |
+| `announce` | `<message>` | Envoie un message d'annonce visible par tous les joueurs connectés. |
 | `players` | - | Affiche la liste des joueurs actuellement connectés au serveur. |
 | `info` | - | Retourne les informations générales du serveur. |
 | `settings` | - | Retourne la configuration actuelle du serveur. |

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
@@ -79,7 +79,7 @@ Con un server Palworld, potete eseguire diversi comandi direttamente dal campo d
 
 | Comando | Argomenti | Descrizione |
 |---------|-----------|-------------|
-| `announce` | - | Invia un messaggio di annuncio visibile a tutti i giocatori connessi. |
+| `announce` | `<message>` | Invia un messaggio di annuncio visibile a tutti i giocatori connessi. |
 | `players` | - | Mostra la lista dei giocatori attualmente connessi al server. |
 | `info` | - | Restituisce le informazioni generali del server. |
 | `settings` | - | Restituisce la configurazione attuale del server. |

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
@@ -79,7 +79,7 @@ Na serwerze Palworld możesz wykonywać różne polecenia bezpośrednio z pola w
 
 | Polecenie | Argumenty | Opis |
 |-----------|-----------|------|
-| `announce` | - | Wysyła komunikat widoczny dla wszystkich połączonych graczy. |
+| `announce` | `<message>` | Wysyła komunikat widoczny dla wszystkich połączonych graczy. |
 | `players` | - | Wyświetla listę graczy aktualnie połączonych z serwerem. |
 | `info` | - | Zwraca ogólne informacje o serwerze. |
 | `settings` | - | Zwraca bieżącą konfigurację serwera. |

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/game-panel-quick-start-palworld.mdx
@@ -79,7 +79,7 @@ Com um servidor Palworld, pode executar diferentes comandos diretamente a partir
 
 | Comando | Argumentos | Descrição |
 |---------|------------|-----------|
-| `announce` | - | Envia uma mensagem de anúncio visível para todos os jogadores ligados. |
+| `announce` | `<message>` | Envia uma mensagem de anúncio visível para todos os jogadores ligados. |
 | `players` | - | Apresenta a lista dos jogadores atualmente ligados ao servidor. |
 | `info` | - | Devolve as informações gerais do servidor. |
 | `settings` | - | Devolve a configuração atual do servidor. |


### PR DESCRIPTION
The announce command takes a message argument; fill the Arguments column for that row (was empty) across all locales.