### PR TITLE
[SK-2743] WEB - Emails - add cross-domain spoofing rejection troubleshooting guide

### DIFF
--- a/components/DomainAlignmentDiagram/DomainAlignmentDiagram.css
+++ b/components/DomainAlignmentDiagram/DomainAlignmentDiagram.css
@@ -1,0 +1,137 @@
+.domain-align {
+  display: flex;
+  align-items: stretch;
+  gap: 0.9rem;
+  margin: 1.75rem 0;
+}
+
+.domain-align__case {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 1.1rem 1.15rem 1.2rem;
+  border: 1px solid var(--rp-c-divider);
+  border-top: 3px solid var(--da-accent);
+  border-radius: 12px;
+  background: var(--rp-c-bg-soft);
+}
+
+.domain-align__case--ok {
+  --da-accent: #2f9e6f;
+  --da-tint: rgba(47, 158, 111, 0.12);
+}
+
+.domain-align__case--ko {
+  --da-accent: #e0564f;
+  --da-tint: rgba(224, 86, 79, 0.12);
+}
+
+.domain-align__situation {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.3rem;
+  font-size: 0.92rem;
+  font-weight: 700;
+  line-height: 1.3;
+  color: var(--rp-c-text-1);
+}
+
+.domain-align__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  color: var(--da-accent);
+  background: var(--da-tint);
+}
+
+.domain-align__row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--rp-c-divider);
+  border-radius: 9px;
+  background: var(--rp-c-bg);
+}
+
+.domain-align__ico {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  color: var(--rp-c-text-2);
+  background: var(--rp-c-bg-soft);
+}
+
+.domain-align__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.domain-align__label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--rp-c-text-2);
+}
+
+.domain-align__addr {
+  font-size: 0.84rem;
+  overflow-wrap: anywhere;
+}
+
+.domain-align__link {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin: 0;
+  padding-left: 0.7rem;
+  font-size: 0.78rem;
+  font-style: italic;
+  color: var(--rp-c-text-2);
+}
+
+.domain-align__link svg {
+  flex-shrink: 0;
+}
+
+.domain-align__result {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0;
+  padding-top: 0.65rem;
+  border-top: 1px dashed var(--rp-c-divider);
+}
+
+.domain-align__result-value {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--da-accent);
+}
+
+.domain-align__note {
+  margin: 0.3rem 0 0;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: var(--rp-c-text-2);
+}
+
+@media (max-width: 768px) {
+  .domain-align {
+    flex-direction: column;
+  }
+}

--- a/components/DomainAlignmentDiagram/DomainAlignmentDiagram.tsx
+++ b/components/DomainAlignmentDiagram/DomainAlignmentDiagram.tsx
@@ -1,0 +1,279 @@
+import { useLang } from '@rspress/core/runtime';
+import './DomainAlignmentDiagram.css';
+
+const svg = {
+  width: 20,
+  height: 20,
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.7,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  'aria-hidden': true,
+  focusable: 'false' as const,
+};
+
+const KeyIcon = () => (
+  <svg {...svg} aria-hidden="true">
+    <circle cx="7.5" cy="15.5" r="4" />
+    <path d="M10.5 12.5 20 3" />
+    <path d="M16 7l3 3" />
+    <path d="M13 10l2.5 2.5" />
+  </svg>
+);
+
+const MailIcon = () => (
+  <svg {...svg} aria-hidden="true">
+    <rect x="3" y="5" width="18" height="14" rx="2" />
+    <path d="m3 7 9 6 9-6" />
+  </svg>
+);
+
+const CheckIcon = () => (
+  <svg {...svg} aria-hidden="true">
+    <path d="M20 6 9 17l-5-5" />
+  </svg>
+);
+
+const CrossIcon = () => (
+  <svg {...svg} aria-hidden="true">
+    <path d="M18 6 6 18M6 6l12 12" />
+  </svg>
+);
+
+const DownIcon = () => (
+  <svg {...svg} aria-hidden="true">
+    <path d="M12 5v14M6 13l6 6 6-6" />
+  </svg>
+);
+
+// Canonical example identities — never translated (kept identical across locales).
+const AUTH = 'john.smith@mydomain.ovh';
+const FROM_OK = 'contact@mydomain.ovh';
+const FROM_KO = 'contact@example.com';
+
+interface Strings {
+  ariaLabel: string;
+  authLabel: string;
+  sendsAs: string;
+  fromLabel: string;
+  situationOk: string;
+  situationKo: string;
+  resultLabel: string;
+  resultOk: string;
+  resultKo: string;
+  noteOk: string;
+  noteKo: string;
+}
+
+// Copy localized via useLang(); locales without their own strings fall back to English.
+// The card carries the two axes of the (now removed) "Situation / Result" table:
+// the header states the SITUATION (same vs different domain), the footer the RESULT
+// (delivered vs rejected 550 5.7.1).
+const STRINGS: Record<string, Strings> = {
+  en: {
+    ariaLabel:
+      'Two sending situations and their result: when the From address is on the same domain as the authenticated mailbox, the email is delivered; when it is on a different domain, it is rejected with a 550 5.7.1 error.',
+    authLabel: 'Authenticated with',
+    sendsAs: 'sends as',
+    fromLabel: 'From address',
+    situationOk: 'Same domain',
+    situationKo: 'Different domain',
+    resultLabel: 'Result',
+    resultOk: 'Delivered',
+    resultKo: 'Rejected — 550 5.7.1',
+    noteOk: 'SPF · DKIM · DMARC aligned',
+    noteKo: 'Alignment broken',
+  },
+  fr: {
+    ariaLabel:
+      "Deux situations d'envoi et leur résultat : lorsque l'adresse From est sur le même domaine que la boîte d'authentification, l'e-mail est distribué ; sur un domaine différent, il est rejeté avec une erreur 550 5.7.1.",
+    authLabel: 'Authentifié avec',
+    sendsAs: 'envoie en tant que',
+    fromLabel: 'Adresse From',
+    situationOk: 'Même domaine',
+    situationKo: 'Domaine différent',
+    resultLabel: 'Résultat',
+    resultOk: 'Distribué',
+    resultKo: 'Rejeté — 550 5.7.1',
+    noteOk: 'SPF · DKIM · DMARC alignés',
+    noteKo: 'Alignement rompu',
+  },
+  de: {
+    ariaLabel:
+      'Zwei Versandsituationen und ihr Ergebnis: Liegt die From-Adresse auf derselben Domain wie das authentifizierte Postfach, wird die E-Mail zugestellt; auf einer anderen Domain wird sie mit dem Fehler 550 5.7.1 abgelehnt.',
+    authLabel: 'Authentifiziert mit',
+    sendsAs: 'sendet als',
+    fromLabel: 'Absenderadresse (From)',
+    situationOk: 'Gleiche Domain',
+    situationKo: 'Andere Domain',
+    resultLabel: 'Ergebnis',
+    resultOk: 'Zugestellt',
+    resultKo: 'Abgelehnt — 550 5.7.1',
+    noteOk: 'SPF · DKIM · DMARC ausgerichtet',
+    noteKo: 'Ausrichtung gebrochen',
+  },
+  es: {
+    ariaLabel:
+      'Dos situaciones de envío y su resultado: cuando la dirección From está en el mismo dominio que el buzón autenticado, el correo se entrega; en un dominio diferente, se rechaza con un error 550 5.7.1.',
+    authLabel: 'Autenticado con',
+    sendsAs: 'envía como',
+    fromLabel: 'Dirección From',
+    situationOk: 'Mismo dominio',
+    situationKo: 'Dominio diferente',
+    resultLabel: 'Resultado',
+    resultOk: 'Entregado',
+    resultKo: 'Rechazado — 550 5.7.1',
+    noteOk: 'SPF · DKIM · DMARC alineados',
+    noteKo: 'Alineación rota',
+  },
+  it: {
+    ariaLabel:
+      "Due situazioni di invio e il loro risultato: quando l'indirizzo From è sullo stesso dominio della casella autenticata, l'e-mail viene consegnata; su un dominio diverso, viene rifiutata con un errore 550 5.7.1.",
+    authLabel: 'Autenticato con',
+    sendsAs: 'invia come',
+    fromLabel: 'Indirizzo From',
+    situationOk: 'Stesso dominio',
+    situationKo: 'Dominio diverso',
+    resultLabel: 'Risultato',
+    resultOk: 'Consegnato',
+    resultKo: 'Rifiutato — 550 5.7.1',
+    noteOk: 'SPF · DKIM · DMARC allineati',
+    noteKo: 'Allineamento interrotto',
+  },
+  pl: {
+    ariaLabel:
+      'Dwie sytuacje wysyłki i ich wynik: gdy adres From znajduje się w tej samej domenie co uwierzytelnione konto, e-mail zostaje dostarczony; w innej domenie zostaje odrzucony z błędem 550 5.7.1.',
+    authLabel: 'Uwierzytelniono jako',
+    sendsAs: 'wysyła jako',
+    fromLabel: 'Adres From',
+    situationOk: 'Ta sama domena',
+    situationKo: 'Inna domena',
+    resultLabel: 'Wynik',
+    resultOk: 'Dostarczono',
+    resultKo: 'Odrzucono — 550 5.7.1',
+    noteOk: 'SPF · DKIM · DMARC zgodne',
+    noteKo: 'Zgodność naruszona',
+  },
+  pt: {
+    ariaLabel:
+      'Duas situações de envio e o respetivo resultado: quando o endereço From está no mesmo domínio que a caixa autenticada, o e-mail é entregue; num domínio diferente, é rejeitado com um erro 550 5.7.1.',
+    authLabel: 'Autenticado com',
+    sendsAs: 'envia como',
+    fromLabel: 'Endereço From',
+    situationOk: 'Mesmo domínio',
+    situationKo: 'Domínio diferente',
+    resultLabel: 'Resultado',
+    resultOk: 'Entregue',
+    resultKo: 'Rejeitado — 550 5.7.1',
+    noteOk: 'SPF · DKIM · DMARC alinhados',
+    noteKo: 'Alinhamento quebrado',
+  },
+};
+
+interface CaseProps {
+  variant: 'ok' | 'ko';
+  situation: string;
+  from: string;
+  result: string;
+  note: string;
+  authLabel: string;
+  sendsAs: string;
+  fromLabel: string;
+  resultLabel: string;
+}
+
+function AlignmentCase({
+  variant,
+  situation,
+  from,
+  result,
+  note,
+  authLabel,
+  sendsAs,
+  fromLabel,
+  resultLabel,
+}: CaseProps) {
+  return (
+    <div className={`domain-align__case domain-align__case--${variant}`}>
+      <p className="domain-align__situation">
+        <span className="domain-align__badge">
+          {variant === 'ok' ? <CheckIcon /> : <CrossIcon />}
+        </span>
+        {situation}
+      </p>
+      <div className="domain-align__row">
+        <span className="domain-align__ico">
+          <KeyIcon />
+        </span>
+        <span className="domain-align__field">
+          <span className="domain-align__label">{authLabel}</span>
+          <code className="domain-align__addr">{AUTH}</code>
+        </span>
+      </div>
+      <p className="domain-align__link">
+        <DownIcon />
+        {sendsAs}
+      </p>
+      <div className="domain-align__row">
+        <span className="domain-align__ico">
+          <MailIcon />
+        </span>
+        <span className="domain-align__field">
+          <span className="domain-align__label">{fromLabel}</span>
+          <code className="domain-align__addr">{from}</code>
+        </span>
+      </div>
+      <p className="domain-align__result">
+        <span className="domain-align__label">{resultLabel}</span>
+        <span className="domain-align__result-value">{result}</span>
+      </p>
+      <p className="domain-align__note">{note}</p>
+    </div>
+  );
+}
+
+/**
+ * Illustrates the core of the cross-domain spoofing rejection: whether the From
+ * address aligns with the authenticated mailbox's domain. Two side-by-side
+ * cases carry the two axes of the former "Situation / Result" table — the header
+ * is the SITUATION (same vs different domain), the footer the RESULT (delivered
+ * vs rejected 550 5.7.1).
+ *
+ * Pure HTML + inline SVG so it inherits the theme colors (Rspress CSS variables)
+ * and adapts to light/dark — no external assets. Copy is localized via useLang();
+ * example addresses are the canonical placeholders and are never translated.
+ */
+export function DomainAlignmentDiagram() {
+  const lang = useLang();
+  const t = STRINGS[lang] ?? STRINGS.en;
+  return (
+    <div className="domain-align" role="img" aria-label={t.ariaLabel}>
+      <AlignmentCase
+        variant="ok"
+        situation={t.situationOk}
+        from={FROM_OK}
+        result={t.resultOk}
+        note={t.noteOk}
+        authLabel={t.authLabel}
+        sendsAs={t.sendsAs}
+        fromLabel={t.fromLabel}
+        resultLabel={t.resultLabel}
+      />
+      <AlignmentCase
+        variant="ko"
+        situation={t.situationKo}
+        from={FROM_KO}
+        result={t.resultKo}
+        note={t.noteKo}
+        authLabel={t.authLabel}
+        sendsAs={t.sendsAs}
+        fromLabel={t.fromLabel}
+        resultLabel={t.resultLabel}
+      />
+    </div>
+  );
+}
+
+export default DomainAlignmentDiagram;

--- a/components/DomainAlignmentDiagram/index.ts
+++ b/components/DomainAlignmentDiagram/index.ts
@@ -1,0 +1,4 @@
+export {
+  DomainAlignmentDiagram,
+  DomainAlignmentDiagram as default,
+} from './DomainAlignmentDiagram';

--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -1955,7 +1955,7 @@
             + [Retrieving email headers](web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers){label=Email headers (.eml)}
             + [Managing the storage space for an email account](web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota){label=Mailbox storage}
             + [Restoring deleted items from your email account](web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention){label=Restore deleted emails}
-            + [What to do if your email is rejected for cross-domain spoofing](web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing){label=Rejected: cross-domain spoofing}
+            + [Email rejected for cross-domain spoofing (550 5.7.1)](web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing){label=Rejected: cross-domain spoofing}
             + [Exchange - Outlook sign-in prompts to Office 365](web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365){label=Outlook sign-in prompts}
             + [Exchange - How to manage logs](web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-manage-logs){label=Managing logs}
         + [MX Plan](products/web-cloud-email-collaborative-solutions-mx-plan){landing=web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan}

--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -1955,6 +1955,7 @@
             + [Retrieving email headers](web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers){label=Email headers (.eml)}
             + [Managing the storage space for an email account](web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota){label=Mailbox storage}
             + [Restoring deleted items from your email account](web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-retention){label=Restore deleted emails}
+            + [What to do if your email is rejected for cross-domain spoofing](web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing){label=Rejected: cross-domain spoofing}
             + [Exchange - Outlook sign-in prompts to Office 365](web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365){label=Outlook sign-in prompts}
             + [Exchange - How to manage logs](web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-manage-logs){label=Managing logs}
         + [MX Plan](products/web-cloud-email-collaborative-solutions-mx-plan){landing=web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan}

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,20 +1,44 @@
 ---
-title: "E-Mail wegen Cross-Domain-Spoofing abgelehnt: Was tun?"
-description: "Beheben Sie E-Mail-Ablehnungen durch den Cross-Domain-Spoofing-Schutz: Verstehen Sie den Fehler 550 5.7.1 und passen Sie Ihre MX Plan-, Zimbra- oder Webhosting-Konfiguration an."
-lastUpdated: 2026-07-20
-availableIn: [eu]
+title: "E-Mail wegen Cross-Domain-Spoofing abgelehnt (550 5.7.1)"
+description: "Beheben Sie E-Mail-Ablehnungen durch den Cross-Domain-Spoofing-Schutz: Verstehen Sie den Fehler 550 5.7.1 und passen Sie Ihre MX Plan- oder Webhosting-Konfiguration an"
+lastUpdated: 2026-07-16
+availableIn: [eu, ca, apac]
 ---
+
+import { DomainAlignmentDiagram } from '@components/DomainAlignmentDiagram';
+import { Region } from '@components/Zone';
 
 ## Ziel
 
-Wenn Sie eine E-Mail über **MX Plan**, **Zimbra** oder den in einem **Webhosting**-Paket enthaltenen E-Mail-Dienst versenden und die Absenderadresse eine andere Domain verwendet als die, mit der Sie sich authentifiziert haben, lehnt OVHcloud die Nachricht ab — ein Schutz gegen *Cross-Domain-Spoofing*, der seit dem **20. Juli 2026** gilt.
+<Region zones={['eu']}>
+
+Wenn Sie eine E-Mail über **MX Plan**, **Zimbra** oder den in einem **Webhosting**-Paket enthaltenen E-Mail-Dienst versenden und die Absenderadresse eine andere Domain verwendet als die, mit der Sie sich authentifiziert haben, lehnt OVHcloud die Nachricht ab — ein Schutz gegen *Cross-Domain-Spoofing*, der ab dem **20. Juli 2026** gilt.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Wenn Sie eine E-Mail über **MX Plan** oder den in einem **Webhosting**-Paket enthaltenen E-Mail-Dienst versenden und die Absenderadresse eine andere Domain verwendet als die, mit der Sie sich authentifiziert haben, lehnt OVHcloud die Nachricht ab — ein Schutz gegen *Cross-Domain-Spoofing*, der ab dem **20. Juli 2026** gilt.
+
+</Region>
 
 **In dieser Anleitung erfahren Sie, wie Sie die Ablehnung nachvollziehen, die Ursache bestätigen und Ihre Konfiguration anpassen, damit Ihre E-Mails wieder zugestellt werden.**
 
 ## Voraussetzungen
 
+<Region zones={['eu']}>
+
 - Sie verfügen über ein OVHcloud E-Mail-Angebot: **MX Plan**, **Zimbra** oder den in einem **Webhosting**-Paket enthaltenen E-Mail-Dienst.
 - Sie haben Zugriff auf das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink>, um Ihre Domains und E-Mail-Accounts zu verwalten.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+- Sie verfügen über ein OVHcloud E-Mail-Angebot: **MX Plan** oder den in einem **Webhosting**-Paket enthaltenen E-Mail-Dienst.
+- Sie haben Zugriff auf das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink>, um Ihre Domains und E-Mail-Accounts zu verwalten.
+
+</Region>
 
 ## In der praktischen Anwendung
 
@@ -30,10 +54,7 @@ Abgelehnte Nachrichten erhalten folgende Meldung:
 Dies geschieht, wenn die Domain der **From**-Adresse (die Adresse, von der aus Sie senden) von der Domain abweicht, mit der Sie sich **authentifiziert** haben (die Zugangsdaten des E-Mail-Accounts, mit denen Sie sich anmelden und senden). Der Versand von einer Adresse auf der **gleichen** Domain wie Ihr Authentifizierungs-Account ist davon nicht betroffen und funktioniert weiterhin.
 :::
 
