### PR TITLE
docs(billing): add e-invoicing rejection codes (210/206) to FR billing guides

### DIFF
--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/best-practices.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/best-practices.mdx
@@ -1,7 +1,7 @@
 ---
 title: Les bonnes pratiques pour la gestion de vos services et de votre compte OVHcloud
 description: Retrouvez ici les éléments indispensables pour la bonne gestion de vos factures, commandes, moyens de paiement et compte client
-lastUpdated: 2026-07-13
+lastUpdated: 2026-07-24
 ---
 
 <Banner kind="siret-fr" />
@@ -78,7 +78,9 @@ Pour plus d'informations sur l'activation du renouvellement automatique, consult
 Si vous décidez de ne pas activer le renouvellement automatique, vous recevrez des notifications par e-mail vous invitant à effectuer un **paiement manuel**. Il vous permettra soit de renouveler votre service à l'avance, soit de régler votre facture en attente.
 
 :::info
-En cas d'erreur de mode de paiement (litige 207 – MODPAI_ERR) constatée sur une facture et si vous êtes concerné par la facturation électronique, nous vous invitons à vérifier la date d'expiration de vos services. Cette date est également disponible sur vos précédentes <ManagerLink to="/#/billing/orders">commandes</ManagerLink> et <ManagerLink to="/#/billing/history">factures</ManagerLink>.
+**Facturation électronique**
+
+En cas d'erreur de mode de paiement (litige 207 – MODPAI_ERR ; Approuvé Partiellement – 206 – MODPAI_ERR) signalée sur une facture et si vous êtes concerné par la facturation électronique, nous vous invitons à vérifier le moyen de paiement enregistré sur votre compte. Pour plus d'informations, consultez le guide [Gérer mes moyens de paiement](/guides/account-and-service-management/managing-billing-payments-and-services/manage-payment-methods).
 
 :::
 
@@ -97,6 +99,13 @@ Si vous souhaitez ne plus utiliser l'un de vos services, vous pouvez le résilie
 - <code className="action">Supprimer immédiatement</code> : sur l'écran suivant, cliquez sur <code className="action">Confirmer</code>. Un e-mail de confirmation vous sera envoyé. Suite à votre validation, votre service sera supprimé **immédiatement et définitivement**.
 
 Pour obtenir plus d’informations sur la résiliation de vos services, consultez le guide [Comment résilier vos services OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/how-to-cancel-services).
+
+:::info
+**Facturation électronique**
+
+En cas de contrat terminé (Refusé – 210 – CONTRAT_TERM) signalé sur une facture et si vous êtes concerné par la facturation électronique, nous vous invitons à vérifier la date d'expiration de vos services depuis la page <ManagerLink to="/#/billing/autorenew/services">Mes offres et services</ManagerLink>. Cette date est également disponible sur vos précédentes <ManagerLink to="/#/billing/orders">commandes</ManagerLink> et <ManagerLink to="/#/billing/history">factures</ManagerLink>.
+
+:::
 
 ### Fermeture de compte
 

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/invoice-management.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/invoice-management.mdx
@@ -1,7 +1,7 @@
 ---
 title: Gérer mes factures OVHcloud
 description: Découvrez comment gérer vos factures et les paiements liés à celles-ci
-lastUpdated: 2025-04-28
+lastUpdated: 2026-07-24
 ---
 
 <Banner kind="siret-fr" />
@@ -150,6 +150,13 @@ Depuis cet espace, vous pouvez également exporter vos justificatifs de paiement
 
 :::info
 Si vous constatez une différence entre un paiement et le montant d'une facture, cela signifie que vous possédiez un avoir qui a automatiquement diminué le montant prélevé.
