### PR TITLE
docs: list clusters in the outline for the shared-hosting IP guide

### DIFF
--- a/docs/de/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
@@ -1,7 +1,7 @@
 ---
 title: Webhosting - Liste der IP-Adressen pro Cluster
 description: Erfahren Sie hier, welche IP-Adresse für Ihr OVHcloud Webhosting zu verwenden ist
-lastUpdated: 2026-02-23
+lastUpdated: 2026-07-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -58,9 +58,11 @@ Um herauszufinden, auf welchem Webhosting Cluster Ihr Dienst liegt, klicken Sie 
 
 <details>
 
-<summary>Cluster 024</summary>
+<summary>
+#### Cluster 024
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -94,9 +96,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 100</summary>
+<summary>
+#### Cluster 100
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -130,9 +134,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 102</summary>
+<summary>
+#### Cluster 102
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -165,9 +171,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 103</summary>
+<summary>
+#### Cluster 103
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -200,9 +208,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 105</summary>
+<summary>
+#### Cluster 105
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -235,9 +245,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 106</summary>
+<summary>
+#### Cluster 106
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -270,9 +282,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 107</summary>
+<summary>
+#### Cluster 107
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -305,9 +319,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 110</summary>
+<summary>
+#### Cluster 110
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -340,9 +356,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 111</summary>
+<summary>
+#### Cluster 111
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -375,9 +393,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 112</summary>
+<summary>
+#### Cluster 112
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -410,9 +430,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 113</summary>
+<summary>
+#### Cluster 113
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -445,9 +467,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 114</summary>
+<summary>
+#### Cluster 114
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -480,9 +504,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 115</summary>
+<summary>
+#### Cluster 115
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -515,9 +541,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 117</summary>
+<summary>
+#### Cluster 117
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -550,9 +578,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 120</summary>
+<summary>
+#### Cluster 120
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -586,9 +616,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 121</summary>
+<summary>
+#### Cluster 121
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -622,9 +654,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 123</summary>
+<summary>
+#### Cluster 123
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -658,9 +692,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 126</summary>
+<summary>
+#### Cluster 126
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -694,9 +730,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 127</summary>
+<summary>
+#### Cluster 127
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -730,9 +768,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 128</summary>
+<summary>
+#### Cluster 128
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -766,9 +806,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 129</summary>
+<summary>
+#### Cluster 129
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -802,9 +844,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 130</summary>
+<summary>
+#### Cluster 130
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -838,9 +882,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 131</summary>
+<summary>
+#### Cluster 131
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -874,9 +920,11 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 <details>
 
-<summary>Cluster 151</summary>
+<summary>
+#### Cluster 151
+</summary>
 
-#### IP-Adressen der Cluster nach Land
+Nachfolgend finden Sie die IP-Adressen des **Clusters** pro Land (für die Geolokalisierung):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|

--- a/docs/en/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Hosting - List of IP addresses by cluster
 description: Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan
-lastUpdated: 2026-02-23
+lastUpdated: 2026-07-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -58,9 +58,11 @@ To find out on which web hosting cluster your service is located, click on the t
 
 <details>
 
