### PR TITLE
docs(finops): add guide to export billing data to a bucket (FR + EN)

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -80,7 +80,7 @@
         + [API](account-and-service-management-managing-billing-payments-and-services-api)
             + [Ordering Public Cloud projects using the OVHcloud API](account-and-service-management/managing-billing-payments-and-services/order-project-api)
     + [FinOps](products/account-and-service-management-finops)
-        + [Export billing data to a bucket](account-and-service-management/finops/export-billing-data-to-bucket)
+        + [Exporting billing data to a bucket](account-and-service-management/finops/export-billing-data-to-bucket)
     + [Reversibility](products/account-and-service-management-reversibility)
         + [Reversibility policies](account-and-service-management-reversibility-reversibility-policies)
             + [Global Reversibility Policy](account-and-service-management/reversibility/global-reversibility-policy)

--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -79,6 +79,8 @@
             + [How can I find out if my IP address is managed by OVHcloud?](network/whois-ip)
         + [API](account-and-service-management-managing-billing-payments-and-services-api)
             + [Ordering Public Cloud projects using the OVHcloud API](account-and-service-management/managing-billing-payments-and-services/order-project-api)
+    + [FinOps](products/account-and-service-management-finops)
+        + [Export billing data to a bucket](account-and-service-management/finops/export-billing-data-to-bucket)
     + [Reversibility](products/account-and-service-management-reversibility)
         + [Reversibility policies](account-and-service-management-reversibility-reversibility-policies)
             + [Global Reversibility Policy](account-and-service-management/reversibility/global-reversibility-policy)

--- a/docs/de/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
+++ b/docs/de/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx

