### PR TITLE
Opcp netbox labels

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -593,6 +593,7 @@
             + [How to see node inventory](hosted-private-cloud/opcp/how-to-see-node-inventory)
             + [How to handle the NetBox rack elevation](hosted-private-cloud/opcp/how-to-handle-rack-elevation)
             + [How the Ironic to NetBox synchronisation works](hosted-private-cloud/opcp/netbox-ironic-synchronisation)
+            + [How to access the NetBox API with a token](hosted-private-cloud/opcp/netbox-api-access)
             + [How to use Terraform](hosted-private-cloud/opcp/use-terraform)
             + [How to update the backup S3 buckets](hosted-private-cloud/opcp/how-to-update-backup-s3-buckets)
         + [Security](hosted-private-cloud-hosted-private-cloud-opcp-security)

--- a/docs/de/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/de/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx

--- a/docs/en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,97 @@
+---
+title: How to access the NetBox API with a token
+description: How to use the NetBox REST API
+lastUpdated: 2026-07-15
+---
+
+## Objective
+
+On an **OVHcloud On-Prem Cloud Platform (OPCP)**, the NetBox web interface is protected by Keycloak SSO. To let an external system — for example your own CMDB or a helpdesk integration — query the NetBox inventory automatically, a dedicated API endpoint is available. This endpoint authenticates directly with a NetBox API token and does **not** go through Keycloak.
+
+**This guide explains how to enable the dedicated endpoint, create a NetBox API token, and reach the NetBox API through that endpoint.**
+
+:::info
+This feature is available from **OPCP Core 3.0.7**.
+:::
+
+## Requirements
+
+- The dedicated API endpoint must be enabled on your platform. It is **disabled by default**; enabling it is the first step below.
+- Access to the NetBox web interface (`netbox.<your-platform-domain>`), reachable through Keycloak SSO.
+- A NetBox user allowed to create API tokens.
+
+## Instructions
+
+### 1. Enable the dedicated API endpoint
+
+The dedicated endpoint is **disabled by default**. To enable it, set the following flag in your OPCP configuration:
+
+```yaml
+netbox_api:
+  enabled: true
+```
+
+Then apply the configuration by running, from a controller:
+
+```bash
+opcp-cli deploy --system
+```
+
+:::info
+In OVHcloud-managed mode, ask your OVHcloud contact to enable this endpoint if you are not able to run the deployment yourself.
+:::
+
+### 2. Create a NetBox API token
+
+1. Log in to the NetBox web interface at `https://netbox.<your-platform-domain>` with your usual Keycloak credentials or SSO.
+2. Open the user menu (top right), go to your profile, then to the **API Tokens** section.
+3. Click <code className="action">Add a token</code>, adjust the options if needed (expiry, allowed IP ranges, read-only or write access), then save.
+4. Copy the generated token and store it in a safe place. It grants access to the NetBox API with your own permissions.
+
+For the full description of tokens and their options, see the official NetBox documentation: [NetBox REST API — Tokens](https://netboxlabs.com/docs/netbox/integrations/rest-api/#tokens).
+
+### 3. Call the API through the dedicated endpoint
+
+The dedicated endpoint exposes the NetBox API at the following URL:
+
+```console
+https://netbox-api.<your-platform-domain>/api
+```
+
+Unlike the web interface, this endpoint does not use Keycloak: authentication relies entirely on your NetBox token, passed in the `Authorization` header of every request.
+
+To verify that your token and the endpoint work, query the NetBox status. A valid token returns an HTTP `200` response with a JSON payload:
+
+```bash
+curl -sS -H "Authorization: Token YOUR_TOKEN" \
+  https://netbox-api.<your-platform-domain>/api/status/
+```
+
+Once the connection is confirmed, you can query any NetBox resource, for example the list of devices:
+
+```bash
+curl -sS -H "Authorization: Token YOUR_TOKEN" \
+  https://netbox-api.<your-platform-domain>/api/dcim/devices/
+```
+
+A request sent without a valid token is rejected. The web interface remains available only on `https://netbox.<your-platform-domain>`, behind Keycloak.
+
+:::tip
+This endpoint is meant for programmatic access. To browse the API interactively (the browsable API, or the Swagger and ReDoc pages), use the main NetBox interface at `https://netbox.<your-platform-domain>/api/`, which is served through Keycloak.
+:::
+
+:::warning
+A token carries the permissions of the user who created it. Keep it secret, prefer a token with the narrowest scope required (read-only whenever possible), and rotate it regularly.
+:::
+
+### References
+
+- [NetBox REST API](https://netboxlabs.com/docs/netbox/integrations/rest-api/)
+- [NetBox REST API — Tokens](https://netboxlabs.com/docs/netbox/integrations/rest-api/#tokens)
+- [How to see the node inventory](/guides/hosted-private-cloud/opcp/how-to-see-node-inventory)
+
+## Go further
+
+For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analysed by our experts.
+
+Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to access the NetBox API with a token
 description: How to use the NetBox REST API
-lastUpdated: 2026-07-15
+lastUpdated: 2026-07-20
 ---
 
 ## Objective
@@ -19,6 +19,7 @@ This feature is available from **OPCP Core 3.0.7**.
 - The dedicated API endpoint must be enabled on your platform. It is **disabled by default**; enabling it is the first step below.
 - Access to the NetBox web interface (`netbox.<your-platform-domain>`), reachable through Keycloak SSO.
 - A NetBox user allowed to create API tokens.
+- If you also plan to make manual changes in NetBox, write access to the NetBox web interface — see [IAM rights management](/guides/hosted-private-cloud/opcp/iam-rights-management) for the required role.
 
 ## Instructions
 
@@ -83,6 +84,68 @@ This endpoint is meant for programmatic access. To browse the API interactively 
 :::warning
 A token carries the permissions of the user who created it. Keep it secret, prefer a token with the narrowest scope required (read-only whenever possible), and rotate it regularly.
 :::
+
+### 4. Interact with your NetBox instance safely
+
+Parts of your NetBox inventory may be managed automatically by an external Source of Truth (SoT). The following explains how to identify those objects and make changes without conflicting with the automation.
+
+#### How NetBox is organised
+
+Your NetBox instance contains two kinds of objects:
+
+- **Objects managed automatically.** These carry the **`automation-managed`** tag. They are created and kept in sync with the external Source of Truth (SoT). You do not need to maintain them.
+
+- **Objects managed by you.** These do not carry the `automation-managed` tag. They are yours: create, edit, delete, retag, comment — whatever your workflow requires.
+
+The `automation-managed` tag is the single signal that tells you which side an object belongs to. When in doubt, check the tag.
+
+:::warning
+Do not remove the `automation-managed` tag from objects that carry it, and do not add it to objects you create yourself. Doing either of these will cause the automation to overwrite your changes on its next run.
+:::
+
+#### Making changes
+
+The method to modify an object depends on whether it is automation-managed.
+
+**For objects without the `automation-managed` tag:**
+
+Make changes directly in the NetBox UI as usual. The automation does not touch these objects.
+
+**For objects with the `automation-managed` tag:**
+
+These are driven by the external Source of Truth.
+
+:::info
+If you edit an `automation-managed` object directly in NetBox, the next automation run will revert your change. The SoT is authoritative for these objects.
+:::
+
+These changes will persist across automation runs.
+
+#### The Automation State tenant
+
+In the **Tenancy** section of NetBox, you will see a tenant named **`Automation State`** (slug: `automation-state`). This tenant holds internal bookkeeping used by the automation.
+
+:::warning
+Do not delete the `Automation State` tenant, and do not edit its custom fields (`automation_non_taggable_state` and `initializer_sot_hash`). Modifying or deleting them will cause the automation to misbehave on its next run.
+:::
+
+#### Quick reference
+
+| Action | Allowed? |
+|---|---|
+| Edit an object without the `automation-managed` tag | Yes |
+| Add journal entries, comments, or other tags on any object | Yes |
+| Edit a field on an `automation-managed` object that the SoT manages | Will be reverted on the next run |
+| Delete an object with the `automation-managed` tag | Will be recreated on the next run |
+| Remove the `automation-managed` tag from an object | Will be added again on the next run |
+| Add the `automation-managed` tag to an object you created | Causes the automation to overwrite or delete it |
+
+#### What to expect during normal operation
+
+- **Changelog entries from the automation account** after each successful run. This is normal.
+- **A short-lived branch** named `initializer-automation`. It is created, used, and merged (or removed) by the automation.
+- **The `automation-managed` tag** present on many objects.
+- **The `Automation State` tenant** present in your tenant list.
 
 ### References
 

--- a/docs/es/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/es/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx

--- a/docs/fr/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,97 @@
+---
+title: Comment accéder à l'API NetBox avec un token
+description: Comment utiliser l'API REST de NetBox
+lastUpdated: 2026-07-15
+---
+
+## Objectif
+
+Sur une plateforme **OVHcloud On-Prem Cloud Platform (OPCP)**, l'interface web de NetBox est protégée par l'authentification unique (SSO) Keycloak. Pour permettre à un système externe — par exemple votre propre CMDB ou une intégration avec votre outil de support — d'interroger automatiquement l'inventaire NetBox, un point d'accès API dédié est disponible. Ce point d'accès s'authentifie directement avec un token API NetBox et ne passe **pas** par Keycloak.
+
+**Ce guide explique comment activer le point d'accès dédié, créer un token API NetBox et joindre l'API NetBox via ce point d'accès.**
+
+:::info
+Cette fonctionnalité est disponible à partir d'**OPCP Core 3.0.7**.
+:::
+
+## Prérequis
+
+- Le point d'accès API dédié doit être activé sur votre plateforme. Il est **désactivé par défaut** ; son activation constitue la première étape ci-dessous.
+- Avoir accès à l'interface web de NetBox (`netbox.<votre-domaine-de-plateforme>`), accessible via le SSO Keycloak.
+- Disposer d'un utilisateur NetBox autorisé à créer des tokens API.
+
+## En pratique
+
+### 1. Activer le point d'accès dédié
+
+Le point d'accès dédié est **désactivé par défaut**. Pour l'activer, positionnez le flag suivant dans la configuration de votre OPCP :
+
+```yaml
+netbox_api:
+  enabled: true
+```
+
+Appliquez ensuite la configuration en exécutant, depuis un contrôleur :
+
+```bash
+opcp-cli deploy --system
+```
+
+:::info
+En mode managé par OVHcloud, demandez à votre interlocuteur OVHcloud d'activer ce point d'accès si vous ne pouvez pas lancer le déploiement vous-même.
+:::
+
+### 2. Créer un token API NetBox
+
+1. Connectez-vous à l'interface web de NetBox à l'adresse `https://netbox.<votre-domaine-de-plateforme>` avec vos identifiants Keycloak habituels ou votre SSO.
+2. Ouvrez le menu utilisateur (en haut à droite), accédez à votre profil, puis à la section **API Tokens**.
+3. Cliquez sur <code className="action">Add a token</code>, ajustez les options si nécessaire (expiration, plages d'adresses IP autorisées, accès en lecture seule ou en écriture), puis enregistrez.
+4. Copiez le token généré et conservez-le en lieu sûr. Il donne accès à l'API NetBox avec vos propres permissions.
+
+Pour la description complète des tokens et de leurs options, consultez la documentation officielle de NetBox : [NetBox REST API — Tokens](https://netboxlabs.com/docs/netbox/integrations/rest-api/#tokens).
+
+### 3. Appeler l'API via le point d'accès dédié
+
+Le point d'accès dédié expose l'API NetBox à l'URL suivante :
+
+```console
+https://netbox-api.<votre-domaine-de-plateforme>/api
+```
+
+Contrairement à l'interface web, ce point d'accès n'utilise pas Keycloak : l'authentification repose entièrement sur votre token NetBox, transmis dans l'en-tête `Authorization` de chaque requête.
+
+Pour vérifier que votre token et le point d'accès fonctionnent, interrogez le statut de NetBox. Un token valide renvoie une réponse HTTP `200` accompagnée d'une charge utile JSON :
+
+```bash
+curl -sS -H "Authorization: Token YOUR_TOKEN" \
+  https://netbox-api.<votre-domaine-de-plateforme>/api/status/
+```
+
+Une fois la connexion confirmée, vous pouvez interroger n'importe quelle ressource NetBox, par exemple la liste des équipements :
+
+```bash
+curl -sS -H "Authorization: Token YOUR_TOKEN" \
+  https://netbox-api.<votre-domaine-de-plateforme>/api/dcim/devices/
+```
+
+Une requête envoyée sans token valide est rejetée. L'interface web reste accessible uniquement sur `https://netbox.<votre-domaine-de-plateforme>`, derrière Keycloak.
+
+:::tip
+Ce point d'accès est destiné à un usage programmatique. Pour explorer l'API de manière interactive (interface browsable, ou pages Swagger et ReDoc), utilisez l'interface principale de NetBox sur `https://netbox.<votre-domaine-de-plateforme>/api/`, servie via Keycloak.
+:::
+
+:::warning
+Un token porte les permissions de l'utilisateur qui l'a créé. Gardez-le secret, privilégiez un token au périmètre le plus restreint possible (en lecture seule autant que possible) et renouvelez-le régulièrement.
+:::
+
+### Références
+
+- [NetBox REST API](https://netboxlabs.com/docs/netbox/integrations/rest-api/)
+- [NetBox REST API — Tokens](https://netboxlabs.com/docs/netbox/integrations/rest-api/#tokens)
+- [Comment consulter l'inventaire des nœuds](/guides/hosted-private-cloud/opcp/how-to-see-node-inventory)
+
+## Aller plus loin
+
+Pour une formation ou une assistance technique à la mise en place de nos solutions, contactez votre commercial ou rendez-vous sur notre page [Professional Services](/links/professional-services) pour demander un devis et faire analyser votre projet par nos experts.
+
+Rejoignez notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comment accéder à l'API NetBox avec un token
 description: Comment utiliser l'API REST de NetBox
-lastUpdated: 2026-07-15
+lastUpdated: 2026-07-20
 ---
 
 ## Objectif
@@ -19,6 +19,7 @@ Cette fonctionnalité est disponible à partir d'**OPCP Core 3.0.7**.
 - Le point d'accès API dédié doit être activé sur votre plateforme. Il est **désactivé par défaut** ; son activation constitue la première étape ci-dessous.
 - Avoir accès à l'interface web de NetBox (`netbox.<votre-domaine-de-plateforme>`), accessible via le SSO Keycloak.
 - Disposer d'un utilisateur NetBox autorisé à créer des tokens API.
+- Si vous prévoyez également d'effectuer des modifications manuelles dans NetBox, disposer d'un accès en écriture à l'interface web de NetBox — voir le guide « [Gestion des droits IAM](/guides/hosted-private-cloud/opcp/iam-rights-management) » pour le rôle requis.
 
 ## En pratique
 
@@ -83,6 +84,68 @@ Ce point d'accès est destiné à un usage programmatique. Pour explorer l'API d
 :::warning
 Un token porte les permissions de l'utilisateur qui l'a créé. Gardez-le secret, privilégiez un token au périmètre le plus restreint possible (en lecture seule autant que possible) et renouvelez-le régulièrement.
 :::
+
+### 4. Interagir avec votre instance NetBox en toute sécurité
+
+Une partie de votre inventaire NetBox peut être gérée automatiquement par une Source of Truth (SoT) externe. Voici comment identifier ces objets et effectuer vos modifications sans entrer en conflit avec l'automatisation.
+
+#### Organisation de NetBox
+
+Votre instance NetBox contient deux types d'objets :
+
+- **Les objets gérés automatiquement.** Ils portent le tag **`automation-managed`**. Ils sont créés et maintenus synchronisés avec la Source of Truth (SoT) externe. Vous n'avez pas à les maintenir.
+
+- **Les objets que vous gérez vous-même.** Ils ne portent pas le tag `automation-managed`. Ils vous appartiennent : créez, modifiez, supprimez, retaguez, commentez — selon les besoins de votre workflow.
+
+Le tag `automation-managed` est le seul indicateur qui vous permet de savoir de quel côté se trouve un objet. En cas de doute, vérifiez le tag.
+
+:::warning
+Ne retirez pas le tag `automation-managed` des objets qui le portent, et ne l'ajoutez pas aux objets que vous créez vous-même. L'une comme l'autre de ces actions conduira l'automatisation à écraser vos modifications lors de sa prochaine exécution.
+:::
+
+#### Effectuer des modifications
+
+La méthode pour modifier un objet dépend du fait qu'il soit géré ou non par l'automatisation.
+
+**Pour les objets sans le tag `automation-managed` :**
+
+Effectuez vos modifications directement dans l'interface de NetBox, comme d'habitude. L'automatisation ne touche pas à ces objets.
+
+**Pour les objets avec le tag `automation-managed` :**
+
+Ils sont pilotés par la Source of Truth externe.
+
+:::info
+Si vous modifiez un objet `automation-managed` directement dans NetBox, la prochaine exécution de l'automatisation annulera votre modification. La SoT fait autorité pour ces objets.
+:::
+
+Ces modifications persistent d'une exécution de l'automatisation à l'autre.
+
+#### Le tenant Automation State
+
+Dans la section **Tenancy** de NetBox, vous verrez un tenant nommé **`Automation State`** (slug : `automation-state`). Ce tenant contient des données de gestion interne utilisées par l'automatisation.
+
+:::warning
+Ne supprimez pas le tenant `Automation State` et ne modifiez pas ses champs personnalisés (`automation_non_taggable_state` et `initializer_sot_hash`). Les modifier ou les supprimer entraînera un dysfonctionnement de l'automatisation lors de sa prochaine exécution.
+:::
+
+#### Référence rapide
+
+| Action | Autorisée ? |
+|---|---|
+| Modifier un objet sans le tag `automation-managed` | Oui |
+| Ajouter des entrées de journal, des commentaires ou d'autres tags sur n'importe quel objet | Oui |
+| Modifier un champ géré par la SoT sur un objet `automation-managed` | Sera annulé à la prochaine exécution |
+| Supprimer un objet portant le tag `automation-managed` | Sera recréé à la prochaine exécution |
+| Retirer le tag `automation-managed` d'un objet | Sera rajouté à la prochaine exécution |
+| Ajouter le tag `automation-managed` à un objet que vous avez créé | Conduit l'automatisation à l'écraser ou à le supprimer |
+
+#### À quoi s'attendre en fonctionnement normal
+
+- **Des entrées de changelog émises par le compte de l'automatisation** après chaque exécution réussie. C'est normal.
+- **Une branche éphémère** nommée `initializer-automation`. Elle est créée, utilisée puis fusionnée (ou supprimée) par l'automatisation.
+- **Le tag `automation-managed`** présent sur de nombreux objets.
+- **Le tenant `Automation State`** présent dans votre liste de tenants.
 
 ### Références
 

--- a/docs/it/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/it/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx

--- a/docs/pl/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/pl/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx

--- a/docs/pt/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
+++ b/docs/pt/guides/hosted-private-cloud/opcp/netbox-api-access.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/netbox-api-access.mdx


### PR DESCRIPTION
Starting v3.1 OPCP-managed netbox items will be labeled accordingly; this documentation should be merged after v3.1.1 release (this should be rebased against develop after the MR about using Netbox API is merged)