### PR TITLE
feat(home): add SIRET banner to FR home page hero

### DIFF
--- a/components/Banner/Banner.tsx
+++ b/components/Banner/Banner.tsx
@@ -1,3 +1,4 @@
+import { trackClick } from '@components/Analytics';
 import { useLang } from '@rspress/core/runtime';
 import { BANNERS } from './registry';
 import './Banner.css';
@@ -54,7 +55,17 @@ export function Banner({ kind }: BannerProps) {
         </div>
 
         <span className="ovh-promo-banner__cta">
-          <a href={banner.cta.href} target="_blank" rel="noopener noreferrer">
+          <a
+            href={banner.cta.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            // Report the CTA click to the OVH TMS. The label carries the banner
+            // `kind` so each banner's CTA is distinguishable (e.g. the SIRET
+            // banner deep-links to the Control Panel profile page). The link
+            // opens in a new tab, so the page isn't torn down and the spa_click
+            // beacon fires reliably.
+            onClick={(e) => trackClick(`cta-banner-${kind}`, e.currentTarget)}
+          >
             {banner.cta.label}
           </a>
         </span>

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -12,10 +12,6 @@ hero:
     Bienvenue sur la documentation OVHcloud. Retrouvez tous nos guides techniques,
     tutoriels pas à pas et ressources pour déployer, configurer et gérer vos
     services cloud en toute sérénité.
-  actions:
-    - text: Gérez votre compte OVHcloud
-      link: /guides/account-and-service-management/account-information/overview
-      theme: alt
   image:
     src: /images/hero.png
     alt: Logo

--- a/theme/components/HomeHero/index.scss
+++ b/theme/components/HomeHero/index.scss
@@ -133,12 +133,41 @@
     border-radius: 8px;
     padding: 0.75rem 2rem;
   }
+
+  /* SIRET banner slot inside the hero box. The banner sits on the light-blue
+     hero background (--rp-c-bg-soft), at the bottom of the hero. Full width of
+     the hero container; the container's own 32px flex gap provides the spacing
+     above it, so we cancel the banner's default guide-toolbar-clearing margin. */
+  &__banner {
+    width: 100%;
+
+    .ovh-promo-banner {
+      margin: 0;
+    }
+  }
 }
 
 .rp-home-hero--no-image {
   .rp-home-hero__container {
     align-items: center;
     text-align: center;
+  }
+}
+
+/* FR home page only: the SIRET banner adds height inside the hero, so crop the
+   empty space between the hero box and the "Explorer" section to keep the
+   product cards above the fold on a ~13" laptop. The hero and the Explorer
+   section are siblings inside .pb-12, so the general-sibling combinator reaches
+   the Explorer heading's top margin from the FR-flagged hero. */
+.rp-home-hero--fr {
+  margin-bottom: 0.25rem;
+
+  ~ .rp-home-explore {
+    margin-top: 0;
+
+    .rp-home-explore__title {
+      margin-top: 0;
+    }
   }
 }
 

--- a/theme/components/HomeHero/index.tsx
+++ b/theme/components/HomeHero/index.tsx
@@ -1,5 +1,10 @@
+import { Banner } from '@components/Banner';
 import type { FrontMatterMeta } from '@rspress/core';
-import { normalizeImagePath, useFrontmatter } from '@rspress/core/runtime';
+import {
+  normalizeImagePath,
+  useFrontmatter,
+  useLang,
+} from '@rspress/core/runtime';
 import { Button, renderHtmlOrText } from '@theme-original';
 import { useLocalizeHref } from '../../hooks/useLocalizedHref';
 
@@ -23,6 +28,11 @@ interface HomeHeroProps {
 function HomeHero({ beforeHeroActions, afterHeroActions }: HomeHeroProps) {
   const localizeHref = useLocalizeHref();
   const { frontmatter } = useFrontmatter();
+  const lang = useLang();
+  // The SIRET banner only renders in FR (see Banner `langs`). On the FR home
+  // page it adds height, so we mark the hero to let the SCSS tighten the gap
+  // above the Explorer section and keep the product cards visible on a laptop.
+  const isFr = lang === 'fr';
   const hero = frontmatter?.hero || DEFAULT_HERO;
   const hasImage = hero.image !== undefined;
   const multiHeroText = hero.text
@@ -38,7 +48,10 @@ function HomeHero({ beforeHeroActions, afterHeroActions }: HomeHeroProps) {
 
   return (
     <div
-      className={clsx('rp-home-hero', { 'rp-home-hero--no-image': !hasImage })}
+      className={clsx('rp-home-hero', {
+        'rp-home-hero--no-image': !hasImage,
+        'rp-home-hero--fr': isFr,
+      })}
     >
       <div className="rp-home-hero__container">
         {hero.badge && <div className="rp-home-hero__badge">{hero.badge}</div>}
@@ -65,19 +78,27 @@ function HomeHero({ beforeHeroActions, afterHeroActions }: HomeHeroProps) {
         ></p>
 
         {beforeHeroActions}
-        <div className="rp-home-hero__actions">
-          {hero.actions?.map((action) => {
-            return (
-              <Button
-                type="a"
-                key={action.link}
-                href={localizeHref(action.link)}
-                theme={action.theme}
-                className="rp-home-hero__action"
-                {...renderHtmlOrText(action.text)}
-              />
-            );
-          })}
+        {hero.actions && hero.actions.length > 0 && (
+          <div className="rp-home-hero__actions">
+            {hero.actions.map((action) => {
+              return (
+                <Button
+                  type="a"
+                  key={action.link}
+                  href={localizeHref(action.link)}
+                  theme={action.theme}
+                  className="rp-home-hero__action"
+                  {...renderHtmlOrText(action.text)}
+                />
+              );
+            })}
+          </div>
+        )}
+        {/* SIRET notice inside the hero box. FR-only: the Banner component
+            itself returns null for any non-fr locale (banner.langs), so this is
+            a no-op on the other locale home pages. */}
+        <div className="rp-home-hero__banner">
+          <Banner kind="siret-fr" />
         </div>
         {afterHeroActions}
       </div>


### PR DESCRIPTION
Render the FR-only SIRET notice inside the home page hero box, replacing the account CTA button (removed from the FR frontmatter). The banner sits on the light-blue hero background and is gated to FR via the Banner component's langs.

Crop the gap above the Explorer section on the FR home page (rp-home-hero--fr) so the product cards stay visible on a ~13-inch laptop. EN and other locales keep their account button and show no banner.