### PR TITLE
docs(web-hosting): keep only Apache 2.4 syntax in htaccess IP-blocking guide

### DIFF
--- a/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -9,11 +9,11 @@ availableIn: [eu, ca, apac]
 
 Dieses Tutorial hilft Ihnen dabei, den Zugang zu Ihren Webseiten von externen Netzwerken abzusichern sowie unbefugten Zugriff und DoS-Angriffe (Denial of Service) zu verhindern.
 
-Sie können das mithilfe einer ".htaccess" Datei erreichen. Es handelt sich dabei um eine spezielle Textdatei, die vom Webserver (Apache) gelesen wird und es ermöglicht, bestimmte Regeln für ein Verzeichnis und dessen Unterverzeichnisse festzulegen.
+Sie können das mithilfe einer ".htaccess"-Datei erreichen. Es handelt sich dabei um eine spezielle Textdatei, die vom Webserver (Apache) gelesen wird und es ermöglicht, bestimmte Regeln für ein Verzeichnis und dessen Unterverzeichnisse festzulegen.
 
-Sie können mehrere ".htaccess" Dateien in [FTP-Bereich](/guides/web-cloud/web-hosting/ftp-connection) Ihres Hostings erstellen, jedoch nur **eine einzige** pro Verzeichnis oder Unterverzeichnis, um Konflikte zwischen verschiedenen ".htaccess" Dateien zu vermeiden.
+Sie können mehrere ".htaccess"-Dateien in [FTP-Bereich](/guides/web-cloud/web-hosting/ftp-connection) Ihres Hostings erstellen, jedoch nur **eine einzige** pro Verzeichnis oder Unterverzeichnis, um Konflikte zwischen verschiedenen ".htaccess"-Dateien zu vermeiden.
 
-**Diese Anleitung erklärt, wie Sie den Zugang zu Ihrer Seite für bestimmte IP-Adressen über eine ".htaccess" Datei blockieren.**
+**Diese Anleitung erklärt, wie Sie den Zugang zu Ihrer Seite für bestimmte IP-Adressen über eine ".htaccess"-Datei blockieren.**
 
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
@@ -28,17 +28,19 @@ Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. De
 ## In der praktischen Anwendung
 
 :::info
-Die ".htaccess" kann in mehreren verschiedenen Ordnern angelegt werden, wobei die Voraussetzung **nur einer** ".htaccess" Datei pro Ordner oder Unterordner einzuhalten ist.
+Die ".htaccess" kann in mehreren verschiedenen Ordnern angelegt werden, wobei die Voraussetzung **nur einer** ".htaccess"-Datei pro Ordner oder Unterordner einzuhalten ist.
 
-Die Parameter einer ".htaccess" Datei gelten für das Verzeichnis, in dem sie sich befindet, sowie für alle Unterverzeichnisse.
+Die Parameter einer ".htaccess"-Datei gelten für das Verzeichnis, in dem sie sich befindet, sowie für alle Unterverzeichnisse.
 
 Um diese Verzeichnisse zu bearbeiten (oder zu erstellen), loggen Sie sich in den FTP-Bereich Ihres Hostings ein. Falls nötig lesen Sie die Anleitung "[Mit dem Speicherplatz eines Webhostings verbinden](/guides/web-cloud/web-hosting/ftp-connection)".
 :::
 
 ### Eine IP, einen IP-Bereich, eine Domain oder alle IPs eines Landes blockieren 
 
-Es sind mehrere Regeln verfügbar, um die Zugänge zu Ihrem Hosting über die ".htaccess" zu sperren.<br/>
-Achten Sie auf die Syntax und die Blockierungseinstellungen, damit Sie sich nicht selbst vom Aufruf Ihrer gehosteten Seiten und/oder Skripte aussperren.<br/>
+Es sind mehrere Regeln verfügbar, um die Zugänge zu Ihrem Hosting über die ".htaccess" zu sperren.
+
+Achten Sie auf die Syntax und die Blockierungseinstellungen, damit Sie sich nicht selbst vom Aufruf Ihrer gehosteten Seiten und/oder Skripte aussperren.
+
 Im Fehlerfall können Sie sich jederzeit in den [FTP-Bereich](/guides/web-cloud/web-hosting/ftp-connection) Ihres Hostings einloggen, um den Fehler zu korrigieren. 
 
 :::info
@@ -95,7 +97,7 @@ Require not ip 203.0.113
 
 Domains können über Weiterleitungen oder Anfragen auf Ihr Hosting zugreifen.
 
-Um eine Domain zu blockieren, tragen Sie den folgenden Code in Ihre ".htaccess" Datei ein:
+Um eine Domain zu blockieren, tragen Sie den folgenden Code in Ihre ".htaccess"-Datei ein:
 
 ```bash
 <RequireAll>
@@ -124,18 +126,14 @@ Blockierungen über ".htaccess" werden über die "Country Codes" (ISO Standard 3
 Mehrere Websites listen die jeweiligen Länder und deren "Country Codes" auf, darunter [https://www.iban.com/country-codes](https://www.iban.com/country-codes) (unabhängig von OVHcloud).
 :::
 
-Um alle IP-Adressen eines Landes zu blockieren, tragen Sie den folgenden Code in Ihre ".htaccess"-Datei ein:
-
-An oberster Stelle der ".htaccess" zu platzieren
+Um alle IP-Adressen eines Landes zu blockieren, tragen Sie den folgenden Code ganz oben in Ihre ".htaccess"-Datei ein:
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Beispiel**: Wenn Sie geolokalisierte IP-Adressen von Fiji (FJ) und Grönland (GR) blockieren möchten, müssen Sie den folgenden Code einfügen:
-
-An oberster Stelle der ".htaccess" zu platzieren
+- **Beispiel**: Wenn Sie geolokalisierte IP-Adressen von Fiji (FJ) und Grönland (GR) blockieren möchten, müssen Sie den folgenden Code ganz oben in Ihre ".htaccess"-Datei einfügen:
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
@@ -148,7 +146,7 @@ Anstatt den Zugang für eine oder mehrere IPs zu beschränken und allen anderen 
 
 #### Eine oder mehrere IPs erlauben
 
-Um nur einer IP den Zugriff auf Ihren Dienst zu erlauben, tragen Sie den folgenden Code in Ihre ".htaccess" Datei ein:
+Um nur einer IP den Zugriff auf Ihren Dienst zu erlauben, tragen Sie den folgenden Code in Ihre ".htaccess"-Datei ein:
 
 ```bash
 Require ip IP_address
@@ -162,17 +160,13 @@ Require ip 203.0.113.0 203.0.113.1
 
 #### Einen IP-Bereich erlauben
 
-Um einem IP-Bereich den Zugriff auf Ihren Dienst zu erlauben, tragen Sie den folgenden Code in Ihre ".htaccess" Datei ein:
-
-An oberster Stelle der ".htaccess" zu platzieren
+Um einem IP-Bereich den Zugriff auf Ihren Dienst zu erlauben, tragen Sie den folgenden Code ganz oben in Ihre ".htaccess"-Datei ein:
 
 ```bash
 Require ip IP_range
 ```
 
-- **Beispiel**: Wenn Sie nur dem IP-Bereich 203.0.113.x den Zugriff auf Ihr Hosting erlauben möchten, fügen Sie den folgenden Code ein:
-
-An oberster Stelle der ".htaccess" zu platzieren
+- **Beispiel**: Wenn Sie nur dem IP-Bereich 203.0.113.x den Zugriff auf Ihr Hosting erlauben möchten, fügen Sie den folgenden Code ganz oben in Ihre ".htaccess"-Datei ein:
 
 ```bash
 Require ip 203.0.113
@@ -180,18 +174,14 @@ Require ip 203.0.113
 
 #### Alle IPs eines Landes erlauben
 
-Um allen IP-Adressen eines Landes den Zugriff auf Ihren Dienst zu erlauben, tragen Sie den folgenden Code in Ihre ".htaccess" Datei ein:
-
-An oberster Stelle der ".htaccess" zu platzieren
+Um allen IP-Adressen eines Landes den Zugriff auf Ihren Dienst zu erlauben, tragen Sie den folgenden Code ganz oben in Ihre ".htaccess"-Datei ein:
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Beispiel**: Wenn Sie nur Fiji (FJ) und Grönland (GR) Zugang zu Ihrem Hosting gewähren möchten, müssen Sie den folgenden Code einfügen:
-
-An oberster Stelle der ".htaccess" zu platzieren
+- **Beispiel**: Wenn Sie nur Fiji (FJ) und Grönland (GR) Zugang zu Ihrem Hosting gewähren möchten, müssen Sie den folgenden Code ganz oben in Ihre ".htaccess"-Datei einfügen:
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
@@ -200,7 +190,7 @@ RewriteRule ^(.*)$ - [F,L]
 
 ### Weitere Aktionen mit ".htaccess"
 
-Abgesehen von der Zugriffssicherheit auf Ihr Hosting erlaubt die ".htaccess" Datei noch weitere Aktionen. Nachfolgend finden Sie weitere OVHcloud Tutorials zum Thema:
+Abgesehen von der Zugriffssicherheit auf Ihr Hosting erlaubt die ".htaccess"-Datei noch weitere Aktionen. Nachfolgend finden Sie weitere OVHcloud Tutorials zum Thema:
 
 - [Den Adminbereich Ihrer Website mit einer .htaccess Datei schützen](/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password)
 - [Fortgeschrittene Operationen mit .htaccess Dateien](/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do)

--- a/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,11 +1,9 @@
 ---
 title: Tutorial - Wie kann ich den Zugang zu meiner Website für bestimmte IP-Adressen über eine .htaccess Datei sperren?
 description: Erfahren Sie hier die Möglichkeiten, um mit .htaccess Dateien den Zugriff auf Ihre Website für bestimmte IP-Adressen zu blockieren
-lastUpdated: 2024-03-14
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
-
-import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Ziel 
 
@@ -44,11 +42,9 @@ Achten Sie auf die Syntax und die Blockierungseinstellungen, damit Sie sich nich
 Im Fehlerfall können Sie sich jederzeit in den [FTP-Bereich](/guides/web-cloud/web-hosting/ftp-connection) Ihres Hostings einloggen, um den Fehler zu korrigieren. 
 
 :::info
-Shared Hosting funktioniert derzeit mit **Apache 2.4**. Seit der Version **Apache 2.3** wurden Variablen implementiert und die Syntax für Zugriffsberechtigungen wurde weiterentwickelt.
+Shared Hosting funktioniert derzeit mit **Apache 2.4**.
 
-Da die alte Syntax sehr häufig verwendet wird, ist sie immer noch auf unseren Infrastrukturen aktiv. Allerdings gilt sie seitens *Apache* als veraltet und ist möglicherweise nicht mehr lange verfügbar. In diesem Tutorial finden Sie Beispiele für beide Varianten der Syntax.
-
-Mehr Informationen zur neuen Syntax finden Sie auf folgenden offiziellen Seiten:
+Weitere Informationen zur in dieser Anleitung beschriebenen Syntax finden Sie auf folgenden offiziellen Seiten:
 
 - [Dokumentation zur Zugriffskontrolle Apache 2.4](https://httpd.apache.org/docs/en/howto/access.html)
 - [Dokumentation zu mod_authz_core Apache 2.4](https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html)
@@ -57,117 +53,63 @@ Mehr Informationen zur neuen Syntax finden Sie auf folgenden offiziellen Seiten:
 
 #### Eine IP blockieren
 
-Um eine bestimmte IP-Adresse zu blockieren, tragen Sie einen der beiden folgenden Codes in Ihrer ".htaccess"-Datei ein:
+Um eine bestimmte IP-Adresse zu blockieren, tragen Sie den folgenden Code in Ihrer ".htaccess"-Datei ein:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    Deny from IP_address
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_address
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_address
+</RequireAll>
+```
 
-- **Beispiel**: Wenn Sie die IP-Adresse 203.0.113.0 blockieren möchten, müssen Sie einen der folgenden Codes einfügen:
+- **Beispiel**: Wenn Sie die IP-Adresse 203.0.113.0 blockieren möchten, müssen Sie den folgenden Code einfügen:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    Deny from 203.0.113.0
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113.0
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113.0
+</RequireAll>
+```
 
 #### Einen IP-Bereich blockieren
 
-Um einen IP-Adressbereich zu blockieren, tragen Sie einen der beiden folgenden Codes in Ihrer ".htaccess" ein:
+Um einen IP-Adressbereich zu blockieren, tragen Sie den folgenden Code in Ihrer ".htaccess" ein:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    Deny from IP_range
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_range
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_range
+</RequireAll>
+```
 
