### PR TITLE
docs(domains): clarify third-party DNS option in dns-server-edit

### DIFF
--- a/docs/de/guides/web-cloud/domains/dns-server-edit.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-server-edit.mdx
@@ -1,7 +1,7 @@
 ---
 title: DNS-Server eines OVHcloud Domainnamens ändern
 description: Erfahren Sie hier, wie Sie die DNS-Server Ihres bei OVHcloud registrierten Domainnamens ändern können
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -127,7 +127,7 @@ Die bisher deklarierten DNS-Server und deren DNS-Konfiguration werden für Ihren
 
 <details>
 
-<summary>Option 2 - Eigene DNS-Server verwenden</summary>
+<summary>Option 2 - Eigene DNS-Server verwenden (oder die eines anderen DNS-Anbieters)</summary>
 
 Mit dieser Option können Sie die DNS-Server einer DNS-Zone deklarieren, die nicht über das OVHcloud Kundencenter verwaltet wird.
 
@@ -202,7 +202,7 @@ Die bisher deklarierten DNS-Server und deren DNS-Konfiguration werden für Ihren
 
 <details>
 
-<summary>Option 3 - OVHcloud DNS-Server und eigene DNS-Server gemeinsam verwenden</summary>
+<summary>Option 3 - OVHcloud DNS-Server und eigene DNS-Server gemeinsam verwenden (oder die eines anderen DNS-Anbieters)</summary>
 
 Mit dieser Option können Sie Ihre eigenen DNS-Server mit den OVHcloud DNS-Servern für Ihren Domainnamen kombinieren. Diese Kombination ermöglicht beispielsweise eine höhere Verfügbarkeit der verschiedenen mit Ihrem Domainnamen verbundenen Dienste (Webhosting, E-Mail-Server, etc.). Wenn eine Gruppe von DNS-Servern für einige Minuten nicht verfügbar ist, können die anderen deklarierten DNS-Server den Betrieb übernehmen.
 

--- a/docs/en/guides/web-cloud/domains/dns-server-edit.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-server-edit.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Modifying an OVHcloud domain name's DNS servers"
 description: Find out how to modify the DNS servers for your OVHcloud registered domain name
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -127,7 +127,7 @@ The old declared DNS servers and the DNS configuration they applied will be deac
 
 <details>
 
-<summary>Option 2 - Use my own DNS servers</summary>
+<summary>Option 2 - Use my own DNS servers (or those of another DNS provider)</summary>
 
 This option allows you to declare the DNS servers of a DNS zone not managed from the OVHcloud Control Panel.
 
@@ -202,7 +202,7 @@ The old declared DNS servers and the DNS configuration they applied will be deac
 
 <details>
 
-<summary>Option 3 - Use OVHcloud DNS servers and my own DNS servers</summary>
+<summary>Option 3 - Use OVHcloud DNS servers and my own DNS servers (or those of another DNS provider)</summary>
 
 This option allows you to combine the use of your own DNS servers while keeping the OVHcloud DNS servers active for your domain name. This combination allows, for example, greater availability for the various services associated with your domain name (web hosting, email servers, etc.). Indeed, if one group of DNS servers becomes unavailable for a few minutes, the other declared DNS servers can take over.
 

--- a/docs/es/guides/web-cloud/domains/dns-server-edit.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-server-edit.mdx
@@ -1,7 +1,7 @@
 ---
 title: Modificar los servidores DNS de un dominio en OVHcloud
 description: Descubra cómo modificar los servidores DNS de su dominio registrado en OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -127,7 +127,7 @@ Los antiguos servidores DNS declarados y la configuración DNS que aplicaban se 
 
 <details>
 
-<summary>Opción 2 - Utilizar mis propios DNS</summary>
+<summary>Opción 2 - Utilizar mis propios DNS (o los de otro proveedor de DNS)</summary>
 
 Esta opción permite declarar los servidores DNS de una zona DNS no gestionada desde el área de cliente de OVHcloud.
 
@@ -202,7 +202,7 @@ Los antiguos servidores DNS declarados y la configuración DNS que aplicaban se 
 
 <details>
 
-<summary>Opción 3 - Utilizar los DNS de OVHcloud y mis propios DNS</summary>
+<summary>Opción 3 - Utilizar los DNS de OVHcloud y mis propios DNS (o los de otro proveedor de DNS)</summary>
 
 Esta opción permite combinar el uso de sus propios servidores DNS manteniendo los servidores DNS de OVHcloud activos para su dominio. Esta combinación permite, por ejemplo, garantizar una mayor disponibilidad para los diferentes servicios asociados a su dominio (alojamiento web, servidores de correo electrónico, etc.). En efecto, si un grupo de servidores DNS deja de estar disponible durante unos minutos, los otros servidores DNS declarados pueden tomar el relevo.
 

