### PR TITLE
docs(domains): clarify authcode wording in .co.uk incoming transfer guide

### DIFF
--- a/docs/de/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/de/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transfer einer .uk-Domainname zu OVHcloud
 description: Erfahren Sie hier, wie Sie Domainnamen mit UK-Ländercode zu OVHcloud transferieren
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -74,7 +74,7 @@ Weitere Informationen finden Sie auf der [Nominet-Website](https://www.nominet.u
 
 #### Schritt 2: Transfer-Autorisierungscode erhalten
 
-Sobald Sie den TAG geändert haben, erhält der Inhaber der Domainname nach einigen Minuten per E-Mail einen Autorisierungscode (“authcode“). Dieser ist 5 Tage gültig und ermöglicht es, die (kostenlose) Bestellung der Domainname bei OVHcloud zu starten.
+Sobald Sie den TAG geändert haben, erhält der Inhaber der Domainname nach einigen Minuten per E-Mail einen Autorisierungscode (Validierungstoken). Dieser ist 5 Tage gültig und ermöglicht es, die (kostenlose) Bestellung der Domainname bei OVHcloud zu starten.
 
 #### Schritt 3: Bestellung des kostenlosen Transfers
 

--- a/docs/en/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/en/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transferring a .uk domain name to OVHcloud
 description: Find out how to transfer a .uk or related domain name to OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -71,7 +71,7 @@ Please refer to [Nominet's website](https://www.nominet.uk/domain-support/) for 
 
 ### Step 2: Obtaining the authorisation code
 
-After you change the TAG, the domain name holder will receive an authorisation code (authcode) by email after a few minutes. This is valid for 5 days and required to initiate the (free) domain name transfer order at OVHcloud.
+After you change the TAG, the domain name holder will receive an authorisation code (validation token) by email after a few minutes. This is valid for 5 days and required to initiate the (free) domain name transfer order at OVHcloud.
 
 ### Step 3: Ordering the free transfer
 

--- a/docs/es/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/es/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transferir un nombre de dominio .uk a OVHcloud
 description: En esta guía encontrará información relativa a la transferencia de un nombre de dominio .uk o asociado a OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -77,7 +77,7 @@ Atención: Esta operación es facturada por Nominet.
 
 #### Etapa 2: Obtener el código de autorización de transferencia
 
-Una vez que haya modificado el TAG, el titular del nombre de dominio recibirá al cabo de unos minutos un código de autorización (código auténtico) por correo electrónico. Dicho registro, válido durante 5 días, permitirá realizar el pedido (gratuito) del nombre de dominio en OVHcloud.
+Una vez que haya modificado el TAG, el titular del nombre de dominio recibirá al cabo de unos minutos un código de autorización (token de validación) por correo electrónico. Dicho registro, válido durante 5 días, permitirá realizar el pedido (gratuito) del nombre de dominio en OVHcloud.
 
 #### Etapa 3: Solicitar la transferencia gratuita
 

--- a/docs/fr/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/fr/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transférer un nom de domaine .uk vers OVHcloud
 description: Vous trouverez dans ce guide différentes informations concernant le transfert d’un nom de domaine .uk ou assimilé vers OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -76,7 +76,7 @@ Attention, cette opération est facturée par Nominet.
 
 #### Étape 2 : Obtention du code d’autorisation de transfert
 
-Une fois que vous aurez modifié le TAG, le titulaire du nom de domaine recevra après quelques minutes un code d’autorisation (authcode) par courriel. Celui-ci, valide pour une durée de 5 jours, permettra d’initier la commande (gratuite) du nom de domaine chez OVHcloud.
+Une fois que vous aurez modifié le TAG, le titulaire du nom de domaine recevra après quelques minutes un code d’autorisation (token de validation) par courriel. Celui-ci, valide pour une durée de 5 jours, permettra d’initier la commande (gratuite) du nom de domaine chez OVHcloud.
 
 #### Étape 3 : Commande du transfert gratuit
 

--- a/docs/it/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/it/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Trasferire un nome di dominio.uk in OVHcloud
 description: Questa guida ti mostra come trasferire un nome di dominio.uk o equiparato a OVHcloud.
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -76,7 +76,7 @@ Attenzione, questa operazione è fatturata per Nominet.
 
 #### Step 2: Ottenimento del codice di autorizzazione al trasferimento
 
-Una volta modificato il TAG, l’**intestatario** del nome di dominio riceverà dopo qualche minuto un codice di autorizzazione ("authcode") via email. Il servizio, valido per 5 giorni, permetterà di avviare l'ordine (gratuito) del nome di dominio presso OVHcloud.
+Una volta modificato il TAG, l’**intestatario** del nome di dominio riceverà dopo qualche minuto un codice di autorizzazione (token di convalida) via email. Il servizio, valido per 5 giorni, permetterà di avviare l'ordine (gratuito) del nome di dominio presso OVHcloud.
 
 #### Step 3: Ordine di trasferimento gratuito
 

--- a/docs/pl/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/pl/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transfer nazwy domeny.uk do OVHcloud
 description: W tym przewodniku znajdziesz różne informacje dotyczące transferu nazwy domeny .uk lub podobnej do OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -76,7 +76,7 @@ Uwaga, ta operacja jest płatna przez Nominet.
 
 #### Etap 2: Uzyskanie kodu autoryzacji transferu
 
-Po zmianie APR abonent nazwy domeny po kilku minutach otrzyma e-mail z kodem autoryzacyjnym ("authcode"). Certyfikat, ważny przez 5 dni, pozwoli rozpocząć (bezpłatnie) zamawianie nazwy domeny w OVHcloud.
+Po zmianie APR abonent nazwy domeny po kilku minutach otrzyma e-mail z kodem autoryzacyjnym (token walidacyjny). Certyfikat, ważny przez 5 dni, pozwoli rozpocząć (bezpłatnie) zamawianie nazwy domeny w OVHcloud.
 
 #### Etap 3: Bezpłatne zamówienie na transfer
 

--- a/docs/pt/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/pt/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transferir um nome de domínio .uk para a OVHcloud
 description: Neste guia encontrará diferentes informações relativas à transferência de um nome de domínio .uk ou equiparado para a OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -76,7 +76,7 @@ Atenção, esta operação é faturada por Nominet.
 
 #### Etapa 2: Obtenção do código de autorização de transferência
 
-Depois de alterar a TAG, o titular do nome de domínio receberá após alguns minutos um código de autorização (authcode) por e-mail. Este, válido por 5 dias, permitirá iniciar a encomenda (gratuita) do nome de domínio na OVHcloud.
+Depois de alterar a TAG, o titular do nome de domínio receberá após alguns minutos um código de autorização (token de validação) por e-mail. Este, válido por 5 dias, permitirá iniciar a encomenda (gratuita) do nome de domínio na OVHcloud.
 
 #### Etapa 3: Encomenda da transferência gratuita
 


### PR DESCRIPTION
Replace the '(authcode)' parenthetical with a localized 'validation token' term across all 7 locales, and bump lastUpdated to 2026-07-24.

## Summary

Clarifies the "authcode" wording in the **.co.uk incoming transfer** guide (`transfer-incoming-couk`). Applied across all 7 locales (fr, en, de, es, it, pl, pt).

## Changes

- **Reworded the authorisation-code parenthetical** — in the sentence about the code the domain holder receives by email, `(authcode)` is replaced by a localized "validation token" term:

  | Locale | Before | After |
  |--------|--------|-------|
  | FR | (authcode) | (token de validation) |
  | EN | (authcode) | (validation token) |
  | DE | (“authcode“) | (Validierungstoken) |
  | ES | (código auténtico) | (token de validación) |
  | IT | ("authcode") | (token di convalida) |
  | PL | ("authcode") | (token walidacyjny) |
  | PT | (authcode) | (token de validação) |

- **Bumped `lastUpdated`** to `2026-07-24` in all 7 locale files.

## Notes

- FR was the source; the other locales follow the standard source-routing (FR → EN/ES/IT/PT, EN → DE/PL).
- Superfluous quotes around the former foreign term (DE/IT/PL) were dropped to match the FR native-term style.
- Documentation wording only — no functional/config changes.
