### PR TITLE
Docs/voip sip expiry 1800

### DIFF
--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
@@ -134,7 +134,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des 6 é
 ### Régler la durée d'enregistrement
 
 :::tip
-Nous vous recommandons une durée d'enregistrement de votre trunk SIP de **1800 secondes** (30 minutes) : une valeur trop faible génère des ré-enregistrements de ligne inutiles, tandis qu'une valeur trop élevée peut laisser la liaison entre votre équipement et le serveur se fermer et empêcher la réception des appels.
+Nous vous recommandons de régler la durée d'enregistrement de votre trunk SIP sur **1800 secondes** (30 minutes) : une valeur trop faible génère des ré-enregistrements inutiles, tandis qu'une valeur trop élevée peut laisser la liaison entre votre équipement et le serveur se fermer et empêcher la réception des appels.
 :::
 
 Ce réglage se trouve dans les paramètres du trunk SIP, onglet **Options**, dans le champ **Timeout Ré-enregistrer** (exprimé en secondes) : indiquez `1800`.

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
@@ -1,7 +1,7 @@
 ---
 title: 3CX - Configuration et utilisation
 description: "Découvrez comment configurer un SIP Trunk OVHcloud avec l'IPBX 3CX et deux DDI"
-lastUpdated: 2026-07-13
+lastUpdated: 2026-07-20
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -129,6 +129,16 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des 6 é
 
   </Tab>
 </Tabs>
+
+
+### Régler la durée d'enregistrement
+
+:::tip
+Nous vous recommandons de régler la durée d'enregistrement de votre trunk SIP sur **1800 secondes** (30 minutes) : une valeur trop faible sollicite inutilement le serveur, sans bénéfice réel.
+
+Ce réglage se trouve dans les paramètres du trunk SIP, onglet **Options**, dans le champ **Re-Register Timeout** (exprimé en secondes) : indiquez `1800`.
+
+:::
 
 
 ### Création et configuration des extensions

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
@@ -136,7 +136,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des 6 é
 :::tip
 Nous vous recommandons de régler la durée d'enregistrement de votre trunk SIP sur **1800 secondes** (30 minutes) : une valeur trop faible sollicite inutilement le serveur, sans bénéfice réel.
 
-Ce réglage se trouve dans les paramètres du trunk SIP, onglet **Options**, dans le champ **Re-Register Timeout** (exprimé en secondes) : indiquez `1800`.
+Ce réglage se trouve dans les paramètres du trunk SIP, onglet **Options**, dans le champ **Timeout Ré-enregistrer** (exprimé en secondes) : indiquez `1800`.
 
 :::
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system.mdx
@@ -1,7 +1,7 @@
 ---
 title: 3CX - Configuration et utilisation
 description: "Découvrez comment configurer un SIP Trunk OVHcloud avec l'IPBX 3CX et deux DDI"
-lastUpdated: 2026-07-20
+lastUpdated: 2026-07-21
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -134,11 +134,10 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des 6 é
 ### Régler la durée d'enregistrement
 
 :::tip
-Nous vous recommandons de régler la durée d'enregistrement de votre trunk SIP sur **1800 secondes** (30 minutes) : une valeur trop faible sollicite inutilement le serveur, sans bénéfice réel.
+Nous vous recommandons une durée d'enregistrement de votre trunk SIP de **1800 secondes** (30 minutes) : une valeur trop faible génère des ré-enregistrements de ligne inutiles, tandis qu'une valeur trop élevée peut laisser la liaison entre votre équipement et le serveur se fermer et empêcher la réception des appels.
+:::
 
 Ce réglage se trouve dans les paramètres du trunk SIP, onglet **Options**, dans le champ **Timeout Ré-enregistrer** (exprimé en secondes) : indiquez `1800`.
-
-:::
 
 
 ### Création et configuration des extensions

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutoriel - Utiliser une ligne SIP OVHcloud sur Linphone
 description: Découvrez comment enregistrer une ligne SIP OVHcloud sur le softphone Linphone
