### PR TITLE
docs: simplify Swift getting-started tab labels and FR CLI naming

### DIFF
--- a/docs/en/guides/storage-and-backup/object-storage/pcs-create-container.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-create-container.mdx
@@ -43,10 +43,10 @@ Depending on the tool you plan to use:
 ### Preparation
 
 <Tabs>
-  <Tab label="Via the OVHcloud Control Panel">
+  <Tab label="OVHcloud Control Panel">
     Log in to your OVHcloud Control Panel and open <code className="action">Object Storage</code> in the left-hand menu under **Storage & backup**.
   </Tab>
-  <Tab label="Via the Swift S3 API">
+  <Tab label="Swift S3 API">
     **Set the OpenStack environment variables**
 
     ```bash
@@ -159,7 +159,7 @@ Depending on the tool you plan to use:
     Both virtual-hosted-style and path-style access are supported; virtual-hosted-style is recommended, as path-style was deprecated after September 30, 2020.
     :::
   </Tab>
-  <Tab label="Via the Swift client">
+  <Tab label="Swift client">
     Set the OpenStack environment variables:
 
     ```bash
@@ -174,7 +174,7 @@ Depending on the tool you plan to use:
 
     For the full list of Swift commands, refer to the [OpenStack documentation](https://docs.openstack.org/python-swiftclient/latest/cli/index.html).
   </Tab>
-  <Tab label="Via the OVHcloud CLI">
+  <Tab label="OVHcloud CLI">
     Ensure the OVHcloud CLI is installed and configured with your credentials. For setup instructions, refer to the [OVHcloud CLI documentation](/guides/manage-and-operate/cli/getting-started).
   </Tab>
 </Tabs>
@@ -193,7 +193,7 @@ When using the **Swift S3 API**, bucket names must follow these rules:
 :::
 
 <Tabs>
-  <Tab label="Via the OVHcloud Control Panel">
+  <Tab label="OVHcloud Control Panel">
     Click <code className="action">Create an object container</code>.
 
     Fill in the creation form:
@@ -209,7 +209,7 @@ When using the **Swift S3 API**, bucket names must follow these rules:
 
     Review the summary panel, then click <code className="action">Create</code>.
   </Tab>
-  <Tab label="Via the Swift S3 API">
+  <Tab label="Swift S3 API">
     ```bash
     aws s3 mb s3://<container_name>
     ```
@@ -218,7 +218,7 @@ When using the **Swift S3 API**, bucket names must follow these rules:
     S3 buckets can only be created on the PCS (Object Storage) policy.
     :::
   </Tab>
-  <Tab label="Via the Swift client">
+  <Tab label="Swift client">
     Create the container:
 
     ```bash
@@ -252,7 +252,7 @@ When using the **Swift S3 API**, bucket names must follow these rules:
     Content-Type: text/plain; charset=utf-8
     ```
   </Tab>
-  <Tab label="Via the OVHcloud CLI">
+  <Tab label="OVHcloud CLI">
     Container creation is not available via the OVHcloud CLI. Use the Control Panel, the Swift S3 API, or the Swift client instead.
   </Tab>
 </Tabs>
@@ -260,10 +260,10 @@ When using the **Swift S3 API**, bucket names must follow these rules:
 ### List your containers
 
 <Tabs>
-  <Tab label="Via the OVHcloud Control Panel">
+  <Tab label="OVHcloud Control Panel">
     Navigate to <code className="action">Object Storage</code> in the left-hand menu. Your containers are listed under the <code className="action">My containers</code> tab.
   </Tab>
-  <Tab label="Via the Swift S3 API">
+  <Tab label="Swift S3 API">
     ```bash
     aws s3 ls
     ```
@@ -272,12 +272,12 @@ When using the **Swift S3 API**, bucket names must follow these rules:
     If you have more than one profile configured, add `--profile <profile_name>` to the command.
     :::
   </Tab>
-  <Tab label="Via the Swift client">
+  <Tab label="Swift client">
     ```bash
     swift list
     ```
   </Tab>
-  <Tab label="Via the OVHcloud CLI">
+  <Tab label="OVHcloud CLI">
     ```bash
     ovhcloud cloud storage swift list
     ```
@@ -287,17 +287,17 @@ When using the **Swift S3 API**, bucket names must follow these rules:
 ### Upload objects
 
 <Tabs>
-  <Tab label="Via the OVHcloud Control Panel">
+  <Tab label="OVHcloud Control Panel">
     Click on the name of your container, then click <code className="action">Add objects</code> in the **Objects** tab.
 
     Select the file you want to upload and click <code className="action">Import</code>.
   </Tab>
-  <Tab label="Via the Swift S3 API">
+  <Tab label="Swift S3 API">
     ```bash
     aws s3 cp /path/to/<object_name> s3://<container_name>/<object_name>
     ```
   </Tab>
-  <Tab label="Via the Swift client">
+  <Tab label="Swift client">
     Upload a single file:
 
     ```bash
@@ -313,7 +313,7 @@ When using the **Swift S3 API**, bucket names must follow these rules:
     images/OVHSummitKeynote.jpg
     ```
   </Tab>
-  <Tab label="Via the OVHcloud CLI">
+  <Tab label="OVHcloud CLI">
     Object upload is not available via the OVHcloud CLI. Use the Control Panel, the Swift S3 API, or the Swift client instead.
   </Tab>
 </Tabs>
@@ -321,15 +321,15 @@ When using the **Swift S3 API**, bucket names must follow these rules:
 ### List objects in a container
 
 <Tabs>
-  <Tab label="Via the OVHcloud Control Panel">
+  <Tab label="OVHcloud Control Panel">
     Click on the name of your container to view its objects in the **Objects** tab.
   </Tab>
-  <Tab label="Via the Swift S3 API">
+  <Tab label="Swift S3 API">
     ```bash
     aws s3 ls s3://<container_name>
     ```
   </Tab>
-  <Tab label="Via the Swift client">
+  <Tab label="Swift client">
     ```bash
     swift list container1
 
@@ -357,7 +357,7 @@ When using the **Swift S3 API**, bucket names must follow these rules:
 
     This URL is composed of an endpoint (available from the [Horizon interface](/guides/public-cloud/cross-functional/compute-horizon-access-security)), the container name, and the object name (including prefix).
   </Tab>
-  <Tab label="Via the OVHcloud CLI">
+  <Tab label="OVHcloud CLI">
     Object listing is not available via the OVHcloud CLI. Use the Control Panel, the Swift S3 API, or the Swift client instead.
   </Tab>
 </Tabs>
@@ -365,15 +365,15 @@ When using the **Swift S3 API**, bucket names must follow these rules:
 ### Download objects
 
 <Tabs>
-  <Tab label="Via the OVHcloud Control Panel">
+  <Tab label="OVHcloud Control Panel">
     Click the download icon on the object line.
   </Tab>
-  <Tab label="Via the Swift S3 API">
+  <Tab label="Swift S3 API">
     ```bash
     aws s3 cp s3://<container_name>/<object_name> .
     ```
   </Tab>
-  <Tab label="Via the Swift client">
+  <Tab label="Swift client">
     Download a single file:
 
     ```bash
@@ -391,7 +391,7 @@ When using the **Swift S3 API**, bucket names must follow these rules:
     images/OVHSummitKeynote.jpg [auth 0.371s, headers 0.514s, total 0.559s, 2.657 MB/s]
     ```
   </Tab>
-  <Tab label="Via the OVHcloud CLI">
+  <Tab label="OVHcloud CLI">
     Object download is not available via the OVHcloud CLI. Use the Control Panel, the Swift S3 API, or the Swift client instead.
   </Tab>
 </Tabs>
@@ -399,12 +399,12 @@ When using the **Swift S3 API**, bucket names must follow these rules:
 ### Delete objects and containers
 
 <Tabs>
-  <Tab label="Via the OVHcloud Control Panel">
+  <Tab label="OVHcloud Control Panel">
     **Delete an object**: Click the delete icon (trash can) on the object line and confirm.
 
     **Delete a container**: Click the <code className="action">...</code> button on the container line, then select <code className="action">Delete</code> and confirm.
   </Tab>
-  <Tab label="Via the Swift S3 API">
+  <Tab label="Swift S3 API">
     **Delete an object:**
 
     ```bash
@@ -417,7 +417,7 @@ When using the **Swift S3 API**, bucket names must follow these rules:
     aws s3 rb s3://<container_name>
     ```
   </Tab>
-  <Tab label="Via the Swift client">
+  <Tab label="Swift client">
     **Delete a file:**
 
     ```bash
@@ -444,7 +444,7 @@ When using the **Swift S3 API**, bucket names must follow these rules:
     text3.txt
     ```
   </Tab>
-  <Tab label="Via the OVHcloud CLI">
+  <Tab label="OVHcloud CLI">
     Container and object deletion is not available via the OVHcloud CLI. Use the Control Panel, the Swift S3 API, or the Swift client instead.
   </Tab>
 </Tabs>

--- a/docs/fr/guides/storage-and-backup/object-storage/pcs-create-container.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/pcs-create-container.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage Swift - Premiers pas
-description: Découvrez comment créer et gérer vos conteneurs Object Storage Swift depuis votre espace client OVHcloud, l'API Swift S3, python-swiftclient ou l'OVHcloud CLI
+description: Découvrez comment créer et gérer vos conteneurs Object Storage Swift depuis votre espace client OVHcloud, l'API Swift S3, python-swiftclient ou la CLI OVHcloud
 lastUpdated: 2026-07-21
 ---
 
@@ -25,7 +25,7 @@ Selon l'outil que vous souhaitez utiliser :
 
 - **API Swift S3<sup>1</sup>** : disposer d'un environnement [préparé pour l'API OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) avec `python-openstackclient` et `awscli` installés
 - **Client Swift** : disposer d'un environnement [préparé pour l'API OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) avec `python-swiftclient` installé
-- **OVHcloud CLI** : disposer de l'[OVHcloud CLI](/guides/manage-and-operate/cli/getting-started) installé et configuré
+- **CLI OVHcloud** : disposer de la [CLI OVHcloud](/guides/manage-and-operate/cli/getting-started) installée et configurée
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -43,10 +43,10 @@ Selon l'outil que vous souhaitez utiliser :
 ### Préparation
 
 <Tabs>
-  <Tab label="Via l'espace client OVHcloud">
+  <Tab label="Espace client OVHcloud">
     Connectez-vous à votre espace client OVHcloud et ouvrez <code className="action">Object Storage</code> dans le menu de gauche sous **Storage & backup**.
   </Tab>
-  <Tab label="Via l'API Swift S3">
+  <Tab label="API Swift S3">
     **Définir les variables d'environnement OpenStack**
 
     ```bash
@@ -159,7 +159,7 @@ Selon l'outil que vous souhaitez utiliser :
     Les accès de type *virtual-hosted* et *path-style* sont tous deux pris en charge ; le type *virtual-hosted* est recommandé, car le *path-style* est obsolète depuis le 30 septembre 2020.
     :::
   </Tab>
-  <Tab label="Via le client Swift">
+  <Tab label="Client Swift">
     Définissez les variables d'environnement OpenStack :
 
     ```bash
@@ -174,8 +174,8 @@ Selon l'outil que vous souhaitez utiliser :
 
     Pour la liste complète des commandes Swift, consultez la [documentation OpenStack](https://docs.openstack.org/python-swiftclient/latest/cli/index.html).
   </Tab>
-  <Tab label="Via l'OVHcloud CLI">
-    Assurez-vous que l'OVHcloud CLI est installé et configuré avec vos identifiants. Pour les instructions de configuration, consultez la [documentation OVHcloud CLI](/guides/manage-and-operate/cli/getting-started).
+  <Tab label="CLI OVHcloud">
+    Assurez-vous que la CLI OVHcloud est installée et configurée avec vos identifiants. Pour les instructions de configuration, consultez la [documentation CLI OVHcloud](/guides/manage-and-operate/cli/getting-started).
   </Tab>
 </Tabs>
 
@@ -193,7 +193,7 @@ Lors de l'utilisation de l'**API Swift S3**, les noms de buckets doivent respect
 :::
 
 <Tabs>
-  <Tab label="Via l'espace client OVHcloud">
+  <Tab label="Espace client OVHcloud">
     Cliquez sur <code className="action">Créer un conteneur d'objets</code>.
 
     Remplissez le formulaire de création :
@@ -209,7 +209,7 @@ Lors de l'utilisation de l'**API Swift S3**, les noms de buckets doivent respect
 
     Vérifiez le panneau récapitulatif, puis cliquez sur <code className="action">Créer</code>.
   </Tab>
-  <Tab label="Via l'API Swift S3">
+  <Tab label="API Swift S3">
     ```bash
     aws s3 mb s3://<container_name>
     ```
@@ -218,7 +218,7 @@ Lors de l'utilisation de l'**API Swift S3**, les noms de buckets doivent respect
     Les buckets S3 ne peuvent être créés que sur la politique PCS (Object Storage).
     :::
   </Tab>
-  <Tab label="Via le client Swift">
+  <Tab label="Client Swift">
     Créez le conteneur :
 
     ```bash
@@ -252,18 +252,18 @@ Lors de l'utilisation de l'**API Swift S3**, les noms de buckets doivent respect
     Content-Type: text/plain; charset=utf-8
     ```
   </Tab>
-  <Tab label="Via l'OVHcloud CLI">
-    La création de conteneur n'est pas disponible via l'OVHcloud CLI. Utilisez l'espace client, l'API Swift S3 ou le client Swift à la place.
+  <Tab label="CLI OVHcloud">
+    La création de conteneur n'est pas disponible via la CLI OVHcloud. Utilisez l'espace client, l'API Swift S3 ou le client Swift à la place.
   </Tab>
 </Tabs>
 
 ### Lister vos conteneurs
 
 <Tabs>
-  <Tab label="Via l'espace client OVHcloud">
+  <Tab label="Espace client OVHcloud">
     Accédez à <code className="action">Object Storage</code> dans le menu de gauche. Vos conteneurs sont listés sous l'onglet <code className="action">Mes conteneurs</code>.
   </Tab>
-  <Tab label="Via l'API Swift S3">
+  <Tab label="API Swift S3">
     ```bash
     aws s3 ls
     ```
@@ -272,12 +272,12 @@ Lors de l'utilisation de l'**API Swift S3**, les noms de buckets doivent respect
     Si vous avez plusieurs profils configurés, ajoutez `--profile <profile_name>` à la commande.
     :::
   </Tab>
-  <Tab label="Via le client Swift">
+  <Tab label="Client Swift">
     ```bash
     swift list
     ```
   </Tab>
-  <Tab label="Via l'OVHcloud CLI">
+  <Tab label="CLI OVHcloud">
     ```bash
     ovhcloud cloud storage swift list
     ```
@@ -287,17 +287,17 @@ Lors de l'utilisation de l'**API Swift S3**, les noms de buckets doivent respect
 ### Téléverser des objets
 
 <Tabs>
-  <Tab label="Via l'espace client OVHcloud">
+  <Tab label="Espace client OVHcloud">
     Cliquez sur le nom de votre conteneur, puis cliquez sur <code className="action">Ajouter des objets</code> dans l'onglet **Objets**.
 
     Sélectionnez le fichier à téléverser et cliquez sur <code className="action">Importer</code>.
   </Tab>
-  <Tab label="Via l'API Swift S3">
+  <Tab label="API Swift S3">
     ```bash
     aws s3 cp /path/to/<object_name> s3://<container_name>/<object_name>
     ```
   </Tab>
-  <Tab label="Via le client Swift">
+  <Tab label="Client Swift">
     Téléverser un seul fichier :
 
     ```bash
@@ -313,23 +313,23 @@ Lors de l'utilisation de l'**API Swift S3**, les noms de buckets doivent respect
     images/OVHSummitKeynote.jpg
     ```
   </Tab>
-  <Tab label="Via l'OVHcloud CLI">
-    Le téléversement d'objets n'est pas disponible via l'OVHcloud CLI. Utilisez l'espace client, l'API Swift S3 ou le client Swift à la place.
+  <Tab label="CLI OVHcloud">
+    Le téléversement d'objets n'est pas disponible via la CLI OVHcloud. Utilisez l'espace client, l'API Swift S3 ou le client Swift à la place.
   </Tab>
 </Tabs>
 
 ### Lister les objets d'un conteneur
 
 <Tabs>
-  <Tab label="Via l'espace client OVHcloud">
+  <Tab label="Espace client OVHcloud">
     Cliquez sur le nom de votre conteneur pour visualiser ses objets dans l'onglet **Objets**.
   </Tab>
-  <Tab label="Via l'API Swift S3">
+  <Tab label="API Swift S3">
     ```bash
     aws s3 ls s3://<container_name>
     ```
   </Tab>
-  <Tab label="Via le client Swift">
+  <Tab label="Client Swift">
     ```bash
     swift list container1
 
@@ -357,23 +357,23 @@ Lors de l'utilisation de l'**API Swift S3**, les noms de buckets doivent respect
 
     Cette URL est composée d'un endpoint (disponible depuis l'[interface Horizon](/guides/public-cloud/cross-functional/compute-horizon-access-security)), du nom du conteneur et du nom de l'objet (préfixe inclus).
   </Tab>