--- a/docs/fr/guides/web-cloud/domains/dns-server-edit.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-server-edit.mdx
@@ -127,7 +127,7 @@ Les anciens serveurs DNS déclarés et la configuration DNS qu’ils appliquaien
 
 <details>
 
-<summary>Option 2 - Utiliser mes propres DNS (ou ceux d'un autre fournisseur DNS)</summary>
+<summary>Option 2 - Utiliser mes propres DNS (ou ceux d’un autre fournisseur DNS)</summary>
 
 Cette option permet de déclarer les serveurs DNS d’une zone DNS non gérée depuis l’espace client OVHcloud.
 
@@ -202,7 +202,7 @@ Les anciens serveurs DNS déclarés et la configuration DNS qu’ils appliquaien
 
 <details>
 
-<summary>Option 3 - Utiliser les DNS OVHcloud et mes propres DNS (ou ceux d'un autre fournisseur DNS)</summary>
+<summary>Option 3 - Utiliser les DNS OVHcloud et mes propres DNS (ou ceux d’un autre fournisseur DNS)</summary>
 
 Cette option permet de combiner l’utilisation de vos propres serveurs DNS tout en conservant les serveurs DNS OVHcloud actifs pour votre nom de domaine. Cette combinaison permet, par exemple, d’assurer d’avantage l’accès aux différents services associés à votre nom de domaine (hébergement web, serveurs e-mail, etc.). En effet, si un groupe de serveurs DNS devient indisponible pendant quelques minutes, les autres serveurs DNS déclarés peuvent prendre le relais.
 

--- a/docs/fr/guides/web-cloud/domains/dns-server-edit.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-server-edit.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Modifier les serveurs DNS d'un nom de domaine OVHcloud"
 description: Découvrez comment modifier les serveurs DNS de votre nom de domaine enregistré chez OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -127,7 +127,7 @@ Les anciens serveurs DNS déclarés et la configuration DNS qu’ils appliquaien
 
 <details>
 
-<summary>Option 2 - Utiliser mes propres DNS</summary>
+<summary>Option 2 - Utiliser mes propres DNS (ou ceux d'un autre fournisseur DNS)</summary>
 
 Cette option permet de déclarer les serveurs DNS d’une zone DNS non gérée depuis l’espace client OVHcloud.
 
@@ -202,7 +202,7 @@ Les anciens serveurs DNS déclarés et la configuration DNS qu’ils appliquaien
 
 <details>
 
-<summary>Option 3 - Utiliser les DNS OVHcloud et mes propres DNS</summary>
+<summary>Option 3 - Utiliser les DNS OVHcloud et mes propres DNS (ou ceux d'un autre fournisseur DNS)</summary>
 
 Cette option permet de combiner l’utilisation de vos propres serveurs DNS tout en conservant les serveurs DNS OVHcloud actifs pour votre nom de domaine. Cette combinaison permet, par exemple, d’assurer d’avantage l’accès aux différents services associés à votre nom de domaine (hébergement web, serveurs e-mail, etc.). En effet, si un groupe de serveurs DNS devient indisponible pendant quelques minutes, les autres serveurs DNS déclarés peuvent prendre le relais.
 

--- a/docs/it/guides/web-cloud/domains/dns-server-edit.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-server-edit.mdx
@@ -1,7 +1,7 @@
 ---
 title: Modificare i server DNS di un nome di dominio OVHcloud
 description: Scopri come modificare i server DNS del tuo nome di dominio registrato in OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -127,7 +127,7 @@ I server DNS dichiarati in precedenza e la configurazione DNS da essi applicata 
 
 <details>
 
-<summary>Opzione 2 - Utilizzare i propri DNS</summary>
+<summary>Opzione 2 - Utilizzare i propri DNS (o quelli di un altro provider DNS)</summary>
 
 Questa opzione consente di dichiarare i server DNS di una zona DNS non gestita dallo Spazio Cliente OVHcloud.
 
@@ -202,7 +202,7 @@ I server DNS dichiarati in precedenza e la configurazione DNS da essi applicata 
 
 <details>
 
-<summary>Opzione 3 - Utilizzare i DNS OVHcloud e i propri DNS</summary>
+<summary>Opzione 3 - Utilizzare i DNS OVHcloud e i propri DNS (o quelli di un altro provider DNS)</summary>
 
 Questa opzione consente di combinare l'utilizzo dei tuoi server DNS mantenendo attivi i server DNS OVHcloud per il tuo nome di dominio. Questa combinazione permette, ad esempio, di garantire maggiormente l'accesso ai diversi servizi associati al tuo nome di dominio (hosting Web, server e-mail, ecc.). Infatti, se un gruppo di server DNS diventa indisponibile per qualche minuto, gli altri server DNS dichiarati possono subentrare.
 

--- a/docs/pl/guides/web-cloud/domains/dns-server-edit.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-server-edit.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zmiana serwerów DNS nazwy domeny OVHcloud
 description: Dowiedz się, jak zmienić serwery DNS Twojej nazwy domeny zarejestrowanej w OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -127,7 +127,7 @@ Poprzednio zadeklarowane serwery DNS i stosowana przez nie konfiguracja DNS zost
 
 <details>
 
-<summary>Opcja 2 — Użyj własnych serwerów DNS</summary>
+<summary>Opcja 2 — Użyj własnych serwerów DNS (lub serwerów innego dostawcy DNS)</summary>
 
 Ta opcja pozwala na zadeklarowanie serwerów DNS strefy DNS niezarządzanej z poziomu Panelu klienta OVHcloud.
 
@@ -202,7 +202,7 @@ Poprzednio zadeklarowane serwery DNS i stosowana przez nie konfiguracja DNS zost
 
 <details>
 
-<summary>Opcja 3 — Użyj serwerów DNS OVHcloud i własnych serwerów DNS</summary>
+<summary>Opcja 3 — Użyj serwerów DNS OVHcloud i własnych serwerów DNS (lub serwerów innego dostawcy DNS)</summary>
 
 Ta opcja pozwala na połączenie korzystania z własnych serwerów DNS przy jednoczesnym zachowaniu aktywnych serwerów DNS OVHcloud dla Twojej nazwy domeny. Ta kombinacja pozwala na przykład na zapewnienie większej dostępności różnych usług powiązanych z Twoją nazwą domeny (hosting WWW, serwery e-mail, etc.). Jeśli jedna grupa serwerów DNS stanie się niedostępna na kilka minut, inne zadeklarowane serwery DNS mogą przejąć jej zadania.
 

--- a/docs/pt/guides/web-cloud/domains/dns-server-edit.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-server-edit.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alterar os servidores DNS de um nome de domínio OVHcloud
 description: Saiba como alterar os servidores DNS do seu nome de domínio registado na OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -127,7 +127,7 @@ Os antigos servidores DNS declarados e a configuração DNS que aplicavam serão
 
 <details>
 
-<summary>Opção 2 - Utilizar os meus próprios DNS</summary>
+<summary>Opção 2 - Utilizar os meus próprios DNS (ou os de outro fornecedor de DNS)</summary>
 
 Esta opção permite declarar os servidores DNS de uma zona DNS não gerida a partir da Área de Cliente OVHcloud.
 
@@ -202,7 +202,7 @@ Os antigos servidores DNS declarados e a configuração DNS que aplicavam serão
 
 <details>
 
-<summary>Opção 3 - Utilizar os DNS da OVHcloud e os meus próprios DNS</summary>
+<summary>Opção 3 - Utilizar os DNS da OVHcloud e os meus próprios DNS (ou os de outro fornecedor de DNS)</summary>
 
 Esta opção permite combinar a utilização dos seus próprios servidores DNS mantendo ativos os servidores DNS da OVHcloud para o seu nome de domínio. Esta combinação permite, por exemplo, assegurar melhor o acesso aos diferentes serviços associados ao seu nome de domínio (alojamento web, servidores de e-mail, etc.). De facto, se um grupo de servidores DNS ficar indisponível durante alguns minutos, os outros servidores DNS declarados podem assumir o controlo.
 


### PR DESCRIPTION
Complete the Option 2 and Option 3 summary labels to mention that another DNS provider's servers can be used, across all 7 locales. Bump lastUpdated to 2026-07-23.

## Summary

Clarifies the DNS server options in the **Edit the DNS servers of a domain name** guide, across all 7 locales (fr, en, de, es, it, pl, pt).

## Changes

- **Option 2** label — added that you can also use another DNS provider's servers:
  - *Use my own DNS servers* → *Use my own DNS servers **(or those of another DNS provider)***
- **Option 3** label — same clarification:
  - *Use OVHcloud DNS servers and my own DNS servers* → *Use OVHcloud DNS servers and my own DNS servers **(or those of another DNS provider)***
- **Bumped `lastUpdated`** to `2026-07-23` in all 7 locale files.

## Notes

- FR was the source; the other locales were translated following the standard source routing (FR → EN, then EN → DE/PL and FR → ES/IT/PT).
- Documentation only — no functional/config changes.