-- **Beispiel**: Wenn Sie alle IP-Adressen in 203.0.113.x blockieren möchten, tragen Sie einen der folgenden Codes ein:
+- **Beispiel**: Wenn Sie alle IP-Adressen in 203.0.113.x blockieren möchten, tragen Sie den folgenden Code ein:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    Deny from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113
+</RequireAll>
+```
 
 #### Eine Domain blockieren
 
 Domains können über Weiterleitungen oder Anfragen auf Ihr Hosting zugreifen.
 
-Um eine Domain zu blockieren, tragen Sie einen der folgenden Codes in Ihre ".htaccess" Datei ein:
+Um eine Domain zu blockieren, tragen Sie den folgenden Code in Ihre ".htaccess" Datei ein:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    Deny from domain
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain
+</RequireAll>
+```
 
-- **Beispiel**: Wenn Sie "domain.tld" blockieren möchten, fügen Sie einen der folgenden Codes ein:
+- **Beispiel**: Wenn Sie "domain.tld" blockieren möchten, fügen Sie den folgenden Code ein:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    Deny from domain.tld
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain.tld
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain.tld
+</RequireAll>
+```
 
 #### Die IPs eines Landes blockieren
 
@@ -182,44 +124,23 @@ Blockierungen über ".htaccess" werden über die "Country Codes" (ISO Standard 3
 Mehrere Websites listen die jeweiligen Länder und deren "Country Codes" auf, darunter [https://www.iban.com/country-codes](https://www.iban.com/country-codes) (unabhängig von OVHcloud).
 :::
 
-Um alle IP-Adressen eines Landes zu blockieren, tragen Sie einen der folgenden Codes in Ihre ".htaccess"-Datei ein:
+Um alle IP-Adressen eines Landes zu blockieren, tragen Sie den folgenden Code in Ihre ".htaccess"-Datei ein:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    An oberster Stelle der ".htaccess" zu platzieren
+An oberster Stelle der ".htaccess" zu platzieren
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Beispiel**: Wenn Sie geolokalisierte IP-Adressen von Fiji (FJ) und Grönland (GR) blockieren möchten, müssen Sie einen der folgenden Codes einfügen:
+- **Beispiel**: Wenn Sie geolokalisierte IP-Adressen von Fiji (FJ) und Grönland (GR) blockieren möchten, müssen Sie den folgenden Code einfügen:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE FJ BlockCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    An oberster Stelle der ".htaccess" zu platzieren
+An oberster Stelle der ".htaccess" zu platzieren
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 ### Um nur einige IPs, einen IP-Bereich oder alle IPs eines Landes zu erlauben
 
@@ -227,125 +148,55 @@ Anstatt den Zugang für eine oder mehrere IPs zu beschränken und allen anderen 
 
 #### Eine oder mehrere IPs erlauben
 
-Um nur einer IP den Zugriff auf Ihren Dienst zu erlauben, tragen Sie einen der folgenden Codes in Ihre ".htaccess" Datei ein:
+Um nur einer IP den Zugriff auf Ihren Dienst zu erlauben, tragen Sie den folgenden Code in Ihre ".htaccess" Datei ein:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_address
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    ```bash
-    Require ip IP_address
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_address
+```
 
-- **Beispiel**: Wenn Sie nur den IPs 203.0.113.0 und 203.0.113.1 den Zugriff auf Ihr Hosting erlauben möchten, verwenden Sie einen der folgenden Codes:
+- **Beispiel**: Wenn Sie nur den IPs 203.0.113.0 und 203.0.113.1 den Zugriff auf Ihr Hosting erlauben möchten, verwenden Sie den folgenden Code:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113.0
-    Allow from 203.0.113.1
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    ```bash
-    Require ip 203.0.113.0 203.0.113.1
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113.0 203.0.113.1
+```
 
 #### Einen IP-Bereich erlauben
 
-Um einem IP-Bereich den Zugriff auf Ihren Dienst zu erlauben, tragen Sie einen der folgenden Codes in Ihre ".htaccess" Datei ein:
+Um einem IP-Bereich den Zugriff auf Ihren Dienst zu erlauben, tragen Sie den folgenden Code in Ihre ".htaccess" Datei ein:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_range
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    An oberster Stelle der ".htaccess" zu platzieren
+An oberster Stelle der ".htaccess" zu platzieren
 
-    ```bash
-    Require ip IP_range
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_range
+```
 
-- **Beispiel**: Wenn Sie nur dem IP-Bereich 203.0.113.x den Zugriff auf Ihr Hosting erlauben möchten, fügen Sie einen der folgenden Codes ein:
+- **Beispiel**: Wenn Sie nur dem IP-Bereich 203.0.113.x den Zugriff auf Ihr Hosting erlauben möchten, fügen Sie den folgenden Code ein:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    An oberster Stelle der ".htaccess" zu platzieren
+An oberster Stelle der ".htaccess" zu platzieren
 
-    ```bash
-    Require ip 203.0.113
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113
+```
 
 #### Alle IPs eines Landes erlauben
 
-Um allen IP-Adressen eines Landes den Zugriff auf Ihren Dienst zu erlauben, tragen Sie einen der folgenden Codes in Ihre ".htaccess" Datei ein:
+Um allen IP-Adressen eines Landes den Zugriff auf Ihren Dienst zu erlauben, tragen Sie den folgenden Code in Ihre ".htaccess" Datei ein:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    An oberster Stelle der ".htaccess" zu platzieren
+An oberster Stelle der ".htaccess" zu platzieren
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Beispiel**: Wenn Sie nur Fiji (FJ) und Grönland (GR) Zugang zu Ihrem Hosting gewähren möchten, müssen Sie einen der folgenden Codes einfügen:
+- **Beispiel**: Wenn Sie nur Fiji (FJ) und Grönland (GR) Zugang zu Ihrem Hosting gewähren möchten, müssen Sie den folgenden Code einfügen:
 
-<Tabs>
-  <Tab label="Historische Syntax">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE FJ AllowCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Syntax ab Apache 2.3">
-    An oberster Stelle der ".htaccess" zu platzieren
+An oberster Stelle der ".htaccess" zu platzieren
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 ### Weitere Aktionen mit ".htaccess"
 

--- a/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,11 +1,9 @@
 ---
 title: Tutorial - How do I block access to my website for certain IP addresses via a .htaccess file?
 description: Find out about the actions you can take via a .htaccess file to block access to your website for certain IP addresses
-lastUpdated: 2024-03-14
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
-
-import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objective
 
@@ -44,11 +42,9 @@ Be careful with the syntax and block settings to prevent blocking yourself from 
 In the event of an error, you can always log in to [the FTP space](/guides/web-cloud/web-hosting/ftp-connection) of your hosting to correct mistakes.
 
 :::info
-Shared hosting currently works with **Apache 2.4**. Since the **Apache 2.3** release, variables have been implemented and the syntax for writing access restrictions/permissions has changed.
+Shared hosting currently works with **Apache 2.4**.
 
-Since the old syntax is very popular, it is still active on our infrastructures. However, it is considered obsolete by *Apache* and may soon be unavailable. In this tutorial, you will find examples detailing the two syntaxes.
-
-For more details on the new syntax, you can consult the following official pages:
+For more details on the syntax described in this guide, consult the following official pages:
 
 - [Apache 2.4 access control documentation](https://httpd.apache.org/docs/2.4/en/howto/access.html)
 - [Apache 2.4 mod_authz_core module documentation](https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html)
@@ -57,117 +53,63 @@ For more details on the new syntax, you can consult the following official pages
 
 ### Block an IP
 
-To block a specific IP address, insert one of the following two codes into your ".htaccess" file:
+To block a specific IP address, insert the following code into your ".htaccess" file:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    Deny from IP_address
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_address
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_address
+</RequireAll>
+```
 
-- **Example**: If you want to block the IP address 203.0.113.0, you will need to write one of the following two codes:
+- **Example**: If you want to block the IP address 203.0.113.0, you will need to write the following code:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    Deny from 203.0.113.0
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113.0
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113.0
+</RequireAll>
+```
 
 ### Block an IP range
 
-To block an IP address range, insert one of the following two codes into your ".htaccess" file:
+To block an IP address range, insert the following code into your ".htaccess" file:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    Deny from IP_range
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_range
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_range
+</RequireAll>
+```
 
-- **Example**: If you want to block all IPs in 203.0.113.x, you will need to write one of the following two codes:
+- **Example**: If you want to block all IPs in 203.0.113.x, you will need to write the following code:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    Deny from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113
+</RequireAll>
+```
 
 ### Block a domain
 
 Some domains might access your hosting via redirections or requests.
 
-To block a domain, insert one of the following two codes into your ".htaccess" file:
+To block a domain, insert the following code into your ".htaccess" file:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    Deny from domain
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain
+</RequireAll>
+```
 
-- **Example**: if you want to block domain.tld, you will need to write one of the following two codes:
+- **Example**: if you want to block domain.tld, you will need to write the following code:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    Deny from domain.tld
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain.tld
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain.tld
+</RequireAll>
+```
 
 ### Block IPs from a country
 
@@ -182,44 +124,23 @@ Blocks via the ".htaccess" are done through the two-letter Country Codes (ISO 31
 Several websites list the countries and their respective Country Codes, including [https://www.iban.com/country-codes](https://www.iban.com/country-codes) (independent of OVHcloud).
 :::
 
-To block all IPs of a country, insert one of the following two codes into your ".htaccess" file:
+To block all IPs of a country, insert the following code into your ".htaccess" file:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    To be placed at the top of your ".htaccess"
+To be placed at the top of your ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Example**: If you want to block geolocated IP addresses from Fiji (FJ) and Greenland (GR), you will need to write one of the following two codes:
+- **Example**: If you want to block geolocated IP addresses from Fiji (FJ) and Greenland (GR), you will need to write the following code:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE FJ BlockCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    To be placed at the top of your ".htaccess"
+To be placed at the top of your ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 ### To authorise selected IPs, a range of IPs or all the IPs of a country
 
@@ -227,125 +148,55 @@ Rather than restricting access to one or more IPs and allowing others to access 
 
 ### Authorise one or more IPs
 
-To authorise only one IP to access your service, insert one of the following two codes into your ".htaccess" file:
+To authorise only one IP to access your service, insert the following code into your ".htaccess" file:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_address
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    ```bash
-    Require ip IP_address
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_address
+```
 
-- **Example**: If you only want to authorise IPs 203.0.113.0 and 203.0.113.1 to access your hosting, you will need to write one of the following two codes:
+- **Example**: If you only want to authorise IPs 203.0.113.0 and 203.0.113.1 to access your hosting, you will need to write the following code:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113.0
-    Allow from 203.0.113.1
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    ```bash
-    Require ip 203.0.113.0 203.0.113.1
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113.0 203.0.113.1
+```
 
 ### Authorise an IP range
 
-To authorise a range of IPs to access your service, insert one of the following two codes into your ".htaccess" file:
+To authorise a range of IPs to access your service, insert the following code into your ".htaccess" file:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_range
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    To be placed at the top of your ".htaccess"
+To be placed at the top of your ".htaccess"
 
-    ```bash
-    Require ip IP_range
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_range
+```
 
-- **Example**: If you only want to authorise the IP range 203.0.113.x to access your hosting, you will need to write one of the following two codes:
+- **Example**: If you only want to authorise the IP range 203.0.113.x to access your hosting, you will need to write the following code:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    To be placed at the top of your ".htaccess"
+To be placed at the top of your ".htaccess"
 
-    ```bash
-    Require ip 203.0.113
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113
+```
 
 ### Authorise all the IPs of a country
 
-To authorise all IPs in a country to access your service, insert one of the following two codes into your ".htaccess" file:
+To authorise all IPs in a country to access your service, insert the following code into your ".htaccess" file:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    To be placed at the top of your ".htaccess"
+To be placed at the top of your ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Example**: If you wish to authorise only Fiji (FJ) and Greenland (GR) to access your hosting, you will need to write one of the following two codes:
+- **Example**: If you wish to authorise only Fiji (FJ) and Greenland (GR) to access your hosting, you will need to write the following code:
 
-<Tabs>
-  <Tab label="Historical Syntax">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE FJ AllowCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Syntax from Apache 2.3">
-    To be placed at the top of your ".htaccess"
+To be placed at the top of your ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 ### Further actions with the ".htaccess" file
 

--- a/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -37,8 +37,10 @@ To edit (or create) these directories, log in to your hosting plan’s FTP space
 
 ### Block an IP, a range of IPs, a domain or all the IPs of a country
 
-Several rules are available to block access to your hosting plan via ".htaccess".<br/>
-Be careful with the syntax and block settings to prevent blocking yourself from viewing your hosted sites and/or scripts.<br/>
+Several rules are available to block access to your hosting plan via ".htaccess".
+
+Be careful with the syntax and block settings to prevent blocking yourself from viewing your hosted sites and/or scripts.
+
 In the event of an error, you can always log in to [the FTP space](/guides/web-cloud/web-hosting/ftp-connection) of your hosting to correct mistakes.
 
 :::info
@@ -124,18 +126,14 @@ Blocks via the ".htaccess" are done through the two-letter Country Codes (ISO 31
 Several websites list the countries and their respective Country Codes, including [https://www.iban.com/country-codes](https://www.iban.com/country-codes) (independent of OVHcloud).
 :::
 
-To block all IPs of a country, insert the following code into your ".htaccess" file:
-
-To be placed at the top of your ".htaccess"
+To block all IPs of a country, insert the following code at the top of your ".htaccess" file:
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Example**: If you want to block geolocated IP addresses from Fiji (FJ) and Greenland (GR), you will need to write the following code:
-
-To be placed at the top of your ".htaccess"
+- **Example**: If you want to block geolocated IP addresses from Fiji (FJ) and Greenland (GR), you will need to write the following code at the top of your ".htaccess" file:
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
@@ -162,17 +160,13 @@ Require ip 203.0.113.0 203.0.113.1
 
 ### Authorise an IP range
 
-To authorise a range of IPs to access your service, insert the following code into your ".htaccess" file:
-
-To be placed at the top of your ".htaccess"
+To authorise a range of IPs to access your service, insert the following code at the top of your ".htaccess" file:
 
 ```bash
 Require ip IP_range
 ```
 
-- **Example**: If you only want to authorise the IP range 203.0.113.x to access your hosting, you will need to write the following code:
-
-To be placed at the top of your ".htaccess"
+- **Example**: If you only want to authorise the IP range 203.0.113.x to access your hosting, you will need to write the following code at the top of your ".htaccess" file:
 
 ```bash
 Require ip 203.0.113