-  <Tab label="Via l'OVHcloud CLI">
-    La liste des objets n'est pas disponible via l'OVHcloud CLI. Utilisez l'espace client, l'API Swift S3 ou le client Swift à la place.
+  <Tab label="CLI OVHcloud">
+    La liste des objets n'est pas disponible via la CLI OVHcloud. Utilisez l'espace client, l'API Swift S3 ou le client Swift à la place.
   </Tab>
 </Tabs>
 
 ### Télécharger des objets
 
 <Tabs>
-  <Tab label="Via l'espace client OVHcloud">
+  <Tab label="Espace client OVHcloud">
     Cliquez sur l'icône de téléchargement sur la ligne de l'objet.
   </Tab>
-  <Tab label="Via l'API Swift S3">
+  <Tab label="API Swift S3">
     ```bash
     aws s3 cp s3://<container_name>/<object_name> .
     ```
   </Tab>
-  <Tab label="Via le client Swift">
+  <Tab label="Client Swift">
     Télécharger un seul fichier :
 
     ```bash
@@ -391,20 +391,20 @@ Lors de l'utilisation de l'**API Swift S3**, les noms de buckets doivent respect
     images/OVHSummitKeynote.jpg [auth 0.371s, headers 0.514s, total 0.559s, 2.657 MB/s]
     ```
   </Tab>