-lastUpdated: 2026-07-20
+lastUpdated: 2026-07-21
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -168,11 +168,10 @@ Vous pouvez dès lors être joint et composer des appels depuis votre ligne SIP 
 ### Régler la durée d'enregistrement
 
 :::tip
-Nous vous recommandons de régler la durée d'enregistrement de la ligne SIP sur **1800 secondes** (30 minutes) : une valeur trop faible sollicite inutilement le serveur, sans bénéfice réel.
+Nous vous recommandons une durée d'enregistrement de **1800 secondes** (30 minutes) : une valeur trop faible génère des ré-enregistrements de ligne inutiles, tandis qu'une valeur trop élevée peut laisser la liaison entre votre équipement et le serveur se fermer et empêcher la réception des appels.
+:::
 
 Ce paramètre n'est pas proposé par l'assistant de configuration : il se trouve dans les **réglages avancés du compte SIP**, dans le champ **Expiration** (exprimé en secondes). Renseignez-y la valeur `1800`.
-
-:::
 
 ### Dépannage
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone.mdx
@@ -168,7 +168,7 @@ Vous pouvez dès lors être joint et composer des appels depuis votre ligne SIP 
 ### Régler la durée d'enregistrement
 
 :::tip
-Nous vous recommandons une durée d'enregistrement de **1800 secondes** (30 minutes) : une valeur trop faible génère des ré-enregistrements de ligne inutiles, tandis qu'une valeur trop élevée peut laisser la liaison entre votre équipement et le serveur se fermer et empêcher la réception des appels.
+Nous vous recommandons de régler la durée d'enregistrement de la ligne SIP sur **1800 secondes** (30 minutes) : une valeur trop faible génère des ré-enregistrements inutiles, tandis qu'une valeur trop élevée peut laisser la liaison entre votre équipement et le serveur se fermer et empêcher la réception des appels.
 :::
 
 Ce paramètre n'est pas proposé par l'assistant de configuration : il se trouve dans les **réglages avancés du compte SIP**, dans le champ **Expiration** (exprimé en secondes). Renseignez-y la valeur `1800`.

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutoriel - Utiliser une ligne SIP OVHcloud sur Linphone
 description: Découvrez comment enregistrer une ligne SIP OVHcloud sur le softphone Linphone
-lastUpdated: 2026-01-09
+lastUpdated: 2026-07-20
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -164,6 +164,15 @@ Depuis la fenêtre **Paramètres principaux du compte SIP**, renseignez dans les
 Vous pouvez dès lors être joint et composer des appels depuis votre ligne SIP OVHcloud.
   </Tab>
 </Tabs>
+
+### Régler la durée d'enregistrement
+
+:::tip
+Nous vous recommandons de régler la durée d'enregistrement de la ligne SIP sur **1800 secondes** (30 minutes) : une valeur trop faible sollicite inutilement le serveur, sans bénéfice réel.
+
+Ce paramètre n'est pas proposé par l'assistant de configuration : il se trouve dans les **réglages avancés du compte SIP**, dans le champ **Expiration** (exprimé en secondes). Renseignez-y la valeur `1800`.
+
+:::
 
 ### Dépannage
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
@@ -221,7 +221,7 @@ Si les informations d'identification de la ligne sont correctes, vous obtiendrez
 ### Régler la durée d'enregistrement
 
 :::tip
-Nous vous recommandons une durée d'enregistrement de **1800 secondes** (30 minutes) : une valeur trop faible génère des ré-enregistrements de ligne inutiles, tandis qu'une valeur trop élevée peut laisser la liaison entre votre équipement et le serveur se fermer et empêcher la réception des appels.
+Nous vous recommandons de régler la durée d'enregistrement de la ligne SIP sur **1800 secondes** (30 minutes) : une valeur trop faible génère des ré-enregistrements inutiles, tandis qu'une valeur trop élevée peut laisser la liaison entre votre équipement et le serveur se fermer et empêcher la réception des appels.
 :::
 
 Par défaut, Zoiper ré-enregistre la ligne toutes les 60 secondes en UDP. Ce paramètre n'est pas proposé par l'assistant de configuration : il se trouve dans les **paramètres avancés du compte**. Ouvrez <code className="action">Réglages</code> > <code className="action">Comptes</code>, sélectionnez votre compte, puis affichez les paramètres avancés (section `Paramètres réseau`). Réglez l'option **Expiration de l'enregistrement** sur une valeur personnalisée de `1800` secondes.

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
@@ -1,7 +1,7 @@
 ---
 title: Enregistrer une ligne SIP OVHcloud sur Zoiper
 description: Découvrez comment enregistrer une ligne SIP OVHcloud sur le softphone Zoiper
