### PR TITLE
Fix/smooth tab height

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -194,6 +194,38 @@ body {
   border-bottom: 1px solid var(--rp-c-divider-light) !important;
   padding: 0 !important;
   gap: 0;
+  /* Keep the label row reachable while reading a long panel: it sticks just
+     below the site nav so the reader can switch tabs without scrolling back
+     up. It only sticks within the bounds of its own .rp-tabs block. */
+  position: sticky !important;
+  top: calc(var(--rp-nav-height) + var(--rp-banner-height, 0px)) !important;
+  z-index: 5;
+}
+
+/* Rspress puts `contain: content` on .rp-tabs, whose paint containment would
+   clip the sticky label row as the block scrolls. Drop paint containment
+   (keep layout/style) so the header can stick; in-panel dropdowns already
+   portal to <body>, so nothing else relies on the paint clip. */
+.rp-tabs {
+  contain: layout style !important;
+}
+
+/* The doc column ships `overflow-x: auto`; because `overflow-y` defaults to
+   `visible`, the spec upgrades it to `auto`, turning the column into a phantom
+   scroll container that TRAPS any sticky descendant (the window is the real
+   scroller). `overflow-x: clip` still prevents wide content from blowing out
+   the page width but is NOT a scroll container, so `overflow-y` stays visible
+   and viewport-based sticky (the tab label row) works.
+   `min-width: 0` is required alongside it: unlike `overflow-x: auto` (a scroll
+   container, whose automatic minimum size is 0), `clip` leaves the column's
+   grid item at `min-width: auto`, so a wide code/inline token would refuse to
+   shrink, grow the column, and squeeze the right-hand outline to zero width.
+   Scoped with `:has(.rp-tabs)` so the rule applies ONLY to a doc column that
+   actually contains a tab block — pages without tabs keep Rspress's stock
+   `overflow-x: auto` untouched, with no JavaScript involved. */
+.rp-doc-layout__doc:has(.rp-tabs) {
+  overflow-x: clip !important;
+  min-width: 0 !important;
 }
 
 .rp-tabs__label__item {

--- a/theme/components/SyncedTabs/index.tsx
+++ b/theme/components/SyncedTabs/index.tsx
@@ -169,6 +169,83 @@ function useHashActivatesTab(rootRef: React.RefObject<HTMLDivElement | null>) {
 }
 
 /**
+ * Keep the clicked tab row fixed in place on tab switch.
+ *
+ * "Anchored" means the label row must not move at all: it stays at the exact
+ * viewport position it had at click time, whatever that was (pinned under the
+ * nav, or mid-page). Because these tabs are synced, one click reflows every
+ * block on the page — blocks above the viewport change height and shove the
+ * clicked row. We neutralise that: capture the row's viewport top BEFORE the
+ * panel swaps, then restore it by the exact delta AFTER the swap.
+ *
+ * Timing is the whole game. The correction must land in the SAME click task,
+ * after React has committed the new panel but before the browser paints — a
+ * `requestAnimationFrame` alone is one step too late and lets the displaced
+ * frame paint (a visible flash of the tab titles). So we hang both listeners
+ * off `document`: capture-phase fires before React's delegated handler (read
+ * the old position), bubble-phase fires after it (React 18 flushes discrete
+ * events synchronously, so the DOM is already swapped) — we correct there,
+ * synchronously, pre-paint. We then repeat the correction once in a rAF: the
+ * synchronous `scrollTo` itself re-clamps the sticky row and reflows the synced
+ * blocks, leaving a one-frame residual that this convergence pass absorbs.
+ *
+ * Gated on {@link tabsBlockHasHeadingAnchors} like the other hooks: per-step/
+ * anchor blocks drive their own hash-scroll and are left alone.
+ */
+function useKeepTabAnchored(rootRef: React.RefObject<HTMLDivElement | null>) {
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root || typeof window === 'undefined') {
+      return;
+    }
+    if (tabsBlockHasHeadingAnchors(root)) {
+      return;
+    }
+
+    const labelTop = () =>
+      root.querySelector<HTMLElement>('.rp-tabs__label')?.getBoundingClientRect()
+        .top ?? null;
+    let before: number | null = null;
+
+    // Capture phase (before React swaps): remember the row's viewport position.
+    const onCapture = (e: MouseEvent) => {
+      const item = (e.target as HTMLElement | null)?.closest(
+        '.rp-tabs__label__item',
+      );
+      before = item && root.contains(item) ? labelTop() : null;
+    };
+
+    // Scroll so the row returns to its remembered viewport position.
+    const align = (anchor: number) => {
+      const delta = (labelTop() ?? anchor) - anchor;
+      if (Math.abs(delta) > 1) {
+        window.scrollTo({ top: window.scrollY + delta, behavior: 'auto' });
+      }
+    };
+
+    // Bubble phase at document (after React committed the swap, still pre-paint):
+    // align synchronously (no flash), then once more next frame to absorb the
+    // residual the scroll/sticky re-clamp leaves behind.
+    const onBubble = () => {
+      if (before == null) {
+        return;
+      }
+      const anchor = before;
+      before = null;
+      align(anchor);
+      requestAnimationFrame(() => align(anchor));
+    };
+
+    document.addEventListener('click', onCapture, true);
+    document.addEventListener('click', onBubble, false);
+    return () => {
+      document.removeEventListener('click', onCapture, true);
+      document.removeEventListener('click', onBubble, false);
+    };
+  }, [rootRef]);
+}
+
+/**
  * Keep tab-panel headings out of the right-side outline.
  *
  * Rspress builds the outline from the *visible* h2/h3/h4 in the DOM, so a
@@ -205,6 +282,7 @@ export function Tabs({ noSync, ...props }: TabsProps): ReactElement {
   const rootRef = useRef<HTMLDivElement | null>(null);
   useHashActivatesTab(rootRef);
   useExcludePanelHeadingsFromToc(rootRef);
+  useKeepTabAnchored(rootRef);
 
   // 1. Explicit opt-out → keep this block local (no sync, no persistence).
   if (noSync) {


### PR DESCRIPTION
Two fixes for the synced <Tabs> component so tabs stay usable in long panels.

- Sticky label row — the tab label row now sticks just under the site nav, so you can switch tabs from anywhere in a long panel without scrolling back to the top. It only sticks within its own .rp-tabs block.
- Anchored switching — on switch, the clicked row stays exactly where it was in the viewport. Synced tabs reflow every block on the page at once, which used to shove the row (visible jump); the row's position is now captured before the swap and restored pre-paint, with a requestAnimationFrame convergence pass for the residual.

Supporting CSS
- .rp-tabs → contain: layout style (drop paint containment that clipped the sticky row).
- .rp-doc-layout__doc:has(.rp-tabs) → overflow-x: clip + min-width: 0 instead of Rspress's stock overflow-x: auto, which is a scroll container that traps viewport-based sticky. Scoped with :has() so pages without tabs are untouched.