### PR TITLE
[SK-2734] - Domain -  SPF guide: recommend the -all qualifier with its prerequisites

### DIFF
--- a/docs/de/guides/web-cloud/domains/dns-zone-spf.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zone-spf.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Sicherheit durch SPF-Eintrag verbessern
 description: Erfahren Sie hier, wie Sie einen SPF-Eintrag für Ihre Domain konfigurieren, um die Sicherheit Ihrer E-Mails zu verbessern
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -168,6 +168,12 @@ Mit dem Konfigurationsassistenten können Sie Ihren SPF-Eintrag nach Ihren Bedü
 - **Nein**: Stellt ein, dass Server, die E-Mails von Ihrer Domain empfangen, diese ohne besondere Aktion akzeptieren, wenn sie von einer nicht-legitimen (in Ihrem SPF nicht genannten) Quelle stammen. Der E-Mail-Header wird jedoch inkrementiert.
 
 </details>
+
+:::tip
+Die Qualifikatoren `~all` und `-all` sind beide gültig. Für den bestmöglichen Schutz empfehlen wir Ihnen jedoch dringend `-all` — die Option **Ja, ich bin mir dessen sicher** oben. Sie fordert die Server, die Ihre E-Mails empfangen, auf, jede Nachricht abzulehnen, die von einer nicht in Ihrem SPF-Eintrag genannten Quelle stammt.
+
+Wählen Sie `-all` erst, wenn Sie sicher sind, dass Ihr Eintrag **alle** legitimen Versandquellen auflistet: Ihre OVHcloud E-Mail-Lösung, aber auch jeden Drittanbieter, der in Ihrem Namen E-Mails versendet (Marketing-Plattform, CRM, Ticketing-Tool usw.). Fehlt eine legitime Quelle, werden deren E-Mails abgelehnt. Wenn Sie nicht sicher sind, ob die Liste vollständig ist, verwenden Sie `~all` (die Option **Ja, aber dennoch den Safe Mode verwenden**), die diese E-Mails kennzeichnet, anstatt sie abzulehnen.
+:::
 
 Wenn Sie fertig sind, klicken Sie auf <code className="action">Weiter</code>. Bestätigen Sie dann, dass die von Ihnen eingegebenen Werte korrekt sind, indem Sie auf <code className="action">Bestätigen</code> klicken.
 

--- a/docs/en/guides/web-cloud/domains/dns-zone-spf.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-spf.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to improve email security with an SPF record
 description: Find out how to configure an SPF record on your domain name to improve email security
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -177,6 +177,12 @@ The configuration wizard enables you to customise your SPF record according to y
 - **No**: Specify that servers receiving emails from your domain name should accept them if they come from illegitimate sources (not present in your SPF record), without any particular action. The email header will however be increased.
 
 </details>
+
+:::tip
+Both the `~all` and `-all` qualifiers are valid, but for the best protection we strongly recommend `-all` — the **Yes, I am sure** option above. It asks the servers receiving your emails to reject any message sent from a source that is not listed in your SPF record.
+
+Only choose `-all` once you are sure your record lists **every** legitimate sending source: your OVHcloud email solution, but also any third party that sends emails on your behalf (marketing platform, CRM, ticketing tool, etc.). If a legitimate source is missing, its emails will be rejected. If you are not certain the list is exhaustive, use `~all` (the **Yes, but use safe mode** option), which flags those emails instead of rejecting them.
+:::
 
 Once finished, click on <code className="action">Next</code> and verify that the values you have entered are correct by clicking <code className="action">Confirm</code>.
 

--- a/docs/es/guides/web-cloud/domains/dns-zone-spf.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-spf.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mejorar la seguridad del correo electrónico mediante el registro SPF
 description: Descubra cómo configurar un registro SPF en un nombre de dominio para mejorar la seguridad del correo
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -183,6 +183,12 @@ A continuación, los explicamos en detalle:
 - **No** : pide a los servidores que reciban mensajes de correo procedentes de su nombre de dominio que los acepten si provienen de un origen no legítimo  (no indicado en su SPF), sin realizar ninguna otra acción. La cabecera del email se incrementará si elige esta opción.
 
 </details>
