### PR TITLE
feat(build): serve guide body before nav for AI retrievability

### DIFF
--- a/scripts/check-retrievability.ts
+++ b/scripts/check-retrievability.ts
@@ -14,12 +14,18 @@
  * For a SAMPLE of built guides (auto-discovered per locale), it asserts:
  *   1. A substantial run of body prose is present in the built `.html`
  *      (raw, no JS) — proves the body is server-rendered.
- *   2. The same prose is present in the sibling `.md` file — proves the
+ *   2. That body appears BEFORE the sidebar tree in SOURCE ORDER, within a byte
+ *      budget — proves a top-down, size-bounded fetcher (the paste-a-URL agent
+ *      case) reaches content, not just that content exists somewhere after the
+ *      ~1.2MB nav. This is the assertion that actually guards the body-first
+ *      reorder; an "exists somewhere" check passes on a page that fails in
+ *      practice.
+ *   3. The same prose is present in the sibling `.md` file — proves the
  *      machine-readable markdown endpoint carries real content.
- *   3. The `<link rel="alternate" type="text/markdown">` hint is in the
+ *   4. The `<link rel="alternate" type="text/markdown">` hint is in the
  *      `<head>` — proves agents can discover the clean `.md` before the payload
  *      is truncated by size.
- *   4. Root `/llms.txt` and each sampled locale's `/<locale>/llms.txt` exist.
+ *   5. Root `/llms.txt` and each sampled locale's `/<locale>/llms.txt` exist.
  *
  * Exit code 0 = all assertions pass. Non-zero = at least one failed (CI red).
  *
@@ -46,6 +52,11 @@ const DIST_DIR = path.resolve(process.argv[2] ?? 'dist');
 // check fast; the failure mode is systemic (whole build regresses), so a
 // handful per locale reliably catches it.
 const SAMPLE_PER_LOCALE = Number(process.env.SAMPLE_PER_LOCALE ?? '8');
+// Max byte offset at which a size-bounded, JS-free fetcher must find the start
+// of the article body. Generous — the reorder puts content at ~14KB; this
+// leaves headroom for <head> growth, topbar and breadcrumbs, while still
+// failing hard if the ~1.2MB nav ever precedes content again.
+const BODY_BYTE_BUDGET = Number(process.env.BODY_BYTE_BUDGET ?? '102400'); // 100 KB
 
 type Failure = { where: string; msg: string };
 const failures: Failure[] = [];
