### PR TITLE
docs(web-hosting): clarify .ovhconfig requirement and default PHP version

### DIFF
--- a/docs/de/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -250,7 +250,7 @@ Klicken Sie bei **Globale PHP-Version** auf <code className="action">...</code> 
     :::info
     Wenn die Schaltfläche <code className="action">Konfiguration ändern</code> ausgegraut ist, wird möglicherweise eine Überprüfung der **Globale PHP-Version** durchgeführt. Ist das der Fall, erscheint neben der Version ein blaues Symbol, das dies anzeigt. Warten Sie einige Minuten, bis der Button <code className="action">Konfiguration ändern</code> wieder verfügbar ist.
 
-    Wenn die Option **Globale PHP-Version** in Ihrem <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> nicht angezeigt wird, überprüfen Sie, ob die *.ovhconfig*-Datei im FTP-Wurzelverzeichnis Ihres Webhostings vorhanden und/oder korrekt konfiguriert ist.
+    Wenn die Option **Globale PHP-Version** in Ihrem <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> nicht angezeigt wird, überprüfen Sie, ob die *.ovhconfig*-Datei im FTP-Wurzelverzeichnis Ihres Webhostings vorhanden und korrekt konfiguriert ist.
 
     Wenn weder eine *.ovhconfig*-Datei noch eine *.htaccess*-Datei vorhanden ist, die eine PHP-Version konfiguriert, wird die standardmäßig vorkonfigurierte PHP-Version auf Ihr Webhosting angewendet.
 

--- a/docs/de/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Webhosting - Laufzeitumgebung, PHP-Version, .ovhconfig
 description: Erfahren Sie hier, wie Sie die Einstellungen von Laufzeitumgebung, PHP-Version, Firewall, Engine, Modus und .ovhconfig ändern
-lastUpdated: 2026-06-16
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -250,7 +250,9 @@ Klicken Sie bei **Globale PHP-Version** auf <code className="action">...</code> 
     :::info
     Wenn die Schaltfläche <code className="action">Konfiguration ändern</code> ausgegraut ist, wird möglicherweise eine Überprüfung der **Globale PHP-Version** durchgeführt. Ist das der Fall, erscheint neben der Version ein blaues Symbol, das dies anzeigt. Warten Sie einige Minuten, bis der Button <code className="action">Konfiguration ändern</code> wieder verfügbar ist.
 
