### PR TITLE
docs(web-hosting): fix corrupted section 2.2 in PL multisites guide

### DIFF
--- a/docs/pl/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
@@ -165,10 +165,22 @@ Znajdź i zmodyfikuj strefę DNS zgodnie z instrukcjami w sekcji przewodnika "[I
     <img className="thumbnail" alt="DNS zone" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/tab.png" loading="lazy" />
     
     :::info
-    Jeśli zakładka <code className="action">Strefa DNS</code> Twojej domeny wyświetla się w następujący sposób:<br/><br/><img className="thumbnail" alt="zone-without-domain-top-of-the-page" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png" loading="lazy" />|Oznacza to, że konfiguracja Twojej domeny jest prawidłowa.<br/>Poczekaj na propagację DNS, jeśli zmiana jest nowsza.<br/><br/>Uruchom ponownie urządzenia (PC, smartphone, box, etc.) i wyczyść pamięć cache przeglądarki internetowej. Możliwe, że poprzednia konfiguracja Twojej domeny nadal znajduje się w pamięci cache, co może opóźnić wyświetlenie aktualizacji.|
-    |Bieżąca strefa DNS nie zawiera rekordów typu A lub AAAA łączących domenę lub subdomenę z adresem IP hostingu.|Dodaj nowy rekord DNS typu A lub AAAA lub popraw istniejący rekord, postępując zgodnie z [tym przewodnikiem](/guides/web-cloud/domains/dns-zone-edit).|
-    |Istniejący rekord DNS typu A lub AAAA w strefie DNS dla Twojej domeny lub subdomeny wskazuje na inny adres IP niż adres IP Twojego hostingu.|Dodaj nowy rekord DNS typu A lub AAAA lub popraw istniejący rekord, postępując zgodnie z [tym przewodnikiem](/guides/web-cloud/domains/dns-zone-edit).|
-    |To ostrzeżenie pojawia się w zakładce <code className="action">Strefa DNS</code> :<br/><br/><img className="thumbnail" alt="message-other-ovh-dns-servers" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png" loading="lazy" />|Zmień odpowiednio serwery DNS Twojej domeny zgodnie z naszym przewodnikiem "[Zmiana serwerów DNS domeny OVHcloud](/guides/web-cloud/domains/dns-server-edit)".|
+    Jeśli zakładka <code className="action">Strefa DNS</code> Twojej domeny wyświetla się w następujący sposób:<br/><br/><img className="thumbnail" alt="zone-without-domain-top-of-the-page" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png" loading="lazy" /><br/>
+
+Oznacza to, że Twoja domena nie jest zarządzana z poziomu Panelu klienta OVHcloud.<br/> Sprawdź jej "operatora" oraz serwery DNS, z którymi jest powiązana, przy użyciu narzędzia [WHOIS](/links/web/domains-whois).<br/> Znajdź i zmodyfikuj odpowiednią strefę DNS zgodnie z instrukcjami w sekcji przewodnika "[Instalacja kilku stron WWW na jednym hostingu - dodaj domenę zewnętrzną](/guides/web-cloud/web-hosting/multisites-configure-multisite)".
+
+    :::
+
+    
+    Przejdź do etapu 4, aby wyświetlić różne możliwe scenariusze oraz działania, które należy podjąć.
+  </Tab>
+  <Tab label="Etap 4">
+    |Możliwe scenariusze|Działanie do podjęcia|
+    |---|---|
+    |W aktywnej strefie DNS Twoja domena lub subdomena wskazuje na adres IP Twojego hostingu za pomocą rekordu typu A (dla adresu IPv4) lub AAAA (dla adresu IPv6).<br/><br/><img className="thumbnail" alt="DNS_IP2 zone" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png" loading="lazy" />|Oznacza to, że Twoja domena jest prawidłowo skonfigurowana.<br/>Poczekaj na zakończenie propagacji DNS, jeśli zmiana jest niedawna.<br/><br/>Uruchom ponownie komputery, urządzenia i wyczyść pamięć podręczną przeglądarki. Poprzednia konfiguracja Twojej domeny może nadal znajdować się w pamięci podręcznej, co może opóźnić wyświetlenie aktualizacji.|
+    |Bieżąca strefa DNS nie zawiera rekordów typu A lub AAAA łączących Twoją domenę lub subdomenę z adresem IP Twojego hostingu.|Dodaj nowy rekord DNS typu A lub AAAA lub popraw istniejący rekord, postępując zgodnie z [tym przewodnikiem](/guides/web-cloud/domains/dns-zone-edit).|
+    |Istniejący rekord DNS typu A lub AAAA w strefie DNS dla Twojej domeny lub subdomeny wskazuje na adres IP inny niż adres Twojego hostingu.|Dodaj nowy rekord DNS typu A lub AAAA lub popraw istniejący rekord, postępując zgodnie z [tym przewodnikiem](/guides/web-cloud/domains/dns-zone-edit).|
+    |To ostrzeżenie pojawia się w zakładce <code className="action">Strefa DNS</code>:<br/><br/><img className="thumbnail" alt="message-other-ovh-dns-servers" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png" loading="lazy" />|Zmień odpowiednio serwery DNS Twojej domeny zgodnie z naszym przewodnikiem "[Zmiana serwerów DNS domeny OVHcloud](/guides/web-cloud/domains/dns-server-edit)".|
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
The Polish version of multisites-website-not-installed was missing tab Step 4 and had the scenario table merged into the Step 3 callout. Rebuild section 2.2 from the EN source: restore the Step 3 info block, add the transition sentence and recreate the Step 4 tab with the full 4-scenario table.

## Summary

Fixes a corrupted section 2.2 in the **Polish** version of the *Website not installed on your web hosting* guide (`multisites-website-not-installed`). A customer reported that the PL content diverged from the other locales and was missing Step 4 in the tabs.

## Root cause

In the PL file, the Step 3 `:::info` callout was never closed, and the Step 4 scenario table had been merged into it — so the guide rendered only 3 tabs instead of 4, even though the intro says "display the 4 steps". The real Step 3 message ("your domain is not managed from the OVHcloud Control Panel…") was overwritten by the misplaced table, whose first-row scenario cell was also lost.

## Changes (PL only)

- **Restored the Step 3 `:::info`** — correct "domain not managed / WHOIS / multisite guide" text, properly closed (mirrors the Step 2 callout style already used in the PL file).
- **Added the transition sentence** — "Przejdź do etapu 4…".
- **Recreated the `Etap 4` tab** with the full 4-scenario, 2-column table (including the first row's scenario cell + `dashboard-entry-a.png` image).
- **Removed the malformed table** that was polluting the Step 3 callout.

## Notes

- Rebuilt from the **EN** source per the translation source-routing rule (`pl` ← `en`); structure now matches FR/EN.
- Action buttons verified against the Manager repo sidebar: `Web Cloud` (`sidebar_web_cloud`), `Strefy DNS` (`sidebar_dns`), `Strefa DNS` (`domain_tab_name_dns_zone`).
- Checked all other locales (de/es/it/pt) — they already match FR/EN (4 tabs, full table); only PL was affected.
- `lastUpdated` left unchanged (intentional).