--- a/docs/en/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
+++ b/docs/en/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
@@ -1,0 +1,307 @@
+---
+title: Export billing data to a bucket
+description: Configure, with the OVHcloud API, a daily export of your billing data — in the FOCUS format — to an S3™-compatible bucket you own.
+lastUpdated: 2026-06-24
+---
+
+import Api from '@components/Api';
+
+## Objective
+
+OVHcloud can push your billing data, converted to the **FOCUS** open standard, to an
+S3™<sup>*</sup>-compatible object storage bucket that **you** own. Once configured, the export runs
+**automatically every day**: no manual download, no portal click — your data lands in
+your bucket as a CSV file ready for your FinOps tooling.
+
+**This guide shows you how to create, track, update and remove that export configuration through the OVHcloud API.**
+
+> This page covers the **bucket export configuration** only. It does not cover reading the
+> exported columns or the FOCUS standard itself.
+
+## Requirements
+
+- An active OVHcloud account with billing data.
+- A **valid OVHcloud API authentication token** with permission to call the `/finops`
+  routes. All requests below must be authenticated; the examples show the token as
+  `$OVH_API_TOKEN`.
+- An **S3™<sup>*</sup>-compatible bucket** you can write to, and a pair of credentials for it:
+  - an **access key** and a **secret key**,
+  - the bucket **endpoint host** (a host name **without** a `http://` / `https://` / `s3://` scheme,
+    e.g. `s3.gra.io.cloud.ovh.net`) and its **region**.
+
+> Connections to your bucket always use **HTTPS** — do not prefix the endpoint with a
+> scheme. See [Frequent errors](#frequent-errors).
+
+> The export works with any S3™<sup>*</sup>-compatible bucket — it does not have to be OVHcloud Object
+> Storage. You provide the endpoint, region and credentials; OVHcloud writes to it.
+
+## How the export works, in short
+
+The configuration is a **declarative resource**. You describe the *target* you want
+(your bucket, the daily hour, the file policy) and OVHcloud reconciles toward it:
+
+1. You **create** the configuration with the bucket details (`POST`).
+2. OVHcloud **validates** it by actually connecting to your bucket and checking it is
+   reachable with the credentials you gave.
+3. When validation succeeds, the resource becomes **`READY`**; if OVHcloud cannot reach
+   your bucket, it becomes **`ERROR`**.
+4. Every day, at the **hour you chose**, OVHcloud regenerates your data for the current
+   month and uploads the file to your bucket.
+
+Because validation involves a real connection test, OVHcloud handles creation and updates
+**asynchronously**: the API answers immediately with a status of `CREATING` (or
+`UPDATING`), and you **poll** the resource until it reaches `READY`.
+
+All examples use the OVHcloud European API endpoint `https://eu.api.ovh.com/v2`. If your
+account is hosted in another region, use your regional API endpoint instead.
+
+## Step 1 — Create the export configuration
+
+Send a `POST` to `/finops/bucketExport` with your target specification.
+
+<Api version="v2" section="/finops" method="POST" route={"/finops/bucketExport"} />
+
+> **Prefer a graphical interface?** The API console above builds and signs the request for
+> you — the `curl` examples below show the equivalent raw call.
+
+```bash
+curl -X POST "https://eu.api.ovh.com/v2/finops/bucketExport" \
+  -H "Authorization: Bearer $OVH_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "targetSpec": {
+      "exportHour": 6,
+      "filePolicy": "CREATE",
+      "bucketConfiguration": {
+        "accessKey": "MY_ACCESS_KEY",
+        "secretKey": "MY_SECRET_KEY",
+        "bucketName": "my-finops-export",
+        "endpointURL": "s3.gra.io.cloud.ovh.net",
+        "region": "gra",
+        "pathPrefix": "./"
+      }
+    }
+  }'
+```
+
+> The `endpointURL` and `region` above use OVHcloud Object Storage values as an example.
+> Replace them with the endpoint host (no scheme) and region of your own S3™<sup>*</sup>-compatible
+> provider.
+
+### `targetSpec` fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `exportHour` | **Yes** | Hour of the day, `0`–`23` (UTC), when the daily export runs. |
+| `filePolicy` | No | `CREATE` (default) keeps one file per day; `REPLACE` keeps a single file per month, overwritten on each run. See [File layout](#file-layout-in-your-bucket). |
+| `bucketConfiguration.accessKey` | **Yes** | Access key for your bucket. |
+| `bucketConfiguration.secretKey` | **Yes** | Secret key for your bucket. |
+| `bucketConfiguration.bucketName` | No | Target bucket name. |
+| `bucketConfiguration.endpointURL` | No | Your bucket's endpoint **host only**, without any scheme (e.g. `s3.gra.io.cloud.ovh.net`, **not** `https://s3.gra.io.cloud.ovh.net` nor `s3://s3.gra.io.cloud.ovh.net`). Connections always use HTTPS. |
+| `bucketConfiguration.region` | No | Region / location code of your bucket. |
+| `bucketConfiguration.pathPrefix` | No | Prefix prepended to every object key written. Use `"./"` to write at the bucket root (recommended). |
+
+> Your **secret key is write-only**: OVHcloud encrypts it on receipt and **never returns**
+> it. In every response the `secretKey` field is masked as `"***"`, whereas OVHcloud returns
+> the access key in clear.
+
+### The response
+
+The API answers `201 Created` with the resource. Note the `id` (you will use it to track
+and manage the configuration) and the `resourceStatus`, which starts at `CREATING`:
+
+```json
+{
+  "id": "f556df9c-a52e-4bc1-8895-e3589cbba0be",
+  "resourceStatus": "CREATING",
+  "checksum": "9b2c5d6e0f1a2b3c4d5e6f7a8b9c0d1e",
+  "targetSpec": {
+    "exportHour": 6,
+    "filePolicy": "CREATE",
+    "bucketConfiguration": {
+      "accessKey": "MY_ACCESS_KEY",
+      "secretKey": "***",
+      "bucketName": "my-finops-export",
+      "endpointURL": "s3.gra.io.cloud.ovh.net",
+      "region": "gra",
+      "pathPrefix": "./"
+    }
+  },
+  "currentState": { "...": "same shape as targetSpec" },
+  "currentTasks": [
+    {
+      "id": "5a1b...",
+      "type": "CREATE_BUCKET_EXPORT",
+      "status": "PENDING",
+      "link": "/finops/bucketExport/f556df9c-a52e-4bc1-8895-e3589cbba0be"
+    }
+  ]
+}
+```
+
+## Step 2 — Follow the provisioning until it is ready
+
+Creation is asynchronous. Poll the resource by its `id` until `resourceStatus` is no
+longer `CREATING`:
+
+<Api version="v2" section="/finops" method="GET" route={"/finops/bucketExport/\{id\}"} />
+
+```bash
+curl "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e3589cbba0be" \
+  -H "Authorization: Bearer $OVH_API_TOKEN"
+```
+
+- **`READY`** — OVHcloud reached your bucket and the configuration is live. The next daily run
+  will upload your data.
+- **`ERROR`** — validation failed (most often OVHcloud could not reach your bucket with the
+  credentials you provided). See [Frequent errors](#frequent-errors).
+
+### Inspecting the provisioning detail
+
+Two read-only sub-resources let you see exactly what happened.
+
+List the tasks (the units of work OVHcloud ran, including finished ones):
+
+<Api version="v2" section="/finops" method="GET" route={"/finops/bucketExport/\{id\}/task"} />
+
+```bash
+curl "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e3589cbba0be/task" \
+  -H "Authorization: Bearer $OVH_API_TOKEN"
+```
+
+List the lifecycle events (a human-readable timeline):
+
+<Api version="v2" section="/finops" method="GET" route={"/finops/bucketExport/\{id\}/event"} />
+
+```bash
+curl "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e3589cbba0be/event" \
+  -H "Authorization: Bearer $OVH_API_TOKEN"
+```
+
+A task carries an `errors` array; when a connection test fails, its message tells you why.
+
+## Step 3 — Retrieve your exported files
+
+Once the configuration is `READY`, OVHcloud uploads a CSV file to your bucket **once a
+day, at the `exportHour` you set (UTC)**.
+
+- **Content**: your billing data converted to the **FOCUS 1.3** standard, as CSV.
+- **Window**: each run covers the **current calendar month up to that moment** (from the
+  1st of the month to now). The file therefore grows through the month as OVHcloud ingests
+  new billing data.
+
+### File layout in your bucket <a name="file-layout-in-your-bucket"></a>
+
+The object key depends on your `filePolicy`:
+
+| `filePolicy` | Object key | Behaviour |
+|--------------|-----------|-----------|
+| `CREATE` (default) | `[<pathPrefix>/]<nichandle>/<YYYY>/<MM>/<DD>/focus.csv` | A **new dated file each day**; OVHcloud keeps previous days. |
+| `REPLACE` | `[<pathPrefix>/]<nichandle>/<YYYY>/<MM>/focus.csv` | A **single file per month**, which OVHcloud overwrites on every run. |
+
+A `pathPrefix` of `"./"` writes at the **bucket root** (no extra folder). For example,
+with `pathPrefix: "./"` and the default `CREATE` policy, your data for 15 June 2026 lands
+at:
+
+```
+<your-nichandle>/2026/06/15/focus.csv
+```
+
+## Managing an existing configuration
+
+### Update it <a name="update-it"></a>
+
+Send a `PUT` to `/finops/bucketExport/{id}` with the **complete** `targetSpec` you want
+(the new spec fully replaces the previous one). As with creation, OVHcloud validates the
+update asynchronously: the response comes back as `UPDATING`, and you poll until `READY`.
+
+<Api version="v2" section="/finops" method="PUT" route={"/finops/bucketExport/\{id\}"} />
+
+```bash
+curl -X PUT "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e3589cbba0be" \
+  -H "Authorization: Bearer $OVH_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "targetSpec": {
+      "exportHour": 8,
+      "filePolicy": "CREATE",
+      "bucketConfiguration": {
+        "accessKey": "MY_ACCESS_KEY",
+        "secretKey": "MY_SECRET_KEY",
+        "bucketName": "my-finops-export",
+        "endpointURL": "s3.gra.io.cloud.ovh.net",
+        "region": "gra",
+        "pathPrefix": "./"
+      }
+    }
+  }'
+```
+
+> While OVHcloud validates an update, the response keeps your **previous** configuration
+> in `currentState` and shows the **requested** configuration in `targetSpec`. OVHcloud does
+> not change your live export until the new configuration reaches `READY`. If validation
+> fails, the resource goes to `ERROR` and the previous configuration remains in effect.
+
+### List your configurations
+
+<Api version="v2" section="/finops" method="GET" route={"/finops/bucketExport"} />
+
+```bash
+curl "https://eu.api.ovh.com/v2/finops/bucketExport" \
+  -H "Authorization: Bearer $OVH_API_TOKEN"
+```
+
+The list is paginated. When more results are available, the response carries an
+`X-Pagination-Cursor-Next` header; pass it back as the `X-Pagination-Cursor` header to
+fetch the next page.
+
+### Delete it
+
+<Api version="v2" section="/finops" method="DELETE" route={"/finops/bucketExport/\{id\}"} />
+
+```bash
+curl -X DELETE "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e3589cbba0be" \
+  -H "Authorization: Bearer $OVH_API_TOKEN"
+```
+
+Deletion stops the daily export. OVHcloud does **not** remove the files already written to
+your bucket.
+
+## Reference: resource status values
+
+| Status | Meaning |
+|--------|---------|
+| `CREATING` | OVHcloud accepted the configuration and is validating it. |
+| `UPDATING` | OVHcloud accepted an update and is validating it. |
+| `READY` | The configuration is valid and live; daily exports run. |
+| `ERROR` | The last create or update failed validation (e.g. bucket unreachable). |
+| `DELETING` | OVHcloud is removing the configuration. |
+
+## Frequent errors <a name="frequent-errors"></a>
+
+Most failures show up as a resource stuck in **`ERROR`** after create or update, because
+OVHcloud validates the configuration by really connecting to your bucket. Always start by
+reading the task `errors` (Step 2) — the message names the cause. The most common ones:
+
+| Symptom | Likely cause | How to fix |
+|---------|--------------|------------|
+| Status goes to `ERROR` right after create/update | **A scheme in `endpointURL`** — the value contains `http://`, `https://` or `s3://`. The endpoint must be a **bare host** (e.g. `s3.gra.io.cloud.ovh.net`); any scheme makes the connection fail. | Remove the scheme and keep the host only. Connections always use HTTPS. |
+| Status goes to `ERROR`, message mentions access denied / signature / forbidden | **Wrong or insufficient credentials** — the access key or secret key is incorrect, or the credentials lack write access to the bucket. | Re-check the **access key** and **secret key**, and confirm they can write to the bucket. OVHcloud never echoes the secret key back, so re-send it in full when you `PUT` a fix. |
+| Status goes to `ERROR`, message mentions the bucket | **Wrong `bucketName` or `region`**, or the bucket does not exist / is not reachable. | Verify the bucket name and region, and that the bucket exists for those credentials. |
+| `404 Not Found` on a configuration `id` | The configuration does not exist, or it belongs to another account. | Confirm the `id` and that you authenticate with the account that owns it. |
+| No file appears in the bucket | The daily run has not happened yet, or the status is not `READY`. | The export runs once a day at `exportHour` (UTC); confirm the resource is `READY` and wait for the next run. |
+| `400 Bad Request` on create/update | A required field is missing (`accessKey`, `secretKey`) or the body has no `targetSpec`. | Send a complete `targetSpec`, including the bucket credentials. |
+
+> After fixing a configuration in `ERROR`, send a corrected `PUT` (see [Update it](#update-it)) and poll
+> again until it reaches `READY`. The previous configuration stays in effect until OVHcloud
+> validates the new one.
+
+## Go further
+
+- The exported file follows the [FOCUS 1.3 CSV standard](https://focus.finops.org) — refer to the official FOCUS specification to interpret each column.
+- Join our [Discord community](https://discord.gg/ovhcloud) to ask questions and share feedback.
+
+---
+
+<sup>*</sup> S3 is a trademark filed by Amazon Technologies, Inc. OVHcloud's service is not
+sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
+++ b/docs/en/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
@@ -1,59 +1,49 @@
 ---
-title: Export billing data to a bucket
-description: Configure, with the OVHcloud API, a daily export of your billing data — in the FOCUS format — to an S3™-compatible bucket you own.
-lastUpdated: 2026-06-24
+title: Exporting billing data to a bucket
+description: Find out how to configure a daily export of your billing data — in the FOCUS format — to an S3-compatible bucket you own, using the OVHcloud API
+lastUpdated: 2026-07-21
 ---
 
 import Api from '@components/Api';
 
 ## Objective
 
-OVHcloud can push your billing data, converted to the **FOCUS** open standard, to an
-S3™<sup>*</sup>-compatible object storage bucket that **you** own. Once configured, the export runs
-**automatically every day**: no manual download, no portal click — your data lands in
-your bucket as a CSV file ready for your FinOps tooling.
+OVHcloud can push your billing data, converted to the **FOCUS** open standard, to an S3<sup>1</sup>-compatible object storage bucket that **you** own. Once configured, the export runs **automatically every day**: no manual download, no portal click — your data lands in your bucket as a CSV file ready for your FinOps tooling.
 
 **This guide shows you how to create, track, update and remove that export configuration through the OVHcloud API.**
 
-> This page covers the **bucket export configuration** only. It does not cover reading the
-> exported columns or the FOCUS standard itself.
+:::info
+This page covers the **bucket export configuration** only. It does not cover reading the exported columns or the FOCUS standard itself.
+:::
 
 ## Requirements
 
 - An active OVHcloud account with billing data.
-- A **valid OVHcloud API authentication token** with permission to call the `/finops`
-  routes. All requests below must be authenticated; the examples show the token as
-  `$OVH_API_TOKEN`.
-- An **S3™<sup>*</sup>-compatible bucket** you can write to, and a pair of credentials for it:
-  - an **access key** and a **secret key**,
-  - the bucket **endpoint host** (a host name **without** a `http://` / `https://` / `s3://` scheme,
-    e.g. `s3.gra.io.cloud.ovh.net`) and its **region**.
+- A **valid OVHcloud API authentication token** with permission to call the `/finops` routes. If needed, see [First Steps with the OVHcloud APIs](/guides/manage-and-operate/api/first-steps) to create one. All requests below must be authenticated; the examples show the token as `$OVH_API_TOKEN`.
+- An **S3-compatible bucket** you can write to, and a pair of credentials for it:
+    - an **access key** and a **secret key**,
+    - the bucket **endpoint host** (a host name **without** a `http://` / `https://` / `s3://` scheme, e.g. `s3.gra.io.cloud.ovh.net`) and its **region**.
 
-> Connections to your bucket always use **HTTPS** — do not prefix the endpoint with a
-> scheme. See [Frequent errors](#frequent-errors).
+:::warning
+Connections to your bucket always use **HTTPS** — do not prefix the endpoint with a scheme. See the [Frequent errors](#frequent-errors) section.
+:::
 
-> The export works with any S3™<sup>*</sup>-compatible bucket — it does not have to be OVHcloud Object
-> Storage. You provide the endpoint, region and credentials; OVHcloud writes to it.
+:::info
+The export works with any S3-compatible bucket — it does not have to be OVHcloud Object Storage. You provide the endpoint, region and credentials; OVHcloud writes to it.
+:::
 
-## How the export works, in short
+## How the export works
 
-The configuration is a **declarative resource**. You describe the *target* you want
-(your bucket, the daily hour, the file policy) and OVHcloud reconciles toward it:
+The configuration is a **declarative resource**. You describe the *target* you want (your bucket, the daily hour, the file policy) and OVHcloud reconciles toward it:
 
 1. You **create** the configuration with the bucket details (`POST`).
-2. OVHcloud **validates** it by actually connecting to your bucket and checking it is
-   reachable with the credentials you gave.
-3. When validation succeeds, the resource becomes **`READY`**; if OVHcloud cannot reach
-   your bucket, it becomes **`ERROR`**.
-4. Every day, at the **hour you chose**, OVHcloud regenerates your data for the current
-   month and uploads the file to your bucket.
+2. OVHcloud **validates** it by actually connecting to your bucket and checking it is reachable with the credentials you gave.
+3. When validation succeeds, the resource becomes **`READY`**; if OVHcloud cannot reach your bucket, it becomes **`ERROR`**.
+4. Every day, at the **hour you chose**, OVHcloud regenerates your data for the current month and uploads the file to your bucket.
 
-Because validation involves a real connection test, OVHcloud handles creation and updates
-**asynchronously**: the API answers immediately with a status of `CREATING` (or
-`UPDATING`), and you **poll** the resource until it reaches `READY`.
+Because validation involves a real connection test, OVHcloud handles creation and updates **asynchronously**: the API answers immediately with a status of `CREATING` (or `UPDATING`), and you **poll** the resource until it reaches `READY`.
 
-All examples use the OVHcloud European API endpoint `https://eu.api.ovh.com/v2`. If your
-account is hosted in another region, use your regional API endpoint instead.
+All examples use the OVHcloud European API endpoint `https://eu.api.ovh.com/v2`. If your account is hosted in another region, use your regional API endpoint instead (for example `https://ca.api.ovh.com/v2` for Canada).
 
 ## Step 1 — Create the export configuration
 
@@ -61,8 +51,9 @@ Send a `POST` to `/finops/bucketExport` with your target specification.
 
 <Api version="v2" section="/finops" method="POST" route={"/finops/bucketExport"} />
 
-> **Prefer a graphical interface?** The API console above builds and signs the request for
-> you — the `curl` examples below show the equivalent raw call.
+:::tip
+**Prefer a graphical interface?** The API console above builds and signs the request for you — the `curl` examples below show the equivalent raw call.
+:::
 
 ```bash
 curl -X POST "https://eu.api.ovh.com/v2/finops/bucketExport" \
@@ -84,9 +75,9 @@ curl -X POST "https://eu.api.ovh.com/v2/finops/bucketExport" \
   }'
 ```
 
-> The `endpointURL` and `region` above use OVHcloud Object Storage values as an example.
-> Replace them with the endpoint host (no scheme) and region of your own S3™<sup>*</sup>-compatible
-> provider.
+:::info
+The `endpointURL` and `region` above use OVHcloud Object Storage values as an example. Replace them with the endpoint host (no scheme) and region of your own S3-compatible provider.
+:::
 
 ### `targetSpec` fields
 
@@ -101,14 +92,13 @@ curl -X POST "https://eu.api.ovh.com/v2/finops/bucketExport" \
 | `bucketConfiguration.region` | No | Region / location code of your bucket. |
 | `bucketConfiguration.pathPrefix` | No | Prefix prepended to every object key written. Use `"./"` to write at the bucket root (recommended). |
 
-> Your **secret key is write-only**: OVHcloud encrypts it on receipt and **never returns**
-> it. In every response the `secretKey` field is masked as `"***"`, whereas OVHcloud returns
-> the access key in clear.
+:::warning
+Your **secret key is write-only**: OVHcloud encrypts it on receipt and **never returns** it. In every response the `secretKey` field is masked as `"***"`, whereas OVHcloud returns the access key in clear.
+:::
 
 ### The response
 
-The API answers `201 Created` with the resource. Note the `id` (you will use it to track
-and manage the configuration) and the `resourceStatus`, which starts at `CREATING`:
+The API answers `201 Created` with the resource. Note the `id` (you will use it to track and manage the configuration) and the `resourceStatus`, which starts at `CREATING`:
 
 ```json
 {
@@ -141,8 +131,7 @@ and manage the configuration) and the `resourceStatus`, which starts at `CREATIN
 
 ## Step 2 — Follow the provisioning until it is ready
 
-Creation is asynchronous. Poll the resource by its `id` until `resourceStatus` is no
-longer `CREATING`:
+Creation is asynchronous. Poll the resource by its `id` until `resourceStatus` is no longer `CREATING`:
 
 <Api version="v2" section="/finops" method="GET" route={"/finops/bucketExport/\{id\}"} />
 
@@ -151,10 +140,8 @@ curl "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e358
   -H "Authorization: Bearer $OVH_API_TOKEN"
 ```
 
-- **`READY`** — OVHcloud reached your bucket and the configuration is live. The next daily run
-  will upload your data.
-- **`ERROR`** — validation failed (most often OVHcloud could not reach your bucket with the
-  credentials you provided). See [Frequent errors](#frequent-errors).
+- **`READY`** — OVHcloud reached your bucket and the configuration is live. The next daily run will upload your data.
+- **`ERROR`** — validation failed (most often OVHcloud could not reach your bucket with the credentials you provided). See the [Frequent errors](#frequent-errors) section.
 
 ### Inspecting the provisioning detail
 
@@ -182,13 +169,10 @@ A task carries an `errors` array; when a connection test fails, its message tell
 
 ## Step 3 — Retrieve your exported files
 
-Once the configuration is `READY`, OVHcloud uploads a CSV file to your bucket **once a
-day, at the `exportHour` you set (UTC)**.
+Once the configuration is `READY`, OVHcloud uploads a CSV file to your bucket **once a day, at the `exportHour` you set (UTC)**.
 
 - **Content**: your billing data converted to the **FOCUS 1.3** standard, as CSV.
-- **Window**: each run covers the **current calendar month up to that moment** (from the
-  1st of the month to now). The file therefore grows through the month as OVHcloud ingests
-  new billing data.
+- **Window**: each run covers the **current calendar month up to that moment** (from the 1st of the month to now). The file therefore grows through the month as OVHcloud ingests new billing data.
 
 ### File layout in your bucket <a name="file-layout-in-your-bucket"></a>
 
@@ -199,11 +183,9 @@ The object key depends on your `filePolicy`:
 | `CREATE` (default) | `[<pathPrefix>/]<nichandle>/<YYYY>/<MM>/<DD>/focus.csv` | A **new dated file each day**; OVHcloud keeps previous days. |
 | `REPLACE` | `[<pathPrefix>/]<nichandle>/<YYYY>/<MM>/focus.csv` | A **single file per month**, which OVHcloud overwrites on every run. |
 
-A `pathPrefix` of `"./"` writes at the **bucket root** (no extra folder). For example,
-with `pathPrefix: "./"` and the default `CREATE` policy, your data for 15 June 2026 lands
-at:
+A `pathPrefix` of `"./"` writes at the **bucket root** (no extra folder). For example, with `pathPrefix: "./"` and the default `CREATE` policy, your data for 15 June 2026 lands at:
 
-```
+```text
 <your-nichandle>/2026/06/15/focus.csv
 ```
 
@@ -211,9 +193,7 @@ at:
 
 ### Update it <a name="update-it"></a>
 
-Send a `PUT` to `/finops/bucketExport/{id}` with the **complete** `targetSpec` you want
-(the new spec fully replaces the previous one). As with creation, OVHcloud validates the
-update asynchronously: the response comes back as `UPDATING`, and you poll until `READY`.
+Send a `PUT` to `/finops/bucketExport/{id}` with the **complete** `targetSpec` you want (the new spec fully replaces the previous one). As with creation, OVHcloud validates the update asynchronously: the response comes back as `UPDATING`, and you poll until `READY`.
 
 <Api version="v2" section="/finops" method="PUT" route={"/finops/bucketExport/\{id\}"} />
 
@@ -237,10 +217,9 @@ curl -X PUT "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-88
   }'
 ```
 
-> While OVHcloud validates an update, the response keeps your **previous** configuration
-> in `currentState` and shows the **requested** configuration in `targetSpec`. OVHcloud does
-> not change your live export until the new configuration reaches `READY`. If validation
-> fails, the resource goes to `ERROR` and the previous configuration remains in effect.
+:::info
+While OVHcloud validates an update, the response keeps your **previous** configuration in `currentState` and shows the **requested** configuration in `targetSpec`. OVHcloud does not change your live export until the new configuration reaches `READY`. If validation fails, the resource goes to `ERROR` and the previous configuration remains in effect.
+:::
 
 ### List your configurations
 
@@ -251,9 +230,7 @@ curl "https://eu.api.ovh.com/v2/finops/bucketExport" \
   -H "Authorization: Bearer $OVH_API_TOKEN"
 ```
 
-The list is paginated. When more results are available, the response carries an
-`X-Pagination-Cursor-Next` header; pass it back as the `X-Pagination-Cursor` header to
-fetch the next page.
+The list is paginated. When more results are available, the response carries an `X-Pagination-Cursor-Next` header; pass it back as the `X-Pagination-Cursor` header to fetch the next page.
 
 ### Delete it
 
@@ -264,8 +241,7 @@ curl -X DELETE "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1
   -H "Authorization: Bearer $OVH_API_TOKEN"
 ```
 
-Deletion stops the daily export. OVHcloud does **not** remove the files already written to
-your bucket.
+Deletion stops the daily export. OVHcloud does **not** remove the files already written to your bucket.
 
 ## Reference: resource status values
 
@@ -279,9 +255,7 @@ your bucket.
 
 ## Frequent errors <a name="frequent-errors"></a>
 
-Most failures show up as a resource stuck in **`ERROR`** after create or update, because
-OVHcloud validates the configuration by really connecting to your bucket. Always start by
-reading the task `errors` (Step 2) — the message names the cause. The most common ones:
+Most failures show up as a resource stuck in **`ERROR`** after create or update, because OVHcloud validates the configuration by actually connecting to your bucket. Always start by reading the task `errors` (Step 2) — the message names the cause. The most common ones:
 
 | Symptom | Likely cause | How to fix |
 |---------|--------------|------------|
@@ -292,16 +266,14 @@ reading the task `errors` (Step 2) — the message names the cause. The most com
 | No file appears in the bucket | The daily run has not happened yet, or the status is not `READY`. | The export runs once a day at `exportHour` (UTC); confirm the resource is `READY` and wait for the next run. |
 | `400 Bad Request` on create/update | A required field is missing (`accessKey`, `secretKey`) or the body has no `targetSpec`. | Send a complete `targetSpec`, including the bucket credentials. |
 
-> After fixing a configuration in `ERROR`, send a corrected `PUT` (see [Update it](#update-it)) and poll
-> again until it reaches `READY`. The previous configuration stays in effect until OVHcloud
-> validates the new one.
+:::info
+After fixing a configuration in `ERROR`, send a corrected `PUT` (see [Update it](#update-it)) and poll again until it reaches `READY`. The previous configuration stays in effect until OVHcloud validates the new one.
+:::
 
 ## Go further
 
-- The exported file follows the [FOCUS 1.3 CSV standard](https://focus.finops.org) — refer to the official FOCUS specification to interpret each column.
-- Join our [Discord community](https://discord.gg/ovhcloud) to ask questions and share feedback.
+The exported file follows the [FOCUS 1.3 CSV standard](https://focus.finops.org) — refer to the official FOCUS specification to interpret each column.
 
----
+Join our [Discord community](https://discord.gg/ovhcloud) to ask questions and share feedback.
 
-<sup>*</sup> S3 is a trademark filed by Amazon Technologies, Inc. OVHcloud's service is not
-sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
+<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
+++ b/docs/es/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx

--- a/docs/fr/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
+++ b/docs/fr/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
@@ -1,0 +1,318 @@
+---
+title: Exporter vos données de facturation vers un bucket
+description: Configurez, via l'API OVHcloud, un export quotidien de vos données de facturation — au format FOCUS — vers un bucket compatible S3™ que vous possédez.
+lastUpdated: 2026-06-24
+---
+
+import Api from '@components/Api';
+
+## Objectif
+
+OVHcloud peut transmettre vos données de facturation, converties au standard ouvert
+**FOCUS**, vers un bucket de stockage objet compatible S3™<sup>*</sup> que **vous** possédez. Une fois
+configuré, l'export s'exécute **automatiquement chaque jour** : aucun téléchargement
+manuel, aucun clic dans l'espace client — vos données arrivent dans votre bucket sous forme
+de fichier CSV, prêt pour vos outils FinOps.
+
+**Ce guide vous explique comment créer, suivre, modifier et supprimer cette configuration d'export via l'API OVHcloud.**
+
+> Cette page couvre uniquement la **configuration de l'export vers un bucket**. Elle ne
+> traite pas de la lecture des colonnes exportées ni du standard FOCUS lui-même.
+
+## Prérequis
+
+- Un compte OVHcloud actif disposant de données de facturation.
+- Un **jeton d'authentification API OVHcloud valide** disposant de la permission d'appeler
+  les routes `/finops`. Toutes les requêtes ci-dessous doivent être authentifiées ; les
+  exemples présentent le jeton sous la forme `$OVH_API_TOKEN`.
+- Un **bucket compatible S3™<sup>*</sup>** dans lequel vous pouvez écrire, ainsi qu'un couple
+  d'identifiants pour celui-ci :
+  - une **clé d'accès** (access key) et une **clé secrète** (secret key),
+  - l'**hôte du endpoint** du bucket (un nom d'hôte **sans** schéma `http://` / `https://` / `s3://`,
+    par exemple `s3.gra.io.cloud.ovh.net`) et sa **région**.
+
+> Les connexions à votre bucket utilisent toujours le **HTTPS** — ne préfixez pas le
+> endpoint avec un schéma. Voir [Erreurs fréquentes](#frequent-errors).
+
+> L'export fonctionne avec n'importe quel bucket compatible S3™<sup>*</sup> — il n'est pas nécessaire
+> qu'il s'agisse d'OVHcloud Object Storage. Vous fournissez le endpoint, la région et les
+> identifiants ; OVHcloud y écrit.
+
+## Fonctionnement de l'export, en bref
+
+La configuration est une **ressource déclarative**. Vous décrivez la *cible* souhaitée
+(votre bucket, l'heure quotidienne, la politique de fichier) et OVHcloud converge vers
+celle-ci :
+
+1. Vous **créez** la configuration avec les informations du bucket (`POST`).
+2. OVHcloud la **valide** en se connectant réellement à votre bucket et en vérifiant qu'il
+   est accessible avec les identifiants que vous avez fournis.
+3. Lorsque la validation réussit, la ressource passe à l'état **`READY`** ; si OVHcloud ne
+   parvient pas à joindre votre bucket, elle passe à **`ERROR`**.
+4. Chaque jour, à l'**heure que vous avez choisie**, OVHcloud régénère vos données pour le
+   mois en cours et téléverse le fichier dans votre bucket.
+
+Comme la validation implique un véritable test de connexion, OVHcloud traite la création et
+les modifications de manière **asynchrone** : l'API répond immédiatement avec un statut
+`CREATING` (ou `UPDATING`), et vous **interrogez** (poll) la ressource jusqu'à ce qu'elle
+atteigne `READY`.
+
+Tous les exemples utilisent le endpoint API européen d'OVHcloud `https://eu.api.ovh.com/v2`.
+Si votre compte est hébergé dans une autre région, utilisez le endpoint API de votre région.
+
+## Étape 1 — Créer la configuration d'export
+
+Envoyez un `POST` à `/finops/bucketExport` avec la spécification de votre cible.
+
+<Api version="v2" section="/finops" method="POST" route={"/finops/bucketExport"} />
+
+> **Vous préférez une interface graphique ?** La console API ci-dessus construit et signe
+> la requête à votre place — les exemples `curl` ci-dessous montrent l'appel brut équivalent.
+
+```bash
+curl -X POST "https://eu.api.ovh.com/v2/finops/bucketExport" \
+  -H "Authorization: Bearer $OVH_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "targetSpec": {
+      "exportHour": 6,
+      "filePolicy": "CREATE",
+      "bucketConfiguration": {
+        "accessKey": "MY_ACCESS_KEY",
+        "secretKey": "MY_SECRET_KEY",
+        "bucketName": "my-finops-export",
+        "endpointURL": "s3.gra.io.cloud.ovh.net",
+        "region": "gra",
+        "pathPrefix": "./"
+      }
+    }
+  }'
+```
+
+> Les valeurs `endpointURL` et `region` ci-dessus utilisent celles d'OVHcloud Object Storage
+> à titre d'exemple. Remplacez-les par l'hôte du endpoint (sans schéma) et la région de
+> votre propre fournisseur compatible S3™<sup>*</sup>.
+
+### Champs de `targetSpec`
+
+| Champ | Requis | Description |
+|-------|--------|-------------|
+| `exportHour` | **Oui** | Heure de la journée, `0`–`23` (UTC), à laquelle l'export quotidien s'exécute. |
+| `filePolicy` | Non | `CREATE` (par défaut) conserve un fichier par jour ; `REPLACE` conserve un seul fichier par mois, écrasé à chaque exécution. Voir [Disposition des fichiers](#file-layout-in-your-bucket). |
+| `bucketConfiguration.accessKey` | **Oui** | Clé d'accès de votre bucket. |
+| `bucketConfiguration.secretKey` | **Oui** | Clé secrète de votre bucket. |
+| `bucketConfiguration.bucketName` | Non | Nom du bucket cible. |
+| `bucketConfiguration.endpointURL` | Non | L'**hôte seul** du endpoint de votre bucket, sans aucun schéma (par exemple `s3.gra.io.cloud.ovh.net`, et **non** `https://s3.gra.io.cloud.ovh.net` ni `s3://s3.gra.io.cloud.ovh.net`). Les connexions utilisent toujours le HTTPS. |
+| `bucketConfiguration.region` | Non | Code de région / d'emplacement de votre bucket. |
+| `bucketConfiguration.pathPrefix` | Non | Préfixe ajouté devant chaque clé d'objet écrite. Utilisez `"./"` pour écrire à la racine du bucket (recommandé). |
+
+> Votre **clé secrète est en écriture seule** : OVHcloud la chiffre à la réception et ne la
+> **renvoie jamais**. Dans chaque réponse, le champ `secretKey` est masqué par `"***"`,
+> tandis qu'OVHcloud renvoie la clé d'accès en clair.
+
+### La réponse
+
+L'API répond `201 Created` avec la ressource. Notez l'`id` (vous l'utiliserez pour suivre
+et gérer la configuration) et le `resourceStatus`, qui démarre à `CREATING` :
+
+```json
+{
+  "id": "f556df9c-a52e-4bc1-8895-e3589cbba0be",
+  "resourceStatus": "CREATING",
+  "checksum": "9b2c5d6e0f1a2b3c4d5e6f7a8b9c0d1e",
+  "targetSpec": {
+    "exportHour": 6,
+    "filePolicy": "CREATE",
+    "bucketConfiguration": {
+      "accessKey": "MY_ACCESS_KEY",
+      "secretKey": "***",
+      "bucketName": "my-finops-export",
+      "endpointURL": "s3.gra.io.cloud.ovh.net",
+      "region": "gra",
+      "pathPrefix": "./"
+    }
+  },
+  "currentState": { "...": "même structure que targetSpec" },
+  "currentTasks": [
+    {
+      "id": "5a1b...",
+      "type": "CREATE_BUCKET_EXPORT",
+      "status": "PENDING",
+      "link": "/finops/bucketExport/f556df9c-a52e-4bc1-8895-e3589cbba0be"
+    }
+  ]
+}
+```
+
+## Étape 2 — Suivre le provisionnement jusqu'à ce qu'il soit prêt
+
+La création est asynchrone. Interrogez la ressource par son `id` jusqu'à ce que
+`resourceStatus` ne soit plus `CREATING` :
+
+<Api version="v2" section="/finops" method="GET" route={"/finops/bucketExport/\{id\}"} />
+
+```bash
+curl "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e3589cbba0be" \
+  -H "Authorization: Bearer $OVH_API_TOKEN"
+```
+
+- **`READY`** — OVHcloud a joint votre bucket et la configuration est active. La prochaine
+  exécution quotidienne téléversera vos données.
+- **`ERROR`** — la validation a échoué (le plus souvent, OVHcloud n'a pas pu joindre votre
+  bucket avec les identifiants que vous avez fournis). Voir [Erreurs fréquentes](#frequent-errors).
+
+### Inspecter le détail du provisionnement
+
+Deux sous-ressources en lecture seule vous permettent de voir exactement ce qui s'est passé.
+
+Listez les tâches (les unités de travail exécutées par OVHcloud, y compris celles terminées) :
+
+<Api version="v2" section="/finops" method="GET" route={"/finops/bucketExport/\{id\}/task"} />
+
+```bash
+curl "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e3589cbba0be/task" \
+  -H "Authorization: Bearer $OVH_API_TOKEN"
+```
+
+Listez les événements du cycle de vie (une chronologie lisible) :
+
+<Api version="v2" section="/finops" method="GET" route={"/finops/bucketExport/\{id\}/event"} />
+
+```bash
+curl "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e3589cbba0be/event" \
+  -H "Authorization: Bearer $OVH_API_TOKEN"
+```
+
+Une tâche comporte un tableau `errors` ; lorsqu'un test de connexion échoue, son message
+vous en indique la raison.
+
+## Étape 3 — Récupérer vos fichiers exportés
+
+Une fois la configuration en `READY`, OVHcloud téléverse un fichier CSV dans votre bucket
+**une fois par jour, à l'`exportHour` que vous avez définie (UTC)**.
+
+- **Contenu** : vos données de facturation converties au standard **FOCUS 1.3**, au format CSV.
+- **Fenêtre** : chaque exécution couvre le **mois calendaire en cours jusqu'à cet instant**
+  (du 1er du mois à maintenant). Le fichier grossit donc au fil du mois à mesure qu'OVHcloud
+  ingère de nouvelles données de facturation.
+
+### Disposition des fichiers dans votre bucket <a name="file-layout-in-your-bucket"></a>
+
+La clé d'objet dépend de votre `filePolicy` :
+
+| `filePolicy` | Clé d'objet | Comportement |
+|--------------|-------------|--------------|
+| `CREATE` (par défaut) | `[<pathPrefix>/]<nichandle>/<YYYY>/<MM>/<DD>/focus.csv` | Un **nouveau fichier daté chaque jour** ; OVHcloud conserve les jours précédents. |
+| `REPLACE` | `[<pathPrefix>/]<nichandle>/<YYYY>/<MM>/focus.csv` | Un **seul fichier par mois**, qu'OVHcloud écrase à chaque exécution. |
+
+Un `pathPrefix` égal à `"./"` écrit à la **racine du bucket** (aucun dossier supplémentaire).
+Par exemple, avec `pathPrefix: "./"` et la politique `CREATE` par défaut, vos données du
+15 juin 2026 arrivent à :
+
+```
+<your-nichandle>/2026/06/15/focus.csv
+```
+
+## Gérer une configuration existante
+
+### La modifier <a name="update-it"></a>
+
+Envoyez un `PUT` à `/finops/bucketExport/{id}` avec le `targetSpec` **complet** souhaité
+(la nouvelle spécification remplace intégralement la précédente). Comme pour la création,
+OVHcloud valide la modification de manière asynchrone : la réponse revient avec le statut
+`UPDATING`, et vous interrogez la ressource jusqu'à `READY`.
+
+<Api version="v2" section="/finops" method="PUT" route={"/finops/bucketExport/\{id\}"} />
+
+```bash
+curl -X PUT "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e3589cbba0be" \
+  -H "Authorization: Bearer $OVH_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "targetSpec": {
+      "exportHour": 8,
+      "filePolicy": "CREATE",
+      "bucketConfiguration": {
+        "accessKey": "MY_ACCESS_KEY",
+        "secretKey": "MY_SECRET_KEY",
+        "bucketName": "my-finops-export",
+        "endpointURL": "s3.gra.io.cloud.ovh.net",
+        "region": "gra",
+        "pathPrefix": "./"
+      }
+    }
+  }'
+```
+
+> Pendant qu'OVHcloud valide une modification, la réponse conserve votre configuration
+> **précédente** dans `currentState` et affiche la configuration **demandée** dans
+> `targetSpec`. OVHcloud ne modifie pas votre export actif tant que la nouvelle
+> configuration n'a pas atteint `READY`. Si la validation échoue, la ressource passe à
+> `ERROR` et la configuration précédente reste en vigueur.
+
+### Lister vos configurations
+
+<Api version="v2" section="/finops" method="GET" route={"/finops/bucketExport"} />
+
+```bash
+curl "https://eu.api.ovh.com/v2/finops/bucketExport" \
+  -H "Authorization: Bearer $OVH_API_TOKEN"
+```
+
+La liste est paginée. Lorsque d'autres résultats sont disponibles, la réponse comporte un
+en-tête `X-Pagination-Cursor-Next` ; renvoyez-le dans l'en-tête `X-Pagination-Cursor` pour
+récupérer la page suivante.
+
+### La supprimer
+
+<Api version="v2" section="/finops" method="DELETE" route={"/finops/bucketExport/\{id\}"} />
+
+```bash
+curl -X DELETE "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e3589cbba0be" \
+  -H "Authorization: Bearer $OVH_API_TOKEN"
+```
+
+La suppression arrête l'export quotidien. OVHcloud ne supprime **pas** les fichiers déjà
+écrits dans votre bucket.
+
+## Référence : valeurs de statut de la ressource
+
+| Statut | Signification |
+|--------|---------------|
+| `CREATING` | OVHcloud a accepté la configuration et la valide. |
+| `UPDATING` | OVHcloud a accepté une modification et la valide. |
+| `READY` | La configuration est valide et active ; les exports quotidiens s'exécutent. |
+| `ERROR` | La dernière création ou modification a échoué à la validation (par exemple, bucket injoignable). |
+| `DELETING` | OVHcloud supprime la configuration. |
+
+## Erreurs fréquentes <a name="frequent-errors"></a>
+
+La plupart des échecs se manifestent par une ressource bloquée en **`ERROR`** après une
+création ou une modification, car OVHcloud valide la configuration en se connectant
+réellement à votre bucket. Commencez toujours par lire les `errors` de la tâche (Étape 2) —
+le message en indique la cause. Les plus courantes :
+
+| Symptôme | Cause probable | Comment corriger |
+|----------|----------------|------------------|
+| Le statut passe à `ERROR` juste après la création/modification | **Un schéma dans `endpointURL`** — la valeur contient `http://`, `https://` ou `s3://`. Le endpoint doit être un **hôte nu** (par exemple `s3.gra.io.cloud.ovh.net`) ; tout schéma fait échouer la connexion. | Retirez le schéma et ne conservez que l'hôte. Les connexions utilisent toujours le HTTPS. |
+| Le statut passe à `ERROR`, le message mentionne un accès refusé / une signature / un « forbidden » | **Identifiants incorrects ou insuffisants** — la clé d'accès ou la clé secrète est erronée, ou les identifiants n'ont pas d'accès en écriture au bucket. | Revérifiez la **clé d'accès** et la **clé secrète**, et confirmez qu'elles peuvent écrire dans le bucket. OVHcloud ne renvoie jamais la clé secrète : renvoyez-la donc en entier lors du `PUT` de correction. |
+| Le statut passe à `ERROR`, le message mentionne le bucket | **`bucketName` ou `region` incorrects**, ou le bucket n'existe pas / n'est pas joignable. | Vérifiez le nom du bucket et la région, ainsi que l'existence du bucket pour ces identifiants. |
+| `404 Not Found` sur un `id` de configuration | La configuration n'existe pas, ou elle appartient à un autre compte. | Vérifiez l'`id` et que vous vous authentifiez avec le compte qui le possède. |
+| Aucun fichier n'apparaît dans le bucket | L'exécution quotidienne n'a pas encore eu lieu, ou le statut n'est pas `READY`. | L'export s'exécute une fois par jour à `exportHour` (UTC) ; confirmez que la ressource est en `READY` et attendez la prochaine exécution. |
+| `400 Bad Request` à la création/modification | Un champ requis est manquant (`accessKey`, `secretKey`) ou le corps ne contient pas de `targetSpec`. | Envoyez un `targetSpec` complet, y compris les identifiants du bucket. |
+
+> Après avoir corrigé une configuration en `ERROR`, envoyez un `PUT` corrigé (voir
+> [La modifier](#update-it)) et interrogez à nouveau la ressource jusqu'à ce qu'elle
+> atteigne `READY`. La configuration précédente reste en vigueur jusqu'à ce qu'OVHcloud
+> valide la nouvelle.
+
+## Pour aller plus loin
+
+- Le fichier exporté suit le [standard CSV FOCUS 1.3](https://focus.finops.org) — reportez-vous à la spécification officielle FOCUS pour interpréter chaque colonne.
+- Rejoignez notre [communauté Discord](https://discord.gg/ovhcloud) pour poser vos questions et partager vos retours.
+
+---
+
+<sup>*</sup> S3 est une marque déposée par Amazon Technologies, Inc. Le service d'OVHcloud
+n'est pas sponsorisé, approuvé, ni affilié de quelque manière que ce soit à Amazon
+Technologies, Inc.

--- a/docs/fr/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
+++ b/docs/fr/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
@@ -1,64 +1,49 @@
 ---
 title: Exporter vos données de facturation vers un bucket
-description: Configurez, via l'API OVHcloud, un export quotidien de vos données de facturation — au format FOCUS — vers un bucket compatible S3™ que vous possédez.
-lastUpdated: 2026-06-24
+description: Découvrez comment configurer un export quotidien de vos données de facturation — au format FOCUS — vers un bucket compatible S3 que vous possédez, via l'API OVHcloud
+lastUpdated: 2026-07-21
 ---
 
 import Api from '@components/Api';
 
 ## Objectif
 
-OVHcloud peut transmettre vos données de facturation, converties au standard ouvert
-**FOCUS**, vers un bucket de stockage objet compatible S3™<sup>*</sup> que **vous** possédez. Une fois
-configuré, l'export s'exécute **automatiquement chaque jour** : aucun téléchargement
-manuel, aucun clic dans l'espace client — vos données arrivent dans votre bucket sous forme
-de fichier CSV, prêt pour vos outils FinOps.
+OVHcloud peut transmettre vos données de facturation, converties au standard ouvert **FOCUS**, vers un bucket de stockage objet compatible S3<sup>1</sup> que **vous** possédez. Une fois configuré, l'export s'exécute **automatiquement chaque jour** : aucun téléchargement manuel, aucun clic dans l'espace client — vos données arrivent dans votre bucket sous forme de fichier CSV, prêt pour vos outils FinOps.
 
 **Ce guide vous explique comment créer, suivre, modifier et supprimer cette configuration d'export via l'API OVHcloud.**
 
-> Cette page couvre uniquement la **configuration de l'export vers un bucket**. Elle ne
-> traite pas de la lecture des colonnes exportées ni du standard FOCUS lui-même.
+:::info
+Cette page couvre uniquement la **configuration de l'export vers un bucket**. Elle ne traite pas de la lecture des colonnes exportées ni du standard FOCUS lui-même.
+:::
 
 ## Prérequis
 
-- Un compte OVHcloud actif disposant de données de facturation.
-- Un **jeton d'authentification API OVHcloud valide** disposant de la permission d'appeler
-  les routes `/finops`. Toutes les requêtes ci-dessous doivent être authentifiées ; les
-  exemples présentent le jeton sous la forme `$OVH_API_TOKEN`.
-- Un **bucket compatible S3™<sup>*</sup>** dans lequel vous pouvez écrire, ainsi qu'un couple
-  d'identifiants pour celui-ci :
-  - une **clé d'accès** (access key) et une **clé secrète** (secret key),
-  - l'**hôte du endpoint** du bucket (un nom d'hôte **sans** schéma `http://` / `https://` / `s3://`,
-    par exemple `s3.gra.io.cloud.ovh.net`) et sa **région**.
+- Disposer d'un compte OVHcloud actif avec des données de facturation.
+- Disposer d'un **jeton d'authentification API OVHcloud valide** ayant la permission d'appeler les routes `/finops`. Si besoin, consultez le guide « [Premiers pas avec les API OVHcloud](/guides/manage-and-operate/api/first-steps) » pour en créer un. Toutes les requêtes ci-dessous doivent être authentifiées ; les exemples présentent le jeton sous la forme `$OVH_API_TOKEN`.
+- Disposer d'un **bucket compatible S3** dans lequel vous pouvez écrire, ainsi que d'un couple d'identifiants pour celui-ci :
+    - une **clé d'accès** (access key) et une **clé secrète** (secret key),
+    - l'**hôte de l'endpoint** du bucket (un nom d'hôte **sans** schéma `http://` / `https://` / `s3://`, par exemple `s3.gra.io.cloud.ovh.net`) et sa **région**.
 
-> Les connexions à votre bucket utilisent toujours le **HTTPS** — ne préfixez pas le
-> endpoint avec un schéma. Voir [Erreurs fréquentes](#frequent-errors).
+:::warning
+Les connexions à votre bucket utilisent toujours le **HTTPS** — ne faites pas précéder l'endpoint d'un schéma. Consultez la section « [Erreurs fréquentes](#frequent-errors) ».
+:::
 
-> L'export fonctionne avec n'importe quel bucket compatible S3™<sup>*</sup> — il n'est pas nécessaire
-> qu'il s'agisse d'OVHcloud Object Storage. Vous fournissez le endpoint, la région et les
-> identifiants ; OVHcloud y écrit.
+:::info
+L'export fonctionne avec n'importe quel bucket compatible S3 — il n'est pas nécessaire qu'il s'agisse d'OVHcloud Object Storage. Vous fournissez l'endpoint, la région et les identifiants ; OVHcloud y écrit.
+:::
 
-## Fonctionnement de l'export, en bref
+## Fonctionnement de l'export
 
-La configuration est une **ressource déclarative**. Vous décrivez la *cible* souhaitée
-(votre bucket, l'heure quotidienne, la politique de fichier) et OVHcloud converge vers
-celle-ci :
+La configuration est une **ressource déclarative**. Vous décrivez la *cible* souhaitée (votre bucket, l'heure quotidienne, la politique de fichier) et OVHcloud converge vers celle-ci :
 
 1. Vous **créez** la configuration avec les informations du bucket (`POST`).
-2. OVHcloud la **valide** en se connectant réellement à votre bucket et en vérifiant qu'il
-   est accessible avec les identifiants que vous avez fournis.
-3. Lorsque la validation réussit, la ressource passe à l'état **`READY`** ; si OVHcloud ne
-   parvient pas à joindre votre bucket, elle passe à **`ERROR`**.
-4. Chaque jour, à l'**heure que vous avez choisie**, OVHcloud régénère vos données pour le
-   mois en cours et téléverse le fichier dans votre bucket.
+2. OVHcloud la **valide** en se connectant réellement à votre bucket et en vérifiant qu'il est accessible avec les identifiants que vous avez fournis.
+3. Lorsque la validation réussit, la ressource passe à l'état **`READY`** ; si OVHcloud ne parvient pas à joindre votre bucket, elle passe à **`ERROR`**.
+4. Chaque jour, à l'**heure que vous avez choisie**, OVHcloud régénère vos données pour le mois en cours et téléverse le fichier dans votre bucket.
 
-Comme la validation implique un véritable test de connexion, OVHcloud traite la création et
-les modifications de manière **asynchrone** : l'API répond immédiatement avec un statut
-`CREATING` (ou `UPDATING`), et vous **interrogez** (poll) la ressource jusqu'à ce qu'elle
-atteigne `READY`.
+Comme la validation implique un véritable test de connexion, OVHcloud traite la création et les modifications de manière **asynchrone** : l'API répond immédiatement avec un statut `CREATING` (ou `UPDATING`), et vous **interrogez** (poll) la ressource jusqu'à ce qu'elle atteigne `READY`.
 
-Tous les exemples utilisent le endpoint API européen d'OVHcloud `https://eu.api.ovh.com/v2`.
-Si votre compte est hébergé dans une autre région, utilisez le endpoint API de votre région.
+Tous les exemples utilisent l'endpoint API européen d'OVHcloud `https://eu.api.ovh.com/v2`. Si votre compte est hébergé dans une autre région, utilisez l'endpoint API de votre région (par exemple `https://ca.api.ovh.com/v2` pour le Canada).
 
 ## Étape 1 — Créer la configuration d'export
 
@@ -66,8 +51,9 @@ Envoyez un `POST` à `/finops/bucketExport` avec la spécification de votre cibl
 
 <Api version="v2" section="/finops" method="POST" route={"/finops/bucketExport"} />
 
-> **Vous préférez une interface graphique ?** La console API ci-dessus construit et signe
-> la requête à votre place — les exemples `curl` ci-dessous montrent l'appel brut équivalent.
+:::tip
+**Vous préférez une interface graphique ?** La console API ci-dessus construit et signe la requête à votre place — les exemples `curl` ci-dessous montrent l'appel brut équivalent.
+:::
 
 ```bash
 curl -X POST "https://eu.api.ovh.com/v2/finops/bucketExport" \
@@ -89,31 +75,30 @@ curl -X POST "https://eu.api.ovh.com/v2/finops/bucketExport" \
   }'
 ```
 
-> Les valeurs `endpointURL` et `region` ci-dessus utilisent celles d'OVHcloud Object Storage
-> à titre d'exemple. Remplacez-les par l'hôte du endpoint (sans schéma) et la région de
-> votre propre fournisseur compatible S3™<sup>*</sup>.
+:::info
+Les valeurs `endpointURL` et `region` ci-dessus utilisent celles d'OVHcloud Object Storage à titre d'exemple. Remplacez-les par l'hôte de l'endpoint (sans schéma) et la région de votre propre fournisseur compatible S3.
+:::
 
 ### Champs de `targetSpec`
 
 | Champ | Requis | Description |
 |-------|--------|-------------|
 | `exportHour` | **Oui** | Heure de la journée, `0`–`23` (UTC), à laquelle l'export quotidien s'exécute. |
-| `filePolicy` | Non | `CREATE` (par défaut) conserve un fichier par jour ; `REPLACE` conserve un seul fichier par mois, écrasé à chaque exécution. Voir [Disposition des fichiers](#file-layout-in-your-bucket). |
+| `filePolicy` | Non | `CREATE` (par défaut) conserve un fichier par jour ; `REPLACE` conserve un seul fichier par mois, écrasé à chaque exécution. Voir [Disposition des fichiers](#file-layout-in-your-bucket). |
 | `bucketConfiguration.accessKey` | **Oui** | Clé d'accès de votre bucket. |
 | `bucketConfiguration.secretKey` | **Oui** | Clé secrète de votre bucket. |
 | `bucketConfiguration.bucketName` | Non | Nom du bucket cible. |
-| `bucketConfiguration.endpointURL` | Non | L'**hôte seul** du endpoint de votre bucket, sans aucun schéma (par exemple `s3.gra.io.cloud.ovh.net`, et **non** `https://s3.gra.io.cloud.ovh.net` ni `s3://s3.gra.io.cloud.ovh.net`). Les connexions utilisent toujours le HTTPS. |
+| `bucketConfiguration.endpointURL` | Non | L'**hôte seul** de l'endpoint de votre bucket, sans aucun schéma (par exemple `s3.gra.io.cloud.ovh.net`, et **non** `https://s3.gra.io.cloud.ovh.net` ni `s3://s3.gra.io.cloud.ovh.net`). Les connexions utilisent toujours le HTTPS. |
 | `bucketConfiguration.region` | Non | Code de région / d'emplacement de votre bucket. |
 | `bucketConfiguration.pathPrefix` | Non | Préfixe ajouté devant chaque clé d'objet écrite. Utilisez `"./"` pour écrire à la racine du bucket (recommandé). |
 
-> Votre **clé secrète est en écriture seule** : OVHcloud la chiffre à la réception et ne la
-> **renvoie jamais**. Dans chaque réponse, le champ `secretKey` est masqué par `"***"`,
-> tandis qu'OVHcloud renvoie la clé d'accès en clair.
+:::warning
+Votre **clé secrète est en écriture seule** : OVHcloud la chiffre à la réception et ne la **renvoie jamais**. Dans chaque réponse, le champ `secretKey` est masqué par `"***"`, tandis qu'OVHcloud renvoie la clé d'accès en clair.
+:::
 
 ### La réponse
 
-L'API répond `201 Created` avec la ressource. Notez l'`id` (vous l'utiliserez pour suivre
-et gérer la configuration) et le `resourceStatus`, qui démarre à `CREATING` :
+L'API répond `201 Created` avec la ressource. Notez l'`id` (vous l'utiliserez pour suivre et gérer la configuration) et le `resourceStatus`, qui démarre à `CREATING` :
 
 ```json
 {
@@ -146,8 +131,7 @@ et gérer la configuration) et le `resourceStatus`, qui démarre à `CREATING` :
 
 ## Étape 2 — Suivre le provisionnement jusqu'à ce qu'il soit prêt
 
-La création est asynchrone. Interrogez la ressource par son `id` jusqu'à ce que
-`resourceStatus` ne soit plus `CREATING` :
+La création est asynchrone. Interrogez la ressource par son `id` jusqu'à ce que `resourceStatus` ne soit plus `CREATING` :
 
 <Api version="v2" section="/finops" method="GET" route={"/finops/bucketExport/\{id\}"} />
 
@@ -156,16 +140,14 @@ curl "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e358
   -H "Authorization: Bearer $OVH_API_TOKEN"
 ```
 
-- **`READY`** — OVHcloud a joint votre bucket et la configuration est active. La prochaine
-  exécution quotidienne téléversera vos données.
-- **`ERROR`** — la validation a échoué (le plus souvent, OVHcloud n'a pas pu joindre votre
-  bucket avec les identifiants que vous avez fournis). Voir [Erreurs fréquentes](#frequent-errors).
+- **`READY`** — OVHcloud a joint votre bucket et la configuration est active. La prochaine exécution quotidienne téléversera vos données.
+- **`ERROR`** — la validation a échoué (le plus souvent, OVHcloud n'a pas pu joindre votre bucket avec les identifiants que vous avez fournis). Consultez la section « [Erreurs fréquentes](#frequent-errors) ».
 
 ### Inspecter le détail du provisionnement
 
 Deux sous-ressources en lecture seule vous permettent de voir exactement ce qui s'est passé.
 
-Listez les tâches (les unités de travail exécutées par OVHcloud, y compris celles terminées) :
+Listez les tâches (les unités de travail exécutées par OVHcloud, y compris celles terminées) :
 
 <Api version="v2" section="/finops" method="GET" route={"/finops/bucketExport/\{id\}/task"} />
 
@@ -174,7 +156,7 @@ curl "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e358
   -H "Authorization: Bearer $OVH_API_TOKEN"
 ```
 
-Listez les événements du cycle de vie (une chronologie lisible) :
+Listez les événements du cycle de vie (une chronologie lisible) :
 
 <Api version="v2" section="/finops" method="GET" route={"/finops/bucketExport/\{id\}/event"} />
 
@@ -183,33 +165,27 @@ curl "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-8895-e358
   -H "Authorization: Bearer $OVH_API_TOKEN"
 ```
 
-Une tâche comporte un tableau `errors` ; lorsqu'un test de connexion échoue, son message
-vous en indique la raison.
+Une tâche comporte un tableau `errors` ; lorsqu'un test de connexion échoue, son message vous en indique la raison.
 
 ## Étape 3 — Récupérer vos fichiers exportés
 
-Une fois la configuration en `READY`, OVHcloud téléverse un fichier CSV dans votre bucket
-**une fois par jour, à l'`exportHour` que vous avez définie (UTC)**.
+Une fois la configuration en `READY`, OVHcloud téléverse un fichier CSV dans votre bucket **une fois par jour, à l'`exportHour` que vous avez définie (UTC)**.
 
-- **Contenu** : vos données de facturation converties au standard **FOCUS 1.3**, au format CSV.
-- **Fenêtre** : chaque exécution couvre le **mois calendaire en cours jusqu'à cet instant**
-  (du 1er du mois à maintenant). Le fichier grossit donc au fil du mois à mesure qu'OVHcloud
-  ingère de nouvelles données de facturation.
+- **Contenu** : vos données de facturation converties au standard **FOCUS 1.3**, au format CSV.
+- **Fenêtre** : chaque exécution couvre le **mois calendaire en cours jusqu'à cet instant** (du 1er du mois à maintenant). Le fichier grossit donc au fil du mois à mesure qu'OVHcloud ingère de nouvelles données de facturation.
 
 ### Disposition des fichiers dans votre bucket <a name="file-layout-in-your-bucket"></a>
 
-La clé d'objet dépend de votre `filePolicy` :
+La clé d'objet dépend de votre `filePolicy` :
 
 | `filePolicy` | Clé d'objet | Comportement |
 |--------------|-------------|--------------|
-| `CREATE` (par défaut) | `[<pathPrefix>/]<nichandle>/<YYYY>/<MM>/<DD>/focus.csv` | Un **nouveau fichier daté chaque jour** ; OVHcloud conserve les jours précédents. |
+| `CREATE` (par défaut) | `[<pathPrefix>/]<nichandle>/<YYYY>/<MM>/<DD>/focus.csv` | Un **nouveau fichier daté chaque jour** ; OVHcloud conserve les jours précédents. |
 | `REPLACE` | `[<pathPrefix>/]<nichandle>/<YYYY>/<MM>/focus.csv` | Un **seul fichier par mois**, qu'OVHcloud écrase à chaque exécution. |
 
-Un `pathPrefix` égal à `"./"` écrit à la **racine du bucket** (aucun dossier supplémentaire).
-Par exemple, avec `pathPrefix: "./"` et la politique `CREATE` par défaut, vos données du
-15 juin 2026 arrivent à :
+Un `pathPrefix` égal à `"./"` écrit à la **racine du bucket** (aucun dossier supplémentaire). Par exemple, avec `pathPrefix: "./"` et la politique `CREATE` par défaut, vos données du 15 juin 2026 arrivent à :
 
-```
+```text
 <your-nichandle>/2026/06/15/focus.csv
 ```
 
@@ -217,10 +193,7 @@ Par exemple, avec `pathPrefix: "./"` et la politique `CREATE` par défaut, vos d
 
 ### La modifier <a name="update-it"></a>
 
-Envoyez un `PUT` à `/finops/bucketExport/{id}` avec le `targetSpec` **complet** souhaité
-(la nouvelle spécification remplace intégralement la précédente). Comme pour la création,
-OVHcloud valide la modification de manière asynchrone : la réponse revient avec le statut
-`UPDATING`, et vous interrogez la ressource jusqu'à `READY`.
+Envoyez un `PUT` à `/finops/bucketExport/{id}` avec le `targetSpec` **complet** souhaité (la nouvelle spécification remplace intégralement la précédente). Comme pour la création, OVHcloud valide la modification de manière asynchrone : la réponse revient avec le statut `UPDATING`, et vous interrogez la ressource jusqu'à `READY`.
 
 <Api version="v2" section="/finops" method="PUT" route={"/finops/bucketExport/\{id\}"} />
 
@@ -244,11 +217,9 @@ curl -X PUT "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1-88
   }'
 ```
 
-> Pendant qu'OVHcloud valide une modification, la réponse conserve votre configuration
-> **précédente** dans `currentState` et affiche la configuration **demandée** dans
-> `targetSpec`. OVHcloud ne modifie pas votre export actif tant que la nouvelle
-> configuration n'a pas atteint `READY`. Si la validation échoue, la ressource passe à
-> `ERROR` et la configuration précédente reste en vigueur.
+:::info
+Pendant qu'OVHcloud valide une modification, la réponse conserve votre configuration **précédente** dans `currentState` et affiche la configuration **demandée** dans `targetSpec`. OVHcloud ne modifie pas votre export actif tant que la nouvelle configuration n'a pas atteint `READY`. Si la validation échoue, la ressource passe à `ERROR` et la configuration précédente reste en vigueur.
+:::
 
 ### Lister vos configurations
 
@@ -259,9 +230,7 @@ curl "https://eu.api.ovh.com/v2/finops/bucketExport" \
   -H "Authorization: Bearer $OVH_API_TOKEN"
 ```
 
-La liste est paginée. Lorsque d'autres résultats sont disponibles, la réponse comporte un
-en-tête `X-Pagination-Cursor-Next` ; renvoyez-le dans l'en-tête `X-Pagination-Cursor` pour
-récupérer la page suivante.
+La liste est paginée. Lorsque d'autres résultats sont disponibles, la réponse comporte un en-tête `X-Pagination-Cursor-Next` ; renvoyez-le dans l'en-tête `X-Pagination-Cursor` pour récupérer la page suivante.
 
 ### La supprimer
 
@@ -272,47 +241,39 @@ curl -X DELETE "https://eu.api.ovh.com/v2/finops/bucketExport/f556df9c-a52e-4bc1
   -H "Authorization: Bearer $OVH_API_TOKEN"
 ```
 
-La suppression arrête l'export quotidien. OVHcloud ne supprime **pas** les fichiers déjà
-écrits dans votre bucket.
+La suppression arrête l'export quotidien. OVHcloud ne supprime **pas** les fichiers déjà écrits dans votre bucket.
 
-## Référence : valeurs de statut de la ressource
+## Référence : valeurs de statut de la ressource
 
 | Statut | Signification |
 |--------|---------------|
 | `CREATING` | OVHcloud a accepté la configuration et la valide. |
 | `UPDATING` | OVHcloud a accepté une modification et la valide. |
-| `READY` | La configuration est valide et active ; les exports quotidiens s'exécutent. |
+| `READY` | La configuration est valide et active ; les exports quotidiens s'exécutent. |
 | `ERROR` | La dernière création ou modification a échoué à la validation (par exemple, bucket injoignable). |
 | `DELETING` | OVHcloud supprime la configuration. |
 
 ## Erreurs fréquentes <a name="frequent-errors"></a>
 
-La plupart des échecs se manifestent par une ressource bloquée en **`ERROR`** après une
-création ou une modification, car OVHcloud valide la configuration en se connectant
-réellement à votre bucket. Commencez toujours par lire les `errors` de la tâche (Étape 2) —
-le message en indique la cause. Les plus courantes :
+La plupart des échecs se manifestent par une ressource bloquée en **`ERROR`** après une création ou une modification, car OVHcloud valide la configuration en se connectant réellement à votre bucket. Commencez toujours par lire les `errors` de la tâche (Étape 2) — le message en indique la cause. Les plus courantes :
 
 | Symptôme | Cause probable | Comment corriger |
 |----------|----------------|------------------|
-| Le statut passe à `ERROR` juste après la création/modification | **Un schéma dans `endpointURL`** — la valeur contient `http://`, `https://` ou `s3://`. Le endpoint doit être un **hôte nu** (par exemple `s3.gra.io.cloud.ovh.net`) ; tout schéma fait échouer la connexion. | Retirez le schéma et ne conservez que l'hôte. Les connexions utilisent toujours le HTTPS. |
-| Le statut passe à `ERROR`, le message mentionne un accès refusé / une signature / un « forbidden » | **Identifiants incorrects ou insuffisants** — la clé d'accès ou la clé secrète est erronée, ou les identifiants n'ont pas d'accès en écriture au bucket. | Revérifiez la **clé d'accès** et la **clé secrète**, et confirmez qu'elles peuvent écrire dans le bucket. OVHcloud ne renvoie jamais la clé secrète : renvoyez-la donc en entier lors du `PUT` de correction. |
+| Le statut passe à `ERROR` juste après la création/modification | **Un schéma dans `endpointURL`** — la valeur contient `http://`, `https://` ou `s3://`. Le endpoint doit être un **hôte nu** (par exemple `s3.gra.io.cloud.ovh.net`) ; tout schéma fait échouer la connexion. | Retirez le schéma et ne conservez que l'hôte. Les connexions utilisent toujours le HTTPS. |
+| Le statut passe à `ERROR`, le message mentionne un accès refusé / une signature / un « forbidden » | **Identifiants incorrects ou insuffisants** — la clé d'accès ou la clé secrète est erronée, ou les identifiants n'ont pas d'accès en écriture au bucket. | Revérifiez la **clé d'accès** et la **clé secrète**, et confirmez qu'elles peuvent écrire dans le bucket. OVHcloud ne renvoie jamais la clé secrète : renvoyez-la donc en entier lors du `PUT` de correction. |
 | Le statut passe à `ERROR`, le message mentionne le bucket | **`bucketName` ou `region` incorrects**, ou le bucket n'existe pas / n'est pas joignable. | Vérifiez le nom du bucket et la région, ainsi que l'existence du bucket pour ces identifiants. |
 | `404 Not Found` sur un `id` de configuration | La configuration n'existe pas, ou elle appartient à un autre compte. | Vérifiez l'`id` et que vous vous authentifiez avec le compte qui le possède. |
-| Aucun fichier n'apparaît dans le bucket | L'exécution quotidienne n'a pas encore eu lieu, ou le statut n'est pas `READY`. | L'export s'exécute une fois par jour à `exportHour` (UTC) ; confirmez que la ressource est en `READY` et attendez la prochaine exécution. |
+| Aucun fichier n'apparaît dans le bucket | L'exécution quotidienne n'a pas encore eu lieu, ou le statut n'est pas `READY`. | L'export s'exécute une fois par jour à `exportHour` (UTC) ; confirmez que la ressource est en `READY` et attendez la prochaine exécution. |
 | `400 Bad Request` à la création/modification | Un champ requis est manquant (`accessKey`, `secretKey`) ou le corps ne contient pas de `targetSpec`. | Envoyez un `targetSpec` complet, y compris les identifiants du bucket. |
 
-> Après avoir corrigé une configuration en `ERROR`, envoyez un `PUT` corrigé (voir
-> [La modifier](#update-it)) et interrogez à nouveau la ressource jusqu'à ce qu'elle
-> atteigne `READY`. La configuration précédente reste en vigueur jusqu'à ce qu'OVHcloud
-> valide la nouvelle.
+:::info
+Après avoir corrigé une configuration en `ERROR`, envoyez un `PUT` corrigé (voir [La modifier](#update-it)) et interrogez à nouveau la ressource jusqu'à ce qu'elle atteigne `READY`. La configuration précédente reste en vigueur jusqu'à ce qu'OVHcloud valide la nouvelle.
+:::
 
-## Pour aller plus loin
+## Aller plus loin
 
-- Le fichier exporté suit le [standard CSV FOCUS 1.3](https://focus.finops.org) — reportez-vous à la spécification officielle FOCUS pour interpréter chaque colonne.
-- Rejoignez notre [communauté Discord](https://discord.gg/ovhcloud) pour poser vos questions et partager vos retours.
+Le fichier exporté suit le [standard CSV FOCUS 1.3](https://focus.finops.org) — reportez-vous à la spécification officielle FOCUS pour interpréter chaque colonne.
 
----
+Rejoignez notre [communauté Discord](https://discord.gg/ovhcloud) pour poser vos questions et partager vos retours.
 
-<sup>*</sup> S3 est une marque déposée par Amazon Technologies, Inc. Le service d'OVHcloud
-n'est pas sponsorisé, approuvé, ni affilié de quelque manière que ce soit à Amazon
-Technologies, Inc.
+<sup>1</sup> : S3 est une marque déposée d'Amazon Technologies, Inc. Le service d'OVHcloud n'est ni sponsorisé, ni approuvé, ni affilié de quelque manière que ce soit à Amazon Technologies, Inc.

--- a/docs/it/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
+++ b/docs/it/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx

--- a/docs/pl/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
+++ b/docs/pl/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx

--- a/docs/pt/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
+++ b/docs/pt/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/account-and-service-management/finops/export-billing-data-to-bucket.mdx

--- a/i18n.json
+++ b/i18n.json
@@ -6650,6 +6650,15 @@
     "pl": "Tworzenie i zarządzanie użytkownikami",
     "pt": "Criação e gestão de utilizadores"
   },
+  "sidebar.gen.accountAndServiceManagementFinops": {
+    "fr": "FinOps",
+    "en": "FinOps",
+    "de": "FinOps",
+    "es": "FinOps",
+    "it": "FinOps",
+    "pl": "FinOps",
+    "pt": "FinOps"
+  },
   "sidebar.gen.accountAndServiceManagementManagingBillingPaymentsAndServices": {
     "fr": "Gérer la facturation, les paiements et les services",
     "en": "Managing billing, payments and services",


### PR DESCRIPTION
Add a how-to guide for configuring a daily FOCUS-format export of billing data to an S3-compatible bucket through the OVHcloud API, in French and English. Introduce a new "FinOps" product under Account and Service Management in the sidebar and seed its i18n label.