### PR TITLE
PCI - Minor updates on a few guides

### DIFF
--- a/docs/de/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -175,11 +175,11 @@ Wechseln Sie vom Dashboard zum Tab <code className="action">VNC-Konsole</code>.
 
 Die VNC-Konsole bietet direkten Zugriff auf Ihre Instanz. Damit dieser Zugang funktioniert, müssen Sie zuerst einen Benutzernamen und ein Passwort auf der Instanz konfigurieren.
 
-Weitere Informationen zu den notwendigen Schritten finden Sie in unserer Anleitung "[Erstellung einer Public Cloud Instanz](/guides/public-cloud/compute/getting-started#vnc-console)".
+Weitere Informationen zu den notwendigen Schritten finden Sie in unserer Anleitung "[Eine Public Cloud Instanz erstellen und darauf zugreifen](/guides/public-cloud/compute/getting-started#vnc-console)".
 
 ## Weiterführende Informationen
 
-[Erste Public Cloud Instanz erstellen und auf dieser einloggen](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[Eine Public Cloud Instanz erstellen und darauf zugreifen](/guides/public-cloud/compute/getting-started)
 
 [Einführung in Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 

--- a/docs/de/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/de/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -137,7 +137,9 @@ NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
 vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
 ```
 
+:::info
 Die folgenden Schritte gelten für **ext2/ext3/ext4**-Dateisysteme. Im Gegensatz zu ext4 kann XFS nicht im ausgehängten Zustand vergrößert werden – das Tool `xfs_growfs` benötigt ein eingehängtes Dateisystem. Wenn Ihr Dateisystem **XFS** ist, hängen Sie die Disk trotzdem wie unten beschrieben aus und erstellen Sie die Partition neu, überspringen Sie dabei jedoch die Schritte `e2fsck` und `resize2fs`: Hängen Sie die Disk stattdessen erneut ein und führen Sie anschließend `sudo xfs_growfs /mnt/disk` aus.
+:::
 
 Überprüfen Sie vor dem Aushängen das aktuelle Partitionslayout:
 
@@ -173,7 +175,7 @@ In unserem Beispiel:
 admin@server:~$ sudo umount /mnt/vdb
 ```
 
-Erstellen Sie die Partition mit folgendem Befehl neu. Dabei wird lediglich die Partitionstabelle neu geschrieben – die Daten Ihres Dateisystems werden nicht angetastet und bleiben erhalten, sofern Sie bei der entsprechenden Abfrage genau denselben Startsektor erneut eingeben.
+Erstellen Sie die Partition mit folgendem Befehl neu. Dabei wird lediglich die Partitionstabelle neu geschrieben – die Daten Ihres Dateisystems bleiben erhalten, sofern Sie bei der entsprechenden Abfrage genau denselben Startsektor erneut eingeben.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
@@ -228,7 +230,7 @@ Created a new partition 1 of type 'Linux' and of size 70 GiB.
 
 Um die Änderungen anzuzeigen, geben Sie erneut `p` ein.
 
-Geben Sie anschließend `w` ein, um die vorgenommenen Änderungen zu speichern:
+Geben Sie anschließend `w` ein, um die Änderungen zu speichern:
 
 ```console
 Command (m for help): w
@@ -302,7 +304,7 @@ Klicken Sie mit der rechten Maustaste auf das Volume und wählen Sie im Kontextm
 
 Klicken Sie im "Volume erweitern-Assistenten" auf <code className="action">Weiter</code>.
 
-In diesem Schritt können Sie den Speicherplatz anpassen, wenn Sie der Partition weniger als die gesamte verfügbare Kapazität hinzufügen möchten. Klicken Sie auf <code className="action">Weiter</code>.
+In diesem Schritt können Sie den Speicherplatz anpassen, um der Partition weniger als die volle verfügbare Kapazität hinzuzufügen. Klicken Sie auf <code className="action">Weiter</code>.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-04.png" loading="lazy" />
 

--- a/docs/de/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -78,7 +78,7 @@ Weitere Informationen finden Sie auf der Seite [OVHcloud Public Cloud Gratis-Tes
 
 ## Weiterführende Informationen
 
-- [Erste Public Cloud Instanz erstellen und auf dieser einloggen](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+- [Eine Public Cloud Instanz erstellen und darauf zugreifen](/guides/public-cloud/compute/getting-started)
 - [Kontakte eines Projekts ändern](/guides/public-cloud/compute/change-project-contacts)
 - [Projekte delegieren](/guides/public-cloud/cross-functional/delegate-projects)
 - [Ein Public Cloud Projekt löschen](/guides/public-cloud/cross-functional/delete-a-project)

--- a/docs/de/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -90,7 +90,7 @@ Weitere Informationen finden Sie unter [diesem Link](https://www.linux-kvm.org/p
 
 Die Verbindung erfolgt mit einem SSH-Schlüsselpaar, das bei der Erstellung Ihrer Public Cloud-Instanz konfiguriert werden muss.
 
-Lesen Sie die Anleitung [Erste Public Cloud Instanz erstellen und auf dieser einloggen](/guides/public-cloud/compute/getting-started).
+Lesen Sie die Anleitung [Eine Public Cloud Instanz erstellen und darauf zugreifen](/guides/public-cloud/compute/getting-started).
 
 </details>
 

--- a/docs/de/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -122,7 +122,7 @@ Die folgende Tabelle vergleicht die wichtigsten Merkmale jedes Tools, um Ihnen d
 
 ## Weiterführende Informationen
 
-[Public Cloud Instanz erstellen und verwenden](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[Eine Public Cloud Instanz erstellen und darauf zugreifen](/guides/public-cloud/compute/getting-started)
 
 Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 

--- a/docs/de/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/de/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-06-10
+lastUpdated: 2026-07-16
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -24,7 +24,7 @@ Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/publ
 
 ## Understanding the Floating IP service
 
-Floating IP is one of the services delivered by the OpenStack DVR (Distributed Virtual Router) services of the OVHcloud Public Cloud.
+Floating IP is one of the services delivered by the OpenStack DVR (Distributed Virtual Router) component of OVHcloud Public Cloud.
 
 Floating IP lets you create a public IP address for your private-network-based VMs, handling both incoming and outgoing traffic. Floating IP addresses can be attached and detached from your VMs at any time. 
 
@@ -36,7 +36,7 @@ You can hold Floating IP addresses without attaching them to any service. They r
 
 The goal of this exercise is to create a VM (**vm4fip**) with a private local network (**test-network**) only, and use a router (**router1**) to set up a Floating IP.
 
-Next, we will use this Floating IP to connect to the instance (VM) from the outside and check its access to the Internet.
+Next, you will use this Floating IP to connect to the instance (VM) from the outside and check its access to the Internet.
 
 ## Instructions
 
@@ -69,7 +69,7 @@ Click one of the two tabs below depending on whether you want to attach a Floati
     
     Before creating your instance, make sure you have created a [private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
     
-    To create a new instance, follow [this guide](/guides/public-cloud/compute/first-steps-with-public-cloud-instance) if necessary. 
+    To create a new instance, follow [this guide](/guides/public-cloud/compute/getting-started) if necessary. 
     
     
     :::warning
@@ -80,9 +80,9 @@ Click one of the two tabs below depending on whether you want to attach a Floati
     
     In Step 5, you can choose a networking mode for your instance: Public or Private.
     
-    By default, the public mode is selected, but since we are creating an instance to which we will attach a Floating IP, we need to create an instance with a private network **ONLY**.
+    By default, the public mode is selected, but since you are creating an instance to which you will attach a Floating IP, you need to create an instance with a private network **ONLY**.
     
-    Select the <code className="action">Private mode</code> and click on the drop down list to select a private network of your choice (the network must have been previously created with a Gateway or linked to a Gateway). 
+    Select the <code className="action">Private mode</code> and click on the drop-down list to select a private network of your choice (the network must have been previously created with a Gateway or linked to a Gateway). 
     
     If you select a private network that is not linked to a Gateway, the system will automatically create a Gateway of size "S" by default and attach it to your network.
     
@@ -96,7 +96,7 @@ When you have applied your choices, click <code className="action">Next</code> t
     
     <img className="thumbnail" alt="selectbilling" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/selectbilling.png" loading="lazy" />
 
-Choose hourly billing if you are unsure about the usage period — you cannot switch to it after delivery. You will have the option to switch to a monthly subscription as soon as the instance is available on the “Instances” page.
+Choose hourly billing if you are unsure about the usage period — you cannot switch to it after delivery. You will have the option to switch to a monthly subscription as soon as the instance is available on the "Instances" page.
     
     :::warning
     If you choose to be billed hourly, you will continue to be billed as long as the instance is not deleted. It does not matter if the instance is not actually used during this time. 
@@ -109,7 +109,7 @@ Choose hourly billing if you are unsure about the usage period — you cannot sw
   <Tab label="Option 2">
     **In case of an existing instance (created with a private network only).**
     
-    Please note that the private network must be linked to a gateway. For more information, consult this guide: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
+    Please note that the private network must be linked to a Gateway. For more information, consult this guide: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
     
     Click on <code className="action">Public IPs</code> in the left-hand menu under **Network**.
     
@@ -132,7 +132,7 @@ In the next step, choose a region for your Floating IPs. The region must be the 
     :::
 
     
-    Next, click on the drop down list to select the instance to attach the Floating IP to, then select the network/IP (this will be in the default range selected when creating the private network of the instance). 
+    Next, click on the drop-down list to select the instance to attach the Floating IP to, then select the network/IP (this will be in the default range selected when creating the private network of the instance). 
     
     <img className="thumbnail" alt="select instance" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/selectinstance.png" loading="lazy" />
     
@@ -193,7 +193,9 @@ Click on the tabs below to view each of the 9 steps in turn.
     ```
   </Tab>
   <Tab label="Step 2">
-    Create a private network if needed.<br/> If you have one already, you can skip this step.
+    Create a private network if needed.
+
+    If you have one already, you can skip this step.
     
     ```bash
     $ openstack network create test-network
@@ -207,7 +209,9 @@ Click on the tabs below to view each of the 9 steps in turn.
     ```
   </Tab>
   <Tab label="Step 3">
-    Create a subnet for your **test-network**.<br/> If you have one already, you can skip this step.
+    Create a subnet for your **test-network**.
+
+    If you have one already, you can skip this step.
     
     The subnet should have the **DHCP** service enabled and a **gateway IP** configured.
     
@@ -281,7 +285,7 @@ Click on the tabs below to view each of the 9 steps in turn.
     +--------+--------+
     ```
     
-    Now we have a VM named **vm4fip** with a private interface only. This VM has no access outside **test-network**.
+    You now have a VM named **vm4fip** with a private interface only. This VM has no access outside **test-network**.
   </Tab>
   <Tab label="Step 8">
     Create a Floating IP from **Ext-Net** network.
@@ -432,7 +436,7 @@ Before you proceed, make sure your instance is linked to a private network **onl
 
 
 
-Log into the Horizon interface, and ensure that you are in the correct region. You can verify this on the top left corner.
+Log into the Horizon interface, and ensure that you are in the correct region. You can verify this in the top left corner.
 
 <img className="thumbnail" alt="Region selection" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/region2021.png" loading="lazy" />
 
@@ -526,7 +530,7 @@ With the OVHcloud API, you can only attach a Floating IP to an existing instance
   <Tab label="Step 3">
     Once you have gathered all the information, you can now create a Floating IP and attach it to an instance using the following call.
     
-    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/instance"} />
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/instance/\{instanceId\}/floatingIp"} />
 
 Fill in the fields according to the following table.
     
@@ -535,11 +539,10 @@ Fill in the fields according to the following table.
     |serviceName|ID of the project|
     |regionName|Name of the region in which the instance is located|
     |instanceId|ID of the instance|
-    |name|Define a name for your Gateway|
-    |ip|The private IP of the instance|
+    |ip|The private IP of the instance to associate the Floating IP with|
     
     :::info
-    The "gateway" property field should be left empty because you are attaching a Floating IP to an instance initially created with a private network **only** and already linked to a Gateway. Please note that for now, the Floating IP will not be created if the instance is linked to a private network that is not attached to a Gateway.
+    The request body also accepts an optional `gateway` object, used to create a new Gateway at the same time. Since this guide assumes your instance's private network is already linked to a Gateway (see [Requirements](#requirements)), leave it out of the request entirely.
 
     :::
 
@@ -550,7 +553,57 @@ Fill in the fields according to the following table.
 
 #### Detaching a Floating IP
 
-This feature is available via the [OpenStack API](#detachip) and the [Horizon interface](#disassociateip). 
+To detach a Floating IP from your instance without deleting it, use the following API calls.
+
+First, retrieve the necessary information.
+
+For the project ID, the calls below allow you to retrieve it.
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project"} />
+
+
+:::info
+This call retrieves the list of projects.
+
+:::
+
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}"} />
+
+
+:::info
+This call identifies the project via the "description" field.
+
+:::
+
+
+For the Floating IP ID, the call below allows you to retrieve it.
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip"} />
+
+
+:::info
+Fill in the fields with the information previously obtained:
+
+- **serviceName**: The project ID
+- **regionName**: The name of the region
+
+:::
+
+
+Once the information has been retrieved, use the following call to detach the Floating IP from the instance. This does not delete it — it returns to your pool of Floating IPs.
+
+<Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip/\{floatingIpId\}/detach"} />
+
+
+:::info
+Fill in the fields with the information previously obtained:
+
+- **serviceName**: The project ID
+- **regionName**: The name of the region in which the Floating IP is located
+- **floatingIpId**: The ID of the Floating IP
+
+:::
 
 #### Deleting a Floating IP
 
@@ -660,6 +713,6 @@ ovhcloud cloud floating-ip delete <floating_ip_id> --region <region>
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or [request a quote from our Professional Services team](/links/professional-services) to get assistance on your specific use case.
+For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analyzed by our experts.
 
 Join our [community of users](/links/community).

--- a/docs/de/guides/public-cloud/network-services/vrack.mdx
+++ b/docs/de/guides/public-cloud/network-services/vrack.mdx
@@ -422,7 +422,7 @@ Im Feld **Name des privaten Netzwerks** legen Sie einen Namen für Ihr privates 
     **Netzwerk-Gateway-Optionen**
     
     - **Die erste Adresse einer bestimmten CIDR als Standard-Gateway ankündigen (DHCP-Option 3)**: Wenn diese Option aktiviert ist, bewirbt der DHCP-Server die erste Adresse im CIDR als Standard-Gateway für Geräte, die mit dem Netzwerk verbunden sind.
-    - **Ein Gateway zuweisen und sich mit dem privaten Netzwerk verbinden**: Wählen Sie diese Option, wenn Sie beabsichtigen, Instanzen mit einem privaten Netzwerk zu erstellen. Weitere Informationen finden Sie in den folgenden Anleitungen: [Ein privates Netzwerk mit Gateway erstellen](/guides/public-cloud/network-services/create-private-network-gateway) und [Erstellen und Verbinden mit Ihrer ersten Public Cloud-Instanz](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
+    - **Ein Gateway zuweisen und sich mit dem privaten Netzwerk verbinden**: Wählen Sie diese Option, wenn Sie beabsichtigen, Instanzen mit einem privaten Netzwerk zu erstellen. Weitere Informationen finden Sie in den folgenden Anleitungen: [Ein privates Netzwerk mit Gateway erstellen](/guides/public-cloud/network-services/create-private-network-gateway) und [Eine Public Cloud Instanz erstellen und darauf zugreifen](/guides/public-cloud/compute/getting-started).
     
     :::warning
     Wenn die zweite Option grau ist, bedeutet dies, dass die ausgewählte Region sie nicht unterstützt. Weitere Informationen finden Sie auf unserer [Seite zur Regionenverfügbarkeit](/links/public-cloud/regions-pci).

--- a/docs/en/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -179,7 +179,7 @@ Consult our [Getting started guide](/guides/public-cloud/compute/getting-started
 
 ## Go further
 
-[Creating and connecting to your first Public Cloud instance](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[How to create a Public Cloud instance and connect to it](/guides/public-cloud/compute/getting-started)
 
 [Introducing Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 

--- a/docs/en/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/en/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -84,7 +84,7 @@ To resize your disk at the right time, monitor disk usage regularly. Below are q
   </Tab>
   <Tab label="On Linux">
     <details>
-    <summary>Using 'df' command</summary>
+    <summary>Using `df` command</summary>
 
     
     To check overall disk usage, run:
@@ -99,7 +99,7 @@ To resize your disk at the right time, monitor disk usage regularly. Below are q
     </details>
     
     <details>
-    <summary>Using 'lsblk' command</summary>
+    <summary>Using `lsblk` command</summary>
 
     
     To view disk partitions and their sizes:
@@ -151,7 +151,9 @@ NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
 vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
 ```
 
+:::info
 The steps below apply to **ext2/ext3/ext4** filesystems. Unlike ext4, XFS cannot be resized while unmounted — the `xfs_growfs` tool requires the filesystem to be mounted. If your filesystem is **XFS**, still unmount the disk and recreate the partition as described below, but skip the `e2fsck` and `resize2fs` steps: remount the disk instead, then run `sudo xfs_growfs /mnt/disk`.
+:::
 
 Before unmounting, check the current partition layout:
 
@@ -187,7 +189,7 @@ In our example:
 admin@server:~$ sudo umount /mnt/vdb
 ```
 
-Recreate the partition using the following command. This process only rewrites the partition table — your filesystem data is not touched and will be preserved, provided you re-enter the exact same start sector when prompted.
+Recreate the partition using the following command. This process only rewrites the partition table — your filesystem data is preserved, provided you re-enter the exact same start sector when prompted.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
@@ -242,7 +244,7 @@ Created a new partition 1 of type 'Linux' and of size 70 GiB.
 
 To list the changes, type `p` again.
 
-Next, type `w` to save the changes made:
+Next, type `w` to save the changes:
 
 ```console
 Command (m for help): w
@@ -252,7 +254,7 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Verify and check the partition (for **ext2/ext3/ext4** filesystems):
+Check the partition (for **ext2/ext3/ext4** filesystems):
 
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
@@ -316,7 +318,7 @@ Right-click on the volume and select <code className="action">Extend Volume</cod
 
 In the "Extend Volume Wizard", click <code className="action">Next</code>.
 
-You can modify the disk space in this step if you want to add less than the entire amount to the partition. Click on <code className="action">Next</code>.
+You can modify the disk space in this step to add less than the full amount to the partition. Click on <code className="action">Next</code>.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-04.png" loading="lazy" />
 

--- a/docs/en/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -72,7 +72,7 @@ Learn more on the [OVHcloud Public Cloud free trial](/links/public-cloud/free-tr
 
 ## Go further
 
-- [Creating and connecting to your first Public Cloud instance](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+- [How to create a Public Cloud instance and connect to it](/guides/public-cloud/compute/getting-started)
 - [Changing project contacts](/guides/public-cloud/compute/change-project-contacts)
 - [Delegating projects](/guides/public-cloud/cross-functional/delegate-projects)
 - [Deleting a Public Cloud project](/guides/public-cloud/cross-functional/delete-a-project)

--- a/docs/en/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -89,7 +89,7 @@ See the [linux-kvm limitations](https://www.linux-kvm.org/page/Nested_Guests#Lim
 
 You can log in using an SSH key set that you need to configure when you create your Public Cloud instance.
 
-Please read our guide on [Creating and connecting to your first Public Cloud instance](/guides/public-cloud/compute/getting-started).
+Please read our guide on [How to create a Public Cloud instance and connect to it](/guides/public-cloud/compute/getting-started).
 
 </details>
 

--- a/docs/en/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -121,7 +121,7 @@ The matrix below compares the key features of each tool to help you choose the s
 
 ## Go further
 
-[Creating and connecting to your first Public Cloud instance](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[How to create a Public Cloud instance and connect to it](/guides/public-cloud/compute/getting-started)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/docs/en/guides/public-cloud/databases/configure-vrack.mdx
+++ b/docs/en/guides/public-cloud/databases/configure-vrack.mdx
@@ -99,7 +99,7 @@ If you want to test the access from an existing instance, read this tutorial to 
 
 ### Step 5 - Example of verification with a Public Cloud Databases for Valkey
 
-We assume that you have an already set SSH key on your project. For more details, read the [Creating and connecting to your first Public Cloud instance](/guides/public-cloud/compute/first-steps-with-public-cloud-instance) page.
+We assume that you have an already set SSH key on your project. For more details, read the [How to create a Public Cloud instance and connect to it](/guides/public-cloud/compute/getting-started) page.
 
 Connect to the instance via SSH:
 

--- a/docs/en/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/en/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-06-10
+lastUpdated: 2026-07-16
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -24,7 +24,7 @@ Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/publ
 
 ## Understanding the Floating IP service
 
-Floating IP is one of the services delivered by the OpenStack DVR (Distributed Virtual Router) services of the OVHcloud Public Cloud.
+Floating IP is one of the services delivered by the OpenStack DVR (Distributed Virtual Router) component of OVHcloud Public Cloud.
 
 Floating IP lets you create a public IP address for your private-network-based VMs, handling both incoming and outgoing traffic. Floating IP addresses can be attached and detached from your VMs at any time. 
 
@@ -36,7 +36,7 @@ You can hold Floating IP addresses without attaching them to any service. They r
 
 The goal of this exercise is to create a VM (**vm4fip**) with a private local network (**test-network**) only, and use a router (**router1**) to set up a Floating IP.
 
-Next, we will use this Floating IP to connect to the instance (VM) from the outside and check its access to the Internet.
+Next, you will use this Floating IP to connect to the instance (VM) from the outside and check its access to the Internet.
 
 ## Instructions
 
@@ -69,7 +69,7 @@ Click one of the two tabs below depending on whether you want to attach a Floati
     
     Before creating your instance, make sure you have created a [private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
     
-    To create a new instance, follow [this guide](/guides/public-cloud/compute/first-steps-with-public-cloud-instance) if necessary. 
+    To create a new instance, follow [this guide](/guides/public-cloud/compute/getting-started) if necessary. 
     
     
     :::warning
@@ -80,9 +80,9 @@ Click one of the two tabs below depending on whether you want to attach a Floati
     
     In Step 5, you can choose a networking mode for your instance: Public or Private.
     
-    By default, the public mode is selected, but since we are creating an instance to which we will attach a Floating IP, we need to create an instance with a private network **ONLY**.
+    By default, the public mode is selected, but since you are creating an instance to which you will attach a Floating IP, you need to create an instance with a private network **ONLY**.
     
-    Select the <code className="action">Private mode</code> and click on the drop down list to select a private network of your choice (the network must have been previously created with a Gateway or linked to a Gateway). 
+    Select the <code className="action">Private mode</code> and click on the drop-down list to select a private network of your choice (the network must have been previously created with a Gateway or linked to a Gateway). 
     
     If you select a private network that is not linked to a Gateway, the system will automatically create a Gateway of size "S" by default and attach it to your network.
     
@@ -96,7 +96,7 @@ When you have applied your choices, click <code className="action">Next</code> t
     
     <img className="thumbnail" alt="selectbilling" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/selectbilling.png" loading="lazy" />
 
-Choose hourly billing if you are unsure about the usage period — you cannot switch to it after delivery. You will have the option to switch to a monthly subscription as soon as the instance is available on the “Instances” page.
+Choose hourly billing if you are unsure about the usage period — you cannot switch to it after delivery. You will have the option to switch to a monthly subscription as soon as the instance is available on the "Instances" page.
     
     :::warning
     If you choose to be billed hourly, you will continue to be billed as long as the instance is not deleted. It does not matter if the instance is not actually used during this time. 
@@ -109,7 +109,7 @@ Choose hourly billing if you are unsure about the usage period — you cannot sw
   <Tab label="Option 2">
     **In case of an existing instance (created with a private network only).**
     
-    Please note that the private network must be linked to a gateway. For more information, consult this guide: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
+    Please note that the private network must be linked to a Gateway. For more information, consult this guide: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
     
     Click on <code className="action">Public IPs</code> in the left-hand menu under **Network**.
     
@@ -132,7 +132,7 @@ In the next step, choose a region for your Floating IPs. The region must be the 
     :::
 
     
-    Next, click on the drop down list to select the instance to attach the Floating IP to, then select the network/IP (this will be in the default range selected when creating the private network of the instance). 
+    Next, click on the drop-down list to select the instance to attach the Floating IP to, then select the network/IP (this will be in the default range selected when creating the private network of the instance). 
     
     <img className="thumbnail" alt="select instance" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/selectinstance.png" loading="lazy" />
     
@@ -193,7 +193,9 @@ Click on the tabs below to view each of the 9 steps in turn.
     ```
   </Tab>
   <Tab label="Step 2">
-    Create a private network if needed.<br/> If you have one already, you can skip this step.
+    Create a private network if needed.
+
+    If you have one already, you can skip this step.
     
     ```bash
     $ openstack network create test-network
@@ -207,7 +209,9 @@ Click on the tabs below to view each of the 9 steps in turn.
     ```
   </Tab>
   <Tab label="Step 3">
-    Create a subnet for your **test-network**.<br/> If you have one already, you can skip this step.
+    Create a subnet for your **test-network**.
+
+    If you have one already, you can skip this step.
     
     The subnet should have the **DHCP** service enabled and a **gateway IP** configured.
     
@@ -281,7 +285,7 @@ Click on the tabs below to view each of the 9 steps in turn.
     +--------+--------+
     ```
     
-    Now we have a VM named **vm4fip** with a private interface only. This VM has no access outside **test-network**.
+    You now have a VM named **vm4fip** with a private interface only. This VM has no access outside **test-network**.
   </Tab>
   <Tab label="Step 8">
     Create a Floating IP from **Ext-Net** network.
@@ -432,7 +436,7 @@ Before you proceed, make sure your instance is linked to a private network **onl
 
 
 
-Log into the Horizon interface, and ensure that you are in the correct region. You can verify this on the top left corner.
+Log into the Horizon interface, and ensure that you are in the correct region. You can verify this in the top left corner.
 
 <img className="thumbnail" alt="Region selection" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/region2021.png" loading="lazy" />
 
@@ -526,7 +530,7 @@ With the OVHcloud API, you can only attach a Floating IP to an existing instance
   <Tab label="Step 3">
     Once you have gathered all the information, you can now create a Floating IP and attach it to an instance using the following call.
     
-    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/instance"} />
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/instance/\{instanceId\}/floatingIp"} />
 
 Fill in the fields according to the following table.
     
@@ -535,11 +539,10 @@ Fill in the fields according to the following table.
     |serviceName|ID of the project|
     |regionName|Name of the region in which the instance is located|
     |instanceId|ID of the instance|
-    |name|Define a name for your Gateway|
-    |ip|The private IP of the instance|
+    |ip|The private IP of the instance to associate the Floating IP with|
     
     :::info
-    The "gateway" property field should be left empty because you are attaching a Floating IP to an instance initially created with a private network **only** and already linked to a Gateway. Please note that for now, the Floating IP will not be created if the instance is linked to a private network that is not attached to a Gateway.
+    The request body also accepts an optional `gateway` object, used to create a new Gateway at the same time. Since this guide assumes your instance's private network is already linked to a Gateway (see [Requirements](#requirements)), leave it out of the request entirely.
 
     :::
 
@@ -550,7 +553,57 @@ Fill in the fields according to the following table.
 
 #### Detaching a Floating IP
 
-This feature is available via the [OpenStack API](#detachip) and the [Horizon interface](#disassociateip). 
+To detach a Floating IP from your instance without deleting it, use the following API calls.
+
+First, retrieve the necessary information.
+
+For the project ID, the calls below allow you to retrieve it.
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project"} />
+
+
+:::info
+This call retrieves the list of projects.
+
+:::
+
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}"} />
+
+
+:::info
+This call identifies the project via the "description" field.
+
+:::
+
+
+For the Floating IP ID, the call below allows you to retrieve it.
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip"} />
+
+
+:::info
+Fill in the fields with the information previously obtained:
+
+- **serviceName**: The project ID
+- **regionName**: The name of the region
+
+:::
+
+
+Once the information has been retrieved, use the following call to detach the Floating IP from the instance. This does not delete it — it returns to your pool of Floating IPs.
+
+<Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip/\{floatingIpId\}/detach"} />
+
+
+:::info
+Fill in the fields with the information previously obtained:
+
+- **serviceName**: The project ID
+- **regionName**: The name of the region in which the Floating IP is located
+- **floatingIpId**: The ID of the Floating IP
+
+:::
 
 #### Deleting a Floating IP
 
@@ -660,6 +713,6 @@ ovhcloud cloud floating-ip delete <floating_ip_id> --region <region>
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or [request a quote from our Professional Services team](/links/professional-services) to get assistance on your specific use case.
+For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analyzed by our experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/vrack.mdx
+++ b/docs/en/guides/public-cloud/network-services/vrack.mdx
@@ -422,7 +422,7 @@ In the **Private Network Name** field, set a name for your private network.
     **Network Gateway Options**
     
     - **Announce the first address of a given CIDR as the default gateway (DHCP option 3)**: When this option is enabled, the DHCP server advertises the first address in the CIDR as the default gateway to machines connected to the network.
-    - **Assign a Gateway and connect to the private network**: Select this option if you intend to create instances with a private network only. For more information, please consult the following guides: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway) and [Creating and connecting to your first Public Cloud instance](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
+    - **Assign a Gateway and connect to the private network**: Select this option if you intend to create instances with a private network only. For more information, please consult the following guides: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway) and [How to create a Public Cloud instance and connect to it](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
     
     :::warning
     If the second option is greyed out, it means the region selected does not support it. For more information, please refer to our [regions availability](/links/public-cloud/regions-pci) page. 

--- a/docs/es/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -177,11 +177,11 @@ Haga clic en la pestaña <code className="action">Consola VNC</code>.
 
 La consola VNC proporciona acceso directo a su instancia. Para que este acceso funcione, primero debe configurar un nombre de usuario y una contraseña en la instancia.
 
-Consulte nuestra guía [Crear una primera instancia de Public Cloud y conectarse a ella](/guides/public-cloud/compute/getting-started#vnc-console) para más información.
+Consulte nuestra guía [Cómo crear una instancia de Public Cloud y conectarse a ella](/guides/public-cloud/compute/getting-started#vnc-console) para más información.
 
 ## Más información
 
-[Crear una primera instancia de Public Cloud y conectarse a ella](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[Cómo crear una instancia de Public Cloud y conectarse a ella](/guides/public-cloud/compute/getting-started)
 
 [Presentación de Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 

--- a/docs/es/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/es/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -84,7 +84,7 @@ Para cambiar el tamaño del disco en el momento adecuado, supervise el uso del d
   </Tab>
   <Tab label="Para Linux">
     <details>
-    <summary>Uso del comando 'df'</summary>
+    <summary>Uso del comando `df`</summary>
 
     
     Para comprobar el uso global del disco, ejecute el comando
@@ -99,7 +99,7 @@ Para cambiar el tamaño del disco en el momento adecuado, supervise el uso del d
     </details>
     
     <details>
-    <summary>Uso del comando 'lsblk'</summary>
+    <summary>Uso del comando `lsblk`</summary>
 
     
     Para ver las particiones del disco y su tamaño:
@@ -151,7 +151,9 @@ NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
 vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
 ```
 
+:::info
 Los siguientes pasos se aplican a los sistemas de archivos **ext2/ext3/ext4**. A diferencia de ext4, XFS no se puede redimensionar cuando está desmontado: la herramienta `xfs_growfs` requiere que el sistema de archivos esté montado. Si su sistema de archivos es **XFS**, desmonte el disco y vuelva a crear la partición como se indica a continuación, pero omita los pasos `e2fsck` y `resize2fs`: vuelva a montar el disco y ejecute `sudo xfs_growfs /mnt/disk`.
+:::
 
 Antes de desmontar, compruebe la disposición actual de la partición:
 
@@ -181,7 +183,7 @@ Desmonte primero el disco:
 admin@server:~$ sudo umount /mnt/disk
 ```
 
-Vuelva a crear la partición con el siguiente comando. Este proceso solo reescribe la tabla de particiones: sus datos no se ven afectados y se conservarán, siempre que introduzca el mismo sector de inicio cuando se le solicite.
+Vuelva a crear la partición con el siguiente comando. Este proceso solo reescribe la tabla de particiones: sus datos se conservarán, siempre que introduzca el mismo sector de inicio cuando se le solicite.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
@@ -246,7 +248,7 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Compruebe y verifique la partición (para los sistemas de archivos **ext2/ext3/ext4**):
+Compruebe la partición (para los sistemas de archivos **ext2/ext3/ext4**):
 
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
@@ -310,7 +312,7 @@ Haga clic con el botón derecho en el volumen y seleccione <code className="acti
 
 En el asistente para extender volumen, haga clic en <code className="action">Siguiente</code>.
 
-En este paso, puede modificar el espacio en disco si desea añadir una capacidad menor que la totalidad de la partición.
+En este paso, puede modificar el espacio en disco para añadir una capacidad menor que la totalidad de la partición.
 
 Haga clic en <code className="action">Siguiente</code>.
 

--- a/docs/es/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -78,7 +78,7 @@ Más información en la página [Prueba gratuita Public Cloud OVHcloud](/links/p
 
 ## Más información
 
-- [Crear y conectarse a una instancia de Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+- [Cómo crear una instancia de Public Cloud y conectarse a ella](/guides/public-cloud/compute/getting-started)
 - [Cambiar los contactos de un proyecto](/guides/public-cloud/compute/change-project-contacts)
 - [Delegar proyectos](/guides/public-cloud/cross-functional/delegate-projects)
 - [Eliminar un proyecto de Public Cloud](/guides/public-cloud/cross-functional/delete-a-project)

--- a/docs/es/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -88,7 +88,7 @@ Siga [este enlace](https://www.linux-kvm.org/page/Nested_Guests#Limitations) par
 
 La conexión se realiza gracias a un par de llaves SSH que deberá configurar al crear la instancia de Public Cloud.
 
-Para más información, consulte la guía [Crear y conectarse a una primera instancia de Public Cloud](/guides/public-cloud/compute/getting-started).
+Para más información, consulte la guía [Cómo crear una instancia de Public Cloud y conectarse a ella](/guides/public-cloud/compute/getting-started).
 
 </details>
 

--- a/docs/es/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -121,7 +121,7 @@ La siguiente matriz compara las características clave de cada herramienta para 
 
 ## Más información
 
-[Crear y conectarse a una instancia de Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[Cómo crear una instancia de Public Cloud y conectarse a ella](/guides/public-cloud/compute/getting-started)
 
 Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 

--- a/docs/es/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/es/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-06-10
+lastUpdated: 2026-07-16
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -24,7 +24,7 @@ Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/publ
 
 ## Understanding the Floating IP service
 
-Floating IP is one of the services delivered by the OpenStack DVR (Distributed Virtual Router) services of the OVHcloud Public Cloud.
+Floating IP is one of the services delivered by the OpenStack DVR (Distributed Virtual Router) component of OVHcloud Public Cloud.
 
 Floating IP lets you create a public IP address for your private-network-based VMs, handling both incoming and outgoing traffic. Floating IP addresses can be attached and detached from your VMs at any time. 
 
@@ -36,7 +36,7 @@ You can hold Floating IP addresses without attaching them to any service. They r
 
 The goal of this exercise is to create a VM (**vm4fip**) with a private local network (**test-network**) only, and use a router (**router1**) to set up a Floating IP.
 
-Next, we will use this Floating IP to connect to the instance (VM) from the outside and check its access to the Internet.
+Next, you will use this Floating IP to connect to the instance (VM) from the outside and check its access to the Internet.
 
 ## Instructions
 
@@ -69,7 +69,7 @@ Click one of the two tabs below depending on whether you want to attach a Floati
     
     Before creating your instance, make sure you have created a [private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
     
-    To create a new instance, follow [this guide](/guides/public-cloud/compute/first-steps-with-public-cloud-instance) if necessary. 
+    To create a new instance, follow [this guide](/guides/public-cloud/compute/getting-started) if necessary. 
     
     
     :::warning
@@ -80,9 +80,9 @@ Click one of the two tabs below depending on whether you want to attach a Floati
     
     In Step 5, you can choose a networking mode for your instance: Public or Private.
     
-    By default, the public mode is selected, but since we are creating an instance to which we will attach a Floating IP, we need to create an instance with a private network **ONLY**.
+    By default, the public mode is selected, but since you are creating an instance to which you will attach a Floating IP, you need to create an instance with a private network **ONLY**.
     
-    Select the <code className="action">Private mode</code> and click on the drop down list to select a private network of your choice (the network must have been previously created with a Gateway or linked to a Gateway). 
+    Select the <code className="action">Private mode</code> and click on the drop-down list to select a private network of your choice (the network must have been previously created with a Gateway or linked to a Gateway). 
     
     If you select a private network that is not linked to a Gateway, the system will automatically create a Gateway of size "S" by default and attach it to your network.
     
@@ -96,7 +96,7 @@ When you have applied your choices, click <code className="action">Next</code> t
     
     <img className="thumbnail" alt="selectbilling" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/selectbilling.png" loading="lazy" />
 
-Choose hourly billing if you are unsure about the usage period — you cannot switch to it after delivery. You will have the option to switch to a monthly subscription as soon as the instance is available on the “Instances” page.
+Choose hourly billing if you are unsure about the usage period — you cannot switch to it after delivery. You will have the option to switch to a monthly subscription as soon as the instance is available on the "Instances" page.
     
     :::warning
     If you choose to be billed hourly, you will continue to be billed as long as the instance is not deleted. It does not matter if the instance is not actually used during this time. 
@@ -109,7 +109,7 @@ Choose hourly billing if you are unsure about the usage period — you cannot sw
   <Tab label="Option 2">
     **In case of an existing instance (created with a private network only).**
     
-    Please note that the private network must be linked to a gateway. For more information, consult this guide: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
+    Please note that the private network must be linked to a Gateway. For more information, consult this guide: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
     
     Click on <code className="action">Public IPs</code> in the left-hand menu under **Network**.
     
@@ -132,7 +132,7 @@ In the next step, choose a region for your Floating IPs. The region must be the 
     :::
 
     
-    Next, click on the drop down list to select the instance to attach the Floating IP to, then select the network/IP (this will be in the default range selected when creating the private network of the instance). 
+    Next, click on the drop-down list to select the instance to attach the Floating IP to, then select the network/IP (this will be in the default range selected when creating the private network of the instance). 
     
     <img className="thumbnail" alt="select instance" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/selectinstance.png" loading="lazy" />
     
@@ -193,7 +193,9 @@ Click on the tabs below to view each of the 9 steps in turn.
     ```
   </Tab>
   <Tab label="Step 2">
-    Create a private network if needed.<br/> If you have one already, you can skip this step.
+    Create a private network if needed.
+
+    If you have one already, you can skip this step.
     
     ```bash
     $ openstack network create test-network
@@ -207,7 +209,9 @@ Click on the tabs below to view each of the 9 steps in turn.
     ```
   </Tab>
   <Tab label="Step 3">
-    Create a subnet for your **test-network**.<br/> If you have one already, you can skip this step.
+    Create a subnet for your **test-network**.
+
+    If you have one already, you can skip this step.
     
     The subnet should have the **DHCP** service enabled and a **gateway IP** configured.
     
@@ -281,7 +285,7 @@ Click on the tabs below to view each of the 9 steps in turn.
     +--------+--------+
     ```
     
-    Now we have a VM named **vm4fip** with a private interface only. This VM has no access outside **test-network**.
+    You now have a VM named **vm4fip** with a private interface only. This VM has no access outside **test-network**.
   </Tab>
   <Tab label="Step 8">
     Create a Floating IP from **Ext-Net** network.
@@ -432,7 +436,7 @@ Before you proceed, make sure your instance is linked to a private network **onl
 
 
 
-Log into the Horizon interface, and ensure that you are in the correct region. You can verify this on the top left corner.
+Log into the Horizon interface, and ensure that you are in the correct region. You can verify this in the top left corner.
 
 <img className="thumbnail" alt="Region selection" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/region2021.png" loading="lazy" />
 
@@ -526,7 +530,7 @@ With the OVHcloud API, you can only attach a Floating IP to an existing instance
   <Tab label="Step 3">
     Once you have gathered all the information, you can now create a Floating IP and attach it to an instance using the following call.
     
-    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/instance"} />
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/instance/\{instanceId\}/floatingIp"} />
 
 Fill in the fields according to the following table.
     
@@ -535,11 +539,10 @@ Fill in the fields according to the following table.
     |serviceName|ID of the project|
     |regionName|Name of the region in which the instance is located|
     |instanceId|ID of the instance|
-    |name|Define a name for your Gateway|
-    |ip|The private IP of the instance|
+    |ip|The private IP of the instance to associate the Floating IP with|
     
     :::info
-    The "gateway" property field should be left empty because you are attaching a Floating IP to an instance initially created with a private network **only** and already linked to a Gateway. Please note that for now, the Floating IP will not be created if the instance is linked to a private network that is not attached to a Gateway.
+    The request body also accepts an optional `gateway` object, used to create a new Gateway at the same time. Since this guide assumes your instance's private network is already linked to a Gateway (see [Requirements](#requirements)), leave it out of the request entirely.
 
     :::
 
@@ -550,7 +553,57 @@ Fill in the fields according to the following table.
 
 #### Detaching a Floating IP
 
-This feature is available via the [OpenStack API](#detachip) and the [Horizon interface](#disassociateip). 
+To detach a Floating IP from your instance without deleting it, use the following API calls.
+
+First, retrieve the necessary information.
+
+For the project ID, the calls below allow you to retrieve it.
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project"} />
+
+
+:::info
+This call retrieves the list of projects.
+
+:::
+
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}"} />
+
+
+:::info
+This call identifies the project via the "description" field.
+
+:::
+
+
+For the Floating IP ID, the call below allows you to retrieve it.
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip"} />
+
+
+:::info
+Fill in the fields with the information previously obtained:
+
+- **serviceName**: The project ID
+- **regionName**: The name of the region
+
+:::
+
+
+Once the information has been retrieved, use the following call to detach the Floating IP from the instance. This does not delete it — it returns to your pool of Floating IPs.
+
+<Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip/\{floatingIpId\}/detach"} />
+
+
+:::info
+Fill in the fields with the information previously obtained:
+
+- **serviceName**: The project ID
+- **regionName**: The name of the region in which the Floating IP is located
+- **floatingIpId**: The ID of the Floating IP
+
+:::
 
 #### Deleting a Floating IP
 
@@ -660,6 +713,6 @@ ovhcloud cloud floating-ip delete <floating_ip_id> --region <region>
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or [request a quote from our Professional Services team](/links/professional-services) to get assistance on your specific use case.
+For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analyzed by our experts.
 
 Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/network-services/vrack.mdx
+++ b/docs/es/guides/public-cloud/network-services/vrack.mdx
@@ -424,7 +424,7 @@ En el campo **Nombre de la red privada**, defina un nombre para su red privada.
     **Opciones de puerta de enlace de red**
     
     - **Anunciar la primera dirección de un CIDR determinado como puerta de enlace predeterminada (opción DHCP 3)**: Cuando esta opción está activada, el servidor DHCP anuncia la primera dirección del CIDR como puerta de enlace predeterminada a las máquinas conectadas a la red.
-    - **Asignar un servicio Gateway y conectarse a la red privada**: Seleccione esta opción si tiene la intención de crear instancias con una red privada únicamente. Para más información, consulte las siguientes guías: [Crear una red privada con una Gateway](/guides/public-cloud/network-services/create-private-network-gateway) y [Crear una primera instancia Public Cloud y conectarse a ella](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
+    - **Asignar un servicio Gateway y conectarse a la red privada**: Seleccione esta opción si tiene la intención de crear instancias con una red privada únicamente. Para más información, consulte las siguientes guías: [Crear una red privada con una Gateway](/guides/public-cloud/network-services/create-private-network-gateway) y [Cómo crear una instancia de Public Cloud y conectarse a ella](/guides/public-cloud/compute/getting-started).
     
     :::warning
     Si la segunda opción está gris, significa que es incompatible con la región seleccionada. Para más información, consulte nuestra página sobre la [disponibilidad de los productos Public Cloud para cada región](/links/public-cloud/regions-pci).

--- a/docs/fr/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -177,11 +177,11 @@ Cliquez alors sur l'onglet <code className="action">Console VNC</code>.
 
 La console VNC fournit un accès direct à votre instance. Pour que cet accès fonctionne, vous devez d'abord configurer un nom d'utilisateur et un mot de passe sur l'instance. 
 
-Consultez notre guide « [Créer une première instance Public Cloud et s'y connecter](/guides/public-cloud/compute/getting-started#vnc-console) » pour plus d'informations.
+Consultez notre guide « [Comment créer une instance Public Cloud et s'y connecter](/guides/public-cloud/compute/getting-started) » pour plus d'informations.
 
 ## Aller plus loin
 
-[Créer une première instance Public Cloud et s’y connecter](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[Comment créer une instance Public Cloud et s'y connecter](/guides/public-cloud/compute/getting-started)
 
 [Présentation d'Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 

--- a/docs/fr/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/fr/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -84,7 +84,7 @@ Pour redimensionner votre disque au bon moment, surveillez régulièrement l'uti
   </Tab>
   <Tab label="Pour Linux">
     <details>
-    <summary>Utilisation de la commande 'df'</summary>
+    <summary>Utilisation de la commande `df`</summary>
 
     
     Pour vérifier l'utilisation globale du disque, exécutez la commande
@@ -99,7 +99,7 @@ Pour redimensionner votre disque au bon moment, surveillez régulièrement l'uti
     </details>
     
     <details>
-    <summary>Utilisation de la commande 'lsblk'</summary>
+    <summary>Utilisation de la commande `lsblk`</summary>
 
     
     Pour afficher les partitions du disque et leur taille :
@@ -151,7 +151,9 @@ NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
 vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
 ```
 
+:::info
 Les étapes ci-dessous s'appliquent aux systèmes de fichiers **ext2/ext3/ext4**. Contrairement à ext4, XFS ne peut pas être redimensionné lorsqu'il est démonté — l'outil `xfs_growfs` nécessite que le système de fichiers soit monté. Si votre système de fichiers est **XFS**, démontez le disque et recréez la partition comme indiqué ci-dessous, mais ignorez les étapes `e2fsck` et `resize2fs` : remontez plutôt le disque, puis exécutez `sudo xfs_growfs /mnt/disk`.
+:::
 
 Avant de démonter, vérifiez la disposition actuelle de la partition :
 
@@ -181,7 +183,7 @@ Démontez d'abord le disque :
 admin@server:~$ sudo umount /mnt/disk
 ```
 
-Recréez la partition à l'aide de la commande suivante. Ce processus réécrit uniquement la table de partitions — vos données ne sont pas touchées et seront préservées, à condition de saisir le même secteur de départ lorsqu'on vous le demande.
+Recréez la partition à l'aide de la commande suivante. Ce processus réécrit uniquement la table de partitions — vos données sont préservées, à condition de saisir le même secteur de départ lorsqu'on vous le demande.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
@@ -246,7 +248,7 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Vérifiez et contrôlez la partition (pour les systèmes de fichiers **ext2/ext3/ext4**) :
+Contrôlez la partition (pour les systèmes de fichiers **ext2/ext3/ext4**) :
 
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
@@ -310,7 +312,7 @@ Faites un clic-droit sur le volume et sélectionnez <code className="action">Ét
 
 Dans l'assistant d'extension de volume, cliquez sur <code className="action">Suivant</code>.
 
-Vous pouvez modifier l'espace disque à cette étape si vous souhaitez ajouter une capacité moindre que la totalité de la partition.
+Vous pouvez modifier l'espace disque à cette étape pour ajouter une capacité moindre que la totalité de la partition.
 
 Cliquez sur <code className="action">Suivant</code>.
 

--- a/docs/fr/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -74,7 +74,7 @@ En savoir plus sur la page [Essai gratuit Public Cloud OVHcloud](/links/public-c
 
 ## Aller plus loin
 
-- [Créer une première instance Public Cloud et s'y connecter](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+- [Comment créer une instance Public Cloud et s'y connecter](/guides/public-cloud/compute/getting-started)
 - [Gestion de contacts d’un projet](/guides/public-cloud/compute/change-project-contacts)
 - [Déléguer des projets](/guides/public-cloud/cross-functional/delegate-projects)
 - [Supprimer un projet Public Cloud](/guides/public-cloud/cross-functional/delete-a-project)

--- a/docs/fr/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -89,7 +89,7 @@ Suivez [ce lien](https://www.linux-kvm.org/page/Nested_Guests#Limitations) pour 
 
 La connexion se fait grâce à un couple de clés SSH à configurer lors de la création de votre instance Public cloud.
 
-Nous vous invitons à consulter le guide [Création et connexion à une première instance Public Cloud](/guides/public-cloud/compute/getting-started).
+Nous vous invitons à consulter le guide [Comment créer une instance Public Cloud et s'y connecter](/guides/public-cloud/compute/getting-started).
 
 </details>
 

--- a/docs/fr/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -121,7 +121,7 @@ La matrice ci-dessous compare les caractéristiques clés de chaque outil afin d
 
 ## Aller plus loin
 
-[Créer une première instance Public Cloud et s’y connecter](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[Comment créer une instance Public Cloud et s'y connecter](/guides/public-cloud/compute/getting-started).
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 

--- a/docs/fr/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/fr/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attacher une adresse Floating IP à une instance Public Cloud
 description: "Comprendre qu'est-ce qu’une Floating IP des services L3 et comment la configurer"
-lastUpdated: 2026-06-10
+lastUpdated: 2026-07-16
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -36,7 +36,7 @@ Vous pouvez garder des adresses Floating IP sans avoir à les attacher à un ser
 
 Le but de cet exercice est de créer une VM (**vm4fip**) uniquement avec un réseau privé local (**test-network**) et d'utiliser un routeur (**router1**) pour configurer une Floating IP.
 
-Ensuite, nous utiliserons cette Floating IP pour nous connecter à l'instance (VM) de l'extérieur et vérifier son accès à Internet.
+Ensuite, vous utiliserez cette Floating IP pour vous connecter à l'instance (VM) depuis l'extérieur et vérifier son accès à Internet.
 
 ## En pratique
 
@@ -69,7 +69,7 @@ Cliquez sur l'un des deux onglets ci-dessous selon que vous souhaitez associer u
     
     Avant de créer votre instance, assurez-vous d'avoir créé un [réseau privé avec Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
     
-    Si vous avez besoin d'assistance pour créer une nouvelle instance, consultez d'abord notre guide pour [créer une instance depuis l'espace client OVHcloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance). 
+    Si vous avez besoin d'assistance pour créer une nouvelle instance, consultez d'abord notre guide pour [créer une instance depuis l'espace client OVHcloud](/guides/public-cloud/compute/getting-started). 
     
     
     :::warning
@@ -80,7 +80,7 @@ Cliquez sur l'un des deux onglets ci-dessous selon que vous souhaitez associer u
     
     À l'étape 5 de la création d'une instance, vous pouvez choisir le « mode public » ou « mode privé » pour le réseau de votre instance.
     
-    Par défaut, le mode public est sélectionné. Cependant, comme nous créons une instance à laquelle nous allons attacher une Floating IP, nous devons créer une instance avec un réseau privé **UNIQUEMENT**.
+    Par défaut, le mode public est sélectionné. Cependant, comme vous créez une instance à laquelle vous allez attacher une Floating IP, vous devez créer une instance avec un réseau privé **UNIQUEMENT**.
     
     Sélectionnez le <code className="action">Mode privé</code> et cliquez sur la flèche déroulante pour sélectionner le réseau privé de votre choix (le réseau doit avoir été préalablement créé avec une Gateway).
     
@@ -189,7 +189,9 @@ Cliquez sur les onglets ci-dessous pour afficher et suivre successivement chacun
     ```
   </Tab>
   <Tab label="Étape 2">
-    Créez un réseau privé si nécessaire.<br/> Si vous en avez déjà un, vous pouvez ignorer cette étape.
+    Créez un réseau privé si nécessaire.
+
+    Si vous en avez déjà un, vous pouvez ignorer cette étape.
     
     ```bash
     $ openstack network create test-network
@@ -203,7 +205,9 @@ Cliquez sur les onglets ci-dessous pour afficher et suivre successivement chacun
     ```
   </Tab>
   <Tab label="Étape 3">
-    Créez un sous-réseau pour le réseau privé **test-network**.<br/> Si vous en avez déjà un, vous pouvez ignorer cette étape.
+    Créez un sous-réseau pour le réseau privé **test-network**.
+
+    Si vous en avez déjà un, vous pouvez ignorer cette étape.
     
     Le service **DHCP** doit être activé sur le sous-réseau et une **gateway ip** doit être configurée.
     
@@ -277,7 +281,7 @@ Cliquez sur les onglets ci-dessous pour afficher et suivre successivement chacun
     +--------+--------+
     ```
     
-    Nous avons maintenant une VM nommée **vm4fip** avec une interface privée uniquement. Cette VM n'a aucun accès en dehors du **test-network** (réseau privé).
+    Vous avez maintenant une VM nommée **vm4fip** avec une interface privée uniquement. Cette VM n'a aucun accès en dehors du **test-network** (réseau privé).
   </Tab>
   <Tab label="Étape 8">
     Créez une Floating IP à partir du réseau **Ext-Net**.
@@ -523,7 +527,7 @@ L'API OVHcloud vous permet d'associer une Floating IP uniquement à une instance
   <Tab label="Étape 3">
     Créez une Floating IP et associez-la à une instance avec l'appel suivant.
     
-    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/instance"} />
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/instance/\{instanceId\}/floatingIp"} />
 
 Remplissez les champs selon le tableau suivant :
     
@@ -531,11 +535,11 @@ Remplissez les champs selon le tableau suivant :
     |---|---| 
     |serviceName|Identifiant du projet|
     |regionName|Nom de la région dans laquelle se trouve l'instance|
-    |instanceid|Identifiant de l'instance|
-    |ip|L'IP privée de l'instance|
+    |instanceId|Identifiant de l'instance|
+    |ip|L'IP privée de l'instance à associer à la Floating IP|
     
     :::info
-    Pour le champ de propriété « Gateway », veuillez choisir l'option `Empty`. Cela est dû au fait que nous attachons une Floating IP à une instance créée au départ avec un réseau privé **uniquement** et qui est déjà rattachée à une gateway. Veuillez noter que, pour le moment, il ne sera pas possible de créer une Floating IP si l'instance est liée à un réseau privé qui n'est pas rattaché à une gateway.
+    Le corps de la requête accepte également un objet `gateway` facultatif, utilisé pour créer une nouvelle Gateway en même temps. Comme ce guide suppose que le réseau privé de votre instance est déjà relié à une Gateway (voir les [Prérequis](#prerequis)), ne l'incluez pas dans la requête.
 
     :::
 
@@ -546,7 +550,57 @@ Remplissez les champs selon le tableau suivant :
 
 #### Détacher une Floating IP
 
-Cette fonctionnalité est actuellement disponible uniquement via [l’API OpenStack](#detachip) et [l'interface Horizon](#disassociateip).
+Pour détacher une Floating IP de votre instance sans la supprimer, utilisez les appels API suivants.
+
+Récupérez tout d'abord les informations nécessaires.
+
+Pour l'identifiant du projet, les appels ci-dessous vous permettent de le récupérer :
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project"} />
+
+
+:::info
+Cet appel récupère la liste des projets.
+
+:::
+
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}"} />
+
+
+:::info
+Cet appel identifie le projet via le champ « description ».
+
+:::
+
+
+Récupérez l'identifiant de la Floating IP avec l'appel ci-dessous :
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip"} />
+
+
+:::info
+Complétez les champs avec les informations précédemment obtenues :
+
+- **serviceName** : ID du projet
+- **regionName** : le nom de la région
+
+:::
+
+
+Une fois les informations récupérées, utilisez l'appel suivant pour détacher la Floating IP de l'instance. Cela ne la supprime pas : elle retourne dans votre pool de Floating IPs.
+
+<Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip/\{floatingIpId\}/detach"} />
+
+
+:::info
+Complétez les champs avec les informations précédemment obtenues :
+
+- **serviceName** : ID du projet
+- **regionName** : le nom de la région où se trouve la Floating IP
+- **floatingIpId** : ID de l'adresse Floating IP
+
+:::
 
 #### Supprimer une Floating IP
 
@@ -656,6 +710,6 @@ ovhcloud cloud floating-ip delete <floating_ip_id> --region <region>
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou [demandez un devis à notre équipe Professional Services](/links/professional-services) pour obtenir une analyse personnalisée de votre projet.
+Pour une formation ou une assistance technique sur la mise en œuvre de nos solutions, contactez votre commercial ou consultez la page [Professional Services](/links/professional-services) pour obtenir un devis et faire analyser votre projet par nos experts.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/network-services/vrack.mdx
+++ b/docs/fr/guides/public-cloud/network-services/vrack.mdx
@@ -424,7 +424,7 @@ Dans le champ **Nom du réseau privé**, définissez un nom pour votre réseau p
     **Options de passerelle réseau**
     
     - **Annoncer la première adresse d'un CIDR donné comme passerelle par défaut (DHCP option 3)** : Lorsque cette option est activée, le serveur DHCP annonce la première adresse du CIDR comme passerelle par défaut aux machines connectées au réseau.
-    - **Assigner une Gateway et connectez-vous au réseau privé** : Sélectionnez cette option si vous avez l'intention de créer des instances avec un réseau privé uniquement. Pour plus d’informations, consultez les guides suivants : [Créer un réseau privé avec une Gateway](/guides/public-cloud/network-services/create-private-network-gateway) et [Créer une première instance Public Cloud et s’y connecter](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
+    - **Assigner une Gateway et connectez-vous au réseau privé** : Sélectionnez cette option si vous avez l'intention de créer des instances avec un réseau privé uniquement. Pour plus d’informations, consultez les guides suivants : [Créer un réseau privé avec une Gateway](/guides/public-cloud/network-services/create-private-network-gateway) et [Comment créer une instance Public Cloud et s'y connecter](/guides/public-cloud/compute/getting-started).
     
     :::warning
     Si la seconde option est grisée, cela signifie qu’elle est incompatible avec la région sélectionnée. Pour plus d’informations, veuillez vous référer à notre page sur la [disponibilité des produits Public Cloud pour chaque région](/links/public-cloud/regions-pci).

--- a/docs/it/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -177,11 +177,11 @@ Clicca sulla scheda <code className="action">Console VNC</code>.
 
 La console VNC fornisce un accesso diretto alla tua istanza. Per il corretto funzionamento di questo accesso, devi prima configurare un nome utente e una password sull'istanza.
 
-Consulta la nostra guida [Creare e connettersi a un'istanza Public Cloud](/guides/public-cloud/compute/getting-started#vnc-console) per maggiori informazioni.
+Consulta la nostra guida [Come creare un'istanza Public Cloud e connettersi](/guides/public-cloud/compute/getting-started) per maggiori informazioni.
 
 ## Per saperne di più
 
-[Creare e connettersi a un'istanza Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[Come creare un'istanza Public Cloud e connettersi](/guides/public-cloud/compute/getting-started)
 
 [Presentazione di Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 

--- a/docs/it/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/it/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -84,7 +84,7 @@ Per ridimensionare il disco al momento giusto, controlla regolarmente l'utilizzo
   </Tab>
   <Tab label="Per Linux">
     <details>
-    <summary>Utilizzo del comando 'df'</summary>
+    <summary>Utilizzo del comando `df`</summary>
 
     
     Per verificare l'utilizzo complessivo del disco, esegui il comando
@@ -99,7 +99,7 @@ Per ridimensionare il disco al momento giusto, controlla regolarmente l'utilizzo
     </details>
     
     <details>
-    <summary>Utilizzo del comando 'lsblk'</summary>
+    <summary>Utilizzo del comando `lsblk`</summary>
 
     
     Per visualizzare le partizioni del disco e le relative dimensioni:
@@ -151,7 +151,9 @@ NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
 vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
 ```
 
+:::info
 I passaggi seguenti si applicano ai file system **ext2/ext3/ext4**. A differenza di ext4, XFS non può essere ridimensionato quando è smontato — lo strumento `xfs_growfs` richiede che il file system sia montato. Se il tuo file system è **XFS**, smonta il disco e ricrea la partizione come indicato di seguito, ma ignora i passaggi `e2fsck` e `resize2fs`: rimonta invece il disco, quindi esegui `sudo xfs_growfs /mnt/disk`.
+:::
 
 Prima di smontare, verifica la disposizione attuale della partizione:
 
@@ -181,7 +183,7 @@ Smonta innanzitutto il disco:
 admin@server:~$ sudo umount /mnt/disk
 ```
 
-Ricrea la partizione utilizzando il comando seguente. Questo processo riscrive solo la tabella delle partizioni — i tuoi dati non vengono toccati e saranno preservati, a condizione di inserire lo stesso settore di partenza quando richiesto.
+Ricrea la partizione utilizzando il comando seguente. Questo processo riscrive solo la tabella delle partizioni — i tuoi dati vengono preservati, a condizione di inserire lo stesso settore di partenza quando richiesto.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
@@ -246,7 +248,7 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Verifica e controlla la partizione (per i file system **ext2/ext3/ext4**):
+Controlla la partizione (per i file system **ext2/ext3/ext4**):
 
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
@@ -310,7 +312,7 @@ Fai clic con il tasto destro sul volume e seleziona <code className="action">Est
 
 Nella procedura guidata di estensione del volume, fai clic su <code className="action">Avanti</code>.
 
-In questo passaggio puoi modificare lo spazio disco se desideri aggiungere una capacità inferiore rispetto all'intera partizione.
+In questo passaggio puoi modificare lo spazio disco per aggiungere una capacità inferiore rispetto alla partizione totale.
 
 Fai clic su <code className="action">Avanti</code>.
 

--- a/docs/it/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -78,7 +78,7 @@ Per saperne di più, consulta la pagina [Prova gratuita Public Cloud OVHcloud](/
 
 ## Per saperne di più
 
-- [Creare e connettersi a un’istanza Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+- [Come creare un'istanza Public Cloud e connettersi](/guides/public-cloud/compute/getting-started)
 - [Modificare i contatti di un progetto](/guides/public-cloud/compute/change-project-contacts)
 - [Delega progetti](/guides/public-cloud/cross-functional/delegate-projects)
 - [Eliminare un progetto Public Cloud](/guides/public-cloud/cross-functional/delete-a-project)

--- a/docs/it/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -89,7 +89,7 @@ Per maggiori informazioni, consulta [la pagina](https://www.linux-kvm.org/page/N
 
 La connessione avviene tramite una coppia di chiavi SSH da configurare durante la creazione dell'istanza Public Cloud.
 
-Per effettuare questa operazione, consulta la guida [Creare e connettersi a un’istanza Public Cloud](/guides/public-cloud/compute/getting-started).
+Per effettuare questa operazione, consulta la guida [Come creare un'istanza Public Cloud e connettersi](/guides/public-cloud/compute/getting-started).
 
 </details>
 

--- a/docs/it/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -121,7 +121,7 @@ La matrice seguente confronta le caratteristiche principali di ogni strumento pe
 
 ## Per saperne di più
 
-[Creare e connettersi a un’istanza Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[Come creare un'istanza Public Cloud e connettersi](/guides/public-cloud/compute/getting-started).
 
 Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 

--- a/docs/it/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/it/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-06-10
+lastUpdated: 2026-07-16
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -24,7 +24,7 @@ Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/publ
 
 ## Understanding the Floating IP service
 
-Floating IP is one of the services delivered by the OpenStack DVR (Distributed Virtual Router) services of the OVHcloud Public Cloud.
+Floating IP is one of the services delivered by the OpenStack DVR (Distributed Virtual Router) component of OVHcloud Public Cloud.
 
 Floating IP lets you create a public IP address for your private-network-based VMs, handling both incoming and outgoing traffic. Floating IP addresses can be attached and detached from your VMs at any time. 
 
@@ -36,7 +36,7 @@ You can hold Floating IP addresses without attaching them to any service. They r
 
 The goal of this exercise is to create a VM (**vm4fip**) with a private local network (**test-network**) only, and use a router (**router1**) to set up a Floating IP.
 
-Next, we will use this Floating IP to connect to the instance (VM) from the outside and check its access to the Internet.
+Next, you will use this Floating IP to connect to the instance (VM) from the outside and check its access to the Internet.
 
 ## Instructions
 
@@ -69,7 +69,7 @@ Click one of the two tabs below depending on whether you want to attach a Floati
     
     Before creating your instance, make sure you have created a [private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
     
-    To create a new instance, follow [this guide](/guides/public-cloud/compute/first-steps-with-public-cloud-instance) if necessary. 
+    To create a new instance, follow [this guide](/guides/public-cloud/compute/getting-started) if necessary. 
     
     
     :::warning
@@ -80,9 +80,9 @@ Click one of the two tabs below depending on whether you want to attach a Floati
     
     In Step 5, you can choose a networking mode for your instance: Public or Private.
     
-    By default, the public mode is selected, but since we are creating an instance to which we will attach a Floating IP, we need to create an instance with a private network **ONLY**.
+    By default, the public mode is selected, but since you are creating an instance to which you will attach a Floating IP, you need to create an instance with a private network **ONLY**.
     
-    Select the <code className="action">Private mode</code> and click on the drop down list to select a private network of your choice (the network must have been previously created with a Gateway or linked to a Gateway). 
+    Select the <code className="action">Private mode</code> and click on the drop-down list to select a private network of your choice (the network must have been previously created with a Gateway or linked to a Gateway). 
     
     If you select a private network that is not linked to a Gateway, the system will automatically create a Gateway of size "S" by default and attach it to your network.
     
@@ -96,7 +96,7 @@ When you have applied your choices, click <code className="action">Next</code> t
     
     <img className="thumbnail" alt="selectbilling" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/selectbilling.png" loading="lazy" />
 
-Choose hourly billing if you are unsure about the usage period — you cannot switch to it after delivery. You will have the option to switch to a monthly subscription as soon as the instance is available on the “Instances” page.
+Choose hourly billing if you are unsure about the usage period — you cannot switch to it after delivery. You will have the option to switch to a monthly subscription as soon as the instance is available on the "Instances" page.
     
     :::warning
     If you choose to be billed hourly, you will continue to be billed as long as the instance is not deleted. It does not matter if the instance is not actually used during this time. 
@@ -109,7 +109,7 @@ Choose hourly billing if you are unsure about the usage period — you cannot sw
   <Tab label="Option 2">
     **In case of an existing instance (created with a private network only).**
     
-    Please note that the private network must be linked to a gateway. For more information, consult this guide: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
+    Please note that the private network must be linked to a Gateway. For more information, consult this guide: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
     
     Click on <code className="action">Public IPs</code> in the left-hand menu under **Network**.
     
@@ -132,7 +132,7 @@ In the next step, choose a region for your Floating IPs. The region must be the 
     :::
 
     
-    Next, click on the drop down list to select the instance to attach the Floating IP to, then select the network/IP (this will be in the default range selected when creating the private network of the instance). 
+    Next, click on the drop-down list to select the instance to attach the Floating IP to, then select the network/IP (this will be in the default range selected when creating the private network of the instance). 
     
     <img className="thumbnail" alt="select instance" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/selectinstance.png" loading="lazy" />
     
@@ -193,7 +193,9 @@ Click on the tabs below to view each of the 9 steps in turn.
     ```
   </Tab>
   <Tab label="Step 2">
-    Create a private network if needed.<br/> If you have one already, you can skip this step.
+    Create a private network if needed.
+
+    If you have one already, you can skip this step.
     
     ```bash
     $ openstack network create test-network
@@ -207,7 +209,9 @@ Click on the tabs below to view each of the 9 steps in turn.
     ```
   </Tab>
   <Tab label="Step 3">
-    Create a subnet for your **test-network**.<br/> If you have one already, you can skip this step.
+    Create a subnet for your **test-network**.
+
+    If you have one already, you can skip this step.
     
     The subnet should have the **DHCP** service enabled and a **gateway IP** configured.
     
@@ -281,7 +285,7 @@ Click on the tabs below to view each of the 9 steps in turn.
     +--------+--------+
     ```
     
-    Now we have a VM named **vm4fip** with a private interface only. This VM has no access outside **test-network**.
+    You now have a VM named **vm4fip** with a private interface only. This VM has no access outside **test-network**.
   </Tab>
   <Tab label="Step 8">
     Create a Floating IP from **Ext-Net** network.
@@ -432,7 +436,7 @@ Before you proceed, make sure your instance is linked to a private network **onl
 
 
 
-Log into the Horizon interface, and ensure that you are in the correct region. You can verify this on the top left corner.
+Log into the Horizon interface, and ensure that you are in the correct region. You can verify this in the top left corner.
 
 <img className="thumbnail" alt="Region selection" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/region2021.png" loading="lazy" />
 
@@ -526,7 +530,7 @@ With the OVHcloud API, you can only attach a Floating IP to an existing instance
   <Tab label="Step 3">
     Once you have gathered all the information, you can now create a Floating IP and attach it to an instance using the following call.
     
-    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/instance"} />
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/instance/\{instanceId\}/floatingIp"} />
 
 Fill in the fields according to the following table.
     
@@ -535,11 +539,10 @@ Fill in the fields according to the following table.
     |serviceName|ID of the project|
     |regionName|Name of the region in which the instance is located|
     |instanceId|ID of the instance|
-    |name|Define a name for your Gateway|
-    |ip|The private IP of the instance|
+    |ip|The private IP of the instance to associate the Floating IP with|
     
     :::info
-    The "gateway" property field should be left empty because you are attaching a Floating IP to an instance initially created with a private network **only** and already linked to a Gateway. Please note that for now, the Floating IP will not be created if the instance is linked to a private network that is not attached to a Gateway.
+    The request body also accepts an optional `gateway` object, used to create a new Gateway at the same time. Since this guide assumes your instance's private network is already linked to a Gateway (see [Requirements](#requirements)), leave it out of the request entirely.
 
     :::
 
@@ -550,7 +553,57 @@ Fill in the fields according to the following table.
 
 #### Detaching a Floating IP
 
-This feature is available via the [OpenStack API](#detachip) and the [Horizon interface](#disassociateip). 
+To detach a Floating IP from your instance without deleting it, use the following API calls.
+
+First, retrieve the necessary information.
+
+For the project ID, the calls below allow you to retrieve it.
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project"} />
+
+
+:::info
+This call retrieves the list of projects.
+
+:::
+
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}"} />
+
+
+:::info
+This call identifies the project via the "description" field.
+
+:::
+
+
+For the Floating IP ID, the call below allows you to retrieve it.
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip"} />
+
+
+:::info
+Fill in the fields with the information previously obtained:
+
+- **serviceName**: The project ID
+- **regionName**: The name of the region
+
+:::
+
+
+Once the information has been retrieved, use the following call to detach the Floating IP from the instance. This does not delete it — it returns to your pool of Floating IPs.
+
+<Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip/\{floatingIpId\}/detach"} />
+
+
+:::info
+Fill in the fields with the information previously obtained:
+
+- **serviceName**: The project ID
+- **regionName**: The name of the region in which the Floating IP is located
+- **floatingIpId**: The ID of the Floating IP
+
+:::
 
 #### Deleting a Floating IP
 
@@ -660,6 +713,6 @@ ovhcloud cloud floating-ip delete <floating_ip_id> --region <region>
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or [request a quote from our Professional Services team](/links/professional-services) to get assistance on your specific use case.
+For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analyzed by our experts.
 
 Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/network-services/vrack.mdx
+++ b/docs/it/guides/public-cloud/network-services/vrack.mdx
@@ -424,7 +424,7 @@ Nel campo **Nome della rete privata**, definisci un nome per la tua rete privata
     **Opzioni gateway di rete**
     
     - **Annunciare il primo indirizzo di un CIDR come gateway predefinito (opzione DHCP 3)**: Quando questa opzione è attivata, il server DHCP annuncia il primo indirizzo del CIDR come gateway predefinito alle macchine collegate alla rete.
-    - **Assegna una Gateway e collegati alla rete privata**: Seleziona questa opzione se hai l'intenzione di creare delle istanze con una rete privata esclusivamente. Per ulteriori informazioni, consulta le seguenti guide: [Creare una rete privata con una Gateway](/guides/public-cloud/network-services/create-private-network-gateway) e [Creare una prima istanza Public Cloud e collegarvisi](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
+    - **Assegna una Gateway e collegati alla rete privata**: Seleziona questa opzione se hai l'intenzione di creare delle istanze con una rete privata esclusivamente. Per ulteriori informazioni, consulta le seguenti guide: [Creare una rete privata con una Gateway](/guides/public-cloud/network-services/create-private-network-gateway) e [Come creare un'istanza Public Cloud e connettersi](/guides/public-cloud/compute/getting-started).
     
     :::warning
     Se la seconda opzione è grigia, significa che è incompatibile con la regione selezionata. Per ulteriori informazioni, ti invitiamo a consultare la nostra pagina sulla [disponibilità dei prodotti Public Cloud per ogni regione](/links/public-cloud/regions-pci).

--- a/docs/pl/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -175,11 +175,11 @@ Przejdź z dashboardu na kartę <code className="action">Konsola VNC</code>.
 
 Konsola VNC zapewnia bezpośredni dostęp do Twojej instancji. Aby ten dostęp działał, musisz najpierw skonfigurować nazwę użytkownika i hasło na instancji.
 
-Więcej informacji o wymaganych krokach znajdziesz w naszym przewodniku [Tworzenie pierwszej instancji Public Cloud i łączenie się z nią](/guides/public-cloud/compute/getting-started#vnc-console).
+Więcej informacji o wymaganych krokach znajdziesz w naszym przewodniku [Jak utworzyć instancję Public Cloud i się z nią połączyć](/guides/public-cloud/compute/getting-started#vnc-console).
 
 ## Sprawdź również
 
-[Tworzenie pierwszej instancji Public Cloud i łączenie się z nią](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[Jak utworzyć instancję Public Cloud i się z nią połączyć](/guides/public-cloud/compute/getting-started)
 
 [Prezentacja Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 

--- a/docs/pl/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/pl/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -84,7 +84,7 @@ Aby zmienić rozmiar dysku w odpowiednim momencie, regularnie monitoruj wykorzys
   </Tab>
   <Tab label="W systemie Linux">
     <details>
-    <summary>Za pomocą polecenia 'df'</summary>
+    <summary>Za pomocą polecenia `df`</summary>
 
     
     Aby sprawdzić całkowite wykorzystanie dysku, uruchom:
@@ -99,7 +99,7 @@ Aby zmienić rozmiar dysku w odpowiednim momencie, regularnie monitoruj wykorzys
     </details>
     
     <details>
-    <summary>Za pomocą polecenia 'lsblk'</summary>
+    <summary>Za pomocą polecenia `lsblk`</summary>
 
     
     Aby wyświetlić partycje dysków i ich rozmiary:
@@ -151,7 +151,9 @@ NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
 vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
 ```
 
+:::info
 Poniższe kroki dotyczą systemów plików **ext2/ext3/ext4**. W przeciwieństwie do ext4, systemu plików XFS nie można rozszerzyć, gdy jest odmontowany — narzędzie `xfs_growfs` wymaga, aby system plików był zamontowany. Jeśli Twój system plików to **XFS**, wciąż odmontuj dysk i odtwórz partycję zgodnie z poniższym opisem, ale pomiń kroki `e2fsck` i `resize2fs`: zamiast tego ponownie zamontuj dysk, a następnie uruchom `sudo xfs_growfs /mnt/disk`.
+:::
 
 Przed odmontowaniem sprawdź bieżący układ partycji:
 
@@ -187,7 +189,7 @@ W naszym przykładzie:
 admin@server:~$ sudo umount /mnt/vdb
 ```
 
-Odtwórz partycję za pomocą następującego polecenia. Ten proces zmienia jedynie tabelę partycji — dane w systemie plików nie są modyfikowane i zostaną zachowane, o ile podczas monitu wprowadzisz ten sam sektor początkowy.
+Odtwórz partycję za pomocą następującego polecenia. Ten proces zmienia jedynie tabelę partycji — dane w systemie plików zostaną zachowane, o ile podczas monitu wprowadzisz ten sam sektor początkowy.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
@@ -242,7 +244,7 @@ Created a new partition 1 of type 'Linux' and of size 70 GiB.
 
 Aby wyświetlić listę zmian, wpisz ponownie `p`.
 
-Następnie wpisz `w`, aby zapisać wprowadzone zmiany:
+Następnie wpisz `w`, aby zapisać zmiany:
 
 ```console
 Command (m for help): w
@@ -252,7 +254,7 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Zweryfikuj i sprawdź partycję (dla systemów plików **ext2/ext3/ext4**):
+Sprawdź partycję (dla systemów plików **ext2/ext3/ext4**):
 
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
@@ -316,7 +318,7 @@ Kliknij prawym przyciskiem myszy wolumen i wybierz <code className="action">Rozs
 
 W "Kreatorze rozszerzania woluminu" kliknij <code className="action">Dalej</code>.
 
-W tym kroku możesz zmodyfikować przestrzeń dyskową, jeśli chcesz dodać do partycji mniej niż całą dostępną pojemność. Kliknij <code className="action">Dalej</code>.
+W tym kroku możesz zmodyfikować przestrzeń dyskową, aby dodać do partycji mniej niż pełną pojemność. Kliknij <code className="action">Dalej</code>.
 
 <img className="thumbnail" alt="windows" src="/images/public-cloud/compute/increase-the-size-of-an-additional-disk/resize-win-04.png" loading="lazy" />
 

--- a/docs/pl/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -80,7 +80,7 @@ Więcej informacji znajdziesz na stronie [Bezpłatny okres próbny OVHcloud Publ
 
 ## Sprawdź również
 
-- [Tworzenie pierwszej instancji Public Cloud i łączenie się z nią](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+- [Jak utworzyć instancję Public Cloud i się z nią połączyć](/guides/public-cloud/compute/getting-started)
 - [Zmiana kontaktów projektu](/guides/public-cloud/compute/change-project-contacts)
 - [Delegowanie projektów](/guides/public-cloud/cross-functional/delegate-projects)
 - [Usuwanie projektu Public Cloud](/guides/public-cloud/cross-functional/delete-a-project)

--- a/docs/pl/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -88,7 +88,7 @@ Więcej informacji można znaleźć [na stronie internetowej](https://www.linux-
 
 Połączenie realizowane jest za pomocą kilku kluczy SSH, które chcesz skonfigurować podczas tworzenia instancji Public Cloud.
 
-Zapraszamy do zapoznania się z przewodnikiem [Tworzenie pierwszej instancji Public Cloud i łączenie się z nią](/guides/public-cloud/compute/getting-started).
+Zapraszamy do zapoznania się z przewodnikiem [Jak utworzyć instancję Public Cloud i się z nią połączyć](/guides/public-cloud/compute/getting-started).
 
 </details>
 

--- a/docs/pl/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -121,7 +121,7 @@ Poniższa macierz porównuje kluczowe cechy każdego narzędzia, aby pomóc Ci w
 
 ## Sprawdź również
 
-[Tworzenie pierwszej instancji Public Cloud i łączenie się z nią](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[Jak utworzyć instancję Public Cloud i się z nią połączyć](/guides/public-cloud/compute/getting-started)
 
 Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 

--- a/docs/pl/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/pl/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-06-10
+lastUpdated: 2026-07-16
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -24,7 +24,7 @@ Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/publ
 
 ## Understanding the Floating IP service
 
-Floating IP is one of the services delivered by the OpenStack DVR (Distributed Virtual Router) services of the OVHcloud Public Cloud.
+Floating IP is one of the services delivered by the OpenStack DVR (Distributed Virtual Router) component of OVHcloud Public Cloud.
 
 Floating IP lets you create a public IP address for your private-network-based VMs, handling both incoming and outgoing traffic. Floating IP addresses can be attached and detached from your VMs at any time. 
 
@@ -36,7 +36,7 @@ You can hold Floating IP addresses without attaching them to any service. They r
 
 The goal of this exercise is to create a VM (**vm4fip**) with a private local network (**test-network**) only, and use a router (**router1**) to set up a Floating IP.
 
-Next, we will use this Floating IP to connect to the instance (VM) from the outside and check its access to the Internet.
+Next, you will use this Floating IP to connect to the instance (VM) from the outside and check its access to the Internet.
 
 ## Instructions
 
@@ -69,7 +69,7 @@ Click one of the two tabs below depending on whether you want to attach a Floati
     
     Before creating your instance, make sure you have created a [private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
     
-    To create a new instance, follow [this guide](/guides/public-cloud/compute/first-steps-with-public-cloud-instance) if necessary. 
+    To create a new instance, follow [this guide](/guides/public-cloud/compute/getting-started) if necessary. 
     
     
     :::warning
@@ -80,9 +80,9 @@ Click one of the two tabs below depending on whether you want to attach a Floati
     
     In Step 5, you can choose a networking mode for your instance: Public or Private.
     
-    By default, the public mode is selected, but since we are creating an instance to which we will attach a Floating IP, we need to create an instance with a private network **ONLY**.
+    By default, the public mode is selected, but since you are creating an instance to which you will attach a Floating IP, you need to create an instance with a private network **ONLY**.
     
-    Select the <code className="action">Private mode</code> and click on the drop down list to select a private network of your choice (the network must have been previously created with a Gateway or linked to a Gateway). 
+    Select the <code className="action">Private mode</code> and click on the drop-down list to select a private network of your choice (the network must have been previously created with a Gateway or linked to a Gateway). 
     
     If you select a private network that is not linked to a Gateway, the system will automatically create a Gateway of size "S" by default and attach it to your network.
     
@@ -96,7 +96,7 @@ When you have applied your choices, click <code className="action">Next</code> t
     
     <img className="thumbnail" alt="selectbilling" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/selectbilling.png" loading="lazy" />
 
-Choose hourly billing if you are unsure about the usage period — you cannot switch to it after delivery. You will have the option to switch to a monthly subscription as soon as the instance is available on the “Instances” page.
+Choose hourly billing if you are unsure about the usage period — you cannot switch to it after delivery. You will have the option to switch to a monthly subscription as soon as the instance is available on the "Instances" page.
     
     :::warning
     If you choose to be billed hourly, you will continue to be billed as long as the instance is not deleted. It does not matter if the instance is not actually used during this time. 
@@ -109,7 +109,7 @@ Choose hourly billing if you are unsure about the usage period — you cannot sw
   <Tab label="Option 2">
     **In case of an existing instance (created with a private network only).**
     
-    Please note that the private network must be linked to a gateway. For more information, consult this guide: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
+    Please note that the private network must be linked to a Gateway. For more information, consult this guide: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
     
     Click on <code className="action">Public IPs</code> in the left-hand menu under **Network**.
     
@@ -132,7 +132,7 @@ In the next step, choose a region for your Floating IPs. The region must be the 
     :::
 
     
-    Next, click on the drop down list to select the instance to attach the Floating IP to, then select the network/IP (this will be in the default range selected when creating the private network of the instance). 
+    Next, click on the drop-down list to select the instance to attach the Floating IP to, then select the network/IP (this will be in the default range selected when creating the private network of the instance). 
     
     <img className="thumbnail" alt="select instance" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/selectinstance.png" loading="lazy" />
     
@@ -193,7 +193,9 @@ Click on the tabs below to view each of the 9 steps in turn.
     ```
   </Tab>
   <Tab label="Step 2">
-    Create a private network if needed.<br/> If you have one already, you can skip this step.
+    Create a private network if needed.
+
+    If you have one already, you can skip this step.
     
     ```bash
     $ openstack network create test-network
@@ -207,7 +209,9 @@ Click on the tabs below to view each of the 9 steps in turn.
     ```
   </Tab>
   <Tab label="Step 3">
-    Create a subnet for your **test-network**.<br/> If you have one already, you can skip this step.
+    Create a subnet for your **test-network**.
+
+    If you have one already, you can skip this step.
     
     The subnet should have the **DHCP** service enabled and a **gateway IP** configured.
     
@@ -281,7 +285,7 @@ Click on the tabs below to view each of the 9 steps in turn.
     +--------+--------+
     ```
     
-    Now we have a VM named **vm4fip** with a private interface only. This VM has no access outside **test-network**.
+    You now have a VM named **vm4fip** with a private interface only. This VM has no access outside **test-network**.
   </Tab>
   <Tab label="Step 8">
     Create a Floating IP from **Ext-Net** network.
@@ -432,7 +436,7 @@ Before you proceed, make sure your instance is linked to a private network **onl
 
 
 
-Log into the Horizon interface, and ensure that you are in the correct region. You can verify this on the top left corner.
+Log into the Horizon interface, and ensure that you are in the correct region. You can verify this in the top left corner.
 
 <img className="thumbnail" alt="Region selection" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/region2021.png" loading="lazy" />
 
@@ -526,7 +530,7 @@ With the OVHcloud API, you can only attach a Floating IP to an existing instance
   <Tab label="Step 3">
     Once you have gathered all the information, you can now create a Floating IP and attach it to an instance using the following call.
     
-    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/instance"} />
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/instance/\{instanceId\}/floatingIp"} />
 
 Fill in the fields according to the following table.
     
@@ -535,11 +539,10 @@ Fill in the fields according to the following table.
     |serviceName|ID of the project|
     |regionName|Name of the region in which the instance is located|
     |instanceId|ID of the instance|
-    |name|Define a name for your Gateway|
-    |ip|The private IP of the instance|
+    |ip|The private IP of the instance to associate the Floating IP with|
     
     :::info
-    The "gateway" property field should be left empty because you are attaching a Floating IP to an instance initially created with a private network **only** and already linked to a Gateway. Please note that for now, the Floating IP will not be created if the instance is linked to a private network that is not attached to a Gateway.
+    The request body also accepts an optional `gateway` object, used to create a new Gateway at the same time. Since this guide assumes your instance's private network is already linked to a Gateway (see [Requirements](#requirements)), leave it out of the request entirely.
 
     :::
 
@@ -550,7 +553,57 @@ Fill in the fields according to the following table.
 
 #### Detaching a Floating IP
 
-This feature is available via the [OpenStack API](#detachip) and the [Horizon interface](#disassociateip). 
+To detach a Floating IP from your instance without deleting it, use the following API calls.
+
+First, retrieve the necessary information.
+
+For the project ID, the calls below allow you to retrieve it.
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project"} />
+
+
+:::info
+This call retrieves the list of projects.
+
+:::
+
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}"} />
+
+
+:::info
+This call identifies the project via the "description" field.
+
+:::
+
+
+For the Floating IP ID, the call below allows you to retrieve it.
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip"} />
+
+
+:::info
+Fill in the fields with the information previously obtained:
+
+- **serviceName**: The project ID
+- **regionName**: The name of the region
+
+:::
+
+
+Once the information has been retrieved, use the following call to detach the Floating IP from the instance. This does not delete it — it returns to your pool of Floating IPs.
+
+<Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip/\{floatingIpId\}/detach"} />
+
+
+:::info
+Fill in the fields with the information previously obtained:
+
+- **serviceName**: The project ID
+- **regionName**: The name of the region in which the Floating IP is located
+- **floatingIpId**: The ID of the Floating IP
+
+:::
 
 #### Deleting a Floating IP
 
@@ -660,6 +713,6 @@ ovhcloud cloud floating-ip delete <floating_ip_id> --region <region>
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or [request a quote from our Professional Services team](/links/professional-services) to get assistance on your specific use case.
+For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analyzed by our experts.
 
 Join our [community of users](/links/community).

--- a/docs/pl/guides/public-cloud/network-services/vrack.mdx
+++ b/docs/pl/guides/public-cloud/network-services/vrack.mdx
@@ -422,7 +422,7 @@ W polu **Nazwa prywatnej sieci** ustaw nazwę swojej prywatnej sieci.
     **Opcje bramy sieciowej**
     
     - **Ogłaszaj pierwszy adres danego CIDR jako bramę domyślną (DHCP opcja 3)**: Gdy ta opcja jest włączona, serwer DHCP ogłasza pierwszy adres w CIDR jako domyślną bramę dla maszyn podłączonych do sieci.
-    - **Przypisz Gateway i połącz się z prywatną siecią**: Wybierz tę opcję, jeśli zamierzasz tworzyć instancje wyłącznie z prywatną siecią. Aby uzyskać więcej informacji, zapoznaj się z poniższymi przewodnikami: [Tworzenie prywatnej sieci z bramą](/guides/public-cloud/network-services/create-private-network-gateway) i [Tworzenie i łączenie się ze swoją pierwszą instancją Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
+    - **Przypisz Gateway i połącz się z prywatną siecią**: Wybierz tę opcję, jeśli zamierzasz tworzyć instancje wyłącznie z prywatną siecią. Aby uzyskać więcej informacji, zapoznaj się z poniższymi przewodnikami: [Tworzenie prywatnej sieci z bramą](/guides/public-cloud/network-services/create-private-network-gateway) i [Jak utworzyć instancję Public Cloud i się z nią połączyć](/guides/public-cloud/compute/getting-started).
     
     :::warning
     Jeśli druga opcja jest wyszarzona, oznacza to, że wybrany region jej nie obsługuje. Aby uzyskać więcej informacji, zapoznaj się z naszą stroną [dostępność regionów](/links/public-cloud/regions-pci).

--- a/docs/pt/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -177,11 +177,11 @@ Clique no separador <code className="action">Consola VNC</code>.
 
 A consola VNC fornece um acesso direto à sua instância. Para que este acesso funcione, primeiro deve configurar um nome de utilizador e uma palavra-passe na instância.
 
-Consulte o nosso guia [Criação e conexão a uma primeira instância Public Cloud](/guides/public-cloud/compute/getting-started#vnc-console) para mais informações.
+Consulte o nosso guia [Como criar uma instância Public Cloud e conectar-se a ela](/guides/public-cloud/compute/getting-started#vnc-console) para mais informações.
 
 ## Quer saber mais?
 
-[Criação e conexão a uma primeira instância Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[Como criar uma instância Public Cloud e conectar-se a ela](/guides/public-cloud/compute/getting-started)
 
 [Apresentação do Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 

--- a/docs/pt/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
+++ b/docs/pt/guides/public-cloud/compute/increase-the-size-of-an-additional-disk.mdx
@@ -75,7 +75,7 @@ Para redimensionar o disco no momento certo, monitorize regularmente a utilizaç
   </Tab>
   <Tab label="Para Linux">
     <details>
-    <summary>Utilização do comando 'df'</summary>
+    <summary>Utilização do comando `df`</summary>
 
     Para verificar a utilização global do disco, execute o comando
 
@@ -88,7 +88,7 @@ Para redimensionar o disco no momento certo, monitorize regularmente a utilizaç
     </details>
 
     <details>
-    <summary>Utilização do comando 'lsblk'</summary>
+    <summary>Utilização do comando `lsblk`</summary>
 
     Para visualizar as partições do disco e o seu tamanho:
 
@@ -137,7 +137,9 @@ NAME   FSTYPE LABEL UUID                                 MOUNTPOINT
 vdb1   ext4         a1b2c3d4-e5f6-7890-abcd-ef1234567890
 ```
 
+:::info
 Os passos abaixo aplicam-se aos sistemas de ficheiros **ext2/ext3/ext4**. Ao contrário do ext4, o XFS não pode ser redimensionado enquanto estiver desmontado — a ferramenta `xfs_growfs` exige que o sistema de ficheiros esteja montado. Se o seu sistema de ficheiros for **XFS**, desmonte o disco e recrie a partição conforme indicado a seguir, mas ignore os passos `e2fsck` e `resize2fs`: volte a montar o disco e execute `sudo xfs_growfs /mnt/disk`.
+:::
 
 Antes de desmontar, verifique a disposição atual da partição:
 
@@ -167,7 +169,7 @@ Desmonte primeiro o disco:
 admin@server:~$ sudo umount /mnt/disk
 ```
 
-Recrie a partição utilizando o comando seguinte. Este processo reescreve apenas a tabela de partições — os seus dados não são afetados e serão preservados, desde que introduza o mesmo setor de início quando solicitado.
+Recrie a partição utilizando o comando seguinte. Este processo reescreve apenas a tabela de partições — os seus dados são preservados, desde que introduza o mesmo setor de início quando solicitado.
 
 ```bash
 admin@server:~$ sudo fdisk /dev/vdb
@@ -232,7 +234,7 @@ Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
 
-Verifique e valide a partição (para os sistemas de ficheiros **ext2/ext3/ext4**):
+Verifique a partição (para os sistemas de ficheiros **ext2/ext3/ext4**):
 
 ```bash
 admin@server:~$ sudo e2fsck -f /dev/vdb1
@@ -296,7 +298,7 @@ Clique com o botão direito no volume e selecione <code className="action">Esten
 
 No assistente de extensão de volume, clique em <code className="action">Seguinte</code>.
 
-Pode alterar o espaço em disco nesta fase se pretender adicionar uma capacidade inferior à totalidade da partição.
+Pode alterar o espaço em disco nesta fase para adicionar uma capacidade inferior à totalidade da partição.
 
 Clique em <code className="action">Seguinte</code>.
 

--- a/docs/pt/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/create-a-public-cloud-project.mdx
@@ -78,7 +78,7 @@ Saiba mais na página [Teste gratuito Public Cloud OVHcloud](/links/public-cloud
 
 ## Quer saber mais?
 
-- [Criação e conexão a uma primeira instância Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+- [Como criar uma instância Public Cloud e conectar-se a ela](/guides/public-cloud/compute/getting-started)
 - [Gestão de contactos de um projeto](/guides/public-cloud/compute/change-project-contacts)
 - [Delegar projetos](/guides/public-cloud/cross-functional/delegate-projects)
 - [Eliminar um projeto Public Cloud](/guides/public-cloud/cross-functional/delete-a-project)

--- a/docs/pt/guides/public-cloud/cross-functional/faq-pci.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/faq-pci.mdx
@@ -88,7 +88,7 @@ Siga [este link](https://www.linux-kvm.org/page/Nested_Guests#Limitations) para 
 
 A ligação faz-se graças a um par de chaves SSH a configurar aquando da criação da sua instância Public Cloud.
 
-Sugerimos que consulte o guia [Criação e conexão a uma primeira instância Public Cloud](/guides/public-cloud/compute/getting-started).
+Sugerimos que consulte o guia [Como criar uma instância Public Cloud e conectar-se a ela](/guides/public-cloud/compute/getting-started).
 
 </details>
 

--- a/docs/pt/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/public-cloud-interface-walk-me.mdx
@@ -121,7 +121,7 @@ A matriz abaixo compara as principais características de cada ferramenta para o
 
 ## Quer saber mais?
 
-[Criação e conexão a uma primeira instância Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance)
+[Como criar uma instância Public Cloud e conectar-se a ela](/guides/public-cloud/compute/getting-started)
 
 Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 

--- a/docs/pt/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/pt/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-06-10
+lastUpdated: 2026-07-16
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -24,7 +24,7 @@ Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/publ
 
 ## Understanding the Floating IP service
 
-Floating IP is one of the services delivered by the OpenStack DVR (Distributed Virtual Router) services of the OVHcloud Public Cloud.
+Floating IP is one of the services delivered by the OpenStack DVR (Distributed Virtual Router) component of OVHcloud Public Cloud.
 
 Floating IP lets you create a public IP address for your private-network-based VMs, handling both incoming and outgoing traffic. Floating IP addresses can be attached and detached from your VMs at any time. 
 
@@ -36,7 +36,7 @@ You can hold Floating IP addresses without attaching them to any service. They r
 
 The goal of this exercise is to create a VM (**vm4fip**) with a private local network (**test-network**) only, and use a router (**router1**) to set up a Floating IP.
 
-Next, we will use this Floating IP to connect to the instance (VM) from the outside and check its access to the Internet.
+Next, you will use this Floating IP to connect to the instance (VM) from the outside and check its access to the Internet.
 
 ## Instructions
 
@@ -69,7 +69,7 @@ Click one of the two tabs below depending on whether you want to attach a Floati
     
     Before creating your instance, make sure you have created a [private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
     
-    To create a new instance, follow [this guide](/guides/public-cloud/compute/first-steps-with-public-cloud-instance) if necessary. 
+    To create a new instance, follow [this guide](/guides/public-cloud/compute/getting-started) if necessary. 
     
     
     :::warning
@@ -80,9 +80,9 @@ Click one of the two tabs below depending on whether you want to attach a Floati
     
     In Step 5, you can choose a networking mode for your instance: Public or Private.
     
-    By default, the public mode is selected, but since we are creating an instance to which we will attach a Floating IP, we need to create an instance with a private network **ONLY**.
+    By default, the public mode is selected, but since you are creating an instance to which you will attach a Floating IP, you need to create an instance with a private network **ONLY**.
     
-    Select the <code className="action">Private mode</code> and click on the drop down list to select a private network of your choice (the network must have been previously created with a Gateway or linked to a Gateway). 
+    Select the <code className="action">Private mode</code> and click on the drop-down list to select a private network of your choice (the network must have been previously created with a Gateway or linked to a Gateway). 
     
     If you select a private network that is not linked to a Gateway, the system will automatically create a Gateway of size "S" by default and attach it to your network.
     
@@ -96,7 +96,7 @@ When you have applied your choices, click <code className="action">Next</code> t
     
     <img className="thumbnail" alt="selectbilling" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/selectbilling.png" loading="lazy" />
 
-Choose hourly billing if you are unsure about the usage period — you cannot switch to it after delivery. You will have the option to switch to a monthly subscription as soon as the instance is available on the “Instances” page.
+Choose hourly billing if you are unsure about the usage period — you cannot switch to it after delivery. You will have the option to switch to a monthly subscription as soon as the instance is available on the "Instances" page.
     
     :::warning
     If you choose to be billed hourly, you will continue to be billed as long as the instance is not deleted. It does not matter if the instance is not actually used during this time. 
@@ -109,7 +109,7 @@ Choose hourly billing if you are unsure about the usage period — you cannot sw
   <Tab label="Option 2">
     **In case of an existing instance (created with a private network only).**
     
-    Please note that the private network must be linked to a gateway. For more information, consult this guide: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
+    Please note that the private network must be linked to a Gateway. For more information, consult this guide: [Creating a private network with Gateway](/guides/public-cloud/network-services/create-private-network-gateway).
     
     Click on <code className="action">Public IPs</code> in the left-hand menu under **Network**.
     
@@ -132,7 +132,7 @@ In the next step, choose a region for your Floating IPs. The region must be the 
     :::
 
     
-    Next, click on the drop down list to select the instance to attach the Floating IP to, then select the network/IP (this will be in the default range selected when creating the private network of the instance). 
+    Next, click on the drop-down list to select the instance to attach the Floating IP to, then select the network/IP (this will be in the default range selected when creating the private network of the instance). 
     
     <img className="thumbnail" alt="select instance" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/selectinstance.png" loading="lazy" />
     
@@ -193,7 +193,9 @@ Click on the tabs below to view each of the 9 steps in turn.
     ```
   </Tab>
   <Tab label="Step 2">
-    Create a private network if needed.<br/> If you have one already, you can skip this step.
+    Create a private network if needed.
+
+    If you have one already, you can skip this step.
     
     ```bash
     $ openstack network create test-network
@@ -207,7 +209,9 @@ Click on the tabs below to view each of the 9 steps in turn.
     ```
   </Tab>
   <Tab label="Step 3">
-    Create a subnet for your **test-network**.<br/> If you have one already, you can skip this step.
+    Create a subnet for your **test-network**.
+
+    If you have one already, you can skip this step.
     
     The subnet should have the **DHCP** service enabled and a **gateway IP** configured.
     
@@ -281,7 +285,7 @@ Click on the tabs below to view each of the 9 steps in turn.
     +--------+--------+
     ```
     
-    Now we have a VM named **vm4fip** with a private interface only. This VM has no access outside **test-network**.
+    You now have a VM named **vm4fip** with a private interface only. This VM has no access outside **test-network**.
   </Tab>
   <Tab label="Step 8">
     Create a Floating IP from **Ext-Net** network.
@@ -432,7 +436,7 @@ Before you proceed, make sure your instance is linked to a private network **onl
 
 
 
-Log into the Horizon interface, and ensure that you are in the correct region. You can verify this on the top left corner.
+Log into the Horizon interface, and ensure that you are in the correct region. You can verify this in the top left corner.
 
 <img className="thumbnail" alt="Region selection" src="/images/public-cloud/network-services/getting-started-03-attach-floating-ip-to-instance/region2021.png" loading="lazy" />
 
@@ -526,7 +530,7 @@ With the OVHcloud API, you can only attach a Floating IP to an existing instance
   <Tab label="Step 3">
     Once you have gathered all the information, you can now create a Floating IP and attach it to an instance using the following call.
     
-    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/instance"} />
+    <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/instance/\{instanceId\}/floatingIp"} />
 
 Fill in the fields according to the following table.
     
@@ -535,11 +539,10 @@ Fill in the fields according to the following table.
     |serviceName|ID of the project|
     |regionName|Name of the region in which the instance is located|
     |instanceId|ID of the instance|
-    |name|Define a name for your Gateway|
-    |ip|The private IP of the instance|
+    |ip|The private IP of the instance to associate the Floating IP with|
     
     :::info
-    The "gateway" property field should be left empty because you are attaching a Floating IP to an instance initially created with a private network **only** and already linked to a Gateway. Please note that for now, the Floating IP will not be created if the instance is linked to a private network that is not attached to a Gateway.
+    The request body also accepts an optional `gateway` object, used to create a new Gateway at the same time. Since this guide assumes your instance's private network is already linked to a Gateway (see [Requirements](#requirements)), leave it out of the request entirely.
 
     :::
 
@@ -550,7 +553,57 @@ Fill in the fields according to the following table.
 
 #### Detaching a Floating IP
 
-This feature is available via the [OpenStack API](#detachip) and the [Horizon interface](#disassociateip). 
+To detach a Floating IP from your instance without deleting it, use the following API calls.
+
+First, retrieve the necessary information.
+
+For the project ID, the calls below allow you to retrieve it.
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project"} />
+
+
+:::info
+This call retrieves the list of projects.
+
+:::
+
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}"} />
+
+
+:::info
+This call identifies the project via the "description" field.
+
+:::
+
+
+For the Floating IP ID, the call below allows you to retrieve it.
+
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip"} />
+
+
+:::info
+Fill in the fields with the information previously obtained:
+
+- **serviceName**: The project ID
+- **regionName**: The name of the region
+
+:::
+
+
+Once the information has been retrieved, use the following call to detach the Floating IP from the instance. This does not delete it — it returns to your pool of Floating IPs.
+
+<Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/region/\{regionName\}/floatingip/\{floatingIpId\}/detach"} />
+
+
+:::info
+Fill in the fields with the information previously obtained:
+
+- **serviceName**: The project ID
+- **regionName**: The name of the region in which the Floating IP is located
+- **floatingIpId**: The ID of the Floating IP
+
+:::
 
 #### Deleting a Floating IP
 
@@ -660,6 +713,6 @@ ovhcloud cloud floating-ip delete <floating_ip_id> --region <region>
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or [request a quote from our Professional Services team](/links/professional-services) to get assistance on your specific use case.
+For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analyzed by our experts.
 
 Join our [community of users](/links/community).

--- a/docs/pt/guides/public-cloud/network-services/vrack.mdx
+++ b/docs/pt/guides/public-cloud/network-services/vrack.mdx
@@ -424,7 +424,7 @@ No campo **Nome da rede privada**, defina um nome para a sua rede privada.
     **Opções de gateway de rede**
     
     - **Anunciar o primeiro endereço de um CIDR dado como gateway predefinido (DHCP opção 3)**: Quando esta opção está ativa, o servidor DHCP anuncia o primeiro endereço do CIDR como gateway predefinido para as máquinas ligadas à rede.
-    - **Atribuir um Gateway e ligar-se à rede privada**: Selecione esta opção se tiver a intenção de criar instâncias com rede privada apenas. Para mais informações, consulte os seguintes guias: [Criar uma rede privada com uma Gateway](/guides/public-cloud/network-services/create-private-network-gateway) e [Criar uma primeira instância Public Cloud e ligar-se a ela](/guides/public-cloud/compute/first-steps-with-public-cloud-instance).
+    - **Atribuir um Gateway e ligar-se à rede privada**: Selecione esta opção se tiver a intenção de criar instâncias com rede privada apenas. Para mais informações, consulte os seguintes guias: [Criar uma rede privada com uma Gateway](/guides/public-cloud/network-services/create-private-network-gateway) e [Como criar uma instância Public Cloud e conectar-se a ela](/guides/public-cloud/compute/getting-started).
     
     :::warning
     Se a segunda opção estiver cinzenta, isso significa que é incompatível com a região selecionada. Para mais informações, consulte a nossa página sobre [disponibilidade dos produtos Public Cloud para cada região](/links/public-cloud/regions-pci).


### PR DESCRIPTION
- Fix the link and title for "How to create a Public Cloud instance and connect to it" in various guides
- Add information about detaching an additional IP from the API (found the api call, the guide previously mentioned it was not possible)
- Fix an API call that wrongly written
- Proofread the guide: Attaching a Floating IP to a Public Cloud instance