+
+:::tip
+Los calificadores `~all` y `-all` son ambos válidos, pero para una protección óptima le recomendamos encarecidamente `-all` — la opción **Sí, estoy seguro** de arriba. Pide a los servidores que reciben sus correos que rechacen cualquier mensaje procedente de un origen no indicado en su SPF.
+
+Elija `-all` únicamente cuando esté seguro de que su registro indica **todos** sus orígenes de envío legítimos: su solución de correo de OVHcloud, pero también cualquier servicio de terceros que envíe correos en su nombre (plataforma de marketing, CRM, herramienta de ticketing, etc.). Si falta un origen legítimo, sus correos se rechazarán. Si no está seguro de que la lista sea exhaustiva, utilice `~all` (la opción **Sí, pero utilizar el modo seguro**), que etiqueta esos correos en lugar de rechazarlos.
+:::
 
 Una vez completada la información, haga clic en <code className="action">Siguiente</code>, asegúrese de que la información mostrada es correcta y haga clic en <code className="action">Confirmar</code>.
 

--- a/docs/fr/guides/web-cloud/domains/dns-zone-spf.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-spf.mdx
@@ -1,7 +1,7 @@
 ---
 title: Améliorer la sécurité des e-mails via un enregistrement SPF
 description: "Découvrez comment configurer un enregistrement SPF sur votre nom de domaine afin d'améliorer la sécurité de vos e-mails"
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -179,10 +179,16 @@ Nous allons les aborder progressivement.
 <summary>"**Est-ce que les informations que vous avez indiquées décrivent tous les hôtes qui envoient du courrier avec votre nom de domaine ?**"</summary>
 
 - **Oui, je suis sûr** : préconisez aux serveurs réceptionnant des e-mails provenant de votre nom de domaine de les rejeter s’ils proviennent d’une source non légitime (non présente dans votre SPF).
-- **Oui, mais utiliser le safe mode** : préconisez aux serveurs réceptionnant des e-mails provenant de votre nom de domaine de les accepter s’ils proviennent d’une source non légitime (non présent dans votre SPF), mais de les taguer afin qu’ils soient identifiables comme potentiellement non légitimes (en tant que "spam" par exemple).
+- **Oui, mais utiliser le safe mode** : préconisez aux serveurs réceptionnant des e-mails provenant de votre nom de domaine de les accepter s’ils proviennent d’une source non légitime (non présent dans votre SPF), mais de les taguer afin qu’ils soient identifiables comme potentiellement non légitimes (en tant que « spam » par exemple).
 - **Non** : préconisez aux serveurs réceptionnant des e-mails provenant de votre nom de domaine de les accepter s’ils proviennent d’une source non légitime (non présente dans votre SPF), sans action particulière. L’entête de l’e-mail sera cependant incrémenté.
 
 </details>
+
+:::tip
+Les qualifieurs `~all` et `-all` sont tous les deux valides, mais pour une protection optimale nous vous recommandons vivement `-all` — l'option **Oui, je suis sûr** ci-dessus. Elle demande aux serveurs qui reçoivent vos e-mails de rejeter tout message provenant d'une source non listée dans votre SPF.
+
+Ne choisissez `-all` qu'une fois certain que votre enregistrement liste **toutes** vos sources d'envoi légitimes : votre solution e-mail OVHcloud, mais aussi tout service tiers qui envoie des e-mails en votre nom (plateforme marketing, CRM, outil de ticketing, etc.). Si une source légitime manque, ses e-mails seront rejetés. Si vous n'êtes pas certain que la liste est exhaustive, utilisez `~all` (l'option **Oui, mais utiliser le safe mode**), qui marque ces e-mails au lieu de les rejeter.
+:::
 
 Une fois les informations complétées, cliquez sur <code className="action">Suivant</code>, assurez-vous que les informations affichées soient bien correctes, puis cliquez sur <code className="action">Confirmer</code>.
 

--- a/docs/it/guides/web-cloud/domains/dns-zone-spf.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zone-spf.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migliora la sicurezza delle email con un record SPF
 description: Questa guida ti mostra come configurare un record SPF sul tuo nome di dominio per migliorare la sicurezza delle email
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -179,10 +179,16 @@ e pertanto di seguito ti forniamo una descrizione dettagliata.
 <summary>"**Le informazioni che hai indicato descrivono tutti gli host che inviano mail dal tuo nome di dominio?**"</summary>
 
 - **Sì, sei sicuro** : per indicare ai server che ricevono email dal tuo nome di dominio di rifiutarle se provengono da una fonte non legittima (non presente nel tuo record SPF)