-| Situation | Ergebnis |
-|---|---|
-| Gleiche Domain (z. B. `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Zugestellt |
-| Unterschiedliche Domain (z. B. `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Abgelehnt — `550 5.7.1` |
+<DomainAlignmentDiagram />
 
 Sie sind wahrscheinlich betroffen, wenn Sie:
 
@@ -43,7 +64,7 @@ Sie sind wahrscheinlich betroffen, wenn Sie:
 - E-Mails **im Auftrag eines Dritten** versenden (z. B. ein Dienstleister, der mit der Domain seines Kunden Rechnungen versendet)
 - den Versand für **mehrere Marken oder Einheiten** zentralisieren, die unterschiedliche Domains innerhalb einer einzigen E-Mail-Infrastruktur nutzen
 
-#### Warum diese Sperre besteht
+#### Warum besteht diese Sperre?
 
 Die Existenz dieser drei weit verbreiteten Standards macht es notwendig, die Praxis des Cross-Domain-Spoofings zu beenden:
 
@@ -59,17 +80,33 @@ Der Versand mit einer anderen Domain als der zur Authentifizierung verwendeten b
 
 #### Empfohlene Lösung — ein E-Mail-Account auf der Versanddomain einrichten
 
-Konfigurieren Sie die Domain, von der Sie senden möchten, in einem **Zimbra Starter**-Paket (siehe unsere Anleitung [Erste Schritte mit Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) und richten Sie darauf einen E-Mail-Account ein. Technisch gesehen **genügt ein einziger E-Mail-Account**: Sobald dieser eingerichtet ist, kann er sich authentifizieren und von **jeder Adresse dieser gleichen Domain** aus senden, da Spoofing innerhalb derselben Domain von dieser Sperre nicht betroffen ist.
+Richten Sie einen E-Mail-Account auf der Domain ein, von der Sie senden möchten, und authentifizieren Sie sich damit. Technisch gesehen **genügt ein einziger E-Mail-Account**: Sobald dieser eingerichtet ist, kann er sich authentifizieren und von **jeder Adresse dieser gleichen Domain** aus senden, da Spoofing innerhalb derselben Domain von dieser Sperre nicht betroffen ist.
+
+<Region zones={['eu']}>
+
+Konfigurieren Sie diese Domain in einem **Zimbra Starter**-Paket — siehe unsere Anleitung [Erste Schritte mit Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add) — und richten Sie darauf einen E-Mail-Account ein.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Fügen Sie diese Domain zu Ihrem **MX Plan** hinzu und richten Sie darauf einen E-Mail-Account ein.
+
+</Region>
 
 :::warning
 **Spoofing innerhalb derselben Domain ist ein Sicherheitsrisiko und wird bald durch den Domain-Administrator deaktivierbar sein.** Derzeit kann jeder E-Mail-Account der Domain als jede andere Adresse dieser gleichen Domain senden — ein einziger Satz von Zugangsdaten legt somit alle Adressen offen, ohne Nachvollziehbarkeit pro Adresse. OVHcloud bereitet eine Einstellung vor, mit der Domain-Administratoren diese Möglichkeit vollständig deaktivieren können; eine Konfiguration, die auf einem gemeinsam genutzten E-Mail-Account beruht, der mehrere Adressen imitiert, funktioniert dann nicht mehr. Bauen Sie Ihre Konfiguration nicht darauf auf — bevorzugen Sie stattdessen:
+
 - **Einen E-Mail-Account pro Adresse**, die Sie tatsächlich verwenden, oder
-- Eine native Exchange-Funktion — **Senden als**, **Senden im Auftrag von** oder **Zugangsrechte** — um kontrollierten Zugriff auf einen bestehenden E-Mail-Account zu gewähren, ohne dessen Passwort weiterzugeben (siehe [Alternative Lösung](#alternative-losung-wenn-sie-innerhalb-derselben-domain-bleiben) weiter unten)
+- Eine Delegationsfunktion, die kontrollierten Zugriff auf einen bestehenden E-Mail-Account gewährt, ohne dessen Passwort weiterzugeben
+
 :::
 
-- **Generische Adresse:** Sie verfügen über `john.smith@mydomain.ovh` auf MX Plan und möchten von `contact@example.com` aus senden. Richten Sie einen E-Mail-Account ein, z. B. `mary.johnson@example.com`, auf Zimbra Starter, und authentifizieren Sie sich damit, um als `contact@example.com` zu senden.
-- **Mehrere Einheiten:** Ihr Unternehmen verwaltet zwei Marken, eine auf `mydomain.ovh` und eine weitere auf `example.com`. Wenn Sie derzeit alle E-Mails von einem einzigen Account auf `mydomain.ovh` versenden, richten Sie über Zimbra Starter einen Account auf `example.com` für die zweite Marke ein.
-- **Versand im Auftrag eines Dritten:** Ihre Agentur versendet Kommunikation für einen Kunden auf `example.com` von Ihrer eigenen Domain aus. Richten Sie über Zimbra Starter einen Account auf `example.com` ein, um sich zu authentifizieren und mit Adressen dieser Domain zu senden.
+- **Generische Adresse:** Sie verfügen über `john.smith@mydomain.ovh` auf MX Plan und möchten von `contact@example.com` aus senden. Richten Sie einen E-Mail-Account ein, z. B. `mary.johnson@example.com`, auf dieser Domain, und authentifizieren Sie sich damit, um als `contact@example.com` zu senden.
+- **Mehrere Einheiten:** Ihr Unternehmen verwaltet zwei Marken, eine auf `mydomain.ovh` und eine weitere auf `example.com`. Wenn Sie derzeit alle E-Mails von einem einzigen Account auf `mydomain.ovh` versenden, richten Sie einen Account auf `example.com` für die zweite Marke ein.
+- **Versand im Auftrag eines Dritten:** Ihre Agentur versendet Kommunikation für einen Kunden auf `example.com` von Ihrer eigenen Domain aus. Richten Sie einen Account auf `example.com` ein, um sich zu authentifizieren und mit Adressen dieser Domain zu senden.
+
+<Region zones={['eu', 'ca']}>
 
 #### Alternative Lösung, wenn Sie innerhalb derselben Domain bleiben
 
@@ -81,6 +118,8 @@ Wenn alle Ihre Adressen bereits eine gemeinsame Domain nutzen, liegt die Ursache
 | *Im Auftrag von* jemandem auf derselben Domain senden | [**Senden im Auftrag von**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Zugriff auf einen E-Mail-Account teilen, ohne das Passwort weiterzugeben | [**Zugangsrechte**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | An eine Kontaktgruppe senden | [**Mailingliste**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) oder [Exchange-Kontaktgruppen](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+</Region>
 
 ### Wenn das Problem weiterhin besteht
 
@@ -94,7 +133,11 @@ Wenn Sie Ihre Konfiguration angepasst haben und Nachrichten weiterhin mit demsel
 
 Informationen zur Verwaltung von Alias und Weiterleitungen einer bestehenden Adresse finden Sie im Leitfaden [E-Mail Alias und Weiterleitung verwenden](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 Weitere Informationen zu [Zimbra Starter](/links/web/emails-zimbra).
+
+</Region>
 
 Vertiefende Informationen zu den zugrunde liegenden Standards finden Sie in [E-Mail-Sicherheit durch SPF-Eintrag verbessern](/guides/web-cloud/domains/dns-zone-spf), [E-Mail-Sicherheit durch DKIM-Eintrag verbessern](/guides/web-cloud/domains/dns-zone-dkim) und [E-Mail-Sicherheit durch DMARC-Eintrag verbessern](/guides/web-cloud/domains/dns-zone-dmarc).
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E-Mail wegen Cross-Domain-Spoofing abgelehnt (550 5.7.1)"
 description: "Beheben Sie E-Mail-Ablehnungen durch den Cross-Domain-Spoofing-Schutz: Verstehen Sie den Fehler 550 5.7.1 und passen Sie Ihre MX Plan- oder Webhosting-Konfiguration an"
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,0 +1,101 @@
+---
+title: "E-Mail wegen Cross-Domain-Spoofing abgelehnt: Was tun?"
+description: "Beheben Sie E-Mail-Ablehnungen durch den Cross-Domain-Spoofing-Schutz: Verstehen Sie den Fehler 550 5.7.1 und passen Sie Ihre MX Plan-, Zimbra- oder Webhosting-Konfiguration an."
+lastUpdated: 2026-07-20
+availableIn: [eu]
+---
+
+## Ziel
+
+Wenn Sie eine E-Mail über **MX Plan**, **Zimbra** oder den in einem **Webhosting**-Paket enthaltenen E-Mail-Dienst versenden und die Absenderadresse eine andere Domain verwendet als die, mit der Sie sich authentifiziert haben, lehnt OVHcloud die Nachricht ab — ein Schutz gegen *Cross-Domain-Spoofing*, der seit dem **20. Juli 2026** gilt.
+
+**In dieser Anleitung erfahren Sie, wie Sie die Ablehnung nachvollziehen, die Ursache bestätigen und Ihre Konfiguration anpassen, damit Ihre E-Mails wieder zugestellt werden.**
+
+## Voraussetzungen
+
+- Sie verfügen über ein OVHcloud E-Mail-Angebot: **MX Plan**, **Zimbra** oder den in einem **Webhosting**-Paket enthaltenen E-Mail-Dienst.
+- Sie haben Zugriff auf das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink>, um Ihre Domains und E-Mail-Accounts zu verwalten.
+
+## In der praktischen Anwendung
+
+### Das Problem erkennen
+
+Abgelehnte Nachrichten erhalten folgende Meldung:
+
+```text
+550 5.7.1 Rejected by policy: From header domain does not align with authenticated domain
+```
+
+:::info
+Dies geschieht, wenn die Domain der **From**-Adresse (die Adresse, von der aus Sie senden) von der Domain abweicht, mit der Sie sich **authentifiziert** haben (die Zugangsdaten des E-Mail-Accounts, mit denen Sie sich anmelden und senden). Der Versand von einer Adresse auf der **gleichen** Domain wie Ihr Authentifizierungs-Account ist davon nicht betroffen und funktioniert weiterhin.
+:::
+
+| Situation | Ergebnis |
+|---|---|
+| Gleiche Domain (z. B. `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Zugestellt |
+| Unterschiedliche Domain (z. B. `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Abgelehnt — `550 5.7.1` |
+
+Sie sind wahrscheinlich betroffen, wenn Sie:
+
+- E-Mails von einer Adresse auf einer anderen Domain als Ihrem Authentifizierungs-Account versenden
+- generische Adressen (`contact@`, `support@`, `noreply@`) auf einer separaten Domain verwalten
+- einen **Bot, ein Skript oder eine Anwendung** betreiben, die mit einer anderen Absenderdomain als der Authentifizierungsdomain versendet
+- E-Mails **im Auftrag eines Dritten** versenden (z. B. ein Dienstleister, der mit der Domain seines Kunden Rechnungen versendet)
+- den Versand für **mehrere Marken oder Einheiten** zentralisieren, die unterschiedliche Domains innerhalb einer einzigen E-Mail-Infrastruktur nutzen
+
+#### Warum diese Sperre besteht
+
+Die Existenz dieser drei weit verbreiteten Standards macht es notwendig, die Praxis des Cross-Domain-Spoofings zu beenden:
+
+| Standard | Rolle |
+|---|---|
+| **SPF** (Sender Policy Framework) | Überprüft, ob der sendende Server von der Absenderdomain autorisiert ist |
+| **DKIM** (DomainKeys Identified Mail) | Fügt eine kryptografische Signatur hinzu, die mit der sendenden Domain verknüpft ist |
+| **DMARC** (Domain-based Message Authentication) | Kombiniert SPF und DKIM und legt fest, was bei einem Fehlschlag geschieht |
+
+Der Versand mit einer anderen Domain als der zur Authentifizierung verwendeten bricht diese Übereinstimmung; die Sperrung schützt den Ruf Ihrer Domains und die Zustellbarkeit Ihrer legitimen Nachrichten.
+
+### Die Ablehnung beheben
+
+#### Empfohlene Lösung — ein E-Mail-Account auf der Versanddomain einrichten
+
+Konfigurieren Sie die Domain, von der Sie senden möchten, in einem **Zimbra Starter**-Paket (siehe unsere Anleitung [Erste Schritte mit Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) und richten Sie darauf einen E-Mail-Account ein. Technisch gesehen **genügt ein einziger E-Mail-Account**: Sobald dieser eingerichtet ist, kann er sich authentifizieren und von **jeder Adresse dieser gleichen Domain** aus senden, da Spoofing innerhalb derselben Domain von dieser Sperre nicht betroffen ist.
+
+:::warning
+**Spoofing innerhalb derselben Domain ist ein Sicherheitsrisiko und wird bald durch den Domain-Administrator deaktivierbar sein.** Derzeit kann jeder E-Mail-Account der Domain als jede andere Adresse dieser gleichen Domain senden — ein einziger Satz von Zugangsdaten legt somit alle Adressen offen, ohne Nachvollziehbarkeit pro Adresse. OVHcloud bereitet eine Einstellung vor, mit der Domain-Administratoren diese Möglichkeit vollständig deaktivieren können; eine Konfiguration, die auf einem gemeinsam genutzten E-Mail-Account beruht, der mehrere Adressen imitiert, funktioniert dann nicht mehr. Bauen Sie Ihre Konfiguration nicht darauf auf — bevorzugen Sie stattdessen:
+- **Einen E-Mail-Account pro Adresse**, die Sie tatsächlich verwenden, oder
+- Eine native Exchange-Funktion — **Senden als**, **Senden im Auftrag von** oder **Zugangsrechte** — um kontrollierten Zugriff auf einen bestehenden E-Mail-Account zu gewähren, ohne dessen Passwort weiterzugeben (siehe [Alternative Lösung](#alternative-losung-wenn-sie-innerhalb-derselben-domain-bleiben) weiter unten)
+:::
+
+- **Generische Adresse:** Sie verfügen über `john.smith@mydomain.ovh` auf MX Plan und möchten von `contact@example.com` aus senden. Richten Sie einen E-Mail-Account ein, z. B. `mary.johnson@example.com`, auf Zimbra Starter, und authentifizieren Sie sich damit, um als `contact@example.com` zu senden.
+- **Mehrere Einheiten:** Ihr Unternehmen verwaltet zwei Marken, eine auf `mydomain.ovh` und eine weitere auf `example.com`. Wenn Sie derzeit alle E-Mails von einem einzigen Account auf `mydomain.ovh` versenden, richten Sie über Zimbra Starter einen Account auf `example.com` für die zweite Marke ein.
+- **Versand im Auftrag eines Dritten:** Ihre Agentur versendet Kommunikation für einen Kunden auf `example.com` von Ihrer eigenen Domain aus. Richten Sie über Zimbra Starter einen Account auf `example.com` ein, um sich zu authentifizieren und mit Adressen dieser Domain zu senden.
+
+#### Alternative Lösung, wenn Sie innerhalb derselben Domain bleiben
+
+Wenn alle Ihre Adressen bereits eine gemeinsame Domain nutzen, liegt die Ursache nicht in dieser Sperre — überprüfen Sie erneut den Abschnitt [Das Problem erkennen](#das-problem-erkennen) oben, da die Ablehnung zwangsläufig von einer anderen Adress-/Domain-Kombination stammt als erwartet. Um mehrere Identitäten auf dieser einen Domain zu verwalten, nutzen Sie stattdessen diese nativen Funktionen anstelle eines gemeinsam genutzten E-Mail-Accounts:
+
+| Bedarf | Funktion | Verfügbar bei |
+|---|---|---|
+| *Als* eine andere Adresse derselben Domain senden | [**Senden als**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| *Im Auftrag von* jemandem auf derselben Domain senden | [**Senden im Auftrag von**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Zugriff auf einen E-Mail-Account teilen, ohne das Passwort weiterzugeben | [**Zugangsrechte**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| An eine Kontaktgruppe senden | [**Mailingliste**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) oder [Exchange-Kontaktgruppen](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+### Wenn das Problem weiterhin besteht
+
+Wenn Sie Ihre Konfiguration angepasst haben und Nachrichten weiterhin mit demselben Fehler `550 5.7.1` abgelehnt werden:
+
+- Überprüfen Sie, ob die Adresse, mit der Sie sich authentifizieren, mit der tatsächlich von Ihrer Versandanwendung oder Ihrem Gerät verwendeten **From**-Adresse übereinstimmt — bei Massenversand oder automatisierten Konfigurationen wird eine Abweichung leicht übersehen.
+- Lassen Sie einem neu eingerichteten E-Mail-Account oder einer Konfigurationsänderung einige Minuten Zeit, um sich zu verbreiten, bevor Sie es erneut versuchen.
+- Kontaktieren Sie den OVHcloud Support mit den vollständigen Headern der abgelehnten Nachricht, der zur Authentifizierung verwendeten Adresse und der beabsichtigten **From**-Adresse.
+
+## Weiterführende Informationen
+
+Informationen zur Verwaltung von Alias und Weiterleitungen einer bestehenden Adresse finden Sie im Leitfaden [E-Mail Alias und Weiterleitung verwenden](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
+
+Weitere Informationen zu [Zimbra Starter](/links/web/emails-zimbra).
+
+Vertiefende Informationen zu den zugrunde liegenden Standards finden Sie in [E-Mail-Sicherheit durch SPF-Eintrag verbessern](/guides/web-cloud/domains/dns-zone-spf), [E-Mail-Sicherheit durch DKIM-Eintrag verbessern](/guides/web-cloud/domains/dns-zone-dkim) und [E-Mail-Sicherheit durch DMARC-Eintrag verbessern](/guides/web-cloud/domains/dns-zone-dmarc).
+
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E-Mail-Diagnose und Fehlerbehebung - OVHcloud E-Mail-Dokumentation"
 description: "Lösen Sie Ihre OVHcloud-E-Mail-Probleme: Senden oder Empfangen nicht möglich, wegen Spam gesperrte Adresse, volles Postfach, vergessenes Passwort oder Wiederherstellung gelöschter E-Mails."
-lastUpdated: 2026-06-30
+lastUpdated: 2026-07-16
 pageType: landing
 banner: true
 tagline: "Erkennen und beheben Sie die häufigsten Probleme mit Ihrem OVHcloud-Postfach."
@@ -62,6 +62,7 @@ Sie bereiten sich auf den Kontakt mit dem Support vor oder möchten eine E-Mail 
 
 <CardGrid>
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Header und .eml-Datei einer E-Mail abrufen" description="Extrahieren Sie die technischen Informationen einer Nachricht zur Analyse oder für den Support." />
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing" title="E-Mails wegen Cross-Domain-Spoofing abgelehnt" description="Verstehen und beheben Sie die Ablehnung 550 5.7.1, wenn Sie von einer anderen Domain als Ihrer authentifizierten senden." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Microsoft Exchange-Fehlerdiagnose" description="Nutzen Sie das Diagnosetool für Exchange-Konten." />
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Wiederkehrende Outlook-Anmeldeaufforderungen" description="Beheben Sie wiederholte Outlook-Anmeldeaufforderungen bei Office 365 auf einem Exchange-Postfach." />

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E-Mail-Diagnose und Fehlerbehebung - OVHcloud E-Mail-Dokumentation"
 description: "Lösen Sie Ihre OVHcloud-E-Mail-Probleme: Senden oder Empfangen nicht möglich, wegen Spam gesperrte Adresse, volles Postfach, vergessenes Passwort oder Wiederherstellung gelöschter E-Mails."
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 pageType: landing
 banner: true
 tagline: "Erkennen und beheben Sie die häufigsten Probleme mit Ihrem OVHcloud-Postfach."

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,0 +1,101 @@
+---
+title: "What to do if your email is rejected for cross-domain spoofing"
+description: "Fix email rejections caused by cross-domain spoofing protection: understand the '550 5.7.1' error and adapt your MX Plan, Zimbra or Web Hosting setup."
+lastUpdated: 2026-07-20
+availableIn: [eu]
+---
+
+## Objective
+
+If you send an email through **MX Plan**, **Zimbra**, or the email service bundled with a **Web Hosting** plan, and the sender address uses a different domain than the one you authenticated with, OVHcloud rejects the message — a protection against *cross-domain spoofing* enforced since **20 July 2026**.
+
+**This guide helps you understand the rejection, confirm the cause, and adapt your configuration so your emails go through again.**
+
+## Requirements
+
+- An OVHcloud email offering: **MX Plan**, **Zimbra**, or the email service bundled with a **Web Hosting** plan
+- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> to manage your domains and mailboxes
+
+## Instructions
+
+### Identifying the issue
+
+Rejected messages return this notification:
+
+```text
+550 5.7.1 Rejected by policy: From header domain does not align with authenticated domain
+```
+
+:::info
+This happens when the domain in the **From** address (the address you send *as*) differs from the domain you **authenticated** with (the mailbox credentials used to log in and send). Sending from an address on the **same** domain as your authentication mailbox is unaffected and keeps working.
+:::
+
+| Situation | Result |
+|---|---|
+| Same domain (e.g. `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Delivered |
+| Different domain (e.g. `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Rejected — `550 5.7.1` |
+
+You're likely hitting this if you:
+
+- Send emails from an address on a different domain than your authentication mailbox
+- Manage generic addresses (`contact@`, `support@`, `noreply@`) on a separate domain
+- Run a **bot, script, or application** that sends with a sender domain different from the authentication domain
+- Send emails **on behalf of a third party** (e.g. a service provider invoicing with their client's domain)
+- Centralise sending for **multiple brands or entities** that use distinct domains from a single email infrastructure
+
+#### Why this is blocked
+
+The existence of these three standards, now widely adopted, is what requires putting an end to the practice of cross-domain spoofing:
+
+| Standard | Role |
+|---|---|
+| **SPF** (Sender Policy Framework) | Verifies that the sending server is authorised by the sender domain |
+| **DKIM** (DomainKeys Identified Mail) | Adds a cryptographic signature linked to the sending domain |
+| **DMARC** (Domain-based Message Authentication) | Combines SPF and DKIM and defines what happens on failure |
+
+Sending as a different domain than the one you authenticate with breaks this alignment; blocking it protects the reputation of your domains and the deliverability of your legitimate messages.
+
+### Resolving the rejection
+
+#### Recommended fix — create a mailbox on the domain you send from
+
+Configure the domain you want to send from on a **Zimbra Starter** plan (see our [Getting started with the Zimbra solution](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add) guide) and create a mailbox on it. Technically, a **single mailbox is enough**: once created, it can authenticate and send from **any address on that same domain**, since same-domain spoofing is unaffected by this block.
+
+:::warning
+**Same-domain spoofing is a security risk, and it will soon become disableable by your domain administrator.** Right now, any mailbox on the domain can send as any other address on that same domain — a single set of credentials exposes every address, with no per-address audit trail. OVHcloud is preparing a setting that lets domain administrators turn this capability off entirely; a setup that depends on one shared mailbox impersonating several addresses will break once it's disabled. Don't build on it — prefer:
+- **One mailbox per address** you actually send from, or
+- A native Exchange feature — **Send As**, **Send On Behalf**, or **Access** — to grant controlled access to an existing mailbox without sharing its password (see [Alternative fix](#alternative-fix-if-you-stay-within-the-same-domain) below)
+:::
+
+- **Generic address:** you have `john.smith@mydomain.ovh` on MX Plan and want to send from `contact@example.com`. Create a mailbox, e.g. `mary.johnson@example.com`, on Zimbra Starter, then authenticate with it to send as `contact@example.com`.
+- **Multiple entities:** your company manages two brands, one on `mydomain.ovh` and another on `example.com`. If you currently send all mail from a single mailbox on `mydomain.ovh`, create a mailbox on `example.com` via Zimbra Starter for the second brand.
+- **Sending on behalf of a third party:** your agency sends communications for a client on `example.com` from your own domain. Create a mailbox on `example.com` via Zimbra Starter to authenticate and send with addresses from that domain.
+
+#### Alternative fix if you stay within the same domain
+
+If all your addresses already share one domain, this block isn't your cause — re-check [Identifying the issue](#identifying-the-issue) above, since the rejection must be coming from a different address/domain pairing than you expect. For managing several identities on that single domain, use these native features instead of a shared mailbox:
+
+| Need | Feature | Available on |
+|---|---|---|
+| Send *as* another address on the same domain | [**Send As**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Send *on behalf of* someone on the same domain | [**Send On Behalf**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Share access to a mailbox without sharing the password | [**Access**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Send to a group of contacts | [**Mailing List**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) or [Exchange groups](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+### If the issue persists
+
+If you've adjusted your configuration and messages are still rejected with the same `550 5.7.1` error:
+
+- Double-check the address you authenticate with against the **From** address actually used by your sending application or device — a mismatch is easy to miss in bulk or automated setups.
+- Allow a few minutes for a newly created mailbox or configuration change to propagate before retesting.
+- Contact OVHcloud support with the rejected message's full headers, the authentication address used, and the intended **From** address.
+
+## Go further
+
+To manage aliases and redirections on an existing address, see [Using email aliases and redirections](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
+
+Find out more about [Zimbra Starter](/links/web/emails-zimbra).
+
+To go deeper on the underlying standards, see [How to improve email security with an SPF record](/guides/web-cloud/domains/dns-zone-spf), [How to improve email security with a DKIM record](/guides/web-cloud/domains/dns-zone-dkim), and [How to improve email security with a DMARC record](/guides/web-cloud/domains/dns-zone-dmarc).
+
+Join our [community of users](/links/community).

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,20 +1,44 @@
 ---
-title: "What to do if your email is rejected for cross-domain spoofing"
-description: "Fix email rejections caused by cross-domain spoofing protection: understand the '550 5.7.1' error and adapt your MX Plan, Zimbra or Web Hosting setup."
-lastUpdated: 2026-07-20
-availableIn: [eu]
+title: "Email rejected for cross-domain spoofing (550 5.7.1)"
+description: "Fix email rejections caused by cross-domain spoofing protection: understand the '550 5.7.1' error and adapt your MX Plan or Web Hosting setup"
+lastUpdated: 2026-07-16
+availableIn: [eu, ca, apac]
 ---
+
+import { DomainAlignmentDiagram } from '@components/DomainAlignmentDiagram';
+import { Region } from '@components/Zone';
 
 ## Objective
 
-If you send an email through **MX Plan**, **Zimbra**, or the email service bundled with a **Web Hosting** plan, and the sender address uses a different domain than the one you authenticated with, OVHcloud rejects the message — a protection against *cross-domain spoofing* enforced since **20 July 2026**.
+<Region zones={['eu']}>
+
+If you send an email through **MX Plan**, **Zimbra**, or the email service bundled with a **Web Hosting** plan, and the sender address uses a different domain than the one you authenticated with, OVHcloud rejects the message — a protection against *cross-domain spoofing* enforced from **20 July 2026**.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+If you send an email through **MX Plan** or the email service bundled with a **Web Hosting** plan, and the sender address uses a different domain than the one you authenticated with, OVHcloud rejects the message — a protection against *cross-domain spoofing* enforced from **20 July 2026**.
+
+</Region>
 
 **This guide helps you understand the rejection, confirm the cause, and adapt your configuration so your emails go through again.**
 
 ## Requirements
 
+<Region zones={['eu']}>
+
 - An OVHcloud email offering: **MX Plan**, **Zimbra**, or the email service bundled with a **Web Hosting** plan
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> to manage your domains and mailboxes
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+- An OVHcloud email offering: **MX Plan** or the email service bundled with a **Web Hosting** plan
+- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> to manage your domains and mailboxes
+
+</Region>
 
 ## Instructions
 
@@ -30,10 +54,7 @@ Rejected messages return this notification:
 This happens when the domain in the **From** address (the address you send *as*) differs from the domain you **authenticated** with (the mailbox credentials used to log in and send). Sending from an address on the **same** domain as your authentication mailbox is unaffected and keeps working.
 :::
 
-| Situation | Result |
-|---|---|
-| Same domain (e.g. `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Delivered |
-| Different domain (e.g. `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Rejected — `550 5.7.1` |
+<DomainAlignmentDiagram />
 
 You're likely hitting this if you:
 
@@ -43,9 +64,9 @@ You're likely hitting this if you:
 - Send emails **on behalf of a third party** (e.g. a service provider invoicing with their client's domain)
 - Centralise sending for **multiple brands or entities** that use distinct domains from a single email infrastructure
 
-#### Why this is blocked
+#### Why is this blocked?
 
-The existence of these three standards, now widely adopted, is what requires putting an end to the practice of cross-domain spoofing:
+These three standards, now widely adopted, are why cross-domain spoofing can no longer be allowed:
 
 | Standard | Role |
 |---|---|
@@ -59,17 +80,33 @@ Sending as a different domain than the one you authenticate with breaks this ali
 
 #### Recommended fix — create a mailbox on the domain you send from
 
-Configure the domain you want to send from on a **Zimbra Starter** plan (see our [Getting started with the Zimbra solution](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add) guide) and create a mailbox on it. Technically, a **single mailbox is enough**: once created, it can authenticate and send from **any address on that same domain**, since same-domain spoofing is unaffected by this block.
+Create a mailbox on the domain you want to send from, then authenticate with it to send. Technically, a **single mailbox is enough**: once created, it can authenticate and send from **any address on that same domain**, since same-domain spoofing is unaffected by this block.
+
+<Region zones={['eu']}>
+
+Set up the domain on a **Zimbra Starter** plan — see our [Getting started with the Zimbra solution](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add) guide — then create a mailbox on it.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Add the domain to your **MX Plan** and create a mailbox on it.
+
+</Region>
 
 :::warning
 **Same-domain spoofing is a security risk, and it will soon become disableable by your domain administrator.** Right now, any mailbox on the domain can send as any other address on that same domain — a single set of credentials exposes every address, with no per-address audit trail. OVHcloud is preparing a setting that lets domain administrators turn this capability off entirely; a setup that depends on one shared mailbox impersonating several addresses will break once it's disabled. Don't build on it — prefer:
+
 - **One mailbox per address** you actually send from, or
-- A native Exchange feature — **Send As**, **Send On Behalf**, or **Access** — to grant controlled access to an existing mailbox without sharing its password (see [Alternative fix](#alternative-fix-if-you-stay-within-the-same-domain) below)
+- A delegation feature that grants controlled access to an existing mailbox without sharing its password
+
 :::
 
-- **Generic address:** you have `john.smith@mydomain.ovh` on MX Plan and want to send from `contact@example.com`. Create a mailbox, e.g. `mary.johnson@example.com`, on Zimbra Starter, then authenticate with it to send as `contact@example.com`.
-- **Multiple entities:** your company manages two brands, one on `mydomain.ovh` and another on `example.com`. If you currently send all mail from a single mailbox on `mydomain.ovh`, create a mailbox on `example.com` via Zimbra Starter for the second brand.
-- **Sending on behalf of a third party:** your agency sends communications for a client on `example.com` from your own domain. Create a mailbox on `example.com` via Zimbra Starter to authenticate and send with addresses from that domain.
+- **Generic address:** you have `john.smith@mydomain.ovh` on MX Plan and want to send from `contact@example.com`. Create a mailbox, e.g. `mary.johnson@example.com`, on that domain, then authenticate with it to send as `contact@example.com`.
+- **Multiple entities:** your company manages two brands, one on `mydomain.ovh` and another on `example.com`. If you currently send all mail from a single mailbox on `mydomain.ovh`, create a mailbox on `example.com` for the second brand.
+- **Sending on behalf of a third party:** your agency sends communications for a client on `example.com` from your own domain. Create a mailbox on `example.com` to authenticate and send with addresses from that domain.
+
+<Region zones={['eu', 'ca']}>
 
 #### Alternative fix if you stay within the same domain
 
@@ -78,9 +115,11 @@ If all your addresses already share one domain, this block isn't your cause — 
 | Need | Feature | Available on |
 |---|---|---|
 | Send *as* another address on the same domain | [**Send As**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
-| Send *on behalf of* someone on the same domain | [**Send On Behalf**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Send *on behalf of* someone on the same domain | [**Send on Behalf**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Share access to a mailbox without sharing the password | [**Access**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Send to a group of contacts | [**Mailing List**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) or [Exchange groups](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+</Region>
 
 ### If the issue persists
 
@@ -94,7 +133,11 @@ If you've adjusted your configuration and messages are still rejected with the s
 
 To manage aliases and redirections on an existing address, see [Using email aliases and redirections](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 Find out more about [Zimbra Starter](/links/web/emails-zimbra).
+
+</Region>
 
 To go deeper on the underlying standards, see [How to improve email security with an SPF record](/guides/web-cloud/domains/dns-zone-spf), [How to improve email security with a DKIM record](/guides/web-cloud/domains/dns-zone-dkim), and [How to improve email security with a DMARC record](/guides/web-cloud/domains/dns-zone-dmarc).
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Email rejected for cross-domain spoofing (550 5.7.1)"
 description: "Fix email rejections caused by cross-domain spoofing protection: understand the '550 5.7.1' error and adapt your MX Plan or Web Hosting setup"
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Email diagnostics and troubleshooting - OVHcloud documentation"
 description: "Solve your OVHcloud email problems: cannot send or receive, address blocked for spam, full mailbox, forgotten password, or recovering deleted emails."
-lastUpdated: 2026-06-30
+lastUpdated: 2026-07-16
 pageType: landing
 banner: true
 tagline: "Identify and resolve the common problems with your OVHcloud mailbox."
@@ -62,6 +62,7 @@ Preparing to contact support, or want to analyse an email in depth? These guides
 
 <CardGrid>
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Retrieve an email's header and .eml file" description="Extract the technical information of a message for analysis or support." />
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing" title="Emails rejected for cross-domain spoofing" description="Understand and fix the 550 5.7.1 rejection when you send from a different domain than the one you authenticated with." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Microsoft Exchange error diagnostics" description="Use the diagnostic tool dedicated to Exchange accounts." />
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Recurring Outlook sign-in prompts" description="Fix Outlook repeatedly asking to sign in to Office 365 on an Exchange mailbox." />

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Email diagnostics and troubleshooting - OVHcloud documentation"
 description: "Solve your OVHcloud email problems: cannot send or receive, address blocked for spam, full mailbox, forgotten password, or recovering deleted emails."
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 pageType: landing
 banner: true
 tagline: "Identify and resolve the common problems with your OVHcloud mailbox."

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Correo rechazado por usurpación de dominio (550 5.7.1)"
 description: "Resuelva los rechazos de correo causados por la protección contra la usurpación de dominio: comprenda el error 550 5.7.1 y adapte su configuración de MX Plan o Hosting"
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,0 +1,101 @@
+---
+title: "Correo rechazado por usurpación de dominio (spoofing): ¿qué hacer?"
+description: "Resuelva los rechazos de correo causados por la protección contra la usurpación de dominio: comprenda el error 550 5.7.1 y adapte su configuración de MX Plan, Zimbra o Hosting."
+lastUpdated: 2026-07-20
+availableIn: [eu]
+---
+
+## Objetivo
+
+Si envía un correo a través de **MX Plan**, **Zimbra** o el servicio de correo incluido en una oferta de **Hosting**, y la dirección de remitente utiliza un dominio diferente al usado para autenticarse, OVHcloud rechaza el mensaje — una protección contra la *usurpación de dominio (cross-domain spoofing)* aplicada desde el **20 de julio de 2026**.
+
+**Esta guía le ayuda a comprender el rechazo, confirmar su causa y adaptar su configuración para que sus correos vuelvan a entregarse.**
+
+## Requisitos
+
+- Una oferta de correo OVHcloud: **MX Plan**, **Zimbra** o el servicio de correo incluido en una oferta de **Hosting**
+- Acceso al <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink> para gestionar sus dominios y cuentas de correo
+
+## Procedimiento
+
+### Identificar el problema
+
+Los mensajes rechazados devuelven la siguiente notificación:
+
+```text
+550 5.7.1 Rejected by policy: From header domain does not align with authenticated domain
+```
+
+:::info
+Esto ocurre cuando el dominio de la dirección **From** (la dirección desde la que envía) difiere del dominio con el que se ha **autenticado** (las credenciales de la cuenta de correo utilizadas para iniciar sesión y enviar). El envío desde una dirección del **mismo** dominio que su cuenta de autenticación no se ve afectado y sigue funcionando.
+:::
+
+| Situación | Resultado |
+|---|---|
+| Mismo dominio (p. ej. `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Entregado |
+| Dominio diferente (p. ej. `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Rechazado — `550 5.7.1` |
+
+Es probable que se vea afectado si usted:
+
+- Envía correos desde una dirección en un dominio diferente al de su cuenta de autenticación
+- Gestiona direcciones genéricas (`contact@`, `support@`, `noreply@`) en un dominio distinto
+- Utiliza un **bot, script o aplicación** que envía correos con un dominio de remitente diferente al dominio de autenticación
+- Envía correos **en nombre de un tercero** (por ejemplo, un proveedor que factura con el dominio de su cliente)
+- Centraliza el envío para **varias marcas o entidades** que utilizan dominios distintos desde una única infraestructura de correo
+
+#### Por qué existe este bloqueo
+
+La existencia de estos tres estándares, hoy ampliamente generalizados, hace necesario poner fin a la práctica de la usurpación de dominio entre dominios:
+
+| Estándar | Función |
+|---|---|
+| **SPF** (Sender Policy Framework) | Verifica que el servidor de envío esté autorizado por el dominio del remitente |
+| **DKIM** (DomainKeys Identified Mail) | Añade una firma criptográfica vinculada al dominio de envío |
+| **DMARC** (Domain-based Message Authentication) | Combina SPF y DKIM y define qué hacer en caso de fallo |
+
+Enviar un correo con un dominio diferente al utilizado para la autenticación rompe esta alineación; bloquearlo protege la reputación de sus dominios y la entregabilidad de sus mensajes legítimos.
+
+### Resolver el rechazo
+
+#### Solución recomendada — crear una cuenta de correo en el dominio de envío
+
+Configure el dominio desde el que desea enviar en una oferta **Zimbra Starter** (consulte nuestra guía [Primeros pasos con el producto Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) y cree en él una cuenta de correo. Técnicamente, **una sola cuenta de correo es suficiente**: una vez creada, puede autenticarse y enviar desde **cualquier dirección de ese mismo dominio**, ya que la usurpación dentro de un mismo dominio no se ve afectada por este bloqueo.
+
+:::warning
+**La usurpación dentro de un mismo dominio es un riesgo de seguridad, y pronto podrá ser desactivada por el administrador del dominio.** Actualmente, cualquier cuenta de correo del dominio puede enviar en nombre de cualquier otra dirección de ese mismo dominio — un único conjunto de credenciales expone así todas las direcciones, sin ningún registro de auditoría por dirección. OVHcloud está preparando una opción que permitirá a los administradores de dominio desactivar por completo esta posibilidad; una configuración que dependa de una cuenta compartida que suplanta varias direcciones dejará de funcionar una vez desactivada. No base su configuración en esto — priorice en su lugar:
+- **Una cuenta de correo por dirección** que utilice realmente, o
+- Una función nativa de Exchange — **enviar como**, **enviar en nombre de** o **permiso de acceso completo** — para otorgar acceso controlado a una cuenta existente sin compartir su contraseña (véase la [solución alternativa](#solucion-alternativa-si-permanece-dentro-del-mismo-dominio) más abajo)
+:::
+
+- **Dirección genérica:** dispone de `john.smith@mydomain.ovh` en MX Plan y desea enviar desde `contact@example.com`. Cree una cuenta de correo, por ejemplo `mary.johnson@example.com`, en Zimbra Starter, y autentíquese con ella para enviar como `contact@example.com`.
+- **Varias entidades:** su empresa gestiona dos marcas, una en `mydomain.ovh` y otra en `example.com`. Si actualmente envía todos sus correos desde una única cuenta en `mydomain.ovh`, cree una cuenta en `example.com` a través de Zimbra Starter para la segunda marca.
+- **Envío en nombre de un tercero:** su agencia envía comunicaciones para un cliente en `example.com` desde su propio dominio. Cree una cuenta en `example.com` a través de Zimbra Starter para autenticarse y enviar con direcciones de ese dominio.
+
+#### Solución alternativa si permanece dentro del mismo dominio
+
+Si todas sus direcciones ya comparten un único dominio, este bloqueo no es la causa — vuelva a comprobar la sección [Identificar el problema](#identificar-el-problema) anterior, ya que el rechazo debe provenir de otra combinación de dirección/dominio distinta de la esperada. Para gestionar varias identidades en ese único dominio, utilice en su lugar estas funciones nativas en vez de una cuenta compartida:
+
+| Necesidad | Función | Disponible en |
+|---|---|---|
+| Enviar *como* otra dirección del mismo dominio | [**Enviar como**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Enviar *en nombre de* alguien del mismo dominio | [**Enviar en nombre de**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Compartir el acceso a una cuenta de correo sin compartir la contraseña | [**Permiso de acceso completo**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Enviar a un grupo de contactos | [**Listas de difusión**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) o [grupos de Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+### Si el problema persiste
+
+Si ha ajustado su configuración y los mensajes siguen rechazándose con el mismo error `550 5.7.1`:
+
+- Compruebe que la dirección utilizada para autenticarse coincide con la dirección **From** realmente utilizada por su aplicación o dispositivo de envío — un desajuste es fácil de pasar por alto en configuraciones masivas o automatizadas.
+- Deje pasar unos minutos para que una cuenta recién creada o un cambio de configuración se propague antes de volver a intentarlo.
+- Contacte con el soporte de OVHcloud aportando los encabezados completos del mensaje rechazado, la dirección utilizada para autenticarse y la dirección **From** prevista.
+
+## Más información
+
+Para gestionar los alias y redirecciones de una dirección existente, consulte la guía [Utilizar los alias y redirecciones de correo](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
+
+Más información sobre [Zimbra Starter](/links/web/emails-zimbra).
+
+Para profundizar en los estándares subyacentes, consulte [Mejorar la seguridad del correo electrónico mediante el registro SPF](/guides/web-cloud/domains/dns-zone-spf), [Mejorar la seguridad del correo electrónico mediante un registro DKIM](/guides/web-cloud/domains/dns-zone-dkim) y [Mejorar la seguridad del correo electrónico mediante el registro DMARC](/guides/web-cloud/domains/dns-zone-dmarc).
+
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,20 +1,44 @@
 ---
-title: "Correo rechazado por usurpación de dominio (spoofing): ¿qué hacer?"
-description: "Resuelva los rechazos de correo causados por la protección contra la usurpación de dominio: comprenda el error 550 5.7.1 y adapte su configuración de MX Plan, Zimbra o Hosting."
-lastUpdated: 2026-07-20
-availableIn: [eu]
+title: "Correo rechazado por usurpación de dominio (550 5.7.1)"
+description: "Resuelva los rechazos de correo causados por la protección contra la usurpación de dominio: comprenda el error 550 5.7.1 y adapte su configuración de MX Plan o Hosting"
+lastUpdated: 2026-07-16
+availableIn: [eu, ca, apac]
 ---
+
+import { DomainAlignmentDiagram } from '@components/DomainAlignmentDiagram';
+import { Region } from '@components/Zone';
 
 ## Objetivo
 
-Si envía un correo a través de **MX Plan**, **Zimbra** o el servicio de correo incluido en una oferta de **Hosting**, y la dirección de remitente utiliza un dominio diferente al usado para autenticarse, OVHcloud rechaza el mensaje — una protección contra la *usurpación de dominio (cross-domain spoofing)* aplicada desde el **20 de julio de 2026**.
+<Region zones={['eu']}>
+
+Si envía un correo a través de **MX Plan**, **Zimbra** o el servicio de correo incluido en una oferta de **Hosting**, y la dirección de remitente utiliza un dominio diferente al usado para autenticarse, OVHcloud rechaza el mensaje — una protección contra la *usurpación de dominio (cross-domain spoofing)* aplicada a partir del **20 de julio de 2026**.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Si envía un correo a través de **MX Plan** o el servicio de correo incluido en una oferta de **Hosting**, y la dirección de remitente utiliza un dominio diferente al usado para autenticarse, OVHcloud rechaza el mensaje — una protección contra la *usurpación de dominio (cross-domain spoofing)* aplicada a partir del **20 de julio de 2026**.
+
+</Region>
 
 **Esta guía le ayuda a comprender el rechazo, confirmar su causa y adaptar su configuración para que sus correos vuelvan a entregarse.**
 
 ## Requisitos
 
+<Region zones={['eu']}>
+
 - Una oferta de correo OVHcloud: **MX Plan**, **Zimbra** o el servicio de correo incluido en una oferta de **Hosting**
 - Acceso al <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink> para gestionar sus dominios y cuentas de correo
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+- Una oferta de correo OVHcloud: **MX Plan** o el servicio de correo incluido en una oferta de **Hosting**
+- Acceso al <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink> para gestionar sus dominios y cuentas de correo
+
+</Region>
 
 ## Procedimiento
 
@@ -30,10 +54,7 @@ Los mensajes rechazados devuelven la siguiente notificación:
 Esto ocurre cuando el dominio de la dirección **From** (la dirección desde la que envía) difiere del dominio con el que se ha **autenticado** (las credenciales de la cuenta de correo utilizadas para iniciar sesión y enviar). El envío desde una dirección del **mismo** dominio que su cuenta de autenticación no se ve afectado y sigue funcionando.
 :::
 
-| Situación | Resultado |
-|---|---|
-| Mismo dominio (p. ej. `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Entregado |
-| Dominio diferente (p. ej. `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Rechazado — `550 5.7.1` |
+<DomainAlignmentDiagram />
 
 Es probable que se vea afectado si usted:
 
@@ -43,7 +64,7 @@ Es probable que se vea afectado si usted:
 - Envía correos **en nombre de un tercero** (por ejemplo, un proveedor que factura con el dominio de su cliente)
 - Centraliza el envío para **varias marcas o entidades** que utilizan dominios distintos desde una única infraestructura de correo
 
-#### Por qué existe este bloqueo
+#### ¿Por qué existe este bloqueo?
 
 La existencia de estos tres estándares, hoy ampliamente generalizados, hace necesario poner fin a la práctica de la usurpación de dominio entre dominios:
 
@@ -59,17 +80,33 @@ Enviar un correo con un dominio diferente al utilizado para la autenticación ro
 
 #### Solución recomendada — crear una cuenta de correo en el dominio de envío
 
-Configure el dominio desde el que desea enviar en una oferta **Zimbra Starter** (consulte nuestra guía [Primeros pasos con el producto Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) y cree en él una cuenta de correo. Técnicamente, **una sola cuenta de correo es suficiente**: una vez creada, puede autenticarse y enviar desde **cualquier dirección de ese mismo dominio**, ya que la usurpación dentro de un mismo dominio no se ve afectada por este bloqueo.
+Cree una cuenta de correo en el dominio desde el que desea enviar y autentíquese con ella. Técnicamente, **una sola cuenta de correo es suficiente**: una vez creada, puede autenticarse y enviar desde **cualquier dirección de ese mismo dominio**, ya que la usurpación dentro de un mismo dominio no se ve afectada por este bloqueo.
+
+<Region zones={['eu']}>
+
+Configure este dominio en una oferta **Zimbra Starter** —consulte nuestra guía [Primeros pasos con el producto Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)— y cree en él una cuenta de correo.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Añada este dominio a su **MX Plan** y cree en él una cuenta de correo.
+
+</Region>
 
 :::warning
 **La usurpación dentro de un mismo dominio es un riesgo de seguridad, y pronto podrá ser desactivada por el administrador del dominio.** Actualmente, cualquier cuenta de correo del dominio puede enviar en nombre de cualquier otra dirección de ese mismo dominio — un único conjunto de credenciales expone así todas las direcciones, sin ningún registro de auditoría por dirección. OVHcloud está preparando una opción que permitirá a los administradores de dominio desactivar por completo esta posibilidad; una configuración que dependa de una cuenta compartida que suplanta varias direcciones dejará de funcionar una vez desactivada. No base su configuración en esto — priorice en su lugar:
+
 - **Una cuenta de correo por dirección** que utilice realmente, o
-- Una función nativa de Exchange — **enviar como**, **enviar en nombre de** o **permiso de acceso completo** — para otorgar acceso controlado a una cuenta existente sin compartir su contraseña (véase la [solución alternativa](#solucion-alternativa-si-permanece-dentro-del-mismo-dominio) más abajo)
+- Una función de delegación que otorga acceso controlado a una cuenta existente sin compartir su contraseña
+
 :::
 
-- **Dirección genérica:** dispone de `john.smith@mydomain.ovh` en MX Plan y desea enviar desde `contact@example.com`. Cree una cuenta de correo, por ejemplo `mary.johnson@example.com`, en Zimbra Starter, y autentíquese con ella para enviar como `contact@example.com`.
-- **Varias entidades:** su empresa gestiona dos marcas, una en `mydomain.ovh` y otra en `example.com`. Si actualmente envía todos sus correos desde una única cuenta en `mydomain.ovh`, cree una cuenta en `example.com` a través de Zimbra Starter para la segunda marca.
-- **Envío en nombre de un tercero:** su agencia envía comunicaciones para un cliente en `example.com` desde su propio dominio. Cree una cuenta en `example.com` a través de Zimbra Starter para autenticarse y enviar con direcciones de ese dominio.
+- **Dirección genérica:** dispone de `john.smith@mydomain.ovh` en MX Plan y desea enviar desde `contact@example.com`. Cree una cuenta de correo, por ejemplo `mary.johnson@example.com`, en ese dominio, y autentíquese con ella para enviar como `contact@example.com`.
+- **Varias entidades:** su empresa gestiona dos marcas, una en `mydomain.ovh` y otra en `example.com`. Si actualmente envía todos sus correos desde una única cuenta en `mydomain.ovh`, cree una cuenta en `example.com` para la segunda marca.
+- **Envío en nombre de un tercero:** su agencia envía comunicaciones para un cliente en `example.com` desde su propio dominio. Cree una cuenta en `example.com` para autenticarse y enviar con direcciones de ese dominio.
+
+<Region zones={['eu', 'ca']}>
 
 #### Solución alternativa si permanece dentro del mismo dominio
 
@@ -81,6 +118,8 @@ Si todas sus direcciones ya comparten un único dominio, este bloqueo no es la c
 | Enviar *en nombre de* alguien del mismo dominio | [**Enviar en nombre de**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Compartir el acceso a una cuenta de correo sin compartir la contraseña | [**Permiso de acceso completo**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Enviar a un grupo de contactos | [**Listas de difusión**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) o [grupos de Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+</Region>
 
 ### Si el problema persiste
 
@@ -94,7 +133,11 @@ Si ha ajustado su configuración y los mensajes siguen rechazándose con el mism
 
 Para gestionar los alias y redirecciones de una dirección existente, consulte la guía [Utilizar los alias y redirecciones de correo](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 Más información sobre [Zimbra Starter](/links/web/emails-zimbra).
+
+</Region>
 
 Para profundizar en los estándares subyacentes, consulte [Mejorar la seguridad del correo electrónico mediante el registro SPF](/guides/web-cloud/domains/dns-zone-spf), [Mejorar la seguridad del correo electrónico mediante un registro DKIM](/guides/web-cloud/domains/dns-zone-dkim) y [Mejorar la seguridad del correo electrónico mediante el registro DMARC](/guides/web-cloud/domains/dns-zone-dmarc).
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnóstico y resolución de problemas de correo - Documentación de correo OVHcloud"
 description: "Resuelva sus problemas de correo de OVHcloud: no puede enviar ni recibir, dirección bloqueada por spam, buzón lleno, contraseña olvidada o recuperación de correos eliminados."
-lastUpdated: 2026-06-30
+lastUpdated: 2026-07-16
 pageType: landing
 banner: true
 tagline: "Identifique y resuelva los problemas habituales de su mensajería OVHcloud."
@@ -62,6 +62,7 @@ Una vez identificado el origen probable, localice su **síntoma** más abajo: la
 
 <CardGrid>
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Recuperar la cabecera y el archivo .eml de un correo" description="Extraiga la información técnica de un mensaje para su análisis o para el soporte." />
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing" title="Correos rechazados por usurpación de dominio (spoofing)" description="Comprenda y corrija el rechazo 550 5.7.1 al enviar desde un dominio distinto al que utiliza para autenticarse." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnóstico de errores de Microsoft Exchange" description="Utilice la herramienta de diagnóstico específica para cuentas Exchange." />
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Solicitudes de conexión de Outlook recurrentes" description="Corrija las solicitudes repetidas de conexión de Outlook a Office 365 en un buzón Exchange." />

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnóstico y resolución de problemas de correo - Documentación de correo OVHcloud"
 description: "Resuelva sus problemas de correo de OVHcloud: no puede enviar ni recibir, dirección bloqueada por spam, buzón lleno, contraseña olvidada o recuperación de correos eliminados."
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 pageType: landing
 banner: true
 tagline: "Identifique y resuelva los problemas habituales de su mensajería OVHcloud."

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,0 +1,101 @@
+---
+title: "Que faire en cas de rejet d'e-mail pour usurpation de domaine (spoofing) ?"
+description: "Résolvez les rejets d'e-mail liés à la protection anti-usurpation de domaine : comprenez l'erreur « 550 5.7.1 » et adaptez votre configuration MX Plan, Zimbra ou hébergement web."
+lastUpdated: 2026-07-20
+availableIn: [eu]
+---
+
+## Objectif
+
+Si vous envoyez un e-mail via **MX Plan**, **Zimbra**, ou le service e-mail inclus dans une offre d'**hébergement web**, et que l'adresse d'expéditeur utilise un domaine différent de celui utilisé lors de l'authentification, OVHcloud rejette le message — une protection contre l'*usurpation de domaine (cross-domain spoofing)* appliquée depuis le **20 juillet 2026**.
+
+**Ce guide vous aide à comprendre le rejet, à en confirmer la cause, et à adapter votre configuration pour que vos e-mails soient de nouveau acheminés.**
+
+## Prérequis
+
+- Une offre e-mail OVHcloud : **MX Plan**, **Zimbra**, ou le service e-mail inclus dans une offre d'**hébergement web**
+- Un accès à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> pour gérer vos noms de domaine et vos boîtes e-mail
+
+## En pratique
+
+### Identifier le problème
+
+Les messages rejetés renvoient la notification suivante :
+
+```text
+550 5.7.1 Rejected by policy: From header domain does not align with authenticated domain
+```
+
+:::info
+Cela se produit lorsque le domaine de l'adresse **From** (l'adresse depuis laquelle vous envoyez) diffère du domaine avec lequel vous vous êtes **authentifié** (les identifiants de la boîte e-mail utilisés pour vous connecter et envoyer). L'envoi depuis une adresse du **même** domaine que votre boîte d'authentification n'est pas concerné et continue de fonctionner.
+:::
+
+| Situation | Résultat |
+|---|---|
+| Même domaine (ex. `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Distribué |
+| Domaine différent (ex. `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Rejeté — `550 5.7.1` |
+
+Vous êtes probablement concerné si vous :
+
+- Envoyez des e-mails depuis une adresse sur un domaine différent de votre boîte d'authentification
+- Gérez des adresses génériques (`contact@`, `support@`, `noreply@`) sur un domaine séparé
+- Exploitez un **bot, un script ou une application** qui envoie des e-mails avec un domaine d'expéditeur différent du domaine d'authentification
+- Envoyez des e-mails **pour le compte d'un tiers** (par exemple un prestataire qui facture avec le domaine de son client)
+- Centralisez l'envoi pour **plusieurs marques ou entités** utilisant des domaines distincts depuis une seule infrastructure e-mail
+
+#### Pourquoi ce blocage
+
+L'existence de ces trois standards, aujourd'hui largement généralisés, impose de mettre fin à la pratique du cross-domain spoofing :
+
+| Standard | Rôle |
+|---|---|
+| **SPF** (Sender Policy Framework) | Vérifie que le serveur d'envoi est autorisé par le domaine d'expéditeur |
+| **DKIM** (DomainKeys Identified Mail) | Ajoute une signature cryptographique liée au domaine d'envoi |
+| **DMARC** (Domain-based Message Authentication) | Combine SPF et DKIM et définit la conduite à tenir en cas d'échec |
+
+Envoyer un e-mail avec un domaine différent de celui utilisé pour l'authentification rompt cet alignement ; le bloquer protège la réputation de vos domaines et la délivrabilité de vos messages légitimes.
+
+### Résoudre le rejet
+
+#### Solution recommandée — créer une boîte e-mail sur le domaine d'envoi
+
+Configurez le domaine depuis lequel vous souhaitez envoyer sur une offre **Zimbra Starter** (voir notre guide [Premiers pas avec l'offre Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) et créez-y une boîte e-mail. Techniquement, **une seule boîte e-mail suffit** : une fois créée, elle peut s'authentifier et envoyer depuis **n'importe quelle adresse de ce même domaine**, l'usurpation au sein d'un même domaine n'étant pas concernée par ce blocage.
+
+:::warning
+**L'usurpation au sein d'un même domaine est un risque de sécurité, et elle deviendra bientôt désactivable par l'administrateur du domaine.** À l'heure actuelle, n'importe quelle boîte e-mail du domaine peut envoyer en tant que n'importe quelle autre adresse de ce même domaine — un seul jeu d'identifiants expose donc toutes les adresses, sans piste d'audit par adresse. OVHcloud prépare un paramètre permettant aux administrateurs de domaine de désactiver entièrement cette possibilité ; une configuration reposant sur une boîte e-mail partagée usurpant plusieurs adresses cessera de fonctionner une fois celle-ci désactivée. Ne construisez pas votre configuration sur cette base — privilégiez plutôt :
+- **Une boîte e-mail par adresse** que vous utilisez réellement, ou
+- Une fonctionnalité native Exchange — **droit d'envoi**, **droit d'envoyer de la part**, ou **droit d'accès** — pour accorder un accès contrôlé à une boîte e-mail existante sans partager son mot de passe (voir la [solution alternative](#solution-alternative-si-vous-restez-au-sein-du-meme-domaine) ci-dessous)
+:::
+
+- **Adresse générique :** vous disposez de `john.smith@mydomain.ovh` sur MX Plan et souhaitez envoyer depuis `contact@example.com`. Créez une boîte e-mail, par exemple `mary.johnson@example.com`, sur Zimbra Starter, puis authentifiez-vous avec celle-ci pour envoyer en tant que `contact@example.com`.
+- **Plusieurs entités :** votre entreprise gère deux marques, l'une sur `mydomain.ovh` et l'autre sur `example.com`. Si vous envoyez actuellement tous vos e-mails depuis une seule boîte sur `mydomain.ovh`, créez une boîte sur `example.com` via Zimbra Starter pour la seconde marque.
+- **Envoi pour le compte d'un tiers :** votre agence envoie des communications pour un client sur `example.com` depuis votre propre domaine. Créez une boîte sur `example.com` via Zimbra Starter pour vous authentifier et envoyer avec des adresses de ce domaine.
+
+#### Solution alternative si vous restez au sein du même domaine
+
+Si toutes vos adresses partagent déjà un seul domaine, ce blocage n'est pas votre cause — vérifiez de nouveau la section [Identifier le problème](#identifier-le-probleme) ci-dessus, car le rejet provient forcément d'une autre combinaison adresse/domaine que celle que vous attendez. Pour gérer plusieurs identités sur ce domaine unique, utilisez plutôt ces fonctionnalités natives à la place d'une boîte e-mail partagée :
+
+| Besoin | Fonctionnalité | Disponible sur |
+|---|---|---|
+| Envoyer *en tant qu'*une autre adresse du même domaine | [**Droit d'envoi**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Envoyer *pour le compte de* quelqu'un sur le même domaine | [**Droit d'envoyer de la part**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Partager l'accès à une boîte e-mail sans partager le mot de passe | [**Droit d'accès**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Envoyer à un groupe de contacts | [**Mailing List**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) ou [groupes Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+### Si le problème persiste
+
+Si vous avez ajusté votre configuration et que les messages sont toujours rejetés avec la même erreur `550 5.7.1` :
+
+- Vérifiez que l'adresse utilisée pour l'authentification correspond bien à l'adresse **From** réellement utilisée par votre application ou votre appareil d'envoi — un décalage est facile à manquer dans les configurations groupées ou automatisées.
+- Laissez quelques minutes à une boîte e-mail nouvellement créée ou à un changement de configuration pour se propager avant de retester.
+- Contactez le support OVHcloud en fournissant l'intégralité des en-têtes du message rejeté, l'adresse utilisée pour l'authentification, et l'adresse **From** visée.
+
+## Aller plus loin
+
+Pour gérer les alias et redirections d'une adresse existante, consultez le guide [Utiliser les alias et redirections e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
+
+En savoir plus sur [Zimbra Starter](/links/web/emails-zimbra).
+
+Pour approfondir les standards sous-jacents, consultez [Améliorer la sécurité des e-mails via un enregistrement SPF](/guides/web-cloud/domains/dns-zone-spf), [Améliorer la sécurité des e-mails via un enregistrement DKIM](/guides/web-cloud/domains/dns-zone-dkim), et [Améliorer la sécurité des e-mails via un enregistrement DMARC](/guides/web-cloud/domains/dns-zone-dmarc).
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E-mail rejeté pour usurpation de domaine (550 5.7.1)"
 description: "Résolvez les rejets d'e-mail liés à la protection anti-usurpation de domaine : comprenez l'erreur « 550 5.7.1 » et adaptez votre configuration MX Plan ou hébergement web"
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,20 +1,44 @@
 ---
-title: "Que faire en cas de rejet d'e-mail pour usurpation de domaine (spoofing) ?"
-description: "Résolvez les rejets d'e-mail liés à la protection anti-usurpation de domaine : comprenez l'erreur « 550 5.7.1 » et adaptez votre configuration MX Plan, Zimbra ou hébergement web."
-lastUpdated: 2026-07-20
-availableIn: [eu]
+title: "E-mail rejeté pour usurpation de domaine (550 5.7.1)"
+description: "Résolvez les rejets d'e-mail liés à la protection anti-usurpation de domaine : comprenez l'erreur « 550 5.7.1 » et adaptez votre configuration MX Plan ou hébergement web"
+lastUpdated: 2026-07-16
+availableIn: [eu, ca, apac]
 ---
+
+import { DomainAlignmentDiagram } from '@components/DomainAlignmentDiagram';
+import { Region } from '@components/Zone';
 
 ## Objectif
 
-Si vous envoyez un e-mail via **MX Plan**, **Zimbra**, ou le service e-mail inclus dans une offre d'**hébergement web**, et que l'adresse d'expéditeur utilise un domaine différent de celui utilisé lors de l'authentification, OVHcloud rejette le message — une protection contre l'*usurpation de domaine (cross-domain spoofing)* appliquée depuis le **20 juillet 2026**.
+<Region zones={['eu']}>
+
+Si vous envoyez un e-mail via **MX Plan**, **Zimbra**, ou le service e-mail inclus dans une offre d'**hébergement web**, et que l'adresse d'expéditeur utilise un domaine différent de celui utilisé lors de l'authentification, OVHcloud rejette le message — une protection contre l'*usurpation de domaine (cross-domain spoofing)* appliquée à partir du **20 juillet 2026**.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Si vous envoyez un e-mail via **MX Plan** ou le service e-mail inclus dans une offre d'**hébergement web**, et que l'adresse d'expéditeur utilise un domaine différent de celui utilisé lors de l'authentification, OVHcloud rejette le message — une protection contre l'*usurpation de domaine (cross-domain spoofing)* appliquée à partir du **20 juillet 2026**.
+
+</Region>
 
 **Ce guide vous aide à comprendre le rejet, à en confirmer la cause, et à adapter votre configuration pour que vos e-mails soient de nouveau acheminés.**
 
 ## Prérequis
 
+<Region zones={['eu']}>
+
 - Une offre e-mail OVHcloud : **MX Plan**, **Zimbra**, ou le service e-mail inclus dans une offre d'**hébergement web**
 - Un accès à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> pour gérer vos noms de domaine et vos boîtes e-mail
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+- Une offre e-mail OVHcloud : **MX Plan** ou le service e-mail inclus dans une offre d'**hébergement web**
+- Un accès à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> pour gérer vos noms de domaine et vos boîtes e-mail
+
+</Region>
 
 ## En pratique
 
@@ -30,10 +54,7 @@ Les messages rejetés renvoient la notification suivante :
 Cela se produit lorsque le domaine de l'adresse **From** (l'adresse depuis laquelle vous envoyez) diffère du domaine avec lequel vous vous êtes **authentifié** (les identifiants de la boîte e-mail utilisés pour vous connecter et envoyer). L'envoi depuis une adresse du **même** domaine que votre boîte d'authentification n'est pas concerné et continue de fonctionner.
 :::
 
-| Situation | Résultat |
-|---|---|
-| Même domaine (ex. `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Distribué |
-| Domaine différent (ex. `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Rejeté — `550 5.7.1` |
+<DomainAlignmentDiagram />
 
 Vous êtes probablement concerné si vous :
 
@@ -43,9 +64,9 @@ Vous êtes probablement concerné si vous :
 - Envoyez des e-mails **pour le compte d'un tiers** (par exemple un prestataire qui facture avec le domaine de son client)
 - Centralisez l'envoi pour **plusieurs marques ou entités** utilisant des domaines distincts depuis une seule infrastructure e-mail
 
-#### Pourquoi ce blocage
+#### Pourquoi ce blocage ?
 
-L'existence de ces trois standards, aujourd'hui largement généralisés, impose de mettre fin à la pratique du cross-domain spoofing :
+Ces trois standards, aujourd'hui largement généralisés, imposent de mettre fin au cross-domain spoofing :
 
 | Standard | Rôle |
 |---|---|
@@ -59,17 +80,33 @@ Envoyer un e-mail avec un domaine différent de celui utilisé pour l'authentifi
 
 #### Solution recommandée — créer une boîte e-mail sur le domaine d'envoi
 
-Configurez le domaine depuis lequel vous souhaitez envoyer sur une offre **Zimbra Starter** (voir notre guide [Premiers pas avec l'offre Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) et créez-y une boîte e-mail. Techniquement, **une seule boîte e-mail suffit** : une fois créée, elle peut s'authentifier et envoyer depuis **n'importe quelle adresse de ce même domaine**, l'usurpation au sein d'un même domaine n'étant pas concernée par ce blocage.
+Créez une boîte e-mail sur le domaine depuis lequel vous souhaitez envoyer, puis authentifiez-vous avec elle. Techniquement, **une seule boîte e-mail suffit** : une fois créée, elle peut s'authentifier et envoyer depuis **n'importe quelle adresse de ce même domaine**, l'usurpation au sein d'un même domaine n'étant pas concernée par ce blocage.
+
+<Region zones={['eu']}>
+
+Configurez ce domaine sur une offre **Zimbra Starter** — voir notre guide [Premiers pas avec l'offre Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add) — puis créez-y une boîte e-mail.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Ajoutez ce domaine à votre **MX Plan** et créez-y une boîte e-mail.
+
+</Region>
 
 :::warning
 **L'usurpation au sein d'un même domaine est un risque de sécurité, et elle deviendra bientôt désactivable par l'administrateur du domaine.** À l'heure actuelle, n'importe quelle boîte e-mail du domaine peut envoyer en tant que n'importe quelle autre adresse de ce même domaine — un seul jeu d'identifiants expose donc toutes les adresses, sans piste d'audit par adresse. OVHcloud prépare un paramètre permettant aux administrateurs de domaine de désactiver entièrement cette possibilité ; une configuration reposant sur une boîte e-mail partagée usurpant plusieurs adresses cessera de fonctionner une fois celle-ci désactivée. Ne construisez pas votre configuration sur cette base — privilégiez plutôt :
+
 - **Une boîte e-mail par adresse** que vous utilisez réellement, ou
-- Une fonctionnalité native Exchange — **droit d'envoi**, **droit d'envoyer de la part**, ou **droit d'accès** — pour accorder un accès contrôlé à une boîte e-mail existante sans partager son mot de passe (voir la [solution alternative](#solution-alternative-si-vous-restez-au-sein-du-meme-domaine) ci-dessous)
+- Une fonctionnalité de délégation permettant d'accorder un accès contrôlé à une boîte e-mail existante sans partager son mot de passe
+
 :::
 
-- **Adresse générique :** vous disposez de `john.smith@mydomain.ovh` sur MX Plan et souhaitez envoyer depuis `contact@example.com`. Créez une boîte e-mail, par exemple `mary.johnson@example.com`, sur Zimbra Starter, puis authentifiez-vous avec celle-ci pour envoyer en tant que `contact@example.com`.
-- **Plusieurs entités :** votre entreprise gère deux marques, l'une sur `mydomain.ovh` et l'autre sur `example.com`. Si vous envoyez actuellement tous vos e-mails depuis une seule boîte sur `mydomain.ovh`, créez une boîte sur `example.com` via Zimbra Starter pour la seconde marque.
-- **Envoi pour le compte d'un tiers :** votre agence envoie des communications pour un client sur `example.com` depuis votre propre domaine. Créez une boîte sur `example.com` via Zimbra Starter pour vous authentifier et envoyer avec des adresses de ce domaine.
+- **Adresse générique :** vous disposez de `john.smith@mydomain.ovh` sur MX Plan et souhaitez envoyer depuis `contact@example.com`. Créez une boîte e-mail, par exemple `mary.johnson@example.com`, sur ce domaine, puis authentifiez-vous avec celle-ci pour envoyer en tant que `contact@example.com`.
+- **Plusieurs entités :** votre entreprise gère deux marques, l'une sur `mydomain.ovh` et l'autre sur `example.com`. Si vous envoyez actuellement tous vos e-mails depuis une seule boîte sur `mydomain.ovh`, créez une boîte sur `example.com` pour la seconde marque.
+- **Envoi pour le compte d'un tiers :** votre agence envoie des communications pour un client sur `example.com` depuis votre propre domaine. Créez une boîte sur `example.com` pour vous authentifier et envoyer avec des adresses de ce domaine.
+
+<Region zones={['eu', 'ca']}>
 
 #### Solution alternative si vous restez au sein du même domaine
 
@@ -81,6 +118,8 @@ Si toutes vos adresses partagent déjà un seul domaine, ce blocage n'est pas vo
 | Envoyer *pour le compte de* quelqu'un sur le même domaine | [**Droit d'envoyer de la part**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Partager l'accès à une boîte e-mail sans partager le mot de passe | [**Droit d'accès**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Envoyer à un groupe de contacts | [**Mailing List**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) ou [groupes Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+</Region>
 
 ### Si le problème persiste
 
@@ -94,7 +133,11 @@ Si vous avez ajusté votre configuration et que les messages sont toujours rejet
 
 Pour gérer les alias et redirections d'une adresse existante, consultez le guide [Utiliser les alias et redirections e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 En savoir plus sur [Zimbra Starter](/links/web/emails-zimbra).
+
+</Region>
 
 Pour approfondir les standards sous-jacents, consultez [Améliorer la sécurité des e-mails via un enregistrement SPF](/guides/web-cloud/domains/dns-zone-spf), [Améliorer la sécurité des e-mails via un enregistrement DKIM](/guides/web-cloud/domains/dns-zone-dkim), et [Améliorer la sécurité des e-mails via un enregistrement DMARC](/guides/web-cloud/domains/dns-zone-dmarc).
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -84,7 +84,7 @@ Créez une boîte e-mail sur le domaine depuis lequel vous souhaitez envoyer, pu
 
 <Region zones={['eu']}>
 
-Configurez ce domaine sur une offre **Zimbra Starter** — voir notre guide [Premiers pas avec l'offre Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add) — puis créez-y une boîte e-mail.
+Configurez ce domaine sur une offre **Zimbra Starter** — voir notre guide « [Premiers pas avec l'offre Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add) » — puis créez-y une boîte e-mail.
 
 </Region>
 
@@ -110,7 +110,7 @@ Ajoutez ce domaine à votre **MX Plan** et créez-y une boîte e-mail.
 
 #### Solution alternative si vous restez au sein du même domaine
 
-Si toutes vos adresses partagent déjà un seul domaine, ce blocage n'est pas votre cause — vérifiez de nouveau la section [Identifier le problème](#identifier-le-probleme) ci-dessus, car le rejet provient forcément d'une autre combinaison adresse/domaine que celle que vous attendez. Pour gérer plusieurs identités sur ce domaine unique, utilisez plutôt ces fonctionnalités natives à la place d'une boîte e-mail partagée :
+Si toutes vos adresses partagent déjà un seul domaine, ce blocage n'est pas votre cause — vérifiez de nouveau la section « [Identifier le problème](#identifier-le-problème) » ci-dessus, car le rejet provient forcément d'une autre combinaison adresse/domaine que celle que vous attendez. Pour gérer plusieurs identités sur ce domaine unique, utilisez plutôt ces fonctionnalités natives à la place d'une boîte e-mail partagée :
 
 | Besoin | Fonctionnalité | Disponible sur |
 |---|---|---|
@@ -131,7 +131,7 @@ Si vous avez ajusté votre configuration et que les messages sont toujours rejet
 
 ## Aller plus loin
 
-Pour gérer les alias et redirections d'une adresse existante, consultez le guide [Utiliser les alias et redirections e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
+Pour gérer les alias et redirections d'une adresse existante, consultez le guide « [Utiliser les alias et redirections e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections) ».
 
 <Region zones={['eu']}>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnostic et dépannage e-mail OVHcloud"
 description: "Résolvez vos problèmes d'e-mail OVHcloud : envoi ou réception impossible, adresse bloquée pour spam, boîte pleine, mot de passe oublié ou récupération d'e-mails supprimés."
-lastUpdated: 2026-06-30
+lastUpdated: 2026-07-16
 pageType: landing
 banner: true
 tagline: "Identifiez et résolvez les problèmes courants de votre messagerie OVHcloud."
@@ -62,6 +62,7 @@ Vous préparez un échange avec le support, ou vous voulez analyser un e-mail en
 
 <CardGrid>
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Récupérer l'en-tête et le fichier .eml d'un e-mail" description="Extrayez les informations techniques d'un message pour analyse ou support." />
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing" title="E-mails rejetés pour usurpation de domaine (spoofing)" description="Comprenez et corrigez le rejet 550 5.7.1 lorsque vous envoyez depuis un domaine différent de votre domaine d'authentification." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnostic d'erreurs Microsoft Exchange" description="Utilisez l'outil de diagnostic dédié aux comptes Exchange." />
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Invites de connexion Outlook répétées" description="Corrigez les demandes de connexion Outlook à Office 365 sur une boîte Exchange." />

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnostic et dépannage e-mail OVHcloud"
 description: "Résolvez vos problèmes d'e-mail OVHcloud : envoi ou réception impossible, adresse bloquée pour spam, boîte pleine, mot de passe oublié ou récupération d'e-mails supprimés."
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 pageType: landing
 banner: true
 tagline: "Identifiez et résolvez les problèmes courants de votre messagerie OVHcloud."

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Email rifiutata per usurpazione di dominio (550 5.7.1)"
 description: "Risolvi i rifiuti delle email causati dalla protezione contro l'usurpazione di dominio: comprendi l'errore 550 5.7.1 e adatta la configurazione di MX Plan o Hosting Web"
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,0 +1,101 @@
+---
+title: "Cosa fare se un'e-mail è rifiutata per usurpazione di dominio (spoofing)?"
+description: "Risolvi i rifiuti delle e-mail causati dalla protezione contro l'usurpazione di dominio: comprendi l'errore 550 5.7.1 e adatta la configurazione di MX Plan, Zimbra o Hosting Web."
+lastUpdated: 2026-07-20
+availableIn: [eu]
+---
+
+## Obiettivo
+
+Se invii un'e-mail tramite **MX Plan**, **Zimbra** o il servizio e-mail incluso in un'offerta di **Hosting Web**, e l'indirizzo del mittente utilizza un dominio diverso da quello con cui ti sei autenticato, OVHcloud rifiuta il messaggio — una protezione contro l'*usurpazione di dominio (cross-domain spoofing)* applicata dal **20 luglio 2026**.
+
+**Questa guida ti aiuta a capire il rifiuto, confermarne la causa e adattare la tua configurazione affinché le tue e-mail vengano di nuovo recapitate.**
+
+## Prerequisiti
+
+- Un'offerta e-mail OVHcloud: **MX Plan**, **Zimbra** o il servizio e-mail incluso in un'offerta di **Hosting Web**
+- Accesso allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> per gestire i tuoi domini e i tuoi account e-mail
+
+## Procedura
+
+### Identificare il problema
+
+I messaggi rifiutati restituiscono la seguente notifica:
+
+```text
+550 5.7.1 Rejected by policy: From header domain does not align with authenticated domain
+```
+
+:::info
+Questo accade quando il dominio dell'indirizzo **From** (l'indirizzo da cui invii) è diverso dal dominio con cui ti sei **autenticato** (le credenziali dell'account e-mail utilizzate per accedere e inviare). L'invio da un indirizzo dello **stesso** dominio del tuo account di autenticazione non è interessato e continua a funzionare.
+:::
+
+| Situazione | Risultato |
+|---|---|
+| Stesso dominio (es. `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Recapitato |
+| Dominio diverso (es. `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Rifiutato — `550 5.7.1` |
+
+Probabilmente sei interessato da questo blocco se:
+
+- Invii e-mail da un indirizzo su un dominio diverso dal tuo account di autenticazione
+- Gestisci indirizzi generici (`contact@`, `support@`, `noreply@`) su un dominio separato
+- Utilizzi un **bot, uno script o un'applicazione** che invia con un dominio del mittente diverso dal dominio di autenticazione
+- Invii e-mail **per conto di terzi** (ad esempio un fornitore che fattura con il dominio del proprio cliente)
+- Centralizzi l'invio per **più marchi o entità** che utilizzano domini distinti da un'unica infrastruttura e-mail
+
+#### Perché esiste questo blocco
+
+L'esistenza di questi tre standard, oggi ampiamente diffusi, rende necessario porre fine alla pratica dell'usurpazione di dominio incrociata:
+
+| Standard | Ruolo |
+|---|---|
+| **SPF** (Sender Policy Framework) | Verifica che il server di invio sia autorizzato dal dominio del mittente |
+| **DKIM** (DomainKeys Identified Mail) | Aggiunge una firma crittografica collegata al dominio di invio |
+| **DMARC** (Domain-based Message Authentication) | Combina SPF e DKIM e definisce cosa fare in caso di esito negativo |
+
+Inviare un'e-mail con un dominio diverso da quello utilizzato per l'autenticazione rompe questo allineamento; bloccarlo protegge la reputazione dei tuoi domini e la recapitabilità dei tuoi messaggi legittimi.
+
+### Risolvere il rifiuto
+
+#### Soluzione consigliata — crea un account e-mail sul dominio da cui invii
+
+Configura il dominio da cui vuoi inviare su un'offerta **Zimbra Starter** (consulta la nostra guida [Per iniziare con l'offerta Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) e crea al suo interno un account e-mail. Tecnicamente, **un solo account e-mail è sufficiente**: una volta creato, può autenticarsi e inviare da **qualsiasi indirizzo dello stesso dominio**, poiché l'usurpazione all'interno dello stesso dominio non è interessata da questo blocco.
+
+:::warning
+**L'usurpazione all'interno dello stesso dominio è un rischio per la sicurezza e presto potrà essere disattivata dall'amministratore del dominio.** Attualmente, qualsiasi account e-mail del dominio può inviare come qualsiasi altro indirizzo dello stesso dominio — un unico set di credenziali espone quindi tutti gli indirizzi, senza alcuna tracciabilità per indirizzo. OVHcloud sta preparando un'impostazione che permetterà agli amministratori di dominio di disattivare completamente questa possibilità; una configurazione che dipende da un account condiviso che si spaccia per più indirizzi smetterà di funzionare una volta disattivata. Non basare la tua configurazione su questo meccanismo — preferisci invece:
+- **Un account e-mail per ogni indirizzo** che utilizzi realmente, oppure
+- Una funzione nativa di Exchange — **Diritto di invio**, **Diritto di invio "da parte di"** o **Diritto di accesso** — per concedere un accesso controllato a un account esistente senza condividerne la password (vedi la [soluzione alternativa](#soluzione-alternativa-se-rimani-nello-stesso-dominio) più sotto)
+:::
+
+- **Indirizzo generico:** hai `john.smith@mydomain.ovh` su MX Plan e vuoi inviare da `contact@example.com`. Crea un account e-mail, ad esempio `mary.johnson@example.com`, su Zimbra Starter, quindi autenticati con esso per inviare come `contact@example.com`.
+- **Più entità:** la tua azienda gestisce due marchi, uno su `mydomain.ovh` e un altro su `example.com`. Se attualmente invii tutte le e-mail da un unico account su `mydomain.ovh`, crea un account su `example.com` tramite Zimbra Starter per il secondo marchio.
+- **Invio per conto di terzi:** la tua agenzia invia comunicazioni per un cliente su `example.com` dal tuo stesso dominio. Crea un account su `example.com` tramite Zimbra Starter per autenticarti e inviare con indirizzi di quel dominio.
+
+#### Soluzione alternativa se rimani nello stesso dominio
+
+Se tutti i tuoi indirizzi condividono già un unico dominio, questo blocco non è la tua causa — controlla di nuovo la sezione [Identificare il problema](#identificare-il-problema) qui sopra, poiché il rifiuto deve provenire da una combinazione indirizzo/dominio diversa da quella che ti aspetti. Per gestire più identità su questo unico dominio, utilizza invece queste funzioni native al posto di un account condiviso:
+
+| Esigenza | Funzione | Disponibile su |
+|---|---|---|
+| Inviare *come* un altro indirizzo dello stesso dominio | [**Diritto di invio**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Inviare *per conto di* qualcuno dello stesso dominio | [**Diritto di invio "da parte di"**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Condividere l'accesso a un account e-mail senza condividerne la password | [**Diritto di accesso**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Inviare a un gruppo di contatti | [**Mailing list**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) o [gruppi Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+### Se il problema persiste
+
+Se hai adattato la tua configurazione e i messaggi vengono ancora rifiutati con lo stesso errore `550 5.7.1`:
+
+- Verifica che l'indirizzo con cui ti autentichi corrisponda all'indirizzo **From** effettivamente utilizzato dalla tua applicazione o dal tuo dispositivo di invio — una discrepanza è facile da non notare in configurazioni massive o automatizzate.
+- Lascia qualche minuto a un account appena creato o a una modifica della configurazione per propagarsi prima di riprovare.
+- Contatta l'assistenza OVHcloud fornendo le intestazioni complete del messaggio rifiutato, l'indirizzo utilizzato per l'autenticazione e l'indirizzo **From** previsto.
+
+## Per saperne di più
+
+Per gestire alias e reindirizzamenti di un indirizzo esistente, consulta la guida [Utilizzare gli alias e i reindirizzamenti email](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
+
+Scopri di più su [Zimbra Starter](/links/web/emails-zimbra).
+
+Per approfondire gli standard sottostanti, consulta [Migliora la sicurezza delle email con un record SPF](/guides/web-cloud/domains/dns-zone-spf), [Migliora la sicurezza delle email con un record DKIM](/guides/web-cloud/domains/dns-zone-dkim) e [Migliora la sicurezza delle email con un record DMARC](/guides/web-cloud/domains/dns-zone-dmarc).
+
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,6 +1,6 @@
 ---
-title: "E-mail rifiutata per usurpazione di dominio (550 5.7.1)"
-description: "Risolvi i rifiuti delle e-mail causati dalla protezione contro l'usurpazione di dominio: comprendi l'errore 550 5.7.1 e adatta la configurazione di MX Plan o Hosting Web"
+title: "Email rifiutata per usurpazione di dominio (550 5.7.1)"
+description: "Risolvi i rifiuti delle email causati dalla protezione contro l'usurpazione di dominio: comprendi l'errore 550 5.7.1 e adatta la configurazione di MX Plan o Hosting Web"
 lastUpdated: 2026-07-16
 availableIn: [eu, ca, apac]
 ---
@@ -12,31 +12,31 @@ import { Region } from '@components/Zone';
 
 <Region zones={['eu']}>
 
-Se invii un'e-mail tramite **MX Plan**, **Zimbra** o il servizio e-mail incluso in un'offerta di **Hosting Web**, e l'indirizzo del mittente utilizza un dominio diverso da quello con cui ti sei autenticato, OVHcloud rifiuta il messaggio — una protezione contro l'*usurpazione di dominio (cross-domain spoofing)* applicata a partire dal **20 luglio 2026**.
+Se invii un'email tramite **MX Plan**, **Zimbra** o il servizio email incluso in un'offerta di **Hosting Web**, e l'indirizzo del mittente utilizza un dominio diverso da quello con cui ti sei autenticato, OVHcloud rifiuta il messaggio — una protezione contro l'*usurpazione di dominio (cross-domain spoofing)* applicata a partire dal **20 luglio 2026**.
 
 </Region>
 
 <Region zones={['ca', 'apac']}>
 
-Se invii un'e-mail tramite **MX Plan** o il servizio e-mail incluso in un'offerta di **Hosting Web**, e l'indirizzo del mittente utilizza un dominio diverso da quello con cui ti sei autenticato, OVHcloud rifiuta il messaggio — una protezione contro l'*usurpazione di dominio (cross-domain spoofing)* applicata a partire dal **20 luglio 2026**.
+Se invii un'email tramite **MX Plan** o il servizio email incluso in un'offerta di **Hosting Web**, e l'indirizzo del mittente utilizza un dominio diverso da quello con cui ti sei autenticato, OVHcloud rifiuta il messaggio — una protezione contro l'*usurpazione di dominio (cross-domain spoofing)* applicata a partire dal **20 luglio 2026**.
 
 </Region>
 
-**Questa guida ti aiuta a capire il rifiuto, confermarne la causa e adattare la tua configurazione affinché le tue e-mail vengano di nuovo recapitate.**
+**Questa guida ti aiuta a capire il rifiuto, confermarne la causa e adattare la tua configurazione affinché le tue email vengano di nuovo recapitate.**
 
 ## Prerequisiti
 
 <Region zones={['eu']}>
 
-- Un'offerta e-mail OVHcloud: **MX Plan**, **Zimbra** o il servizio e-mail incluso in un'offerta di **Hosting Web**
-- Accesso allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> per gestire i tuoi domini e i tuoi account e-mail
+- Un'offerta email OVHcloud: **MX Plan**, **Zimbra** o il servizio email incluso in un'offerta di **Hosting Web**
+- Accesso allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> per gestire i tuoi domini e i tuoi account email
 
 </Region>
 
 <Region zones={['ca', 'apac']}>
 
-- Un'offerta e-mail OVHcloud: **MX Plan** o il servizio e-mail incluso in un'offerta di **Hosting Web**
-- Accesso allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> per gestire i tuoi domini e i tuoi account e-mail
+- Un'offerta email OVHcloud: **MX Plan** o il servizio email incluso in un'offerta di **Hosting Web**
+- Accesso allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> per gestire i tuoi domini e i tuoi account email
 
 </Region>
 
@@ -51,18 +51,18 @@ I messaggi rifiutati restituiscono la seguente notifica:
 ```
 
 :::info
-Questo accade quando il dominio dell'indirizzo **From** (l'indirizzo da cui invii) è diverso dal dominio con cui ti sei **autenticato** (le credenziali dell'account e-mail utilizzate per accedere e inviare). L'invio da un indirizzo dello **stesso** dominio del tuo account di autenticazione non è interessato e continua a funzionare.
+Questo accade quando il dominio dell'indirizzo **From** (l'indirizzo da cui invii) è diverso dal dominio con cui ti sei **autenticato** (le credenziali dell'account email utilizzate per accedere e inviare). L'invio da un indirizzo dello **stesso** dominio del tuo account di autenticazione non è interessato e continua a funzionare.
 :::
 
 <DomainAlignmentDiagram />
 
 Probabilmente sei interessato da questo blocco se:
 
-- Invii e-mail da un indirizzo su un dominio diverso dal tuo account di autenticazione
+- Invii email da un indirizzo su un dominio diverso dal tuo account di autenticazione
 - Gestisci indirizzi generici (`contact@`, `support@`, `noreply@`) su un dominio separato
 - Utilizzi un **bot, uno script o un'applicazione** che invia con un dominio del mittente diverso dal dominio di autenticazione
-- Invii e-mail **per conto di terzi** (ad esempio un fornitore che fattura con il dominio del proprio cliente)
-- Centralizzi l'invio per **più marchi o entità** che utilizzano domini distinti da un'unica infrastruttura e-mail
+- Invii email **per conto di terzi** (ad esempio un fornitore che fattura con il dominio del proprio cliente)
+- Centralizzi l'invio per **più marchi o entità** che utilizzano domini distinti da un'unica infrastruttura email
 
 #### Perché esiste questo blocco?
 
@@ -74,36 +74,36 @@ L'esistenza di questi tre standard, oggi ampiamente diffusi, rende necessario po
 | **DKIM** (DomainKeys Identified Mail) | Aggiunge una firma crittografica collegata al dominio di invio |
 | **DMARC** (Domain-based Message Authentication) | Combina SPF e DKIM e definisce cosa fare in caso di esito negativo |
 
-Inviare un'e-mail con un dominio diverso da quello utilizzato per l'autenticazione rompe questo allineamento; bloccarlo protegge la reputazione dei tuoi domini e la recapitabilità dei tuoi messaggi legittimi.
+Inviare un'email con un dominio diverso da quello utilizzato per l'autenticazione rompe questo allineamento; bloccarlo protegge la reputazione dei tuoi domini e la recapitabilità dei tuoi messaggi legittimi.
 
 ### Risolvere il rifiuto
 
-#### Soluzione consigliata — crea un account e-mail sul dominio da cui invii
+#### Soluzione consigliata — crea un account email sul dominio da cui invii
 
-Crea un account e-mail sul dominio da cui vuoi inviare, quindi autenticati con esso. Tecnicamente, **un solo account e-mail è sufficiente**: una volta creato, può autenticarsi e inviare da **qualsiasi indirizzo dello stesso dominio**, poiché l'usurpazione all'interno dello stesso dominio non è interessata da questo blocco.
+Crea un account email sul dominio da cui vuoi inviare, quindi autenticati con esso. Tecnicamente, **un solo account email è sufficiente**: una volta creato, può autenticarsi e inviare da **qualsiasi indirizzo dello stesso dominio**, poiché l'usurpazione all'interno dello stesso dominio non è interessata da questo blocco.
 
 <Region zones={['eu']}>
 
-Configura questo dominio su un'offerta **Zimbra Starter** — consulta la nostra guida [Per iniziare con l'offerta Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add) — e crea al suo interno un account e-mail.
+Configura questo dominio su un'offerta **Zimbra Starter** — consulta la nostra guida [Per iniziare con l'offerta Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add) — e crea al suo interno un account email.
 
 </Region>
 
 <Region zones={['ca', 'apac']}>
 
-Aggiungi questo dominio al tuo **MX Plan** e crea al suo interno un account e-mail.
+Aggiungi questo dominio al tuo **MX Plan** e crea al suo interno un account email.
 
 </Region>
 
 :::warning
-**L'usurpazione all'interno dello stesso dominio è un rischio per la sicurezza e presto potrà essere disattivata dall'amministratore del dominio.** Attualmente, qualsiasi account e-mail del dominio può inviare come qualsiasi altro indirizzo dello stesso dominio — un unico set di credenziali espone quindi tutti gli indirizzi, senza alcuna tracciabilità per indirizzo. OVHcloud sta preparando un'impostazione che permetterà agli amministratori di dominio di disattivare completamente questa possibilità; una configurazione che dipende da un account condiviso che si spaccia per più indirizzi smetterà di funzionare una volta disattivata. Non basare la tua configurazione su questo meccanismo — preferisci invece:
+**L'usurpazione all'interno dello stesso dominio è un rischio per la sicurezza e presto potrà essere disattivata dall'amministratore del dominio.** Attualmente, qualsiasi account email del dominio può inviare come qualsiasi altro indirizzo dello stesso dominio — un unico set di credenziali espone quindi tutti gli indirizzi, senza alcuna tracciabilità per indirizzo. OVHcloud sta preparando un'impostazione che permetterà agli amministratori di dominio di disattivare completamente questa possibilità; una configurazione che dipende da un account condiviso che si spaccia per più indirizzi smetterà di funzionare una volta disattivata. Non basare la tua configurazione su questo meccanismo — preferisci invece:
 
-- **Un account e-mail per ogni indirizzo** che utilizzi realmente, oppure
+- **Un account email per ogni indirizzo** che utilizzi realmente, oppure
 - Una funzione di delega che concede un accesso controllato a un account esistente senza condividerne la password
 
 :::
 
-- **Indirizzo generico:** hai `john.smith@mydomain.ovh` su MX Plan e vuoi inviare da `contact@example.com`. Crea un account e-mail, ad esempio `mary.johnson@example.com`, su questo dominio, quindi autenticati con esso per inviare come `contact@example.com`.
-- **Più entità:** la tua azienda gestisce due marchi, uno su `mydomain.ovh` e un altro su `example.com`. Se attualmente invii tutte le e-mail da un unico account su `mydomain.ovh`, crea un account su `example.com` per il secondo marchio.
+- **Indirizzo generico:** hai `john.smith@mydomain.ovh` su MX Plan e vuoi inviare da `contact@example.com`. Crea un account email, ad esempio `mary.johnson@example.com`, su questo dominio, quindi autenticati con esso per inviare come `contact@example.com`.
+- **Più entità:** la tua azienda gestisce due marchi, uno su `mydomain.ovh` e un altro su `example.com`. Se attualmente invii tutte le email da un unico account su `mydomain.ovh`, crea un account su `example.com` per il secondo marchio.
 - **Invio per conto di terzi:** la tua agenzia invia comunicazioni per un cliente su `example.com` dal tuo stesso dominio. Crea un account su `example.com` per autenticarti e inviare con indirizzi di quel dominio.
 
 <Region zones={['eu', 'ca']}>
@@ -116,8 +116,8 @@ Se tutti i tuoi indirizzi condividono già un unico dominio, questo blocco non �
 |---|---|---|
 | Inviare *come* un altro indirizzo dello stesso dominio | [**Diritto di invio**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Inviare *per conto di* qualcuno dello stesso dominio | [**Diritto di invio "da parte di"**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
-| Condividere l'accesso a un account e-mail senza condividerne la password | [**Diritto di accesso**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
-| Inviare a un gruppo di contatti | [**Mailing list**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) o [gruppi Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+| Condividere l'accesso a un account email senza condividerne la password | [**Diritto di accesso**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Inviare a un gruppo di contatti | [**Mailing List**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) o [gruppi Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,20 +1,44 @@
 ---
-title: "Cosa fare se un'e-mail è rifiutata per usurpazione di dominio (spoofing)?"
-description: "Risolvi i rifiuti delle e-mail causati dalla protezione contro l'usurpazione di dominio: comprendi l'errore 550 5.7.1 e adatta la configurazione di MX Plan, Zimbra o Hosting Web."
-lastUpdated: 2026-07-20
-availableIn: [eu]
+title: "E-mail rifiutata per usurpazione di dominio (550 5.7.1)"
+description: "Risolvi i rifiuti delle e-mail causati dalla protezione contro l'usurpazione di dominio: comprendi l'errore 550 5.7.1 e adatta la configurazione di MX Plan o Hosting Web"
+lastUpdated: 2026-07-16
+availableIn: [eu, ca, apac]
 ---
+
+import { DomainAlignmentDiagram } from '@components/DomainAlignmentDiagram';
+import { Region } from '@components/Zone';
 
 ## Obiettivo
 
-Se invii un'e-mail tramite **MX Plan**, **Zimbra** o il servizio e-mail incluso in un'offerta di **Hosting Web**, e l'indirizzo del mittente utilizza un dominio diverso da quello con cui ti sei autenticato, OVHcloud rifiuta il messaggio — una protezione contro l'*usurpazione di dominio (cross-domain spoofing)* applicata dal **20 luglio 2026**.
+<Region zones={['eu']}>
+
+Se invii un'e-mail tramite **MX Plan**, **Zimbra** o il servizio e-mail incluso in un'offerta di **Hosting Web**, e l'indirizzo del mittente utilizza un dominio diverso da quello con cui ti sei autenticato, OVHcloud rifiuta il messaggio — una protezione contro l'*usurpazione di dominio (cross-domain spoofing)* applicata a partire dal **20 luglio 2026**.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Se invii un'e-mail tramite **MX Plan** o il servizio e-mail incluso in un'offerta di **Hosting Web**, e l'indirizzo del mittente utilizza un dominio diverso da quello con cui ti sei autenticato, OVHcloud rifiuta il messaggio — una protezione contro l'*usurpazione di dominio (cross-domain spoofing)* applicata a partire dal **20 luglio 2026**.
+
+</Region>
 
 **Questa guida ti aiuta a capire il rifiuto, confermarne la causa e adattare la tua configurazione affinché le tue e-mail vengano di nuovo recapitate.**
 
 ## Prerequisiti
 
+<Region zones={['eu']}>
+
 - Un'offerta e-mail OVHcloud: **MX Plan**, **Zimbra** o il servizio e-mail incluso in un'offerta di **Hosting Web**
 - Accesso allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> per gestire i tuoi domini e i tuoi account e-mail
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+- Un'offerta e-mail OVHcloud: **MX Plan** o il servizio e-mail incluso in un'offerta di **Hosting Web**
+- Accesso allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> per gestire i tuoi domini e i tuoi account e-mail
+
+</Region>
 
 ## Procedura
 
@@ -30,10 +54,7 @@ I messaggi rifiutati restituiscono la seguente notifica:
 Questo accade quando il dominio dell'indirizzo **From** (l'indirizzo da cui invii) è diverso dal dominio con cui ti sei **autenticato** (le credenziali dell'account e-mail utilizzate per accedere e inviare). L'invio da un indirizzo dello **stesso** dominio del tuo account di autenticazione non è interessato e continua a funzionare.
 :::
 
-| Situazione | Risultato |
-|---|---|
-| Stesso dominio (es. `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Recapitato |
-| Dominio diverso (es. `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Rifiutato — `550 5.7.1` |
+<DomainAlignmentDiagram />
 
 Probabilmente sei interessato da questo blocco se:
 
@@ -43,7 +64,7 @@ Probabilmente sei interessato da questo blocco se:
 - Invii e-mail **per conto di terzi** (ad esempio un fornitore che fattura con il dominio del proprio cliente)
 - Centralizzi l'invio per **più marchi o entità** che utilizzano domini distinti da un'unica infrastruttura e-mail
 
-#### Perché esiste questo blocco
+#### Perché esiste questo blocco?
 
 L'esistenza di questi tre standard, oggi ampiamente diffusi, rende necessario porre fine alla pratica dell'usurpazione di dominio incrociata:
 
@@ -59,17 +80,33 @@ Inviare un'e-mail con un dominio diverso da quello utilizzato per l'autenticazio
 
 #### Soluzione consigliata — crea un account e-mail sul dominio da cui invii
 
-Configura il dominio da cui vuoi inviare su un'offerta **Zimbra Starter** (consulta la nostra guida [Per iniziare con l'offerta Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) e crea al suo interno un account e-mail. Tecnicamente, **un solo account e-mail è sufficiente**: una volta creato, può autenticarsi e inviare da **qualsiasi indirizzo dello stesso dominio**, poiché l'usurpazione all'interno dello stesso dominio non è interessata da questo blocco.
+Crea un account e-mail sul dominio da cui vuoi inviare, quindi autenticati con esso. Tecnicamente, **un solo account e-mail è sufficiente**: una volta creato, può autenticarsi e inviare da **qualsiasi indirizzo dello stesso dominio**, poiché l'usurpazione all'interno dello stesso dominio non è interessata da questo blocco.
+
+<Region zones={['eu']}>
+
+Configura questo dominio su un'offerta **Zimbra Starter** — consulta la nostra guida [Per iniziare con l'offerta Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add) — e crea al suo interno un account e-mail.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Aggiungi questo dominio al tuo **MX Plan** e crea al suo interno un account e-mail.
+
+</Region>
 
 :::warning
 **L'usurpazione all'interno dello stesso dominio è un rischio per la sicurezza e presto potrà essere disattivata dall'amministratore del dominio.** Attualmente, qualsiasi account e-mail del dominio può inviare come qualsiasi altro indirizzo dello stesso dominio — un unico set di credenziali espone quindi tutti gli indirizzi, senza alcuna tracciabilità per indirizzo. OVHcloud sta preparando un'impostazione che permetterà agli amministratori di dominio di disattivare completamente questa possibilità; una configurazione che dipende da un account condiviso che si spaccia per più indirizzi smetterà di funzionare una volta disattivata. Non basare la tua configurazione su questo meccanismo — preferisci invece:
+
 - **Un account e-mail per ogni indirizzo** che utilizzi realmente, oppure
-- Una funzione nativa di Exchange — **Diritto di invio**, **Diritto di invio "da parte di"** o **Diritto di accesso** — per concedere un accesso controllato a un account esistente senza condividerne la password (vedi la [soluzione alternativa](#soluzione-alternativa-se-rimani-nello-stesso-dominio) più sotto)
+- Una funzione di delega che concede un accesso controllato a un account esistente senza condividerne la password
+
 :::
 
-- **Indirizzo generico:** hai `john.smith@mydomain.ovh` su MX Plan e vuoi inviare da `contact@example.com`. Crea un account e-mail, ad esempio `mary.johnson@example.com`, su Zimbra Starter, quindi autenticati con esso per inviare come `contact@example.com`.
-- **Più entità:** la tua azienda gestisce due marchi, uno su `mydomain.ovh` e un altro su `example.com`. Se attualmente invii tutte le e-mail da un unico account su `mydomain.ovh`, crea un account su `example.com` tramite Zimbra Starter per il secondo marchio.
-- **Invio per conto di terzi:** la tua agenzia invia comunicazioni per un cliente su `example.com` dal tuo stesso dominio. Crea un account su `example.com` tramite Zimbra Starter per autenticarti e inviare con indirizzi di quel dominio.
+- **Indirizzo generico:** hai `john.smith@mydomain.ovh` su MX Plan e vuoi inviare da `contact@example.com`. Crea un account e-mail, ad esempio `mary.johnson@example.com`, su questo dominio, quindi autenticati con esso per inviare come `contact@example.com`.
+- **Più entità:** la tua azienda gestisce due marchi, uno su `mydomain.ovh` e un altro su `example.com`. Se attualmente invii tutte le e-mail da un unico account su `mydomain.ovh`, crea un account su `example.com` per il secondo marchio.
+- **Invio per conto di terzi:** la tua agenzia invia comunicazioni per un cliente su `example.com` dal tuo stesso dominio. Crea un account su `example.com` per autenticarti e inviare con indirizzi di quel dominio.
+
+<Region zones={['eu', 'ca']}>
 
 #### Soluzione alternativa se rimani nello stesso dominio
 
@@ -81,6 +118,8 @@ Se tutti i tuoi indirizzi condividono già un unico dominio, questo blocco non �
 | Inviare *per conto di* qualcuno dello stesso dominio | [**Diritto di invio "da parte di"**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Condividere l'accesso a un account e-mail senza condividerne la password | [**Diritto di accesso**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Inviare a un gruppo di contatti | [**Mailing list**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) o [gruppi Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+</Region>
 
 ### Se il problema persiste
 
@@ -94,7 +133,11 @@ Se hai adattato la tua configurazione e i messaggi vengono ancora rifiutati con 
 
 Per gestire alias e reindirizzamenti di un indirizzo esistente, consulta la guida [Utilizzare gli alias e i reindirizzamenti email](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 Scopri di più su [Zimbra Starter](/links/web/emails-zimbra).
+
+</Region>
 
 Per approfondire gli standard sottostanti, consulta [Migliora la sicurezza delle email con un record SPF](/guides/web-cloud/domains/dns-zone-spf), [Migliora la sicurezza delle email con un record DKIM](/guides/web-cloud/domains/dns-zone-dkim) e [Migliora la sicurezza delle email con un record DMARC](/guides/web-cloud/domains/dns-zone-dmarc).
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnostica e risoluzione dei problemi e-mail - Documentazione email OVHcloud"
 description: "Risolvete i vostri problemi e-mail OVHcloud: invio o ricezione impossibili, indirizzo bloccato per spam, casella piena, password dimenticata o recupero di e-mail eliminate."
-lastUpdated: 2026-06-30
+lastUpdated: 2026-07-16
 pageType: landing
 banner: true
 tagline: "Individuate e risolvete i problemi più comuni della vostra messaggistica OVHcloud."
@@ -62,6 +62,7 @@ Vi state preparando a contattare il supporto o volete analizzare un'e-mail in mo
 
 <CardGrid>
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Recuperare l'intestazione e il file .eml di un'e-mail" description="Estraete le informazioni tecniche di un messaggio per l'analisi o il supporto." />
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing" title="E-mail rifiutate per usurpazione di dominio (spoofing)" description="Comprendi e correggi il rifiuto 550 5.7.1 quando invii da un dominio diverso da quello con cui ti autentichi." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnostica degli errori di Microsoft Exchange" description="Utilizzate lo strumento di diagnostica dedicato agli account Exchange." />
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Richieste di accesso ripetute di Outlook" description="Risolvi le richieste ripetute di accesso di Outlook a Office 365 su una casella Exchange." />

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnostica e risoluzione dei problemi e-mail - Documentazione email OVHcloud"
 description: "Risolvete i vostri problemi e-mail OVHcloud: invio o ricezione impossibili, indirizzo bloccato per spam, casella piena, password dimenticata o recupero di e-mail eliminate."
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 pageType: landing
 banner: true
 tagline: "Individuate e risolvete i problemi più comuni della vostra messaggistica OVHcloud."

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,0 +1,101 @@
+---
+title: "E-mail odrzucony z powodu cross-domain spoofingu: co zrobić?"
+description: "Rozwiąż problem odrzucania e-maili spowodowany ochroną przed cross-domain spoofingiem: zrozum błąd 550 5.7.1 i dostosuj konfigurację MX Plan, Zimbra lub Hostingu."
+lastUpdated: 2026-07-20
+availableIn: [eu]
+---
+
+## Wprowadzenie
+
+Jeśli wysyłasz e-mail za pośrednictwem **MX Plan**, **Zimbra** lub usługi e-mail dołączonej do oferty **Hostingu**, a adres nadawcy używa innej domeny niż ta, za pomocą której się uwierzytelniłeś, OVHcloud odrzuca wiadomość — to zabezpieczenie przed *cross-domain spoofingiem*, egzekwowane od **20 lipca 2026 roku**.
+
+**Ten przewodnik pomoże Ci zrozumieć przyczynę odrzucenia, potwierdzić jej źródło i dostosować konfigurację, aby Twoje e-maile znów były dostarczane.**
+
+## Wymagania początkowe
+
+- Posiadanie oferty e-mail OVHcloud: **MX Plan**, **Zimbra** lub usługi e-mail dołączonej do oferty **Hostingu**
+- Dostęp do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink> w celu zarządzania domenami i skrzynkami e-mail
+
+## W praktyce
+
+### Rozpoznanie problemu
+
+Odrzucone wiadomości zwracają następujące powiadomienie:
+
+```text
+550 5.7.1 Rejected by policy: From header domain does not align with authenticated domain
+```
+
+:::info
+Dzieje się tak, gdy domena adresu **From** (adresu, z którego wysyłasz wiadomość) różni się od domeny, za pomocą której się **uwierzytelniłeś** (danych logowania konta e-mail używanych do zalogowania się i wysyłki). Wysyłanie z adresu w **tej samej** domenie co konto uwierzytelniające nie jest objęte tym ograniczeniem i nadal działa.
+:::
+
+| Sytuacja | Wynik |
+|---|---|
+| Ta sama domena (np. `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Dostarczone |
+| Inna domena (np. `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Odrzucone — `550 5.7.1` |
+
+Prawdopodobnie napotykasz ten problem, jeśli:
+
+- Wysyłasz e-maile z adresu w innej domenie niż Twoje konto uwierzytelniające
+- Zarządzasz ogólnymi adresami (`contact@`, `support@`, `noreply@`) w oddzielnej domenie
+- Obsługujesz **bota, skrypt lub aplikację**, które wysyłają wiadomości z domeną nadawcy inną niż domena uwierzytelniania
+- Wysyłasz e-maile **w imieniu strony trzeciej** (np. dostawca usług wystawiający faktury z domeną swojego klienta)
+- Centralizujesz wysyłkę dla **wielu marek lub podmiotów** korzystających z odrębnych domen w ramach jednej infrastruktury e-mail
+
+#### Dlaczego to ograniczenie istnieje
+
+Istnienie tych trzech standardów, dziś powszechnie stosowanych, wymaga zakończenia praktyki cross-domain spoofingu:
+
+| Standard | Rola |
+|---|---|
+| **SPF** (Sender Policy Framework) | Sprawdza, czy serwer wysyłający jest autoryzowany przez domenę nadawcy |
+| **DKIM** (DomainKeys Identified Mail) | Dodaje podpis kryptograficzny powiązany z domeną wysyłającą |
+| **DMARC** (Domain-based Message Authentication) | Łączy SPF i DKIM oraz określa, co dzieje się w przypadku niepowodzenia |
+
+Wysyłka z inną domeną niż ta użyta do uwierzytelnienia łamie tę spójność; blokowanie takich wiadomości chroni reputację Twoich domen oraz dostarczalność Twoich prawidłowych wiadomości.
+
+### Rozwiązanie problemu odrzucenia
+
+#### Zalecane rozwiązanie — utwórz konto e-mail w domenie, z której wysyłasz
+
+Skonfiguruj domenę, z której chcesz wysyłać wiadomości, w ramach oferty **Zimbra Starter** (zobacz nasz przewodnik [Pierwsze kroki z ofertą Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) i utwórz w niej konto e-mail. Technicznie **wystarczy jedno konto e-mail**: po jego utworzeniu może ono uwierzytelniać się i wysyłać wiadomości z **dowolnego adresu w tej samej domenie**, ponieważ podszywanie się w obrębie tej samej domeny nie jest objęte tym ograniczeniem.
+
+:::warning
+**Podszywanie się w obrębie tej samej domeny stanowi zagrożenie bezpieczeństwa i wkrótce administrator domeny będzie mógł je wyłączyć.** Obecnie każde konto e-mail w domenie może wysyłać wiadomości jako dowolny inny adres w tej samej domenie — jeden zestaw danych logowania naraża więc wszystkie adresy, bez możliwości śledzenia działań według adresu. OVHcloud przygotowuje ustawienie, które pozwoli administratorom domen całkowicie wyłączyć tę możliwość; konfiguracja oparta na jednym współdzielonym koncie podszywającym się pod kilka adresów przestanie wtedy działać. Nie opieraj swojej konfiguracji na tym mechanizmie — zamiast tego wybierz:
+- **Jedno konto e-mail na adres**, którego faktycznie używasz, lub
+- Natywną funkcję Exchange — **prawo do wysyłki poczty**, **uprawnienia do wysyłki „w imieniu”** lub **prawo dostępu** — aby przyznać kontrolowany dostęp do istniejącego konta bez udostępniania jego hasła (zobacz [rozwiązanie alternatywne](#rozwiazanie-alternatywne-jesli-pozostajesz-w-obrebie-tej-samej-domeny) poniżej)
+:::
+
+- **Adres ogólny:** posiadasz `john.smith@mydomain.ovh` na MX Plan i chcesz wysyłać wiadomości z `contact@example.com`. Utwórz konto e-mail, np. `mary.johnson@example.com`, na Zimbra Starter, a następnie uwierzytelnij się nim, aby wysyłać jako `contact@example.com`.
+- **Wiele podmiotów:** Twoja firma zarządza dwiema markami, jedną w domenie `mydomain.ovh`, a drugą w `example.com`. Jeśli obecnie wysyłasz wszystkie e-maile z jednego konta w `mydomain.ovh`, utwórz konto w `example.com` za pomocą Zimbra Starter dla drugiej marki.
+- **Wysyłka w imieniu strony trzeciej:** Twoja agencja wysyła wiadomości dla klienta w domenie `example.com` z własnej domeny. Utwórz konto w `example.com` za pomocą Zimbra Starter, aby uwierzytelniać się i wysyłać wiadomości z adresów tej domeny.
+
+#### Rozwiązanie alternatywne, jeśli pozostajesz w obrębie tej samej domeny
+
+Jeśli wszystkie Twoje adresy znajdują się już w jednej domenie, to ograniczenie nie jest przyczyną problemu — sprawdź ponownie sekcję [Rozpoznanie problemu](#rozpoznanie-problemu) powyżej, ponieważ odrzucenie musi wynikać z innej kombinacji adresu i domeny, niż się spodziewasz. Aby zarządzać wieloma tożsamościami w ramach tej jednej domeny, skorzystaj zamiast tego z poniższych natywnych funkcji zamiast współdzielonego konta e-mail:
+
+| Potrzeba | Funkcja | Dostępna w |
+|---|---|---|
+| Wysyłanie *jako* inny adres w tej samej domenie | [**Prawo do wysyłki poczty**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Wysyłanie *w imieniu* kogoś w tej samej domenie | [**Uprawnienia do wysyłki „w imieniu”**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Udostępnienie dostępu do konta e-mail bez udostępniania hasła | [**Prawo dostępu**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Wysyłanie do grupy kontaktów | [**Listy mailingowe**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) lub [grupy Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+### Jeśli problem nadal występuje
+
+Jeśli dostosowałeś już konfigurację, a wiadomości są nadal odrzucane z tym samym błędem `550 5.7.1`:
+
+- Sprawdź dokładnie, czy adres używany do uwierzytelniania odpowiada adresowi **From** faktycznie używanemu przez Twoją aplikację lub urządzenie wysyłające — niezgodność łatwo przeoczyć w konfiguracjach masowych lub zautomatyzowanych.
+- Odczekaj kilka minut, aż nowo utworzone konto e-mail lub zmiana konfiguracji się rozpropaguje, zanim spróbujesz ponownie.
+- Skontaktuj się z pomocą techniczną OVHcloud, podając pełne nagłówki odrzuconej wiadomości, adres użyty do uwierzytelnienia oraz zamierzony adres **From**.
+
+## Sprawdź również
+
+Aby zarządzać aliasami i przekierowaniami istniejącego adresu, zobacz przewodnik [Korzystanie z aliasów i przekierowań e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
+
+Dowiedz się więcej o [Zimbra Starter](/links/web/emails-zimbra).
+
+Aby pogłębić wiedzę na temat omawianych standardów, zobacz [Poprawa bezpieczeństwa e-maili poprzez rekord SPF](/guides/web-cloud/domains/dns-zone-spf), [Poprawa bezpieczeństwa e-maili dzięki rejestracji DKIM](/guides/web-cloud/domains/dns-zone-dkim) oraz [Poprawa bezpieczeństwa e-maili dzięki rejestracji DMARC](/guides/web-cloud/domains/dns-zone-dmarc).
+
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E-mail odrzucony: cross-domain spoofing (550 5.7.1)"
 description: "Rozwiąż problem odrzucania e-maili spowodowany ochroną przed cross-domain spoofingiem: zrozum błąd 550 5.7.1 i dostosuj konfigurację MX Plan lub Hostingu"
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,20 +1,44 @@
 ---
-title: "E-mail odrzucony z powodu cross-domain spoofingu: co zrobić?"
-description: "Rozwiąż problem odrzucania e-maili spowodowany ochroną przed cross-domain spoofingiem: zrozum błąd 550 5.7.1 i dostosuj konfigurację MX Plan, Zimbra lub Hostingu."
-lastUpdated: 2026-07-20
-availableIn: [eu]
+title: "E-mail odrzucony: cross-domain spoofing (550 5.7.1)"
+description: "Rozwiąż problem odrzucania e-maili spowodowany ochroną przed cross-domain spoofingiem: zrozum błąd 550 5.7.1 i dostosuj konfigurację MX Plan lub Hostingu"
+lastUpdated: 2026-07-16
+availableIn: [eu, ca, apac]
 ---
+
+import { DomainAlignmentDiagram } from '@components/DomainAlignmentDiagram';
+import { Region } from '@components/Zone';
 
 ## Wprowadzenie
 
+<Region zones={['eu']}>
+
 Jeśli wysyłasz e-mail za pośrednictwem **MX Plan**, **Zimbra** lub usługi e-mail dołączonej do oferty **Hostingu**, a adres nadawcy używa innej domeny niż ta, za pomocą której się uwierzytelniłeś, OVHcloud odrzuca wiadomość — to zabezpieczenie przed *cross-domain spoofingiem*, egzekwowane od **20 lipca 2026 roku**.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Jeśli wysyłasz e-mail za pośrednictwem **MX Plan** lub usługi e-mail dołączonej do oferty **Hostingu**, a adres nadawcy używa innej domeny niż ta, za pomocą której się uwierzytelniłeś, OVHcloud odrzuca wiadomość — to zabezpieczenie przed *cross-domain spoofingiem*, egzekwowane od **20 lipca 2026 roku**.
+
+</Region>
 
 **Ten przewodnik pomoże Ci zrozumieć przyczynę odrzucenia, potwierdzić jej źródło i dostosować konfigurację, aby Twoje e-maile znów były dostarczane.**
 
 ## Wymagania początkowe
 
+<Region zones={['eu']}>
+
 - Posiadanie oferty e-mail OVHcloud: **MX Plan**, **Zimbra** lub usługi e-mail dołączonej do oferty **Hostingu**
 - Dostęp do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink> w celu zarządzania domenami i skrzynkami e-mail
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+- Posiadanie oferty e-mail OVHcloud: **MX Plan** lub usługi e-mail dołączonej do oferty **Hostingu**
+- Dostęp do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink> w celu zarządzania domenami i skrzynkami e-mail
+
+</Region>
 
 ## W praktyce
 
@@ -30,10 +54,7 @@ Odrzucone wiadomości zwracają następujące powiadomienie:
 Dzieje się tak, gdy domena adresu **From** (adresu, z którego wysyłasz wiadomość) różni się od domeny, za pomocą której się **uwierzytelniłeś** (danych logowania konta e-mail używanych do zalogowania się i wysyłki). Wysyłanie z adresu w **tej samej** domenie co konto uwierzytelniające nie jest objęte tym ograniczeniem i nadal działa.
 :::
 
-| Sytuacja | Wynik |
-|---|---|
-| Ta sama domena (np. `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Dostarczone |
-| Inna domena (np. `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Odrzucone — `550 5.7.1` |
+<DomainAlignmentDiagram />
 
 Prawdopodobnie napotykasz ten problem, jeśli:
 
@@ -43,7 +64,7 @@ Prawdopodobnie napotykasz ten problem, jeśli:
 - Wysyłasz e-maile **w imieniu strony trzeciej** (np. dostawca usług wystawiający faktury z domeną swojego klienta)
 - Centralizujesz wysyłkę dla **wielu marek lub podmiotów** korzystających z odrębnych domen w ramach jednej infrastruktury e-mail
 
-#### Dlaczego to ograniczenie istnieje
+#### Dlaczego to ograniczenie istnieje?
 
 Istnienie tych trzech standardów, dziś powszechnie stosowanych, wymaga zakończenia praktyki cross-domain spoofingu:
 
@@ -59,17 +80,33 @@ Wysyłka z inną domeną niż ta użyta do uwierzytelnienia łamie tę spójnoś
 
 #### Zalecane rozwiązanie — utwórz konto e-mail w domenie, z której wysyłasz
 
-Skonfiguruj domenę, z której chcesz wysyłać wiadomości, w ramach oferty **Zimbra Starter** (zobacz nasz przewodnik [Pierwsze kroki z ofertą Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) i utwórz w niej konto e-mail. Technicznie **wystarczy jedno konto e-mail**: po jego utworzeniu może ono uwierzytelniać się i wysyłać wiadomości z **dowolnego adresu w tej samej domenie**, ponieważ podszywanie się w obrębie tej samej domeny nie jest objęte tym ograniczeniem.
+Utwórz konto e-mail w domenie, z której chcesz wysyłać wiadomości, a następnie uwierzytelnij się nim. Technicznie **wystarczy jedno konto e-mail**: po jego utworzeniu może ono uwierzytelniać się i wysyłać wiadomości z **dowolnego adresu w tej samej domenie**, ponieważ podszywanie się w obrębie tej samej domeny nie jest objęte tym ograniczeniem.
+
+<Region zones={['eu']}>
+
+Skonfiguruj tę domenę w ramach oferty **Zimbra Starter** (zobacz nasz przewodnik [Pierwsze kroki z ofertą Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) i utwórz w niej konto e-mail.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Dodaj tę domenę do swojego **MX Plan** i utwórz w niej konto e-mail.
+
+</Region>
 
 :::warning
 **Podszywanie się w obrębie tej samej domeny stanowi zagrożenie bezpieczeństwa i wkrótce administrator domeny będzie mógł je wyłączyć.** Obecnie każde konto e-mail w domenie może wysyłać wiadomości jako dowolny inny adres w tej samej domenie — jeden zestaw danych logowania naraża więc wszystkie adresy, bez możliwości śledzenia działań według adresu. OVHcloud przygotowuje ustawienie, które pozwoli administratorom domen całkowicie wyłączyć tę możliwość; konfiguracja oparta na jednym współdzielonym koncie podszywającym się pod kilka adresów przestanie wtedy działać. Nie opieraj swojej konfiguracji na tym mechanizmie — zamiast tego wybierz:
+
 - **Jedno konto e-mail na adres**, którego faktycznie używasz, lub
-- Natywną funkcję Exchange — **prawo do wysyłki poczty**, **uprawnienia do wysyłki „w imieniu”** lub **prawo dostępu** — aby przyznać kontrolowany dostęp do istniejącego konta bez udostępniania jego hasła (zobacz [rozwiązanie alternatywne](#rozwiazanie-alternatywne-jesli-pozostajesz-w-obrebie-tej-samej-domeny) poniżej)
+- Funkcję delegowania, która przyznaje kontrolowany dostęp do istniejącego konta bez udostępniania jego hasła
+
 :::
 
-- **Adres ogólny:** posiadasz `john.smith@mydomain.ovh` na MX Plan i chcesz wysyłać wiadomości z `contact@example.com`. Utwórz konto e-mail, np. `mary.johnson@example.com`, na Zimbra Starter, a następnie uwierzytelnij się nim, aby wysyłać jako `contact@example.com`.
-- **Wiele podmiotów:** Twoja firma zarządza dwiema markami, jedną w domenie `mydomain.ovh`, a drugą w `example.com`. Jeśli obecnie wysyłasz wszystkie e-maile z jednego konta w `mydomain.ovh`, utwórz konto w `example.com` za pomocą Zimbra Starter dla drugiej marki.
-- **Wysyłka w imieniu strony trzeciej:** Twoja agencja wysyła wiadomości dla klienta w domenie `example.com` z własnej domeny. Utwórz konto w `example.com` za pomocą Zimbra Starter, aby uwierzytelniać się i wysyłać wiadomości z adresów tej domeny.
+- **Adres ogólny:** posiadasz `john.smith@mydomain.ovh` na MX Plan i chcesz wysyłać wiadomości z `contact@example.com`. Utwórz konto e-mail, np. `mary.johnson@example.com`, w tej domenie, a następnie uwierzytelnij się nim, aby wysyłać jako `contact@example.com`.
+- **Wiele podmiotów:** Twoja firma zarządza dwiema markami, jedną w domenie `mydomain.ovh`, a drugą w `example.com`. Jeśli obecnie wysyłasz wszystkie e-maile z jednego konta w `mydomain.ovh`, utwórz konto w `example.com` dla drugiej marki.
+- **Wysyłka w imieniu strony trzeciej:** Twoja agencja wysyła wiadomości dla klienta w domenie `example.com` z własnej domeny. Utwórz konto w `example.com`, aby uwierzytelniać się i wysyłać wiadomości z adresów tej domeny.
+
+<Region zones={['eu', 'ca']}>
 
 #### Rozwiązanie alternatywne, jeśli pozostajesz w obrębie tej samej domeny
 
@@ -78,9 +115,11 @@ Jeśli wszystkie Twoje adresy znajdują się już w jednej domenie, to ogranicze
 | Potrzeba | Funkcja | Dostępna w |
 |---|---|---|
 | Wysyłanie *jako* inny adres w tej samej domenie | [**Prawo do wysyłki poczty**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
-| Wysyłanie *w imieniu* kogoś w tej samej domenie | [**Uprawnienia do wysyłki „w imieniu”**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Wysyłanie *w imieniu* kogoś w tej samej domenie | [**Uprawnienia do wysyłki "w imieniu"**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Udostępnienie dostępu do konta e-mail bez udostępniania hasła | [**Prawo dostępu**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Wysyłanie do grupy kontaktów | [**Listy mailingowe**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) lub [grupy Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+</Region>
 
 ### Jeśli problem nadal występuje
 
@@ -94,7 +133,11 @@ Jeśli dostosowałeś już konfigurację, a wiadomości są nadal odrzucane z ty
 
 Aby zarządzać aliasami i przekierowaniami istniejącego adresu, zobacz przewodnik [Korzystanie z aliasów i przekierowań e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 Dowiedz się więcej o [Zimbra Starter](/links/web/emails-zimbra).
+
+</Region>
 
 Aby pogłębić wiedzę na temat omawianych standardów, zobacz [Poprawa bezpieczeństwa e-maili poprzez rekord SPF](/guides/web-cloud/domains/dns-zone-spf), [Poprawa bezpieczeństwa e-maili dzięki rejestracji DKIM](/guides/web-cloud/domains/dns-zone-dkim) oraz [Poprawa bezpieczeństwa e-maili dzięki rejestracji DMARC](/guides/web-cloud/domains/dns-zone-dmarc).
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnostyka i rozwiązywanie problemów z pocztą - Dokumentacja e-mail OVHcloud"
 description: "Rozwiąż problemy z pocztą OVHcloud: brak możliwości wysyłania lub odbierania, adres zablokowany z powodu spamu, pełna skrzynka, zapomniane hasło lub odzyskiwanie usuniętych wiadomości."
-lastUpdated: 2026-06-30
+lastUpdated: 2026-07-16
 pageType: landing
 banner: true
 tagline: "Zidentyfikuj i rozwiąż najczęstsze problemy ze swoją skrzynką OVHcloud."
@@ -62,6 +62,7 @@ Przygotowujesz się do kontaktu z pomocą techniczną lub chcesz dokładnie prze
 
 <CardGrid>
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Pobierz nagłówek i plik .eml wiadomości" description="Wyodrębnij informacje techniczne wiadomości do analizy lub dla pomocy technicznej." />
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing" title="E-maile odrzucone z powodu cross-domain spoofingu" description="Zrozum i rozwiąż odrzucenie 550 5.7.1 podczas wysyłania z domeny innej niż domena uwierzytelniania." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnostyka błędów Microsoft Exchange" description="Skorzystaj z narzędzia diagnostycznego dla kont Exchange." />
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Powtarzające się monity logowania Outlook" description="Rozwiąż powtarzające się monity logowania Outlook do Office 365 na skrzynce Exchange." />

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnostyka i rozwiązywanie problemów z pocztą - Dokumentacja e-mail OVHcloud"
 description: "Rozwiąż problemy z pocztą OVHcloud: brak możliwości wysyłania lub odbierania, adres zablokowany z powodu spamu, pełna skrzynka, zapomniane hasło lub odzyskiwanie usuniętych wiadomości."
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 pageType: landing
 banner: true
 tagline: "Zidentyfikuj i rozwiąż najczęstsze problemy ze swoją skrzynką OVHcloud."

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -117,7 +117,7 @@ Se todos os seus endereços já partilharem um único domínio, este bloqueio n�
 | Enviar *como* outro endereço do mesmo domínio | [**Direito de envio**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Enviar *em nome de* alguém do mesmo domínio | [**Direito de enviar em nome de**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Partilhar o acesso a uma conta de e-mail sem partilhar a palavra-passe | [**Direito de acesso**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
-| Enviar para um grupo de contactos | [**Mailing lists**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) ou [grupos do Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+| Enviar para um grupo de contactos | [**Mailing List**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) ou [grupos do Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E-mail rejeitado por usurpação de domínio (550 5.7.1)"
 description: "Resolva as rejeições de e-mail causadas pela proteção contra a usurpação de domínio: compreenda o erro 550 5.7.1 e adapte a configuração do MX Plan ou Alojamentos web"
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,20 +1,44 @@
 ---
-title: "E-mail rejeitado por usurpação de domínio (spoofing): o que fazer?"
-description: "Resolva as rejeições de e-mail causadas pela proteção contra a usurpação de domínio: compreenda o erro 550 5.7.1 e adapte a configuração do MX Plan, Zimbra ou Alojamentos web."
-lastUpdated: 2026-07-20
-availableIn: [eu]
+title: "E-mail rejeitado por usurpação de domínio (550 5.7.1)"
+description: "Resolva as rejeições de e-mail causadas pela proteção contra a usurpação de domínio: compreenda o erro 550 5.7.1 e adapte a configuração do MX Plan ou Alojamentos web"
+lastUpdated: 2026-07-16
+availableIn: [eu, ca, apac]
 ---
+
+import { DomainAlignmentDiagram } from '@components/DomainAlignmentDiagram';
+import { Region } from '@components/Zone';
 
 ## Objetivo
 
-Se enviar um e-mail através do **MX Plan**, **Zimbra** ou do serviço de e-mail incluído numa oferta de **Alojamentos web**, e o endereço do remetente utilizar um domínio diferente daquele com que se autenticou, a OVHcloud rejeita a mensagem — uma proteção contra a *usurpação de domínio (cross-domain spoofing)* aplicada desde **20 de julho de 2026**.
+<Region zones={['eu']}>
+
+Se enviar um e-mail através do **MX Plan**, **Zimbra** ou do serviço de e-mail incluído numa oferta de **Alojamentos web**, e o endereço do remetente utilizar um domínio diferente daquele com que se autenticou, a OVHcloud rejeita a mensagem — uma proteção contra a *usurpação de domínio (cross-domain spoofing)* aplicada a partir de **20 de julho de 2026**.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Se enviar um e-mail através do **MX Plan** ou do serviço de e-mail incluído numa oferta de **Alojamentos web**, e o endereço do remetente utilizar um domínio diferente daquele com que se autenticou, a OVHcloud rejeita a mensagem — uma proteção contra a *usurpação de domínio (cross-domain spoofing)* aplicada a partir de **20 de julho de 2026**.
+
+</Region>
 
 **Este guia ajuda-o a compreender a rejeição, a confirmar a sua causa e a adaptar a sua configuração para que os seus e-mails voltem a ser entregues.**
 
 ## Requisitos
 
+<Region zones={['eu']}>
+
 - Uma oferta de e-mail da OVHcloud: **MX Plan**, **Zimbra** ou o serviço de e-mail incluído numa oferta de **Alojamentos web**
 - Acesso à <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> para gerir os seus domínios e contas de e-mail
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+- Uma oferta de e-mail da OVHcloud: **MX Plan** ou o serviço de e-mail incluído numa oferta de **Alojamentos web**
+- Acesso à <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> para gerir os seus domínios e contas de e-mail
+
+</Region>
 
 ## Instruções
 
@@ -30,10 +54,7 @@ As mensagens rejeitadas devolvem a seguinte notificação:
 Isto acontece quando o domínio do endereço **From** (o endereço a partir do qual envia) difere do domínio com que se **autenticou** (as credenciais da conta de e-mail utilizadas para iniciar sessão e enviar). O envio a partir de um endereço do **mesmo** domínio que a sua conta de autenticação não é afetado e continua a funcionar.
 :::
 
-| Situação | Resultado |
-|---|---|
-| Mesmo domínio (ex.: `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Entregue |
-| Domínio diferente (ex.: `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Rejeitado — `550 5.7.1` |
+<DomainAlignmentDiagram />
 
 É provável que seja afetado se:
 
@@ -43,7 +64,7 @@ Isto acontece quando o domínio do endereço **From** (o endereço a partir do q
 - Enviar e-mails **em nome de terceiros** (por exemplo, um prestador de serviços que fatura com o domínio do seu cliente)
 - Centralizar o envio para **várias marcas ou entidades** que utilizam domínios distintos a partir de uma única infraestrutura de e-mail
 
-#### Porque existe este bloqueio
+#### Porque existe este bloqueio?
 
 A existência destas três normas, hoje amplamente generalizadas, torna necessário pôr fim à prática da usurpação de domínio entre domínios:
 
@@ -59,17 +80,33 @@ Enviar um e-mail com um domínio diferente do utilizado para a autenticação qu
 
 #### Solução recomendada — criar uma conta de e-mail no domínio a partir do qual envia
 
-Configure o domínio a partir do qual pretende enviar numa oferta **Zimbra Starter** (consulte o nosso guia [Primeiros passos com a oferta Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) e crie nele uma conta de e-mail. Tecnicamente, **basta uma única conta de e-mail**: assim que criada, pode autenticar-se e enviar a partir de **qualquer endereço desse mesmo domínio**, uma vez que a usurpação dentro do mesmo domínio não é afetada por este bloqueio.
+Crie uma conta de e-mail no domínio a partir do qual pretende enviar e autentique-se com ela. Tecnicamente, **basta uma única conta de e-mail**: assim que criada, pode autenticar-se e enviar a partir de **qualquer endereço desse mesmo domínio**, uma vez que a usurpação dentro do mesmo domínio não é afetada por este bloqueio.
+
+<Region zones={['eu']}>
+
+Configure este domínio numa oferta **Zimbra Starter** (consulte o nosso guia [Primeiros passos com a oferta Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) e crie nele uma conta de e-mail.
+
+</Region>
+
+<Region zones={['ca', 'apac']}>
+
+Adicione este domínio ao seu **MX Plan** e crie nele uma conta de e-mail.
+
+</Region>
 
 :::warning
 **A usurpação dentro do mesmo domínio é um risco de segurança e, em breve, poderá ser desativada pelo administrador do domínio.** Atualmente, qualquer conta de e-mail do domínio pode enviar como qualquer outro endereço desse mesmo domínio — um único conjunto de credenciais expõe assim todos os endereços, sem qualquer registo de auditoria por endereço. A OVHcloud está a preparar uma opção que permitirá aos administradores de domínio desativar completamente esta possibilidade; uma configuração que dependa de uma conta partilhada que se faz passar por vários endereços deixará de funcionar assim que for desativada. Não baseie a sua configuração nisto — dê preferência a:
+
 - **Uma conta de e-mail por endereço** que utilize realmente, ou
-- Uma funcionalidade nativa do Exchange — **Direito de envio**, **Direito de enviar em nome de** ou **Direito de acesso** — para conceder acesso controlado a uma conta existente sem partilhar a respetiva palavra-passe (veja a [solução alternativa](#solucao-alternativa-se-permanecer-dentro-do-mesmo-dominio) abaixo)
+- Uma funcionalidade de delegação que concede acesso controlado a uma conta existente sem partilhar a respetiva palavra-passe
+
 :::
 
-- **Endereço genérico:** dispõe de `john.smith@mydomain.ovh` no MX Plan e pretende enviar a partir de `contact@example.com`. Crie uma conta de e-mail, por exemplo `mary.johnson@example.com`, no Zimbra Starter, e autentique-se com ela para enviar como `contact@example.com`.
-- **Várias entidades:** a sua empresa gere duas marcas, uma em `mydomain.ovh` e outra em `example.com`. Se atualmente enviar todos os seus e-mails a partir de uma única conta em `mydomain.ovh`, crie uma conta em `example.com` através do Zimbra Starter para a segunda marca.
-- **Envio em nome de terceiros:** a sua agência envia comunicações para um cliente em `example.com` a partir do seu próprio domínio. Crie uma conta em `example.com` através do Zimbra Starter para se autenticar e enviar com endereços desse domínio.
+- **Endereço genérico:** dispõe de `john.smith@mydomain.ovh` no MX Plan e pretende enviar a partir de `contact@example.com`. Crie uma conta de e-mail, por exemplo `mary.johnson@example.com`, nesse domínio, e autentique-se com ela para enviar como `contact@example.com`.
+- **Várias entidades:** a sua empresa gere duas marcas, uma em `mydomain.ovh` e outra em `example.com`. Se atualmente enviar todos os seus e-mails a partir de uma única conta em `mydomain.ovh`, crie uma conta em `example.com` para a segunda marca.
+- **Envio em nome de terceiros:** a sua agência envia comunicações para um cliente em `example.com` a partir do seu próprio domínio. Crie uma conta em `example.com` para se autenticar e enviar com endereços desse domínio.
+
+<Region zones={['eu', 'ca']}>
 
 #### Solução alternativa se permanecer dentro do mesmo domínio
 
@@ -81,6 +118,8 @@ Se todos os seus endereços já partilharem um único domínio, este bloqueio n�
 | Enviar *em nome de* alguém do mesmo domínio | [**Direito de enviar em nome de**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Partilhar o acesso a uma conta de e-mail sem partilhar a palavra-passe | [**Direito de acesso**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
 | Enviar para um grupo de contactos | [**Mailing lists**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) ou [grupos do Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+</Region>
 
 ### Se o problema persistir
 
@@ -94,7 +133,11 @@ Se já ajustou a sua configuração e as mensagens continuam a ser rejeitadas co
 
 Para gerir os alias e reencaminhamentos de um endereço existente, consulte o guia [Utilizar os alias e reencaminhamentos de e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
 
+<Region zones={['eu']}>
+
 Saiba mais sobre o [Zimbra Starter](/links/web/emails-zimbra).
+
+</Region>
 
 Para aprofundar as normas subjacentes, consulte [Melhorar a segurança dos e-mails através do registo SPF](/guides/web-cloud/domains/dns-zone-spf), [Melhorar a segurança dos e-mails através do registo DKIM](/guides/web-cloud/domains/dns-zone-dkim) e [Melhorar a segurança dos e-mails através do registo DMARC](/guides/web-cloud/domains/dns-zone-dmarc).
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing.mdx
@@ -1,0 +1,101 @@
+---
+title: "E-mail rejeitado por usurpação de domínio (spoofing): o que fazer?"
+description: "Resolva as rejeições de e-mail causadas pela proteção contra a usurpação de domínio: compreenda o erro 550 5.7.1 e adapte a configuração do MX Plan, Zimbra ou Alojamentos web."
+lastUpdated: 2026-07-20
+availableIn: [eu]
+---
+
+## Objetivo
+
+Se enviar um e-mail através do **MX Plan**, **Zimbra** ou do serviço de e-mail incluído numa oferta de **Alojamentos web**, e o endereço do remetente utilizar um domínio diferente daquele com que se autenticou, a OVHcloud rejeita a mensagem — uma proteção contra a *usurpação de domínio (cross-domain spoofing)* aplicada desde **20 de julho de 2026**.
+
+**Este guia ajuda-o a compreender a rejeição, a confirmar a sua causa e a adaptar a sua configuração para que os seus e-mails voltem a ser entregues.**
+
+## Requisitos
+
+- Uma oferta de e-mail da OVHcloud: **MX Plan**, **Zimbra** ou o serviço de e-mail incluído numa oferta de **Alojamentos web**
+- Acesso à <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> para gerir os seus domínios e contas de e-mail
+
+## Instruções
+
+### Identificar o problema
+
+As mensagens rejeitadas devolvem a seguinte notificação:
+
+```text
+550 5.7.1 Rejected by policy: From header domain does not align with authenticated domain
+```
+
+:::info
+Isto acontece quando o domínio do endereço **From** (o endereço a partir do qual envia) difere do domínio com que se **autenticou** (as credenciais da conta de e-mail utilizadas para iniciar sessão e enviar). O envio a partir de um endereço do **mesmo** domínio que a sua conta de autenticação não é afetado e continua a funcionar.
+:::
+
+| Situação | Resultado |
+|---|---|
+| Mesmo domínio (ex.: `john.smith@mydomain.ovh` → `contact@mydomain.ovh`) | ✅ Entregue |
+| Domínio diferente (ex.: `john.smith@mydomain.ovh` → `contact@example.com`) | ❌ Rejeitado — `550 5.7.1` |
+
+É provável que seja afetado se:
+
+- Enviar e-mails a partir de um endereço num domínio diferente da sua conta de autenticação
+- Gerir endereços genéricos (`contact@`, `support@`, `noreply@`) num domínio separado
+- Utilizar um **bot, script ou aplicação** que envia com um domínio de remetente diferente do domínio de autenticação
+- Enviar e-mails **em nome de terceiros** (por exemplo, um prestador de serviços que fatura com o domínio do seu cliente)
+- Centralizar o envio para **várias marcas ou entidades** que utilizam domínios distintos a partir de uma única infraestrutura de e-mail
+
+#### Porque existe este bloqueio
+
+A existência destas três normas, hoje amplamente generalizadas, torna necessário pôr fim à prática da usurpação de domínio entre domínios:
+
+| Norma | Função |
+|---|---|
+| **SPF** (Sender Policy Framework) | Verifica se o servidor de envio está autorizado pelo domínio do remetente |
+| **DKIM** (DomainKeys Identified Mail) | Adiciona uma assinatura criptográfica associada ao domínio de envio |
+| **DMARC** (Domain-based Message Authentication) | Combina o SPF e o DKIM e define o que fazer em caso de falha |
+
+Enviar um e-mail com um domínio diferente do utilizado para a autenticação quebra este alinhamento; bloqueá-lo protege a reputação dos seus domínios e a entregabilidade das suas mensagens legítimas.
+
+### Resolver a rejeição
+
+#### Solução recomendada — criar uma conta de e-mail no domínio a partir do qual envia
+
+Configure o domínio a partir do qual pretende enviar numa oferta **Zimbra Starter** (consulte o nosso guia [Primeiros passos com a oferta Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra#domains-add)) e crie nele uma conta de e-mail. Tecnicamente, **basta uma única conta de e-mail**: assim que criada, pode autenticar-se e enviar a partir de **qualquer endereço desse mesmo domínio**, uma vez que a usurpação dentro do mesmo domínio não é afetada por este bloqueio.
+
+:::warning
+**A usurpação dentro do mesmo domínio é um risco de segurança e, em breve, poderá ser desativada pelo administrador do domínio.** Atualmente, qualquer conta de e-mail do domínio pode enviar como qualquer outro endereço desse mesmo domínio — um único conjunto de credenciais expõe assim todos os endereços, sem qualquer registo de auditoria por endereço. A OVHcloud está a preparar uma opção que permitirá aos administradores de domínio desativar completamente esta possibilidade; uma configuração que dependa de uma conta partilhada que se faz passar por vários endereços deixará de funcionar assim que for desativada. Não baseie a sua configuração nisto — dê preferência a:
+- **Uma conta de e-mail por endereço** que utilize realmente, ou
+- Uma funcionalidade nativa do Exchange — **Direito de envio**, **Direito de enviar em nome de** ou **Direito de acesso** — para conceder acesso controlado a uma conta existente sem partilhar a respetiva palavra-passe (veja a [solução alternativa](#solucao-alternativa-se-permanecer-dentro-do-mesmo-dominio) abaixo)
+:::
+
+- **Endereço genérico:** dispõe de `john.smith@mydomain.ovh` no MX Plan e pretende enviar a partir de `contact@example.com`. Crie uma conta de e-mail, por exemplo `mary.johnson@example.com`, no Zimbra Starter, e autentique-se com ela para enviar como `contact@example.com`.
+- **Várias entidades:** a sua empresa gere duas marcas, uma em `mydomain.ovh` e outra em `example.com`. Se atualmente enviar todos os seus e-mails a partir de uma única conta em `mydomain.ovh`, crie uma conta em `example.com` através do Zimbra Starter para a segunda marca.
+- **Envio em nome de terceiros:** a sua agência envia comunicações para um cliente em `example.com` a partir do seu próprio domínio. Crie uma conta em `example.com` através do Zimbra Starter para se autenticar e enviar com endereços desse domínio.
+
+#### Solução alternativa se permanecer dentro do mesmo domínio
+
+Se todos os seus endereços já partilharem um único domínio, este bloqueio não é a causa — volte a verificar a secção [Identificar o problema](#identificar-o-problema) acima, uma vez que a rejeição deve resultar de uma combinação endereço/domínio diferente da esperada. Para gerir várias identidades nesse domínio único, utilize antes estas funcionalidades nativas em vez de uma conta partilhada:
+
+| Necessidade | Funcionalidade | Disponível em |
+|---|---|---|
+| Enviar *como* outro endereço do mesmo domínio | [**Direito de envio**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Enviar *em nome de* alguém do mesmo domínio | [**Direito de enviar em nome de**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Partilhar o acesso a uma conta de e-mail sem partilhar a palavra-passe | [**Direito de acesso**](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) | Exchange |
+| Enviar para um grupo de contactos | [**Mailing lists**](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/feature-mailing-list) (MX Plan) ou [grupos do Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/feature-groups) | MX Plan, Exchange |
+
+### Se o problema persistir
+
+Se já ajustou a sua configuração e as mensagens continuam a ser rejeitadas com o mesmo erro `550 5.7.1`:
+
+- Verifique se o endereço utilizado para autenticação corresponde ao endereço **From** efetivamente utilizado pela sua aplicação ou dispositivo de envio — uma incompatibilidade é fácil de não notar em configurações em massa ou automatizadas.
+- Aguarde alguns minutos para que uma conta recém-criada ou uma alteração de configuração se propague antes de tentar novamente.
+- Contacte o suporte da OVHcloud fornecendo os cabeçalhos completos da mensagem rejeitada, o endereço utilizado para autenticação e o endereço **From** pretendido.
+
+## Quer saber mais?
+
+Para gerir os alias e reencaminhamentos de um endereço existente, consulte o guia [Utilizar os alias e reencaminhamentos de e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
+
+Saiba mais sobre o [Zimbra Starter](/links/web/emails-zimbra).
+
+Para aprofundar as normas subjacentes, consulte [Melhorar a segurança dos e-mails através do registo SPF](/guides/web-cloud/domains/dns-zone-spf), [Melhorar a segurança dos e-mails através do registo DKIM](/guides/web-cloud/domains/dns-zone-dkim) e [Melhorar a segurança dos e-mails através do registo DMARC](/guides/web-cloud/domains/dns-zone-dmarc).
+
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnóstico e resolução de problemas de e-mail - Documentação de e-mail OVHcloud"
 description: "Resolva os seus problemas de e-mail OVHcloud: envio ou receção impossível, endereço bloqueado por spam, caixa cheia, palavra-passe esquecida ou recuperação de e-mails eliminados."
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-17
 pageType: landing
 banner: true
 tagline: "Identifique e resolva os problemas comuns do seu serviço de e-mail OVHcloud."

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnóstico e resolução de problemas de e-mail - Documentação de e-mail OVHcloud"
 description: "Resolva os seus problemas de e-mail OVHcloud: envio ou receção impossível, endereço bloqueado por spam, caixa cheia, palavra-passe esquecida ou recuperação de e-mails eliminados."
-lastUpdated: 2026-06-30
+lastUpdated: 2026-07-16
 pageType: landing
 banner: true
 tagline: "Identifique e resolva os problemas comuns do seu serviço de e-mail OVHcloud."
@@ -62,6 +62,7 @@ Está a preparar-se para contactar o suporte ou pretende analisar um e-mail em p
 
 <CardGrid>
   <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers" title="Obter o cabeçalho e o ficheiro .eml de um e-mail" description="Extraia as informações técnicas de uma mensagem para análise ou suporte." />
+  <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-rejected-cross-domain-spoofing" title="E-mails rejeitados por usurpação de domínio (spoofing)" description="Compreenda e corrija a rejeição 550 5.7.1 ao enviar a partir de um domínio diferente daquele com que se autentica." />
   <Region zones={['eu', 'ca']}>
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/diagnostic-advanced" title="Diagnóstico de erros do Microsoft Exchange" description="Utilize a ferramenta de diagnóstico dedicada às contas Exchange." />
     <LinkCard href="/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365" title="Pedidos de início de sessão recorrentes do Outlook" description="Corrija os pedidos repetidos de início de sessão do Outlook no Office 365 numa caixa Exchange." />

--- a/i18n.json
+++ b/i18n.json
@@ -23353,5 +23353,14 @@
     "it": "Bloccato per spam",
     "pl": "Zablokowany za spam",
     "pt": "Bloqueado por spam"
+  },
+  "sidebar.gen.webCloudEmailAndCollaborativeSolutionsTroubleshootingEmailRejectedCrossDomainSpoofing": {
+    "fr": "Rejeté : usurpation de domaine",
+    "en": "Rejected: cross-domain spoofing",
+    "de": "Abgelehnt: Cross-Domain-Spoofing",
+    "es": "Rechazado: usurpación de dominio",
+    "it": "Rifiutato: usurpazione di dominio",
+    "pl": "Odrzucono: cross-domain spoofing",
+    "pt": "Rejeitado: usurpação de domínio"
   }
 }


### PR DESCRIPTION
**Original comment:**
`Guides customers through the 550 5.7.1 rejection enforced from 20 July 2026 when a Control Panel email service (MX Plan, Zimbra, Web Hosting) sends with a From domain that differs from the authenticated domain. Covers the SPF/ DKIM/DMARC rationale, the EU-only Zimbra Starter fix, and native Exchange alternatives (Send As / Send On Behalf / Access) for same-domain setups.`

## Summary

This guide helps customers hit by the **`550 5.7.1` cross-domain spoofing** rejection that OVHcloud enforces from **20 July 2026** on Control Panel email services (MX Plan, Zimbra, and the email bundled with Web Hosting): a message is rejected when the `From`-address domain differs from the domain of the authenticated mailbox. The guide explains the rejection, its cause, and the fix for each commercial zone — in all **7 locales** (en, fr, de, es, it, pl, pt).

## What the guide covers

- **Identify the issue** — the exact `550 5.7.1` notification, when it triggers, and an inline diagram (`DomainAlignmentDiagram`) contrasting the authenticated domain with the `From` address: same domain = delivered, different domain = rejected.
- **Why it's blocked** — SPF / DKIM / DMARC alignment, explained in a short table.
- **Recommended fix** — create a mailbox on the domain you send from (a single mailbox can then authenticate and send as any address on that same domain).
- **Alternative fix** — for managing several identities on one domain, use native Exchange delegation (Send As / Send on Behalf / Access) instead of a shared mailbox.
- **If it persists** — checks and support escalation.

## Per-zone content (`eu` / `ca` / `apac`)

The rejection applies to every zone, but the available fix differs, so the guide is `availableIn: [eu, ca, apac]` with content gated via `<Region>`:

| Section | EU | CA | APAC |
|---|:--:|:--:|:--:|
| Recommended fix | Zimbra Starter | MX Plan | MX Plan |
| Alternative fix (Exchange delegation) | ✅ | ✅ | — (no Exchange) |
| Diagnosis, diagram, SPF/DKIM/DMARC | ✅ | ✅ | ✅ |

## Illustration component

`DomainAlignmentDiagram` — inline SVG, theme-aware (light/dark), 7-language i18n, no external assets. Carries the two axes of the former situation/result table (situation in the header, result in the footer).

## SEO & discoverability

- Titles ≤ 60 chars, including the `550 5.7.1` code; "why is this blocked?" question-format heading.
- Enforcement date phrased in the future ("from 20 July 2026").
- Card added to the "Diagnostics & troubleshooting" landing page (all zones); sidebar entry with a localized label (`i18n.json`).

## Validation

- `build:en` + `build:fr` green (SSG renders, component included).
- Zone check: no out-of-zone product leak (Zimbra EU-only, Exchange never shown in APAC).
- `biome lint` + `sidebar:check` clean; proofread / fact-check / SEO / verify-links (none) / verify-buttons (none) passes done.

---

Follow-up commit `32f7764` adds the illustration, zone-adaptation, SEO and landing/sidebar wiring on top of the original guide — happy to adjust anything.


