### PR TITLE
docs: recommend a 1800s SIP registration expiry on softphones/phones

### DIFF
--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
@@ -1,7 +1,7 @@
 ---
 title: 3CX - Configuration et utilisation
 description: "Découvrez comment configurer un SIP Trunk OVHcloud avec l'IPBX 3CX et deux DDI"
-lastUpdated: 2026-07-13
+lastUpdated: 2026-07-20
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -129,6 +129,16 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des 6 é
 
   </Tab>
 </Tabs>
+
+
+### Régler la durée d'enregistrement
+
+:::tip
+Nous vous recommandons de régler la durée d'enregistrement de votre trunk SIP sur **1800 secondes** (30 minutes) : une valeur trop faible sollicite inutilement le serveur, sans bénéfice réel.
+
+Ce réglage se trouve dans les paramètres du trunk SIP, onglet **Options**, dans le champ **Re-Register Timeout** (exprimé en secondes) : indiquez `1800`.
+
+:::
 
 
 ### Création et configuration des extensions

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
@@ -136,7 +136,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des 6 é
 :::tip
 Nous vous recommandons de régler la durée d'enregistrement de votre trunk SIP sur **1800 secondes** (30 minutes) : une valeur trop faible sollicite inutilement le serveur, sans bénéfice réel.
 
-Ce réglage se trouve dans les paramètres du trunk SIP, onglet **Options**, dans le champ **Re-Register Timeout** (exprimé en secondes) : indiquez `1800`.
+Ce réglage se trouve dans les paramètres du trunk SIP, onglet **Options**, dans le champ **Timeout Ré-enregistrer** (exprimé en secondes) : indiquez `1800`.
 
 :::
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutoriel - Utiliser une ligne SIP OVHcloud sur Linphone
 description: Découvrez comment enregistrer une ligne SIP OVHcloud sur le softphone Linphone
-lastUpdated: 2026-01-09
+lastUpdated: 2026-07-20
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -164,6 +164,15 @@ Depuis la fenêtre **Paramètres principaux du compte SIP**, renseignez dans les
 Vous pouvez dès lors être joint et composer des appels depuis votre ligne SIP OVHcloud.
   </Tab>
 </Tabs>
+
+### Régler la durée d'enregistrement
+
+:::tip
+Nous vous recommandons de régler la durée d'enregistrement de la ligne SIP sur **1800 secondes** (30 minutes) : une valeur trop faible sollicite inutilement le serveur, sans bénéfice réel.
+
+Ce paramètre n'est pas proposé par l'assistant de configuration : il se trouve dans les **réglages avancés du compte SIP**, dans le champ **Expiration** (exprimé en secondes). Renseignez-y la valeur `1800`.
+
+:::
 
 ### Dépannage
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
@@ -1,7 +1,7 @@
 ---
 title: Enregistrer une ligne SIP OVHcloud sur Zoiper
 description: Découvrez comment enregistrer une ligne SIP OVHcloud sur le softphone Zoiper
-lastUpdated: 2025-10-06
+lastUpdated: 2026-07-20
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -217,6 +217,17 @@ Si les informations d'identification de la ligne sont correctes, vous obtiendrez
 </Tabs>
 
 </details>
+
+### Régler la durée d'enregistrement
+
+:::tip
+Nous vous recommandons de régler la durée d'enregistrement de la ligne SIP sur **1800 secondes** (30 minutes) : une valeur trop faible sollicite inutilement le serveur, sans bénéfice réel.
+
+Ce paramètre n'est pas proposé par l'assistant de configuration. Il se trouve dans les **paramètres avancés du compte** : ouvrez <code className="action">Réglages</code> > <code className="action">Comptes</code>, sélectionnez votre compte, puis affichez les paramètres avancés (section `Paramètres réseau`). Réglez l'option **Expiration de l'enregistrement** sur une valeur personnalisée de `1800` secondes. Par défaut, Zoiper ré-enregistre la ligne toutes les 60 secondes en UDP.
+
+Sur iOS, la version gratuite *Zoiper Lite* ne propose pas ce réglage.
+
+:::
 
 ### Dépannage <a name="depannage"></a>
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
@@ -221,9 +221,11 @@ Si les informations d'identification de la ligne sont correctes, vous obtiendrez
 ### Régler la durée d'enregistrement
 
 :::tip