@@ -180,18 +174,14 @@ Require ip 203.0.113
 
 ### Authorise all the IPs of a country
 
-To authorise all IPs in a country to access your service, insert the following code into your ".htaccess" file:
-
-To be placed at the top of your ".htaccess"
+To authorise all IPs in a country to access your service, insert the following code at the top of your ".htaccess" file:
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Example**: If you wish to authorise only Fiji (FJ) and Greenland (GR) to access your hosting, you will need to write the following code:
-
-To be placed at the top of your ".htaccess"
+- **Example**: If you wish to authorise only Fiji (FJ) and Greenland (GR) to access your hosting, you will need to write the following code at the top of your ".htaccess" file:
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$

--- a/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,11 +1,9 @@
 ---
 title: Tutorial - ¿Cómo bloquear el acceso a mi sitio web para determinadas direcciones IP a través de un archivo .htaccess?
 description: Descubra las posibles acciones a través de un archivo .htaccess para bloquear el acceso a su sitio web a determinadas direcciones IP.
-lastUpdated: 2024-03-14
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
-
-import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objetivo
 
@@ -44,11 +42,9 @@ Preste especial atención a la sintaxis y a los parámetros que bloquee para evi
 En caso de error, puede conectarse a [el espacio FTP](/guides/web-cloud/web-hosting/ftp-connection) de su alojamiento para corregir la situación. 
 
 :::info
-Los alojamientos compartidos funcionan actualmente con **Apache 2.4**. Desde la versión **Apache 2.3**, se han implementado variables y la sintaxis de redacción de las restricciones/autorizaciones de acceso ha cambiado.
+Los alojamientos compartidos funcionan actualmente con **Apache 2.4**.
 