-  <Tab label="Via l'OVHcloud CLI">
-    Le téléchargement d'objets n'est pas disponible via l'OVHcloud CLI. Utilisez l'espace client, l'API Swift S3 ou le client Swift à la place.
+  <Tab label="CLI OVHcloud">
+    Le téléchargement d'objets n'est pas disponible via la CLI OVHcloud. Utilisez l'espace client, l'API Swift S3 ou le client Swift à la place.
   </Tab>
 </Tabs>
 
 ### Supprimer des objets et des conteneurs
 
 <Tabs>
-  <Tab label="Via l'espace client OVHcloud">
+  <Tab label="Espace client OVHcloud">
     **Supprimer un objet** : Cliquez sur l'icône de suppression (corbeille) sur la ligne de l'objet et confirmez.
 
     **Supprimer un conteneur** : Cliquez sur le bouton <code className="action">...</code> sur la ligne du conteneur, puis sélectionnez <code className="action">Supprimer</code> et confirmez.
   </Tab>
-  <Tab label="Via l'API Swift S3">
+  <Tab label="API Swift S3">
     **Supprimer un objet :**
 
     ```bash
@@ -417,7 +417,7 @@ Lors de l'utilisation de l'**API Swift S3**, les noms de buckets doivent respect
     aws s3 rb s3://<container_name>
     ```
   </Tab>
-  <Tab label="Via le client Swift">
+  <Tab label="Client Swift">
     **Supprimer un fichier :**
 
     ```bash
@@ -444,8 +444,8 @@ Lors de l'utilisation de l'**API Swift S3**, les noms de buckets doivent respect
     text3.txt
     ```
   </Tab>
-  <Tab label="Via l'OVHcloud CLI">
-    La suppression de conteneurs et d'objets n'est pas disponible via l'OVHcloud CLI. Utilisez l'espace client, l'API Swift S3 ou le client Swift à la place.
+  <Tab label="CLI OVHcloud">
+    La suppression de conteneurs et d'objets n'est pas disponible via la CLI OVHcloud. Utilisez l'espace client, l'API Swift S3 ou le client Swift à la place.
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
Drop the "Via" prefix from every tab label (FR + EN) in the Swift Object Storage getting-started guide, and rename "OVHcloud CLI" to "CLI OVHcloud" throughout the FR copy (tab labels + prose), with the feminine article and agreement ("la CLI OVHcloud … installée et configurée").