-<summary>Cluster 024</summary>
+<summary>
+#### Cluster 024
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -94,9 +96,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 100</summary>
+<summary>
+#### Cluster 100
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -130,9 +134,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 102</summary>
+<summary>
+#### Cluster 102
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -165,9 +171,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 103</summary>
+<summary>
+#### Cluster 103
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -200,9 +208,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 105</summary>
+<summary>
+#### Cluster 105
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -235,9 +245,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 106</summary>
+<summary>
+#### Cluster 106
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -270,9 +282,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 107</summary>
+<summary>
+#### Cluster 107
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -305,9 +319,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 110</summary>
+<summary>
+#### Cluster 110
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -340,9 +356,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 111</summary>
+<summary>
+#### Cluster 111
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -375,9 +393,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 112</summary>
+<summary>
+#### Cluster 112
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -410,9 +430,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 113</summary>
+<summary>
+#### Cluster 113
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -445,9 +467,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 114</summary>
+<summary>
+#### Cluster 114
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -480,9 +504,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 115</summary>
+<summary>
+#### Cluster 115
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -515,9 +541,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 117</summary>
+<summary>
+#### Cluster 117
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -550,9 +578,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 120</summary>
+<summary>
+#### Cluster 120
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -586,9 +616,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 121</summary>
+<summary>
+#### Cluster 121
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -622,9 +654,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 123</summary>
+<summary>
+#### Cluster 123
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -658,9 +692,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 126</summary>
+<summary>
+#### Cluster 126
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -694,9 +730,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 127</summary>
+<summary>
+#### Cluster 127
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -730,9 +768,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 128</summary>
+<summary>
+#### Cluster 128
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -766,9 +806,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 129</summary>
+<summary>
+#### Cluster 129
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -802,9 +844,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 130</summary>
+<summary>
+#### Cluster 130
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -838,9 +882,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 131</summary>
+<summary>
+#### Cluster 131
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -874,9 +920,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 <details>
 
-<summary>Cluster 151</summary>
+<summary>
+#### Cluster 151
+</summary>
 
-#### Cluster IP addresses per country
+Below are the **cluster** IP addresses for each country (for geolocation):
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|

--- a/docs/es/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web hosting - Lista de direcciones IP por cluster
 description: Descubra todas las direcciones IP disponibles con nuestros alojamientos web
-lastUpdated: 2026-02-23
+lastUpdated: 2026-07-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -59,7 +59,9 @@ Para conocer el cluster de alojamiento web en el que se encuentra su servicio, h
 
 <details>
 
-<summary>Cluster 024</summary>
+<summary>
+#### Cluster 024
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -95,7 +97,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 100</summary>
+<summary>
+#### Cluster 100
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -131,7 +135,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 102</summary>
+<summary>
+#### Cluster 102
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -166,7 +172,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 103</summary>
+<summary>
+#### Cluster 103
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -201,7 +209,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 105</summary>
+<summary>
+#### Cluster 105
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -236,7 +246,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 106</summary>
+<summary>
+#### Cluster 106
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -271,7 +283,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 107</summary>
+<summary>
+#### Cluster 107
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -306,7 +320,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 110</summary>
+<summary>
+#### Cluster 110
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -341,7 +357,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 111</summary>
+<summary>
+#### Cluster 111
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -376,7 +394,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 112</summary>
+<summary>
+#### Cluster 112
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -411,7 +431,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 113</summary>
+<summary>
+#### Cluster 113
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -446,7 +468,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 114</summary>
+<summary>
+#### Cluster 114
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -481,7 +505,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 115</summary>
+<summary>
+#### Cluster 115
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -516,7 +542,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 117</summary>
+<summary>
+#### Cluster 117
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -551,7 +579,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 120</summary>
+<summary>
+#### Cluster 120
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -587,7 +617,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 121</summary>
+<summary>
+#### Cluster 121
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -623,7 +655,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 123</summary>
+<summary>
+#### Cluster 123
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -659,7 +693,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 126</summary>
+<summary>
+#### Cluster 126
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -695,7 +731,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 127</summary>
+<summary>
+#### Cluster 127
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -731,7 +769,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 128</summary>
+<summary>
+#### Cluster 128
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -767,7 +807,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 129</summary>
+<summary>
+#### Cluster 129
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -803,7 +845,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 130</summary>
+<summary>
+#### Cluster 130
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -839,7 +883,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 131</summary>
+<summary>
+#### Cluster 131
+</summary>
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
@@ -875,7 +921,9 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 <details>
 
-<summary>Cluster 151</summary>
+<summary>
+#### Cluster 151
+</summary>
 
 A continuación indicamos las direcciones IP del **cluster** para cada país (para la geolocalización):
 

--- a/docs/fr/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hébergement web - Liste des adresses IP par cluster
 description: "Découvrez l'ensemble des adresses IP disponibles avec nos hébergements web"