-- **Sì, ma vuoi utilizzare il safe mode** : per indicare ai server che ricevono email dal tuo nome di dominio di accettarle se provengono da una fonte non legittima (non presente nel tuo record SPF), ma di identificarle in modo che siano riconosciute come potenzialmente non legittime (ad esempio come “spam”)
+- **Sì, ma vuoi utilizzare il safe mode** : per indicare ai server che ricevono email dal tuo nome di dominio di accettarle se provengono da una fonte non legittima (non presente nel tuo record SPF), ma di identificarle in modo che siano riconosciute come potenzialmente non legittime (ad esempio come "spam")
 - **No** : per indicare ai server che ricevono email dal tuo nome di dominio di accettarle se provengono da una fonte non legittima (non presente nel tuo SPF), senza nessuna impostazione particolare. L’oggetto dell’email sarà tuttavia evidenziato.
 
 </details>
+
+:::tip
+I qualificatori `~all` e `-all` sono entrambi validi, ma per una protezione ottimale ti consigliamo vivamente `-all`: l'opzione **Sì, sei sicuro** qui sopra. Chiede ai server che ricevono le tue email di rifiutare qualsiasi messaggio proveniente da una fonte non presente nel tuo record SPF.
+
+Scegli `-all` solo quando sei certo che il tuo record elenchi **tutte** le tue fonti di invio legittime: la tua soluzione email OVHcloud, ma anche qualsiasi servizio di terze parti che invia email per tuo conto (piattaforma di marketing, CRM, strumento di ticketing, ecc.). Se manca una fonte legittima, le sue email verranno rifiutate. Se non sei certo che l'elenco sia completo, utilizza `~all` (l'opzione **Sì, ma vuoi utilizzare il safe mode**), che contrassegna queste email invece di rifiutarle.
+:::
 
 Clicca su <code className="action">Seguente</code>, verifica che le informazioni siano corrette e poi clicca su <code className="action">Conferma</code>.
 

--- a/docs/pl/guides/web-cloud/domains/dns-zone-spf.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-spf.mdx
@@ -1,7 +1,7 @@
 ---
 title: Poprawa bezpieczeństwa e-maili poprzez rekord SPF
 description: Dowiedz się, jak skonfigurować rekord SPF dla Twojej nazwy domeny, aby zwiększyć bezpieczeństwo e-maili
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -183,6 +183,12 @@ Będziemy je stopniowo rozwiązywać.
 - **Nie** : zalecamy, aby serwery odbierające e-maile z Twojej nazwy domeny były akceptowane, jeśli pochodzą z nieuprawnionego źródła (nie zawartego w SPF), bez podejmowania żadnych działań. Nagłówek e-maila zostanie jednak zwiększony.
 
 </details>
+
+:::tip
+Kwalifikatory `~all` i `-all` są oba prawidłowe, ale dla najlepszej ochrony zdecydowanie zalecamy `-all` — opcję **Tak, jestem pewien** powyżej. Nakazuje ona serwerom odbierającym Twoje e-maile odrzucanie każdej wiadomości pochodzącej ze źródła, które nie jest wymienione w Twoim rekordzie SPF.
+
+Wybierz `-all` dopiero wtedy, gdy masz pewność, że Twój rekord wymienia **wszystkie** legalne źródła wysyłki: Twoje rozwiązanie e-mail OVHcloud, ale także każdą usługę zewnętrzną wysyłającą e-maile w Twoim imieniu (platforma marketingowa, CRM, narzędzie do obsługi zgłoszeń itp.). Jeśli brakuje legalnego źródła, jego e-maile zostaną odrzucone. Jeśli nie masz pewności, że lista jest kompletna, użyj `~all` (opcja **Tak, ale użyć safe mode**), która oznacza takie e-maile zamiast je odrzucać.
+:::
 
 Po podaniu informacji, kliknij <code className="action">Dalej</code>, po czym sprawdź czy wyświetlone informacje są poprawne, i następnie kliknij <code className="action">Zatwierdź</code>.
 

