### PR TITLE
docs(vps): clarify cross-location VPS migration in FAQ; retranslate pt to pt-PT

### DIFF
--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud VPS FAQ
 description: Finden Sie Antworten auf die am häufigsten gestellten Fragen zu unseren VPS-Angeboten
-lastUpdated: 2026-06-11
+lastUpdated: 2026-07-16
 ---
 
 import Api from '@components/Api';
@@ -355,10 +355,12 @@ Bevor Sie fortfahren, stellen Sie sicher, dass Sie [alle noch benötigten Daten 
 <summary>Kann ich meinen VPS in ein anderes OVHcloud Rechenzentrum in einem anderen Land verschieben?</summary>
 
 
-Eine Migration eines VPS in ein anderes Rechenzentrum ist nicht möglich. Um dies zu erreichen, können Sie eine [manuelle Migration](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) durchführen:
+Es ist nicht möglich, einen VPS von einem Standort an einen anderen zu migrieren, sei es in ein anderes Rechenzentrum, ein anderes Land oder auf einen anderen Kontinent (zum Beispiel von Deutschland nach Kanada).
+
+Um den Standort zu wechseln, müssen Sie einen neuen VPS am gewünschten Standort bestellen, Ihre Daten dorthin übertragen und anschließend Ihren alten VPS stornieren. Sie können diese [manuelle Migration](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) wie folgt durchführen:
 
 - Laden Sie Ihre Daten vom aktuellen VPS herunter.
-- Bestellen Sie einen neuen VPS.
+- Bestellen Sie einen neuen VPS am gewünschten Standort.
 - Laden Sie Ihre Daten auf den neuen VPS hoch.
 - [Stornieren Sie den alten VPS](/guides/account-and-service-management/managing-billing-payments-and-services/how-to-cancel-services).
 

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud VPS FAQ
 description: Find the answers to the most frequently asked questions about our VPS offers
-lastUpdated: 2026-06-11
+lastUpdated: 2026-07-16
 ---
 
 import Api from '@components/Api';
@@ -355,10 +355,12 @@ Before you proceed, ensure that you have [migrated any data still needed](/guide
 <summary>Can I move my VPS to a different OVHcloud data centre in a different country?</summary>
 
 
-It is not possible to migrate a VPS to another data centre. To achieve this, you can perform a [manual migration](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another):
+It is not possible to migrate a VPS from one location to another, whether to another data centre, another country, or another continent (for example, from Germany to Canada).
+
+To change location, you need to order a new VPS in the desired location, transfer your data to it, then cancel your old VPS. You can perform this [manual migration](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) as follows:
 
 - Download your data from the current VPS.
-- Order a new VPS.
+- Order a new VPS in the desired location.
 - Upload your data to the new VPS.
 - [Cancel the old VPS](/guides/account-and-service-management/managing-billing-payments-and-services/how-to-cancel-services).
 

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud VPS FAQ
 description: Encuentre las respuestas a las preguntas más frecuentes sobre nuestras ofertas de VPS
-lastUpdated: 2026-06-11
+lastUpdated: 2026-07-16
 ---
 
 import Api from '@components/Api';
@@ -356,10 +356,12 @@ Antes de proceder, asegúrate de que hayas [migrado cualquier dato aún necesari
 <summary>¿Puedo mover mi VPS a un centro de datos de OVHcloud diferente en otro país?</summary>
 
 
-No es posible migrar un VPS a otro centro de datos. Para lograrlo, puedes realizar una [migración manual](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another):
+No es posible migrar un VPS de una ubicación a otra, ya sea a otro centro de datos, a otro país o a otro continente (por ejemplo, de Alemania a Canadá).
+
+Para cambiar de ubicación, debes pedir un nuevo VPS en la ubicación deseada, transferir tus datos y, a continuación, cancelar tu VPS anterior. Puedes realizar esta [migración manual](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) de la siguiente manera:
 
 - Descarga tus datos del VPS actual.
-- Pide un nuevo VPS.
+- Pide un nuevo VPS en la ubicación deseada.
 - Sube tus datos al nuevo VPS.
 - [Cancela el VPS antiguo](/guides/account-and-service-management/managing-billing-payments-and-services/how-to-cancel-services).
 

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ sur les VPS OVHcloud
 description: Trouvez les réponses aux questions les plus fréquemment posées sur nos offres VPS
-lastUpdated: 2026-06-11
+lastUpdated: 2026-07-16
 ---
 
 import Api from '@components/Api';
@@ -357,10 +357,12 @@ Avant de continuer, assurez-vous d’avoir [migré les données encore nécessai
 <summary>Puis-je déplacer mon VPS vers un autre datacentre OVHcloud dans un autre pays ?</summary>
 
 
-Il n’est pas possible de migrer un VPS vers un autre datacentre. Pour ce faire, vous pouvez effectuer une [migration manuelle](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) :
+Il n’est pas possible de migrer un VPS d’un emplacement vers un autre, que ce soit vers un autre datacentre, un autre pays ou un autre continent (par exemple de l’Allemagne vers le Canada).
+
+Pour changer d’emplacement, vous devez commander un nouveau VPS dans la localisation souhaitée, y transférer vos données, puis résilier votre ancien VPS. Vous pouvez effectuer cette [migration manuelle](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) comme suit :
 
 1. Téléchargez vos données depuis le VPS actuel.
-1. Commandez un nouveau VPS.
+1. Commandez un nouveau VPS dans l’emplacement souhaité.
 1. Déposez vos données sur le nouveau VPS.
 1. [Résiliez l'ancien VPS](/guides/account-and-service-management/managing-billing-payments-and-services/how-to-cancel-services).
 

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ su VPS OVHcloud
 description: Trovate le risposte alle domande più frequenti sulle nostre offerte VPS
-lastUpdated: 2026-06-11
+lastUpdated: 2026-07-16
 ---
 
 import Api from '@components/Api';
@@ -354,10 +354,12 @@ Prima di procedere, assicurati di aver [migrato i dati ancora necessari](/guides
 <summary>Posso spostare il mio VPS in un diverso data center OVHcloud in un paese diverso?</summary>
 
 
-Non è possibile migrare un VPS in un altro data center. Per ottenere questo risultato, puoi eseguire una [migrazione manuale](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another):
+Non è possibile migrare un VPS da una posizione a un'altra, sia verso un altro data center, un altro paese o un altro continente (ad esempio dalla Germania al Canada).
+
+Per cambiare posizione, devi ordinare un nuovo VPS nella posizione desiderata, trasferirvi i tuoi dati e successivamente annullare il tuo vecchio VPS. Puoi eseguire questa [migrazione manuale](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) come segue:
 
 - Scarica i tuoi dati dal VPS corrente.
-- Ordina un nuovo VPS.
+- Ordina un nuovo VPS nella posizione desiderata.
 - Carica i tuoi dati sul nuovo VPS.
 - [Annulla il vecchio VPS](/guides/account-and-service-management/managing-billing-payments-and-services/how-to-cancel-services).
 

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud VPS - często zadawane pytania
 description: Znajdź odpowiedzi na najczęściej zadawane pytania dotyczące ofert VPS
-lastUpdated: 2026-06-11
+lastUpdated: 2026-07-16
 ---
 
 import Api from '@components/Api';
@@ -355,10 +355,12 @@ Zanim przystąpisz do tej operacji, upewnij się, że [przeniosłeś wszystkie d
 <summary>Czy mogę przenieść mój VPS do innego centrum danych OVHcloud w innym kraju?</summary>
 
 
-Nie można przenieść VPS do innego centrum danych. W tym celu możesz przeprowadzić [migrację ręczną](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another):
+Nie można migrować VPS z jednej lokalizacji do innej, niezależnie od tego, czy jest to inne centrum danych, inny kraj czy inny kontynent (na przykład z Niemiec do Kanady).
+
+Aby zmienić lokalizację, musisz zamówić nowy VPS w wybranej lokalizacji, przenieść na niego swoje dane, a następnie anulować stary VPS. Tę [migrację ręczną](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) możesz przeprowadzić w następujący sposób:
 
 - Pobierz dane z aktualnego VPS.
-- Zamów nowy VPS.
+- Zamów nowy VPS w wybranej lokalizacji.
 - Prześlij dane na nowy VPS.
 - [Anuluj stary VPS](/guides/account-and-service-management/managing-billing-payments-and-services/how-to-cancel-services).
 

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/vps-faq.mdx
@@ -1,7 +1,7 @@
 ---
-title: OVHcloud VPS Perguntas frequentes
-description: Encontre as respostas às perguntas mais frequentes sobre nossas ofertas de VPS
-lastUpdated: 2026-06-11
+title: FAQ sobre os VPS OVHcloud
+description: Encontre as respostas às perguntas mais frequentes sobre as nossas ofertas VPS
+lastUpdated: 2026-07-16
 ---
 
 import Api from '@components/Api';
@@ -9,24 +9,24 @@ import Api from '@components/Api';
 
 
 
-## Perguntas gerais sobre as ofertas de VPS
+## Perguntas gerais sobre as ofertas VPS
 
 <details>
 
 <summary>O que é um VPS e para que serve?</summary>
 
 
-Um servidor virtual privado (VPS) é usado para hospedar sites (comércio eletrônico, conteúdo, mídia visual) e aplicações de software (portais, extranets, soluções colaborativas, wikis, CRM). Ao contrário da hospedagem compartilhada, um VPS oferece um ambiente isolado, dedicado ao cliente. Nossas soluções de VPS preenchem a lacuna entre a hospedagem web compartilhada e os servidores dedicados, combinando desempenho e confiabilidade sem a carga de gerenciamento de hardware. Você também pode atualizar facilmente sua configuração sem trocar de servidores.
+Um servidor privado virtual (VPS) é utilizado para alojar sites (e-commerce, conteúdos, suportes visuais) e aplicações de software (portais, extranets, soluções colaborativas, wikis, CRM). Ao contrário do alojamento partilhado, um VPS oferece um ambiente isolado, dedicado ao cliente. As nossas soluções VPS combinam desempenho e fiabilidade sem o encargo da gestão do hardware. Pode também atualizar facilmente a sua configuração sem mudar de servidor.
 
 </details>
 
 
 <details>
 
-<summary>Quais são as vantagens de um VPS da OVHcloud?</summary>
+<summary>Quais são as vantagens do VPS OVHcloud?</summary>
 
 
-As ofertas de VPS da OVHcloud oferecem um excelente custo-benefício, com tráfego ilimitado e várias localizações globais para baixa latência e acessibilidade aprimorada, dependendo das suas necessidades. 
+Os VPS OVHcloud oferecem uma excelente relação desempenho/preço, com tráfego ilimitado e várias localizações mundiais para uma latência reduzida e uma acessibilidade melhorada, consoante as suas necessidades.
 
 </details>
 
@@ -36,33 +36,33 @@ As ofertas de VPS da OVHcloud oferecem um excelente custo-benefício, com tráfe
 <summary>Uma solução VPS é a escolha certa para mim?</summary>
 
 
-Usar um VPS requer conhecimentos básicos de administração de servidores. Lembrar disso é crucial para gerenciar efetivamente seu sistema operacional (Linux ou Windows) e configurar suas aplicações, como o PrestaShop ou o WordPress, por exemplo.
+A utilização de um VPS requer conhecimentos básicos de administração de servidores. Ter isto em mente é crucial para gerir eficazmente o seu sistema operativo (Linux ou Windows) e para configurar as suas aplicações, como o PrestaShop ou o WordPress, por exemplo.
 
-Se você precisa de um VPS, mas não tem a expertise técnica para gerenciá-lo, considere entrar em contato com um de nossos [parceiros](/links/partner) para obter assistência. 
+Se precisa de um VPS mas não tem as competências técnicas para o gerir, contacte um dos nossos [parceiros](/links/partner) para obter ajuda.
 
-Se você precisa de recursos provisionados, mas prefere não lidar com a administração do servidor, recomendamos optar por nossos planos de hospedagem web Performance.
-
-</details>
-
-
-<details>
-
-<summary>Posso atualizar facilmente meu VPS para uma faixa superior ou reduzir para uma configuração inferior?</summary>
-
-
-Sim, você pode atualizar sua configuração pelo OVHcloud Control Panel, sem migrar manualmente seus dados. As opções de atualização disponíveis dependem da faixa e do modelo do VPS.
-
-No entanto, para reduzir sua configuração, você precisará assinar um novo plano, transferir seus dados e, em seguida, cancelar seu serviço antigo. Nossa equipe de suporte está disponível para ajudá-lo, se necessário.
+Se precisa de recursos alocados, mas prefere não se ocupar da administração do servidor, recomendamos que opte pelas nossas ofertas de alojamento web Performance.
 
 </details>
 
 
 <details>
 
-<summary>Qual região ou país devo escolher para meu VPS?</summary>
+<summary>Posso facilmente fazer evoluir o meu VPS para uma gama superior ou para uma configuração inferior?</summary>
 
 
-Quanto mais próximo seu centro de dados estiver de sua audiência, menor será a latência, resultando em uma melhor experiência do usuário e maior confiança em seus serviços. 
+Sim, pode atualizar a sua configuração a partir da sua Área de Cliente, sem migração manual dos seus dados. As opções de atualização disponíveis dependem da gama e do modelo do VPS.
+
+No entanto, para passar para uma configuração inferior, terá de subscrever uma nova oferta, transferir os seus dados e, em seguida, rescindir o seu serviço antigo. O nosso suporte está à sua disposição, se necessário.
+
+</details>
+
+
+<details>
+
+<summary>Que região ou país escolher para o meu VPS?</summary>
+
+
+Quanto mais próximo o seu datacenter estiver do seu público, menor será a latência. Isto permite uma melhor experiência do utilizador e uma maior confiança nos seus serviços.
 
 </details>
 
@@ -72,103 +72,123 @@ Quanto mais próximo seu centro de dados estiver de sua audiência, menor será 
 <summary>Qual é a vantagem de um VPS localizado na Europa?</summary>
 
 
-Hospedar seu VPS com a OVHcloud na França ou, em geral, dentro da UE oferece vantagens como preços competitivos e proteção de dados reforçada. Seu serviço não está sujeito ao CLOUD Act dos EUA, protegendo-o de interferências fora da Europa.
+Alojar o seu VPS na OVHcloud em França ou, de forma mais geral, na UE oferece vantagens como preços competitivos e uma proteção reforçada dos dados. O seu serviço não está sujeito ao CLOUD Act norte-americano, protegendo-o de interferências não europeias.
 
 </details>
 
 
 <details>
 
-<summary>Os backups estão incluídos com meu VPS?</summary>
+<summary>As cópias de segurança estão incluídas no meu VPS?</summary>
 
 
-Sim, ao adquirir um VPS, uma opção de backup diário é incluída gratuitamente.
+Sim, ao encomendar um VPS, uma opção de cópia de segurança diária está incluída gratuitamente.
 
-Para uma proteção ainda melhor, você também pode optar por nossa opção de backup Premium. Ela oferece:
+Para uma proteção ainda melhor, pode também optar pela nossa opção de cópia de segurança Premium. Esta oferece:
 
-- A opção de reverter para um backup com até uma semana de idade.
-- A opção de agendar backups, otimizando o gerenciamento de dados e minimizando o impacto nas operações comerciais.
+- A possibilidade de repor uma cópia de segurança com uma semana.
+- A possibilidade de agendar cópias de segurança, de otimizar a gestão dos dados e de minimizar o impacto nas operações comerciais.
 
-Além disso, oferecemos:
+Além disso, propomos-lhe:
 
-- Snapshots: Você pode criar snapshots manuais e instantâneos que capturam o estado exato do seu VPS antes de uma atualização ou mudança crítica.
-- Um backup externo: Armazene seus dados em um disco separado e seguro, permitindo uma recuperação fácil em caso de incidente grave.
+- Snapshots: pode criar snapshots manuais e instantâneos que capturam o estado exato do seu VPS mesmo antes de uma atualização ou de uma alteração crítica.
+- Uma cópia de segurança externa: armazene os seus dados num disco separado e seguro, permitindo uma recuperação fácil em caso de incidente grave.
 
-Ao usar essas soluções, você pode personalizar o gerenciamento de backup para atender às suas necessidades de segurança e continuidade do negócio.
+Graças a estas soluções, pode personalizar a gestão das suas cópias de segurança em função das suas necessidades em matéria de segurança e de continuidade da atividade.
 
-Visite nossa [página web de VPS](/links/bare-metal/vps) para saber mais sobre as opções disponíveis.
-
-</details>
-
-
-<details>
-
-<summary>Posso hospedar vários sites em um VPS?</summary>
-
-
-Sim, um VPS pode ser configurado para hospedar vários sites ou projetos. Você pode particionar seu espaço de armazenamento conforme suas necessidades e usar interfaces especializadas, como o Plesk ou o cPanel, para simplificar o gerenciamento de seus sites. 
+Consulte a nossa [página web VPS](/links/bare-metal/vps) para saber mais sobre as opções disponíveis.
 
 </details>
 
 
 <details>
 
-<summary>Vou receber um nome de domínio e serviço de e-mail incluído com meu VPS?</summary>
+<summary>Posso alojar vários sites num VPS?</summary>
 
 
-Não, nossas soluções de VPS não incluem um nome de domínio ou serviço de e-mail. Esses serviços podem ser adquiridos separadamente no OVHcloud Control Panel.
+Sim, um VPS pode ser configurado para alojar vários sites ou projetos. Pode particionar o seu espaço de armazenamento consoante as suas necessidades e utilizar interfaces especializadas como o Plesk ou o cPanel para simplificar a gestão do seu site.
 
 </details>
 
 
 <details>
 
-<summary>Como escolher entre um VPS e um plano de alojamento web?</summary>
+<summary>Um nome de domínio e um serviço de e-mail estão incluídos no meu VPS?</summary>
 
 
-**Plano de alojamento web**
+Não, os nossos VPS não incluem nome de domínio nem serviço de e-mail. Estes serviços podem ser encomendados separadamente na sua Área de Cliente.
 
-- Ideal para necessidades básicas de alojamento com uma configuração pré-configurada.
+</details>
+
+
+<details>
+
+<summary>Como escolher entre um VPS e um alojamento web?</summary>
+
+
+**Alojamento web**
+
+- Ideal para as suas necessidades básicas, com uma instalação pré-configurada.
 
 **VPS**
 
-- Mais flexibilidade e controle, perfeito para projetos escaláveis com necessidades de configuração complexa.
+- Mais flexibilidade e controlo, ideal para fazer evoluir projetos com necessidades de configuração complexas.
 
-Hospedar serviços web em um VPS permite que você instale seu software preferido, personalize as configurações do servidor e hospede vários sites com recursos dedicados. Observe que um VPS precisa ser configurado de forma a atender às necessidades de sua aplicação e ser adaptado ao crescimento do seu negócio.
-
-</details>
-
-
-<details>
-
-<summary>Qual é a diferença entre um VPS e soluções de Public Cloud?</summary>
-
-
-**VPS**
-
-- Uma máquina virtual otimizada e dedicada adequada tanto para pré-produção quanto para produção, projetada para hospedar vários projetos web.
-
-**OVHcloud Public Cloud**
-
-- Oferece uma infraestrutura multi-servidor com alta disponibilidade e uma rede privada (vRack), projetada para arquiteturas complexas e escaláveis.
+O alojamento de serviços web num VPS permite-lhe instalar o software da sua escolha, personalizar os parâmetros do servidor e alojar vários sites com recursos dedicados. Note que um VPS deve ser configurado de forma a responder às necessidades das suas aplicações e a adaptar-se ao crescimento da sua atividade.
 
 </details>
 
 
 <details>
 
-<summary>Quais são as vantagens de um VPS em comparação com um servidor dedicado?</summary>
+<summary>Qual é a diferença entre um VPS e uma solução Public Cloud?</summary>
 
 
 **VPS**
 
-- Oferece gerenciamento simplificado sem manutenção de hardware, ideal para projetos que precisam de controle rigoroso. 
+- Uma máquina virtual otimizada e dedicada, adequada tanto à pré-produção como à produção, concebida para alojar vários projetos web.
 
-**Servidor dedicado** 
+**Public Cloud OVHcloud**
 
-- Recomendado para infraestruturas complexas que exigem controle total de hardware e desempenho garantido. 
+- Oferece uma infraestrutura multisservidor de alta disponibilidade e uma rede privada (vRack), concebida para arquiteturas complexas e escaláveis.
 
-Um VPS elimina a necessidade de gerenciar hardware físico, como armazenamento, RAM e CPU, tornando-o adequado para a maioria das aplicações web. À medida que seu negócio cresce, você pode atualizar seu VPS ou migrar para um servidor dedicado ou uma solução de Public Cloud para uma infraestrutura mais flexível e poderosa.
+</details>
+
+
+<details>
+
+<summary>Quais são as vantagens de um VPS em relação a um servidor dedicado?</summary>
+
+
+**VPS**
+
+- Oferece uma gestão simplificada sem manutenção de hardware, ideal para os projetos que necessitam de um controlo rigoroso.
+
+**Servidor dedicado**
+
+- Recomendado para as infraestruturas complexas que necessitam de um controlo total do hardware e de um desempenho garantido.
+
+O VPS elimina a necessidade de gerir o hardware físico, como o armazenamento, a RAM e o CPU, o que o torna adequado à maioria das aplicações web. À medida que a sua empresa se desenvolve, pode fazer evoluir o seu VPS ou migrar para um servidor dedicado ou uma solução Public Cloud para beneficiar de uma infraestrutura mais flexível e mais potente.
+
+</details>
+
+
+<details>
+
+<summary>Que largura de banda é atribuída ao meu VPS? É garantida?</summary>
+
+
+A largura de banda indicada na nossa [página web VPS](/links/bare-metal/vps) é garantida. Trata-se do valor mínimo atribuído ao seu serviço.
+
+</details>
+
+
+<details>
+
+<summary>Que SLA é aplicado ao meu VPS?</summary>
+
+
+Um VPS OVHcloud inclui um SLA de 99,9%.
 
 </details>
 
@@ -176,92 +196,73 @@ Um VPS elimina a necessidade de gerenciar hardware físico, como armazenamento, 
 
 <details>
 
-<summary>Qual largura de banda é alocada para meu VPS? É garantida?</summary>
+<summary>Quais são as especificidades de um VPS Local Zone?</summary>
 
 
-A largura de banda listada em nossa [página web de VPS](/links/bare-metal/vps) é garantida. É a quantidade mínima alocada para seu serviço.
+Graças ao VPS Local Zone, reduz significativamente os tempos de acesso aos seus sites e aplicações, pois os seus dados são alojados o mais próximo possível dos seus utilizadores. O utilizador beneficia assim de uma melhor experiência, uma vez que a latência é reduzida para cada aplicação que necessite de um tempo de resposta mínimo. Basta selecionar uma das nossas implantações mundiais no momento da encomenda.
 
-</details>
+Tenha em atenção que um VPS Local Zone, ao contrário de um VPS comum, não inclui funcionalidades de segurança, como o anti-DDoS, nem opções avançadas, como o Additional IP e o Load Balancer.
 
-
-<details>
-
-<summary>Qual SLA é aplicado ao meu VPS?</summary>
-
-
-Um VPS da OVHcloud inclui um SLA de 99,9%.
+Um VPS Local Zone responde também às necessidades dos projetos com exigências de localização dos dados e de soberania. Ao alojar os seus serviços numa região específica, pode facilmente cumprir as regulamentações locais relativas ao tratamento e ao armazenamento dos dados, como o RGPD europeu.
 
 </details>
 
 
 <details>
 
-<summary>Quais são os recursos exclusivos de um VPS da Zona Local?</summary>
+<summary>Posso migrar o meu VPS de uma Local Zone para um datacenter, e vice-versa?</summary>
 
 
-Com um VPS da Zona Local, você pode reduzir significativamente os tempos de acesso aos seus sites e aplicações, pois seus dados são hospedados mais próximos de seus usuários. Isso cria uma melhor experiência do usuário ao reduzir a latência sempre que as aplicações exigirem um tempo de resposta mínimo. Basta selecionar uma de nossas localizações globais ao fazer o pedido. 
-
-Lembre-se de que um VPS da Zona Local, ao contrário de um VPS comum, não inclui recursos de segurança como Anti-DDoS, ou opções avançadas como IP Adicional e Balanceador de Carga.
-
-Um VPS da Zona Local também atende às necessidades de projetos com requisitos de residência e soberania de dados. Ao hospedar seus serviços em uma região específica, você pode facilmente atender às regulamentações locais relacionadas ao processamento e armazenamento de dados, como o GDPR europeu.
+Não, não é possível migrar os serviços diretamente. Deve subscrever o VPS da sua escolha, transferir os seus dados e, em seguida, rescindir o seu serviço antigo. O nosso suporte pode orientá-lo nestas etapas, se necessário.
 
 </details>
 
 
 <details>
 
-<summary>Posso migrar meu VPS de uma Zona Local para um centro de dados, e vice-versa?</summary>
+<summary>Quais são os riscos de utilizar um VPS sem proteção DDoS?</summary>
 
 
-Não, você não pode migrar serviços diretamente. Você precisará assinar o VPS escolhido, transferir seus dados e, em seguida, cancelar seu serviço antigo. Nossa equipe de suporte pode guiá-lo por essas etapas, se necessário.
+Os servidores privados virtuais sem proteção anti-DDoS ficam automaticamente expostos a ataques de negação de serviço distribuído (DDoS), que podem provocar falhas de serviço e graves violações de segurança.
+
+- Exposição direta: se o seu servidor for alvo de um ataque DDoS, a afluência de pedidos maliciosos pode sobrecarregá-lo, tornando os seus sites e aplicações inacessíveis.
+- Sem mitigação automática: para proteger o seu servidor, terá de repelir os ataques com recurso a software de segurança de terceiros ou a configurações específicas.
+- Carga de gestão adicional: a ausência de uma segurança integrada robusta representa um risco importante, sublinhando a necessidade de uma monitorização vigilante e de estratégias proativas, em particular para os projetos com tráfego elevado.
+
+Se a resiliência face aos ataques DDoS for um fator crítico para o seu projeto, recomendamos que opte por um VPS OVHcloud alojado num dos nossos datacenters, que beneficia de uma proteção integrada.
+
+</details>
+
+
+
+## Perguntas relativas à administração do VPS
+
+<details>
+
+<summary>Como me ligar ao meu VPS?</summary>
+
+
+Pode ligar-se ao seu VPS remotamente graças às credenciais fornecidas por e-mail após a entrega do serviço.
+
+O método de ligação depende dos sistemas operativos utilizados.
+
+Todos os detalhes são apresentados no nosso guia "[Primeiros passos com um VPS](/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps)".
 
 </details>
 
 
 <details>
 
-<summary>Quais são os riscos de usar um VPS sem proteção contra DDoS?</summary>
+<summary>A OVHcloud fornece assistência na configuração de software do meu VPS?</summary>
 
 
-Servidores virtuais privados sem proteção contra DDoS estão automaticamente expostos a ataques de negação de serviço distribuídos (DDoS), potencialmente resultando em interrupções de serviço e brechas de segurança graves. 
+Embora não possamos prestar assistência em matéria de configuração ou de administração de software, disponibilizamos ferramentas e recursos para o ajudar a começar.
 
-- Exposição direta: Se seu servidor for alvo de um ataque DDoS, o influxo de solicitações maliciosas pode sobrecarregar o servidor, tornando seus sites e aplicações inacessíveis.
-- Nenhuma mitigação automática: Para proteger seu servidor, você precisará se defender dos ataques usando software de segurança de terceiros ou configurações específicas.
-- Carga adicional de gerenciamento: A falta de segurança robusta integrada apresenta um risco significativo, destacando a necessidade de monitoramento vigilante e estratégias proativas, especialmente para projetos com alto tráfego. 
+Por exemplo, propomos uma gama de modelos e imagens pré-configurados para os sistemas operativos e as aplicações mais populares, para o ajudar a implementar rapidamente o seu VPS. Disponibilizamos também a Área de Cliente OVHcloud, onde pode gerir o seu VPS, incluindo tarefas como o reinício, a reinstalação e a monitorização dos recursos.
 
-Se a resiliência contra ataques DDoS for um fator crítico para seu projeto, recomendamos optar por um VPS da OVHcloud hospedado em um dos nossos centros de dados, que vem com proteção integrada.
+Além disso, a nossa documentação e a nossa base de conhecimentos contêm inúmeras informações sobre a configuração e a gestão do seu VPS.
 
-</details>
-
-
-
-## Perguntas relacionadas à administração do VPS
-
-<details>
-
-<summary>Como faço para me conectar ao meu VPS?</summary>
-
-
-Você pode fazer login no seu VPS remotamente, usando as credenciais fornecidas por e-mail após a entrega do serviço.  
-O método de conexão depende dos sistemas operacionais em uso.
-
-Todos os detalhes estão descritos em nosso guia sobre [como começar com um VPS](/guides/bare-metal-cloud/virtual-private-servers/starting-with-a-vps).
-
-</details>
-
-
-<details>
-
-<summary>A OVHcloud fornece assistência na configuração de software para meu VPS?</summary>
-
-
-Embora não possamos oferecer assistência na configuração ou administração de software, fornecemos algumas ferramentas e recursos para ajudá-lo a começar.
-
-Por exemplo, oferecemos uma gama de modelos e imagens pré-configurados para sistemas operacionais e aplicações populares para ajudá-lo a implantar rapidamente seu VPS. Também oferecemos o OVHcloud Control Panel, onde você pode gerenciar seu VPS, incluindo tarefas como reiniciar, reinstalar e monitorar recursos.
-
-Além disso, nossa documentação e base de conhecimento contêm uma riqueza de informações sobre como configurar e gerenciar seu VPS.
-
-No entanto, para assistência específica na configuração de software, recomendamos entrar em contato com nossa [comunidade](/links/community) ou buscar a ajuda de um administrador de sistema ou desenvolvedor qualificado por meio de nosso [portal de parceiros](/links/partner).
+Contudo, para obter uma assistência específica em matéria de configuração de software, recomendamos que contacte a nossa [comunidade de utilizadores](/links/community) ou que solicite a ajuda de um administrador de sistemas ou de um programador qualificado através do nosso [Portal de Parceiros](/links/partner).
 
 </details>
 
@@ -288,103 +289,106 @@ Para mais informações, consulte o nosso guia dedicado: [Como evitar que os seu
 
 <details>
 
-<summary>Posso instalar mais de um sistema operacional no meu VPS?</summary>
+<summary>Posso instalar mais do que um sistema operativo no meu VPS?</summary>
 
 
-Os modelos de instalação da OVHcloud permitem apenas um sistema operacional.  
-Configurações personalizadas podem ser aplicadas do lado do cliente e são de responsabilidade do administrador do servidor. Os serviços da OVHcloud não incluem tarefas de administração, como configuração de software ou uso de ferramentas externas.
+Os modelos de instalação da OVHcloud permitem apenas um sistema operativo.
+As configurações personalizadas podem ser aplicadas do lado do cliente e são da responsabilidade do administrador do servidor. Os serviços OVHcloud não incluem tarefas de administração, tais como a configuração de software ou de ferramentas externas.
 
-Se você encontrar problemas de configuração e administração, recomendamos entrar em contato com nossa [comunidade](/links/community) ou buscar a ajuda de um administrador de sistema ou desenvolvedor qualificado por meio de nosso [portal de parceiros](/links/partner). 
-
-</details>
-
-
-
-<details>
-
-<summary>Posso instalar máquinas virtuais em um VPS usando software de virtualização (como o Proxmox)?</summary>
-
-
-Os modelos de instalação da OVHcloud para VPS não incluem o Proxmox Operating System ou um sistema operacional semelhante para virtualização. 
-
-Configurações personalizadas podem ser aplicadas do lado do cliente e são de responsabilidade do administrador do servidor. Os serviços da OVHcloud não incluem tarefas de administração, como configuração de software ou uso de ferramentas externas.
-
-Se você encontrar problemas de configuração e administração, recomendamos entrar em contato com nossa [comunidade](/links/community) ou buscar a ajuda de um administrador de sistema ou desenvolvedor qualificado por meio de nosso [portal de parceiros](/links/partner). 
+Se tiver problemas de configuração e de administração, recomendamos que contacte a nossa [comunidade de utilizadores](/links/community) ou que solicite a ajuda de um administrador de sistemas ou de um programador qualificado através do nosso [Portal de Parceiros](/links/partner).
 
 </details>
 
 
 <details>
 
-<summary>É possível escolher o hardware para meu VPS (GPU, CPU, etc.) ou atualizá-lo?</summary>
+<summary>Posso instalar máquinas virtuais num VPS utilizando um software de virtualização (como o Proxmox)?</summary>
 
 
-Um VPS não pode ser personalizado ou modificado no nível de hardware.  
-Selecione um [modelo de VPS](/links/bare-metal/vps) no processo de pedido que atenda aos seus requisitos mínimos, e depois você poderá atualizá-lo conforme necessário.  
+Os modelos de instalação OVHcloud para VPS não incluem o sistema operativo Proxmox ou um sistema operativo semelhante para a virtualização.
 
-</details>
+As configurações personalizadas podem ser aplicadas do lado do cliente e são da responsabilidade do administrador do servidor. Os serviços OVHcloud não incluem tarefas de administração, tais como a configuração de software ou a utilização de ferramentas externas.
 
-
-<details>
-
-<summary>Meu VPS está muito lento, posso mover meu VPS para outro host?</summary>
-
-
-Para resolver problemas de desempenho no seu VPS, você precisará fornecer resultados de testes específicos à nossa equipe de suporte.
-
-Observe que seu VPS deve ser inicializado no [modo de recuperação](/guides/bare-metal-cloud/virtual-private-servers/rescue) para descartar quaisquer possíveis problemas de software.
-
-Entre em contato com nossa equipe de suporte ao [criar uma solicitação no OVHcloud Centro de Ajuda](/links/support-contact) para que possamos fornecer a você a lista completa de testes necessários para uma avaliação adequada.
+Se tiver problemas de configuração e de administração, recomendamos que contacte a nossa [comunidade de utilizadores](/links/community) ou que solicite a ajuda de um administrador de sistemas ou de um programador qualificado através do nosso [Portal de Parceiros](/links/partner).
 
 </details>
 
 
 <details>
 
-<summary>Comprei um novo VPS, posso transferir o tempo restante da assinatura do meu VPS antigo ou terei um reembolso?</summary>
+<summary>É possível escolher o hardware do meu VPS (GPU, CPU, etc.) ou fazê-lo evoluir?</summary>
 
 
-Isso geralmente é possível, mas o processo requer uma [solicitação à nossa equipe de suporte via OVHcloud Centro de Ajuda](/links/support-contact).
+Um VPS não pode ser personalizado nem modificado ao nível do hardware.
 
-Antes de prosseguir, certifique-se de que você tenha [migrado qualquer dado ainda necessário](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) para seu novo serviço ou crie cópias de segurança dos seus dados.
-
-</details>
-
-
-<details>
-
-<summary>Posso mover meu VPS para um centro de dados da OVHcloud em outro país?</summary>
-
-
-Não é possível migrar um VPS para outro centro de dados. Para isso, você pode realizar uma [migração manual](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another):
-
-- Faça o download dos seus dados do VPS atual.
-- Compre um novo VPS.
-- Faça o upload dos seus dados para o novo VPS.
-- [Cancele o VPS antigo](/guides/account-and-service-management/managing-billing-payments-and-services/how-to-cancel-services).
+Selecione um [modelo de VPS](/links/bare-metal/vps) no processo de encomenda que responda aos seus requisitos mínimos; poderá depois atualizá-lo, se necessário.
 
 </details>
 
 
 <details>
 
-<summary>Quantos IPs Adicionais posso configurar em um VPS?</summary>
+<summary>O meu VPS está demasiado lento, posso mover o meu VPS para outro host?</summary>
 
 
-Um VPS é limitado a [16 IPs Adicionais](/links/network/additional-ip).
+Para resolver os problemas de desempenho do seu VPS, terá de fornecer resultados de testes específicos à nossa equipa de suporte.
 
-Consulte nosso guia sobre [como configurar alias de IP](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing) para exemplos de configuração de endereços IP.
+Note que o seu VPS deve ser iniciado em [modo rescue](/guides/bare-metal-cloud/virtual-private-servers/rescue) para excluir qualquer eventual problema de software.
+
+Contacte o nosso suporte [criando um pedido no centro de ajuda da OVHcloud](/links/support-contact) para que possamos fornecer-lhe a lista completa dos testes necessários para uma avaliação correta.
 
 </details>
 
 
 <details>
 
-<summary>Posso adicionar blocos de IP ao meu VPS?</summary>
+<summary>Encomendei um novo VPS, posso transferir o tempo de compromisso restante do meu VPS antigo ou obter o respetivo reembolso?</summary>
 
 
-Não é possível adicionar blocos de IP a um VPS.  
-Você pode configurar até [16 IPs Adicionais](/links/network/additional-ip) em um VPS.
+Isto é geralmente possível, mas o processo requer um pedido à nossa equipa de suporte através do [centro de ajuda da OVHcloud](/links/support-contact).
+
+Antes de continuar, certifique-se de que [migrou os dados ainda necessários](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) para o seu novo serviço ou de que criou cópias de segurança dos seus dados.
+
+</details>
+
+
+<details>
+
+<summary>Posso mover o meu VPS para um datacenter da OVHcloud noutro país?</summary>
+
+
+Não é possível migrar um VPS de uma localização para outra, seja para outro datacenter, outro país ou outro continente (por exemplo, da Alemanha para o Canadá).
+
+Para mudar de localização, deve encomendar um novo VPS na localização pretendida, transferir os seus dados e, em seguida, rescindir o seu VPS antigo. Pode realizar esta [migração manual](/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another) da seguinte forma:
+
+1\. Transfira os seus dados a partir do VPS atual.
+1\. Encomende um novo VPS na localização pretendida.
+1\. Coloque os seus dados no novo VPS.
+1\. [Rescinda o VPS antigo](/guides/account-and-service-management/managing-billing-payments-and-services/how-to-cancel-services).
+
+</details>
+
+
+<details>
+
+<summary>Quantos Additional IP posso configurar num VPS?</summary>
+
+
+Um VPS está limitado a [16 Additional IP](/links/network/additional-ip).
+
+Consulte o nosso guia "[Configurar um endereço IP em alias](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing)" para exemplos de configuração de endereços IP.
+
+</details>
+
+
+<details>
+
+<summary>Posso adicionar blocos de endereços IP ao meu VPS?</summary>
+
+
+Não é possível adicionar blocos de endereços IP a um VPS.
+
+Pode configurar até [16 Additional IP](/links/network/additional-ip) num VPS.
 
 </details>
 
@@ -394,11 +398,11 @@ Você pode configurar até [16 IPs Adicionais](/links/network/additional-ip) em 
 <summary>Posso alterar o VPS associado à minha licença (Plesk, cPanel)?</summary>
 
 
-Licenças podem ser movidas entre servidores, mas existem limitações.
+As licenças podem ser movidas de um servidor para outro, mas existem limitações.
 
-A melhor opção é fazer login em nossa <ApiLink>console da API</ApiLink> com suas credenciais de conta de cliente e verificar se sua licença pode ser movida para um VPS diferente. Encontre as bases em nosso guia sobre [como começar com a API da OVHcloud](/guides/manage-and-operate/api/first-steps).
+A melhor opção consiste em abrir a nossa <ApiLink>consola API</ApiLink> e verificar se a sua licença pode ser movida para outro VPS. Encontre os fundamentos no nosso guia "[Primeiros passos com as API OVHcloud](/guides/manage-and-operate/api/first-steps)".
 
-Uma vez conectado, use as seguintes chamadas dependendo do software em uso:
+Depois de estabelecer a ligação, utilize as seguintes chamadas em função do software utilizado:
 
 **Plesk**
 
@@ -409,20 +413,20 @@ Uma vez conectado, use as seguintes chamadas dependendo do software em uso:
 <Api version="v1" section="/license/cpanel" method="GET" route={"/license/cpanel/\{serviceName\}/canLicenseBeMovedTo"} />
 
 
-<img className="thumbnail" alt="Licença da API" src="/images/bare-metal-cloud/virtual-private-servers/vps-faq/getlicense.png" loading="lazy" />
+<img className="thumbnail" alt="Licença API" src="/images/bare-metal-cloud/virtual-private-servers/vps-faq/getlicense.png" loading="lazy" />
 
-Insira os parâmetros da seguinte forma:
+Introduza os parâmetros da seguinte forma:
 
-- `serviceName`: Insira o nome interno da sua licença (consulte a seção `Licenças` no seu <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>).
-- `destinationIp`: Insira o endereço IPv4 do serviço de destino.
+- `serviceName`: indique o nome interno da sua licença (consulte a secção `Licenças` na sua <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>).
+- `destinationIp`: indique o endereço IPv4 do serviço de destino.
 
 Clique no botão <code className="action">EXECUTE</code>.
 
-Se o resultado for negativo (`false`), o motivo será incluído no campo `RESPONSE`.
+Se o resultado for negativo (`false`), o motivo será indicado no campo `RESPONSE`.
 
-<img className="thumbnail" alt="Licença da API" src="/images/bare-metal-cloud/virtual-private-servers/vps-faq/getlicense_response.png" loading="lazy" />
+<img className="thumbnail" alt="Licença API" src="/images/bare-metal-cloud/virtual-private-servers/vps-faq/getlicense_response.png" loading="lazy" />
 
-Se o IP de destino for compatível com sua licença (`true`), você poderá usar a chamada correspondente para movê-la:
+Se o endereço IP de destino for compatível com a sua licença (`true`), pode utilizar a chamada correspondente para a mover:
 
 **Plesk**
 
@@ -437,81 +441,82 @@ Se o IP de destino for compatível com sua licença (`true`), você poderá usar
 
 
 
-## Perguntas sobre segurança e backup
+## Perguntas sobre segurança e cópias de segurança
 
 <details>
 
-<summary>Como faço para proteger meu VPS?</summary>
+<summary>Como proteger o meu VPS?</summary>
 
 
-Por padrão, o VPS é fornecido com apenas o sistema operacional selecionado instalado. O administrador do VPS é responsável por aplicar uma configuração de segurança apropriada após a entrega do VPS.  
-Para isso, consulte nosso guia sobre [como proteger um VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps).
+Por predefinição, apenas o sistema operativo selecionado está instalado no VPS. O administrador do VPS é responsável por aplicar uma configuração de segurança adequada após a entrega do VPS.
+
+Para tal, apoie-se no nosso guia "[Proteger um VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)".
 
 </details>
 
 
 <details>
 
-<summary>Como posso baixar meus arquivos ou um backup do VPS?</summary>
+<summary>Como posso transferir os meus ficheiros ou uma cópia de segurança do VPS?</summary>
 
 
-Existem várias opções disponíveis, por exemplo:
+Tem várias possibilidades ao seu dispor, por exemplo:
 
-- Baixar via SFTP: Conecte-se ao seu VPS com um cliente de software capaz de SFTP (por exemplo, [FileZilla](/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp)), depois transfira todos os arquivos no diretório raiz do sistema.
-- Baixar via `rsync` (ferramenta de linha de comando): Use o comando `rsync -avz -e ssh username@vps_ip_address:/ /local_directory/` para baixar todos os arquivos e pastas do seu VPS.
-- Baixar via a opção **Backup Automático**: Siga nosso guia sobre [como usar backups automáticos em um VPS](/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps) para baixar arquivos de um backup.
-- Baixar via a opção **Snapshot**: Siga nosso guia sobre [como usar snapshots em um VPS](/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps) para baixar um snapshot do VPS.
-
-</details>
-
-
-<details>
-
-<summary>Como posso baixar meu VPS como um arquivo de VM?</summary>
-
-
-Não é possível baixar um arquivo de VM de um VPS da OVHcloud. No entanto, você pode utilizar a opção **Snapshot** do seu OVHcloud Control Panel para recuperar um arquivo de imagem.
-
-Siga nosso guia sobre [como usar snapshots em um VPS](/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps) para criar e baixar um snapshot do VPS.
-
-Você pode então converter localmente o arquivo de snapshot baixado em um formato correspondente às suas necessidades.
-
-Considere entrar em contato com um de nossos [parceiros](/links/partner) para obter assistência adicional. 
+- Transferência via SFTP: ligue-se ao seu VPS com um software cliente SFTP (por exemplo, o [FileZilla](/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp)) e, em seguida, transfira todos os ficheiros do diretório raiz do sistema.
+- Transferência via `rsync` (ferramenta de linha de comandos): utilize o comando `rsync -avz -e ssh username@vps_ip_address:/ /local_directory/` para transferir todos os ficheiros e pastas do seu VPS.
+- Transferência através da opção **Backup automatizado**: siga o nosso guia sobre [a utilização das cópias de segurança automatizadas num VPS](/guides/bare-metal-cloud/virtual-private-servers/using-automated-backups-on-a-vps) para transferir ficheiros a partir de uma cópia de segurança.
+- Transferência através da opção **Snapshot**: siga o nosso guia sobre [a utilização dos snapshots num VPS](/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps) para transferir um snapshot do VPS.
 
 </details>
 
 
 <details>
 
-<summary>Como posso acessar meu armazenamento de backup a partir de um endereço IP fora do meu serviço?</summary>
+<summary>Como posso transferir o meu VPS enquanto ficheiro VM?</summary>
 
 
-O acesso ao armazenamento de backup do seu VPS (armazenamento FTP) pode estar restrito a endereços IP vinculados a um serviço dentro da sua conta de cliente OVHcloud.
+Não é possível transferir um ficheiro VM de um VPS OVHcloud. No entanto, pode utilizar a opção **Snapshot** do seu VPS a partir da sua Área de Cliente OVHcloud para recuperar um ficheiro de imagem.
 
-Para adicionar outros endereços IP a partir dos quais acessar, você pode usar a API da OVHcloud.  
-Isso permitirá recuperar seus dados de backup a partir de um serviço diferente por meio de vários protocolos (FTP, NFS, CIFS).
+Siga o nosso guia "[Utilizar os snapshots num VPS](/guides/bare-metal-cloud/virtual-private-servers/using-snapshots-on-a-vps)" para criar e transferir um snapshot do VPS.
+
+Pode depois converter localmente o ficheiro de snapshot transferido num formato correspondente às suas necessidades.
+
+Considere contactar um dos nossos [parceiros](/links/partner) para obter ajuda.
+
+</details>
+
+
+<details>
+
+<summary>Como aceder ao meu Backup Storage a partir de um endereço IP exterior ao meu serviço?</summary>
+
+
+O acesso ao Backup Storage do seu VPS (armazenamento FTP) pode estar limitado aos endereços IP associados a um serviço na sua conta de cliente OVHcloud.
+
+Para autorizar o acesso a partir de outros endereços IP, pode utilizar a API OVHcloud.
+Isto permitir-lhe-á recuperar os seus dados de cópia de segurança a partir de um serviço diferente através de vários protocolos (FTP, NFS, CIFS).
 
 :::warning
-Apenas endereços IP da OVHcloud podem ser autorizados.
+Apenas os endereços IP OVHcloud podem ser autorizados.
 
 :::
 
 
-Abra a <ApiLink>console da API da OVHcloud</ApiLink> e use a seguinte chamada:
+Aceda à <ApiLink>consola API OVHcloud</ApiLink> e utilize a seguinte chamada:
 
 <Api version="v1" section="/vps" method="POST" route={"/vps/\{serviceName\}/backupftp/access"} />
 
-Edite os parâmetros da seguinte forma:
+Modifique os parâmetros da seguinte forma:
 
-- `serviceName`: Insira o nome interno do seu VPS (`vps-x11x11xyy.vps.ovh.net`).
-- `cifs`: Defina como `true` se aplicável.
-- `ftp`: Defina como `true` se aplicável.
-- `ipBlock`: Insira o endereço IP que terá acesso, no formato `203.0.113.100/32`.
-- `nfs`: Defina como `true` se aplicável.
+- `serviceName`: indique o nome interno do seu VPS (`vps-x11x11xyy.vps.ovh.net`).
+- `cifs`: definido como `true` se aplicável.
+- `ftp`: definido como `true` se aplicável.
+- `ipBlock`: indique o endereço IP que terá acesso, sob a forma `203.0.113.100/32`.
+- `nfs`: definido como `true` se aplicável.
 
 Clique no botão <code className="action">EXECUTE</code>.
 
-Para verificar se seu endereço IP está autorizado, use a seguinte chamada:
+Para verificar se o seu endereço IP está autorizado, utilize a seguinte chamada:
 
 <Api version="v1" section="/vps" method="GET" route={"/vps/\{serviceName\}/backupftp/access"} />
 
@@ -522,47 +527,50 @@ Para verificar se seu endereço IP está autorizado, use a seguinte chamada:
 
 <details>
 
-<summary>Meu VPS está protegido contra ataques externos?</summary>
+<summary>O meu VPS está protegido contra ataques externos?</summary>
 
 
-Embora a OVHcloud aplique medidas de segurança para proteger toda a infraestrutura, o administrador de um VPS é responsável pela segurança das aplicações e dados hospedados nele.
+Embora a OVHcloud aplique medidas de segurança para proteger toda a infraestrutura, o administrador de um VPS é responsável pela segurança das aplicações e dos dados nele alojados.
 
-- Siga nosso guia sobre [como configurar a firewall da OVHcloud Edge Network](/guides/bare-metal-cloud/dedicated-servers/firewall-network), integrada em nossa infraestrutura Anti-DDoS, limitando a exposição dos seus serviços a ataques DDoS.
-- Além disso, você pode usar nossos guias sobre [como configurar sua própria firewall](/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable) com `iptables` em distribuições baseadas em Linux e [como ativar a firewall no Windows](/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win).
-- Para distribuições baseadas em Linux em um VPS, você pode seguir as instruções em nosso guia sobre [como proteger um VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps) para aplicar medidas de segurança adicionais.
-
-</details>
-
-
-<details>
-
-<summary>Como faço para proteger meu VPS contra ataques DDoS?</summary>
-
-
-A OVHcloud oferece várias funcionalidades de segurança para proteger seu VPS contra tráfego malicioso:
-
-- Proteção Anti-DDoS: Nossos serviços de VPS são protegidos por padrão pela nossa [infraestrutura Anti-DDoS](/links/security/antiddos), que detecta e mitiga ataques DDoS em tempo real.
-- Bloqueio de IP: Você pode [impedir endereços IP ou faixas específicas](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps) de acessar seu VPS.
-- Regras de firewall: Você pode [configurar regras de firewall personalizadas](/guides/bare-metal-cloud/dedicated-servers/firewall-network) para controlar o tráfego de entrada e saída diretamente no seu VPS.
-- VAC (VPS Anti-DDoS): Nosso sistema VAC oferece uma camada adicional de proteção contra ataques DDoS, incluindo filtragem de tráfego e limitação de taxa.
+- Siga o nosso guia "[Como configurar o Edge Network Firewall da OVHcloud](/guides/bare-metal-cloud/dedicated-servers/firewall-network)", serviço integrado na nossa infraestrutura Anti-DDoS para limitar a exposição dos seus serviços aos ataques DDoS.
+- Além disso, pode utilizar os nossos guias:
+    - [Configurar a firewall no Linux com o Iptables](/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable)
+    - [Configurar a firewall no Windows](/guides/bare-metal-cloud/virtual-private-servers/activate-port-firewall-soft-win).
+- Para as distribuições Linux num VPS, pode seguir as instruções do nosso guia "[Proteger um VPS](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps)" para aplicar medidas de segurança adicionais.
 
 </details>
 
 
 <details>
 
-<summary>Quero usar um VPS como um servidor de jogo, ele beneficiará da mesma firewall que protege os Servidores Dedicados de Jogo?</summary>
+<summary>Como proteger o meu VPS contra os ataques DDoS?</summary>
 
 
-A Proteção contra DDoS de Jogo da OVHcloud está disponível apenas para nossos Servidores Dedicados de Jogo. Se você adquirir um VPS para hospedagem de jogos, será necessário configurar a firewall diretamente no seu sistema, adaptada ao jogo desejado. Você pode encontrar mais informações em nosso guia sobre [como configurar a firewall no Linux com iptables](/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable).
+A OVHcloud fornece várias funcionalidades de segurança para proteger o seu VPS contra o tráfego malicioso:
 
-A vantagem de um VPS em comparação com um servidor dedicado é a possibilidade de escalar seus recursos de acordo com o uso real. Você pode atualizar seu VPS com apenas alguns cliques para beneficiar-se de um sistema mais potente.
+- Proteção anti-DDoS: os nossos serviços VPS estão protegidos por predefinição pela nossa [infraestrutura anti-DDoS](/links/security/antiddos), que deteta e mitiga os ataques DDoS em tempo real.
+- Bloqueio de endereços IP: pode [impedir que endereços IP ou intervalos de endereços IP específicos](/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps) alcancem o seu VPS.
+- Regras de firewall: pode [configurar regras de firewall personalizadas](/guides/bare-metal-cloud/dedicated-servers/firewall-network) para controlar o tráfego de entrada e de saída diretamente no seu VPS.
+- VAC (VPS Anti-DDoS): o nosso sistema VAC fornece uma camada adicional de proteção contra os ataques DDoS, incluindo a filtragem do tráfego e a limitação do débito.
 
 </details>
+
+
+<details>
+
+<summary>Pretendo utilizar um VPS como servidor de jogos, beneficiará da mesma firewall que protege os servidores dedicados Game?</summary>
+
+
+A proteção anti-DDoS Game da OVHcloud está disponível apenas para os nossos servidores dedicados Game. Se encomendar um VPS para o alojamento de jogos, terá de configurar a firewall diretamente no seu sistema, em função do jogo pretendido. Encontre mais informações no nosso guia sobre [a configuração da firewall no Linux com o Iptables](/guides/bare-metal-cloud/virtual-private-servers/firewall-linux-iptable).
+
+A vantagem de um VPS em relação a um servidor dedicado é a possibilidade de adaptar os seus recursos à sua utilização real. Pode fazer evoluir o seu VPS com apenas alguns cliques para beneficiar de um sistema mais potente.
+
+</details>
+
 
 
 ## Quer saber mais?
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
 
-Fale com nossa [comunidade de utilizadores](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).


### PR DESCRIPTION
Expand the "move VPS to another datacentre/country" FAQ entry to state a VPS cannot be migrated across locations (datacentre, country or continent) and that the method is to order a new VPS in the target location, transfer data, then cancel the old one.

Applied to EN + FR (reference) and propagated to de/es/it/pl/pt. Also fully retranslated the pt guide from Brazilian to European Portuguese (pt-PT) and bumped lastUpdated.