-lastUpdated: 2026-02-23
+lastUpdated: 2026-07-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -59,7 +59,9 @@ Pour connaître le cluster d’hébergement web sur lequel se trouve votre servi
 
 <details>
 
-<summary>Cluster 024</summary>
+<summary>
+#### Cluster 024
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -95,7 +97,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 100</summary>
+<summary>
+#### Cluster 100
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -131,7 +135,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 102</summary>
+<summary>
+#### Cluster 102
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -166,7 +172,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 103</summary>
+<summary>
+#### Cluster 103
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -201,7 +209,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 105</summary>
+<summary>
+#### Cluster 105
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -236,7 +246,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 106</summary>
+<summary>
+#### Cluster 106
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -271,7 +283,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 107</summary>
+<summary>
+#### Cluster 107
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -306,7 +320,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 110</summary>
+<summary>
+#### Cluster 110
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -341,7 +357,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 111</summary>
+<summary>
+#### Cluster 111
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -376,7 +394,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 112</summary>
+<summary>
+#### Cluster 112
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -411,7 +431,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 113</summary>
+<summary>
+#### Cluster 113
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -446,7 +468,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 114</summary>
+<summary>
+#### Cluster 114
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -481,7 +505,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 115</summary>
+<summary>
+#### Cluster 115
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -516,7 +542,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 117</summary>
+<summary>
+#### Cluster 117
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -551,7 +579,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 120</summary>
+<summary>
+#### Cluster 120
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -587,7 +617,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 121</summary>
+<summary>
+#### Cluster 121
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -623,7 +655,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 123</summary>
+<summary>
+#### Cluster 123
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -659,7 +693,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 126</summary>
+<summary>
+#### Cluster 126
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -695,7 +731,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 127</summary>
+<summary>
+#### Cluster 127
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -731,7 +769,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 128</summary>
+<summary>
+#### Cluster 128
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -767,7 +807,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 129</summary>
+<summary>
+#### Cluster 129
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -803,7 +845,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 130</summary>
+<summary>
+#### Cluster 130
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -839,7 +883,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 131</summary>
+<summary>
+#### Cluster 131
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
@@ -875,7 +921,9 @@ Si vous avez besoin de l’adresse IP de la **passerelle de sortie** de votre h�
 
 <details>
 
-<summary>Cluster 151</summary>
+<summary>
+#### Cluster 151
+</summary>
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 

--- a/docs/it/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hosting Web - Lista degli indirizzi IP per cluster
 description: Questa guida elenca tutti gli indirizzi IP disponibili con i nostri hosting Web
-lastUpdated: 2026-02-23
+lastUpdated: 2026-07-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -58,7 +58,9 @@ Per conoscere il cluster di hosting Web su cui si trova il tuo servizio, clicca 
 
 <details>
 
-<summary>Cluster 024</summary>
+<summary>
+#### Cluster 024
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -94,7 +96,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 100</summary>
+<summary>
+#### Cluster 100
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -130,7 +134,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 102</summary>
+<summary>
+#### Cluster 102
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -165,7 +171,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 103</summary>
+<summary>
+#### Cluster 103
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -200,7 +208,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 105</summary>
+<summary>
+#### Cluster 105
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -235,7 +245,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 106</summary>
+<summary>
+#### Cluster 106
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -270,7 +282,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 107</summary>
+<summary>
+#### Cluster 107
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -305,7 +319,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 110</summary>
+<summary>
+#### Cluster 110
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -340,7 +356,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 111</summary>
+<summary>
+#### Cluster 111
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -375,7 +393,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 112</summary>
+<summary>
+#### Cluster 112
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -410,7 +430,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 113</summary>
+<summary>
+#### Cluster 113
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -445,7 +467,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 114</summary>
+<summary>
+#### Cluster 114
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -480,7 +504,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 115</summary>
+<summary>
+#### Cluster 115
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -515,7 +541,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 117</summary>
+<summary>
+#### Cluster 117
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -550,7 +578,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 120</summary>
+<summary>
+#### Cluster 120
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -586,7 +616,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 121</summary>
+<summary>
+#### Cluster 121
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -622,7 +654,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 123</summary>
+<summary>
+#### Cluster 123
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -658,7 +692,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 126</summary>
+<summary>
+#### Cluster 126
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -694,7 +730,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 127</summary>
+<summary>
+#### Cluster 127
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -730,7 +768,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 128</summary>
+<summary>
+#### Cluster 128
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -766,7 +806,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 129</summary>
+<summary>
+#### Cluster 129
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -802,7 +844,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 130</summary>
+<summary>
+#### Cluster 130
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -838,7 +882,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 131</summary>
+<summary>
+#### Cluster 131
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 
@@ -874,7 +920,9 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 <details>
 