--- a/docs/pt/guides/web-cloud/domains/dns-zone-spf.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zone-spf.mdx
@@ -1,7 +1,7 @@
 ---
 title: Melhorar a segurança dos e-mails através do registo SPF
 description: Saiba como configurar um registo SPF no seu nome de domínio para melhorar a segurança dos seus e-mails
-lastUpdated: 2026-02-10
+lastUpdated: 2026-07-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -179,10 +179,16 @@ Vamos abordá-las gradualmente.
 <summary>"**as informações indicadas descrevem todos os hosts que enviam e-mail através do seu nome de domínio?**"</summary>
 
 - **Sim, tenho a certeza** : pede aos servidores que recebem e-mails associados ao seu nome de domínio para rejeitarem mensagens de origem não fidedigna (não indicada no registo SPF).
-- **Sim, mas prefiro usar o safe mode»** : pede aos servidores que recebem e-mails associados ao seu nome de domínio para aceitarem e-mails de origem não fidedigna (não indicada no SPF), e que estes sejam marcados (tagged) como potencialmente não fidedignos (como spam, por exemplo). 
+- **Sim, mas prefiro usar o safe mode** : pede aos servidores que recebem e-mails associados ao seu nome de domínio para aceitarem e-mails de origem não fidedigna (não indicada no SPF), e que estes sejam marcados (tagged) como potencialmente não fidedignos (como spam, por exemplo).
 - **Não** : pede aos servidores que recebem e-mails associados ao seu nome de domínio para aceitarem e-mails de origem não fidedigna, sem outras ações. Com esta opção, o cabeçalho (header) do e-mail ficará maior.
 
 </details>
+
+:::tip
+Os qualificadores `~all` e `-all` são ambos válidos, mas para uma proteção ideal recomendamos vivamente `-all` — a opção **Sim, tenho a certeza** acima. Pede aos servidores que recebem os seus e-mails para rejeitarem qualquer mensagem proveniente de uma origem não indicada no seu registo SPF.
+
+Escolha `-all` apenas quando tiver a certeza de que o seu registo indica **todas** as suas origens de envio legítimas: a sua solução de e-mail OVHcloud, mas também qualquer serviço de terceiros que envie e-mails em seu nome (plataforma de marketing, CRM, ferramenta de ticketing, etc.). Se faltar uma origem legítima, os seus e-mails serão rejeitados. Se não tiver a certeza de que a lista é exaustiva, utilize `~all` (a opção **Sim, mas prefiro usar o safe mode**), que marca esses e-mails em vez de os rejeitar.
+:::
 
 Depois de inseridas todas as informações, clique em <code className="action">Seguinte</code>. Certifique-se de que as informações estão corretas e clique em <code className="action">Confirmar</code>.
 


### PR DESCRIPTION
## Context

JIRA SK-2734 (reporter: Mikolaj Musical; tech lead: Piotr Molik). OVHcloud DNS zones generate an SPF record ending in either `~all` or `-all`, and **both are valid by design**. The guide didn't make this explicit, nor did it guide the reader on which qualifier to choose. Per the ticket's follow-up, `-all` gives the best protection and should be recommended — with the prerequisite that the record must be exhaustive.

## What this PR does

Adds a `:::tip` in the SPF guide, right after the qualifier wizard step ("Does the data describe all hosts…?"), that:
- states both `~all` and `-all` are valid;
- **strongly recommends `-all`** (the *Yes, I am sure* wizard option) for the best protection;
- states the **prerequisite**: the record must list **every** legitimate sending source (OVHcloud email solution + any third party sending on the domain's behalf), otherwise legitimate emails are rejected;
- tells the reader to fall back to `~all` (*safe mode*) if the list may be incomplete.

The tip references each locale's exact wizard option label (e.g. `Oui, je suis sûr`, `Ja, ich bin mir dessen sicher`, `Sí, estoy seguro`). No other content changed — the `~all` form example and the wizard options are untouched.

## Scope

1 guide × 7 locales (`en`, `fr`, `de`, `es`, `it`, `pl`, `pt`):
`web-cloud/domains/dns-zone-spf`. `lastUpdated` bumped to 2026-07-24.

## Verification

`content:lint` (pass), directive fences balanced, diff-scoped prepass (only pre-existing out-of-scope items), full **FR build** (renders correctly). Content-only change: no new components, no frontmatter change beyond `lastUpdated`.

---
Ticket: **SK-2734**