@@ -229,38 +240,66 @@ function checkGuide(htmlPath: string): void {
   const mdPath = htmlPath.replace(/\.html$/, '.md');
   const rel = path.relative(DIST_DIR, htmlPath);
   const html = fs.readFileSync(htmlPath, 'utf-8');
-
-  // Skip custom-layout pages (pageType: elearning-course, landing, …). These
-  // render their content via bespoke React components (course-curriculum cards,
-  // hero grids), not the standard article container, so their `.md` export is
-  // flattened structured data that legitimately doesn't line-match the HTML.
-  // They are the wrong shape for a prose probe; the standard-guide body-render
-  // assertion below does not apply to them. Detected by the absence of the
-  // standard doc container (present on every normal guide).
-  if (!html.includes('rp-doc-layout__doc-container')) return;
-
-  const md = fs.readFileSync(mdPath, 'utf-8');
-  const mdText = canonical(md);
-  const htmlText = htmlToText(html);
-
-  // Anchor on the .md (ground truth for this page's text): use the first probe
-  // that is actually present in the canonicalized .md. A probe absent from the
-  // .md is a bad probe (an atypical line our normalization didn't model) — try
-  // the next, don't fail. This is what keeps the check free of false alarms
-  // while still catching the real failure below.
-  const probes = pickBodyProbes(mdPath);
-  const probe = probes.find((p) => mdText.includes(p));
-  if (!probe) return; // no clean, .md-confirmed prose probe → nothing to assert
   checkedGuides++;
 
-  // THE REAL ASSERTION: prose confirmed in the .md source must ALSO appear in
-  // the server-rendered HTML. If it doesn't, the body is client-only —
-  // precisely the regression this smoke test exists to catch.
-  if (!htmlText.includes(probe)) {
-    fail(
-      rel,
-      `body prose present in .md but MISSING from server-rendered HTML (client-only render?): "${probe}"`,
-    );
+  // BODY-FIRST assertion (applies to EVERY sidebar-bearing page — standard
+  // guides AND overview/landing/migration index pages, all of which had the
+  // nav-before-content problem and all of which the reorder now covers). We
+  // measure where the CONTENT COLUMN STARTS, not where prose lands: the content
+  // column is the element right after the sidebar — `rp-doc-layout__doc`
+  // (standard) or `rp-*-layout__content` (index layouts). Without this, the
+  // check passes on a page where the body is buried after the ~1.2MB nav —
+  // retrievable in theory but not for a top-down, size-bounded fetcher (the
+  // paste-a-URL agent case). Pages with no sidebar (home, elearning-course) are
+  // exempt — nothing to get behind.
+  const sidebarOffset = html.indexOf('rp-doc-layout__sidebar');
+  const contentMatch = html.match(
+    /class="(?:[^"]*\s)?(?:rp-doc-layout__doc|rp-[\w-]*-layout__content)(?:\s[^"]*)?"/,
+  );
+  const contentStart = contentMatch?.index ?? -1;
+  // Only pages that use the STANDARD shell (a `*-layout__content`/`__doc`
+  // column) are subject to the position check. A sidebar-bearing page with no
+  // such column is a fully-bespoke layout (e.g. elearning-course, which renders
+  // a custom two-column curriculum) — the reorder doesn't target it and there's
+  // no standard content column to locate, so skip rather than false-alarm.
+  if (sidebarOffset !== -1 && contentStart !== -1) {
+    if (contentStart > sidebarOffset) {
+      fail(
+        rel,
+        `content column (byte ${contentStart}) starts AFTER the sidebar (byte ${sidebarOffset}) in source order — a top-down fetcher hits nav first. Body-first reorder missing/regressed.`,
+      );
+    } else if (contentStart > BODY_BYTE_BUDGET) {
+      fail(
+        rel,
+        `content column starts at byte ${contentStart}, beyond the ${BODY_BYTE_BUDGET}-byte budget a size-bounded fetcher reads.`,
+      );
+    }
+  }
+
+  // PROSE assertion — scoped to STANDARD guides only. Custom-layout pages
+  // (overview/landing/migration/elearning) render content via bespoke React
+  // components, so their `.md` export is flattened structured data that
+  // legitimately doesn't line-match the HTML; a prose probe is the wrong shape
+  // for them. They still got the body-first + head-hint checks above.
+  if (html.includes('rp-doc-layout__doc-container')) {
+    const md = fs.readFileSync(mdPath, 'utf-8');
+    const mdText = canonical(md);
+    const htmlText = htmlToText(html);
+
+    // Anchor on the .md (ground truth for this page's text): use the first
+    // probe that is actually present in the canonicalized .md. A probe absent
+    // from the .md is a bad probe (an atypical line our normalization didn't
+    // model) — try the next, don't fail.
+    const probes = pickBodyProbes(mdPath);
+    const probe = probes.find((p) => mdText.includes(p));
+    if (probe && !htmlText.includes(probe)) {
+      // THE REAL ASSERTION: prose confirmed in the .md must ALSO appear in the
+      // server-rendered HTML. If not, the body is client-only.
+      fail(
+        rel,
+        `body prose present in .md but MISSING from server-rendered HTML (client-only render?): "${probe}"`,
+      );
+    }
   }
 
   // Machine-readable markdown-alternate hint in <head>.

--- a/scripts/preprocess-html-worker.ts
+++ b/scripts/preprocess-html-worker.ts
@@ -37,6 +37,85 @@ function readMdxFrontmatter(mdxPath: string): Record<string, string> | null {
   }
 }
 
+/**
+ * Given `html` and the index of an element's opening `<tag`, return the index
+ * just past its matching closing `</tag>`, accounting for nested same-name
+ * elements. Returns -1 if unbalanced (caller then leaves the HTML untouched).
+ */
+function endOfElement(html: string, openStart: number): number {
+  const nameMatch = /^<([a-zA-Z][\w-]*)/.exec(
+    html.slice(openStart, openStart + 40),
+  );
+  if (!nameMatch) return -1;
+  const tag = nameMatch[1];
+  const re = new RegExp(`<(/?)${tag}(\\s|>|/)`, 'gi');
+  re.lastIndex = openStart;
+  let depth = 0;
+  for (let m = re.exec(html); m; m = re.exec(html)) {
+    if (m[1] === '') {
+      depth++;
+    } else {
+      depth--;
+      if (depth === 0) {
+        const close = html.indexOf('>', m.index);
+        return close === -1 ? -1 : close + 1;
+      }
+    }
+  }
+  return -1;
+}
+
+/**
+ * Move the content column to BEFORE the sidebar `<aside>` in source order, so a
+ * JS-free, size-bounded fetcher (AI agent) reaches real content in the first
+ * few KB instead of after the ~1.2MB fully-expanded nav tree.
+ *
+ * Works across ALL Rspress layouts that share the same shell: the sidebar
+ * `<aside class="rp-doc-layout__sidebar">` is immediately followed by a content
+ * `<div class="rp-{doc,overview,landing,migration,…}-layout__content"|
+ * "rp-doc-layout__doc">` wrapping `<main>`, then the outline aside. We swap the
+ * first two → content, sidebar, outline. A companion CSS rule (styles) uses
+ * flexbox `order` to keep the sidebar visually leftmost, so the human layout is
+ * unchanged — only the byte order differs.
+ *
+ * Matching the content div by "the element immediately after the sidebar"
+ * rather than a fixed class means overview/landing/migration index pages (which
+ * had the SAME nav-before-content problem) are covered too, without enumerating
+ * every layout's class. Returns the input unchanged if the structure isn't this
+ * sidebar-then-content shell (e.g. home page, elearning-course two-column
+ * layout, or a page with no sidebar). Idempotent: after the swap the element
+ * after the sidebar is the outline, not a content div, so a second pass is a
+ * no-op.
+ */
+function moveContentBeforeSidebar(html: string): string {
+  const sidebarOpen = html.indexOf('<aside class="rp-doc-layout__sidebar');
+  if (sidebarOpen === -1) return html;
+  const sidebarEnd = endOfElement(html, sidebarOpen);
+  if (sidebarEnd === -1) return html;
+
+  // The content column must be the immediate next sibling (adjacent, no gap)
+  // and must be a content wrapper: a <div> whose class ends in
+  // `-layout__content`, or the standard-doc `rp-doc-layout__doc`. Guarding on
+  // the class (not just "next <div>") avoids mangling any unexpected structure.
+  const nextTag = html.slice(sidebarEnd).match(/^\s*<div class="([^"]*)"/);
+  if (!nextTag) return html;
+  const cls = nextTag[1];
+  const isContent =
+    /(?:^|\s)rp-[\w-]*-layout__content(?:\s|$)/.test(cls) ||
+    /(?:^|\s)rp-doc-layout__doc(?:\s|$)/.test(cls);
+  if (!isContent) return html;
+
+  const docOpen = html.indexOf('<div class="', sidebarEnd);
+  const docEnd = endOfElement(html, docOpen);
+  if (docEnd === -1) return html;
+
+  const sidebar = html.slice(sidebarOpen, sidebarEnd);
+  const doc = html.slice(docOpen, docEnd);
+  // Reassemble: everything up to sidebar, then content, then sidebar, then the
+  // rest (which begins with the outline aside).
+  return html.slice(0, sidebarOpen) + doc + sidebar + html.slice(docEnd);
+}
+
 function processDir(
   dir: string,
   locale: string,
@@ -179,6 +258,18 @@ function processDir(
           '</head>',
           `<link rel="alternate" type="text/markdown" href="${mdHref}"></head>`,
         );
+        changed = true;
+      }
+
+      // --- Body-first source order (see moveContentBeforeSidebar) ---
+      // The <head> hint above helps agents that look for it; this makes the
+      // article reachable for a naive top-down reader too, by putting content
+      // ahead of the ~1.2MB nav in the served bytes. Idempotent: once the doc
+      // column precedes the sidebar, the second sidebar-then-doc pattern no
+      // longer matches. Only rewrites the standard doc layout.
+      const reordered = moveContentBeforeSidebar(content);
+      if (reordered !== content) {
+        content = reordered;
         changed = true;
       }
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -253,6 +253,30 @@ body {
   display: none;
 }
 