-<summary>Cluster 151</summary>
+<summary>
+#### Cluster 151
+</summary>
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
 

--- a/docs/pl/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hosting WWW - Lista adresów IP według klastra
 description: Poznaj wszystkie dostępne adresy IP na naszych hostingach
-lastUpdated: 2026-02-23
+lastUpdated: 2026-07-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -59,7 +59,9 @@ Aby poznać klaster hostingu WWW, w którym znajduje się Twoja usługa, kliknij
 
 <details>
 
-<summary>Klaster 024</summary>
+<summary>
+#### Klaster 024
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -95,7 +97,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 100</summary>
+<summary>
+#### Klaster 100
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -131,7 +135,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 102</summary>
+<summary>
+#### Klaster 102
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -166,7 +172,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 103</summary>
+<summary>
+#### Klaster 103
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -201,7 +209,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 105</summary>
+<summary>
+#### Klaster 105
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -236,7 +246,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 106</summary>
+<summary>
+#### Klaster 106
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -271,7 +283,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 107</summary>
+<summary>
+#### Klaster 107
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -306,7 +320,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 110</summary>
+<summary>
+#### Klaster 110
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -341,7 +357,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 111</summary>
+<summary>
+#### Klaster 111
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -376,7 +394,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 112</summary>
+<summary>
+#### Klaster 112
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -411,7 +431,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 113</summary>
+<summary>
+#### Klaster 113
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -446,7 +468,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 114</summary>
+<summary>
+#### Klaster 114
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -481,7 +505,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 115</summary>
+<summary>
+#### Klaster 115
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -516,7 +542,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 117</summary>
+<summary>
+#### Klaster 117
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -551,7 +579,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 120</summary>
+<summary>
+#### Klaster 120
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -587,7 +617,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 121</summary>
+<summary>
+#### Klaster 121
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -623,7 +655,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 123</summary>
+<summary>
+#### Klaster 123
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -659,7 +693,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 126</summary>
+<summary>
+#### Klaster 126
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -695,7 +731,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 127</summary>
+<summary>
+#### Klaster 127
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -731,7 +769,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 128</summary>
+<summary>
+#### Klaster 128
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -767,7 +807,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 129</summary>
+<summary>
+#### Klaster 129
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -803,7 +845,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 130</summary>
+<summary>
+#### Klaster 130
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -839,7 +883,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 131</summary>
+<summary>
+#### Klaster 131
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 
@@ -875,7 +921,9 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 <details>
 
-<summary>Klaster 151</summary>
+<summary>
+#### Klaster 151
+</summary>
 
 Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji):
 

--- a/docs/pt/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alojamento web - Lista dos endereços IP por cluster
 description: Saiba todos os endereços IP disponíveis nos nossos alojamentos web
-lastUpdated: 2026-02-23
+lastUpdated: 2026-07-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -58,7 +58,9 @@ Para conhecer o cluster de alojamento web no qual se encontra o seu serviço, cl
 
 <details>
 