-    Wenn die Option **Globale PHP-Version** in Ihrem <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> nicht angezeigt wird, überprüfen Sie, ob die *.ovhconfig*-Datei im FTP-Wurzelverzeichnis Ihres Webhostings vorhanden ist.
+    Wenn die Option **Globale PHP-Version** in Ihrem <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> nicht angezeigt wird, überprüfen Sie, ob die *.ovhconfig*-Datei im FTP-Wurzelverzeichnis Ihres Webhostings vorhanden und/oder korrekt konfiguriert ist.
+
+    Wenn weder eine *.ovhconfig*-Datei noch eine *.htaccess*-Datei vorhanden ist, die eine PHP-Version konfiguriert, wird die standardmäßig vorkonfigurierte PHP-Version auf Ihr Webhosting angewendet.
 
     Alle Informationen zur Datei *.ovhconfig* finden Sie im dritten Teil „[Methode 2: Webhosting-Konfiguration über die Datei “.ovhconfig”](#setting-ovhconfig)” dieser Anleitung.
 

--- a/docs/en/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -251,9 +251,9 @@ On the right-hand side of <code className="action">Global PHP version</code> loc
     :::info
     If the <code className="action">Modify configuration</code> button is greyed out, it may be that the **Global PHP version** is being verified. If this is the case, a blue round symbol will appear next to the version, indicating that a check is in progress. Wait a few minutes for the <code className="action">Modify configuration</code> button to become accessible again.
 
-    If the **Global PHP version** option does not appear in your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, check that the *.ovhconfig* file exists in the FTP root of your OVHcloud web hosting plan and/or that it is correctly configured.
+    If the **Global PHP version** option does not appear in your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, check that the *.ovhconfig* file exists in the FTP root of your OVHcloud web hosting plan and that it is correctly configured.
 
-    If there is no *.ovhconfig* file or no *.htaccess* file configuring a PHP version, the default pre-configured PHP version applies to your web hosting plan.
+    If neither a *.ovhconfig* file nor a *.htaccess* file configures a PHP version, the default pre-configured PHP version applies to your web hosting plan.
 
     Find all the information about the *.ovhconfig* file in the third part “[Method 2: Modify your Web Hosting plan’s configuration with the “.ovhconfig” file](#setting-ovhconfig)” of this guide.
 

--- a/docs/en/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Hosting - Environment, PHP version, .ovhconfig
 description: Find out how to modify a web hosting plan’s runtime environment, PHP version, application firewall, engine, mode and .ovhconfig
-lastUpdated: 2026-06-16
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -141,7 +141,6 @@ You can find out which PHP version is currently used by your web hosting plan in
 <details>
 <summary>In the OVHcloud Control Panel</summary>
 
-{/* CP-STEPS-START:check-php-version */}
 Click on the tabs below to view each of the **2** steps.
 
 <Tabs>
@@ -163,7 +162,6 @@ Click on the tabs below to view each of the **2** steps.
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:check-php-version */}
 
 </details>
 
@@ -235,7 +233,6 @@ As a reminder, changing at least one of these elements may affect the display or
 
 :::
 
-{/* CP-STEPS-START:modify-config-cp */}
 Click on the tabs below to view each of the **3** steps.
 
 <Tabs>
@@ -254,7 +251,9 @@ On the right-hand side of <code className="action">Global PHP version</code> loc
     :::info
     If the <code className="action">Modify configuration</code> button is greyed out, it may be that the **Global PHP version** is being verified. If this is the case, a blue round symbol will appear next to the version, indicating that a check is in progress. Wait a few minutes for the <code className="action">Modify configuration</code> button to become accessible again.
 
-    If the **Global PHP version** option does not appear in your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, check that the *.ovhconfig* file exists in the FTP root of your OVHcloud web hosting plan.
+    If the **Global PHP version** option does not appear in your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, check that the *.ovhconfig* file exists in the FTP root of your OVHcloud web hosting plan and/or that it is correctly configured.
+
+    If there is no *.ovhconfig* file or no *.htaccess* file configuring a PHP version, the default pre-configured PHP version applies to your web hosting plan.
 
     Find all the information about the *.ovhconfig* file in the third part “[Method 2: Modify your Web Hosting plan’s configuration with the “.ovhconfig” file](#setting-ovhconfig)” of this guide.
 
@@ -280,7 +279,6 @@ On the right-hand side of <code className="action">Global PHP version</code> loc
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:modify-config-cp */}
 
 ### 3 - Method 2: Modify the web hosting plan configuration with the ".ovhconfig" file <a name="setting-ovhconfig"></a>
 
@@ -288,7 +286,6 @@ On the right-hand side of <code className="action">Global PHP version</code> loc
 
 You will need your primary FTP username, its password, and the FTP server address.
 
-{/* CP-STEPS-START:retrieve-ftp-credentials */}
 Click on the tabs below to view each of the **3** steps.
 
 <Tabs>
@@ -311,7 +308,6 @@ For the FTP user password, please refer to our guide on [Modifying an FTP user p
   </Tab>
 </Tabs>
 
-{/* CP-STEPS-END:retrieve-ftp-credentials */}
 
 #### 3.2 - Create or open the .ovhconfig file
 

--- a/docs/es/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web hosting - Entorno, versión PHP, .ovhconfig
 description: Descubra cómo cambiar el entorno de ejecución, la versión PHP, el firewall de aplicaciones, el motor, el modo y el .ovhconfig de un alojamiento web
-lastUpdated: 2026-06-16
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -251,7 +251,9 @@ Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
     :::info
     Si el botón <code className="action">Editar la configuración</code> aparece atenuado, es posible que se esté realizando una comprobación de la **Versión PHP Global**. En ese caso, aparecerá un círculo de color azul junto a la versión, indicando que se está realizando una comprobación. Espere unos minutos hasta que el botón <code className="action">Editar la configuración</code> vuelva a estar disponible.
 
-    Si la opción **Versión PHP Global** no aparece en su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, compruebe que el archivo *.ovhconfig* existe en la raíz FTP de su alojamiento compartido de OVHcloud.
+    Si la opción **Versión PHP Global** no aparece en su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, compruebe que el archivo *.ovhconfig* existe en la raíz FTP de su alojamiento web de OVHcloud y/o que está correctamente configurado.
+
+    En ausencia de un archivo *.ovhconfig* o de un archivo *.htaccess* que configure una versión de PHP, se aplica a su alojamiento web la versión de PHP preconfigurada por defecto.
 
     Encontrará toda la información relativa al archivo *.ovhconfig* en la tercera parte "[Método 2: modificar la configuración del alojamiento web desde el archivo ".ovhconfig"](#setting-ovhconfig)" de esta guía.
 

--- a/docs/es/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -251,7 +251,7 @@ Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
     :::info
     Si el botón <code className="action">Editar la configuración</code> aparece atenuado, es posible que se esté realizando una comprobación de la **Versión PHP Global**. En ese caso, aparecerá un círculo de color azul junto a la versión, indicando que se está realizando una comprobación. Espere unos minutos hasta que el botón <code className="action">Editar la configuración</code> vuelva a estar disponible.
 
-    Si la opción **Versión PHP Global** no aparece en su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, compruebe que el archivo *.ovhconfig* existe en la raíz FTP de su alojamiento web de OVHcloud y/o que está correctamente configurado.
+    Si la opción **Versión PHP Global** no aparece en su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, compruebe que el archivo *.ovhconfig* existe en la raíz FTP de su alojamiento web de OVHcloud y que está correctamente configurado.
 
     En ausencia de un archivo *.ovhconfig* o de un archivo *.htaccess* que configure una versión de PHP, se aplica a su alojamiento web la versión de PHP preconfigurada por defecto.
 

--- a/docs/fr/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hébergement web - Environnement, version PHP, « .ovhconfig »
 description: "Découvrez comment modifier l'environnement d'exécution, la version PHP, le pare-feu applicatif, le moteur, le mode et le « .ovhconfig » d'un hébergement web"
-lastUpdated: 2026-06-16
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -251,7 +251,9 @@ Cliquez sur le bouton <code className="action">...</code> à droite de la mentio
     :::info
     Si le bouton <code className="action">Modifier la configuration</code> est grisé, il se peut qu'une vérification de la **version PHP globale** soit en cours. Si tel est le cas, un symbole rond de couleur bleue s'affichera à côté de la version, indiquant qu'une vérification est cours. Patientez alors quelques minutes pour que le bouton <code className="action">Modifier la configuration</code> redevienne accessible.
 
-    Si l'option **version PHP globale** n'apparaît pas dans votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, vérifiez que fichier *.ovhconfig* existe bien à la racine FTP de votre hébergement mutualisé OVHcloud.
+    Si l'option **version PHP globale** n'apparaît pas dans votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, vérifiez que le fichier *.ovhconfig* existe bien à la racine FTP de votre hébergement web OVHcloud et / ou que celui-ci est correctement configuré.
+
+    En l'absence de fichier *.ovhconfig* ou d'un fichier *.htaccess* configurant une version de PHP, c'est la version de PHP pré-configurée par défaut qui s'applique à votre hébergement web.
 
     Retrouvez toutes les informations concernant le fichier *.ovhconfig* dans la troisième partie « [Méthode 2 : modifier la configuration de l'hébergement web depuis le fichier « .ovhconfig »](#setting-ovhconfig) » du présent guide.
 

--- a/docs/fr/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -251,9 +251,9 @@ Cliquez sur le bouton <code className="action">...</code> à droite de la mentio
     :::info
     Si le bouton <code className="action">Modifier la configuration</code> est grisé, il se peut qu'une vérification de la **version PHP globale** soit en cours. Si tel est le cas, un symbole rond de couleur bleue s'affichera à côté de la version, indiquant qu'une vérification est cours. Patientez alors quelques minutes pour que le bouton <code className="action">Modifier la configuration</code> redevienne accessible.
 
-    Si l'option **version PHP globale** n'apparaît pas dans votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, vérifiez que le fichier *.ovhconfig* existe bien à la racine FTP de votre hébergement web OVHcloud et / ou que celui-ci est correctement configuré.
+    Si l'option **version PHP globale** n'apparaît pas dans votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, vérifiez que le fichier *.ovhconfig* existe bien à la racine FTP de votre hébergement web OVHcloud et que celui-ci est correctement configuré.
 
-    En l'absence de fichier *.ovhconfig* ou d'un fichier *.htaccess* configurant une version de PHP, c'est la version de PHP pré-configurée par défaut qui s'applique à votre hébergement web.
+    En l'absence d'un fichier *.ovhconfig* ou d'un fichier *.htaccess* configurant une version de PHP, c'est la version de PHP préconfigurée par défaut qui s'applique à votre hébergement web.
 
     Retrouvez toutes les informations concernant le fichier *.ovhconfig* dans la troisième partie « [Méthode 2 : modifier la configuration de l'hébergement web depuis le fichier « .ovhconfig »](#setting-ovhconfig) » du présent guide.
 

--- a/docs/it/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -251,7 +251,7 @@ A destra della voce **Versione PHP**, situata quasi al centro della pagina, clic
     :::info
     Se il pulsante <code className="action">Modifica la configurazione</code> è disattivato, è possibile che una verifica della **Versione PHP** sia in corso. In questo caso, accanto alla versione verrà visualizzato un cerchio blu che indica che è in corso un controllo. Attendi qualche minuto fino a quando il pulsante <code className="action">Modifica la configurazione</code> sarà nuovamente disponibile.
 
-    Se l’opzione **Versione PHP** non compare nel tuo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, verifica che il file *.ovhconfig* esista effettivamente nella root FTP del tuo hosting web OVHcloud e/o che sia configurato correttamente.
+    Se l’opzione **Versione PHP** non compare nel tuo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, verifica che il file *.ovhconfig* esista effettivamente nella root FTP del tuo hosting web OVHcloud e che sia configurato correttamente.
 
     In assenza di un file *.ovhconfig* o di un file *.htaccess* che configuri una versione di PHP, al tuo hosting web viene applicata la versione di PHP preconfigurata predefinita.
 

--- a/docs/it/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hosting Web - Ambiente, versione PHP, .ovhconfig
 description: Questa guida ti mostra come modificare ambiente di esecuzione, versione PHP, firewall applicativo, motore, modalità e .ovhconfig di un hosting Web
-lastUpdated: 2026-06-16
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -251,7 +251,9 @@ A destra della voce **Versione PHP**, situata quasi al centro della pagina, clic
     :::info
     Se il pulsante <code className="action">Modifica la configurazione</code> è disattivato, è possibile che una verifica della **Versione PHP** sia in corso. In questo caso, accanto alla versione verrà visualizzato un cerchio blu che indica che è in corso un controllo. Attendi qualche minuto fino a quando il pulsante <code className="action">Modifica la configurazione</code> sarà nuovamente disponibile.
 
-    Se l’opzione **Versione PHP** non compare nel tuo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, verifica che il file *.ovhconfig* esista effettivamente nella root FTP del tuo hosting condiviso OVHcloud.
+    Se l’opzione **Versione PHP** non compare nel tuo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, verifica che il file *.ovhconfig* esista effettivamente nella root FTP del tuo hosting web OVHcloud e/o che sia configurato correttamente.
+
+    In assenza di un file *.ovhconfig* o di un file *.htaccess* che configuri una versione di PHP, al tuo hosting web viene applicata la versione di PHP preconfigurata predefinita.
 
     Tutte le informazioni relative al file *.ovhconfig* sono disponibili nella terza parte "[Metodo 2: modificare la configurazione dell’hosting Web dal file ".ovhconfig"](#setting-ovhconfig)" di questa guida.
 

--- a/docs/pl/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -251,7 +251,7 @@ Z prawej strony wzmianki **Ogólna wersja PHP** znajdującej się prawie na śro
     :::info
     Jeśli przycisk <code className="action">Zmień konfigurację</code> jest wyszarzony, możliwe jest, że trwa weryfikacja **Ogólna wersja PHP**. W takim przypadku obok wersji wyświetli się okrągły niebieski symbol oznaczający, że weryfikacja jest w toku. Odczekaj kilka minut, aby przycisk <code className="action">Zmień konfigurację</code> stał się znowu dostępny.
 
-    Jeśli opcja **Ogólna wersja PHP** nie wyświetla się w Twoim <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, sprawdź, czy plik *.ovhconfig* znajduje się w katalogu głównym FTP Twojego hostingu OVHcloud i/lub czy jest poprawnie skonfigurowany.
+    Jeśli opcja **Ogólna wersja PHP** nie wyświetla się w Twoim <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, sprawdź, czy plik *.ovhconfig* znajduje się w katalogu głównym FTP Twojego hostingu OVHcloud i czy jest poprawnie skonfigurowany.
 
     W przypadku braku pliku *.ovhconfig* lub pliku *.htaccess* konfigurującego wersję PHP, do Twojego hostingu stosowana jest domyślnie skonfigurowana wersja PHP.
 

--- a/docs/pl/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hosting WWW - Środowisko, wersja PHP, .ovhconfig
 description: Dowiedz się, jak zmienić środowisko uruchomieniowe, wersję PHP, zaporę aplikacyjną, silnik, tryb i .ovhconfig na hostingu WWW
-lastUpdated: 2026-06-16
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -251,7 +251,9 @@ Z prawej strony wzmianki **Ogólna wersja PHP** znajdującej się prawie na śro
     :::info
     Jeśli przycisk <code className="action">Zmień konfigurację</code> jest wyszarzony, możliwe jest, że trwa weryfikacja **Ogólna wersja PHP**. W takim przypadku obok wersji wyświetli się okrągły niebieski symbol oznaczający, że weryfikacja jest w toku. Odczekaj kilka minut, aby przycisk <code className="action">Zmień konfigurację</code> stał się znowu dostępny.
 
-    Jeśli opcja **Ogólna wersja PHP** nie wyświetla się w Twoim <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, sprawdź, czy plik *.ovhconfig* znajduje się w katalogu głównym FTP Twojego hostingu OVHcloud.
+    Jeśli opcja **Ogólna wersja PHP** nie wyświetla się w Twoim <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, sprawdź, czy plik *.ovhconfig* znajduje się w katalogu głównym FTP Twojego hostingu OVHcloud i/lub czy jest poprawnie skonfigurowany.
+
+    W przypadku braku pliku *.ovhconfig* lub pliku *.htaccess* konfigurującego wersję PHP, do Twojego hostingu stosowana jest domyślnie skonfigurowana wersja PHP.
 
     Wszystkie informacje dotyczące pliku *.ovhconfig* znajdziesz w trzeciej części "[Metoda 2: Modyfikacja konfiguracji hostingu WWW z poziomu pliku ".ovhconfig"](#setting-ovhconfig)" niniejszego przewodnika.
 

--- a/docs/pt/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -251,7 +251,7 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
     :::info
     Se o botão <code className="action">Alterar configuração</code> estiver cinzento, é possível que esteja a decorrer uma verificação da **Versão global de PHP**. Se for o caso, aparecerá um símbolo redondo azul junto da versão, indicando que a verificação está em curso. Aguarde alguns minutos para que o botão <code className="action">Alterar configuração</code> volte a ficar acessível.
 
-    Se a opção **Versão global de PHP** não aparecer na <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, verifique se o ficheiro *.ovhconfig* existe na raiz de FTP do seu alojamento web OVHcloud e/ou se está corretamente configurado.
+    Se a opção **Versão global de PHP** não aparecer na <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, verifique se o ficheiro *.ovhconfig* existe na raiz de FTP do seu alojamento web OVHcloud e se está corretamente configurado.
 
     Na ausência de um ficheiro *.ovhconfig* ou de um ficheiro *.htaccess* que configure uma versão de PHP, é aplicada ao seu alojamento web a versão de PHP pré-configurada por predefinição.
 

--- a/docs/pt/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alojamento web - Ambiente, versão PHP, .ovhconfig
 description: Saiba como alterar o ambiente de execução, a versão PHP, a firewall aplicacional, o motor, o modo e o .ovhconfig de um alojamento web
-lastUpdated: 2026-06-16
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -251,7 +251,9 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
     :::info
     Se o botão <code className="action">Alterar configuração</code> estiver cinzento, é possível que esteja a decorrer uma verificação da **Versão global de PHP**. Se for o caso, aparecerá um símbolo redondo azul junto da versão, indicando que a verificação está em curso. Aguarde alguns minutos para que o botão <code className="action">Alterar configuração</code> volte a ficar acessível.
 
-    Se a opção **Versão global de PHP** não aparecer na <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, verifique se o ficheiro *.ovhconfig* existe na raiz de FTP do seu alojamento partilhado OVHcloud.
+    Se a opção **Versão global de PHP** não aparecer na <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, verifique se o ficheiro *.ovhconfig* existe na raiz de FTP do seu alojamento web OVHcloud e/ou se está corretamente configurado.
+
+    Na ausência de um ficheiro *.ovhconfig* ou de um ficheiro *.htaccess* que configure uma versão de PHP, é aplicada ao seu alojamento web a versão de PHP pré-configurada por predefinição.
 
     Encontre todas as informações relativas ao ficheiro *.ovhconfig* na terceira parte "[Método 2: alterar a configuração do alojamento web a partir do ficheiro ".ovhconfig"](#setting-ovhconfig)" deste guia.
 


### PR DESCRIPTION

Update the configure-your-web-hosting guide across all 7 locales:
- clarify that the .ovhconfig file must exist and be correctly configured
- add a note on the default pre-configured PHP version when no .ovhconfig or .htaccess file sets one
- bump lastUpdated to 2026-07-23

## Summary

Clarifies the `.ovhconfig` requirement and documents the default PHP version behaviour in the **Configure your web hosting** guide, across all 7 locales (fr, en, de, es, it, pl, pt).

## Changes

- **Reworded the `.ovhconfig` note**: the file must not only exist at the FTP root of the web hosting plan, but also be **correctly configured**. Also replaced the outdated "shared hosting" wording with "web hosting".
- **Added a new note**: when neither a `.ovhconfig` file nor a `.htaccess` file sets a PHP version, the **default pre-configured PHP version** applies to the web hosting plan.
- **Bumped `lastUpdated`** to `2026-07-23` in all 7 locale files.

## Notes

- FR was the source; EN/DE/ES/IT/PL/PT were translated following the standard source routing (FR → EN, then EN → DE/PL and FR → ES/IT/PT).
- Proofread pass applied (fixed a missing article in the FR sentence).
- No functional/config changes — documentation only.