-lastUpdated: 2025-10-06
+lastUpdated: 2026-07-20
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -217,6 +217,17 @@ Si les informations d'identification de la ligne sont correctes, vous obtiendrez
 </Tabs>
 
 </details>
+
+### Régler la durée d'enregistrement
+
+:::tip
+Nous vous recommandons de régler la durée d'enregistrement de la ligne SIP sur **1800 secondes** (30 minutes) : une valeur trop faible sollicite inutilement le serveur, sans bénéfice réel.
+
+Ce paramètre n'est pas proposé par l'assistant de configuration. Il se trouve dans les **paramètres avancés du compte** : ouvrez <code className="action">Réglages</code> > <code className="action">Comptes</code>, sélectionnez votre compte, puis affichez les paramètres avancés (section `Paramètres réseau`). Réglez l'option **Expiration de l'enregistrement** sur une valeur personnalisée de `1800` secondes. Par défaut, Zoiper ré-enregistre la ligne toutes les 60 secondes en UDP.
+
+Sur iOS, la version gratuite *Zoiper Lite* ne propose pas ce réglage.
+
+:::
 
 ### Dépannage <a name="depannage"></a>
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
@@ -1,7 +1,7 @@
 ---
 title: Enregistrer une ligne SIP OVHcloud sur Zoiper
 description: Découvrez comment enregistrer une ligne SIP OVHcloud sur le softphone Zoiper
-lastUpdated: 2026-07-20
+lastUpdated: 2026-07-21
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -221,15 +221,12 @@ Si les informations d'identification de la ligne sont correctes, vous obtiendrez
 ### Régler la durée d'enregistrement
 
 :::tip
-Par défaut, Zoiper ré-enregistre la ligne toutes les 60 secondes en UDP.
+Nous vous recommandons une durée d'enregistrement de **1800 secondes** (30 minutes) : une valeur trop faible génère des ré-enregistrements de ligne inutiles, tandis qu'une valeur trop élevée peut laisser la liaison entre votre équipement et le serveur se fermer et empêcher la réception des appels.
+:::
 
-Nous vous recommandons de régler la durée d'enregistrement de la ligne SIP sur **1800 secondes** (30 minutes) : une valeur trop faible sollicite inutilement le serveur, sans bénéfice réel.
-
-Ce paramètre n'est pas proposé par l'assistant de configuration. Il se trouve dans les **paramètres avancés du compte** : ouvrez <code className="action">Réglages</code> > <code className="action">Comptes</code>, sélectionnez votre compte, puis affichez les paramètres avancés (section `Paramètres réseau`). Réglez l'option **Expiration de l'enregistrement** sur une valeur personnalisée de `1800` secondes.
+Par défaut, Zoiper ré-enregistre la ligne toutes les 60 secondes en UDP. Ce paramètre n'est pas proposé par l'assistant de configuration : il se trouve dans les **paramètres avancés du compte**. Ouvrez <code className="action">Réglages</code> > <code className="action">Comptes</code>, sélectionnez votre compte, puis affichez les paramètres avancés (section `Paramètres réseau`). Réglez l'option **Expiration de l'enregistrement** sur une valeur personnalisée de `1800` secondes.
 
 Sur iOS, la version gratuite *Zoiper Lite* ne propose pas ce réglage.
-
-:::
 
 ### Dépannage <a name="depannage"></a>
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper.mdx
@@ -221,9 +221,11 @@ Si les informations d'identification de la ligne sont correctes, vous obtiendrez
 ### Régler la durée d'enregistrement
 
 :::tip