+
+:::
+
+:::info
+**Facturation électronique**
+
+En cas de facture en doublon (Refusé – 210 – DOUBLON) et si vous êtes concerné par la facturation électronique, nous vous invitons à consulter vos commandes afin de faire le point sur les produits et services présents dans la facture, en vous aidant de la section [Comprendre votre facture](#comprendre-votre-facture). Consultez également les paiements associés à vos factures.
 
 :::
 

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders.mdx
@@ -1,7 +1,7 @@
 ---
 title: Gérer mes commandes OVHcloud
 description: Découvrez comment gérer vos commandes chez OVHcloud
-lastUpdated: 2026-07-13
+lastUpdated: 2026-07-24
 ---
 
 <Banner kind="siret-fr" />
@@ -130,16 +130,20 @@ Vous serez remboursé des sommes initialement versées, déduction faite des jou
 
 Une erreur peut être constatée sur une facture au regard de votre commande initiale. Elle correspond à l'un des cas suivants :
 
-- litige 207 – REF_ERR
-- litige 207 – PU_ERR
-- litige 207 – REM_ERR
-- litige 207 – ART_ERR
-- litige 207 – LIVR_INCOMP
-- litige 207 – QTE_ERR
+| Litige (207) | Refusé (210) | Approuvé partiellement (206) |
+|---|---|---|
+| litige 207 – REF_ERR | Refusé – 210 – TRANSAC_INC | Approuvé Partiellement – 206 – Prix_Unit_Inc |
+| litige 207 – PU_ERR | Refusé – 210 – EMMET_INC | Approuvé Partiellement – 206 – Remise_ERR |
+| litige 207 – REM_ERR | Refusé – 210 – MONTANTTOTAL_ERR | Approuvé Partiellement – 206 – Quantité_Err |
+| litige 207 – ART_ERR | Refusé – 210 – CALCUL_ERR | Approuvé Partiellement – 206 – Article_INC |
+| litige 207 – LIVR_INCOMP | | Approuvé Partiellement – 206 – PRB_LIV |
+| litige 207 – QTE_ERR | | |
 
 Si vous êtes concerné par la facturation électronique, nous vous invitons à consulter votre commande initiale et à vérifier que les produits, services et options qu'elle contient correspondent bien à ceux figurant sur votre facture, disponible sur la page <ManagerLink to="/#/billing/history">Mes factures</ManagerLink>.
 
-Pour les produits facturés à la consommation (litige 207 – QTE_ERR), faites le point sur cette même page. La facturation de ce type se base sur votre consommation du mois précédent.
+Pour les produits facturés à la consommation (litige 207 – QTE_ERR, Approuvé Partiellement – 206 – Quantité_Err), faites le point sur cette même page. La facturation de ce type se base sur votre consommation du mois précédent.
+
+En cas de facturation en double (Refusé – 210 – DOUBLE_FACT) ou de numéro de commande erroné (Refusé – 210 – CMD_ERR), consultez également les paiements associés à vos factures. Pour cela, reportez-vous à la section [Suivre vos paiements](/guides/account-and-service-management/managing-billing-payments-and-services/invoice-management#suivre-vos-paiements) du guide dédié à la gestion de vos factures.
 
 ## Aller plus loin
 

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders.mdx
@@ -136,7 +136,7 @@ Une erreur peut être constatée sur une facture au regard de votre commande ini
 | litige 207 – PU_ERR | Refusé – 210 – EMMET_INC | Approuvé Partiellement – 206 – Remise_ERR |
 | litige 207 – REM_ERR | Refusé – 210 – MONTANTTOTAL_ERR | Approuvé Partiellement – 206 – Quantité_Err |
 | litige 207 – ART_ERR | Refusé – 210 – CALCUL_ERR | Approuvé Partiellement – 206 – Article_INC |
-| litige 207 – LIVR_INCOMP | | Approuvé Partiellement – 206 – PRB_LIV |
+| litige 207 – LIVR_INCOMP | Refusé – 210 – NON_CONFORME | Approuvé Partiellement – 206 – PRB_LIV |
 | litige 207 – QTE_ERR | | |
 
 Si vous êtes concerné par la facturation électronique, nous vous invitons à consulter votre commande initiale et à vérifier que les produits, services et options qu'elle contient correspondent bien à ceux figurant sur votre facture, disponible sur la page <ManagerLink to="/#/billing/history">Mes factures</ManagerLink>.

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
@@ -1,14 +1,20 @@
 ---
 title: Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA
 description: Découvrez comment renseigner votre numéro de SIRET pour mettre à jour le taux de TVA de votre compte de facturation OVHcloud
-lastUpdated: 2026-07-21
+lastUpdated: 2026-07-24
 ---
 
 ## Objectif
 
 **L'espace client OVHcloud vous permet de mettre à jour les données liées à votre taux de TVA.**
 
-Si vous disposez d'un compte de type société, renseigner votre numéro de SIRET met automatiquement à jour les coordonnées de votre entreprise, dont votre taux de TVA. Ce guide explique comment renseigner votre numéro de SIRET depuis votre profil lorsqu'une erreur de taux de TVA (litige 207 – TX_TVA_ERR) ou une erreur de SIRET (litige 207 – SIRET_ERR) a été renseignée sur une facture.
+Si vous disposez d'un compte de type société, renseigner votre numéro de SIRET met automatiquement à jour les coordonnées de votre entreprise, dont votre taux de TVA.
+
+Ce guide explique comment renseigner votre numéro de SIRET depuis votre profil. Cette démarche permet également de corriger une facture sur laquelle l'une des erreurs suivantes a été renseignée :
+
+- une erreur de taux de TVA (litige 207 – TX_TVA_ERR) ;
+- une erreur de SIRET (litige 207 – SIRET_ERR ; Approuvé Partiellement – 206 – SIRET_ERR) ;
+- une erreur de destinataire (Refusé – 210 – DEST-ERR, cas de multi-société dans un groupe).
 
 ## Prérequis
 

--- a/docs/fr/guides/manage-and-operate/api/enterprise-payment.mdx
+++ b/docs/fr/guides/manage-and-operate/api/enterprise-payment.mdx
@@ -1,7 +1,7 @@
 ---
 title: Gérer le paiement et la facturation de vos services OVHcloud
 description: Découvrez comment ajouter un moyen de paiement, automatiser sa prise en compte et gérer votre facturation Entreprise
-lastUpdated: 2020-01-02
+lastUpdated: 2026-07-24
 ---
 
 import Api from '@components/Api';
@@ -42,6 +42,13 @@ Dans l'APIv6 et dans votre manager, dans vos moyens de paiement apparaitra un no
 Afin que OVHcloud puisse éditer les factures avec le numéro de **Purchase Order (PO)** souhaité, contactez votre commercial afin de lui donner ce numéro.
 
 En cas de modification de ce numéro de **PO**, contactez votre commercial dans les plus brefs délais.
+
+:::info
+**Facturation électronique**
+
+En cas de référence manquante (Refusé – 210 – REF_CT_ABSENT ; Approuvé Partiellement – 206 – REF_ABT) ou de référence incorrecte (Approuvé Partiellement – 206 – REF_INC) signalée sur une facture et si vous êtes concerné par la facturation électronique, vérifiez le numéro de **Purchase Order (PO)** communiqué à votre commercial en suivant la procédure ci-dessus.
+
+:::
 
 #### Récupérer les factures des sous-comptes
 


### PR DESCRIPTION
Add the new e-invoicing status codes to the callouts of the FR billing guides, alongside the existing 207 codes:

- ovh-orders: 3-column code table + DOUBLE_FACT/CMD_ERR payment note
- update-vat-rate: DEST-ERR, SIRET_ERR in the intro bullet list
- best-practices: split MODPAI (payment methods) and CONTRAT_TERM (cancellation)
- invoice-management: DOUBLON callout
- enterprise-payment: REF_CT_ABSENT, REF_INC, REF_ABT (PO reference)