-Debido a que la sintaxis antigua es muy utilizada, esta sigue activa en nuestras infraestructuras. Sin embargo, *Apache* la considera obsoleta y podría no estar disponible en breve. En este tutorial encontrará ejemplos que detallan ambas sintaxis.
-
-Para más información sobre la nueva sintaxis, puede consultar las siguientes páginas oficiales:
+Para más información sobre la sintaxis descrita en esta guía, consulte las siguientes páginas oficiales:
 
 - [Documentación sobre el control de acceso Apache 2.4](https://httpd.apache.org/docs/2.4/en/howto/access.html) 
 - [Documentación sobre el módulo mod_authz_core Apache 2.4](https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html) 
@@ -57,117 +53,63 @@ Para más información sobre la nueva sintaxis, puede consultar las siguientes p
 
 #### Bloquear una IP
 
-Para bloquear una dirección IP específica, introduzca uno de los siguientes códigos en el archivo ".htaccess":
+Para bloquear una dirección IP específica, introduzca el siguiente código en el archivo ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    Deny from IP_address
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_address
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_address
+</RequireAll>
+```
 
-- **Ejemplo** : si desea bloquear la dirección IP 203.0.113.0, deberá escribir uno de los siguientes códigos:
+- **Ejemplo** : si desea bloquear la dirección IP 203.0.113.0, deberá escribir el siguiente código:
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    Deny from 203.0.113.0
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113.0
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113.0
+</RequireAll>
+```
 
 #### Bloquear un rango de IP
 
-Para bloquear un rango de direcciones IP, introduzca uno de los siguientes códigos en su archivo ".htaccess":
+Para bloquear un rango de direcciones IP, introduzca el siguiente código en su archivo ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    Deny from IP_range
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_range
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_range
+</RequireAll>
+```
 
-- **Ejemplo** : si desea bloquear todas las IP en 203.0.113.x, deberá escribir uno de los dos códigos siguientes:
+- **Ejemplo** : si desea bloquear todas las IP en 203.0.113.x, deberá escribir el siguiente código:
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    Deny from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113
+</RequireAll>
+```
 
 #### Bloquear un dominio
 
 Algunos dominios pueden acceder al alojamiento a través de redirecciones o peticiones.
 
-Para bloquear un dominio, introduzca uno de los dos códigos siguientes en el archivo ".htaccess":
+Para bloquear un dominio, introduzca el siguiente código en el archivo ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    Deny from domain
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain
+</RequireAll>
+```
 
-- **Ejemplo** : si desea bloquear el dominio.tld, deberá escribir uno de los dos códigos siguientes:
+- **Ejemplo** : si desea bloquear el dominio.tld, deberá escribir el siguiente código:
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    Deny from domain.tld
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain.tld
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain.tld
+</RequireAll>
+```
 
 #### Bloquear las IP de un país
 
@@ -182,44 +124,23 @@ Los bloqueos a través del ".htaccess" se realizan a través de los "Country Cod
 Varios sitios web enumeran los países y sus respectivos "Country Codes", de los que [https://www.iban.com/country-codes](https://www.iban.com/country-codes)  (independiente de OVHcloud).
 :::
 
-Para bloquear todas las IP de un país, introduzca uno de los siguientes códigos en su archivo ".htaccess":
+Para bloquear todas las IP de un país, introduzca el siguiente código en su archivo ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    Poner todo en la parte superior de su ".htaccess"
+Poner todo en la parte superior de su ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Ejemplo** : si desea bloquear las direcciones IP geolocalizadas en Fiyi (FJ) y Groenlandia (GR), deberá escribir uno de los siguientes códigos:
+- **Ejemplo** : si desea bloquear las direcciones IP geolocalizadas en Fiyi (FJ) y Groenlandia (GR), deberá escribir el siguiente código:
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE FJ BlockCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    Poner todo en la parte superior de su ".htaccess"
+Poner todo en la parte superior de su ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 ### Para autorizar solo algunas IP, un rango de IP o el conjunto de IP de un país
 
@@ -227,125 +148,55 @@ En lugar de restringir el acceso a una o más IP y dejar que el resto acceda al 
 
 #### Autorizar una o más IP
 
-Para autorizar solo una IP a acceder al servicio, introduzca uno de los siguientes códigos en el archivo ".htaccess":
+Para autorizar solo una IP a acceder al servicio, introduzca el siguiente código en el archivo ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_address
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    ```bash
-    Require ip IP_address
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_address
+```
 
-- **Ejemplo** : si solo quiere autorizar a las IPs 203.0.113.0 y 203.0.113.1 a acceder a su alojamiento, deberá escribir uno de los siguientes códigos:
+- **Ejemplo** : si solo quiere autorizar a las IPs 203.0.113.0 y 203.0.113.1 a acceder a su alojamiento, deberá escribir el siguiente código:
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113.0
-    Allow from 203.0.113.1
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    ```bash
-    Require ip 203.0.113.0 203.0.113.1
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113.0 203.0.113.1
+```
 
 #### Autorizar un rango de IP
 
-Para autorizar a un rango de IP a acceder al servicio, introduzca uno de los siguientes códigos en su archivo ".htaccess":
+Para autorizar a un rango de IP a acceder al servicio, introduzca el siguiente código en su archivo ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_range
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    Poner todo en la parte superior de su ".htaccess"
+Poner todo en la parte superior de su ".htaccess"
 
-    ```bash
-    Require ip IP_range
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_range
+```
 
-- **Ejemplo** : si solo desea autorizar el acceso al alojamiento al rango de IPs 203.0.113.x, deberá escribir uno de los siguientes códigos:
+- **Ejemplo** : si solo desea autorizar el acceso al alojamiento al rango de IPs 203.0.113.x, deberá escribir el siguiente código:
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    Poner todo en la parte superior de su ".htaccess"
+Poner todo en la parte superior de su ".htaccess"
 
-    ```bash
-    Require ip 203.0.113
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113
+```
 
 #### Autorizar el conjunto de IP de un país
 
-Para autorizar a todas las IP de un país a acceder al servicio, introduzca uno de los siguientes códigos en el archivo ".htaccess":
+Para autorizar a todas las IP de un país a acceder al servicio, introduzca el siguiente código en el archivo ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    Poner todo en la parte superior de su ".htaccess"
+Poner todo en la parte superior de su ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Ejemplo** : si únicamente desea autorizar a las islas Fiyi (FJ) y Groenlandia (GR) a acceder a su alojamiento, deberá escribir uno de los siguientes códigos:
+- **Ejemplo** : si únicamente desea autorizar a las islas Fiyi (FJ) y Groenlandia (GR) a acceder a su alojamiento, deberá escribir el siguiente código:
 
-<Tabs>
-  <Tab label="Sintaxis histórica">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE FJ AllowCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Sintaxis de Apache 2.3">
-    Poner todo en la parte superior de su ".htaccess"
+Poner todo en la parte superior de su ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 ### Complementos en el archivo ".htaccess"
 

--- a/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -37,8 +37,10 @@ Para editar (o crear) estos directorios, conéctese al espacio FTP de su alojami
 
 ### Bloquear una IP, un rango de IP, un dominio o todas las IP de un país 
 
-Hay varias reglas disponibles para bloquear los accesos al alojamiento a través del ".htaccess".<br/>
-Preste especial atención a la sintaxis y a los parámetros que bloquee para evitar que se bloquee usted mismo durante la consulta de sus sitios web y/o scripts alojados.<br/>
+Hay varias reglas disponibles para bloquear los accesos al alojamiento a través del ".htaccess".
+
+Preste especial atención a la sintaxis y a los parámetros que bloquee para evitar que se bloquee usted mismo durante la consulta de sus sitios web y/o scripts alojados.
+
 En caso de error, puede conectarse a [el espacio FTP](/guides/web-cloud/web-hosting/ftp-connection) de su alojamiento para corregir la situación. 
 
 :::info
@@ -124,18 +126,14 @@ Los bloqueos a través del ".htaccess" se realizan a través de los "Country Cod
 Varios sitios web enumeran los países y sus respectivos "Country Codes", de los que [https://www.iban.com/country-codes](https://www.iban.com/country-codes)  (independiente de OVHcloud).
 :::
 
-Para bloquear todas las IP de un país, introduzca el siguiente código en su archivo ".htaccess":
-
-Poner todo en la parte superior de su ".htaccess"
+Para bloquear todas las IP de un país, introduzca el siguiente código en la parte superior de su archivo ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Ejemplo** : si desea bloquear las direcciones IP geolocalizadas en Fiyi (FJ) y Groenlandia (GR), deberá escribir el siguiente código:
-
-Poner todo en la parte superior de su ".htaccess"
+- **Ejemplo** : si desea bloquear las direcciones IP geolocalizadas en Fiyi (FJ) y Groenlandia (GR), deberá escribir el siguiente código en la parte superior de su archivo ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
@@ -162,17 +160,13 @@ Require ip 203.0.113.0 203.0.113.1
 
 #### Autorizar un rango de IP
 
-Para autorizar a un rango de IP a acceder al servicio, introduzca el siguiente código en su archivo ".htaccess":
-
-Poner todo en la parte superior de su ".htaccess"
+Para autorizar a un rango de IP a acceder al servicio, introduzca el siguiente código en la parte superior de su archivo ".htaccess":
 
 ```bash
 Require ip IP_range
 ```
 
-- **Ejemplo** : si solo desea autorizar el acceso al alojamiento al rango de IPs 203.0.113.x, deberá escribir el siguiente código:
-
-Poner todo en la parte superior de su ".htaccess"
+- **Ejemplo** : si solo desea autorizar el acceso al alojamiento al rango de IPs 203.0.113.x, deberá escribir el siguiente código en la parte superior de su archivo ".htaccess":
 
 ```bash
 Require ip 203.0.113
@@ -180,18 +174,14 @@ Require ip 203.0.113
 
 #### Autorizar el conjunto de IP de un país
 
-Para autorizar a todas las IP de un país a acceder al servicio, introduzca el siguiente código en el archivo ".htaccess":
-
-Poner todo en la parte superior de su ".htaccess"
+Para autorizar a todas las IP de un país a acceder al servicio, introduzca el siguiente código en la parte superior del archivo ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Ejemplo** : si únicamente desea autorizar a las islas Fiyi (FJ) y Groenlandia (GR) a acceder a su alojamiento, deberá escribir el siguiente código:
-
-Poner todo en la parte superior de su ".htaccess"
+- **Ejemplo** : si únicamente desea autorizar a las islas Fiyi (FJ) y Groenlandia (GR) a acceder a su alojamiento, deberá escribir el siguiente código en la parte superior de su archivo ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$

--- a/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,11 +1,9 @@
 ---
 title: "Tutoriel - Comment bloquer l'accès à mon site pour certaines adresses IP via un fichier .htaccess ?"
 description: "Découvrez les actions possibles via un fichier .htaccess afin de bloquer l'accès à votre site à certaines adresses IP"
-lastUpdated: 2024-03-14
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
-
-import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objectif
 
@@ -44,11 +42,9 @@ Soyez vigilant sur la syntaxe et sur les paramètres que vous bloquez afin de ne
 En cas d’erreur, vous pouvez toujours vous connecter à [l’espace FTP](/guides/web-cloud/web-hosting/ftp-connection) de votre hébergement pour corriger la situation. 
 
 :::info
-Les hébergements mutualisés fonctionnent actuellement avec **Apache 2.4**. Depuis la version **Apache 2.3**, des variables ont été implémentées et la syntaxe de rédaction des restrictions/autorisations d’accès a évolué.
+Les hébergements mutualisés fonctionnent actuellement avec **Apache 2.4**.
 
-Du fait que l’ancienne syntaxe est très utilisée, celle-ci est toujours active sur nos infrastructures. Cependant, elle est considérée comme obsolète par *Apache* et pourrait prochainement ne plus être disponible. Vous trouverez donc dans ce tutoriel des exemples détaillant les deux syntaxes.
-
-Pour plus de détails sur la nouvelle syntaxe, vous pouvez consulter les pages officielles suivantes :
+Pour plus de détails sur la syntaxe décrite dans ce guide, consultez les pages officielles suivantes :
 
 - [Documentation sur le contrôle d’accès Apache 2.4](https://httpd.apache.org/docs/2.4/fr/howto/access.html)
 - [Documentation sur le module mod_authz_core Apache 2.4](https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html)
@@ -57,117 +53,63 @@ Pour plus de détails sur la nouvelle syntaxe, vous pouvez consulter les pages o
 
 #### Bloquer une IP
 
-Pour bloquer une adresse IP spécifique, insérez l’un des deux codes suivants dans votre fichier « .htaccess » :
+Pour bloquer une adresse IP spécifique, insérez le code suivant dans votre fichier « .htaccess » :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    Deny from IP_address
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_address
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_address
+</RequireAll>
+```
 
-- **Exemple** : si vous souhaitez bloquer l’adresse IP 203.0.113.0, vous devrez écrire l’un des deux codes suivants :
+- **Exemple** : si vous souhaitez bloquer l’adresse IP 203.0.113.0, vous devrez écrire le code suivant :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    Deny from 203.0.113.0
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113.0
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113.0
+</RequireAll>
+```
 
 #### Bloquer une plage d’IPs
 
-Pour bloquer une plage d’adresses IP, insérez l’un des deux codes suivants dans votre fichier « .htaccess » :
+Pour bloquer une plage d’adresses IP, insérez le code suivant dans votre fichier « .htaccess » :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    Deny from IP_range
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_range
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_range
+</RequireAll>
+```
 
-- **Exemple** : si vous souhaitez bloquer toutes les IPs en 203.0.113.x, vous devrez écrire l’un des deux codes suivants :
+- **Exemple** : si vous souhaitez bloquer toutes les IPs en 203.0.113.x, vous devrez écrire le code suivant :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    Deny from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113
+</RequireAll>
+```
 
 #### Bloquer un domaine
 
 Certains domaines peuvent accéder à votre hébergement via des redirections ou des requêtes.
 
-Pour bloquer un domaine, insérez l’un des deux codes suivants dans votre fichier « .htaccess » :
+Pour bloquer un domaine, insérez le code suivant dans votre fichier « .htaccess » :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    Deny from domain
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain
+</RequireAll>
+```
 
-- **Exemple** : si vous souhaitez bloquer le domaine domain.tld, vous devrez écrire l’un des deux codes suivants :
+- **Exemple** : si vous souhaitez bloquer le domaine domain.tld, vous devrez écrire le code suivant :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    Deny from domain.tld
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain.tld
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain.tld
+</RequireAll>
+```
 
 #### Bloquer les IPs d’un pays
 
@@ -182,44 +124,23 @@ Les blocages via le « .htaccess » s’effectuent par le biais des « Country C
 Plusieurs sites listent les pays et leurs « Country Codes » respectifs, dont [https://www.iban.com/country-codes](https://www.iban.com/country-codes) (indépendant d’OVHcloud).
 :::
 
-Pour bloquer l’ensemble des IPs d’un pays, insérez l’un des deux codes suivants dans votre fichier « .htaccess » :
+Pour bloquer l’ensemble des IPs d’un pays, insérez le code suivant dans votre fichier « .htaccess » :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    À placer tout en haut de votre « .htaccess »
+À placer tout en haut de votre « .htaccess »
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Exemple** : si vous souhaitez bloquer les adresses IPs géolocalisées aux îles Fidji (FJ) et au Groenland (GR), vous devrez écrire l’un des deux codes suivants :
+- **Exemple** : si vous souhaitez bloquer les adresses IPs géolocalisées aux îles Fidji (FJ) et au Groenland (GR), vous devrez écrire le code suivant :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE FJ BlockCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    À placer tout en haut de votre « .htaccess »
+À placer tout en haut de votre « .htaccess »
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 ### Pour autoriser seulement quelques IPs, une plage d’IPs ou l’ensemble des IPs d’un pays
 
@@ -227,125 +148,55 @@ Plutôt que de restreindre l’accès à une ou plusieurs IPs et laisser les aut
 
 #### Autoriser une ou plusieurs IPs
 
-Pour n’autoriser qu’une seule IP à accéder à votre service, insérez l’un des deux codes suivants dans votre fichier « .htaccess » :
+Pour n’autoriser qu’une seule IP à accéder à votre service, insérez le code suivant dans votre fichier « .htaccess » :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_address
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    ```bash
-    Require ip IP_address
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_address
+```
 
-- **Exemple** : si vous souhaitez autoriser uniquement les IPs 203.0.113.0 et 203.0.113.1 à accéder à votre hébergement, vous devrez écrire l’un des deux codes suivants :
+- **Exemple** : si vous souhaitez autoriser uniquement les IPs 203.0.113.0 et 203.0.113.1 à accéder à votre hébergement, vous devrez écrire le code suivant :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113.0
-    Allow from 203.0.113.1
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    ```bash
-    Require ip 203.0.113.0 203.0.113.1
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113.0 203.0.113.1
+```
 
 #### Autoriser une plage d’IPs
 
-Pour autoriser une plage d’IPs à accéder à votre service, insérez l’un des deux codes suivants dans votre fichier « .htaccess » :
+Pour autoriser une plage d’IPs à accéder à votre service, insérez le code suivant dans votre fichier « .htaccess » :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_range
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    À placer tout en haut de votre « .htaccess »
+À placer tout en haut de votre « .htaccess »
 
-    ```bash
-    Require ip IP_range
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_range
+```
 
-- **Exemple** : si vous souhaitez autoriser uniquement la plage d’IPs 203.0.113.x à accéder à votre hébergement, vous devrez écrire l’un des deux codes suivants :
+- **Exemple** : si vous souhaitez autoriser uniquement la plage d’IPs 203.0.113.x à accéder à votre hébergement, vous devrez écrire le code suivant :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    À placer tout en haut de votre « .htaccess »
+À placer tout en haut de votre « .htaccess »
 
-    ```bash
-    Require ip 203.0.113
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113
+```
 
 #### Autoriser l’ensemble des IPs d’un pays
 
-Pour autoriser l’ensemble des IPs d’un pays à accéder à votre service, insérez l’un des deux codes suivants dans votre fichier « .htaccess » :
+Pour autoriser l’ensemble des IPs d’un pays à accéder à votre service, insérez le code suivant dans votre fichier « .htaccess » :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    À placer tout en haut de votre « .htaccess »
+À placer tout en haut de votre « .htaccess »
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Exemple** : si vous souhaitez autoriser uniquement les îles Fidji (FJ) et le Groenland (GR) à accéder à votre hébergement, vous devrez écrire l’un des deux codes suivants :
+- **Exemple** : si vous souhaitez autoriser uniquement les îles Fidji (FJ) et le Groenland (GR) à accéder à votre hébergement, vous devrez écrire le code suivant :
 
-<Tabs>
-  <Tab label="Syntaxe historique">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE FJ AllowCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Syntaxe à partir d’Apache 2.3">
-    À placer tout en haut de votre « .htaccess »
+À placer tout en haut de votre « .htaccess »
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 ### Compléments sur le fichier « .htaccess »
 

--- a/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Tutoriel - Comment bloquer l'accès à mon site pour certaines adresses IP via un fichier .htaccess ?"
+title: "Tutoriel - Comment bloquer l'accès à mon site pour certaines adresses IP via un fichier .htaccess ?"
 description: "Découvrez les actions possibles via un fichier .htaccess afin de bloquer l'accès à votre site à certaines adresses IP"
 lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
@@ -9,16 +9,16 @@ availableIn: [eu, ca, apac]
 
 Ce tutoriel a pour objectif de vous aider à sécuriser l’accès à vos sites du réseau extérieur, à prévenir ou corriger d’éventuelles intrusions ou tentatives d’attaques DDoS (attaques par déni de service).
 
-Vous pouvez réaliser ceci grâce à un fichier « .htaccess », un fichier texte particulier, détecté par le serveur web (Apache), et qui permet de définir des règles spéciales sur un répertoire et l’ensemble de ses sous-répertoires.
+Vous pouvez réaliser ceci grâce à un fichier « .htaccess », un fichier texte particulier, détecté par le serveur web (Apache), et qui permet de définir des règles spéciales sur un répertoire et l’ensemble de ses sous-répertoires.
 
-Vous pouvez créer plusieurs fichiers « .htaccess » dans [l’espace FTP](/guides/web-cloud/web-hosting/ftp-connection) de votre hébergement mais **un seul** par répertoire ou sous-répertoire afin d’éviter les conflits entre différents fichiers « .htaccess ».
+Vous pouvez créer plusieurs fichiers « .htaccess » dans [l’espace FTP](/guides/web-cloud/web-hosting/ftp-connection) de votre hébergement mais **un seul** par répertoire ou sous-répertoire afin d’éviter les conflits entre différents fichiers « .htaccess ».
 
-**Découvrez comment bloquer l’accès à votre site pour certaines adresses IP via un fichier « .htaccess ».**
+**Découvrez comment bloquer l’accès à votre site pour certaines adresses IP via un fichier « .htaccess ».**
 
 :::warning
 OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
 
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
+Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section « [Aller plus loin](#go-further) » de ce guide.
 :::
 
 ## Prérequis
@@ -28,23 +28,25 @@ Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur
 ## En pratique
 
 :::info
-Le fichier « .htaccess » peut être placé dans plusieurs dossiers différents tout en respectant la règle d’un **seul** fichier « .htaccess » par dossier ou sous-dossier.
+Le fichier « .htaccess » peut être placé dans plusieurs dossiers différents tout en respectant la règle d’un **seul** fichier « .htaccess » par dossier ou sous-dossier.
 
-Les paramètres définis par un fichier « .htaccess » s’appliquent au répertoire où il est installé ainsi qu’à tous ses sous-répertoires.
+Les paramètres définis par un fichier « .htaccess » s’appliquent au répertoire où il est installé ainsi qu’à tous ses sous-répertoires.
 
-Pour éditer (ou créer) ces répertoires, connectez-vous à l’espace FTP de votre hébergement. Au besoin, aidez-vous du guide « [Accéder à mon espace de stockage](/guides/web-cloud/web-hosting/ftp-connection) ».
+Pour éditer (ou créer) ces répertoires, connectez-vous à l’espace FTP de votre hébergement. Au besoin, aidez-vous du guide « [Accéder à mon espace de stockage](/guides/web-cloud/web-hosting/ftp-connection) ».
 :::
 
 ### Bloquer une IP, une plage d’IPs, un domaine ou toutes les IPs d’un Pays 
 
-Plusieurs règles sont disponibles afin de bloquer les accès à votre hébergement via le « .htaccess ».<br/>
-Soyez vigilant sur la syntaxe et sur les paramètres que vous bloquez afin de ne pas vous retrouver vous-même bloqué lors de la consultation de vos sites et/ou scripts hébergés.<br/>
+Plusieurs règles sont disponibles afin de bloquer les accès à votre hébergement via le « .htaccess ».
+
+Soyez vigilant sur la syntaxe et sur les paramètres que vous bloquez afin de ne pas vous retrouver vous-même bloqué lors de la consultation de vos sites et/ou scripts hébergés.
+
 En cas d’erreur, vous pouvez toujours vous connecter à [l’espace FTP](/guides/web-cloud/web-hosting/ftp-connection) de votre hébergement pour corriger la situation. 
 
 :::info
 Les hébergements mutualisés fonctionnent actuellement avec **Apache 2.4**.
 
-Pour plus de détails sur la syntaxe décrite dans ce guide, consultez les pages officielles suivantes :
+Pour plus de détails sur la syntaxe décrite dans ce guide, consultez les pages officielles suivantes :
 
 - [Documentation sur le contrôle d’accès Apache 2.4](https://httpd.apache.org/docs/2.4/fr/howto/access.html)
 - [Documentation sur le module mod_authz_core Apache 2.4](https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html)
@@ -53,7 +55,7 @@ Pour plus de détails sur la syntaxe décrite dans ce guide, consultez les pages
 
 #### Bloquer une IP
 
-Pour bloquer une adresse IP spécifique, insérez le code suivant dans votre fichier « .htaccess » :
+Pour bloquer une adresse IP spécifique, insérez le code suivant dans votre fichier « .htaccess » :
 
 ```bash
 <RequireAll>
@@ -62,7 +64,7 @@ Require not ip IP_address
 </RequireAll>
 ```
 
-- **Exemple** : si vous souhaitez bloquer l’adresse IP 203.0.113.0, vous devrez écrire le code suivant :
+- **Exemple** : si vous souhaitez bloquer l’adresse IP 203.0.113.0, vous devrez écrire le code suivant :
 
 ```bash
 <RequireAll>
@@ -73,7 +75,7 @@ Require not ip 203.0.113.0
 
 #### Bloquer une plage d’IPs
 
-Pour bloquer une plage d’adresses IP, insérez le code suivant dans votre fichier « .htaccess » :
+Pour bloquer une plage d’adresses IP, insérez le code suivant dans votre fichier « .htaccess » :
 
 ```bash
 <RequireAll>
@@ -82,7 +84,7 @@ Require not ip IP_range
 </RequireAll>
 ```
 
-- **Exemple** : si vous souhaitez bloquer toutes les IPs en 203.0.113.x, vous devrez écrire le code suivant :
+- **Exemple** : si vous souhaitez bloquer toutes les IPs en 203.0.113.x, vous devrez écrire le code suivant :
 
 ```bash
 <RequireAll>
@@ -95,7 +97,7 @@ Require not ip 203.0.113
 
 Certains domaines peuvent accéder à votre hébergement via des redirections ou des requêtes.
 
-Pour bloquer un domaine, insérez le code suivant dans votre fichier « .htaccess » :
+Pour bloquer un domaine, insérez le code suivant dans votre fichier « .htaccess » :
 
 ```bash
 <RequireAll>
@@ -103,7 +105,7 @@ Require not host domain
 </RequireAll>
 ```
 
-- **Exemple** : si vous souhaitez bloquer le domaine domain.tld, vous devrez écrire le code suivant :
+- **Exemple** : si vous souhaitez bloquer le domaine domain.tld, vous devrez écrire le code suivant :
 
 ```bash
 <RequireAll>
@@ -116,26 +118,22 @@ Require not host domain.tld
 :::info
 L’ensemble des adresses IP (notamment les adresses IP publiques) disposent d’une géolocalisation à l’échelle d’un pays. Ceci permet d’avoir un aperçu de la provenance des flux d’une IP et de repérer physiquement l’IP. 
 
-Le « .htaccess » permet, grâce à cet élément, de bloquer l’ensemble des IPs géolocalisées dans un pays. 
+Le « .htaccess » permet, grâce à cet élément, de bloquer l’ensemble des IPs géolocalisées dans un pays. 
 En d’autres termes, toutes les personnes qui tenteront de visiter votre site depuis ce pays seront bloquées (sauf si elles utilisent une connexion VPN avec une IP géolocalisée dans un autre pays).
 
-Les blocages via le « .htaccess » s’effectuent par le biais des « Country Codes » à deux lettres (Norme ISO 3166-1 alpha2) des pays.
+Les blocages via le « .htaccess » s’effectuent par le biais des « Country Codes » à deux lettres (Norme ISO 3166-1 alpha2) des pays.
 
-Plusieurs sites listent les pays et leurs « Country Codes » respectifs, dont [https://www.iban.com/country-codes](https://www.iban.com/country-codes) (indépendant d’OVHcloud).
+Plusieurs sites listent les pays et leurs « Country Codes » respectifs, dont [https://www.iban.com/country-codes](https://www.iban.com/country-codes) (indépendant d’OVHcloud).
 :::
 
-Pour bloquer l’ensemble des IPs d’un pays, insérez le code suivant dans votre fichier « .htaccess » :
-
-À placer tout en haut de votre « .htaccess »
+Pour bloquer l’ensemble des IPs d’un pays, insérez le code suivant tout en haut de votre fichier « .htaccess » :
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Exemple** : si vous souhaitez bloquer les adresses IPs géolocalisées aux îles Fidji (FJ) et au Groenland (GR), vous devrez écrire le code suivant :
-
-À placer tout en haut de votre « .htaccess »
+- **Exemple** : si vous souhaitez bloquer les adresses IPs géolocalisées aux îles Fidji (FJ) et au Groenland (GR), vous devrez écrire le code suivant tout en haut de votre fichier « .htaccess » :
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
@@ -148,13 +146,13 @@ Plutôt que de restreindre l’accès à une ou plusieurs IPs et laisser les aut
 
 #### Autoriser une ou plusieurs IPs
 
-Pour n’autoriser qu’une seule IP à accéder à votre service, insérez le code suivant dans votre fichier « .htaccess » :
+Pour n’autoriser qu’une seule IP à accéder à votre service, insérez le code suivant dans votre fichier « .htaccess » :
 
 ```bash
 Require ip IP_address
 ```
 
-- **Exemple** : si vous souhaitez autoriser uniquement les IPs 203.0.113.0 et 203.0.113.1 à accéder à votre hébergement, vous devrez écrire le code suivant :
+- **Exemple** : si vous souhaitez autoriser uniquement les IPs 203.0.113.0 et 203.0.113.1 à accéder à votre hébergement, vous devrez écrire le code suivant :
 
 ```bash
 Require ip 203.0.113.0 203.0.113.1
@@ -162,17 +160,13 @@ Require ip 203.0.113.0 203.0.113.1
 
 #### Autoriser une plage d’IPs
 
-Pour autoriser une plage d’IPs à accéder à votre service, insérez le code suivant dans votre fichier « .htaccess » :
-
-À placer tout en haut de votre « .htaccess »
+Pour autoriser une plage d’IPs à accéder à votre service, insérez le code suivant tout en haut de votre fichier « .htaccess » :
 
 ```bash
 Require ip IP_range
 ```
 
-- **Exemple** : si vous souhaitez autoriser uniquement la plage d’IPs 203.0.113.x à accéder à votre hébergement, vous devrez écrire le code suivant :
-
-À placer tout en haut de votre « .htaccess »
+- **Exemple** : si vous souhaitez autoriser uniquement la plage d’IPs 203.0.113.x à accéder à votre hébergement, vous devrez écrire le code suivant tout en haut de votre fichier « .htaccess » :
 
 ```bash
 Require ip 203.0.113
@@ -180,35 +174,31 @@ Require ip 203.0.113
 
 #### Autoriser l’ensemble des IPs d’un pays
 
-Pour autoriser l’ensemble des IPs d’un pays à accéder à votre service, insérez le code suivant dans votre fichier « .htaccess » :
-
-À placer tout en haut de votre « .htaccess »
+Pour autoriser l’ensemble des IPs d’un pays à accéder à votre service, insérez le code suivant tout en haut de votre fichier « .htaccess » :
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Exemple** : si vous souhaitez autoriser uniquement les îles Fidji (FJ) et le Groenland (GR) à accéder à votre hébergement, vous devrez écrire le code suivant :
-
-À placer tout en haut de votre « .htaccess »
+- **Exemple** : si vous souhaitez autoriser uniquement les îles Fidji (FJ) et le Groenland (GR) à accéder à votre hébergement, vous devrez écrire le code suivant tout en haut de votre fichier « .htaccess » :
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-### Compléments sur le fichier « .htaccess »
+### Compléments sur le fichier « .htaccess »
 
-Indépendamment de la sécurité sur l’accès général à l’hébergement, le fichier « .htaccess » permet de réaliser d’autres actions. Vous trouverez ci-après trois autres tutoriels OVHcloud sur le sujet :
+Indépendamment de la sécurité sur l’accès général à l’hébergement, le fichier « .htaccess » permet de réaliser d’autres actions. Vous trouverez ci-après trois autres tutoriels OVHcloud sur le sujet :
 
-- [Protéger l’interface d’administration de votre site via le « .htaccess »](/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password).
-- [Réécrire vos URLs grâce au « mod_rewrite »](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite).
-- [Effectuer d’autres opérations avec le fichier « .htaccess »](/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do).
+- [Protéger l’interface d’administration de votre site via le « .htaccess »](/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password).
+- [Réécrire vos URLs grâce au « mod_rewrite »](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite).
+- [Effectuer d’autres opérations avec le fichier « .htaccess »](/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do).
 
 ## Aller plus loin <a name="go-further"></a>
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner).
+Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](/links/partner).
 
 Si vous souhaitez bénéficier d’une assistance à l’usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).
 

--- a/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,11 +1,9 @@
 ---
 title: "Tutorial - Come bloccare l'accesso al mio sito per alcuni indirizzi IP tramite un file .htaccess?"
 description: "Scopri le azioni possibili tramite un file .htaccess per bloccare l'accesso al tuo sito ad alcuni indirizzi IP"
-lastUpdated: 2024-03-14
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
-
-import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Obiettivo
 
@@ -44,11 +42,9 @@ Presta particolare attenzione alla sintassi e alle impostazioni bloccate per non
 In caso di errore, accedi allo [spazio FTP](/guides/web-cloud/web-hosting/ftp-connection) dell'hosting per correggere la situazione. 
 
 :::info
-Gli hosting condivisi funzionano attualmente con **Apache 2.4**. Dalla versione **Apache 2.3**, sono state implementate alcune variabili e la sintassi di redazione delle restrizioni/autorizzazioni di accesso è cambiata.
+Gli hosting condivisi funzionano attualmente con **Apache 2.4**.
 
-La precedente sintassi è molto utilizzata e continua ad essere attiva sulle nostre infrastrutture. Tuttavia, l'Apache è considerata obsoleta da *Apache* e potrebbe presto non essere più disponibile. In questo tutorial troverai esempi che illustrano le due sintassi.
-
-Per maggiori informazioni sulla nuova sintassi, consulta le seguenti pagine ufficiali:
+Per maggiori informazioni sulla sintassi descritta in questa guida, consulta le seguenti pagine ufficiali:
 
 - [Documentazione Apache 2.4 relativa al controllo degli accessi](https://httpd.apache.org/docs/2.4/en/howto/access.html)
 - [Documentazione relativa al modulo mod_authz_core Apache 2.4](https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html)
@@ -57,117 +53,63 @@ Per maggiori informazioni sulla nuova sintassi, consulta le seguenti pagine uffi
 
 #### Bloccare un IP
 
-Per bloccare un indirizzo IP specifico, inserisci uno dei due codici seguenti nel tuo file ".htaccess":
+Per bloccare un indirizzo IP specifico, inserisci il seguente codice nel tuo file ".htaccess":
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    Deny from IP_address
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_address
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_address
+</RequireAll>
+```
 
-- **Esempio**: per bloccare l'indirizzo IP 203.0.113.0, è necessario scrivere uno dei due codici seguenti:
+- **Esempio**: per bloccare l'indirizzo IP 203.0.113.0, è necessario scrivere il seguente codice:
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    Deny from 203.0.113.0
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113.0
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113.0
+</RequireAll>
+```
 
 #### Bloccare una gamma di IP
 
-Per bloccare un intervallo di indirizzi IP, inserisci uno dei due codici seguenti nel tuo file ".htaccess":
+Per bloccare un intervallo di indirizzi IP, inserisci il seguente codice nel tuo file ".htaccess":
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    Deny from IP_range
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_range
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_range
+</RequireAll>
+```
 
-- **Esempio**: per bloccare tutti gli IP nel 203.0.113.x, è necessario scrivere uno dei due codici seguenti:
+- **Esempio**: per bloccare tutti gli IP nel 203.0.113.x, è necessario scrivere il seguente codice:
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    Deny from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113
+</RequireAll>
+```
 
 #### Bloccare un dominio
 
 Alcuni domini possono accedere al tuo hosting tramite reindirizzamenti o richieste.
 
-Per bloccare un dominio, inserisci uno dei due codici seguenti nel tuo file ".htaccess":
+Per bloccare un dominio, inserisci il seguente codice nel tuo file ".htaccess":
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    Deny from domain
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain
+</RequireAll>
+```
 
-- **Esempio**: se vuoi bloccare il dominio domain.tld, devi scrivere uno dei due codici seguenti:
+- **Esempio**: se vuoi bloccare il dominio domain.tld, devi scrivere il seguente codice:
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    Deny from domain.tld
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain.tld
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain.tld
+</RequireAll>
+```
 
 ##### Blocca gli IP di un Paese
 
@@ -182,44 +124,23 @@ I blocchi via ".htaccess" sono effettuati tramite i "Country Codes" a due letter
 Alcuni siti Internet con i rispettivi "Country Codes", tra cui [https://www.iban.com/country-codes](https://www.iban.com/country-codes) (indipendente da OVHcloud).
 :::
 
-Per bloccare tutti gli IP di un paese, inserisci uno dei due codici seguenti nel tuo file ".htaccess":
+Per bloccare tutti gli IP di un paese, inserisci il seguente codice nel tuo file ".htaccess":
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    Da mettere in alto nel vostro ".htaccess"
+Da mettere in alto nel vostro ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Esempio**: per bloccare gli indirizzi IP geolocalizzati nelle isole Figi (FJ) e in Groenlandia (GR), è necessario scrivere uno dei due codici seguenti:
+- **Esempio**: per bloccare gli indirizzi IP geolocalizzati nelle isole Figi (FJ) e in Groenlandia (GR), è necessario scrivere il seguente codice:
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE FJ BlockCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    Da mettere in alto nel vostro ".htaccess"
+Da mettere in alto nel vostro ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 ### Per autorizzare solo alcuni IP, una gamma di IP o l'insieme degli IP di un paese
 
@@ -227,125 +148,55 @@ Anziché restringere l'accesso ad uno o più IP e lasciare gli altri utenti al t
 
 #### Autorizza uno o più IP
 
-Per autorizzare un solo IP ad accedere al tuo servizio, inserisci uno dei due codici seguenti nel tuo file ".htaccess":
+Per autorizzare un solo IP ad accedere al tuo servizio, inserisci il seguente codice nel tuo file ".htaccess":
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_address
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    ```bash
-    Require ip IP_address
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_address
+```
 
-- **Esempio**: se vuoi autorizzare l'accesso al tuo hosting solo agli IP 203.0.113.0 e 203.0.113.1, devi scrivere uno dei due codici seguenti:
+- **Esempio**: se vuoi autorizzare l'accesso al tuo hosting solo agli IP 203.0.113.0 e 203.0.113.1, devi scrivere il seguente codice:
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113.0
-    Allow from 203.0.113.1
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    ```bash
-    Require ip 203.0.113.0 203.0.113.1
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113.0 203.0.113.1
+```
 
 #### Autorizza una gamma di IP
 
-Per autorizzare un intervallo di IP ad accedere al tuo servizio, inserisci uno dei due codici seguenti nel tuo file ".htaccess":
+Per autorizzare un intervallo di IP ad accedere al tuo servizio, inserisci il seguente codice nel tuo file ".htaccess":
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_range
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    Da mettere in alto nel vostro ".htaccess"
+Da mettere in alto nel vostro ".htaccess"
 
-    ```bash
-    Require ip IP_range
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_range
+```
 
-- **Esempio**: se vuoi autorizzare l'accesso al tuo hosting solo alla gamma di IP 203.0.113.x, devi scrivere uno dei due codici seguenti:
+- **Esempio**: se vuoi autorizzare l'accesso al tuo hosting solo alla gamma di IP 203.0.113.x, devi scrivere il seguente codice:
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    Da mettere in alto nel vostro ".htaccess"
+Da mettere in alto nel vostro ".htaccess"
 
-    ```bash
-    Require ip 203.0.113
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113
+```
 
 #### Autorizza tutti gli IP di un Paese
 
-Per autorizzare tutti gli IP di un paese ad accedere al tuo servizio, inserisci uno dei due codici seguenti nel tuo file ".htaccess":
+Per autorizzare tutti gli IP di un paese ad accedere al tuo servizio, inserisci il seguente codice nel tuo file ".htaccess":
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    Da mettere in alto nel vostro ".htaccess"
+Da mettere in alto nel vostro ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Esempio**: se vuoi autorizzare l'accesso al tuo hosting solo alle Figi (FJ) e alla Groenlandia (GR), è necessario scrivere uno dei due codici seguenti:
+- **Esempio**: se vuoi autorizzare l'accesso al tuo hosting solo alle Figi (FJ) e alla Groenlandia (GR), è necessario scrivere il seguente codice:
 
-<Tabs>
-  <Tab label="Sintassi storici">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE FJ AllowCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Sintassi a partire da Apache 2.3">
-    Da mettere in alto nel vostro ".htaccess"
+Da mettere in alto nel vostro ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 ### Complementi sul file ".htaccess"
 

--- a/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -37,8 +37,10 @@ Per modificare (o creare) queste directory, accedi allo spazio FTP del tuo hosti
 
 ### Bloccare un IP, una gamma di IP, un dominio o tutti gli IP di un Paese 
 
-Sono disponibili diverse regole per bloccare gli accessi al tuo hosting tramite ".htaccess".<br/>
-Presta particolare attenzione alla sintassi e alle impostazioni bloccate per non ritrovarsi bloccati durante la consultazione dei tuoi siti e/o script ospitati.<br/>
+Sono disponibili diverse regole per bloccare gli accessi al tuo hosting tramite ".htaccess".
+
+Presta particolare attenzione alla sintassi e alle impostazioni bloccate per non ritrovarsi bloccati durante la consultazione dei tuoi siti e/o script ospitati.
+
 In caso di errore, accedi allo [spazio FTP](/guides/web-cloud/web-hosting/ftp-connection) dell'hosting per correggere la situazione. 
 
 :::info
@@ -124,18 +126,14 @@ I blocchi via ".htaccess" sono effettuati tramite i "Country Codes" a due letter
 Alcuni siti Internet con i rispettivi "Country Codes", tra cui [https://www.iban.com/country-codes](https://www.iban.com/country-codes) (indipendente da OVHcloud).
 :::
 
-Per bloccare tutti gli IP di un paese, inserisci il seguente codice nel tuo file ".htaccess":
-
-Da mettere in alto nel vostro ".htaccess"
+Per bloccare tutti gli IP di un paese, inserisci il seguente codice in alto nel tuo file ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Esempio**: per bloccare gli indirizzi IP geolocalizzati nelle isole Figi (FJ) e in Groenlandia (GR), è necessario scrivere il seguente codice:
-
-Da mettere in alto nel vostro ".htaccess"
+- **Esempio**: per bloccare gli indirizzi IP geolocalizzati nelle isole Figi (FJ) e in Groenlandia (GR), è necessario scrivere il seguente codice in alto nel tuo file ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
@@ -162,17 +160,13 @@ Require ip 203.0.113.0 203.0.113.1
 
 #### Autorizza una gamma di IP
 
-Per autorizzare un intervallo di IP ad accedere al tuo servizio, inserisci il seguente codice nel tuo file ".htaccess":
-
-Da mettere in alto nel vostro ".htaccess"
+Per autorizzare un intervallo di IP ad accedere al tuo servizio, inserisci il seguente codice in alto nel tuo file ".htaccess":
 
 ```bash
 Require ip IP_range
 ```
 
-- **Esempio**: se vuoi autorizzare l'accesso al tuo hosting solo alla gamma di IP 203.0.113.x, devi scrivere il seguente codice:
-
-Da mettere in alto nel vostro ".htaccess"
+- **Esempio**: se vuoi autorizzare l'accesso al tuo hosting solo alla gamma di IP 203.0.113.x, devi scrivere il seguente codice in alto nel tuo file ".htaccess":
 
 ```bash
 Require ip 203.0.113
@@ -180,18 +174,14 @@ Require ip 203.0.113
 
 #### Autorizza tutti gli IP di un Paese
 
-Per autorizzare tutti gli IP di un paese ad accedere al tuo servizio, inserisci il seguente codice nel tuo file ".htaccess":
-
-Da mettere in alto nel vostro ".htaccess"
+Per autorizzare tutti gli IP di un paese ad accedere al tuo servizio, inserisci il seguente codice in alto nel tuo file ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Esempio**: se vuoi autorizzare l'accesso al tuo hosting solo alle Figi (FJ) e alla Groenlandia (GR), è necessario scrivere il seguente codice:
-
-Da mettere in alto nel vostro ".htaccess"
+- **Esempio**: se vuoi autorizzare l'accesso al tuo hosting solo alle Figi (FJ) e alla Groenlandia (GR), è necessario scrivere il seguente codice in alto nel tuo file ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
@@ -207,7 +197,7 @@ Indipendentemente dalla sicurezza sull'accesso generale all'hosting, il file ".h
 
 ## Per saperne di più <a name="go-further"></a>
 
-Per prestazioni specializzate (referenziamento, sviluppo, ecc...), contatta i [partner OVHcloud](/links/partner).
+Per prestazioni specializzate (referenziamento, sviluppo, ecc.), contatta i [partner OVHcloud](/links/partner).
 
 Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre soluzioni [offerte di supporto](/links/support).
 

--- a/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,11 +1,9 @@
 ---
 title: Tutorial - Jak zablokować dostęp do mojej strony dla niektórych adresów IP za pomocą pliku .htaccess?
 description: Odkryj operacje możliwe przy użyciu pliku .htaccess, w celu zablokowania dostępu do Twojej strony WWW dla niektórych adresów IP
-lastUpdated: 2024-03-14
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
-
-import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Wprowadzenie 
 
@@ -44,11 +42,9 @@ Zalecamy ostrożność podczas tworzenia składni oraz ustawień, które blokuje
 W przypadku błędu możesz zawsze zalogować się do [przestrzeni FTP](/guides/web-cloud/web-hosting/ftp-connection) Twojego hostingu, aby poprawić tę sytuację. 
 
 :::info
-Hosting współdzielony działa obecnie z **Apache 2.4**. Od wersji **Apache 2.3** wprowadzono zmienne i zmieniła się składnia edycji ograniczeń/zezwoleń na dostęp.
+Hosting współdzielony działa obecnie z **Apache 2.4**.
 
-Ponieważ poprzednia składnia jest bardzo popularna, jest ona nadal aktywna w naszych infrastrukturach. Jednak Apache* jest uważany za przestarzałą i wkrótce może nie być już dostępny. W niniejszym tutorialu znajdują się przykłady opisujące obydwie składnie.
-
-Szczegółowe informacje na temat nowej składni znajdują się na następujących oficjalnych stronach:
+Szczegółowe informacje na temat składni opisanej w tym przewodniku znajdują się na następujących oficjalnych stronach:
 
 - [Dokumentacja kontroli dostępu Apache 2.4](https://httpd.apache.org/docs/2.4/en/howto/access.html)
 - [Dokumentacja dotycząca modułu mod_authz_core Apache 2.4](https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html)
@@ -57,117 +53,63 @@ Szczegółowe informacje na temat nowej składni znajdują się na następujący
 
 #### Zablokuj IP
 
-Aby zablokować określony adres IP, wprowadź jeden z dwóch poniższych kodów do Twojego pliku ".htaccess":
+Aby zablokować określony adres IP, wprowadź poniższy kod do Twojego pliku ".htaccess":
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    Deny from IP_address
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_address
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_address
+</RequireAll>
+```
 
-- **Przykład**: jeśli chcesz zablokować adres IP 203.0.113.0, musisz napisać jeden z dwóch poniższych kodów:
+- **Przykład**: jeśli chcesz zablokować adres IP 203.0.113.0, musisz napisać poniższy kod:
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    Deny from 203.0.113.0
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113.0
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113.0
+</RequireAll>
+```
 
 #### Zablokuj zakres adresów IP
 
-Aby zablokować zakres adresów IP, wprowadź jeden z dwóch poniższych kodów do pliku ".htaccess":
+Aby zablokować zakres adresów IP, wprowadź poniższy kod do pliku ".htaccess":
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    Deny from IP_range
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_range
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_range
+</RequireAll>
+```
 
-- **Przykład**: jeśli chcesz zablokować wszystkie adresy IP 203.0.113.x, wpisz jeden z dwóch poniższych kodów:
+- **Przykład**: jeśli chcesz zablokować wszystkie adresy IP 203.0.113.x, wpisz poniższy kod:
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    Deny from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113
+</RequireAll>
+```
 
 #### Zablokuj domenę
 
 Niektóre domeny mają dostęp do Twojego hostingu poprzez przekierowania lub zapytania.
 
-Aby zablokować domenę, wprowadź jeden z dwóch poniższych kodów do pliku ".htaccess":
+Aby zablokować domenę, wprowadź poniższy kod do pliku ".htaccess":
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    Deny from domain
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain
+</RequireAll>
+```
 
-- **Przykład**: jeśli chcesz zablokować domenę domain.tld, napisz jeden z dwóch kodów:
+- **Przykład**: jeśli chcesz zablokować domenę domain.tld, napisz poniższy kod:
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    Deny from domain.tld
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain.tld
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain.tld
+</RequireAll>
+```
 
 #### Blokuj adresy IP danego kraju
 
@@ -182,44 +124,23 @@ Blokowanie przez ".htaccess" odbywa się za pomocą dwuliterowych "Country Codes
 Kilka stron WWW zawiera listę krajów oraz ich odpowiednich kodów "Country Codes" (w tym [https://www.iban.com/country-codes](https://www.iban.com/country-codes) (niezależny od OVHcloud).
 :::
 
-Aby zablokować wszystkie adresy IP danego kraju, wprowadź jeden z dwóch poniższych kodów do pliku ".htaccess":
+Aby zablokować wszystkie adresy IP danego kraju, wprowadź poniższy kod do pliku ".htaccess":
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    Umieść wszystko na górze ".htaccess"
+Umieść wszystko na górze ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Przykład**: jeśli chcesz zablokować geolokalizowane adresy IP na Fidżi (FJ) i Grenlandii (GR), musisz napisać jeden z następujących kodów:
+- **Przykład**: jeśli chcesz zablokować geolokalizowane adresy IP na Fidżi (FJ) i Grenlandii (GR), musisz napisać poniższy kod:
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE FJ BlockCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    Umieść wszystko na górze ".htaccess"
+Umieść wszystko na górze ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 ### Aby autoryzować tylko kilka IP, zakres IP lub wszystkie adresy IP w danym kraju
 
@@ -227,125 +148,55 @@ Zamiast ograniczać dostęp do jednego lub kilku adresów IP i dawać innym dost
 
 #### Zezwalaj na jeden lub kilka adresów IP
 
-Aby nadać tylko jednemu adresowi IP dostęp do Twojej usługi, wprowadź jeden z dwóch poniższych kodów w Twoim pliku ".htaccess":
+Aby nadać tylko jednemu adresowi IP dostęp do Twojej usługi, wprowadź poniższy kod w Twoim pliku ".htaccess":
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_address
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    ```bash
-    Require ip IP_address
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_address
+```
 
-- **Przykład**: jeśli chcesz autoryzować dostęp do hostingu tylko dla adresów IP 203.0.113.0 i 203.0.113.1, wpisz jeden z dwóch poniższych kodów:
+- **Przykład**: jeśli chcesz autoryzować dostęp do hostingu tylko dla adresów IP 203.0.113.0 i 203.0.113.1, wpisz poniższy kod:
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113.0
-    Allow from 203.0.113.1
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    ```bash
-    Require ip 203.0.113.0 203.0.113.1
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113.0 203.0.113.1
+```
 
 #### Zezwalaj na przedział adresów IP
 
-Aby zezwolić na dostęp do zakresu adresów IP, wprowadź jeden z dwóch poniższych kodów w pliku ".htaccess":
+Aby zezwolić na dostęp do zakresu adresów IP, wprowadź poniższy kod w pliku ".htaccess":
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_range
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    Umieść wszystko na górze ".htaccess"
+Umieść wszystko na górze ".htaccess"
 
-    ```bash
-    Require ip IP_range
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_range
+```
 
-- **Przykład**: jeśli chcesz autoryzować dostęp do Twojego hostingu tylko dla adresów IP 203.0.113.x, wpisz jeden z dwóch poniższych kodów:
+- **Przykład**: jeśli chcesz autoryzować dostęp do Twojego hostingu tylko dla adresów IP 203.0.113.x, wpisz poniższy kod:
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    Umieść wszystko na górze ".htaccess"
+Umieść wszystko na górze ".htaccess"
 
-    ```bash
-    Require ip 203.0.113
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113
+```
 
 #### Zatwierdź wszystkie adresy IP danego kraju
 
-Aby zezwolić na dostęp do Twojej usługi dla wszystkich adresów IP danego kraju, wprowadź do Twojego pliku ".htaccess" jeden z dwóch poniższych kodów:
+Aby zezwolić na dostęp do Twojej usługi dla wszystkich adresów IP danego kraju, wprowadź do Twojego pliku ".htaccess" poniższy kod:
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    Umieść wszystko na górze ".htaccess"
+Umieść wszystko na górze ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Przykład**: jeśli chcesz autoryzować dostęp do hostingu wyłącznie na Fidżi (FJ) i Grenlandii (GR), musisz napisać jeden z dwóch kodów:
+- **Przykład**: jeśli chcesz autoryzować dostęp do hostingu wyłącznie na Fidżi (FJ) i Grenlandii (GR), musisz napisać poniższy kod:
 
-<Tabs>
-  <Tab label="Składnia historyczna">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE FJ AllowCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Składnia od Apache 2.3">
-    Umieść wszystko na górze ".htaccess"
+Umieść wszystko na górze ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 ## Suplementy do pliku ".htaccess"
 

--- a/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -37,8 +37,10 @@ Aby edytować (lub utworzyć) te katalogi, zaloguj się do przestrzeni FTP Twoje
 
 ### Blokuj IP, zakres adresów IP, domenę lub wszystkie adresy IP w danym kraju 
 
-Aby zablokować dostęp do Twojego hostingu za pomocą ".htaccess".<br/>
-Zalecamy ostrożność podczas tworzenia składni oraz ustawień, które blokujesz, aby uniknąć blokady Twojej strony WWW podczas wyświetlania strony i/lub hostowanych skryptów.<br/>
+Aby zablokować dostęp do Twojego hostingu za pomocą ".htaccess".
+
+Zalecamy ostrożność podczas tworzenia składni oraz ustawień, które blokujesz, aby uniknąć blokady Twojej strony WWW podczas wyświetlania strony i/lub hostowanych skryptów.
+
 W przypadku błędu możesz zawsze zalogować się do [przestrzeni FTP](/guides/web-cloud/web-hosting/ftp-connection) Twojego hostingu, aby poprawić tę sytuację. 
 
 :::info
@@ -124,18 +126,14 @@ Blokowanie przez ".htaccess" odbywa się za pomocą dwuliterowych "Country Codes
 Kilka stron WWW zawiera listę krajów oraz ich odpowiednich kodów "Country Codes" (w tym [https://www.iban.com/country-codes](https://www.iban.com/country-codes) (niezależny od OVHcloud).
 :::
 
-Aby zablokować wszystkie adresy IP danego kraju, wprowadź poniższy kod do pliku ".htaccess":
-
-Umieść wszystko na górze ".htaccess"
+Aby zablokować wszystkie adresy IP danego kraju, wprowadź poniższy kod na górze pliku ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Przykład**: jeśli chcesz zablokować geolokalizowane adresy IP na Fidżi (FJ) i Grenlandii (GR), musisz napisać poniższy kod:
-
-Umieść wszystko na górze ".htaccess"
+- **Przykład**: jeśli chcesz zablokować geolokalizowane adresy IP na Fidżi (FJ) i Grenlandii (GR), musisz napisać poniższy kod na górze pliku ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
@@ -162,17 +160,13 @@ Require ip 203.0.113.0 203.0.113.1
 
 #### Zezwalaj na przedział adresów IP
 
-Aby zezwolić na dostęp do zakresu adresów IP, wprowadź poniższy kod w pliku ".htaccess":
-
-Umieść wszystko na górze ".htaccess"
+Aby zezwolić na dostęp do zakresu adresów IP, wprowadź poniższy kod na górze pliku ".htaccess":
 
 ```bash
 Require ip IP_range
 ```
 
-- **Przykład**: jeśli chcesz autoryzować dostęp do Twojego hostingu tylko dla adresów IP 203.0.113.x, wpisz poniższy kod:
-
-Umieść wszystko na górze ".htaccess"
+- **Przykład**: jeśli chcesz autoryzować dostęp do Twojego hostingu tylko dla adresów IP 203.0.113.x, wpisz poniższy kod na górze pliku ".htaccess":
 
 ```bash
 Require ip 203.0.113
@@ -180,18 +174,14 @@ Require ip 203.0.113
 
 #### Zatwierdź wszystkie adresy IP danego kraju
 
-Aby zezwolić na dostęp do Twojej usługi dla wszystkich adresów IP danego kraju, wprowadź do Twojego pliku ".htaccess" poniższy kod:
-
-Umieść wszystko na górze ".htaccess"
+Aby zezwolić na dostęp do Twojej usługi dla wszystkich adresów IP danego kraju, wprowadź poniższy kod na górze pliku ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Przykład**: jeśli chcesz autoryzować dostęp do hostingu wyłącznie na Fidżi (FJ) i Grenlandii (GR), musisz napisać poniższy kod:
-
-Umieść wszystko na górze ".htaccess"
+- **Przykład**: jeśli chcesz autoryzować dostęp do hostingu wyłącznie na Fidżi (FJ) i Grenlandii (GR), musisz napisać poniższy kod na górze pliku ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
@@ -208,7 +198,7 @@ Niezależnie od bezpieczeństwa ogólnego dostępu do hostingu plik ".htaccess" 
 
 ## Sprawdź również <a name="go-further"></a>
 
-W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj się z [partnerami OVHcloud](/links/partner).
+W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, itp.) skontaktuj się z [partnerami OVHcloud](/links/partner).
 
 Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](/links/support).
 

--- a/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,11 +1,9 @@
 ---
 title: Tutorial - Como bloquear o acesso ao meu site para alguns endereços IP através de um ficheiro .htaccess ?
 description: Descubra as ações possíveis através de um ficheiro .htaccess para bloquear o acesso ao seu site a determinados endereços IP
-lastUpdated: 2024-03-14
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
-
-import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objetivo
 
@@ -44,11 +42,9 @@ Esteja atento à sintaxe e aos parâmetros que bloqueia para não ficar bloquead
 Em caso de erro, pode aceder ao [espaço FTP](/guides/web-cloud/web-hosting/ftp-connection) do alojamento para corrigir a situação. 
 
 :::info
-Os alojamentos partilhados funcionam atualmente com **Apache 2.4**. Desde a versão **Apache 2.3**, foram implementadas variáveis e a sintaxe de redação das restrições/autorizações de acesso evoluiu.
+Os alojamentos partilhados funcionam atualmente com **Apache 2.4**.
 
-Uma vez que a antiga sintaxe é muito utilizada, ela ainda está ativa nas nossas infraestruturas. No entanto, é considerada obsoleta por *Apache* e poderá em breve deixar de estar disponível. Neste tutorial, encontrará exemplos que detalham as duas sintaxe.
-
-Para mais pormenores sobre a nova sintaxe, pode consultar as seguintes páginas oficiais:
+Para mais pormenores sobre a sintaxe descrita neste guia, consulte as seguintes páginas oficiais:
 
 - [Documentação sobre o controlo de acesso Apache 2.4](https://httpd.apache.org/docs/2.4/en/howto/access.html) 
 - [Documentação sobre o módulo mod_authz_core Apache 2.4](https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html) 
@@ -57,117 +53,63 @@ Para mais pormenores sobre a nova sintaxe, pode consultar as seguintes páginas 
 
 #### Bloquear um IP
 
-Para bloquear um endereço IP específico, insira um dos dois códigos seguintes no seu ficheiro ".htaccess":
+Para bloquear um endereço IP específico, insira o seguinte código no seu ficheiro ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    Deny from IP_address
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_address
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_address
+</RequireAll>
+```
 
-- **Exemplo** : se pretender bloquear o endereço IP 203.0.113.0, deverá escrever um dos dois códigos seguintes:
+- **Exemplo** : se pretender bloquear o endereço IP 203.0.113.0, deverá escrever o seguinte código:
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    Deny from 203.0.113.0
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113.0
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113.0
+</RequireAll>
+```
 
 #### Bloquear uma gama de endereços IP
 
-Para bloquear um intervalo de endereços IP, insira um dos dois códigos seguintes no seu ficheiro ".htaccess":
+Para bloquear um intervalo de endereços IP, insira o seguinte código no seu ficheiro ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    Deny from IP_range
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip IP_range
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip IP_range
+</RequireAll>
+```
 
-- **Exemplo** : se pretender bloquear todos os IPs em 203.0.113.x, deverá escrever um dos dois códigos seguintes:
+- **Exemplo** : se pretender bloquear todos os IPs em 203.0.113.x, deverá escrever o seguinte código:
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    Deny from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require all granted
-    Require not ip 203.0.113
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require all granted
+Require not ip 203.0.113
+</RequireAll>
+```
 
 #### Bloquear um domínio
 
 Alguns domínios podem aceder ao seu alojamento através de reencaminhamentos ou pedidos.
 
-Para bloquear um domínio, insira um dos dois códigos seguintes no seu ficheiro ".htaccess":
+Para bloquear um domínio, insira o seguinte código no seu ficheiro ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    Deny from domain
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain
+</RequireAll>
+```
 
-- **Exemplo** : se pretender bloquear o domínio domain.tld, deverá escrever um dos dois códigos seguintes:
+- **Exemplo** : se pretender bloquear o domínio domain.tld, deverá escrever o seguinte código:
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    Deny from domain.tld
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    ```bash
-    <RequireAll>
-    Require not host domain.tld
-    </RequireAll>
-    ```
-  </Tab>
-</Tabs>
+```bash
+<RequireAll>
+Require not host domain.tld
+</RequireAll>
+```
 
 #### Bloquear os endereços IP de um país
 
@@ -182,44 +124,23 @@ Os bloqueios através do ".htaccess" efetuam-se através dos "Country Codes" de 
 Vários sites listam os países e os respetivos "Country Codes", entre os quais [https://www.iban.com/country-codes](https://www.iban.com/country-codes)  (independente da OVHcloud).
 :::
 
-Para bloquear o conjunto dos IPs de um país, insira um dos dois códigos seguintes no seu ficheiro ".htaccess":
+Para bloquear o conjunto dos IPs de um país, insira o seguinte código no seu ficheiro ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    A colocar no topo do seu ".htaccess"
+A colocar no topo do seu ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Exemplo** : Se pretender bloquear os endereços IP geolocalizados nas Fiji (FJ) e na Gronelândia (GR), deverá escrever um dos dois códigos seguintes:
+- **Exemplo** : Se pretender bloquear os endereços IP geolocalizados nas Fiji (FJ) e na Gronelândia (GR), deverá escrever o seguinte código:
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    SetEnvIf GEOIP_COUNTRY_CODE FJ BlockCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR BlockCountry
-    Deny from env=BlockCountry
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    A colocar no topo do seu ".htaccess"
+A colocar no topo do seu ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 #### Para autorizar apenas alguns endereços IP, uma gama de endereços IP ou o conjunto de endereços IP de um país
 
@@ -227,125 +148,55 @@ Em vez de restringir o acesso a um ou vários IP e deixar os outros aceder ao se
 
 ##### Autorizar um ou vários endereços IP
 
-Para autorizar apenas um IP a aceder ao seu serviço, insira um dos dois códigos seguintes no seu ficheiro ".htaccess":
+Para autorizar apenas um IP a aceder ao seu serviço, insira o seguinte código no seu ficheiro ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_address
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    ```bash
-    Require ip IP_address
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_address
+```
 
-- **Exemplo** : se pretender autorizar apenas o acesso ao seu alojamento aos IPs 203.0.113.0 e 203.0.113.1, deverá escrever um dos dois códigos seguintes:
+- **Exemplo** : se pretender autorizar apenas o acesso ao seu alojamento aos IPs 203.0.113.0 e 203.0.113.1, deverá escrever o seguinte código:
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113.0
-    Allow from 203.0.113.1
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    ```bash
-    Require ip 203.0.113.0 203.0.113.1
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113.0 203.0.113.1
+```
 
 ##### Autorizar uma gama de endereços IP
 
-Para autorizar um intervalo de endereços IP a aceder ao seu serviço, insira um dos dois códigos seguintes no seu ficheiro ".htaccess":
+Para autorizar um intervalo de endereços IP a aceder ao seu serviço, insira o seguinte código no seu ficheiro ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from IP_range
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    A colocar no topo do seu ".htaccess"
+A colocar no topo do seu ".htaccess"
 
-    ```bash
-    Require ip IP_range
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip IP_range
+```
 
-- **Exemplo** : se pretender autorizar apenas o acesso ao seu alojamento ao intervalo de endereços IP 203.0.113.x, deverá escrever um dos dois códigos seguintes:
+- **Exemplo** : se pretender autorizar apenas o acesso ao seu alojamento ao intervalo de endereços IP 203.0.113.x, deverá escrever o seguinte código:
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    order deny,allow
-    deny from all
-    Allow from 203.0.113
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    A colocar no topo do seu ".htaccess"
+A colocar no topo do seu ".htaccess"
 
-    ```bash
-    Require ip 203.0.113
-    ```
-  </Tab>
-</Tabs>
+```bash
+Require ip 203.0.113
+```
 
 ##### Autorizar o conjunto dos endereços IP de um país
 
-Para autorizar o acesso ao seu serviço a todos os endereços IP de um país, insira um dos seguintes códigos no seu ficheiro ".htaccess":
+Para autorizar o acesso ao seu serviço a todos os endereços IP de um país, insira o seguinte código no seu ficheiro ".htaccess":
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE Country_Code AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    A colocar no topo do seu ".htaccess"
+A colocar no topo do seu ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
-- **Exemplo** : Se pretender autorizar apenas o acesso ao seu alojamento pelas Fiji (FJ) e pela Gronelândia (GR), deverá escrever um dos dois códigos seguintes:
+- **Exemplo** : Se pretender autorizar apenas o acesso ao seu alojamento pelas Fiji (FJ) e pela Gronelândia (GR), deverá escrever o seguinte código:
 
-<Tabs>
-  <Tab label="Sintaxe histórico">
-    ```bash
-    order deny,allow
-    deny from all
-    SetEnvIf GEOIP_COUNTRY_CODE FJ AllowCountry
-    SetEnvIf GEOIP_COUNTRY_CODE GR AllowCountry
-    Allow from env=AllowCountry
-    ```
-  </Tab>
-  <Tab label="Sintaxe a partir de Apache 2.3">
-    A colocar no topo do seu ".htaccess"
+A colocar no topo do seu ".htaccess"
 
-    ```bash
-    RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
-    RewriteRule ^(.*)$ - [F,L]
-    ```
-  </Tab>
-</Tabs>
+```bash
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
+RewriteRule ^(.*)$ - [F,L]
+```
 
 ### Complementos no ficheiro ".htaccess"
 

--- a/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -37,8 +37,10 @@ Para editar (ou criar) estes diretórios, aceda ao espaço FTP do seu alojamento
 
 ### Bloquear um IP, uma gama de IP, um domínio ou todos os IP de um País 
 
-Existem várias regras para bloquear os acessos ao seu alojamento através do ".htaccess".<br/>
-Esteja atento à sintaxe e aos parâmetros que bloqueia para não ficar bloqueado durante a consulta dos seus websites e/ou scripts alojados.<br/>
+Existem várias regras para bloquear os acessos ao seu alojamento através do ".htaccess".
+
+Esteja atento à sintaxe e aos parâmetros que bloqueia para não ficar bloqueado durante a consulta dos seus websites e/ou scripts alojados.
+
 Em caso de erro, pode aceder ao [espaço FTP](/guides/web-cloud/web-hosting/ftp-connection) do alojamento para corrigir a situação. 
 
 :::info
@@ -124,18 +126,14 @@ Os bloqueios através do ".htaccess" efetuam-se através dos "Country Codes" de 
 Vários sites listam os países e os respetivos "Country Codes", entre os quais [https://www.iban.com/country-codes](https://www.iban.com/country-codes)  (independente da OVHcloud).
 :::
 
-Para bloquear o conjunto dos IPs de um país, insira o seguinte código no seu ficheiro ".htaccess":
-
-A colocar no topo do seu ".htaccess"
+Para bloquear o conjunto dos IPs de um país, insira o seguinte código no topo do seu ficheiro ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Exemplo** : Se pretender bloquear os endereços IP geolocalizados nas Fiji (FJ) e na Gronelândia (GR), deverá escrever o seguinte código:
-
-A colocar no topo do seu ".htaccess"
+- **Exemplo** : Se pretender bloquear os endereços IP geolocalizados nas Fiji (FJ) e na Gronelândia (GR), deverá escrever o seguinte código no topo do seu ficheiro ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^(FJ|GR)$
@@ -162,17 +160,13 @@ Require ip 203.0.113.0 203.0.113.1
 
 ##### Autorizar uma gama de endereços IP
 
-Para autorizar um intervalo de endereços IP a aceder ao seu serviço, insira o seguinte código no seu ficheiro ".htaccess":
-
-A colocar no topo do seu ".htaccess"
+Para autorizar um intervalo de endereços IP a aceder ao seu serviço, insira o seguinte código no topo do seu ficheiro ".htaccess":
 
 ```bash
 Require ip IP_range
 ```
 
-- **Exemplo** : se pretender autorizar apenas o acesso ao seu alojamento ao intervalo de endereços IP 203.0.113.x, deverá escrever o seguinte código:
-
-A colocar no topo do seu ".htaccess"
+- **Exemplo** : se pretender autorizar apenas o acesso ao seu alojamento ao intervalo de endereços IP 203.0.113.x, deverá escrever o seguinte código no topo do seu ficheiro ".htaccess":
 
 ```bash
 Require ip 203.0.113
@@ -180,18 +174,14 @@ Require ip 203.0.113
 
 ##### Autorizar o conjunto dos endereços IP de um país
 
-Para autorizar o acesso ao seu serviço a todos os endereços IP de um país, insira o seguinte código no seu ficheiro ".htaccess":
-
-A colocar no topo do seu ".htaccess"
+Para autorizar o acesso ao seu serviço a todos os endereços IP de um país, insira o seguinte código no topo do seu ficheiro ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(Country_Code)$
 RewriteRule ^(.*)$ - [F,L]
 ```
 
-- **Exemplo** : Se pretender autorizar apenas o acesso ao seu alojamento pelas Fiji (FJ) e pela Gronelândia (GR), deverá escrever o seguinte código:
-
-A colocar no topo do seu ".htaccess"
+- **Exemplo** : Se pretender autorizar apenas o acesso ao seu alojamento pelas Fiji (FJ) e pela Gronelândia (GR), deverá escrever o seguinte código no topo do seu ficheiro ".htaccess":
 
 ```bash
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} !^(FJ|GR)$
@@ -207,7 +197,7 @@ Independentemente da segurança do acesso geral ao alojamento, o ficheiro ".htac
 
 ## Quer saber mas? <a name="go-further"></a>
 
-Para serviços especializados (referenciamento, desenvolvimento, etc), contacte os [parceiros OVHcloud](/links/partner).
+Para serviços especializados (referenciamento, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
 


### PR DESCRIPTION
Remove the legacy pre-Apache 2.3 syntax from the .htaccess IP-restriction guide across all 7 locales: flatten the 14 syntax Tabs to the current syntax only, shorten the intro callout, and switch the now-single-code sentences to the singular. Bump lastUpdated to 2026-07-23.

## Summary

Removes the legacy (pre-Apache 2.3) syntax from the **How to block a specific IP address via .htaccess** guide, keeping only the current Apache 2.4 syntax. Applied across all 7 locales (fr, en, de, es, it, pl, pt).

## Changes

- **Flattened the 14 syntax `<Tabs>` blocks** — dropped the "Historical syntax" tab in each, keeping only the "Syntax from Apache 2.3" code (with its "place at the top of your .htaccess" preamble where present). Removed the now-unused `import { Tab, Tabs }`.
- **Shortened the intro callout** — removed the paragraph about the obsolete old syntax / "two syntaxes"; kept the Apache 2.4 statement and the two official Apache doc links. Intro reworded to "for more details on the syntax described in this guide".
- **Singularised the wording** — 14 sentences per locale changed from *"insert one of the two following codes"* → *"insert the following code"*, since only one code block now remains.
- **Bumped `lastUpdated`** to `2026-07-23`.

## Notes

- FR was the source; the other locales mirror the same structural change with translated labels/wording.
- Content/structure only — no functional changes; all code samples are unchanged.
- Pre-existing items left untouched (out of scope): a couple of the Apache doc links point to the `/en/` version in some locales, and the ES `description` ends with a period — can be addressed separately if wanted.