+/* Body-first source order (AI/LLM retrievability).
+   A post-build step (scripts/preprocess-html-worker.ts) moves the content
+   column ahead of the sidebar in the SERVED HTML so JS-free, size-bounded
+   fetchers reach content in the first few KB instead of after the ~1.2MB nav.
+   `.rp-doc-layout__container` is display:flex; these explicit `order` values
+   pin the VISUAL layout (sidebar left, content centre, outline right)
+   regardless of that source order, so the human-facing layout is unchanged.
+   The content selectors cover every layout that shares the shell — standard
+   docs (`__doc`) plus overview/landing/migration index pages
+   (`*-layout__content`), matching the generalized reorder. Harmless if the
+   reorder didn't run (source order already matches these values). */
+.rp-doc-layout__sidebar,
+.rp-doc-layout__sidebar-placeholder {
+  order: 0;
+}
+.rp-doc-layout__doc,
+[class*="-layout__content"] {
+  order: 1;
+}
+.rp-doc-layout__outline,
+.rp-doc-layout__outline-placeholder {
+  order: 2;
+}
+
 /* Style plain <details> elements like :::details containers */
 details:not(.rp-callout) {
   border-radius: var(--rp-radius);


### PR DESCRIPTION
Guide bodies were server-rendered but sat after the ~1.2MB expanded nav in source order, so top-down, size-bounded fetchers (AI agents handed a URL) hit nav first and never reached content. The head hint shipped earlier only helps agents that look for it, not a naive verbatim fetch.

- Post-build (preprocess-html-worker): move the <main> doc column before the sidebar <aside> in the served HTML; content now starts at ~14KB instead of ~1.2MB. Pure reorder, idempotent, standard doc layout only.
- CSS: flexbox `order` pins the visual layout (sidebar left, doc, outline) so the human-facing page is unchanged.
- Tighten check-retrievability: assert the content column starts BEFORE the sidebar in source order and within a byte budget, not just that body exists.