+Par défaut, Zoiper ré-enregistre la ligne toutes les 60 secondes en UDP.
+
 Nous vous recommandons de régler la durée d'enregistrement de la ligne SIP sur **1800 secondes** (30 minutes) : une valeur trop faible sollicite inutilement le serveur, sans bénéfice réel.
 
-Ce paramètre n'est pas proposé par l'assistant de configuration. Il se trouve dans les **paramètres avancés du compte** : ouvrez <code className="action">Réglages</code> > <code className="action">Comptes</code>, sélectionnez votre compte, puis affichez les paramètres avancés (section `Paramètres réseau`). Réglez l'option **Expiration de l'enregistrement** sur une valeur personnalisée de `1800` secondes. Par défaut, Zoiper ré-enregistre la ligne toutes les 60 secondes en UDP.
+Ce paramètre n'est pas proposé par l'assistant de configuration. Il se trouve dans les **paramètres avancés du compte** : ouvrez <code className="action">Réglages</code> > <code className="action">Comptes</code>, sélectionnez votre compte, puis affichez les paramètres avancés (section `Paramètres réseau`). Réglez l'option **Expiration de l'enregistrement** sur une valeur personnalisée de `1800` secondes.
 
 Sur iOS, la version gratuite *Zoiper Lite* ne propose pas ce réglage.
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ligne SIP - Configuration sur un softphone / téléphone personnel
 description: Découvrez comment enregistrer une ligne SIP OVHcloud sur un softphone tel que Linphone ou Zoiper ou sur votre téléphone personnel
-lastUpdated: 2026-07-20
+lastUpdated: 2026-07-21
 ---
 
 :::tip
@@ -54,11 +54,6 @@ Avant toute utilisation d'une ligne SIP sans matériel fournie par OVHcloud, nou
 
 Contrairement aux lignes pré-configurées sur des téléphones OVHcloud, vous avez accès, depuis l'espace client OVHcloud, à la gestion du **mot de passe SIP** d'une ligne sans matériel. Il est primordial de définir un mot de passe SIP **fort**. Retrouvez plus d'informations sur notre guide pour [Modifier le mot de passe d'une ligne SIP](/guides/web-cloud/phone-and-fax/voip/modifier-mot-de-passe-ligne-sip).
 
-:::tip
-Sur votre softphone ou votre téléphone, nous vous recommandons de régler la durée d'enregistrement de votre ligne SIP (paramètre `expires`, dont le nom diffère suivant les éditeurs et constructeurs) sur **1800 secondes** (30 minutes). Une valeur trop faible (60 ou 300 secondes) sollicite inutilement le serveur, sans bénéfice réel.
-
-:::
-
 ### Étape 1 : Retrouver vos identifiants SIP
 
 Vous devez **impérativement** disposer des quatre informations suivantes afin de pouvoir enregistrer votre ligne :
@@ -107,6 +102,11 @@ Cliquez sur les liens ci-dessous pour lire les tutoriels :
 
 - [Tutoriel - Enregistrer une ligne SIP OVHcloud sur Linphone](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-linphone).
 - [Tutoriel - Enregistrer une ligne SIP OVHcloud sur Zoiper](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper).
+
+:::tip
+Sur votre softphone ou votre téléphone, nous vous recommandons de régler la durée d'enregistrement de votre ligne SIP (paramètre `expires`, dont le nom diffère suivant les éditeurs et constructeurs) sur **1800 secondes** (30 minutes). Une valeur trop faible génère des ré-enregistrements de ligne inutiles, tandis qu'une valeur trop élevée peut laisser la liaison entre votre équipement et le serveur se fermer et empêcher la réception des appels.
+
+:::
 
 ## Aller plus loin
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ligne SIP - Configuration sur un softphone / téléphone personnel
 description: Découvrez comment enregistrer une ligne SIP OVHcloud sur un softphone tel que Linphone ou Zoiper ou sur votre téléphone personnel
-lastUpdated: 2025-10-06
+lastUpdated: 2026-07-20
 ---
 
 :::tip
