### PR TITLE
[SK-2751] - WEB - Email - migration guides: emphasize post-migration verification and recommend a pre-migration backup

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -1942,10 +1942,10 @@
             + [Using Zimbra webmail](web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra){label=Webmail Zimbra}
             + [Using your email account via the RoundCube webmail interface](web-cloud/email-and-collaborative-solutions/mx-plan/email-roundcube){label=Webmail Roundcube}
         + [Migrating](web-cloud-email-collaborative-solutions-migration)
-            + [Migrating an MX Plan email account to an Email Pro or Exchange account](web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
+            + [MX Plan - Migrate to Exchange, Email Pro or Zimbra](web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel)
             + [Manually migrate your email account](web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)
             + [Migrating email accounts using OVHcloud Mail Migrator](web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud)
-            + [Migrating your email account from one OVHcloud email platform to another](web-cloud/email-and-collaborative-solutions/migrating/migration-platform)
+            + [Migrate email accounts between OVHcloud platforms](web-cloud/email-and-collaborative-solutions/migrating/migration-platform)
         + [Troubleshooting](web-cloud-email-collaborative-solutions-troubleshooting){landing=web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting}
             + [Unable to send or receive emails](web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-advanced){label=Cannot send or receive}
             + [What to do if your account is blocked for spam](web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam){label=Blocked for spam}
@@ -2048,7 +2048,7 @@
                 + [Using Zimbra webmail](web-cloud/email-and-collaborative-solutions/mx-plan/email-zimbra)
                 + [FAQ Zimbra OVHcloud](web-cloud/email-and-collaborative-solutions/mx-plan/faq-zimbra)
                 + [Configure Zimbra account on email client](web-cloud/email-and-collaborative-solutions/zimbra/mail-apps)
-                + [How to migrate an MX Plan email address to a Zimbra account](web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra)
+                + [Zimbra - Migrate an MX Plan email account](web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra)
                 + [How to configure a Zimbra email account on the Zimbra mobile application](web-cloud/email-and-collaborative-solutions/zimbra/mail-app-zimbra-for-android-ios)
                 + [Synchronize a Zimbra CalDAV calendar in an application](web-cloud/email-and-collaborative-solutions/zimbra/zimbra-calendar-sync)
                 + [How to mount a Zimbra WebDAV folder in an OS](web-cloud/email-and-collaborative-solutions/zimbra/webdav-mount)

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
-title: E-Mail-Accounts von MX Plan zu E-Mail Pro, Exchange oder Zimbra migrieren
-description: Erfahren Sie hier, wie Sie einen MX Plan E-Mail-Account zu E-Mail Pro, Exchange oder Zimbra umziehen
-lastUpdated: 2026-03-30
+title: MX Plan - Umzug zu Exchange, Email Pro oder Zimbra
+description: Migrieren Sie Ihren MX Plan E-Mail-Account zu Exchange, Email Pro oder Zimbra und behalten Sie Ihre Nachrichten, Kontakte und Ordner
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -73,6 +73,10 @@ Wenn Ihre E-Mails nur lokal gespeichert sind (POP-Konfiguration oder lokales Arc
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Unabhängig von der gewählten Migrationsmethode empfehlen wir Ihnen dringend, Ihr Postfach vorab zu sichern, um jeglichem Datenverlust vorzubeugen. Unsere Anleitung [E-Mail-Adresse manuell migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) erklärt Schritt für Schritt, wie Sie ein Postfach sichern (zum Beispiel durch einen Export als PST-Datei): Erstellen Sie diese Sicherung, bevor Sie mit der Migration beginnen.
+:::
+
 ## In der praktischen Anwendung
 
 ### Schritt 1: Ihr Projekt definieren
@@ -103,7 +107,7 @@ Die E-Mail-Technologie Ihrer MX Plan-Angebot kann je nach Aktivierungsdatum Ihre
 1. Der Tab <code className="action">Allgemeine Informationen</code> ist standardmäßig ausgewählt.
 1. Notieren Sie sich die genutzte Technologie unter der Bezeichnung **Webmail** im Feld `Abonnement`.
 
-<img className="thumbnail" alt="MX plan" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
+<img className="thumbnail" alt="MX Plan-Abonnementbereich mit der Webmail-Technologie im OVHcloud Kundencenter" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
 :::
 
@@ -127,7 +131,7 @@ Wenn Sie Ihr neues E-Mail Angebot gerade erst bestellt haben, fügen Sie zuerst 
 
 Wählen Sie den Tab <code className="action">Assoziierte Domains</code> oder <code className="action">Domain</code> auf Ihrer Plattform aus und klicken Sie auf <code className="action">Domain hinzufügen</code>. Sobald der Domainname hinzugefügt wurde, stellen Sie sicher, dass die Bezeichnung `OK` oder <code className="action">Aktiv</code> in der Spalte `Status` angezeigt wird.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Hinzufügen des Domainnamens zur Ziel-E-Mail-Plattform" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
 
 <Region zones={['eu']}>
 Weitere Informationen zum Hinzufügen eines Domainnamens finden Sie in den Hilfen zu [E-Mail Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config), [Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain) oder [Zimbra-Leitfaden](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra).
@@ -148,7 +152,7 @@ Die Migration Ihres MX Plan erfolgt in 3 Schritten: **Umbenennen**, **Erstellen*
 
 Klicken Sie im Tab <code className="action">E-Mails</code> auf den Button <code className="action">...</code> und dann auf <code className="action">Account bearbeiten</code>.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
+<img className="thumbnail" alt="Konfiguration des MX Plan-Kontos für die Migration im OVHcloud Kundencenter, Schritt 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
 
 :::info
 Die Änderung des Accounts ist nicht sofort aktiv. Bitte warten Sie bis zum Abschluss der Operation, bevor Sie zum nächsten Schritt übergehen.
@@ -160,17 +164,19 @@ Die Änderung des Accounts ist nicht sofort aktiv. Bitte warten Sie bis zum Absc
 
 Klicken Sie im Tab <code className="action">E-Mail-Accounts</code> Ihrer E-Mail Pro oder Exchange Plattform auf den Button <code className="action">...</code> und dann auf <code className="action">Ändern</code>.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
+<img className="thumbnail" alt="Konfiguration des MX Plan-Kontos für die Migration im OVHcloud Kundencenter, Schritt 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
 3\. **Migrieren** des Accounts mithilfe unseres OMM-Tools ([OVHcloud Mail Migrator](https://omm.ovhcloud.com/)) auf das Konto Ihrer neuen Plattform.
 
 Weitere Informationen zu OMM finden Sie in unserer Anleitung [E-Mail-Accounts über OVHcloud Mail Migrator migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
+<img className="thumbnail" alt="Konfiguration des MX Plan-Kontos für die Migration im OVHcloud Kundencenter, Schritt 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
 
 Die Migrationsdauer hängt davon ab, wie viele Inhalte auf Ihren neuen Account migriert werden sollen. Dieser kann von einigen Minuten bis zu mehreren Stunden variieren.
 
-Überprüfen Sie nach der Migration, ob alle Elemente vorhanden sind, indem Sie sich am [Webmail OVHcloud](https://www.ovhcloud.com/de/mail/) anmelden.
+:::warning
+Überprüfen Sie nach der Migration, ob alle Elemente vorhanden sind, indem Sie sich am [Webmail OVHcloud](/links/web/email) anmelden. **Löschen Sie Ihre ursprüngliche Adresse erst, wenn Sie sich vergewissert haben, dass alles korrekt migriert wurde.** Sobald die ursprüngliche Adresse gelöscht ist, gehen nicht migrierte Elemente unwiderruflich verloren.
+:::
 
 Sie können den ursprünglichen Account nach dieser Migration mit dem vorläufigen Namen beibehalten oder löschen.
 
@@ -203,7 +209,7 @@ Die Migration kann über zwei Interfaces durchgeführt werden:<br/>
 
 > Zur Erinnerung: Vergewissern Sie sich vor Beginn der Migration, dass keine **Weiterleitung** oder **Auto-Antworten** für Ihren MX Plan eingerichtet sind.
 >
-> <img className="thumbnail" alt="E-Mail" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
+> <img className="thumbnail" alt="Überprüfung, dass keine Weiterleitung für das MX Plan-Konto eingerichtet ist" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
 
 Wenn Sie bereit sind, folgen Sie der Anleitung entsprechend dem gewählten Interface. Die Migrationsdauer hängt davon ab, wie viele Inhalte auf Ihren neuen Account migriert werden. Es kann sich daher um einige Minuten bis zu mehreren Stunden handeln.
 
@@ -225,7 +231,7 @@ Wenn der Konfigurationsassistent nicht startet, werden stattdessen die allgemein
 
 Um die Migration über dieses Interface durchzuführen, wählen Sie im Bereich <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> Ihres OVHcloud Kundencenters die betreffende Domain aus. Klicken Sie im Tab <code className="action">E-Mails</code> auf <code className="action">...</code> in der Zeile des betreffenden E-Mail-Accounts (auch als Quell-Account bezeichnet) und dann auf <code className="action">Account überführen</code>.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
+<img className="thumbnail" alt="Zugriff auf das Migrationstool über die MX Plan-Oberfläche" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
 
 Wählen Sie im angezeigten Fenster den Zieldienst (den Dienst, auf den Sie den Account migrieren möchten) aus und klicken Sie dann auf <code className="action">Weiter</code>. Wenn es mindestens einen "freien" Account (noch nicht konfiguriert) gibt, wird die Migration auf einen dieser Accounts durchgeführt. Lesen Sie die angezeigten Informationen, bestätigen Sie diese und klicken Sie anschließend auf <code className="action">Weiter</code>, um mit der Änderung fortzufahren.
 
@@ -233,7 +239,7 @@ Wenn Sie keinen "freien" Account haben, erscheint ein Button zum Bestellen. Folg
 
 Bestätigen Sie anschließend das Passwort des Quell-Accounts (die Adresse, die Sie migrieren möchten) und klicken Sie dann auf <code className="action">Migrieren</code>. Dieser Vorgang ist so oft wie nötig zu wiederholen, um weitere Accounts zu migrieren.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
+<img className="thumbnail" alt="Auswahl der zu migrierenden MX Plan-Konten in der Oberfläche" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
 
 </Region>
 
@@ -249,7 +255,7 @@ Dazu wählen Sie den betreffenden E-Mail Pro-, Exchange- oder Zimbra-Dienst aus 
 Dazu wählen Sie den betreffenden Exchange-Dienst aus und gehen Sie auf den Tab <code className="action">Assoziierte Domains</code> oder <code className="action">Domain</code> auf Ihrer Plattform. Überprüfen Sie den Abschnitt oder die Spalte <code className="action">Diagnose</code>.
 </Region>
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Überprüfung der DNS-Einträge der zugehörigen Domainnamen" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
 Wenn Sie gerade die Migration durchgeführt oder einen DNS-Eintrag Ihres Domainnamens geändert haben, kann es einige Stunden dauern, bis das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> aktualisiert wird.
@@ -269,7 +275,7 @@ Wenn Sie einen der migrierten Accounts auf einem E-Mail-Client (wie Outlook) ein
 
 Wenn Sie sich zum ersten Mal in Ihrem neuen E-Mail-Account einloggen, können migrierte Inhalte teilweise verborgen sein. Um alle Elemente anzuzeigen, klicken Sie im Webmail auf den Pfeil neben `Posteingang`, um die Subordner freizugeben. Der migrierte Inhalt Ihres alten E-Mail-Accounts sollte erscheinen.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
+<img className="thumbnail" alt="Ansicht der migrierten Ordner und E-Mails im OVHcloud Webmail" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
 
 Standardordner wie "Gesendete Elemente" oder "Papierkorb" erscheinen in englischer Benennung ("Sent items" und "Trash"), mit Ausnahme der Ordner, die Sie selbst erstellt haben.
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
-title: Ihre E-Mail-Adressen von einer OVHcloud E-Mail-Plattform auf eine andere migrieren
-description: Erfahren Sie, wie Sie E-Mail-Adressen von einer Exchange- oder E-Mail Pro-Plattform zu einer anderen Exchange-, E-Mail Pro-, MX Plan- oder Zimbra-Plattform migrieren können
-lastUpdated: 2026-03-30
+title: E-Mail-Accounts zwischen OVHcloud-Plattformen migrieren
+description: Migrieren Sie E-Mail-Accounts zwischen zwei OVHcloud-Plattformen (Exchange, Email Pro, MX Plan), ohne Nachrichten, Kontakte oder Ordner zu verlieren
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -75,6 +75,10 @@ Um eine MX Plan Lösung nach Exchange zu migrieren, folgen Sie unserer Anleitung
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Unabhängig von der gewählten Migrationsmethode empfehlen wir Ihnen dringend, Ihr Postfach vorab zu sichern, um jeglichem Datenverlust vorzubeugen. Unsere Anleitung [E-Mail-Adresse manuell migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) erklärt Schritt für Schritt, wie Sie ein Postfach sichern (zum Beispiel durch einen Export als PST-Datei): Erstellen Sie diese Sicherung, bevor Sie mit der Migration beginnen.
+:::
+
 ## In der praktischen Anwendung
 
 ### Die Zielplattform konfigurieren
@@ -84,7 +88,7 @@ Vor Beginn der Migration, wenn Sie Ihr neues E-Mail-Angebot bestellt haben, füg
 
 Wählen Sie den Tab <code className="action">Assoziierte Domains</code> oder <code className="action">Domain</code> auf Ihrer Plattform aus und klicken Sie auf <code className="action">Domain hinzufügen</code>. Nachdem der Domainname hinzugefügt wurde, stellen Sie sicher, dass die Bezeichnung `OK` oder <code className="action">Aktiv</code> in der Spalte `Status` angezeigt wird.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Hinzufügen des Domainnamens zur Ziel-E-Mail-Plattform" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
 
 Weitere Informationen zum Hinzufügen eines Domainnamens finden Sie im [E-Mail Pro-Leitfaden](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config), im [Exchange-Leitfaden](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain) oder im [Zimbra-Leitfaden](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra).
 
@@ -112,7 +116,7 @@ Geben Sie dem zu migrierenden E-Mail-Account einen temporären Namen (Beispiel: 
 
 Klicken Sie dazu im Tab <code className="action">E-Mail-Accounts</code> Ihres Dienstes auf den Button <code className="action">...</code> und dann auf <code className="action">Ändern</code>.
 
-<img className="thumbnail" alt="email-migration" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Umbenennen eines E-Mail-Kontos auf der Zielplattform" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Erstellen
 
@@ -120,7 +124,7 @@ Erstellen Sie die E-Mail-Adresse neu als Account von E-Mail Pro, Exchange oder M
 
 Klicken Sie im Tab <code className="action">E-Mail-Accounts</code> Ihrer betreffenden Plattform auf <code className="action">...</code> rechts neben dem Ziel-Account und dann auf <code className="action">Ändern</code>.
 
-<img className="thumbnail" alt="email-migration" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
+<img className="thumbnail" alt="Erstellen des E-Mail-Kontos auf der Zielplattform" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
 
 #### Migrieren
 
@@ -140,11 +144,13 @@ Migrieren Sie den Quell-E-Mail-Account mithilfe unseres Tools [OMM](https://omm.
 
 Weitere Informationen zu OMM finden Sie in unserer Anleitung "[E-Mail-Accounts über den OVHcloud Mail Migrator migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud)".
 
-<img className="thumbnail" alt="email-migration" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
+<img className="thumbnail" alt="Migration des E-Mail-Kontos mit dem OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
 
 Die Migrationsdauer hängt davon ab, wie viele Daten auf Ihren neuen Account migriert werden sollen. Dies kann von einigen Minuten bis zu mehreren Stunden variieren.
 
-Überprüfen Sie nach der Migration, ob alle Ihre Elemente vorhanden sind, indem Sie sich im Webmail einloggen: [Webmail](https://www.ovhcloud.com/de/mail/).
+:::warning
+Überprüfen Sie nach der Migration, ob alle Ihre Elemente vorhanden sind, indem Sie sich im Webmail einloggen: [Webmail](/links/web/email). **Löschen Sie Ihre ursprüngliche Adresse erst, wenn Sie sich vergewissert haben, dass alles korrekt migriert wurde.** Sobald die ursprüngliche Adresse gelöscht ist, gehen nicht migrierte Elemente unwiderruflich verloren.
+:::
 
 Nach der Migration können Sie den ursprünglichen Account mit dem geänderten Namen beibehalten oder löschen.
 
@@ -156,7 +162,7 @@ Ihre E-Mail-Adressen sollten bereits migriert und funktionsfähig sein. Aus Sich
 
 Wählen Sie den betreffenden E-Mail Pro-, Exchange- oder Zimbra-Service aus und gehen Sie zum Tab <code className="action">Assoziierte Domains</code> oder <code className="action">Domain</code> auf Ihrer Plattform. Überprüfen Sie den Abschnitt oder die Spalte <code className="action">Diagnose</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Überprüfung der DNS-Einträge der zugehörigen Domainnamen" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
 Wenn Sie gerade die Migration durchgeführt oder einen DNS-Eintrag Ihrer Domain geändert haben, kann es noch einige Stunden dauern, bis die Anzeige im <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> aktualisiert wird.
@@ -166,7 +172,7 @@ Wenn Sie gerade die Migration durchgeführt oder einen DNS-Eintrag Ihrer Domain 
 
 Um die Konfiguration zu ändern, klicken Sie auf das rote Feld und führen Sie die dort beschriebene Aktion durch. Der Vorgang benötigt eine Propagationszeit von 4 bis maximal 24 Stunden, bis die Änderung voll wirksam ist.
 
-<img className="thumbnail" alt="email-migration" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Überprüfung der DNS-Einträge der zugehörigen Domainnamen" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 ### Migrierte E-Mail-Adressen verwenden
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Accounts mit dem OVHcloud Mail Migrator migrieren
-description: Erfahren Sie, wie Sie Ihre E-Mail-Accounts mit dem OVHcloud Mail Migrator zu OVHcloud migrieren
-lastUpdated: 2026-03-30
+description: Migrieren Sie Ihre E-Mail-Accounts mit dem OVHcloud Mail Migrator (OMM) zu OVHcloud, inklusive Nachrichten, Kontakten und Kalendern
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -34,11 +34,15 @@ import { Region } from '@components/Zone';
 - Sie verfügen über die Login-Daten für die Quell-Accounts, die Sie migrieren möchten.
 - Sie verfügen über die Login-Daten der Ziel-Accounts.
 
+:::tip
+Unabhängig von der gewählten Migrationsmethode empfehlen wir Ihnen dringend, Ihr Postfach vorab zu sichern, um jeglichem Datenverlust vorzubeugen. Unsere Anleitung [E-Mail-Adresse manuell migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) erklärt Schritt für Schritt, wie Sie ein Postfach sichern (zum Beispiel durch einen Export als PST-Datei): Erstellen Sie diese Sicherung, bevor Sie mit der Migration beginnen.
+:::
+
 ## In der praktischen Anwendung
 
 Um auf OMM zuzugreifen, verwenden Sie die Adresse: [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/)
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
+<img className="thumbnail" alt="Startseite des OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
 ### Projekt für Migration erstellen <a name="create-project"></a>
 
@@ -53,7 +57,7 @@ Klicken Sie auf <code className="action">Create my project</code>, um die Erstel
 
 Auf die E-Mail-Adresse des Projekt-Kontakts erhalten Sie eine Bestätigungsmail, die die eindeutige Projekt-ID und einen Link enthält, um darauf zuzugreifen.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
+<img className="thumbnail" alt="Erstellen eines Migrationsprojekts im OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
 
 :::info
 Das Migrationsprojekt und die damit verbundenen Daten werden nach 60 Tagen Inaktivität automatisch gelöscht.
@@ -69,13 +73,13 @@ Sobald Ihr Projekt erstellt ist, melden Sie sich wie folgt an:
 - Geben Sie das `Project password` ein, das Sie bei der Erstellung festgelegt haben.
 - Klicken Sie auf <code className="action">Connect to project</code>, um abzuschließen.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Erstellen einer neuen Migration im OVHcloud Mail Migrator, Schritt 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Sie befinden sich nun auf der Startseite des Projekts, von der aus Sie Ihre erste Migration starten können.
 
 - Klicken Sie auf <code className="action">New migration</code> oben links in der Tabelle.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Erstellen einer neuen Migration im OVHcloud Mail Migrator, Schritt 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 Eine neue Seite wird angezeigt, auf der Sie die Zugangsdaten für den Quell-Account und den Ziel-Accounts eingeben können, um die Migration zu planen oder direkt zu starten. Der Inhalt des **Source Account** wird zum **Destination Account** migriert.
 
@@ -85,7 +89,7 @@ Bevor Sie Ihre Migration starten, ist es wichtig, die 3 Arten von Accounts zu ke
 - **Others**: E-Mail-Dienste, die außerhalb von OVHcloud abgeschlossen wurden. Eine nicht erschöpfende Liste der von OMM unterstützten E-Mail-Dienste wird angezeigt. Wenn Ihr E-Mail-Account-Typ nicht aufgelistet ist, verwenden Sie die Protokolle `IMAP` oder `POP`, die mit den meisten E-Mail-Servern kompatibel sind.
 - **Importing files**: Es ist möglich, den Inhalt von PST-, ICS-, CSV- und XML-Dateien über OMM zu einem Ziel-E-Mail-Account zu migrieren. Wenn diese Funktion ausgewählt wird, genügt es, Ihre Datei in das Feld zu ziehen oder über den Button <code className="action">Browse your files</code> Ihre Dateien zu durchsuchen.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Erstellen einer neuen Migration im OVHcloud Mail Migrator, Schritt 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Füllen Sie die Informationen entsprechend des Accounttyps aus:
 
@@ -112,7 +116,7 @@ Füllen Sie die Informationen entsprechend des Accounttyps aus:
 - **Start of Transfers**: Sie können die Migration unmittelbar über `Immediately` starten oder `Later` ankreuzen, um die Migration zu verschieben. Eine verschobene Migration ermöglicht es, Datum und Uhrzeit des Starts zu definieren.
 - **Data to transfer**: Abhängig vom Typ des zu migrierenden E-Mail-Accounts und des Ziel-Accounts zeigt Ihnen dieser Abschnitt die verschiedenen Arten von Daten an, die bei der Migration unterstützt werden. Dies hängt vom Quell-Account und vom Ziel-Account ab.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Erstellen einer neuen Migration im OVHcloud Mail Migrator, Schritt 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 Wenn Sie einen Account migrieren, der Funktionen hat, die der Ziel-Account nicht hat, müssen Sie die Elemente, die von OMM nicht migriert werden können, eigenständig sichern. Konsultieren Sie unsere Anleitung "[Manuelles Migrieren Ihrer E-Mail-Adresse](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)".
@@ -128,7 +132,7 @@ Sobald die Parameter der Quell- und Ziel-Accounts ausgefüllt sind, klicken Sie 
 
 Bei einer Migration zu oder von einem OVHcloud Kunden-Account können Sie unsere Angebote `MX Plan`, `E-Mail Pro`, `Exchange` und `Zimbra` auswählen.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
+<img className="thumbnail" alt="Migration über die OVHcloud-Kontoverbindung in OMM, Schritt 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
 
 Wenn Sie eines dieser Angebote auswählen, folgen Sie den unten stehenden Schritten:
 
@@ -136,7 +140,7 @@ Wenn Sie eines dieser Angebote auswählen, folgen Sie den unten stehenden Schrit
   <Tab label="Schritt 1">
     - Klicken Sie auf <code className="action">Login</code>, um das Anmeldefenster für den OVHcloud Kundencenter anzuzeigen.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Migration über die OVHcloud-Kontoverbindung in OMM, Schritt 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 2">
     Melden Sie sich im OVHcloud Kundencenter an:
@@ -149,19 +153,19 @@ Wenn Sie eines dieser Angebote auswählen, folgen Sie den unten stehenden Schrit
     :::
 
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
+    <img className="thumbnail" alt="Migration über die OVHcloud-Kontoverbindung in OMM, Schritt 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 3">
     - Ein neues Fenster wird angezeigt, das Ihnen ermöglicht, OMM die Berechtigung zu erteilen, auf die Funktionen Ihres OVHcloud Kundencenters zuzugreifen, die die verfügbaren Dienste und E-Mail-Accounts auflisten. Standardmäßig beträgt die Gültigkeit (Validity) dieser Berechtigungen 24 Stunden. Legen Sie die gewünschte zeitliche Gültigkeit fest und klicken Sie auf <code className="action">Authorize</code>.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
+    <img className="thumbnail" alt="Migration über die OVHcloud-Kontoverbindung in OMM, Schritt 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 4">
     - Sie können nun Ihre Dienste und -Accounts über Dropdown-Menüs auswählen, was die Suche nach Elementen erleichtert und Eingabefehler vermeidet. Es ist jedoch erforderlich, das Passwort des ausgewählten E-Mail-Accounts einzugeben.
     
     Beispiel mit einem Zimbra-Dienst:
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
+    <img className="thumbnail" alt="Migration über die OVHcloud-Kontoverbindung in OMM, Schritt 5" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -169,7 +173,7 @@ Wenn Sie eines dieser Angebote auswählen, folgen Sie den unten stehenden Schrit
 :::warning
 Sie können die aktiven Zugriffe zum OVHcloud Kundencenter durch Klicken auf <code className="action">Log out</code> beenden. Klicken Sie dann bei `OVHcloud account ID` auf <code className="action">Log out the account</code>.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
+<img className="thumbnail" alt="Migration über die OVHcloud-Kontoverbindung in OMM, Schritt 6" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
 :::
 
 
@@ -182,7 +186,7 @@ Es gibt zwei Möglichkeiten, den Status zu verfolgen:
 
 Klicken Sie anschließend auf <code className="action">Connect to project</code>, um zur Startseite des Projekts zu gelangen und Ihre Migrationen zu verfolgen.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Erstellen einer neuen Migration im OVHcloud Mail Migrator, Schritt 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Auf dieser Seite finden Sie die Liste der laufenden oder geplanten Migrationen. Der Status des Projekts wird ebenfalls rechts angezeigt.
 
@@ -192,16 +196,20 @@ Klicken Sie auf den Button <code className="action">⋮</code> rechts in der Zei
 - <code className="action">Cancel migration</code>: Ermöglicht es, die laufende Migration abzubrechen. Die bereits migrierten Elemente bleiben auf dem Ziel-Account.
 - <code className="action">Delete migration data (GDPR)</code>: Diese Option löst die Löschung aller Daten der Migration des Accounts. Sie behalten jedoch die Informationen zu den Ereignissen, die während der Migration stattgefunden haben.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
+<img className="thumbnail" alt="Verfolgen des Fortschritts einer Migration in OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
 
 Beispiel für die Nachverfolgung einer Migration:
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
+<img className="thumbnail" alt="Beispiel für die Migrationsverfolgung in OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
 
 :::info
 Wenn während der Migration ein Fehler auftritt, wird Ihnen in dem Fenster <code className="action">See more details</code> ein Link zum Fehlerprotokoll bereitgestellt.
 :::
 
+
+:::warning
+Melden Sie sich nach Abschluss der Migration am Zielkonto an und überprüfen Sie, ob alle Elemente (E-Mails, Ordner, Kontakte, Kalender) vorhanden sind — für eine OVHcloud-E-Mail-Adresse nutzen Sie das [Webmail OVHcloud](/links/web/email). **Löschen Sie das Quellkonto erst, wenn Sie sich vergewissert haben, dass alles korrekt migriert wurde**, andernfalls gehen nicht migrierte Elemente unwiderruflich verloren.
+:::
 
 ## Weiterführende Informationen
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
-title: MX Plan E-Mail-Account auf einen OVHcloud Zimbra E-Mail-Account migrieren
-description: Erfahren Sie hier, wie Sie einen MX Plan E-Mail-Account auf einen OVHcloud Zimbra E-Mail-Account migrieren
-lastUpdated: 2026-06-23
+title: Zimbra - MX Plan E-Mail-Account migrieren
+description: Migrieren Sie einen MX Plan E-Mail-Account zu einem OVHcloud Zimbra-Account und weisen Sie dessen Adresse anschließend neu zu
+lastUpdated: 2026-07-23
 availableIn: [eu]
 ---
 
@@ -35,6 +35,10 @@ Wenn Sie Ihr MX Plan E-Mail-Angebot auf ein [OVHcloud Zimbra](/links/web/zimbra)
 
 </Region>
 
+:::tip
+Unabhängig von der gewählten Migrationsmethode empfehlen wir Ihnen dringend, Ihr Postfach vorab zu sichern, um jeglichem Datenverlust vorzubeugen. Unsere Anleitung [E-Mail-Adresse manuell migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) erklärt Schritt für Schritt, wie Sie ein Postfach sichern (zum Beispiel durch einen Export als PST-Datei): Erstellen Sie diese Sicherung, bevor Sie mit der Migration beginnen.
+:::
+
 ## In der praktischen Anwendung
 
 :::warning
@@ -53,7 +57,7 @@ Die Migration eines MX Plan E-Mail-Accounts auf einen Zimbra E-Mail-Account erfo
 
 Im folgenden Beispiel migrieren wir die Adresse `contact@mydomain.ovh`. Dazu erstellen wir den Zimbra Account unter dem Namen `contact2@mydomain.ovh`.
 
-<img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
+<img className="thumbnail" alt="Überblick über die E-Mail-Migration von MX Plan zu Zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
 
 ### 1 - Den Inhalt des MX Plan Accounts auf einen Zimbra Account übertragen <a name="step1"></a>
 
@@ -79,7 +83,7 @@ Die Migration mit OMM erfolgt in 3 Schritten: Erstellen eines Projekts, Konfigur
 
     Rufen Sie [OVHcloud Mail Migrator](/links/web/omm) auf und klicken Sie auf <code className="action">New migration</code>.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Startseite des OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
 
     - **Project contact email address**: Geben Sie eine E-Mail-Adresse ein, die die Zugangsdaten und Tracking-Benachrichtigungen erhält. Verwenden Sie keine Adresse, die in diesem Projekt migriert werden soll.
     - **Project password**: Legen Sie ein Passwort fest (mindestens 10 Zeichen, mit mindestens 1 Sonderzeichen, 1 Zahl, 1 Großbuchstaben und 1 Kleinbuchstaben).
@@ -93,7 +97,7 @@ Die Migration mit OMM erfolgt in 3 Schritten: Erstellen eines Projekts, Konfigur
 
     Klicken Sie dann auf <code className="action">New migration</code>, um Ihre Migration zu konfigurieren:
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
+    <img className="thumbnail" alt="Erstellen der Migration von MX Plan zu Zimbra im OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
     - **Source account**:
         - **Account type**: Wählen Sie unter der Kategorie `OVHcloud` die Option `MX Plan` oder `Autodetect`. Klicken Sie auf <code className="action">Log in</code>, um sich mit Ihrem OVHcloud Account zu identifizieren und den Dienst sowie die zu migrierende Adresse automatisch auszuwählen (Beispiel: `contact@mydomain.ovh`). Geben Sie dann das Passwort für diesen E-Mail-Account ein.
@@ -104,7 +108,7 @@ Die Migration mit OMM erfolgt in 3 Schritten: Erstellen eines Projekts, Konfigur
 
     Klicken Sie auf <code className="action">Migrate my account</code>, um die Migration zu starten.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Konfiguration des Zimbra-Zielkontos im OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 3">
     **Migration verfolgen**
@@ -120,7 +124,7 @@ Die Migration mit OMM erfolgt in 3 Schritten: Erstellen eines Projekts, Konfigur
     - <code className="action">Cancel migration</code>: Bricht die laufende Migration ab. Bereits migrierte Elemente werden im Ziel-Account beibehalten.
     - <code className="action">Delete my migration data (GDPR)</code>: Löst das Löschen aller migrationsbezogenen Daten aus. Informationen zu Migrationsereignissen bleiben erhalten.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
+    <img className="thumbnail" alt="Verfolgen des Migrationsfortschritts im OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -139,6 +143,10 @@ Bevor Sie Ihren MX Plan Account löschen, **sichern Sie Ihre E-Mails**, um Daten
 Verwenden Sie die Exportoptionen Ihres E-Mail-Clients. In unserer Anleitung "[E-Mail-Adresse manuell migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)" finden Sie Details zum manuellen Export einer E-Mail-Adresse aus einem E-Mail-Client.
 
 ### 2 - Den ursprünglichen MX Plan Account löschen und seine Adresse dem Zimbra Account zuweisen <a name="step2"></a>
+
+:::warning
+Melden Sie sich vor dem Löschen Ihres ursprünglichen MX Plan-Kontos am [Webmail OVHcloud](/links/web/email) an und überprüfen Sie, ob alle Elemente (E-Mails, Ordner, Kontakte, Kalender) in das Zimbra-Konto migriert wurden. Sobald das ursprüngliche Konto gelöscht ist, gehen nicht migrierte Elemente unwiderruflich verloren.
+:::
 
 #### 2.1 - Löschen der alten MX Plan E-Mail-Adresse <a name="step21"></a>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrating an MX Plan email account to another OVHcloud email solution
-description: Find out how to migrate an MX Plan email address to another OVHcloud email offer available in your region
-lastUpdated: 2026-03-30
+title: MX Plan - Migrate to Exchange, Email Pro or Zimbra
+description: Migrate your MX Plan email account to an Exchange, Email Pro or Zimbra offer while keeping your messages, contacts and folders
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -74,6 +74,10 @@ If your emails are only stored locally (POP configuration or local archiving), y
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Whatever migration method you use, we strongly recommend backing up your mailbox beforehand, as a precaution against any data loss. Our guide [Manually migrate your email address](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) explains step by step how to back up a mailbox (for example by exporting it to a PST file): make this backup before you start the migration.
+:::
+
 ## Instructions
 
 ### Step 1: Defining your project
@@ -104,7 +108,7 @@ The email technology of your MX Plan offer may vary depending on the date of act
 1. The <code className="action">General information</code> tab is selected by default.
 1. Note the technology used under the mention **Webmail** in the `Subscription` box.
 
-<img className="thumbnail" alt="MX plan" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
+<img className="thumbnail" alt="MX Plan subscription panel showing the Webmail technology in the OVHcloud Control Panel" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
 :::
 
@@ -128,7 +132,7 @@ If you have just ordered your new email solution, first add the domain name to y
 
 Select the <code className="action">Associated Domains</code> or <code className="action">Domain</code> tab on your platform, then click on <code className="action">Add a domain</code>. Once the domain name is added, make sure that the mention `OK` or <code className="action">Active</code> is present in the `Status` column.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Adding the domain name to the destination email platform" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
 
 <Region zones={['eu']}>
 To find out more about adding a domain name, follow the [Email Pro guide](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config), [Exchange guide](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain) or [the Zimbra guide](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra).
@@ -149,7 +153,7 @@ Your MX Plan migration will be done in 3 main steps: **Renaming**, **Creating** 
 
 In the <code className="action">Email accounts</code> tab for your MX Plan platform, click the <code className="action">...</code> button, then <code className="action">Modify the account</code>.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
+<img className="thumbnail" alt="Configuring the MX Plan account for migration in the Control Panel, step 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
 
 :::info
 Account modification is not immediate, please wait until the operation is complete before proceeding to the next step.
@@ -161,17 +165,19 @@ Account modification is not immediate, please wait until the operation is comple
 
 In the <code className="action">Email accounts</code> tab for your Email Pro or Exchange platform, click the <code className="action">...</code> button, then <code className="action">Edit</code>.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
+<img className="thumbnail" alt="Configuring the MX Plan account for migration in the Control Panel, step 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
 3\. **Migrate** the MX Plan account to your new platform account using our [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator) tool.
 
 For more information on OMM, please read our guide on [Migrating email accounts via the OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
+<img className="thumbnail" alt="Configuring the MX Plan account for migration in the Control Panel, step 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
 
 The migration time depends on the amount of content to migrate to your new account. This may vary from a few minutes to several hours.
 
-Check that you can find your items after the migration by logging into the [OVHcloud webmail](https://www.ovhcloud.com/en-gb/mail/).
+:::warning
+Check that you can find your items after the migration by logging into the [OVHcloud webmail](/links/web/email). **Do not delete or reset your original account until you have confirmed that everything has been migrated correctly** — once the original account is deleted, any items that were not migrated will be permanently lost.
+:::
 
 You can keep or delete the original account with the temporary name after this migration.
 
@@ -204,7 +210,7 @@ You can migrate from two interfaces:<br/>
 
 > As a reminder, before starting the migration, make sure that no **redirection** or **auto-replies** are configured on your MX Plan.
 >
-> <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
+> <img className="thumbnail" alt="Checking that no redirection is set on the MX Plan account" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
 
 Once you are ready, follow the steps below, depending on the interface you have selected. Please note that the migration time depends on the quantity of content to be migrated to your new account. This may vary from a few minutes to several hours.
 
@@ -226,7 +232,7 @@ If the configuration wizard does not appear, the general information for the Exc
 
 To migrate from this interface, go to the <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> section of your OVHcloud Control Panel and select the relevant domain. In the <code className="action">Emails</code> tab, click on <code className="action">...</code> on the line of the relevant email account (also called the source account), then on <code className="action">Migrate account</code>.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
+<img className="thumbnail" alt="Accessing the migration tool from the MX Plan interface" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
 
 In the window that appears, select the destination service (the one you want to migrate the account to), then click <code className="action">Next</code>. If the user has at least one "empty" account (i.e. one that has not yet been set up), the migration will be carried out to one of these accounts. Once you have done this, read the information listed, confirm it, then click <code className="action">Next</code> to continue editing.
 
@@ -234,7 +240,7 @@ If you do not have an empty account, an <code className="action">Order accounts<
 
 Finally, confirm the password for the source email account (the one you want to migrate), then click <code className="action">Migrate</code>. You will need to repeat this process as many times as you need to for migrating other accounts.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
+<img className="thumbnail" alt="Selecting the MX Plan accounts to migrate in the interface" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
 
 </Region>
 
@@ -250,7 +256,7 @@ To do this, select the relevant Email Pro, Exchange or Zimbra service, then go t
 To do this, select the relevant Exchange service, then go to the <code className="action">Associated Domains</code> or <code className="action">Domain</code> tab on your platform. Check the <code className="action">Diagnostic</code> section or column.
 </Region>
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Checking the DNS records of the associated domain names" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
 If you have just migrated or modified a DNS record for your domain, it may take a few hours to be updated in your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
@@ -270,7 +276,7 @@ If you have configured one of the migrated accounts on an email client (such as 
 
 When you first log in to your new email account, the migrated content may be partially hidden. To view all items in the webmail, click on the arrow symbol next to the `Inbox` to reveal the subfolders. The migrated content of your old email account should appear.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
+<img className="thumbnail" alt="Viewing the migrated folders and emails in the OVHcloud webmail" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
 
 The default folders, such as "sent items" or "trash" appear in English ("Sent items" and "Trash"), except for the folders you have created.
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrating your email addresses from one OVHcloud email platform to another
-description: Find out how to migrate email addresses from one OVHcloud email platform to another
-lastUpdated: 2026-03-30
+title: Migrate email accounts between OVHcloud platforms
+description: Migrate email accounts between two OVHcloud platforms (Exchange, Email Pro or MX Plan) without losing your messages, contacts or folders
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -75,6 +75,10 @@ To migrate an MX Plan solution to an Exchange platform, please follow our guide 
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Whatever migration method you use, we strongly recommend backing up your mailbox beforehand, as a precaution against any data loss. Our guide [Manually migrate your email address](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) explains step by step how to back up a mailbox (for example by exporting it to a PST file): make this backup before you start the migration.
+:::
+
 ## Instructions
 
 ### Configuring the destination platform
@@ -84,7 +88,7 @@ Before starting your migration, if you have just ordered your new email offer, f
 
 Select the <code className="action">Associated domains</code> or <code className="action">Domain</code> tab on your platform, then click on <code className="action">Add a domain</code>. Once the domain name is added, make sure the `OK` or <code className="action">Active</code> mention is present in the `Status` column.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Adding the domain name to the destination email platform" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
 
 For more details on adding a domain name, follow [the Email Pro guide](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config), [the Exchange guide](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain) or [the Zimbra guide](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra).
 
@@ -112,7 +116,7 @@ Rename the email account to be migrated with a provisional name (example: to mig
 
 In the <code className="action">Email accounts</code> tab for your email platform, click on the <code className="action">...</code> button, then <code className="action">Edit</code>.
 
-<img className="thumbnail" alt="email-migration" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Renaming an email account on the destination platform" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Create
 
@@ -120,7 +124,7 @@ Re-create your email address on the new account for your Email Pro, Exchange or 
 
 In the <code className="action">Email accounts</code> tab for your platform, click on the <code className="action">...</code> button, to the right of the target email account, then <code className="action">Edit</code>.
 
-<img className="thumbnail" alt="email-migration" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
+<img className="thumbnail" alt="Creating the email account on the destination platform" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
 
 #### Migrate
 
@@ -140,11 +144,13 @@ Migrate the source email account to your new platform account using our [OMM](ht
 
 For more information on OMM, please read our guide on [Migrating email accounts via the OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
-<img className="thumbnail" alt="email-migration" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
+<img className="thumbnail" alt="Migrating the email account with the OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
 
 The migration time depends on the amount of data to migrate to your new account. This may vary from a few minutes to several hours.
 
-After the migration, verify that all of your elements are present by logging into webmail at [Webmail](https://www.ovhcloud.com/en-gb/mail/).
+:::warning
+After the migration, verify that all of your elements are present by logging into webmail at [Webmail](/links/web/email). **Do not delete or reset your original account until you have confirmed that everything has been migrated correctly** — once the original account is deleted, any items that were not migrated will be permanently lost.
+:::
 
 Once the migration is complete, you can keep or delete the original account with the temporary name.
 
@@ -156,7 +162,7 @@ At this stage, your email addresses should already be migrated and functional. F
 
 To do this, select the relevant Email Pro, Exchange or Zimbra service, then go to the <code className="action">Associated domains</code> or <code className="action">Domain</code> tab on your platform. Check the <code className="action">Diagnostics</code> section or column.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Checking the DNS records of the associated domain names" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
 If you have just migrated or modified a DNS record for your domain, it may take a few hours to be updated when you go to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrate email accounts via OVHcloud Mail Migrator
-description: Find out how to migrate your email accounts to OVHcloud using our OVHcloud Mail Migrator tool
-lastUpdated: 2026-03-30
+description: Migrate your email accounts to OVHcloud with the OVHcloud Mail Migrator (OMM), transferring messages, contacts and calendars
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -34,11 +34,15 @@ import { Region } from '@components/Zone';
 - Login details for the email accounts you want to migrate (the source accounts).
 - Login details for the destination email accounts.
 
+:::tip
+Whatever migration method you use, we strongly recommend backing up your mailbox beforehand, as a precaution against any data loss. Our guide [Manually migrate your email address](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) explains step by step how to back up a mailbox (for example by exporting it to a PST file): make this backup before you start the migration.
+:::
+
 ## Instructions
 
 To access OMM, go to [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/).
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
+<img className="thumbnail" alt="OVHcloud Mail Migrator home page" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
 ### Create a migration project <a name="create-project"></a>
 
@@ -53,7 +57,7 @@ Click on <code className="action">Create my project</code> to start creating the
 
 On the project contact email address, you will receive a confirmation email containing the unique project identifier and a link to access it.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
+<img className="thumbnail" alt="Creating a migration project in the OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
 
 :::info
 If there is no activity for 60 days, the migration project and all associated data will be automatically deleted.
@@ -69,13 +73,13 @@ Once your project is created, log in to it from the [OMM](https://omm.ovhcloud.c
 - Enter the `Project password` you set at its creation.
 - Click on <code className="action">Connect to project</code> to complete.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 You are now on the project homepage, which will allow you to start your first migration.
 
 - Click on <code className="action">New migration</code> in the top left of the table.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 On the new page that appears, enter the connection information of the source account and the destination account to schedule the migration or to start it immediately. To recall, the content of the **source account** will be migrated to the **destination account**.
 
@@ -85,7 +89,7 @@ Before starting your migration, it is important to know the 3 types of accounts 
 - **Others**: They refer to email services outside of OVHcloud. You will find a non-exhaustive list of email services supported by OMM. If the type of service of your email account is not listed, use the `IMAP` or `POP` protocols, which are compatible with most email servers.
 - **Importing files**: It is possible to migrate the content of PST, ICS, CSV, and XML rules files via OMM to a destination email account. When this function is selected, simply drag and drop your document into the designated area or browse your files using the <code className="action">Browse your files</code> button.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Complete the information according to the type of account:
 
@@ -114,7 +118,7 @@ Complete the information according to the type of account:
 - **Start of transfer**: You can start the migration `Immediately` or check `Later` to postpone it. The deferred migration allows you to start it automatically at a date and time you define.
 - **Data to transfer**: Depending on the type of email account you are migrating and the destination account, this section will indicate the different types of data that are supported during the migration. This depends on the source account and the destination account.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 If you are migrating an account that has features the destination account does not have, **you will need to save by your means the items that cannot be migrated by OMM**. To help you, refer to our guide "[Manually migrate your email address](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)".
@@ -130,7 +134,7 @@ Once the source and destination account settings are completed, click on:
 
 When migrating to or from an OVHcloud account, you can select one of our offers `MX plan`, `Email Pro`, `Exchange` or `Zimbra`.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
+<img className="thumbnail" alt="Migrating through the OVHcloud account connection in OMM, step 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
 
 When you select one of these offers, follow the steps below:
 
@@ -138,7 +142,7 @@ When you select one of these offers, follow the steps below:
   <Tab label="Step 1">
     - Click on <code className="action">Login</code> to display the OVHcloud Control Panel login window.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrating through the OVHcloud account connection in OMM, step 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
   </Tab>
   <Tab label="Step 2">
     Log in to the OVHcloud customer account:
@@ -151,19 +155,19 @@ When you select one of these offers, follow the steps below:
     :::
 
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrating through the OVHcloud account connection in OMM, step 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
   </Tab>
   <Tab label="Step 3">
     - A new window appears. It allows you to authorize OMM to access the functions of your customer area, and to list the offers and email accounts present. By default, the validity of these rights is 24 hours. Set the validity period that suits you, then click on <code className="action">Authorize</code>.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrating through the OVHcloud account connection in OMM, step 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
   </Tab>
   <Tab label="Step 4">
     - You will now be able to select your services and accounts using drop-down menus. This facilitates the search for items and avoids typing errors. It is nevertheless necessary to enter the password associated with the selected email account.
     
     Example with a Zimbra service:
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrating through the OVHcloud account connection in OMM, step 5" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -171,7 +175,7 @@ When you select one of these offers, follow the steps below:
 :::warning
 It is possible to disconnect current accesses from an OVHcloud Control Panel by clicking on <code className="action">Log out</code>, then under `OVHcloud account ID`, click on <code className="action">Log out of the account</code>.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
+<img className="thumbnail" alt="Migrating through the OVHcloud account connection in OMM, step 6" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
 :::
 
 
@@ -184,7 +188,7 @@ There are two ways to access the migration project tracking:
 
 Click on <code className="action">Connect to project</code> to access the project homepage and follow your migrations.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 From this page, you will find the list of ongoing or scheduled migrations. The project status also appears on the right.
 
@@ -194,16 +198,20 @@ Click on the <code className="action">⋮</code> button to the right of a migrat
 - <code className="action">Cancel migration</code>: Allows you to cancel the ongoing migration. The items already migrated will remain on the destination account.
 - <code className="action">Delete migration data (GDPR)</code>: This option triggers the deletion of all data related to the migration of the account. You will still keep the information concerning the events that occurred during the migration.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
+<img className="thumbnail" alt="Following the progress of a migration in OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
 
 Example of migration tracking:
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
+<img className="thumbnail" alt="Example of migration tracking in OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
 
 :::info
 If an error occurs during the migration, a link to the error log will be provided in the <code className="action">See more details</code> window.
 :::
 
+
+:::warning
+Once the migration is complete, log in to the destination account and check that all your items (emails, folders, contacts, calendars) are present — for an OVHcloud email address, use the [OVHcloud webmail](/links/web/email). **Do not delete the source account until you have confirmed that everything has been migrated correctly**, otherwise any items that were not migrated will be permanently lost.
+:::
 
 ## Go further
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
-title: How to migrate an MX Plan email address to an OVHcloud Zimbra account
-description: Find out how to migrate an MX Plan email address to an OVHcloud Zimbra account
-lastUpdated: 2026-06-23
+title: Zimbra - Migrate an MX Plan email account
+description: Migrate an MX Plan email account to an OVHcloud Zimbra account, then reassign its address to complete the switch
+lastUpdated: 2026-07-23
 availableIn: [eu]
 ---
 
@@ -35,6 +35,10 @@ If you want to upgrade your MX Plan email solution to an [OVHcloud Zimbra](/link
 
 </Region>
 
+:::tip
+Whatever migration method you use, we strongly recommend backing up your mailbox beforehand, as a precaution against any data loss. Our guide [Manually migrate your email address](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) explains step by step how to back up a mailbox (for example by exporting it to a PST file): make this backup before you start the migration.
+:::
+
 ## Instructions
 
 :::warning
@@ -53,7 +57,7 @@ Migrating an MX Plan email account to a Zimbra email account is done in 2 stages
 
 In the example below, we are migrating the address `contact@mydomain.ovh`. To do this, we will create the Zimbra account under the name `contact2@mydomain.ovh`.
 
-<img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
+<img className="thumbnail" alt="Overview of the MX Plan to Zimbra email migration" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
 
 ### 1 - Transfer the contents of the MX Plan account to a Zimbra account <a name="step1"></a>
 
@@ -79,7 +83,7 @@ The migration with OMM is carried out in 3 steps: create a project, configure th
 
     Go to [OVHcloud Mail Migrator](/links/web/omm) and click <code className="action">New migration</code>.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
+    <img className="thumbnail" alt="OVHcloud Mail Migrator home page" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
 
     - **Project contact email address**: Enter an email address that will receive the login credentials and tracking notifications. Do not use an address that will be migrated in this project.
     - **Project password**: Set a password (minimum 10 characters, with at least 1 special character, 1 number, 1 uppercase and 1 lowercase letter).
@@ -93,7 +97,7 @@ The migration with OMM is carried out in 3 steps: create a project, configure th
 
     Then click <code className="action">New migration</code> to configure your migration:
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
+    <img className="thumbnail" alt="Creating the MX Plan to Zimbra migration in the OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
     - **Source account**:
         - **Account type**: Under the `OVHcloud` category, choose `MX Plan` or `Autodetect`. Click <code className="action">Log in</code> to authenticate with your OVHcloud account and automatically select the service and address to migrate (e.g. `contact@mydomain.ovh`). Then enter the password for this email account.
@@ -104,7 +108,7 @@ The migration with OMM is carried out in 3 steps: create a project, configure th
 
     Click <code className="action">Migrate my account</code> to start the migration.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Configuring the Zimbra destination account in the OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
   </Tab>
   <Tab label="Step 3">
     **Track the migration**
@@ -120,7 +124,7 @@ The migration with OMM is carried out in 3 steps: create a project, configure th
     - <code className="action">Cancel migration</code>: Cancels the ongoing migration. Items already migrated are kept in the destination account.
     - <code className="action">Delete my migration data (GDPR)</code>: Triggers the deletion of all migration-related data. Information on migration events is retained.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
+    <img className="thumbnail" alt="Following the migration progress in the OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -139,6 +143,10 @@ Before deleting your MX Plan account, **back up your emails** to avoid any data 
 Use the export options of your email client. In our guide "[Migrating your email address manually](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)", you can find the details for manually exporting an email address from an email client.
 
 ### 2 - Delete the original MX Plan account and reassign its address to the Zimbra account <a name="step2"></a>
+
+:::warning
+Before deleting your original MX Plan account, log in to the [OVHcloud webmail](/links/web/email) and check that all your items (emails, folders, contacts, calendars) have been migrated to the Zimbra account. Once the original account is deleted, any items that were not migrated will be permanently lost.
+:::
 
 #### 2.1 - Deletion of the old MX Plan email address <a name="step21"></a>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrar una dirección de correo electrónico MX Plan a una cuenta de correo electrónico profesional, Exchange o Zimbra
-description: Descubra cómo migrar una dirección de correo electrónico MX Plan a una cuenta de correo electrónico profesional, Exchange o Zimbra
-lastUpdated: 2026-03-30
+title: MX Plan - Migrar a Exchange, Email Pro o Zimbra
+description: Migre su cuenta de correo MX Plan a una oferta Exchange, Email Pro o Zimbra conservando sus mensajes, contactos y carpetas
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -73,6 +73,10 @@ Si sus correos electrónicos están almacenados únicamente de forma local (conf
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Sea cual sea el método de migración, le recomendamos encarecidamente que haga previamente una copia de seguridad de su buzón de correo, como precaución frente a cualquier pérdida de datos. Nuestra guía [Migrar manualmente su dirección de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) explica paso a paso cómo hacer una copia de seguridad de un buzón (por ejemplo, exportándolo a un archivo PST): realice esta copia de seguridad antes de iniciar la migración.
+:::
+
 ## Procedimiento
 
 ### Etapa 1: Delimitar su proyecto
@@ -103,7 +107,7 @@ La tecnología de correo de su oferta MX Plan puede variar según la fecha de ac
 1. El apartado <code className="action">Información general</code> se selecciona por defecto.
 1. Anote la tecnología utilizada bajo la mención **Webmail** en el recuadro `Suscripción`.
 
-<img className="thumbnail" alt="MX plan" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
+<img className="thumbnail" alt="Panel de suscripción de MX Plan que muestra la tecnología Webmail en el área de cliente de OVHcloud" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
 :::
 
@@ -127,7 +131,7 @@ Si acaba de contratar un nuevo servicio de correo, añada el dominio a su plataf
 
 Seleccione la pestaña <code className="action">Dominios asociados</code> en su plataforma y haga clic en <code className="action">Añadir un dominio</code>. Una vez añadido el dominio, asegúrese de que la mención `OK` aparezca en la columna `Estado`.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Añadir el nombre de dominio a la plataforma de correo electrónico de destino" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
 
 <Region zones={['eu']}>
 Para más información sobre la adición de un dominio, consulte [la guía Email Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config) o [la guía Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
@@ -146,7 +150,7 @@ La migración de su MX Plan se realizará en 3 grandes etapas: **Renombrar**, **
 
 En la pestaña <code className="action">Cuentas de correo</code> de su plataforma MX Plan, haga clic en el botón <code className="action">...</code> y luego en <code className="action">Editar</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
+<img className="thumbnail" alt="Configurar la cuenta de MX Plan para la migración en el área de cliente, paso 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
 
 :::info
 El cambio de la cuenta no es inmediato. Espere hasta que finalice la operación antes de continuar en el siguiente paso.
@@ -158,17 +162,19 @@ El cambio de la cuenta no es inmediato. Espere hasta que finalice la operación 
 
 En la pestaña <code className="action">Cuentas de correo</code> de su plataforma Email Pro o Exchange, haga clic en el botón <code className="action">...</code> y luego en <code className="action">Editar</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
+<img className="thumbnail" alt="Configurar la cuenta de MX Plan para la migración en el área de cliente, paso 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
 3\. **Migre** la cuenta MX Plan a la cuenta de su nueva plataforma utilizando nuestra herramienta [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
 
 Para más información sobre OMM, consulte nuestra guía [Migrar cuentas de correo a través de OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
+<img className="thumbnail" alt="Configurar la cuenta de MX Plan para la migración en el área de cliente, paso 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
 
 El tiempo de migración dependerá de cuánto contenido quiera migrar a la nueva cuenta. Éste puede variar desde unos minutos hasta varias horas.
 
-Una vez realizada la migración, compruebe que encuentra todos sus elementos conectándose al [Webmail OVHcloud](https://www.ovhcloud.com/es-es/mail/).
+:::warning
+Una vez realizada la migración, compruebe que encuentra todos sus elementos conectándose al [Webmail OVHcloud](/links/web/email). **No elimine su dirección de origen hasta que haya confirmado que todo se ha migrado correctamente.** Una vez eliminada la dirección de origen, los elementos que no se hayan migrado se perderán de forma permanente.
+:::
 
 Una vez realizada la migración, puede conservar o eliminar la cuenta original con el nombre provisional.
 
@@ -201,7 +207,7 @@ La migración puede realizarse desde dos interfaces:<br/>
 
 > Le recordamos que antes de iniciar la migración, asegúrese de que no haya ninguna **redirección** o ningún **contestador** configurado en su MX Plan.
 >
-> <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
+> <img className="thumbnail" alt="Comprobar que no haya ninguna redirección configurada en la cuenta de MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
 
 Continúe leyendo esta guía en la interfaz seleccionada. Le recordamos que el tiempo de migración dependerá de la cantidad de contenido que quiera migrar a su nueva cuenta. Éste puede variar desde unos minutos hasta varias horas.
 
@@ -223,7 +229,7 @@ Si no aparece el asistente de configuración, la información general del servic
 
 Para realizar la migración desde esta interfaz, acceda a la sección <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> de su área de cliente de OVHcloud y seleccione el dominio correspondiente. En la pestaña <code className="action">Correo electrónico</code>, haga clic en <code className="action">...</code> en la línea de la cuenta de correo correspondiente (también llamada cuenta de origen) y seleccione <code className="action">Migrar la cuenta</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
+<img className="thumbnail" alt="Acceder a la herramienta de migración desde la interfaz de MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
 
 En la nueva ventana, seleccione el servicio de destino (el servicio al que quiere migrar la dirección) y haga clic en <code className="action">Siguiente</code>. Si posee al menos una cuenta "libre" (es decir, aún no configurada), la migración se realizará hacia una de estas cuentas. Lea atentamente la información que se muestra y acepte y haga clic en <code className="action">Siguiente</code> para continuar.
 
@@ -231,7 +237,7 @@ Si no tiene una cuenta "libre", aparecerá un botón <code className="action">co
 
 Por último, confirme la contraseña de la dirección de correo de origen (la que quiera migrar) y haga clic en <code className="action">Migrar</code>. Esta operación se repetirá tantas veces como sea necesario para la migración de otras cuentas.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
+<img className="thumbnail" alt="Seleccionar las cuentas de MX Plan que se van a migrar en la interfaz" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
 
 </Region>
 
@@ -247,7 +253,7 @@ Para ello, seleccione el servicio Email Pro o Exchange correspondiente y abra la
 Para ello, seleccione el servicio Exchange correspondiente y abra la pestaña <code className="action">Dominios asociados</code>. A continuación, en la columna "Diagnóstico", explicaremos si la configuración DNS es correcta: se mostrará una etiqueta roja si la configuración ha de modificarse.
 </Region>
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Comprobar los registros DNS de los nombres de dominio asociados" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
 Si acaba de realizar la migración o de modificar un registro DNS del dominio, es posible que la actualización tarde unas horas en mostrarse en el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>.
@@ -267,7 +273,7 @@ Si ha configurado alguna de las cuentas migradas en un cliente de correo (p. ej.
 
 Al conectarse por primera vez a su nueva cuenta de correo, el contenido migrado puede ocultarse parcialmente. Para ver todos los elementos, haga clic en la cabecera situada al lado de la `bandeja de entrada` para revelar los subdirectorios. El contenido migrado de su antigua cuenta de correo debe aparecer.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
+<img className="thumbnail" alt="Ver las carpetas y los correos electrónicos migrados en el webmail de OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
 
 Las carpetas predeterminadas, como "elementos enviados" o "papelera", aparecen en inglés ("Sent items" y "Trash"), a excepción de las carpetas que haya creado.
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrar sus direcciones de correo de una plataforma de correo de OVHcloud a otra
-description: Cómo migrar las direcciones de correo de una plataforma Exchange o Email Pro a otra plataforma Exchange, Email Pro, MX Plan o Zimbra
-lastUpdated: 2026-03-30
+title: Migrar cuentas de correo entre plataformas de OVHcloud
+description: Migre cuentas de correo entre dos plataformas de OVHcloud (Exchange, Email Pro, MX Plan) sin perder sus mensajes, contactos ni carpetas
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -75,6 +75,10 @@ Para migrar una solución MX Plan a una plataforma Exchange, consulte nuestra gu
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Sea cual sea el método de migración, le recomendamos encarecidamente que haga previamente una copia de seguridad de su buzón de correo, como precaución frente a cualquier pérdida de datos. Nuestra guía [Migrar manualmente su dirección de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) explica paso a paso cómo hacer una copia de seguridad de un buzón (por ejemplo, exportándolo a un archivo PST): realice esta copia de seguridad antes de iniciar la migración.
+:::
+
 ## Procedimiento
 
 ### Configurar la plataforma de destino
@@ -84,7 +88,7 @@ Antes de comenzar su migración, si acaba de pedir su nueva oferta de correo ele
 
 Seleccione la pestaña <code className="action">Dominios asociados</code> o <code className="action">Dominio</code> en su plataforma, y haga clic en <code className="action">Añadir un dominio</code>. Una vez que el nombre de dominio se haya agregado, asegúrese de que la mención `OK` o <code className="action">Activo</code> esté bien presente en la columna `Estado`.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Añadir el nombre de dominio a la plataforma de correo electrónico de destino" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
 
 Para más detalles sobre la adición de un nombre de dominio, siga [la guía Email Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config), [la guía Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain) o [la guía Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra).
 
@@ -112,7 +116,7 @@ Renombra la cuenta de correo que quiera migrar con un nombre provisional (por ej
 
 En la pestaña <code className="action">Cuentas de correo</code> de su plataforma de correo, haga clic en el botón <code className="action">...</code> y luego en <code className="action">Editar</code>.
 
-<img className="thumbnail" alt="email-migración" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Renombrar una cuenta de correo electrónico en la plataforma de destino" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Crear
 
@@ -120,7 +124,7 @@ Cree su dirección de correo electrónico en la nueva cuenta de su plataforma Em
 
 En la pestaña <code className="action">Cuentas de correo</code> de su plataforma, haga clic en el botón <code className="action">...</code>, a la derecha de la cuenta de correo de destino, y luego en <code className="action">Editar</code>.
 
-<img className="thumbnail" alt="email-migración" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
+<img className="thumbnail" alt="Crear la cuenta de correo electrónico en la plataforma de destino" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
 
 #### Migrar
 
@@ -140,11 +144,13 @@ Migre la cuenta de correo de origen a la cuenta de su nueva plataforma utilizand
 
 Para más información sobre OMM, consulte nuestra guía [Migrar cuentas de correo a través de OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
-<img className="thumbnail" alt="email-migración" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
+<img className="thumbnail" alt="Migrar la cuenta de correo electrónico con OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
 
 El tiempo de migración dependerá de la cantidad de datos que quiera migrar a la nueva cuenta. Éste puede variar desde unos minutos hasta varias horas.
 
-Una vez realizada la migración, compruebe que todos sus elementos se encuentren conectándose al webmail en la dirección [Webmail](https://www.ovhcloud.com/es-es/mail/).
+:::warning
+Una vez realizada la migración, compruebe que todos sus elementos se encuentren conectándose al webmail en la dirección [Webmail](/links/web/email). **No elimine su dirección de origen hasta que haya confirmado que todo se ha migrado correctamente.** Una vez eliminada la dirección de origen, los elementos que no se hayan migrado se perderán de forma permanente.
+:::
 
 Una vez realizada la migración, podrá conservar o eliminar la cuenta de origen con el nombre provisional.
 
@@ -156,7 +162,7 @@ En este punto, sus direcciones de correo ya deben migrarse y ser funcionales. Po
 
 Para ello, seleccione el servicio Email Pro, Exchange o Zimbra concernido, y diríjase a la pestaña <code className="action">Dominios asociados</code> o <code className="action">Dominio</code> en su plataforma. Verifique la sección o la columna <code className="action">Diagnóstico</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Comprobar los registros DNS de los nombres de dominio asociados" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
 Si acaba de realizar la migración o de modificar un registro DNS de su dominio, es posible que la visualización en el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink> necesite algunas horas para actualizarse.
@@ -166,7 +172,7 @@ Si acaba de realizar la migración o de modificar un registro DNS de su dominio,
 
 Para modificar la configuración, haga clic en la etiqueta roja y realice la operación solicitada. Esta operación tarda entre 4 y 24 horas en propagarse y ser efectiva.
 
-<img className="thumbnail" alt="email-migración" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Comprobar los registros DNS de los nombres de dominio asociados" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 ### Utilizar las direcciones de correo migradas
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar cuentas de correo electrónico con OVHcloud Mail Migrator
-description: Descubra cómo migrar sus cuentas de correo electrónico a OVHcloud con nuestra herramienta OVHcloud Mail Migrator
-lastUpdated: 2026-03-30
+description: Migre sus cuentas de correo a OVHcloud con OVHcloud Mail Migrator (OMM), transfiriendo mensajes, contactos y calendarios
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -34,11 +34,15 @@ import { Region } from '@components/Zone';
 - Tener los identificadores relacionados con las cuentas de correo electrónico que desea migrar (las cuentas de correo electrónico de origen).
 - Tener los identificadores relacionados con las cuentas de correo electrónico de destino.
 
+:::tip
+Sea cual sea el método de migración, le recomendamos encarecidamente que haga previamente una copia de seguridad de su buzón de correo, como precaución frente a cualquier pérdida de datos. Nuestra guía [Migrar manualmente su dirección de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) explica paso a paso cómo hacer una copia de seguridad de un buzón (por ejemplo, exportándolo a un archivo PST): realice esta copia de seguridad antes de iniciar la migración.
+:::
+
 ## Procedimiento
 
 Para acceder a OMM, vaya a la dirección [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/).
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
+<img className="thumbnail" alt="Página de inicio de OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
 ### Crear un proyecto de migración <a name="create-project"></a>
 
@@ -53,7 +57,7 @@ Haga clic en <code className="action">Create my project</code> para iniciar la c
 
 En la dirección de correo electrónico de contacto del proyecto, recibirá un correo electrónico de confirmación que contiene el identificador único del proyecto y un enlace para acceder a él.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
+<img className="thumbnail" alt="Crear un proyecto de migración en OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
 
 :::info
 En caso de inactividad durante 60 días, el proyecto de migración y todos los datos asociados se eliminarán automáticamente.
@@ -69,13 +73,13 @@ Una vez creado su proyecto, conéctese a él desde la página de inicio de [OMM]
 - Introduzca la `Project password` que definió al crearlo.
 - Haga clic en <code className="action">Connect to project</code> para finalizar.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Crear una nueva migración en OVHcloud Mail Migrator, paso 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Ahora está en la página de inicio del proyecto, desde la cual podrá iniciar su primera migración.
 
 - Haga clic en <code className="action">New migration</code> en la parte superior izquierda de la tabla.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Crear una nueva migración en OVHcloud Mail Migrator, paso 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 En la nueva página que aparece, introduzca las informaciones de conexión de la cuenta de origen y de la cuenta de destino para programar la migración o iniciarla inmediatamente. Para recordar, el contenido del **source account** se migrará al **destination account**.
 
@@ -85,7 +89,7 @@ Antes de comenzar su migración, es importante conocer bien los 3 tipos de cuent
 - **Others**: Se trata de servicios de correo electrónico contratados fuera de OVHcloud. Una lista no exhaustiva de servicios de correo electrónico compatibles con OMM está disponible. Si el tipo de servicio de su cuenta de correo electrónico no aparece en esta lista, utilice los protocolos `IMAP` o `POP`, compatibles con la mayoría de los servidores de correo electrónico.
 - **Importing files**: Es posible migrar el contenido de archivos PST, ICS, CSV y XML Rules a través de OMM a una cuenta de correo electrónico de destino. Cuando se selecciona esta función, basta con arrastrar y soltar su documento en la zona correspondiente o navegar por su terminal mediante el botón <code className="action">Browse your files</code>.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Crear una nueva migración en OVHcloud Mail Migrator, paso 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Complete las informaciones según el tipo de cuenta:
 
@@ -114,7 +118,7 @@ Complete las informaciones según el tipo de cuenta:
 - **Start of transfer**: Puede iniciar la migración `Immediately` o marcar `Later` para posponerla. La migración diferida le permite iniciarla automáticamente en una fecha y hora que usted defina.
 - **Data to transfer**: Según el tipo de cuenta de correo electrónico que migre y la cuenta de destino, esta sección le indicará los diferentes tipos de datos que se admiten durante la migración. Esto depende de la cuenta de origen y la cuenta de destino.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Crear una nueva migración en OVHcloud Mail Migrator, paso 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 Si migra una cuenta que dispone de funcionalidades que la cuenta de destino no posee, **deberá guardar por sus propios medios los elementos que no puedan ser migrados por OMM**. Para ayudarle, consulte nuestra guía "[Migrar manualmente su dirección de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)".
@@ -130,7 +134,7 @@ Una vez completados los parámetros de las cuentas de origen y de destino, haga 
 
 Durante una migración hacia o desde una cuenta de OVHcloud, es posible seleccionar una de nuestras ofertas `MX plan`, `Email Pro`, `Exchange` o `Zimbra`.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
+<img className="thumbnail" alt="Migrar mediante la conexión con la cuenta de OVHcloud en OMM, paso 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
 
 Cuando seleccione una de estas ofertas, siga los pasos siguientes:
 
@@ -138,7 +142,7 @@ Cuando seleccione una de estas ofertas, siga los pasos siguientes:
   <Tab label="Paso 1">
     - Haga clic en <code className="action">Login</code> para mostrar la ventana de conexión al área de cliente de OVHcloud.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrar mediante la conexión con la cuenta de OVHcloud en OMM, paso 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 2">
     Conéctese a la cuenta cliente de OVHcloud:
@@ -151,19 +155,19 @@ Cuando seleccione una de estas ofertas, siga los pasos siguientes:
     :::
 
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrar mediante la conexión con la cuenta de OVHcloud en OMM, paso 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 3">
     - Aparecerá una nueva ventana. Le permite autorizar a OMM para que acceda a las funciones de su espacio cliente y liste las ofertas y cuentas de correo electrónico presentes. Por defecto, la validez (Validity) de estos derechos es de 24 horas (1 día). Defina la duración de validez que le convenga y haga clic en <code className="action">Authorize</code>.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrar mediante la conexión con la cuenta de OVHcloud en OMM, paso 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 4">
     - Ahora podrá seleccionar sus servicios y cuentas mediante menús desplegables. Esto facilita la búsqueda de los elementos y evita errores de escritura. Es, sin embargo, necesario introducir la contraseña asociada a la cuenta de correo electrónico seleccionada.
     
     Ejemplo con un servicio Zimbra:
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrar mediante la conexión con la cuenta de OVHcloud en OMM, paso 5" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -171,7 +175,7 @@ Cuando seleccione una de estas ofertas, siga los pasos siguientes:
 :::warning
 Es posible desconectar los accesos en curso desde un área de cliente de OVHcloud haciendo clic en <code className="action">Log out</code>, y luego, bajo la mención `OVHcloud account ID`, haga clic en <code className="action">Log out of the account</code>.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
+<img className="thumbnail" alt="Migrar mediante la conexión con la cuenta de OVHcloud en OMM, paso 6" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
 :::
 
 
@@ -184,7 +188,7 @@ Existen dos maneras de acceder al seguimiento del proyecto de migración:
 
 Haga clic después en <code className="action">Connect to project</code> para acceder a la página de inicio del proyecto y seguir sus migraciones.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Crear una nueva migración en OVHcloud Mail Migrator, paso 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Desde esta página, encontrará la lista de las migraciones en curso o programadas. El estado del proyecto también se muestra a la derecha.
 
@@ -194,16 +198,20 @@ Haga clic en el botón <code className="action">⋮</code> a la derecha de la l�
 - <code className="action">Cancel migration</code>: Permite cancelar la migración en curso. Los elementos ya migrados se conservarán en la cuenta de destino.
 - <code className="action">Delete migration data (GDPR)</code>: Esta opción desencadena la eliminación de todos los datos relativos a la migración de la cuenta. Sin embargo, conservará la información concerniente a los eventos ocurridos durante la migración.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
+<img className="thumbnail" alt="Seguir el progreso de una migración en OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
 
 Ejemplo de seguimiento de migración:
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
+<img className="thumbnail" alt="Ejemplo de seguimiento de una migración en OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
 
 :::info
 Si se produce un error durante la migración, se le proporcionará un enlace al registro de errores en la ventana <code className="action">See more details</code>.
 :::
 
+
+:::warning
+Una vez finalizada la migración, conéctese a la cuenta de destino y compruebe que todos sus elementos (correos, carpetas, contactos, calendarios) están presentes; para una dirección de correo de OVHcloud, utilice el [Webmail OVHcloud](/links/web/email). **No elimine la cuenta de origen hasta que haya confirmado que todo se ha migrado correctamente**, ya que de lo contrario los elementos que no se hayan migrado se perderán de forma permanente.
+:::
 
 ## Más información
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrar una dirección de correo MX Plan a una cuenta Zimbra OVHcloud
-description: Descubra cómo migrar una cuenta MX Plan a una cuenta de OVHcloud
-lastUpdated: 2026-06-23
+title: Zimbra - Migrar una cuenta de correo MX Plan
+description: Migre una cuenta de correo MX Plan a una cuenta Zimbra de OVHcloud y reasigne su dirección para completar el cambio
+lastUpdated: 2026-07-23
 availableIn: [eu]
 ---
 
@@ -35,6 +35,10 @@ Si desea cambiar su servicio de correo electrónico MX Plan por un servicio [Zim
 
 </Region>
 
+:::tip
+Sea cual sea el método de migración, le recomendamos encarecidamente que haga previamente una copia de seguridad de su buzón de correo, como precaución frente a cualquier pérdida de datos. Nuestra guía [Migrar manualmente su dirección de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) explica paso a paso cómo hacer una copia de seguridad de un buzón (por ejemplo, exportándolo a un archivo PST): realice esta copia de seguridad antes de iniciar la migración.
+:::
+
 ## Procedimiento
 
 :::warning
@@ -53,7 +57,7 @@ La migración de una cuenta de correo electrónico MX Plan a una cuenta de corre
 
 En el ejemplo siguiente, migramos la dirección `contact@mydomain.ovh`. Para ello, vamos a crear la cuenta Zimbra con el nombre `contact2@mydomain.ovh`.
 
-<img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
+<img className="thumbnail" alt="Vista general de la migración de correo electrónico de MX Plan a Zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
 
 ### 1 - Transferir el contenido de la cuenta MX Plan a una cuenta Zimbra <a name="step1"></a>
 
@@ -79,7 +83,7 @@ La migración con OMM se realiza en 3 pasos: crear un proyecto, configurar la mi
 
     Acceda a [OVHcloud Mail Migrator](/links/web/omm) y haga clic en <code className="action">New migration</code>.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Página de inicio de OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
 
     - **Project contact email address**: Introduzca una dirección de correo electrónico que recibirá las credenciales de acceso y las notificaciones de seguimiento. No utilice una dirección que vaya a migrarse en este proyecto.
     - **Project password**: Defina una contraseña (mínimo 10 caracteres, con al menos 1 carácter especial, 1 número, 1 mayúscula y 1 minúscula).
@@ -93,7 +97,7 @@ La migración con OMM se realiza en 3 pasos: crear un proyecto, configurar la mi
 
     A continuación, haga clic en <code className="action">New migration</code> para configurar su migración:
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
+    <img className="thumbnail" alt="Crear la migración de MX Plan a Zimbra en OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
     - **Source account**:
         - **Account type**: En la categoría `OVHcloud`, elija `MX Plan` o `Autodetect`. Haga clic en <code className="action">Log in</code> para identificarse con su cuenta de OVHcloud y seleccionar automáticamente el servicio y la dirección que desea migrar (p. ej.: `contact@mydomain.ovh`). Introduzca a continuación la contraseña de esta cuenta de correo electrónico.
@@ -104,7 +108,7 @@ La migración con OMM se realiza en 3 pasos: crear un proyecto, configurar la mi
 
     Haga clic en <code className="action">Migrate my account</code> para iniciar la migración.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Configurar la cuenta de destino de Zimbra en OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 3">
     **Seguir la migración**
@@ -120,7 +124,7 @@ La migración con OMM se realiza en 3 pasos: crear un proyecto, configurar la mi
     - <code className="action">Cancel migration</code>: Cancela la migración en curso. Los elementos ya migrados se conservan en la cuenta de destino.
     - <code className="action">Delete my migration data (GDPR)</code>: Activa la eliminación de todos los datos relacionados con la migración. La información sobre los eventos de la migración se conserva.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
+    <img className="thumbnail" alt="Seguir el progreso de la migración en OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -139,6 +143,10 @@ Antes de eliminar su cuenta MX Plan, **realice una copia de seguridad de sus cor
 Utilice las opciones de exportación de su cliente de correo electrónico. En nuestra guía «[Migrar manualmente su dirección de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)», encontrará los detalles de exportación manual de una dirección de correo electrónico desde un cliente de correo.
 
 ### 2 - Eliminar la cuenta MX Plan original y reasignar su dirección a la cuenta Zimbra <a name="step2"></a>
+
+:::warning
+Antes de eliminar su cuenta MX Plan original, conéctese al [Webmail OVHcloud](/links/web/email) y compruebe que todos sus elementos (correos, carpetas, contactos, calendarios) se han migrado a la cuenta Zimbra. Una vez eliminada la cuenta original, los elementos que no se hayan migrado se perderán de forma permanente.
+:::
 
 #### 2.1 - Eliminación de la antigua dirección de correo electrónico MX Plan <a name="step21"></a>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrer une adresse e-mail MX Plan vers un compte Email Pro, Exchange ou Zimbra
-description: Découvrez comment migrer une adresse e-mail MX Plan vers un compte Email Pro, Exchange ou Zimbra
-lastUpdated: 2026-03-30
+title: MX Plan - Migrer vers Exchange, Email Pro ou Zimbra
+description: Migrez votre compte e-mail MX Plan vers une offre Exchange, Email Pro ou Zimbra en conservant vos messages, contacts et dossiers
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -75,6 +75,10 @@ Si vos e-mails sont uniquement enregistrés en local (configuration en POP ou ar
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Quelle que soit la méthode de migration, nous vous recommandons vivement de sauvegarder votre boîte e-mail au préalable, par précaution contre toute perte de données. Notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) » explique, étape par étape, comment sauvegarder une boîte e-mail (par exemple via un export au format PST) : réalisez cette sauvegarde avant de démarrer la migration.
+:::
+
 ## En pratique
 
 ### Étape 1 : Délimiter votre projet
@@ -105,7 +109,7 @@ La technologie e-mail de votre offre MX Plan peut varier selon la date d’activ
 1. L’onglet <code className="action">Informations générales</code> est sélectionné par défaut.
 1. Relevez la technologie utilisée sous la mention **Webmail** dans l’encadré `Abonnement`.
 
-<img className="thumbnail" alt="MX plan" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
+<img className="thumbnail" alt="Panneau d'abonnement MX Plan affichant la technologie Webmail dans l'espace client OVHcloud" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
 :::
 
@@ -129,7 +133,7 @@ Si vous venez de commander votre nouvelle offre e-mail, ajoutez d'abord le nom d
 
 Sélectionnez l’onglet <code className="action">Domaines associés</code> ou <code className="action">Domaine</code> sur votre plateforme, puis cliquez sur <code className="action">Ajouter un domaine</code>. Une fois le nom de domaine ajouté, assurez-vous que la mention `OK` ou <code className="action">Actif</code> est bien présente dans la colonne `Statut`.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Ajout du nom de domaine à la plateforme e-mail de destination" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
 
 <Region zones={['eu']}>
 Pour plus de détails sur l'ajout d'un nom de domaine, suivez [le guide Email Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config), [le guide Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain) ou [le guide Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra).
@@ -150,7 +154,7 @@ La migration de votre MX Plan se fera en 3 grandes étapes, **Renommer**, **Cré
 
 Dans l'onglet <code className="action">Comptes e-mail</code> de votre plateforme MX Plan, cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Modifier</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
+<img className="thumbnail" alt="Configuration du compte MX Plan pour la migration dans l'espace client OVHcloud, étape 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
 
 :::info
 La modification du compte n'est pas immédiate, veuillez patienter jusqu'à la fin de l'opération avant de passer à l'étape suivante.
@@ -162,17 +166,19 @@ La modification du compte n'est pas immédiate, veuillez patienter jusqu'à la f
 
 Dans l'onglet <code className="action">Comptes e-mail</code> de votre plateforme Email Pro ou Exchange, cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Modifier</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
+<img className="thumbnail" alt="Configuration du compte MX Plan pour la migration dans l'espace client OVHcloud, étape 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
 3\. **Migrez** le compte MX Plan vers le compte de votre nouvelle plateforme à l'aide de notre outil [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
 
 Pour plus d'informations sur OMM, consultez notre guide [Migrer des comptes e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
+<img className="thumbnail" alt="Configuration du compte MX Plan pour la migration dans l'espace client OVHcloud, étape 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
 
 Le délai de migration dépend de la quantité de contenu à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
 
-Après la migration, vérifiez que vous retrouvez vos éléments en vous connectant au [Webmail OVHcloud](https://www.ovhcloud.com/fr/mail/).
+:::warning
+Après la migration, vérifiez que vous retrouvez vos éléments en vous connectant au [Webmail OVHcloud](/links/web/email). **Ne supprimez pas votre adresse d'origine tant que vous n'avez pas confirmé que tout a bien été migré** : une fois l'adresse supprimée, les éléments non migrés seront définitivement perdus.
+:::
 
 Vous pouvez conserver ou supprimer le compte d'origine avec le nom provisoire après cette migration.
 
@@ -205,7 +211,7 @@ La migration peut être effectuée depuis deux interfaces :<br/>
 
 > Pour rappel, avant de débuter la migration, assurez-vous qu'aucune **redirection** ou qu'aucun **répondeur** ne soient paramétrés sur votre MX Plan.
 >
-> <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
+> <img className="thumbnail" alt="Vérification de l'absence de redirection sur le compte MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
 
 Une fois que vous êtes prêt, poursuivez la lecture de cette documentation selon l'interface sélectionnée. Nous vous rappelons que le délai de migration dépend de la quantité de contenu à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
 
@@ -227,7 +233,7 @@ Si l'assistant de configuration ne s'affiche pas, les informations générales d
 
 Pour réaliser la migration depuis cette interface, rendez-vous dans la section <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> de votre espace client OVHcloud et sélectionnez le domaine concerné. Dans l'onglet <code className="action">Emails</code>, cliquez sur <code className="action">...</code> sur la ligne du compte e-mail concerné (également appelé compte source), puis sur <code className="action">Migrer le compte</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
+<img className="thumbnail" alt="Accès à l'outil de migration depuis l'interface MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
 
 Dans la fenêtre qui s'affiche, sélectionnez le service de destination (celui vers lequel vous souhaitez migrer l'adresse) puis cliquez sur <code className="action">Suivant</code>. S'il possède au minimum un compte « libre » (c'est-à-dire encore non paramétré), la migration s'effectuera vers l'un de ces comptes. Dès lors, prenez connaissance des informations qui s'affichent, validez-les, puis cliquez sur <code className="action">Suivant</code> pour poursuivre l'opération.
 
@@ -235,7 +241,7 @@ Si vous ne possédez pas de compte « libre », un bouton <code className="actio
 
 Confirmez enfin le mot de passe de l'adresse e-mail source (celle que vous voulez migrer), puis cliquez sur <code className="action">Migrer</code>. Cette manipulation sera à répéter autant de fois que nécessaire pour la migration d'autres comptes.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
+<img className="thumbnail" alt="Sélection des comptes MX Plan à migrer dans l'interface" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
 
 </Region>
 
@@ -251,7 +257,7 @@ Pour cela, sélectionnez le service Email Pro, Exchange ou Zimbra concerné, pui
 Pour cela, sélectionnez le service Exchange concerné, puis rendez-vous sur l'onglet <code className="action">Domaines associés</code> ou <code className="action">Domaine</code> sur votre plateforme. Vérifiez la rubrique ou la colonne <code className="action">Diagnostics</code>.
 </Region>
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Vérification des enregistrements DNS des noms de domaine associés" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
 Si vous venez juste de réaliser la migration ou de modifier un enregistrement DNS de votre domaine, il se peut que l’affichage dans l’<ManagerLink to="/">espace client OVHcloud</ManagerLink> nécessite quelques heures pour se mettre à jour.
@@ -271,7 +277,7 @@ Si vous avez configuré l'un des comptes migrés sur un client de messagerie (co
 
 Lorsque vous vous connectez pour la première fois sur votre nouveau compte e-mail, le contenu migré peut être partiellement caché. Pour afficher l'ensemble des éléments, depuis le webmail, cliquez sur le chevron à côté de la `Boîte de réception` pour révéler les sous-dossiers. Le contenu migré de votre ancien compte e-mail devrait apparaitre.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
+<img className="thumbnail" alt="Affichage des dossiers et e-mails migrés dans le webmail OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
 
 Les dossiers par défaut, comme « éléments envoyés » ou « corbeille » apparaissent en anglais (« Sent items » et « Trash »), à l'exception des dossiers que vous avez créés.
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Migrer vos adresses e-mail d'une plateforme e-mail OVHcloud vers une autre"
-description: "Découvrez comment migrer les adresses e-mail d'une plateforme Exchange ou Email Pro vers une autre plateforme Exchange, Email Pro, MX Plan ou Zimbra"
-lastUpdated: 2026-03-30
+title: Migrer des comptes e-mail entre plateformes OVHcloud
+description: Migrez des comptes e-mail entre deux plateformes OVHcloud (Exchange, Email Pro, MX Plan) sans perdre vos messages, contacts ni dossiers
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -75,6 +75,10 @@ Pour migrer une solution MX Plan vers une plateforme Exchange, nous vous inviton
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Quelle que soit la méthode de migration, nous vous recommandons vivement de sauvegarder votre boîte e-mail au préalable, par précaution contre toute perte de données. Notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) » explique, étape par étape, comment sauvegarder une boîte e-mail (par exemple via un export au format PST) : réalisez cette sauvegarde avant de démarrer la migration.
+:::
+
 ## En pratique
 
 ### Configurer la plateforme de destination
@@ -84,7 +88,7 @@ Avant de commencer votre migration, si vous venez de commander votre nouvelle of
 
 Sélectionnez l’onglet <code className="action">Domaines associés</code> ou <code className="action">Domaine</code> sur votre plateforme, puis cliquez sur <code className="action">Ajouter un domaine</code>. Une fois le nom de domaine ajouté, assurez-vous que la mention `OK` ou <code className="action">Actif</code> est bien présente dans la colonne `Statut`.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Ajout du nom de domaine à la plateforme e-mail de destination" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
 
 Pour plus de détails sur l'ajout d'un nom de domaine, suivez [le guide Email Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config), [le guide Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain) ou [le guide Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra).
 
@@ -112,7 +116,7 @@ Renommez le compte e-mail à migrer avec un nom provisoire (exemple: pour migrer
 
 Dans l'onglet <code className="action">Comptes e-mail</code> de votre plateforme e-mail, cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Modifier</code>.
 
-<img className="thumbnail" alt="email-migration" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Renommage d'un compte e-mail sur la plateforme de destination" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Créer
 
@@ -120,7 +124,7 @@ Créez votre adresse e-mail sur le nouveau compte de votre plateforme Email Pro,
 
 Dans l'onglet <code className="action">Comptes e-mail</code> de votre plateforme, cliquez sur le bouton <code className="action">...</code>, à droite du compte e-mail de destination, puis sur <code className="action">Modifier</code>.
 
-<img className="thumbnail" alt="email-migration" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
+<img className="thumbnail" alt="Création du compte e-mail sur la plateforme de destination" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
 
 #### Migrer
 
@@ -140,11 +144,13 @@ Migrez le compte e-mail « source » vers le compte de votre nouvelle plateforme
 
 Pour plus d'informations sur OMM, consultez notre guide [Migrer des comptes e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
-<img className="thumbnail" alt="email-migration" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
+<img className="thumbnail" alt="Migration du compte e-mail avec OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
 
 Le délai de migration dépend de la quantité de données à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
 
-Vérifiez, après la migration, que vous retrouvez tous vos éléments en vous connectant au webmail à l'adresse [Webmail](https://www.ovhcloud.com/fr/mail/).
+:::warning
+Vérifiez, après la migration, que vous retrouvez tous vos éléments en vous connectant au webmail à l'adresse [Webmail](/links/web/email). **Ne supprimez pas votre adresse d'origine tant que vous n'avez pas confirmé que tout a bien été migré** : une fois l'adresse supprimée, les éléments non migrés seront définitivement perdus.
+:::
 
 Une fois la migration effectuée, vous pouvez conserver ou supprimer le compte d'origine avec le nom provisoire.
 
@@ -156,7 +162,7 @@ Si vous souhaitez le supprimer, dirigez-vous dans l'onglet <code className="acti
 
 Pour cela, sélectionnez le service Email Pro, Exchange ou Zimbra concerné, puis rendez-vous sur l'onglet <code className="action">Domaines associés</code> ou <code className="action">Domaine</code> sur votre plateforme. Vérifiez la rubrique ou la colonne <code className="action">Diagnostic</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Vérification des enregistrements DNS des noms de domaine associés" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
 Si vous venez juste de réaliser la migration ou de modifier un enregistrement DNS de votre domaine, il se peut que l’affichage dans l’<ManagerLink to="/">espace client OVHcloud</ManagerLink> nécessite quelques heures pour se mettre à jour.

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrer des comptes e-mail via OVHcloud Mail Migrator
-description: Découvrez comment migrer vos comptes e-mail vers OVHcloud grâce à notre outil OVHcloud Mail Migrator
-lastUpdated: 2026-03-30
+description: Migrez vos comptes e-mail vers OVHcloud avec OVHcloud Mail Migrator (OMM), avec transfert des messages, contacts et agendas
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -34,11 +34,15 @@ import { Region } from '@components/Zone';
 - Disposer des identifiants relatifs aux comptes e-mail que vous souhaitez migrer (les comptes e-mail source).
 - Disposer des identifiants relatifs aux comptes e-mail de destination.
 
+:::tip
+Quelle que soit la méthode de migration, nous vous recommandons vivement de sauvegarder votre boîte e-mail au préalable, par précaution contre toute perte de données. Notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) » explique, étape par étape, comment sauvegarder une boîte e-mail (par exemple via un export au format PST) : réalisez cette sauvegarde avant de démarrer la migration.
+:::
+
 ## En pratique
 
 Pour accéder à OMM, rendez-vous sur l'adresse [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/).
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
+<img className="thumbnail" alt="Page d'accueil d'OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
 ### Créer un projet de migration <a name="create-project"></a>
 
@@ -53,7 +57,7 @@ Cliquez sur <code className="action">Créer mon projet</code> pour lancer la cr�
 
 Sur l'adresse e-mail de contact du projet, vous recevrez un e-mail de confirmation contenant l'identifiant unique du projet et un lien pour y accéder.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
+<img className="thumbnail" alt="Création d'un projet de migration dans OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
 
 :::info
 En cas d’inactivité pendant 60 jours, le projet de migration et toutes les données associées seront automatiquement supprimés.
@@ -69,13 +73,13 @@ Une fois votre projet créé, connectez-vous à celui-ci depuis la page d'accuei
 - Saisissez le `Mot de passe du projet` que vous avez défini à sa création.
 - Cliquez sur <code className="action">Se connecter au projet</code> pour terminer.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Vous êtes maintenant sur la page d'accueil du projet qui vous permettra de lancer votre première migration.
 
 - Cliquez sur <code className="action">Nouvelle migration</code> en haut à gauche du tableau.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 Sur la nouvelle page qui s’affiche, renseignez les informations de connexion du compte source et du compte de destination afin de planifier la migration ou de la lancer immédiatement. Pour rappel, le contenu du **compte source** sera migré vers le **compte de destination**.
 
@@ -85,7 +89,7 @@ Avant de commencer votre migration, il est important de bien connaître les 3 ty
 - **Autres** : Il s'agit de services e-mail souscrits hors OVHcloud. Une liste non exhaustive de services e-mail pris en charge par OMM est disponible. Si le type de service de votre compte e-mail n'y figure pas, utilisez les protocoles `IMAP` ou `POP`, compatibles avec la plupart des serveurs e-mail.
 - **Importation de fichiers** : Il est possible de migrer le contenu de fichiers PST, ICS, CSV et XML Rules via OMM vers un compte e-mail de destination. Lorsque cette fonction est sélectionnée, il suffit de glisser-déposer votre document dans la zone prévue à cet effet ou de parcourir votre terminal via le bouton <code className="action">Parcourir vos fichiers</code>.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Complétez les informations selon le type de compte :
 
@@ -114,7 +118,7 @@ Complétez les informations selon le type de compte :
 - **Début du transfert** : Vous pouvez lancer la migration `Immédiatement` ou cocher `Plus tard` pour la reporter. La migration différée vous permet de la déclencher automatiquement à une date et une heure que vous définissez.
 - **Données à transférer** : En fonction du type de compte e-mail que vous migrez et du compte de destination, cette section vous indiquera les différents types de données qui sont prises en charge lors de la migration. Cela dépend du compte source et du compte de destination.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 Si vous migrez un compte disposant de fonctionnalités que le compte destination ne possède pas, **il vous sera nécessaire de sauvegarder par vos moyens les éléments qui ne pourront pas être migrés par OMM**. Pour vous aider, référez-vous à notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) ».
@@ -130,7 +134,7 @@ Une fois les paramètres des comptes source et destination complétés, cliquez 
 
 Lors d'une migration vers ou depuis un compte OVHcloud, vous pouvez sélectionner l'une de nos offres `MX plan`, `Email Pro`, `Exchange` ou `Zimbra`.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
+<img className="thumbnail" alt="Migration via la connexion au compte OVHcloud dans OMM, étape 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
 
 Lorsque vous sélectionnez l'une de ces offres, suivez les étapes ci-dessous :
 
@@ -138,7 +142,7 @@ Lorsque vous sélectionnez l'une de ces offres, suivez les étapes ci-dessous :
   <Tab label="Étape 1">
     - Cliquez sur <code className="action">Se connecter</code> pour afficher la fenêtre de connexion à l'espace client OVHcloud.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Migration via la connexion au compte OVHcloud dans OMM, étape 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 2">
     Connectez-vous au compte client OVHcloud :
@@ -151,19 +155,19 @@ Lorsque vous sélectionnez l'une de ces offres, suivez les étapes ci-dessous :
     :::
 
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
+    <img className="thumbnail" alt="Migration via la connexion au compte OVHcloud dans OMM, étape 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 3">
     - Une nouvelle fenêtre s'affiche. Elle vous permet d'autoriser OMM à accéder aux fonctions de votre espace client, et de lister les offres et comptes e-mail présents. Par défaut, la validité de ces droits est de 24 heures. Définissez la durée de validité qui vous convient, puis cliquez sur <code className="action">Authorize</code>.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
+    <img className="thumbnail" alt="Migration via la connexion au compte OVHcloud dans OMM, étape 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 4">
     - Vous serez à présent en mesure de sélectionner vos services et comptes à l'aide de menus déroulants. Cela facilite la recherche des éléments et permet d'éviter les erreurs de saisie. Il est toutefois nécessaire de saisir le mot de passe associé au compte e-mail sélectionné.
     
     Exemple avec un service Zimbra :
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
+    <img className="thumbnail" alt="Migration via la connexion au compte OVHcloud dans OMM, étape 5" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -171,7 +175,7 @@ Lorsque vous sélectionnez l'une de ces offres, suivez les étapes ci-dessous :
 :::warning
 Il est possible de déconnecter les accès en cours depuis un espace client OVHcloud en cliquant sur <code className="action">Se déconnecter</code>, puis sous la mention `Identifiant OVHcloud` cliquez sur <code className="action">Se déconnecter du compte</code>.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
+<img className="thumbnail" alt="Migration via la connexion au compte OVHcloud dans OMM, étape 6" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
 :::
 
 
@@ -184,7 +188,7 @@ Il existe deux moyens pour accéder au suivi de projet de migration :
 
 Cliquez ensuite sur <code className="action">Se connecter au projet</code> pour accéder à la page d'accueil du projet et suivre vos migrations.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Depuis cette page, vous retrouvez la liste des migrations en cours ou planifiées. Le statut du projet s'affiche également à droite.
 
@@ -194,16 +198,20 @@ Cliquez sur le bouton <code className="action">⋮</code> à droite de la ligne 
 - <code className="action">Annuler la migration</code> : Permet d'annuler la migration en cours. Les éléments déjà migrés seront conservés sur le compte de destination.
 - <code className="action">Supprimer mes données de migration (RGPD)</code> : Cette option déclenche la suppression de toutes les données relatives à la migration du compte. Vous conserverez néanmoins les informations concernant les événements survenus durant la migration.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
+<img className="thumbnail" alt="Suivi de l'avancement d'une migration dans OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
 
 Exemple de suivi de migration :
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
+<img className="thumbnail" alt="Exemple de suivi de migration dans OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
 
 :::info
 Si une erreur survient durant la migration, un lien vers le journal des erreurs vous sera fourni dans la fenêtre <code className="action">Voir plus de détails</code>.
 :::
 
+
+:::warning
+Une fois la migration terminée, connectez-vous au compte de destination et vérifiez que vous retrouvez tous vos éléments (e-mails, dossiers, contacts, agendas) — pour une adresse e-mail OVHcloud, utilisez le [Webmail OVHcloud](/links/web/email). **Ne supprimez pas le compte source tant que vous n'avez pas confirmé que tout a bien été migré**, faute de quoi les éléments non migrés seront définitivement perdus.
+:::
 
 ## Aller plus loin
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrer une adresse e-mail MX Plan vers un compte Zimbra OVHcloud
-description: Découvrez comment migrer une adresse e-mail MX Plan vers un compte Zimbra OVHcloud
-lastUpdated: 2026-06-23
+title: Zimbra - Migrer un compte e-mail MX Plan
+description: Migrez un compte e-mail MX Plan vers un compte Zimbra OVHcloud, puis réattribuez son adresse pour finaliser le changement
+lastUpdated: 2026-07-23
 availableIn: [eu]
 ---
 
@@ -35,6 +35,10 @@ Si vous souhaitez faire évoluer votre offre e-mail MX Plan vers une offre [Zimb
 
 </Region>
 
+:::tip
+Quelle que soit la méthode de migration, nous vous recommandons vivement de sauvegarder votre boîte e-mail au préalable, par précaution contre toute perte de données. Notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) » explique, étape par étape, comment sauvegarder une boîte e-mail (par exemple via un export au format PST) : réalisez cette sauvegarde avant de démarrer la migration.
+:::
+
 ## En pratique
 
 :::warning
@@ -53,7 +57,7 @@ La migration d'un compte e-mail MX Plan vers un compte e-mail Zimbra se fait en 
 
 Dans l'exemple ci-dessous, nous migrons l'adresse `contact@mydomain.ovh`. Pour cela nous allons créer le compte Zimbra sous le nom `contact2@mydomain.ovh`.
 
-<img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
+<img className="thumbnail" alt="Vue d'ensemble de la migration e-mail de MX Plan vers Zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
 
 ### 1 - Transférer le contenu du compte MX Plan vers un compte Zimbra <a name="step1"></a>
 
@@ -79,7 +83,7 @@ La migration avec OMM se déroule en 3 étapes : créer un projet, configurer la
 
     Rendez-vous sur [OVHcloud Mail Migrator](/links/web/omm) et cliquez sur <code className="action">Nouvelle migration</code>.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Page d'accueil d'OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
 
     - **Adresse e-mail de contact du projet** : Saisissez une adresse e-mail qui recevra les identifiants et les notifications de suivi. N'utilisez pas une adresse qui sera migrée dans ce projet.
     - **Mot de passe du projet** : Définissez un mot de passe (10 caractères minimum, avec au moins 1 caractère spécial, 1 chiffre, 1 majuscule et 1 minuscule).
@@ -93,7 +97,7 @@ La migration avec OMM se déroule en 3 étapes : créer un projet, configurer la
 
     Cliquez ensuite sur <code className="action">Nouvelle migration</code> pour paramétrer votre migration :
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
+    <img className="thumbnail" alt="Création de la migration de MX Plan vers Zimbra dans OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
     - **Compte source** :
         - **Type de compte** : sous la catégorie `OVHcloud`, choisissez `MX Plan` ou `Auto détection`. Cliquez sur <code className="action">Se connecter</code> pour vous identifier avec votre compte OVHcloud et sélectionner automatiquement le service et l'adresse à migrer (exemple : `contact@mydomain.ovh`). Saisissez ensuite le mot de passe de ce compte e-mail.
@@ -104,7 +108,7 @@ La migration avec OMM se déroule en 3 étapes : créer un projet, configurer la
 
     Cliquez sur <code className="action">Migrer mon compte</code> pour lancer la migration.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Configuration du compte de destination Zimbra dans OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 3">
     **Suivre la migration**
@@ -120,7 +124,7 @@ La migration avec OMM se déroule en 3 étapes : créer un projet, configurer la
     - <code className="action">Annuler la migration</code> : Annule la migration en cours. Les éléments déjà migrés sont conservés sur le compte de destination.
     - <code className="action">Supprimer mes données de migration (RGPD)</code> : Déclenche la suppression de toutes les données relatives à la migration. Les informations sur les événements de la migration sont conservées.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
+    <img className="thumbnail" alt="Suivi de l'avancement de la migration dans OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -139,6 +143,10 @@ Avant de supprimer votre compte MX Plan, **effectuez une sauvegarde de vos e-mai
 Utilisez les options d'export de votre client de messagerie. Vous trouverez, dans notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) », les détails d'export manuel d'une adresse e-mail depuis un client de messagerie.
 
 ### 2 - Supprimer le compte MX Plan d'origine et réassigner son adresse au compte Zimbra <a name="step2"></a>
+
+:::warning
+Avant de supprimer votre compte MX Plan d'origine, connectez-vous au [Webmail OVHcloud](/links/web/email) et vérifiez que tous vos éléments (e-mails, dossiers, contacts, agendas) ont bien été migrés vers le compte Zimbra. Une fois le compte d'origine supprimé, les éléments non migrés seront définitivement perdus.
+:::
 
 #### 2.1 - Suppression de l'ancienne adresse e-mail MX Plan <a name="step21"></a>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrare un indirizzo email MX Plan verso un account Email Pro, Exchange o Zimbra
-description: Come migrare un indirizzo email MX Plan verso un account Email Pro, Exchange o Zimbra
-lastUpdated: 2026-03-30
+title: MX Plan - Migrare verso Exchange, Email Pro o Zimbra
+description: Migra il tuo account email MX Plan verso un'offerta Exchange, Email Pro o Zimbra mantenendo messaggi, contatti e cartelle
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -73,6 +73,10 @@ Se le tue e-mail sono conservate localmente (configurazione POP o archivio local
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Qualunque sia il metodo di migrazione scelto, ti consigliamo vivamente di eseguire preventivamente un backup della tua casella email, per precauzione contro eventuali perdite di dati. La nostra guida [Migrare manualmente il tuo indirizzo email](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) spiega passo dopo passo come eseguire il backup di una casella email (ad esempio esportandola in un file PST): esegui questo backup prima di avviare la migrazione.
+:::
+
 ## Procedura
 
 ### Passaggio 1: Definisci il tuo progetto
@@ -103,7 +107,7 @@ La tecnologia e-mail della vostra offerta MX Plan può variare in base alla data
 1. La scheda <code className="action">Informazioni generali</code> è selezionata per impostazione predefinita.
 1. Individuate la tecnologia utilizzata sotto la dicitura **Webmail** nell'area `Abbonamento`.
 
-<img className="thumbnail" alt="MX plan" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
+<img className="thumbnail" alt="Pannello dell'abbonamento MX Plan che mostra la tecnologia Webmail nello Spazio Cliente OVHcloud" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
 :::
 
@@ -127,7 +131,7 @@ Se hai appena ordinato il nuovo servizio di posta, aggiungi il dominio alla tua 
 
 Seleziona la scheda <code className="action">Domini associati</code> o <code className="action">Dominio</code> sulla vostra piattaforma, quindi cliccate su <code className="action">Aggiungi un dominio</code>. Una volta aggiunto il nome di dominio, assicuratevi che l'indicazione `OK` o <code className="action">Attivo</code> sia presente nella colonna `Stato`.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Aggiunta del nome a dominio alla piattaforma email di destinazione" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
 
 <Region zones={['eu']}>
 Per ulteriori dettagli sull'aggiunta di un nome di dominio, seguite [la guida Email Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config), [la guida Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain) o [la guida Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra).
@@ -148,7 +152,7 @@ La migrazione del tuo MX Plan avverrà in 3 step, **Rinominare**, **Creare** e *
 
 Nella scheda <code className="action">Account email</code> della tua piattaforma MX Plan, clicca sul pulsante <code className="action">...</code> e poi su <code className="action">Modifica</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
+<img className="thumbnail" alt="Configurazione dell'account MX Plan per la migrazione nello Spazio Cliente, passaggio 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
 
 :::info
 La modifica dell'account non è immediata, ti preghiamo di attendere fino al termine dell'operazione prima di passare allo step successivo.
@@ -160,17 +164,19 @@ La modifica dell'account non è immediata, ti preghiamo di attendere fino al ter
 
 Nella scheda <code className="action">Account email</code> della tua piattaforma Email Pro o Exchange, clicca sul pulsante <code className="action">...</code> e poi su <code className="action">Modifica</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
+<img className="thumbnail" alt="Configurazione dell'account MX Plan per la migrazione nello Spazio Cliente, passaggio 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
 3\. **Migra** l'account MX Plan verso l'account della tua nuova piattaforma con l'aiuto del nostro tool [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
 
 Per maggiori informazioni su OMM, consulta la guida [Migrare account email via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
+<img className="thumbnail" alt="Configurazione dell'account MX Plan per la migrazione nello Spazio Cliente, passaggio 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
 
 Il tempo di migrazione dipende dalla quantità di contenuto da migrare verso il nuovo account. che può variare da pochi minuti a diverse ore.
 
-Una volta completata la migrazione, verifica di trovare i tuoi elementi accedendo alla [Webmail OVHcloud](https://www.ovhcloud.com/it/mail/).
+:::warning
+Una volta completata la migrazione, verifica di trovare i tuoi elementi accedendo alla [Webmail OVHcloud](/links/web/email). **Non eliminare l'indirizzo di origine prima di aver verificato che tutto sia stato migrato correttamente.** Una volta eliminato l'indirizzo di origine, gli elementi non migrati andranno persi in modo definitivo.
+:::
 
 Dopo la migrazione è possibile conservare o eliminare l'account di origine.
 
@@ -203,7 +209,7 @@ La migrazione può essere effettuata da due interfacce:<br/>
 
 > Ti ricordiamo che, prima di iniziare la migrazione, assicurati che sul tuo MX Plan non siano configurati **reindirizzamento** o che non siano impostati **segreteria**.
 >
-> <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
+> <img className="thumbnail" alt="Verifica che nessun reindirizzamento sia impostato sull'account MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
 
 Quando tutto è pronto, prosegui nella lettura di questa guida utilizzando l'interfaccia selezionata. Ti ricordiamo che il tempo di migrazione dipende dalla quantità di contenuto da migrare verso il tuo nuovo account. che può variare da pochi minuti a diverse ore.
 
@@ -225,7 +231,7 @@ Se l'assistente di configurazione non compare, visualizzi le informazioni genera
 
 Per effettuare la migrazione da questa interfaccia, accedi alla sezione <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> del tuo Spazio Cliente OVHcloud e seleziona il dominio interessato. Nella scheda <code className="action">Email</code>, clicca su <code className="action">...</code> sulla riga dell'account email interessato (chiamato anche account sorgente) e poi su <code className="action">Migra l'account</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
+<img className="thumbnail" alt="Accesso allo strumento di migrazione dall'interfaccia MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
 
 Nella nuova finestra, seleziona il servizio di destinazione (quello verso cui vuoi migrare l'indirizzo) e clicca su <code className="action">Continua</code>. Se ha almeno un account "libero" (cioè non ancora configurato), la migrazione avverrà verso uno di questi account. Leggi le informazioni mostrate, conferma e clicca su <code className="action">Continua</code> per continuare.
 
@@ -233,7 +239,7 @@ Se non hai un account "libero", apparirà un pulsante <code className="action">o
 
 Conferma la password associata all'indirizzo email sorgente (quello che vuoi migrare) e clicca su <code className="action">Trasferisci</code>. Questa operazione deve essere ripetuta per ogni trasferimento di account.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
+<img className="thumbnail" alt="Selezione degli account MX Plan da migrare nell'interfaccia" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
 
 </Region>
 
@@ -249,7 +255,7 @@ seleziona il tuo servizio Email Pro o Exchange e clicca sulla scheda <code class
 seleziona il tuo servizio Exchange e clicca sulla scheda <code className="action">Domini associati</code>. Nella tabella che appare, la colonna "Diagnostica" ti permette di vedere se la configurazione DNS è corretta: se è necessario modificare la configurazione, appare una casellina rossa.
 </Region>
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Verifica dei record DNS dei nomi a dominio associati" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
 Se hai appena effettuato la migrazione o modificato un record DNS del tuo dominio, è possibile che l'aggiornamento della pagina nello <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> richieda qualche ora.
@@ -269,7 +275,7 @@ Se hai configurato uno degli account migrati su un client di posta elettronica (
 
 Quando ti connetti per la prima volta al tuo nuovo account email, il contenuto migrato può essere parzialmente nascosto. Per visualizzare tutti gli elementi, clicca sul tuo nome utente in corrispondenza della `Casella di ricevimento` e inserisci le sottocartelle. Il contenuto migrato del tuo vecchio account email dovrebbe apparire.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
+<img className="thumbnail" alt="Visualizzazione delle cartelle e delle email migrate nella webmail OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
 
 Le cartelle predefinite, come "elementi inviati" o "cestino", sono disponibili in inglese ("Sent items" e "Trash"), ad eccezione delle cartelle che hai creato.
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Migrare i tuoi indirizzi email da una piattaforma OVHcloud verso un'altra"
-description: "Questa guida ti mostra come migrare gli indirizzi email da una piattaforma Exchange o Email Pro verso un'altra piattaforma Exchange, Email Pro, MX Plan o Zimbra"
-lastUpdated: 2026-03-30
+title: Migrare account email tra piattaforme OVHcloud
+description: Migra account email tra due piattaforme OVHcloud (Exchange, Email Pro, MX Plan) senza perdere messaggi, contatti e cartelle
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -75,6 +75,10 @@ Per migrare una soluzione MX Plan verso una piattaforma Exchange, consulta la gu
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Qualunque sia il metodo di migrazione scelto, ti consigliamo vivamente di eseguire preventivamente un backup della tua casella email, per precauzione contro eventuali perdite di dati. La nostra guida [Migrare manualmente il tuo indirizzo email](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) spiega passo dopo passo come eseguire il backup di una casella email (ad esempio esportandola in un file PST): esegui questo backup prima di avviare la migrazione.
+:::
+
 ## Procedura
 
 ### Configura la piattaforma di destinazione
@@ -84,7 +88,7 @@ Prima di iniziare la tua migrazione, se hai appena ordinato la tua nuova offerta
 
 Seleziona l'opzione <code className="action">Domini associati</code> o <code className="action">Dominio</code> sulla tua piattaforma, quindi clicca su <code className="action">Aggiungi un dominio</code>. Una volta aggiunto il nome del dominio, assicurati che l'indicazione `OK` o <code className="action">Attivo</code> sia presente nella colonna `Stato`.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Aggiunta del nome a dominio alla piattaforma email di destinazione" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
 
 Per ulteriori dettagli sull'aggiunta di un nome di dominio, segui la [guida Email Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config), la [guida Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain) o la [guida Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra).
 
@@ -112,7 +116,7 @@ Rinomina l'account email da migrare con un nome provvisorio (ad esempio: per mig
 
 Nella scheda <code className="action">Account email</code> della tua piattaforma email, clicca sui tre puntini <code className="action">...</code> e poi su <code className="action">Modifica</code>.
 
-<img className="thumbnail" alt="email-migrazione" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Rinomina di un account email sulla piattaforma di destinazione" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Crea
 
@@ -120,7 +124,7 @@ Crea il tuo indirizzo email sul nuovo account della tua piattaforma Email Pro, E
 
 Nella scheda <code className="action">Account email</code> della tua piattaforma, clicca sui tre puntini in corrispondenza dell'account <code className="action">...</code>. e seleziona <code className="action">Modifica</code>.
 
-<img className="thumbnail" alt="email-migrazione" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
+<img className="thumbnail" alt="Creazione dell'account email sulla piattaforma di destinazione" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
 
 #### Migrare
 
@@ -140,11 +144,13 @@ Migra l'account email "sorgente" verso l'account della tua nuova piattaforma con
 
 Per maggiori informazioni su OMM, consulta la guida [Migrare account email via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
-<img className="thumbnail" alt="email-migrazione" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
+<img className="thumbnail" alt="Migrazione dell'account email con OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
 
 Il tempo di migrazione dipende dalla quantità di dati da migrare verso il nuovo account. che può variare da pochi minuti a diverse ore.
 
-Una volta completata la migrazione, verifica di trovare tutti i tuoi elementi accedendo alla Webmail all'indirizzo Web [Webmail](https://www.ovhcloud.com/it/mail/).
+:::warning
+Una volta completata la migrazione, verifica di trovare tutti i tuoi elementi accedendo alla Webmail all'indirizzo Web [Webmail](/links/web/email). **Non eliminare l'indirizzo di origine prima di aver verificato che tutto sia stato migrato correttamente.** Una volta eliminato l'indirizzo di origine, gli elementi non migrati andranno persi in modo definitivo.
+:::
 
 Una volta completata la migrazione, puoi conservare o eliminare l'account di origine con il nome provvisorio.
 
@@ -156,7 +162,7 @@ In questa fase, gli account email devono essere già migrati e funzionali. Per m
 
 Per farlo, seleziona il servizio Email Pro, Exchange o Zimbra interessato, quindi vai nell'opzione <code className="action">Domini associati</code> o <code className="action">Dominio</code> sulla tua piattaforma. Verifica la sezione o la colonna <code className="action">Diagnostica</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Verifica dei record DNS dei nomi a dominio associati" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
 Se hai appena effettuato la migrazione o modificato un record DNS del tuo dominio, è possibile che l'aggiornamento della pagina nello <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> richieda qualche ora.

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrare accounti email tramite OVHcloud Mail Migrator
-description: Scopri come migrare i tuoi account email su OVHcloud utilizzando il nostro strumento OVHcloud Mail Migrator
-lastUpdated: 2025-11-25
+title: Migrare account email tramite OVHcloud Mail Migrator
+description: Migra i tuoi account email verso OVHcloud con OVHcloud Mail Migrator (OMM), inclusi messaggi, contatti e calendari
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -34,11 +34,15 @@ import { Region } from '@components/Zone';
 - Disporre delle credenziali relativi agli account email che si desidera migrare (gli account email sorgente).
 - Disporre delle credenziali relativi agli account email di destinazione.
 
+:::tip
+Qualunque sia il metodo di migrazione scelto, ti consigliamo vivamente di eseguire preventivamente un backup della tua casella email, per precauzione contro eventuali perdite di dati. La nostra guida [Migrare manualmente il tuo indirizzo email](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) spiega passo dopo passo come eseguire il backup di una casella email (ad esempio esportandola in un file PST): esegui questo backup prima di avviare la migrazione.
+:::
+
 ## Procedura
 
 Per accedere a OMM, vai all'indirizzo [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/).
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
+<img className="thumbnail" alt="Pagina iniziale di OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
 ### Creare un progetto di migrazione <a name="create-project"></a>
 
@@ -53,7 +57,7 @@ Clicca su <code className="action">Create my project</code> per avviare la creaz
 
 Sull'indirizzo email di contatto del progetto, riceverai un'email di conferma contenente l'identificativo unico del progetto e un link per accedervi.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
+<img className="thumbnail" alt="Creazione di un progetto di migrazione in OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
 
 :::info
 In caso di inattività per 60 giorni, il progetto di migrazione e tutti i dati associati verranno automaticamente eliminati.
@@ -69,13 +73,13 @@ Una volta creato il tuo progetto, accedi a esso dalla pagina iniziale di [OMM](h
 - Inserisci la `Project password` definita al momento della sua creazione.
 - Clicca su <code className="action">Connect to project</code> per completare.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Creazione di una nuova migrazione in OVHcloud Mail Migrator, passaggio 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Ora sei sulla pagina iniziale del progetto che ti permetterà di avviare la tua prima migrazione.
 
 - Clicca su <code className="action">New migration</code> in alto a sinistra del tavolo.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Creazione di una nuova migrazione in OVHcloud Mail Migrator, passaggio 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 Nella nuova pagina che appare, inserisci le informazioni di accesso dell'account sorgente e dell'account di destinazione per pianificare la migrazione o avviarla immediatamente. Ricorda, il contenuto dal **source account** verrà migrato verso al **destination account**.
 
@@ -85,7 +89,7 @@ Prima di iniziare la tua migrazione, è importante conoscere bene i 3 tipi di ac
 - **Others**: Si tratta di servizi email sottoscritti fuori da OVHcloud. È disponibile un elenco non esaustivo di servizi email supportati da OMM. Se il tipo di servizio del tuo account email non è incluso, utilizza i protocolli `IMAP` o `POP`, compatibili con la maggior parte dei server email.
 - **Importing files**: È possibile migrare il contenuto di file PST, ICS, CSV e XML Rules tramite OMM verso un account email di destinazione. Quando questa funzione è selezionata, basta trascinare e rilasciare il tuo documento nell'area dedicata o esplorare il tuo terminale tramite il pulsante <code className="action">Browse your files</code>.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Creazione di una nuova migrazione in OVHcloud Mail Migrator, passaggio 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Completa le informazioni in base al tipo di account:
 
@@ -114,7 +118,7 @@ Completa le informazioni in base al tipo di account:
 - **Start of transfer**: Puoi avviare la migrazione `Immediately` o selezionare `Later` per rimandarla. La migrazione differita ti permette di attivarla automaticamente a una data e un'ora che definisci.
 - **Data to transfer**: In base al tipo di account email che stai migrando e all'account di destinazione, questa sezione ti indicherà i diversi tipi di dati supportati durante la migrazione. Questo dipende dall'account sorgente e dall'account di destinazione.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Creazione di una nuova migrazione in OVHcloud Mail Migrator, passaggio 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 Se stai migrando un account che dispone di funzionalità che l'account di destinazione non possiede, **sarà necessario salvare autonomamente gli elementi che non potranno essere migrati da OMM**. Per aiutarti, consulta la nostra guida "[Migrare manualmente la tua email](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)".
@@ -130,7 +134,7 @@ Una volta completati i parametri degli account sorgente e di destinazione, clicc
 
 Durante una migrazione verso o da un account OVHcloud, è possibile selezionare una delle nostre offerte `MX plan`, `Email Pro`, `Exchange` o `Zimbra`.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
+<img className="thumbnail" alt="Migrazione tramite la connessione all'account OVHcloud in OMM, passaggio 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
 
 Quando si seleziona una di queste offerte, segui le seguenti fasi:
 
@@ -138,7 +142,7 @@ Quando si seleziona una di queste offerte, segui le seguenti fasi:
   <Tab label="Passo 1">
     - Clicca su <code className="action">Login</code> per visualizzare la finestra di accesso allo Spazio Cliente OVHcloud.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrazione tramite la connessione all'account OVHcloud in OMM, passaggio 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
   </Tab>
   <Tab label="Passo 2">
     Connetti l'account cliente OVHcloud:
@@ -151,19 +155,19 @@ Quando si seleziona una di queste offerte, segui le seguenti fasi:
     :::
 
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrazione tramite la connessione all'account OVHcloud in OMM, passaggio 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
   </Tab>
   <Tab label="Passo 3">
     - Si aprirà una nuova finestra. Ti permette di autorizzare OMM ad accedere alle funzioni del tuo spazio cliente e di elencare le offerte e gli account email presenti. Per default, la validità (Validity) di questi diritti è di 24 ore (1 day). Definisci la durata di validità che ti conviene, quindi clicca su <code className="action">Authorize</code>.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrazione tramite la connessione all'account OVHcloud in OMM, passaggio 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
   </Tab>
   <Tab label="Passo 4">
     - Ora sarai in grado di selezionare i tuoi servizi e account tramite menu a discesa. Questo facilita la ricerca degli elementi e permette di evitare errori di digitazione. È tuttavia necessario inserire la password associata all'account email selezionato.
     
     Esempio con un servizio Zimbra:
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrazione tramite la connessione all'account OVHcloud in OMM, passaggio 5" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -171,7 +175,7 @@ Quando si seleziona una di queste offerte, segui le seguenti fasi:
 :::warning
 È possibile disconnettere gli accessi in corso da uno Spazio Cliente OVHcloud cliccando su <code className="action">Log out</code>, quindi sotto la dicitura `OVHcloud account ID` clicca su <code className="action">Log out of the account</code>.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
+<img className="thumbnail" alt="Migrazione tramite la connessione all'account OVHcloud in OMM, passaggio 6" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
 :::
 
 
@@ -184,7 +188,7 @@ Esistono due modi per accedere al monitoraggio del progetto di migrazione:
 
 Clicca quindi su <code className="action">Connect to project</code> per accedere alla pagina iniziale del progetto e seguire le tue migrazioni.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Creazione di una nuova migrazione in OVHcloud Mail Migrator, passaggio 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Da questa pagina, troverai l'elenco delle migrazioni in corso o pianificate. Lo stato del progetto viene visualizzato anche a destra.
 
@@ -194,16 +198,20 @@ Clicca sul pulsante <code className="action">⋮</code> a destra della riga di u
 - <code className="action">Cancel migration</code>: Permette di annullare la migrazione in corso. Gli elementi già migrati verranno conservati sull'account di destinazione.
 - <code className="action">Delete migration data (GDPR)</code>: Questa opzione attiva l'eliminazione di tutti i dati relativi alla migrazione dell'account. Conserverai comunque le informazioni riguardanti gli eventi verificatisi durante la migrazione.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
+<img className="thumbnail" alt="Monitoraggio dell'avanzamento di una migrazione in OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
 
 Esempio di monitoraggio della migrazione:
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
+<img className="thumbnail" alt="Esempio di monitoraggio di una migrazione in OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
 
 :::info
 Se si verifica un errore durante la migrazione, ti verrà fornito un link al registro degli errori nella finestra <code className="action">See more details</code>.
 :::
 
+
+:::warning
+Una volta completata la migrazione, accedi all'account di destinazione e verifica che tutti i tuoi elementi (email, cartelle, contatti, calendari) siano presenti; per un indirizzo email OVHcloud, utilizza la [Webmail OVHcloud](/links/web/email). **Non eliminare l'account di origine prima di aver verificato che tutto sia stato migrato correttamente**, altrimenti gli elementi non migrati andranno persi in modo definitivo.
+:::
 
 ## Per saperne di più
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrare un indirizzo email MX Plan verso un account Zimbra OVHcloud
-description: Scopri come migrare un indirizzo email MX Plan verso un account Zimbra OVHcloud
-lastUpdated: 2026-06-23
+title: Zimbra - Migrare un account email MX Plan
+description: Migra un account email MX Plan verso un account Zimbra OVHcloud, poi riassegna il suo indirizzo per completare il passaggio
+lastUpdated: 2026-07-23
 availableIn: [eu]
 ---
 
@@ -35,6 +35,10 @@ Per fare evolvere il tuo servizio e-mail MX Plan verso un servizio [Zimbra OVHcl
 
 </Region>
 
+:::tip
+Qualunque sia il metodo di migrazione scelto, ti consigliamo vivamente di eseguire preventivamente un backup della tua casella email, per precauzione contro eventuali perdite di dati. La nostra guida [Migrare manualmente il tuo indirizzo email](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) spiega passo dopo passo come eseguire il backup di una casella email (ad esempio esportandola in un file PST): esegui questo backup prima di avviare la migrazione.
+:::
+
 ## Procedura
 
 :::warning
@@ -53,7 +57,7 @@ La migrazione di un account e-mail MX Plan verso un account e-mail Zimbra avvien
 
 Nell'esempio seguente, migriamo l'indirizzo `contact@mydomain.ovh`. Per farlo, creeremo l'account Zimbra con il nome `contact2@mydomain.ovh`.
 
-<img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
+<img className="thumbnail" alt="Panoramica della migrazione email da MX Plan a Zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
 
 ### 1 - Trasferire il contenuto dell'account MX Plan verso un account Zimbra <a name="step1"></a>
 
@@ -79,7 +83,7 @@ La migrazione con OMM avviene in 3 step: creare un progetto, configurare la migr
 
     Accedi a [OVHcloud Mail Migrator](/links/web/omm) e clicca su <code className="action">New migration</code>.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Pagina iniziale di OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
 
     - **Project contact email address**: Inserisci un indirizzo e-mail che riceverà le credenziali di accesso e le notifiche di monitoraggio. Non utilizzare un indirizzo che verrà migrato in questo progetto.
     - **Project password**: Definisci una password (minimo 10 caratteri, con almeno 1 carattere speciale, 1 cifra, 1 lettera maiuscola e 1 lettera minuscola).
@@ -93,7 +97,7 @@ La migrazione con OMM avviene in 3 step: creare un progetto, configurare la migr
 
     Clicca quindi su <code className="action">New migration</code> per configurare la tua migrazione:
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
+    <img className="thumbnail" alt="Creazione della migrazione da MX Plan a Zimbra in OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
     - **Source account**:
         - **Account type**: Nella categoria `OVHcloud`, scegli `MX Plan` o `Autodetect`. Clicca su <code className="action">Log in</code> per identificarti con il tuo account OVHcloud e selezionare automaticamente il servizio e l'indirizzo da migrare (esempio: `contact@mydomain.ovh`). Inserisci poi la password di questo account e-mail.
@@ -104,7 +108,7 @@ La migrazione con OMM avviene in 3 step: creare un progetto, configurare la migr
 
     Clicca su <code className="action">Migrate my account</code> per avviare la migrazione.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Configurazione dell'account di destinazione Zimbra in OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
   </Tab>
   <Tab label="Step 3">
     **Seguire la migrazione**
@@ -120,7 +124,7 @@ La migrazione con OMM avviene in 3 step: creare un progetto, configurare la migr
     - <code className="action">Cancel migration</code>: Annulla la migrazione in corso. Gli elementi già migrati vengono conservati nell'account di destinazione.
     - <code className="action">Delete my migration data (GDPR)</code>: Avvia l'eliminazione di tutti i dati relativi alla migrazione. Le informazioni sugli eventi della migrazione vengono conservate.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
+    <img className="thumbnail" alt="Monitoraggio dell'avanzamento della migrazione in OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -139,6 +143,10 @@ Prima di eliminare il tuo account MX Plan, **esegui un backup delle tue e-mail**
 Utilizza le opzioni di esportazione del tuo client di posta elettronica. Nella nostra guida "[Migrare manualmente il tuo indirizzo e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)", troverai i dettagli per l'esportazione manuale di un indirizzo e-mail da un client di posta.
 
 ### 2 - Eliminare l'account MX Plan originale e riassegnare il suo indirizzo all'account Zimbra <a name="step2"></a>
+
+:::warning
+Prima di eliminare il tuo account MX Plan originale, accedi alla [Webmail OVHcloud](/links/web/email) e verifica che tutti i tuoi elementi (email, cartelle, contatti, calendari) siano stati migrati sull'account Zimbra. Una volta eliminato l'account originale, gli elementi non migrati andranno persi in modo definitivo.
+:::
 
 #### 2.1 - Eliminazione del vecchio indirizzo e-mail MX Plan <a name="step21"></a>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrowanie adresu e-mail MX Plan do konta E-mail Pro, Exchange lub Zimbra
-description: Dowiedz się, jak przeprowadzić migrację adresu e-mail MX Plan do konta E-mail Pro, Exchange lub Zimbra
-lastUpdated: 2026-03-30
+title: MX Plan - Migracja do Exchange, Email Pro lub Zimbra
+description: Zmigruj konto e-mail MX Plan do oferty Exchange, Email Pro lub Zimbra, zachowując wiadomości, kontakty i foldery
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -73,6 +73,10 @@ Jeśli Twoje e-maile są zapisane lokalnie (konfiguracja POP lub archiwizacja lo
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Niezależnie od wybranej metody migracji zdecydowanie zalecamy wcześniejsze wykonanie kopii zapasowej skrzynki e-mail, aby zabezpieczyć się przed utratą danych. Nasz przewodnik [Ręczna migracja adresu e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) wyjaśnia krok po kroku, jak wykonać kopię zapasową skrzynki e-mail (na przykład poprzez eksport do pliku PST): wykonaj tę kopię zapasową przed rozpoczęciem migracji.
+:::
+
 ## W praktyce
 
 ### Etap 1: Określenie ram projektu
@@ -103,7 +107,7 @@ Technologia e-maila oferty MX Plan może się różnić w zależności od daty a
 1. Zazwyczaj wybrany jest zakładka <code className="action">Informacje ogólne</code>.
 1. Zanotuj technologię używaną pod hasłem **Webmail** w sekcji `Abonament`.
 
-<img className="thumbnail" alt="MX plan" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
+<img className="thumbnail" alt="Panel subskrypcji MX Plan pokazujący technologię webmail w Panelu klienta OVHcloud" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
 :::
 
@@ -127,7 +131,7 @@ Jeśli właśnie zamówiłeś nową ofertę e-mail, przed rozpoczęciem migracji
 
 Wybierz kartę <code className="action">Przypisane domeny</code> lub <code className="action">Domena</code> na swojej platformie, a następnie kliknij <code className="action">Dodaj domenę</code>. Po dodaniu nazwy domeny upewnij się, że w kolumnie `Status` znajduje się oznaczenie `OK` lub <code className="action">Aktywny</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Dodawanie nazwy domeny do docelowej platformy e-mail" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
 
 <Region zones={['eu']}>
 Aby uzyskać więcej informacji na temat dodania domeny, sprawdź [przewodnik E-mail Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config) lub [przewodnik Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
@@ -148,7 +152,7 @@ Migracja MX Plan przebiega 3 etapach. **Zmień nazwę**, **Utwórz** i **Migracj
 
 W zakładce <code className="action">Konta e-mail</code> na Twojej platformie MX Plan kliknij przycisk <code className="action">...</code>, a następnie <code className="action">Zmień</code>.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
+<img className="thumbnail" alt="Konfigurowanie konta MX Plan do migracji w Panelu klienta, krok 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
 
 :::info
 Modyfikacja konta nie jest natychmiastowa. Prosimy o cierpliwość do końca operacji, zanim przejdziesz do kolejnego etapu.
@@ -160,17 +164,19 @@ Modyfikacja konta nie jest natychmiastowa. Prosimy o cierpliwość do końca ope
 
 W zakładce <code className="action">Konta e-mail</code> na Twojej platformie E-mail Pro lub Exchange kliknij przycisk <code className="action">...</code>, a następnie <code className="action">Zmień</code>.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
+<img className="thumbnail" alt="Konfigurowanie konta MX Plan do migracji w Panelu klienta, krok 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
 3\. **Przenieś** konto MX Plan na konto nowej platformy za pomocą narzędzia [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
 
 Aby uzyskać więcej informacji na temat narzędzia OMM, zapoznaj się z naszym przewodnikiem [Migracja kont e-mail przez OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
+<img className="thumbnail" alt="Konfigurowanie konta MX Plan do migracji w Panelu klienta, krok 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
 
 Czas migracji zależy od ilości treści, które chcesz przenieść na nowe konto. Może się on różnić od kilku minut do kilku godzin.
 
-Po przeprowadzeniu migracji sprawdź, czy odnajdujesz swoje elementy, logując się do [Webmail OVHcloud](https://www.ovhcloud.com/pl/mail/).
+:::warning
+Po przeprowadzeniu migracji sprawdź, czy odnajdujesz swoje elementy, logując się do [Webmail OVHcloud](/links/web/email). **Nie usuwaj swojego pierwotnego adresu, dopóki nie potwierdzisz, że wszystko zostało poprawnie zmigrowane.** Po usunięciu pierwotnego adresu elementy, które nie zostały zmigrowane, zostaną bezpowrotnie utracone.
+:::
 
 Po przeprowadzeniu migracji możesz zachować lub usunąć konto źródłowe, używając tymczasowej nazwy.
 
@@ -203,7 +209,7 @@ Migracja może zostać przeprowadzona z dwóch interfejsów:<br/>
 
 > Przypominamy, że przed rozpoczęciem migracji upewnij się, że na serwerze MX Plan nie ma **przekierowania** lub żadna **autoresponder**.
 >
-> <img className="thumbnail" alt="e-mail" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
+> <img className="thumbnail" alt="Sprawdzanie, czy na koncie MX Plan nie ustawiono przekierowania" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
 
 Kiedy wszystko jest gotowe, przejdź do opisu operacji w wybranym interfejsie. Przypominamy, że czas migracji zależy od ilości treści, które chcesz przenieść na nowe konto. Może się on różnić od kilku minut do kilku godzin.
 
@@ -225,7 +231,7 @@ Jeśli asystent konfiguracji nie wyświetla się, wyświetlą się ogólne infor
 
 Aby przeprowadzić migrację w tym interfejsie, przejdź do sekcji <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> Panelu klienta OVHcloud i wybierz odpowiednią domenę. W karcie <code className="action">E-maile</code> kliknij logo w kształcie koła zębatego na linii odpowiedniego konta e-mail (zwane również kontem źródłowym), a następnie kliknij <code className="action">Przeprowadź migrację konta</code>.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
+<img className="thumbnail" alt="Dostęp do narzędzia migracji z poziomu interfejsu MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
 
 W oknie, które się wyświetla wybierz usługę docelową (do której chcesz przenieść adres) i kliknij <code className="action">Dalej</code>. Jeśli posiada co najmniej jedno "wolne" konto (tj. jeszcze nie skonfigurowane), migracja zostanie przeprowadzona na jedno z tych kont. Zapoznaj się z informacjami, które się wyświetlą, zatwierdź je, następnie kliknij <code className="action">Dalej</code>, aby kontynuować operację.
 
@@ -233,7 +239,7 @@ Jeśli nie posiadasz "wolnego" konta, pojawi się przycisk <code className="acti
 
 Następnie potwierdź hasło do źródłowego konta e-mail (które chcesz przenieść), następnie kliknij <code className="action">Migracja</code>. Operacja ta zostanie powtórzona tyle razy, ile będzie to konieczne do migracji innych kont.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
+<img className="thumbnail" alt="Wybieranie kont MX Plan do migracji w interfejsie" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
 
 </Region>
 
@@ -257,7 +263,7 @@ Jeśli właśnie przeprowadziłeś migrację lub zmodyfikowałeś rekord DNS Two
 
 Aby zmienić konfigurację, kliknij czerwony przycisk i wykonaj żądaną operację. Efekty modyfikacji domeny staną się widoczne po upływie 4-24 godzin ze względu na niezbędny czas propagacji.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Sprawdzanie rekordów DNS powiązanych nazw domen" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 ### Etap 5: Korzystać z migrowanych kont e-mail
 
@@ -269,7 +275,7 @@ Jeśli skonfigurowałeś jedno z kont przeniesionych na klienta poczty elektroni
 
 Podczas pierwszego logowania do nowego konta e-mail migrowane treści mogą być częściowo ukryte. Aby wyświetlić wszystkie elementy, w interfejsie Webmail kliknij przycisk "Przywozie" obok `Skrzynki odbiorczej`, aby wyświetlić podfoldery. Powinna pojawić się przeniesiona zawartość Twojego starego konta e-mail.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
+<img className="thumbnail" alt="Przeglądanie zmigrowanych folderów i e-maili w webmailu OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
 
 Domyślne katalogi, takie jak "elementy wysłane" lub "kosz", są wyświetlane w języku angielskim ("Sent items" i "Trash"), z wyjątkiem utworzonych przez Ciebie katalogów.
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migracja kont e-mail z jednej platformy e-mail OVHcloud do innej
-description: Dowiedz się, jak migrować adresy e-mail z jednej platformy Exchange lub E-mail Pro do innej platformy Exchange, E-mail Pro, MX Plan lub Zimbra
-lastUpdated: 2026-03-30
+title: Migracja kont e-mail między platformami OVHcloud
+description: Migruj konta e-mail między dwiema platformami OVHcloud (Exchange, Email Pro, MX Plan) bez utraty wiadomości, kontaktów i folderów
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -75,6 +75,10 @@ Aby przenieść rozwiązanie MX Plan na platformę Exchange, zapoznaj się z nas
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Niezależnie od wybranej metody migracji zdecydowanie zalecamy wcześniejsze wykonanie kopii zapasowej skrzynki e-mail, aby zabezpieczyć się przed utratą danych. Nasz przewodnik [Ręczna migracja adresu e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) wyjaśnia krok po kroku, jak wykonać kopię zapasową skrzynki e-mail (na przykład poprzez eksport do pliku PST): wykonaj tę kopię zapasową przed rozpoczęciem migracji.
+:::
+
 ## W praktyce
 
 ### Konfiguracja platformy docelowej
@@ -84,7 +88,7 @@ Przed rozpoczęciem migracji, jeśli właśnie zamówiłeś nową ofertę e-mail
 
 Wybierz kartę <code className="action">Przypisane domeny</code> lub <code className="action">Domena</code> na swojej platformie, a następnie kliknij <code className="action">Dodaj domenę</code>. Po dodaniu nazwy domeny upewnij się, że w kolumnie `Status` widoczna jest marka `OK` lub <code className="action">Aktywny</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Dodawanie nazwy domeny do docelowej platformy e-mail" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
 
 Aby uzyskać więcej informacji na temat dodania domeny, zapoznaj się [z przewodnikiem E-mail Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config) lub [przewodnikiem Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
 
@@ -112,7 +116,7 @@ Zmień nazwę konta e-mail, które chcesz przenieść, używając tymczasowej na
 
 W karcie <code className="action">Konta e-mail</code> Twojej platformy e-mail kliknij przycisk <code className="action">...</code>, a następnie <code className="action">Zmień</code>.
 
-<img className="thumbnail" alt="e-mail-migracja" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Zmiana nazwy konta e-mail na platformie docelowej" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Stwórz
 
@@ -120,7 +124,7 @@ Utwórz konto e-mail na nowym koncie w Twojej platformie E-mail Pro, Exchange lu
 
 W karcie <code className="action">Konta e-mail</code> Twojej platformy kliknij przycisk <code className="action">...</code> znajdujący się po prawej stronie docelowego konta e-mail, a następnie wybierz <code className="action">Zmień</code>.
 
-<img className="thumbnail" alt="e-mail-migracja" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
+<img className="thumbnail" alt="Tworzenie konta e-mail na platformie docelowej" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
 
 #### Migracja
 
@@ -140,11 +144,13 @@ Przenieś konto e-mail "source" na konto Twojej nowej platformy, korzystając z 
 
 Aby uzyskać więcej informacji na temat narzędzia OMM, zapoznaj się z naszym przewodnikiem [Migracja kont e-mail przez OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
-<img className="thumbnail" alt="e-mail-migracja" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
+<img className="thumbnail" alt="Migracja konta e-mail za pomocą OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
 
 Czas migracji zależy od ilości danych, które chcesz przenieść na nowe konto. Może się on różnić od kilku minut do kilku godzin.
 
-Po przeprowadzeniu migracji sprawdź, czy wszystkie Twoje dane znajdują się na stronie WWW pod linkiem [Webmail](https://www.ovhcloud.com/pl/mail/).
+:::warning
+Po przeprowadzeniu migracji sprawdź, czy wszystkie Twoje dane znajdują się na stronie WWW pod linkiem [Webmail](/links/web/email). **Nie usuwaj swojego pierwotnego adresu, dopóki nie potwierdzisz, że wszystko zostało poprawnie zmigrowane.** Po usunięciu pierwotnego adresu elementy, które nie zostały zmigrowane, zostaną bezpowrotnie utracone.
+:::
 
 Po przeprowadzeniu migracji możesz zachować lub usunąć konto źródłowe używając tymczasowej nazwy.
 
@@ -156,7 +162,7 @@ Na tym etapie Twoje konta e-mail muszą być migrowane i działać. Ze względó
 
 Aby to zrobić, wybierz odpowiedni serwis E-mail Pro, Exchange lub Zimbra, a następnie przejdź do karty <code className="action">Przypisane domeny</code> lub <code className="action">Domena</code> na swojej platformie. Sprawdź sekcję lub kolumnę <code className="action">Diagnostyka</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Sprawdzanie rekordów DNS powiązanych nazw domen" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
 Jeśli właśnie przeprowadziłeś migrację lub zmodyfikowałeś rekord DNS Twojej domeny, aktualizacja może potrwać kilka godzin, jeśli wyświetlenie się w <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>.

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrowanie kont e-mailowych za pomocą OVHcloud Mail Migrator
-description: Dowiedz się, jak przenieść swoje konta e-mail do OVHcloud, korzystając z naszego narzędzia OVHcloud Mail Migrator
-lastUpdated: 2025-11-25
+description: Przenieś konta e-mail do OVHcloud za pomocą OVHcloud Mail Migrator (OMM), w tym wiadomości, kontakty i kalendarze
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -34,11 +34,15 @@ import { Region } from '@components/Zone';
 - Posiadaj dane logowania do kont e-mailowych, które chcesz przenieść (konta źródłowe).
 - Posiadaj dane logowania do kont e-mailowych docelowych.
 
+:::tip
+Niezależnie od wybranej metody migracji zdecydowanie zalecamy wcześniejsze wykonanie kopii zapasowej skrzynki e-mail, aby zabezpieczyć się przed utratą danych. Nasz przewodnik [Ręczna migracja adresu e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) wyjaśnia krok po kroku, jak wykonać kopię zapasową skrzynki e-mail (na przykład poprzez eksport do pliku PST): wykonaj tę kopię zapasową przed rozpoczęciem migracji.
+:::
+
 ## W praktyce
 
 Aby uzyskać dostęp do OMM, przejdź na [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/).
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
+<img className="thumbnail" alt="Strona główna OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
 ### Tworzenie projektu migracji <a name="create-project"></a>
 
@@ -53,7 +57,7 @@ Kliknij <code className="action">Create my project</code>, aby rozpocząć tworz
 
 Na adres e-mail kontaktowy projektu otrzymasz wiadomość e-mail potwierdzającą zawierającą unikalny identyfikator projektu i link do jego otwarcia.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
+<img className="thumbnail" alt="Tworzenie projektu migracji w OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
 
 :::info
 Jeśli nie będzie żadnej aktywności przez 60 dni, projekt migracji i wszystkie powiązane z nim dane zostaną automatycznie usunięte.
@@ -69,13 +73,13 @@ Po utworzeniu projektu zaloguj się do niego z [strony głównej OMM](https://om
 - Wprowadź `Project password` ustawione podczas jego tworzenia.
 - Kliknij <code className="action">Connect to project</code>, aby ukończyć.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Tworzenie nowej migracji w OVHcloud Mail Migrator, krok 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Teraz jesteś na stronie głównej projektu, która pozwoli Ci rozpocząć pierwszą migrację.
 
 - Kliknij <code className="action">New migration</code> w lewym górnym rogu tabeli.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Tworzenie nowej migracji w OVHcloud Mail Migrator, krok 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 Na nowej stronie, która się pojawi, wprowadź dane logowania konta źródłowego i konta docelowego, aby zaplanować migrację lub rozpocząć ją od razu. Dla przypomnienia, zawartość **source account** zostanie przeniesiona do **destination account**.
 
@@ -85,7 +89,7 @@ Przed rozpoczęciem migracji ważne jest, aby wiedzieć o trzech typach kont, kt
 - **Others**: Są to usługi poczty e-mail subskrybowane poza OVHcloud. Dostępna jest niekompletna lista usług poczty e-mail obsługiwanych przez OMM. Jeśli typ usługi Twojego konta e-mail nie znajduje się na liście, użyj protokołów `IMAP` lub `POP`, kompatybilnych z większością serwerów poczty e-mail.
 - **Importing files**: Możliwe jest przeniesienie zawartości plików PST, ICS, CSV i XML Rules przez OMM do konta poczty e-mail docelowego. Gdy ta funkcja zostanie wybrana, po prostu przeciągnij i upuść swój dokument do wyznaczonej strefy lub przejdź do terminala za pomocą przycisku <code className="action">Browse your files</code>.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Tworzenie nowej migracji w OVHcloud Mail Migrator, krok 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Uzupełnij informacje zgodnie z typem konta:
 
@@ -114,7 +118,7 @@ Uzupełnij informacje zgodnie z typem konta:
 - **Start of transfer**: Możesz rozpocząć migrację `Immediately` lub zaznaczyć `Later`, aby odłożyć ją. Odłożona migracja pozwala na jej automatyczne rozpoczęcie w dniu i godzinie, które określisz.
 - **Data to transfer**: W zależności od typu konta e-mail, którego przenosisz, i konta docelowego, ta sekcja wskazuje różne typy danych obsługiwane podczas migracji. To zależy od konta źródłowego i konta docelowego.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Tworzenie nowej migracji w OVHcloud Mail Migrator, krok 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 Jeśli przenosisz konto, które ma funkcje, których konto docelowe nie posiada, **będziesz musiał samodzielnie zapisać elementy, które nie mogą zostać przeniesione przez OMM**. Aby Ci w tym pomóc, zapoznaj się z naszym przewodnikiem "[Ręczna migracja Twojego konta e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)".
@@ -130,7 +134,7 @@ Po uzupełnieniu ustawień konta źródłowego i docelowego kliknij:
 
 Przy migracji do lub z konta OVHcloud możesz wybrać jedną z naszych ofert `MX plan`, `E-mail Pro`, `Exchange` lub `Zimbra`.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
+<img className="thumbnail" alt="Migracja poprzez połączenie z kontem OVHcloud w OMM, krok 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
 
 Gdy wybierzesz jedną z tych ofert, wykonaj poniższe kroki:
 
@@ -138,7 +142,7 @@ Gdy wybierzesz jedną z tych ofert, wykonaj poniższe kroki:
   <Tab label="Krok 1">
     - Kliknij <code className="action">Login</code>, aby wyświetlić okno logowania do Panelu klienta OVHcloud.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Migracja poprzez połączenie z kontem OVHcloud w OMM, krok 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
   </Tab>
   <Tab label="Krok 2">
     Zaloguj się do konta klienta OVHcloud:
@@ -151,19 +155,19 @@ Gdy wybierzesz jedną z tych ofert, wykonaj poniższe kroki:
     :::
 
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
+    <img className="thumbnail" alt="Migracja poprzez połączenie z kontem OVHcloud w OMM, krok 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
   </Tab>
   <Tab label="Krok 3">
     - Pojawia się nowe okno. Pozwala ono na udzielenie OMM uprawnień do dostępu do funkcji Twojej strefy klienta, a także na wyświetlenie ofert i kont pocztowych. Domyślnie ważność (Validity) tych uprawnień wynosi 24 godziny (1 dzień). Ustaw okres ważności, który Ci odpowiada, a następnie kliknij <code className="action">Authorize</code>.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
+    <img className="thumbnail" alt="Migracja poprzez połączenie z kontem OVHcloud w OMM, krok 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
   </Tab>
   <Tab label="Krok 4">
     - Możesz teraz wybrać swoje usługi i konta z użyciem rozwijanych list. Umożliwia to łatwe wyszukiwanie elementów i uniknięcie błędów wpisywania. Należy jednak wpisać hasło powiązane z wybranym kontem e-mail.
     
     Przykład z usługą Zimbra:
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
+    <img className="thumbnail" alt="Migracja poprzez połączenie z kontem OVHcloud w OMM, krok 5" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -171,7 +175,7 @@ Gdy wybierzesz jedną z tych ofert, wykonaj poniższe kroki:
 :::warning
 Możesz wylogować bieżące połączenia z Panelu klienta OVHcloud, klikając <code className="action">Log out</code>, a następnie pod spodem przy wzmiance `OVHcloud account ID`, kliknij <code className="action">Log out of the account</code>.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
+<img className="thumbnail" alt="Migracja poprzez połączenie z kontem OVHcloud w OMM, krok 6" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
 :::
 
 
@@ -184,7 +188,7 @@ Istnieją dwa sposoby uzyskania dostępu do śledzenia projektu migracji:
 
 Kliknij <code className="action">Connect to project</code>, aby uzyskać dostęp do strony głównej projektu i śledzić swoje migracje.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Tworzenie nowej migracji w OVHcloud Mail Migrator, krok 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Na tej stronie znajdziesz listę trwających lub zaplanowanych migracji. Status projektu również pojawia się po prawej stronie.
 
@@ -194,16 +198,20 @@ Kliknij przycisk <code className="action">⋮</code> po prawej stronie wiersza m
 - <code className="action">Cancel migration</code>: Pozwala to na anulowanie trwającej migracji. Przemieszczone elementy zostaną nadal na koncie docelowym.
 - <code className="action">Delete migration data (GDPR)</code>: Ta opcja uruchamia usunięcie wszystkich danych związanych z migracją konta. Nadal zachowasz informacje dotyczące zdarzeń, które miały miejsce podczas migracji.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
+<img className="thumbnail" alt="Śledzenie postępu migracji w OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
 
 Przykład śledzenia migracji:
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
+<img className="thumbnail" alt="Przykład śledzenia migracji w OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
 
 :::info
 Jeśli podczas migracji wystąpi błąd, link do logu błędu zostanie wyświetlony w oknie <code className="action">See more details</code>.
 :::
 
+
+:::warning
+Po zakończeniu migracji zaloguj się na konto docelowe i sprawdź, czy wszystkie Twoje elementy (wiadomości, foldery, kontakty, kalendarze) są obecne — w przypadku adresu e-mail OVHcloud skorzystaj z [Webmail OVHcloud](/links/web/email). **Nie usuwaj konta źródłowego, dopóki nie potwierdzisz, że wszystko zostało poprawnie zmigrowane**, w przeciwnym razie elementy, które nie zostały zmigrowane, zostaną bezpowrotnie utracone.
+:::
 
 ## Sprawdź również
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migracja adresu e-mail MX Plan na konto Zimbra OVHcloud
-description: Dowiedz się, jak przenieść adres e-mail MX Plan na konto Zimbra OVHcloud
-lastUpdated: 2026-06-23
+title: Zimbra - Migracja konta e-mail MX Plan
+description: Zmigruj konto e-mail MX Plan na konto Zimbra OVHcloud, a następnie ponownie przypisz jego adres, aby zakończyć zmianę
+lastUpdated: 2026-07-23
 availableIn: [eu]
 ---
 
@@ -35,6 +35,10 @@ Jeśli chcesz przenieść swoją ofertę e-mail MX Plan na ofertę [Zimbra OVHcl
 
 </Region>
 
+:::tip
+Niezależnie od wybranej metody migracji zdecydowanie zalecamy wcześniejsze wykonanie kopii zapasowej skrzynki e-mail, aby zabezpieczyć się przed utratą danych. Nasz przewodnik [Ręczna migracja adresu e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) wyjaśnia krok po kroku, jak wykonać kopię zapasową skrzynki e-mail (na przykład poprzez eksport do pliku PST): wykonaj tę kopię zapasową przed rozpoczęciem migracji.
+:::
+
 ## W praktyce
 
 :::warning
@@ -53,7 +57,7 @@ Migracja konta e-mail MX Plan na konto e-mail Zimbra odbywa się w 2 etapach. Ab
 
 W poniższym przykładzie migrujemy adres `contact@mydomain.ovh`. W tym celu utworzymy konto Zimbra o nazwie `contact2@mydomain.ovh`.
 
-<img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
+<img className="thumbnail" alt="Przegląd migracji e-mail z MX Plan do Zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
 
 ### 1 - Przeniesienie zawartości konta MX Plan na konto Zimbra <a name="step1"></a>
 
@@ -79,7 +83,7 @@ Migracja za pomocą OMM przebiega w 3 krokach: tworzenie projektu, konfiguracja 
 
     Przejdź na stronę [OVHcloud Mail Migrator](/links/web/omm) i kliknij <code className="action">New migration</code>.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Strona główna OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
 
     - **Project contact email address**: Wpisz adres e-mail, który będzie otrzymywał dane logowania i powiadomienia o postępach. Nie używaj adresu, który będzie migrowany w tym projekcie.
     - **Project password**: Ustaw hasło (co najmniej 10 znaków, w tym co najmniej 1 znak specjalny, 1 cyfra, 1 wielka litera i 1 mała litera).
@@ -93,7 +97,7 @@ Migracja za pomocą OMM przebiega w 3 krokach: tworzenie projektu, konfiguracja 
 
     Następnie kliknij <code className="action">New migration</code>, aby skonfigurować migrację:
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
+    <img className="thumbnail" alt="Tworzenie migracji z MX Plan do Zimbra w OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
     - **Source account**:
         - **Account type**: W kategorii `OVHcloud` wybierz `MX Plan` lub `Autodetect`. Kliknij <code className="action">Log in</code>, aby zalogować się na swoje konto OVHcloud i automatycznie wybrać usługę oraz adres do migracji (np.: `contact@mydomain.ovh`). Następnie wpisz hasło do tego konta e-mail.
@@ -104,7 +108,7 @@ Migracja za pomocą OMM przebiega w 3 krokach: tworzenie projektu, konfiguracja 
 
     Kliknij <code className="action">Migrate my account</code>, aby rozpocząć migrację.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Konfigurowanie docelowego konta Zimbra w OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
   </Tab>
   <Tab label="Krok 3">
     **Śledzenie migracji**
@@ -120,7 +124,7 @@ Migracja za pomocą OMM przebiega w 3 krokach: tworzenie projektu, konfiguracja 
     - <code className="action">Cancel migration</code>: Anuluje trwającą migrację. Elementy już zmigrowane są zachowane na koncie docelowym.
     - <code className="action">Delete my migration data (GDPR)</code>: Powoduje usunięcie wszystkich danych związanych z migracją. Informacje o zdarzeniach migracji są zachowywane.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
+    <img className="thumbnail" alt="Śledzenie postępu migracji w OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -139,6 +143,10 @@ Przed usunięciem konta MX Plan **wykonaj kopię zapasową swoich e-maili**, aby
 Skorzystaj z opcji eksportu w programie pocztowym. W naszym przewodniku "[Ręczna migracja adresu e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)" znajdziesz szczegółowe informacje na temat ręcznego eksportu adresu e-mail z programu pocztowego.
 
 ### 2 - Usunięcie pierwotnego konta MX Plan i przypisanie jego adresu do konta Zimbra <a name="step2"></a>
+
+:::warning
+Przed usunięciem pierwotnego konta MX Plan zaloguj się do [Webmail OVHcloud](/links/web/email) i sprawdź, czy wszystkie Twoje elementy (wiadomości, foldery, kontakty, kalendarze) zostały zmigrowane na konto Zimbra. Po usunięciu pierwotnego konta elementy, które nie zostały zmigrowane, zostaną bezpowrotnie utracone.
+:::
 
 #### 2.1 - Usunięcie starego adresu e-mail MX Plan <a name="step21"></a>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrar um endereço de e-mail MX Plan para uma conta de E-mail Pro, Exchange ou Zimbra
-description: Descubra como migrar um endereço de e-mail MX Plan para uma conta de E-mail Pro, Exchange ou Zimbra
-lastUpdated: 2026-03-30
+title: MX Plan - Migrar para Exchange, Email Pro ou Zimbra
+description: Migre a sua conta de e-mail MX Plan para uma oferta Exchange, Email Pro ou Zimbra mantendo mensagens, contactos e pastas
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -73,6 +73,10 @@ Se os seus e-mails estiverem apenas armazenados localmente (configuração em PO
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Seja qual for o método de migração, recomendamos vivamente que faça previamente uma cópia de segurança da sua caixa de e-mail, como precaução contra qualquer perda de dados. O nosso guia [Migrar manualmente o seu endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) explica passo a passo como fazer uma cópia de segurança de uma caixa de e-mail (por exemplo, exportando-a para um ficheiro PST): faça esta cópia de segurança antes de iniciar a migração.
+:::
+
 ## Instruções
 
 ### Etapa 1: Definir o projeto
@@ -103,7 +107,7 @@ A tecnologia de e-mail da sua oferta MX Plan pode variar consoante a data de ati
 1. O separador <code className="action">Informações gerais</code> está selecionado por defeito.
 1. Registe a tecnologia utilizada sob a menção **Webmail** no quadro `Subscrição`.
 
-<img className="thumbnail" alt="MX plan" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
+<img className="thumbnail" alt="Painel de subscrição do MX Plan a mostrar a tecnologia Webmail na Área de Cliente OVHcloud" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
 :::
 
@@ -127,7 +131,7 @@ Se acabou de encomendar a sua nova oferta de e-mail, adicione o domínio à sua 
 
 Selecione o separador <code className="action">Domínios associados</code> na sua plataforma, e clique em <code className="action">Adicionar domínio</code>. Uma vez adicionado o domínio, certifique-se de que a menção `OK` está na coluna `Estado`.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Adicionar o nome de domínio à plataforma de e-mail de destino" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
 
 <Region zones={['eu']}>
 Para mais detalhes sobre a adição de um nome de domínio, siga [o guia E-mail Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config), [o guia Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain) ou [o guia Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra).
@@ -148,7 +152,7 @@ A migração do seu MX Plan far-se-á em 3 grandes etapas, **Renomear**, **Criar
 
 No separador <code className="action">Contas de e-mail</code> da plataforma MX Plan, clique no botão <code className="action">...</code> e depois em <code className="action">Alterar</code>.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
+<img className="thumbnail" alt="Configurar a conta MX Plan para migração na Área de Cliente, passo 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
 
 :::info
 A alteração da conta não é imediata. Aguarde até ao fim da operação antes de avançar para a etapa seguinte.
@@ -160,17 +164,19 @@ A alteração da conta não é imediata. Aguarde até ao fim da operação antes
 
 No separador <code className="action">Contas de e-mail</code> da plataforma E-mail Pro ou Exchange, clique no botão <code className="action">...</code> e depois em <code className="action">Alterar</code>.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
+<img className="thumbnail" alt="Configurar a conta MX Plan para migração na Área de Cliente, passo 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
 3\. **Migre** a conta MX Plan para a sua nova plataforma com a nossa ferramenta [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
 
 Para mais informações sobre OMM, consulte o nosso guia [Migrar contas de e-mail através do OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
+<img className="thumbnail" alt="Configurar a conta MX Plan para migração na Área de Cliente, passo 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
 
 O tempo de migração depende da quantidade de conteúdo a migrar para a sua nova conta. Pode variar de alguns minutos a várias horas.
 
-Após a migração, verifique que encontra os seus elementos ao aceder ao [Webmail OVHcloud](https://www.ovhcloud.com/pt/mail/).
+:::warning
+Após a migração, verifique que encontra os seus elementos ao aceder ao [Webmail OVHcloud](/links/web/email). **Não elimine o seu endereço de origem enquanto não tiver confirmado que tudo foi corretamente migrado.** Depois de eliminado o endereço de origem, os elementos que não tenham sido migrados serão perdidos de forma permanente.
+:::
 
 Pode conservar ou eliminar a conta de origem com o nome provisório após esta migração.
 
@@ -203,7 +209,7 @@ A migração pode ser efetuada a partir de duas interfaces:<br/>
 
 > Lembre-se de que antes de iniciar a migração, certifique-se de que nenhum *reencaminhamento* ou que nenhum *atendedor automático* está configurado no seu MX Plan.
 >
-> <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
+> <img className="thumbnail" alt="Verificar que não existe nenhuma redireção definida na conta MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
 
 Quando estiver pronto, continue a ler este manual em função da interface selecionada. Lembramos que o tempo de migração depende da quantidade de conteúdo a migrar para a sua nova conta. Pode variar de alguns minutos a várias horas.
 
@@ -225,7 +231,7 @@ Se o assistente de configuração não for apresentado, aparecerão as informaç
 
 Para realizar a migração a partir desta interface, aceda à secção <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> da sua Área de Cliente OVHcloud e selecione o domínio em causa. No separador <code className="action">E-mails</code>, clique no ícone em forma de engrenagem na linha da conta de e-mail em causa (também designada conta de origem) e, a seguir, em <code className="action">Migrar conta</code>.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
+<img className="thumbnail" alt="Aceder à ferramenta de migração a partir da interface do MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
 
 Na nova janela, selecione o destino (para o qual pretende migrar o endereço) e clique em <code className="action">Seguinte</code>. Se possuir no mínimo uma conta "livre" (ou seja, ainda não parametrizada), a migração efetuar-se-á para uma destas contas. De seguida, leia as informações apresentadas, valide-as e clique em <code className="action">Seguinte</code>.
 
@@ -233,7 +239,7 @@ Se não possuir uma conta "livre", aparecerá um botão <code className="action"
 
 Por fim, confirme a palavra-passe do endereço de e-mail original (aquela que pretende migrar) e clique em <code className="action">Migrar</code>. Esta operação deve ser repetida tantas vezes quantas as necessárias para a migração de outras contas.
 
-<img className="thumbnail" alt="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
+<img className="thumbnail" alt="Selecionar as contas MX Plan a migrar na interface" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_steps.png" loading="lazy" />
 
 </Region>
 
@@ -249,7 +255,7 @@ Para isso, selecione o serviço E-mail Pro ou Exchange em questão e aceda ao se
 Para isso, selecione o serviço Exchange em questão e aceda ao separador <code className="action">Domínios associados</code>. Na tabela que vai aparecer, a coluna "Diagnóstico" irá permitir-lhe ver se a configuração DNS está correta: se a configuração tiver de ser alterada, aparecerá uma etiqueta vermelha.
 </Region>
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Verificar os registos DNS dos nomes de domínio associados" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
 Se acabou de migrar ou alterar um registo DNS do seu domínio, é possível que a visualização na <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> necessite de algumas horas para se atualizar.
@@ -269,7 +275,7 @@ Se configurou uma das contas migradas num cliente de e-mail (como o Outlook), de
 
 Quando se liga pela primeira vez à sua nova conta de e-mail, o conteúdo migrado pode estar parcialmente oculto. Para apresentar todos os elementos, a partir do webmail, clique no master junto da "Caixa de Receção" para revelar os subpasta. O conteúdo migrado da sua antiga conta de e-mail deverá aparecer.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
+<img className="thumbnail" alt="Consultar as pastas e os e-mails migrados no webmail da OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
 
 As pastas predefinidas, como "elementos enviados" ou "lixeira", aparecem em inglês ("Sent items" e "Trash"), à exceção das pastas que criou.
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrar os endereços de e-mail de uma plataforma de e-mail OVHcloud para outra
-description: Saiba como migrar os endereços de e-mail de uma plataforma Exchange ou E-mail Pro para outra plataforma Exchange, E-mail Pro, MX Plan ou Zimbra
-lastUpdated: 2026-03-30
+title: Migrar contas de e-mail entre plataformas OVHcloud
+description: Migre contas de e-mail entre duas plataformas OVHcloud (Exchange, Email Pro, MX Plan) sem perder mensagens, contactos ou pastas
+lastUpdated: 2026-07-23
 availableIn: [eu, ca]
 ---
 
@@ -75,6 +75,10 @@ Para migrar uma solução MX Plan para uma plataforma Exchange, sugerimos que si
 {/* CP-NAV-END:web-email-pro */}
 {/* CP-NAV-END:web-mx-plan */}
 
+:::tip
+Seja qual for o método de migração, recomendamos vivamente que faça previamente uma cópia de segurança da sua caixa de e-mail, como precaução contra qualquer perda de dados. O nosso guia [Migrar manualmente o seu endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) explica passo a passo como fazer uma cópia de segurança de uma caixa de e-mail (por exemplo, exportando-a para um ficheiro PST): faça esta cópia de segurança antes de iniciar a migração.
+:::
+
 ## Instruções
 
 ### Configurar a plataforma de destino
@@ -84,7 +88,7 @@ Antes de iniciar a sua migração, se acabou de encomendar a sua nova oferta de 
 
 Selecione o separador <code className="action">Domínios associados</code> ou <code className="action">Domínio</code> na sua plataforma, em seguida clique em <code className="action">Adicionar domínio</code>. Uma vez o nome de domínio adicionado, certifique-se de que a indicação `OK` ou <code className="action">Ativo</code> está bem presente na coluna `Estado`.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
+<img className="thumbnail" alt="Adicionar o nome de domínio à plataforma de e-mail de destino" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
 
 Para mais informações sobre a adição de um domínio, siga [o guia E-mail Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/first-config) ou [o guia Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
 
@@ -112,7 +116,7 @@ Dê um nome provisório à conta de e-mail a migrar (exemplo: para migrar a cont
 
 No separador <code className="action">Contas de e-mail</code> da sua plataforma de e-mail, clique no botão <code className="action">...</code> e depois em <code className="action">Alterar</code>.
 
-<img className="thumbnail" alt="email-migração" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Renomear uma conta de e-mail na plataforma de destino" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Criar
 
@@ -120,7 +124,7 @@ Crie o seu endereço de e-mail na nova conta da sua plataforma E-mail Pro, Excha
 
 No separador <code className="action">Contas de e-mail</code> da sua plataforma, clique no botão <code className="action">...</code>, à direita da conta de e-mail de destino, e depois em <code className="action">Alterar</code>.
 
-<img className="thumbnail" alt="email-migração" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
+<img className="thumbnail" alt="Criar a conta de e-mail na plataforma de destino" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform05.png" loading="lazy" />
 
 #### Migrar
 
@@ -140,11 +144,13 @@ Migre a conta de e-mail "source" para a sua nova plataforma com a ajuda da nossa
 
 Para mais informações sobre OMM, consulte o nosso guia [Migrar contas de e-mail através do OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
-<img className="thumbnail" alt="email-migração" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
+<img className="thumbnail" alt="Migrar a conta de e-mail com o OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
 
 O tempo de migração depende da quantidade de dados a migrar para a sua nova conta. Pode variar de alguns minutos a várias horas.
 
-Depois da migração, verifique que encontra todos os seus elementos ao aceder ao webmail [Webmail](https://www.ovhcloud.com/pt/mail/).
+:::warning
+Depois da migração, verifique que encontra todos os seus elementos ao aceder ao webmail [Webmail](/links/web/email). **Não elimine o seu endereço de origem enquanto não tiver confirmado que tudo foi corretamente migrado.** Depois de eliminado o endereço de origem, os elementos que não tenham sido migrados serão perdidos de forma permanente.
+:::
 
 Depois de efetuar a migração, pode conservar ou eliminar a conta de origem com o nome provisório.
 
@@ -156,7 +162,7 @@ Nesta etapa, os seus endereços de e-mail já devem ser migrados e funcionais. P
 
 Para isso, selecione o serviço E-mail Pro, Exchange ou Zimbra em causa, em seguida dirija-se ao separador <code className="action">Domínios associados</code> ou <code className="action">Domínio</code> na sua plataforma. Verifique a rubrica ou a coluna <code className="action">Diagnóstico</code>.
 
-<img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
+<img className="thumbnail" alt="Verificar os registos DNS dos nomes de domínio associados" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
 Se acabou de migrar ou alterar um registo DNS do seu domínio, é possível que a visualização na <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> necessite de algumas horas para se atualizar.

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar contas de e-mail com o OVHcloud Mail Migrator
-description: Saiba como migrar as suas contas de e-mail para a OVHcloud com a nossa ferramenta OVHcloud Mail Migrator
-lastUpdated: 2025-11-25
+description: Migre as suas contas de e-mail para a OVHcloud com o OVHcloud Mail Migrator (OMM), incluindo mensagens, contactos e calendários
+lastUpdated: 2026-07-23
 availableIn: [eu, ca, apac]
 ---
 
@@ -34,11 +34,15 @@ import { Region } from '@components/Zone';
 - Dispor das credenciais das contas de e-mail que pretende migrar (as contas de e-mail fonte).
 - Dispor das credenciais das contas de e-mail de destino.
 
+:::tip
+Seja qual for o método de migração, recomendamos vivamente que faça previamente uma cópia de segurança da sua caixa de e-mail, como precaução contra qualquer perda de dados. O nosso guia [Migrar manualmente o seu endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) explica passo a passo como fazer uma cópia de segurança de uma caixa de e-mail (por exemplo, exportando-a para um ficheiro PST): faça esta cópia de segurança antes de iniciar a migração.
+:::
+
 ## Instruções
 
 Para aceder ao OMM, dirija-se ao endereço [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/).
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
+<img className="thumbnail" alt="Página inicial do OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
 ### Criar um projeto de migração <a name="create-project"></a>
 
@@ -53,7 +57,7 @@ Clique em <code className="action">Create my project</code> para iniciar a cria�
 
 No endereço de e-mail de contacto do projeto, receberá um e-mail de confirmação contendo o identificador único do projeto e um link para aceder a ele.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
+<img className="thumbnail" alt="Criar um projeto de migração no OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
 
 :::info
 Em caso de inatividade durante 60 dias, o projeto de migração e todos os dados associados serão automaticamente eliminados.
@@ -69,13 +73,13 @@ Depois de criar o seu projeto, faça login no projeto a partir da página inicia
 - Introduza a `Project password` definida na sua criação.
 - Clique em <code className="action">Connect to project</code> para terminar.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Criar uma nova migração no OVHcloud Mail Migrator, passo 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Agora está na página inicial do projeto, que lhe permitirá iniciar a sua primeira migração.
 
 - Clique em <code className="action">New migration</code> no canto superior esquerdo da tabela.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Criar uma nova migração no OVHcloud Mail Migrator, passo 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 Na nova página que aparece, preencha as informações de conexão da conta de origem e da conta de destino para planejar a migração ou iniciá-la imediatamente. Lembre-se de que o conteúdo da **source account** será migrado para o **destination account**.
 
@@ -85,7 +89,7 @@ Antes de iniciar a sua migração, é importante conhecer bem os 3 tipos de cont
 - **Others**: Trata-se de serviços de e-mail subscritos fora da OVHcloud. Uma lista não exaustiva de serviços de e-mail suportados pelo OMM está disponível. Se o tipo de serviço da sua conta de e-mail não estiver lá, utilize os protocolos `IMAP` ou `POP`, compatíveis com a maioria dos servidores de e-mail.
 - **Importing files**: É possível migrar o conteúdo de ficheiros PST, ICS, CSV e XML Rules através do OMM para uma conta de e-mail de destino. Quando esta função é selecionada, basta arrastar e largar o seu documento na área apropriada ou navegar no seu terminal através do botão <code className="action">Browse your files</code>.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Criar uma nova migração no OVHcloud Mail Migrator, passo 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Complete as informações de acordo com o tipo de conta:
 
@@ -114,7 +118,7 @@ Complete as informações de acordo com o tipo de conta:
 - **Start of transfer**: Pode iniciar a migração `Immediately` ou marcar `Later` para a adiar. A migração adiada permite-lhe iniciá-la automaticamente numa data e hora que definir.
 - **Data to transfer**: Consoante o tipo de conta de e-mail que está a migrar e a conta de destino, esta secção indica-lhe os diferentes tipos de dados suportados durante a migração. Isto depende da conta de origem e da conta de destino.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Criar uma nova migração no OVHcloud Mail Migrator, passo 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 Se migrar uma conta com funcionalidades que a conta de destino não possui, **será necessário guardar por sua conta os elementos que não poderão ser migrados pelo OMM**. Para o ajudar, consulte o nosso guia "[Migrar manualmente o seu endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)".
@@ -130,7 +134,7 @@ Depois de completar as definições das contas de origem e de destino, clique em
 
 Durante uma migração para ou a partir de uma conta OVHcloud, é possível selecionar uma das nossas ofertas `MX plan`, `E-mail Pro`, `Exchange` ou `Zimbra`.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
+<img className="thumbnail" alt="Migrar através da ligação à conta OVHcloud no OMM, passo 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
 
 Quando seleciona uma destas ofertas, siga as etapas abaixo:
 
@@ -138,7 +142,7 @@ Quando seleciona uma destas ofertas, siga as etapas abaixo:
   <Tab label="Passo 1">
     - Clique em <code className="action">Login</code> para mostrar a janela de login no área de cliente OVHcloud.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrar através da ligação à conta OVHcloud no OMM, passo 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
   </Tab>
   <Tab label="Passo 2">
     Faça login na conta cliente OVHcloud:
@@ -151,19 +155,19 @@ Quando seleciona uma destas ofertas, siga as etapas abaixo:
     :::
 
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrar através da ligação à conta OVHcloud no OMM, passo 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-02.png" loading="lazy" />
   </Tab>
   <Tab label="Passo 3">
     - Uma nova janela aparece. Permite-lhe autorizar o OMM a aceder às funções do seu espaço cliente e listar as ofertas e contas de e-mail presentes. Por defeito, a validade (Validity) destes direitos é de 24 horas (1 day). Defina o período de validade que desejar e clique em <code className="action">Authorize</code>.
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrar através da ligação à conta OVHcloud no OMM, passo 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
   </Tab>
   <Tab label="Passo 4">
     - Agora será possível selecionar os seus serviços e contas através de menus suspensos. Isto facilita a pesquisa dos elementos e evita erros de introdução. No entanto, será necessário introduzir a palavra-passe associada à conta de e-mail selecionada.
     
     Exemplo com um serviço Zimbra:
     
-    <img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
+    <img className="thumbnail" alt="Migrar através da ligação à conta OVHcloud no OMM, passo 5" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -171,7 +175,7 @@ Quando seleciona uma destas ofertas, siga as etapas abaixo:
 :::warning
 É possível desligar os acessos atuais a partir de um área de cliente OVHcloud clicando em <code className="action">Log out</code>, depois, sob a menção `OVHcloud account ID`, clique em <code className="action">Log out of the account</code>.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
+<img className="thumbnail" alt="Migrar através da ligação à conta OVHcloud no OMM, passo 6" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
 :::
 
 
@@ -184,7 +188,7 @@ Existem duas formas de aceder ao acompanhamento do projeto de migração:
 
 Clique depois em <code className="action">Connect to project</code> para aceder à página inicial do projeto e seguir as suas migrações.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Criar uma nova migração no OVHcloud Mail Migrator, passo 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 A partir desta página, encontra a lista das migrações em curso ou programadas. O estado do projeto também aparece à direita.
 
@@ -194,16 +198,20 @@ Clique no botão <code className="action">⋮</code> à direita da linha de uma 
 - <code className="action">Cancel migration</code>: Permite cancelar a migração em curso. Os elementos já migrados serão mantidos na conta de destino.
 - <code className="action">Delete migration data (GDPR)</code>: Esta opção inicia a eliminação de todos os dados relativos à migração da conta. No entanto, manterá as informações sobre os eventos ocorridos durante a migração.
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
+<img className="thumbnail" alt="Acompanhar o progresso de uma migração no OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
 
 Exemplo de acompanhamento de migração:
 
-<img className="thumbnail" alt="omm" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
+<img className="thumbnail" alt="Exemplo de acompanhamento de migração no OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
 
 :::info
 Se ocorrer um erro durante a migração, será fornecido um link para o registo de erros na janela <code className="action">See more details</code>.
 :::
 
+
+:::warning
+Uma vez concluída a migração, aceda à conta de destino e verifique que todos os seus elementos (e-mails, pastas, contactos, calendários) estão presentes — para um endereço de e-mail OVHcloud, utilize o [Webmail OVHcloud](/links/web/email). **Não elimine a conta de origem enquanto não tiver confirmado que tudo foi corretamente migrado**, caso contrário os elementos que não tenham sido migrados serão perdidos de forma permanente.
+:::
 
 ## Quer saber mais?
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
-title: Migrar um endereço de e-mail MX Plan para uma conta Zimbra OVHcloud
-description: Saiba como migrar um endereço de e-mail MX Plan para uma conta Zimbra OVHcloud
-lastUpdated: 2026-06-23
+title: Zimbra - Migrar uma conta de e-mail MX Plan
+description: Migre uma conta de e-mail MX Plan para uma conta Zimbra da OVHcloud e reatribua o seu endereço para concluir a mudança
+lastUpdated: 2026-07-23
 availableIn: [eu]
 ---
 
@@ -35,6 +35,10 @@ Se pretende migrar a sua oferta de e-mail MX Plan para uma oferta [Zimbra OVHclo
 
 </Region>
 
+:::tip
+Seja qual for o método de migração, recomendamos vivamente que faça previamente uma cópia de segurança da sua caixa de e-mail, como precaução contra qualquer perda de dados. O nosso guia [Migrar manualmente o seu endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) explica passo a passo como fazer uma cópia de segurança de uma caixa de e-mail (por exemplo, exportando-a para um ficheiro PST): faça esta cópia de segurança antes de iniciar a migração.
+:::
+
 ## Instruções
 
 :::warning
@@ -53,7 +57,7 @@ A migração de uma conta de e-mail MX Plan para uma conta de e-mail Zimbra é f
 
 No exemplo abaixo, migramos o endereço `contact@mydomain.ovh`. Para isso, vamos criar a conta Zimbra com o nome `contact2@mydomain.ovh`.
 
-<img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
+<img className="thumbnail" alt="Vista geral da migração de e-mail do MX Plan para o Zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/zimbra_migration_mxplan.png" loading="lazy" />
 
 ### 1 - Transferir o conteúdo da conta MX Plan para uma conta Zimbra <a name="step1"></a>
 
@@ -79,7 +83,7 @@ A migração com o OMM realiza-se em 3 etapas: criar um projeto, configurar a mi
 
     Aceda a [OVHcloud Mail Migrator](/links/web/omm) e clique em <code className="action">New migration</code>.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Página inicial do OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
 
     - **Project contact email address**: Introduza um endereço de e-mail que receberá as credenciais de acesso e as notificações de acompanhamento. Não utilize um endereço que irá ser migrado neste projeto.
     - **Project password**: Defina uma palavra-passe (mínimo 10 caracteres, com pelo menos 1 carácter especial, 1 número, 1 maiúscula e 1 minúscula).
@@ -93,7 +97,7 @@ A migração com o OMM realiza-se em 3 etapas: criar um projeto, configurar a mi
 
     A seguir, clique em <code className="action">New migration</code> para configurar a sua migração:
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
+    <img className="thumbnail" alt="Criar a migração do MX Plan para o Zimbra no OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
     - **Source account**:
         - **Account type**: Na categoria `OVHcloud`, escolha `MX Plan` ou `Autodetect`. Clique em <code className="action">Log in</code> para se identificar com a sua conta OVHcloud e selecionar automaticamente o serviço e o endereço a migrar (exemplo: `contact@mydomain.ovh`). Introduza depois a palavra-passe desta conta de e-mail.
@@ -104,7 +108,7 @@ A migração com o OMM realiza-se em 3 etapas: criar um projeto, configurar a mi
 
     Clique em <code className="action">Migrate my account</code> para iniciar a migração.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
+    <img className="thumbnail" alt="Configurar a conta de destino Zimbra no OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-zimbra-01.png" loading="lazy" />
   </Tab>
   <Tab label="Etapa 3">
     **Acompanhar a migração**
@@ -120,7 +124,7 @@ A migração com o OMM realiza-se em 3 etapas: criar um projeto, configurar a mi
     - <code className="action">Cancel migration</code>: Cancela a migração em curso. Os elementos já migrados são conservados na conta de destino.
     - <code className="action">Delete my migration data (GDPR)</code>: Desencadeia a eliminação de todos os dados relativos à migração. As informações sobre os eventos de migração são conservadas.
 
-    <img className="thumbnail" alt="zimbra" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
+    <img className="thumbnail" alt="Acompanhar o progresso da migração no OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-migration-follow.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -139,6 +143,10 @@ Antes de eliminar a sua conta MX Plan, **efetue uma cópia de segurança dos seu
 Utilize as opções de exportação do seu cliente de e-mail. No nosso manual "[Migrar manualmente o seu endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)", encontrará os detalhes de exportação manual de um endereço de e-mail a partir de um cliente de e-mail.
 
 ### 2 - Eliminar a conta MX Plan de origem e reatribuir o seu endereço à conta Zimbra <a name="step2"></a>
+
+:::warning
+Antes de eliminar a sua conta MX Plan de origem, aceda ao [Webmail OVHcloud](/links/web/email) e verifique que todos os seus elementos (e-mails, pastas, contactos, calendários) foram migrados para a conta Zimbra. Depois de eliminada a conta de origem, os elementos que não tenham sido migrados serão perdidos de forma permanente.
+:::
 
 #### 2.1 - Eliminação do antigo endereço de e-mail MX Plan <a name="step21"></a>
 


### PR DESCRIPTION
## Context

Support/customer feedback: in the email migration guides, the instruction to verify your content in the OVHcloud Webmail after a migration is plain inline text. Customers overlook it, delete/reset their original address too early, and end up with missing emails they cannot recover. This PR makes that step impossible to miss and, while in these guides, applies an SEO pass.

## What this PR does

### Safety callouts (the feedback)
- **Post-migration verification → `:::warning`.** The verification step is now a warning that explicitly says **not to delete/reset the original account until everything has been confirmed migrated** (deleted, non-migrated content is lost).
  - `migration-control-panel` & `migration-platform`: reused the existing localized sentence + added the "do not delete until verified" clause.
  - `omm-migrate-email-account-to-ovhcloud`: warning **added** (was missing).
  - `migrate-mxplan-to-zimbra`: warning **added right before the account-deletion step**.
- **Pre-migration backup → `:::tip`.** Before the *Instructions* section of all four guides, a tip recommends backing up the mailbox (e.g. PST export) before starting — whatever the migration type — and points to the *Manually migrate your email address* guide that details how.

### SEO pass
- **Titles:** shortened the 3 over-length titles under the 60-char SERP limit, keeping the product name and naming the migration targets; fixed an IT typo in the OMM title.
- **Meta descriptions:** dropped the "Find out how to" opener, start with an action verb, added the value proposition, no trailing period (classic-guide rule).
- **Image alt-text:** replaced generic/duplicated alt (`omm`, `exchange`, `zimbra`…) with descriptive, unique, localized alt — 247 images.

### Housekeeping
- Centralized the webmail links to `/links/web/email` (auto-resolves per locale).
- Bumped `lastUpdated`.
- Re-synced the 3 renamed EN labels in `config/sidebar/index.md`.

## Scope

4 migration guides × 7 locales (`en`, `fr`, `de`, `es`, `it`, `pl`, `pt`) + `config/sidebar/index.md`.

- `web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel`
- `web-cloud/email-and-collaborative-solutions/migrating/migration-platform`
- `web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud`
- `web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra`

## Verification

`content:lint`, `sidebar:check`, `overview:validate`, `retrievability:check`, diff-scoped proofread (2 passes) + `/verify-links` (webmail URLs → 200), frontmatter YAML parse, and a full **7-locale build** (`build:fast` + combine) — all green. Content-only change: no new components, no action buttons, no API tags, no deleted/renamed guides.
