### PR TITLE
style: distinguish action buttons from inline code

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -458,6 +458,24 @@ details:not(.rp-callout) > summary a.header-anchor {
   background-color: rgba(110, 168, 254, 0.12);
 }
 
+/* Action buttons: UI elements the user clicks (`label`{.action} →
+   <code className="action">). Styled as a pill to distinguish them
+   from plain inline code (backticks). */
+.rp-doc code.action {
+  color: var(--rp-c-brand-lighter);
+  background-color: rgba(0, 80, 215, 0.1);
+  border: 1px solid rgba(0, 80, 215, 0.25);
+  border-radius: 6px;
+  padding: 0.1em 0.5em;
+  font-weight: 500;
+}
+
+:where(html.rp-dark) .rp-doc code.action {
+  color: #6ea8fe;
+  background-color: rgba(110, 168, 254, 0.14);
+  border-color: rgba(110, 168, 254, 0.3);
+}
+
 /* Blockquote styling: match old platform's grey box */
 .rp-doc blockquote {
   background-color: var(--rp-c-bg-soft);


### PR DESCRIPTION
Add a pill style (brand colour, tinted background, border, rounded corners) to `code.action` so clickable UI buttons ({.action}) are visually distinct from plain inline code (backticks). Includes a dark-mode variant.