### PR TITLE
docs(secret-manager): recommend native ESO provider and fix IAM rights on Vault guide

### DIFF
--- a/docs/de/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/de/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes External Secrets Operator mit Secret Manager verwenden
 description: Konfigurieren Sie den External Secrets Operator, um Kubernetes-Secrets im OVHcloud Secret Manager zu speichern
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-23
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -11,6 +11,12 @@ import Api from '@components/Api';
 ## Ziel
 
 Diese Anleitung erklärt, wie Sie den Kubernetes External Secrets Operator einrichten, um den OVHcloud Secret Manager als Provider zu verwenden.
+
+:::warning
+Diese Anleitung beschreibt die Verwendung von External Secrets Operator mit dem **HashiCorp Vault**-Provider und dem OVHcloud Secret Manager über die HashiCorp Vault KV2-kompatible API.
+
+OVHcloud stellt mittlerweile einen **nativen External Secrets Operator-Provider** bereit. Wir empfehlen, diesen für neue Deployments zu verwenden. Weitere Informationen finden Sie in der [Dokumentation zum OVHcloud-Provider](https://external-secrets.io/latest/provider/ovhcloud/).
+:::
 
 ## Voraussetzungen
 
@@ -33,6 +39,7 @@ Der Benutzer sollte Mitglied einer Gruppe mit der Rolle ADMIN sein. Wenn Sie sta
 
 - `okms:apikms:secret/create`
 - `okms:apikms:secret/version/getData`
+- `okms:apikms:secret/get`
 - `okms:apiovh:secret/get`
 
 Alternativ ist es möglich, einen Benutzer mit der [OVHcloud CLI](https://github.com/ovh/ovhcloud-cli) zu erstellen:

--- a/docs/de/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/de/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -13,7 +13,7 @@ import Api from '@components/Api';
 Diese Anleitung erklärt, wie Sie den Kubernetes External Secrets Operator einrichten, um den OVHcloud Secret Manager als Provider zu verwenden.
 
 :::warning
-Diese Anleitung beschreibt die Verwendung von External Secrets Operator mit dem **HashiCorp Vault**-Provider und dem OVHcloud Secret Manager über die HashiCorp Vault KV2-kompatible API.
+Diese Anleitung beschreibt die Verwendung von External Secrets Operator mit dem **HashiCorp Vault**-Provider, um auf den OVHcloud Secret Manager über die HashiCorp Vault KV2-kompatible API zuzugreifen.
 
 OVHcloud stellt mittlerweile einen **nativen External Secrets Operator-Provider** bereit. Wir empfehlen, diesen für neue Deployments zu verwenden. Weitere Informationen finden Sie in der [Dokumentation zum OVHcloud-Provider](https://external-secrets.io/latest/provider/ovhcloud/).
 :::

--- a/docs/en/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/en/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to use Kubernetes External Secrets Operator with Secret Manager
 description: Configure External Secrets Operator to store Kubernetes secrets on the OVHcloud Secret Manager
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-23
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -11,6 +11,12 @@ import Api from '@components/Api';
 ## Objective
 
 This guide explains how to set up the Kubernetes External Secrets Operator to use the OVHcloud Secret Manager as a provider.
+
+:::warning
+This guide describes how to use External Secrets Operator with the **HashiCorp Vault** provider against the OVHcloud Secret Manager using HashiCorp Vault KV2-compatible API.
+
+OVHcloud now provides a **native External Secrets Operator provider**. We recommend using it for new deployments. See the [OVHcloud provider documentation](https://external-secrets.io/latest/provider/ovhcloud/).
+:::
 
 ## Requirements
 
@@ -33,6 +39,7 @@ The user should be a member of a group with the ADMIN role. If you are using [IA
 
 - `okms:apikms:secret/create`
 - `okms:apikms:secret/version/getData`
+- `okms:apikms:secret/get`
 - `okms:apiovh:secret/get`
 
 Alternatively, it's possible to create a user using [OVHcloud CLI](https://github.com/ovh/ovhcloud-cli):

--- a/docs/en/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/en/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -13,7 +13,7 @@ import Api from '@components/Api';
 This guide explains how to set up the Kubernetes External Secrets Operator to use the OVHcloud Secret Manager as a provider.
 
 :::warning
-This guide describes how to use External Secrets Operator with the **HashiCorp Vault** provider against the OVHcloud Secret Manager using HashiCorp Vault KV2-compatible API.
+This guide describes how to use External Secrets Operator with the **HashiCorp Vault** provider to access the OVHcloud Secret Manager through the HashiCorp Vault KV2-compatible API.
 
 OVHcloud now provides a **native External Secrets Operator provider**. We recommend using it for new deployments. See the [OVHcloud provider documentation](https://external-secrets.io/latest/provider/ovhcloud/).
 :::

--- a/docs/es/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/es/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -13,7 +13,7 @@ import Api from '@components/Api';
 Esta guía explica cómo configurar el External Secrets Operator de Kubernetes para utilizar el Secret Manager de OVHcloud como proveedor.
 
 :::warning
-Esta guía describe el uso de External Secrets Operator con el proveedor **HashiCorp Vault** y el Secret Manager de OVHcloud mediante la API compatible con HashiCorp Vault KV2.
+Esta guía describe el uso de External Secrets Operator con el proveedor **HashiCorp Vault** para acceder al Secret Manager de OVHcloud mediante la API compatible con HashiCorp Vault KV2.
 
 OVHcloud ofrece ahora un **proveedor nativo de External Secrets Operator**. Recomendamos utilizarlo para los nuevos despliegues. Consulte la [documentación del proveedor OVHcloud](https://external-secrets.io/latest/provider/ovhcloud/).
 :::

--- a/docs/es/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/es/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cómo utilizar Kubernetes External Secrets Operator con Secret Manager
 description: Descubra cómo configurar External Secrets Operator para almacenar los secretos de Kubernetes en el Secret Manager de OVHcloud
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-23
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -11,6 +11,12 @@ import Api from '@components/Api';
 ## Objetivo
 
 Esta guía explica cómo configurar el External Secrets Operator de Kubernetes para utilizar el Secret Manager de OVHcloud como proveedor.
+
+:::warning
+Esta guía describe el uso de External Secrets Operator con el proveedor **HashiCorp Vault** y el Secret Manager de OVHcloud mediante la API compatible con HashiCorp Vault KV2.
+
+OVHcloud ofrece ahora un **proveedor nativo de External Secrets Operator**. Recomendamos utilizarlo para los nuevos despliegues. Consulte la [documentación del proveedor OVHcloud](https://external-secrets.io/latest/provider/ovhcloud/).
+:::
 
 ## Requisitos
 
@@ -33,6 +39,7 @@ El usuario debe pertenecer a un grupo con el rol ADMIN o, si utiliza [políticas
 
 - `okms:apikms:secret/create`
 - `okms:apikms:secret/version/getData`
+- `okms:apikms:secret/get`
 - `okms:apiovh:secret/get`
 
 También es posible crear un usuario con la [CLI OVHcloud](https://github.com/ovh/ovhcloud-cli):

--- a/docs/fr/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/fr/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -13,7 +13,7 @@ import Api from '@components/Api';
 Ce guide explique comment configurer l'External Secrets Operator Kubernetes pour utiliser le Secret Manager d'OVHcloud en tant que fournisseur.
 
 :::warning
-Ce guide décrit l'utilisation d'External Secrets Operator avec le fournisseur **HashiCorp Vault** et le Secret Manager OVHcloud via l'API compatible HashiCorp Vault KV2.
+Ce guide décrit l'utilisation d'External Secrets Operator avec le fournisseur **HashiCorp Vault** pour accéder au Secret Manager d'OVHcloud via l'API compatible HashiCorp Vault KV2.
 
 OVHcloud propose désormais un **fournisseur External Secrets Operator natif**. Nous recommandons de l'utiliser pour les nouveaux déploiements. Consultez la [documentation du fournisseur OVHcloud](https://external-secrets.io/latest/provider/ovhcloud/).
 :::

--- a/docs/fr/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/fr/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comment utiliser Kubernetes External Secrets Operator avec Secret Manager
 description: "Découvrez comment configurer External Secrets Operator pour stocker les secrets Kubernetes sur le Secret Manager d'OVHcloud"
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-23
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -11,6 +11,12 @@ import Api from '@components/Api';
 ## Objectif
 
 Ce guide explique comment configurer l'External Secrets Operator Kubernetes pour utiliser le Secret Manager d'OVHcloud en tant que fournisseur.
+
+:::warning
+Ce guide décrit l'utilisation d'External Secrets Operator avec le fournisseur **HashiCorp Vault** et le Secret Manager OVHcloud via l'API compatible HashiCorp Vault KV2.
+
+OVHcloud propose désormais un **fournisseur External Secrets Operator natif**. Nous recommandons de l'utiliser pour les nouveaux déploiements. Consultez la [documentation du fournisseur OVHcloud](https://external-secrets.io/latest/provider/ovhcloud/).
+:::
 
 ## Prérequis
 
@@ -33,6 +39,7 @@ L'utilisateur doit appartenir à un groupe avec le rôle ADMIN, ou si vous utili
 
 - `okms:apikms:secret/create`
 - `okms:apikms:secret/version/getData`
+- `okms:apikms:secret/get`
 - `okms:apiovh:secret/get`
 
 Il est aussi possible de créer un utilisateur avec l'[OVHcloud CLI](https://github.com/ovh/ovhcloud-cli) :

--- a/docs/it/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/it/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -13,7 +13,7 @@ import Api from '@components/Api';
 Questa guida spiega come configurare l'External Secrets Operator di Kubernetes per utilizzare il Secret Manager di OVHcloud come provider.
 
 :::warning
-Questa guida descrive l'utilizzo di External Secrets Operator con il provider **HashiCorp Vault** e il Secret Manager di OVHcloud tramite l'API compatibile HashiCorp Vault KV2.
+Questa guida descrive l'utilizzo di External Secrets Operator con il provider **HashiCorp Vault** per accedere al Secret Manager di OVHcloud tramite l'API compatibile HashiCorp Vault KV2.
 
 OVHcloud fornisce ora un **provider External Secrets Operator nativo**. Ti consigliamo di utilizzarlo per i nuovi deployment. Consulta la [documentazione del provider OVHcloud](https://external-secrets.io/latest/provider/ovhcloud/).
 :::

--- a/docs/it/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/it/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -1,7 +1,7 @@
 ---
 title: Come utilizzare Kubernetes External Secrets Operator con Secret Manager
 description: Scopri come configurare External Secrets Operator per archiviare i secret Kubernetes sul Secret Manager di OVHcloud
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-23
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -11,6 +11,12 @@ import Api from '@components/Api';
 ## Obiettivo
 
 Questa guida spiega come configurare l'External Secrets Operator di Kubernetes per utilizzare il Secret Manager di OVHcloud come provider.
+
+:::warning
+Questa guida descrive l'utilizzo di External Secrets Operator con il provider **HashiCorp Vault** e il Secret Manager di OVHcloud tramite l'API compatibile HashiCorp Vault KV2.
+
+OVHcloud fornisce ora un **provider External Secrets Operator nativo**. Ti consigliamo di utilizzarlo per i nuovi deployment. Consulta la [documentazione del provider OVHcloud](https://external-secrets.io/latest/provider/ovhcloud/).
+:::
 
 ## Prerequisiti
 
@@ -33,6 +39,7 @@ L'utente deve appartenere a un gruppo con il ruolo ADMIN oppure, se utilizzi del
 
 - `okms:apikms:secret/create`
 - `okms:apikms:secret/version/getData`
+- `okms:apikms:secret/get`
 - `okms:apiovh:secret/get`
 
 È anche possibile creare un utente con la [CLI OVHcloud](https://github.com/ovh/ovhcloud-cli):

--- a/docs/pl/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/pl/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -13,7 +13,7 @@ import Api from '@components/Api';
 Ten przewodnik wyjaśnia, jak skonfigurować Kubernetes External Secrets Operator, aby używać OVHcloud Secret Manager jako dostawcy.
 
 :::warning
-Ten przewodnik opisuje korzystanie z External Secrets Operator z dostawcą **HashiCorp Vault** oraz OVHcloud Secret Manager przy użyciu API zgodnego z HashiCorp Vault KV2.
+Ten przewodnik opisuje korzystanie z External Secrets Operator z dostawcą **HashiCorp Vault**, aby uzyskać dostęp do OVHcloud Secret Manager za pośrednictwem API zgodnego z HashiCorp Vault KV2.
 
 OVHcloud udostępnia teraz **natywnego dostawcę External Secrets Operator**. Zalecamy korzystanie z niego w nowych wdrożeniach. Zobacz [dokumentację dostawcy OVHcloud](https://external-secrets.io/latest/provider/ovhcloud/).
 :::

--- a/docs/pl/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/pl/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -1,7 +1,7 @@
 ---
 title: Jak używać Kubernetes External Secrets Operator z Secret Manager
 description: Skonfiguruj External Secrets Operator, aby przechowywać sekrety Kubernetes w OVHcloud Secret Manager
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-23
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -11,6 +11,12 @@ import Api from '@components/Api';
 ## Wprowadzenie
 
 Ten przewodnik wyjaśnia, jak skonfigurować Kubernetes External Secrets Operator, aby używać OVHcloud Secret Manager jako dostawcy.
+
+:::warning
+Ten przewodnik opisuje korzystanie z External Secrets Operator z dostawcą **HashiCorp Vault** oraz OVHcloud Secret Manager przy użyciu API zgodnego z HashiCorp Vault KV2.
+
+OVHcloud udostępnia teraz **natywnego dostawcę External Secrets Operator**. Zalecamy korzystanie z niego w nowych wdrożeniach. Zobacz [dokumentację dostawcy OVHcloud](https://external-secrets.io/latest/provider/ovhcloud/).
+:::
 
 ## Wymagania początkowe
 
@@ -33,6 +39,7 @@ Użytkownik powinien należeć do grupy z rolą ADMIN. Jeśli zamiast tego używ
 
 - `okms:apikms:secret/create`
 - `okms:apikms:secret/version/getData`
+- `okms:apikms:secret/get`
 - `okms:apiovh:secret/get`
 
 Alternatywnie można utworzyć użytkownika za pomocą [CLI OVHcloud](https://github.com/ovh/ovhcloud-cli):

--- a/docs/pt/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/pt/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -1,7 +1,7 @@
 ---
 title: Como utilizar o Kubernetes External Secrets Operator com o Secret Manager
 description: Descubra como configurar o External Secrets Operator para armazenar os segredos Kubernetes no Secret Manager da OVHcloud
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-23
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -11,6 +11,12 @@ import Api from '@components/Api';
 ## Objetivo
 
 Este manual explica como configurar o External Secrets Operator do Kubernetes para utilizar o Secret Manager da OVHcloud como fornecedor.
+
+:::warning
+Este manual descreve a utilização do External Secrets Operator com o fornecedor **HashiCorp Vault** e o Secret Manager da OVHcloud através da API compatível com HashiCorp Vault KV2.
+
+A OVHcloud disponibiliza agora um **fornecedor External Secrets Operator nativo**. Recomendamos a sua utilização para novos deployments. Consulte a [documentação do fornecedor OVHcloud](https://external-secrets.io/latest/provider/ovhcloud/).
+:::
 
 ## Requisitos
 
@@ -33,6 +39,7 @@ O utilizador deve pertencer a um grupo com a função ADMIN ou, caso utilize [po
 
 - `okms:apikms:secret/create`
 - `okms:apikms:secret/version/getData`
+- `okms:apikms:secret/get`
 - `okms:apiovh:secret/get`
 
 Também é possível criar um utilizador com a [CLI OVHcloud](https://github.com/ovh/ovhcloud-cli):

--- a/docs/pt/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
+++ b/docs/pt/guides/manage-and-operate/secret-manager/external-secret-operator.mdx
@@ -13,9 +13,9 @@ import Api from '@components/Api';
 Este manual explica como configurar o External Secrets Operator do Kubernetes para utilizar o Secret Manager da OVHcloud como fornecedor.
 
 :::warning
-Este manual descreve a utilização do External Secrets Operator com o fornecedor **HashiCorp Vault** e o Secret Manager da OVHcloud através da API compatível com HashiCorp Vault KV2.
+Este manual descreve a utilização do External Secrets Operator com o fornecedor **HashiCorp Vault** para aceder ao Secret Manager da OVHcloud através da API compatível com HashiCorp Vault KV2.
 
-A OVHcloud disponibiliza agora um **fornecedor External Secrets Operator nativo**. Recomendamos a sua utilização para novos deployments. Consulte a [documentação do fornecedor OVHcloud](https://external-secrets.io/latest/provider/ovhcloud/).
+A OVHcloud disponibiliza agora um **fornecedor External Secrets Operator nativo**. Recomendamos a sua utilização para novas implementações. Consulte a [documentação do fornecedor OVHcloud](https://external-secrets.io/latest/provider/ovhcloud/).
 :::
 
 ## Requisitos


### PR DESCRIPTION
## Summary
- Clarify that the External Secrets Operator guide covers the **HashiCorp Vault** provider against Secret Manager via the HashiCorp Vault KV2-compatible API.
- Add a warning banner recommending the [native OVHcloud ESO provider](https://external-secrets.io/latest/provider/ovhcloud/) for new deployments.
- Add the missing IAM right `okms:apikms:secret/get` to the required permissions list.
- Apply the updates to all locales (en, fr, de, es, it, pl, pt) and bump `lastUpdated`.