@@ -53,6 +53,11 @@ Une ligne SIP **fournie avec un téléphone OVHcloud** ne peut pas être enregis
 Avant toute utilisation d'une ligne SIP sans matériel fournie par OVHcloud, nous vous recommandons de **sécuriser** celle-ci. Consultez notre guide pour [sécuriser une ligne SIP OVHcloud](/guides/web-cloud/phone-and-fax/voip/secure-sip-line).
 
 Contrairement aux lignes pré-configurées sur des téléphones OVHcloud, vous avez accès, depuis l'espace client OVHcloud, à la gestion du **mot de passe SIP** d'une ligne sans matériel. Il est primordial de définir un mot de passe SIP **fort**. Retrouvez plus d'informations sur notre guide pour [Modifier le mot de passe d'une ligne SIP](/guides/web-cloud/phone-and-fax/voip/modifier-mot-de-passe-ligne-sip).
+
+:::tip
+Sur votre softphone ou votre téléphone, nous vous recommandons de régler la durée d'enregistrement de votre ligne SIP (paramètre `expires`, dont le nom diffère suivant les éditeurs et constructeurs) sur **1800 secondes** (30 minutes). Une valeur trop faible (60 ou 300 secondes) sollicite inutilement le serveur, sans bénéfice réel.
+
+:::
 
 ### Étape 1 : Retrouver vos identifiants SIP
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/register-sip-softphone.mdx
@@ -104,7 +104,7 @@ Cliquez sur les liens ci-dessous pour lire les tutoriels :
 - [Tutoriel - Enregistrer une ligne SIP OVHcloud sur Zoiper](/guides/web-cloud/phone-and-fax/voip/register-sip-softphone-zoiper).
 
 :::tip
-Sur votre softphone ou votre téléphone, nous vous recommandons de régler la durée d'enregistrement de votre ligne SIP (paramètre `expires`, dont le nom diffère suivant les éditeurs et constructeurs) sur **1800 secondes** (30 minutes). Une valeur trop faible génère des ré-enregistrements de ligne inutiles, tandis qu'une valeur trop élevée peut laisser la liaison entre votre équipement et le serveur se fermer et empêcher la réception des appels.
+Sur votre softphone ou votre téléphone, nous vous recommandons de régler la durée d'enregistrement de votre ligne SIP (paramètre `expires`, dont le nom diffère suivant les éditeurs et constructeurs) sur **1800 secondes** (30 minutes). Une valeur trop faible génère des ré-enregistrements inutiles, tandis qu'une valeur trop élevée peut laisser la liaison entre votre équipement et le serveur se fermer et empêcher la réception des appels.
 
 :::
 


### PR DESCRIPTION
## Context

Some customers register their SIP line with a very short registration expiry
(`expires` of 60 or 300 s). Each device then re-sends a REGISTER far too often,
needlessly loading the SIP servers with no benefit to the customer. This PR adds
a recommendation to use **1800 s (30 minutes)** in the guides where a user
configures a SIP line or trunk.

## Changes (4 guides, FR)

- **register-sip-softphone**: general note in the "En pratique" section (the
  `expires` parameter, whose label differs across vendors/manufacturers).
- **register-sip-softphone-zoiper**: new "Régler la durée d'enregistrement"
  section — default behaviour first (60 s over UDP), then the path
  *Paramètres réseau > Expiration de l'enregistrement*; the setting is not
  available in *Zoiper Lite* on iOS.
- **register-sip-softphone-linphone**: new section — the *Expiration* field in
  the SIP account's advanced settings.
- **configuration-basique-dun-sip-trunk-ovh-sur-3cx-phone-system**: new section
  — *Options* tab > *Timeout Ré-enregistrer* field.

`lastUpdated` bumped to 2026-07-20 on all four guides.

## Verification

- **Zoiper**: setting confirmed on the free macOS version (default 60 s over UDP);
  absent from *Zoiper Lite* on iOS; FR UI labels taken from the interface.
- **Linphone**: *Expiration* field confirmed in the FR app.
- **3CX**: *Options* tab / *Timeout Ré-enregistrer* confirmed via 3CX documentation
  and French 3CX forums (OVH default ~300 s, recommended 1800 s).