+Par défaut, Zoiper ré-enregistre la ligne toutes les 60 secondes en UDP.
+
 Nous vous recommandons de régler la durée d'enregistrement de la ligne SIP sur **1800 secondes** (30 minutes) : une valeur trop faible sollicite inutilement le serveur, sans bénéfice réel.
 
-Ce paramètre n'est pas proposé par l'assistant de configuration. Il se trouve dans les **paramètres avancés du compte** : ouvrez <code className="action">Réglages</code> > <code className="action">Comptes</code>, sélectionnez votre compte, puis affichez les paramètres avancés (section `Paramètres réseau`). Réglez l'option **Expiration de l'enregistrement** sur une valeur personnalisée de `1800` secondes. Par défaut, Zoiper ré-enregistre la ligne toutes les 60 secondes en UDP.
+Ce paramètre n'est pas proposé par l'assistant de configuration. Il se trouve dans les **paramètres avancés du compte** : ouvrez <code className="action">Réglages</code> > <code className="action">Comptes</code>, sélectionnez votre compte, puis affichez les paramètres avancés (section `Paramètres réseau`). Réglez l'option **Expiration de l'enregistrement** sur une valeur personnalisée de `1800` secondes.
 
 Sur iOS, la version gratuite *Zoiper Lite* ne propose pas ce réglage.
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ligne SIP - Configuration sur un softphone / téléphone personnel
 description: Découvrez comment enregistrer une ligne SIP OVHcloud sur un softphone tel que Linphone ou Zoiper ou sur votre téléphone personnel
-lastUpdated: 2025-10-06
+lastUpdated: 2026-07-20
 ---
 
 :::tip
@@ -53,6 +53,11 @@ Une ligne SIP **fournie avec un téléphone OVHcloud** ne peut pas être enregis
 Avant toute utilisation d'une ligne SIP sans matériel fournie par OVHcloud, nous vous recommandons de **sécuriser** celle-ci. Consultez notre guide pour [sécuriser une ligne SIP OVHcloud](/guides/web-cloud/phone-and-fax/voip/secure-sip-line).
 
 Contrairement aux lignes pré-configurées sur des téléphones OVHcloud, vous avez accès, depuis l'espace client OVHcloud, à la gestion du **mot de passe SIP** d'une ligne sans matériel. Il est primordial de définir un mot de passe SIP **fort**. Retrouvez plus d'informations sur notre guide pour [Modifier le mot de passe d'une ligne SIP](/guides/web-cloud/phone-and-fax/voip/modifier-mot-de-passe-ligne-sip).
+
+:::tip
+Sur votre softphone ou votre téléphone, nous vous recommandons de régler la durée d'enregistrement de votre ligne SIP (paramètre `expires`, dont le nom diffère suivant les éditeurs et constructeurs) sur **1800 secondes** (30 minutes). Une valeur trop faible (60 ou 300 secondes) sollicite inutilement le serveur, sans bénéfice réel.
+
+:::
 
 ### Étape 1 : Retrouver vos identifiants SIP
 


### PR DESCRIPTION
Add a recommendation to set the SIP line registration duration (expires) to 1800 seconds, to avoid low values (60/300s) needlessly loading the server:
- register-sip-softphone: general note in "En pratique"
- register-sip-softphone-zoiper: where to set it (Paramètres réseau >
  Expiration de l'enregistrement); not available on iOS Zoiper Lite
- register-sip-softphone-linphone: "Expiration" field in advanced settings

Bump lastUpdated to 2026-07-20 on the three guides.