-<summary>Cluster 024</summary>
+<summary>
+#### Cluster 024
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -94,7 +96,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 100</summary>
+<summary>
+#### Cluster 100
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -130,7 +134,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 102</summary>
+<summary>
+#### Cluster 102
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -165,7 +171,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 103</summary>
+<summary>
+#### Cluster 103
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -200,7 +208,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 105</summary>
+<summary>
+#### Cluster 105
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -235,7 +245,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 106</summary>
+<summary>
+#### Cluster 106
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -270,7 +282,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 107</summary>
+<summary>
+#### Cluster 107
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -305,7 +319,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 110</summary>
+<summary>
+#### Cluster 110
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -340,7 +356,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 111</summary>
+<summary>
+#### Cluster 111
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -375,7 +393,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 112</summary>
+<summary>
+#### Cluster 112
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -410,7 +430,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 113</summary>
+<summary>
+#### Cluster 113
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -445,7 +467,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 114</summary>
+<summary>
+#### Cluster 114
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -480,7 +504,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 115</summary>
+<summary>
+#### Cluster 115
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -515,7 +541,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 117</summary>
+<summary>
+#### Cluster 117
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -550,7 +578,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 120</summary>
+<summary>
+#### Cluster 120
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -586,7 +616,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 121</summary>
+<summary>
+#### Cluster 121
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -622,7 +654,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 123</summary>
+<summary>
+#### Cluster 123
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -658,7 +692,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 126</summary>
+<summary>
+#### Cluster 126
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -694,7 +730,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 127</summary>
+<summary>
+#### Cluster 127
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -730,7 +768,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 128</summary>
+<summary>
+#### Cluster 128
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -766,7 +806,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 129</summary>
+<summary>
+#### Cluster 129
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -802,7 +844,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 130</summary>
+<summary>
+#### Cluster 130
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -838,7 +882,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 131</summary>
+<summary>
+#### Cluster 131
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 
@@ -874,7 +920,9 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 <details>
 
-<summary>Cluster 151</summary>
+<summary>
+#### Cluster 151
+</summary>
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -275,6 +275,24 @@ details:not(.rp-callout) > summary {
   color: var(--rp-c-text-1);
 }
 
+/* A heading may be used as the <summary> label so it feeds the right-side
+   outline. Render it inline like plain summary text (no block break, inherit
+   the summary font) and hide its hover anchor. */
+details:not(.rp-callout) > summary :is(h1, h2, h3, h4, h5, h6) {
+  display: inline;
+  margin: 0;
+  padding: 0;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  color: inherit;
+}
+
+details:not(.rp-callout) > summary :is(h1, h2, h3, h4, h5, h6) .header-anchor,
+details:not(.rp-callout) > summary a.header-anchor {
+  display: none;
+}
+
 /* Hide the left color bar on :::details containers to match plain <details> styling */
 .rp-callout--details .rp-callout__title::before {
   display: none !important;


### PR DESCRIPTION
## Contexte

Sur le guide "Hébergement web - Liste des adresses IP par cluster", le sommaire de navigation de droite était inutilisable :
- en EN et DE, chaque bloc cluster contenait un titre #### au texte identique ("Cluster IP addresses per country"), répété 24 fois → 24 entrées identiques dans le sommaire ;
- les noms de clusters (Cluster 024, Cluster 100, ...) n'apparaissaient pas car ils étaient dans des "summary" (non repris par la prod).

## Modifications

- Nettoyage EN/DE : suppression des titres répétés "Cluster IP addresses per country", remplacés par une phrase descriptive (aligné sur les 5 autres langues).
- Sommaire de droite : chaque cluster porte désormais un vrai titre "#### Cluster XXX" à l'intérieur du <summary>, sur les 7 langues → la liste des clusters est accessible directement depuis le menu de droite, tout en gardant les blocs repliables.
- styles/index.css : ajout d'une règle qui affiche en inline (taille/graisse d'origine, sans ancre #) tout titre placé dans un <summary> → l'aspect du libellé repliable est identique à avant.
- Mise à jour de lastUpdated → 2026-07-21 sur les 7 langues.

## Effet de bord

Aucun sur les autres guides : sur les 883 fichiers utilisant <details>, seul ce guide place un titre dans un <summary>. Les conteneurs :::details (.rp-callout) sont explicitement exclus de la règle CSS.

## Vérifications

- pnpm dev : recompilation OK, sommaire de droite listant les clusters, libellés repliables au rendu d'origine.
- Comportement identique sur les 7 locales.
