### PR TITLE
docs(network): introduce firewall copy rule

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aktivieren und Konfigurieren der Edge Network Firewall
 description: Erfahren Sie, wie Sie die Edge Network Firewall für Ihre Dienste konfigurieren
-lastUpdated: 2026-05-28
+lastUpdated: 2026-08-11
 ---
 
 ## Ziel
@@ -165,6 +165,31 @@ Firewall-Konfigurationen, die nur `Accept`-Regeln enthalten, sind nicht wirksam.
 Nach der Bestätigung wird die Firewall aktiviert bzw. deaktiviert.
 
 Beachten Sie, dass Regeln deaktiviert bleiben, bis ein Angriff erkannt wird, und dann aktiviert werden. Diese Logik kann für Regeln verwendet werden, die nur bei einem bekannten, wiederkehrenden Angriff aktiv sein sollen.
+
+### Firewall-Regeln auf eine andere IP-Adresse kopieren
+
+Wenn Sie bereits Firewall-Regeln für eine IP-Adresse konfiguriert haben, können Sie diese auf eine andere IP-Adresse kopieren, anstatt jede Regel manuell neu zu erstellen. Dies ist nützlich, wenn mehrere Ihrer Dienste dieselbe Edge Network Firewall-Konfiguration benötigen.
+
+:::info
+Diese Funktion ist derzeit nur in der Beta-Version des OVHcloud Kundencenters verfügbar. Die Quell-IP-Adresse muss bereits über mindestens eine Firewall-Regel verfügen, damit die Kopieroption verfügbar ist.
+
+:::
+
+Klicken Sie auf der Konfigurationsseite der Edge Network Firewall der IP-Adresse, deren Regeln Sie kopieren möchten, neben der Regelliste auf die Schaltfläche <code className="action">Auf eine andere IP kopieren</code>.
+
+Im Fenster **Firewall-Regeln auf eine andere IP kopieren** zeigt das Feld **Von** die Quell-IP-Adresse an. Wählen Sie im Feld <code className="action">Nach</code> die Ziel-IP-Adresse aus, auf die die Regeln angewendet werden sollen.
+
+Je nach ausgewählter Ziel-IP-Adresse:
+
+- Wenn sie keine Firewall-Regeln enthält, wird die Meldung *"Die Ziel-IP enthält keine Firewall-Regel."* angezeigt, und die Regeln werden unverändert kopiert.
+- Wenn sie bereits Firewall-Regeln enthält, wird die Warnung *"Wenn Sie den Kopiervorgang bestätigen, werden die auf der Ziel-IP vorhandenen Firewall-Regeln gelöscht."* angezeigt.
+
+:::warning
+Das Kopieren von Regeln auf eine Ziel-IP, die bereits Firewall-Regeln enthält, **ersetzt** deren bestehende Konfiguration: Die auf der Ziel-IP vorhandenen Regeln werden gelöscht, bevor die Quellregeln kopiert werden.
+
+:::
+
+Klicken Sie auf die Schaltfläche <code className="action">Bestätigen</code>, um den Kopiervorgang zu starten. Verfügt die Ziel-IP noch nicht über eine Firewall, wird automatisch eine erstellt, die dem aktivierten oder deaktivierten Zustand der Quell-Firewall entspricht.
 
 ### Häufige Fehler und Best Practices
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Enabling and configuring the Edge Network Firewall
 description: Find out how to configure the Edge Network Firewall for your services
-lastUpdated: 2026-07-24
+lastUpdated: 2026-08-11
 ---
 
 ## Objective
@@ -175,23 +175,21 @@ This feature is currently only available in the beta version of the OVHcloud Con
 
 :::
 
-
 From the Edge Network Firewall configuration page of the IP address whose rules you want to copy, click the <code className="action">Copy to another IP</code> button next to the rules list.
 
-In the **Copy firewall rules to another IP** window, the <code className="action">From</code> field displays the source IP address. In the <code className="action">To</code> field, select the destination IP address to which the rules will be applied.
+In the **Copy firewall rules to another IP** window, the **From** field displays the source IP address. In the <code className="action">To</code> field, select the destination IP address to which the rules will be applied.
 
 Depending on the destination IP address you select:
 
-- If it has no firewall rules, the message *"The destination IP does not contain any firewall rule."* is displayed, and the rules are copied as they are.
-- If it already has firewall rules, a warning informs you that confirming the copy will delete the rules currently configured on the destination IP.
+- If it has no firewall rules, the message *"The destination IP does not contain any firewall rule."* is displayed, and the rules are copied as-is.
+- If it already has firewall rules, the warning *"Confirming the copy will delete the firewall rules already present on the destination IP."* is displayed.
 
 :::warning
 Copying rules to a destination IP that already has firewall rules **replaces** its existing configuration: the rules present on the destination IP are deleted before the source rules are copied.
 
 :::
 
-
-Click the <code className="action">Confirm</code> button to start the copy. If the destination IP does not have a firewall yet, one is created automatically, matching the enabled or disabled state of the source firewall. Once the copy is complete, click the <code className="action">Close</code> button.
+Click the <code className="action">Confirm</code> button to start the copy. If the destination IP does not have a firewall yet, one is created automatically, matching the enabled or disabled state of the source firewall.
 
 ### Common mistakes and best practices
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Enabling and configuring the Edge Network Firewall
 description: Find out how to configure the Edge Network Firewall for your services
-lastUpdated: 2026-05-28
+lastUpdated: 2026-07-24
 ---
 
 ## Objective
@@ -165,6 +165,33 @@ Firewall setups with only `Accept` mode rules are not effective at all. There mu
 After confirmation, the firewall will be enabled or disabled.
 
 Note that rules are disabled until the moment an attack is detected - then they are activated. This logic can be used for rules that are only active when a known repeated attack is incoming.
+
+### Copy firewall rules to another IP
+
+If you have already configured firewall rules on one IP address, you can copy them to another IP address instead of recreating each rule manually. This is useful when several of your services require the same Edge Network Firewall configuration.
+
+:::info
+This feature is currently only available in the beta version of the OVHcloud Control Panel. The source IP address must already have at least one firewall rule for the copy option to be available.
+
+:::
+
+
+From the Edge Network Firewall configuration page of the IP address whose rules you want to copy, click the <code className="action">Copy to another IP</code> button next to the rules list.
+
+In the **Copy firewall rules to another IP** window, the <code className="action">From</code> field displays the source IP address. In the <code className="action">To</code> field, select the destination IP address to which the rules will be applied.
+
+Depending on the destination IP address you select:
+
+- If it has no firewall rules, the message *"The destination IP does not contain any firewall rule."* is displayed, and the rules are copied as they are.
+- If it already has firewall rules, a warning informs you that confirming the copy will delete the rules currently configured on the destination IP.
+
+:::warning
+Copying rules to a destination IP that already has firewall rules **replaces** its existing configuration: the rules present on the destination IP are deleted before the source rules are copied.
+
+:::
+
+
+Click the <code className="action">Confirm</code> button to start the copy. If the destination IP does not have a firewall yet, one is created automatically, matching the enabled or disabled state of the source firewall. Once the copy is complete, click the <code className="action">Close</code> button.
 
 ### Common mistakes and best practices
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Activar y configurar el Edge Network Firewall
 description: Descubra cómo configurar el Edge Network Firewall para sus servicios
-lastUpdated: 2026-05-28
+lastUpdated: 2026-08-11
 ---
 
 ## Objetivo
@@ -165,6 +165,31 @@ Las configuraciones de firewall con únicamente reglas en modo "Aceptar" no son 
 Tras la validación, el firewall se activará o desactivará.
 
 Tenga en cuenta que las reglas permanecen desactivadas hasta que se detecta un ataque, momento en el que se activan. Esta lógica puede utilizarse para reglas que solo están activas cuando se produce un ataque repetido conocido.
+
+### Copiar las reglas de firewall a otra dirección IP
+
+Si ya ha configurado reglas de firewall en una dirección IP, puede copiarlas a otra dirección IP en lugar de volver a crear cada regla manualmente. Esto resulta útil cuando varios de sus servicios requieren la misma configuración del Edge Network Firewall.
+
+:::info
+Esta función solo está disponible actualmente en la versión beta del área de cliente de OVHcloud. La dirección IP de origen debe tener al menos una regla de firewall para que la opción de copia esté disponible.
+
+:::
+
+Desde la página de configuración del Edge Network Firewall de la dirección IP cuyas reglas desea copiar, haga clic en el botón <code className="action">Copiar a otra IP</code> situado junto a la lista de reglas.
+
+En la ventana **Copiar las reglas del firewall a otra IP**, el campo **Desde** muestra la dirección IP de origen. En el campo <code className="action">A</code>, seleccione la dirección IP de destino a la que se aplicarán las reglas.
+
+Según la dirección IP de destino seleccionada:
+
+- Si no tiene ninguna regla de firewall, se muestra el mensaje *"La IP de destino no contiene ninguna regla de firewall."* y las reglas se copian tal cual.
+- Si ya tiene reglas de firewall, se muestra el aviso *"Confirmar la copia eliminará las reglas de firewall ya presentes en la IP de destino."*.
+
+:::warning
+Copiar reglas a una IP de destino que ya tiene reglas de firewall **sustituye** su configuración existente: las reglas presentes en la IP de destino se eliminan antes de copiar las reglas de origen.
+
+:::
+
+Haga clic en el botón <code className="action">Confirmar</code> para iniciar la copia. Si la IP de destino aún no dispone de un firewall, se crea uno automáticamente, adoptando el estado activado o desactivado del firewall de origen.
 
 ### Errores frecuentes y buenas prácticas
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Activer et configurer le Edge Network Firewall
 description: Découvrez comment configurer le Edge Network Firewall pour vos services
-lastUpdated: 2026-05-28
+lastUpdated: 2026-07-24
 ---
 
 ## Objectif
@@ -165,6 +165,33 @@ Les configurations de pare-feu avec seulement des règles de mode  `Accept` ne s
 Après validation, le pare-feu sera activé ou désactivé.
 
 Notez que les règles sont désactivées jusqu'au moment où une attaque est détectée, puis qu'elles sont activées. Cette logique peut être utilisée pour les règles qui ne sont actives que lorsqu'une attaque répétée connue arrive.
+
+### Copier les règles de pare-feu vers une autre adresse IP
+
+Si vous avez déjà configuré des règles de pare-feu sur une adresse IP, vous pouvez les copier vers une autre adresse IP plutôt que de recréer chaque règle manuellement. Cela s'avère pratique lorsque plusieurs de vos services nécessitent la même configuration du Edge Network Firewall.
+
+:::info
+Cette fonctionnalité n'est actuellement disponible que dans la version bêta de l'espace client OVHcloud. L'adresse IP source doit comporter au moins une règle de pare-feu pour que l'option de copie soit accessible.
+
+:::
+
+
+Depuis la page de configuration du Edge Network Firewall de l'adresse IP dont vous souhaitez copier les règles, cliquez sur le bouton <code className="action">Copier vers une autre IP</code> situé à côté de la liste des règles.
+
+Dans la fenêtre **Copier les règles du pare-feu vers une autre IP**, le champ <code className="action">De</code> affiche l'adresse IP source. Dans le champ <code className="action">Vers</code>, sélectionnez l'adresse IP de destination à laquelle appliquer les règles.
+
+Selon l'adresse IP de destination sélectionnée :
+
+- Si elle ne comporte aucune règle de pare-feu, le message *« L'IP de destination ne contient aucune règle. »* s'affiche et les règles sont copiées telles quelles.
+- Si elle comporte déjà des règles de pare-feu, un avertissement vous indique que confirmer la copie supprimera les règles actuellement configurées sur l'IP de destination.
+
+:::warning
+Copier des règles vers une adresse IP de destination qui comporte déjà des règles de pare-feu **remplace** sa configuration existante : les règles présentes sur l'IP de destination sont supprimées avant la copie des règles source.
+
+:::
+
+
+Cliquez sur le bouton <code className="action">Confirmer</code> pour lancer la copie. Si l'IP de destination ne dispose pas encore d'un pare-feu, celui-ci est créé automatiquement, en reprenant l'état activé ou désactivé du pare-feu source. Une fois la copie terminée, cliquez sur le bouton <code className="action">Fermer</code>.
 
 ### Erreurs courantes et bonnes pratiques
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Activer et configurer le Edge Network Firewall
 description: Découvrez comment configurer le Edge Network Firewall pour vos services
-lastUpdated: 2026-07-24
+lastUpdated: 2026-08-11
 ---
 
 ## Objectif
@@ -175,23 +175,21 @@ Cette fonctionnalité n'est actuellement disponible que dans la version bêta de
 
 :::
 
-
 Depuis la page de configuration du Edge Network Firewall de l'adresse IP dont vous souhaitez copier les règles, cliquez sur le bouton <code className="action">Copier vers une autre IP</code> situé à côté de la liste des règles.
 
-Dans la fenêtre **Copier les règles du pare-feu vers une autre IP**, le champ <code className="action">De</code> affiche l'adresse IP source. Dans le champ <code className="action">Vers</code>, sélectionnez l'adresse IP de destination à laquelle appliquer les règles.
+Dans la fenêtre **Copier les règles du pare-feu vers une autre IP**, le champ **De** affiche l'adresse IP source. Dans le champ <code className="action">Vers</code>, sélectionnez l'adresse IP de destination à laquelle appliquer les règles.
 
 Selon l'adresse IP de destination sélectionnée :
 
 - Si elle ne comporte aucune règle de pare-feu, le message *« L'IP de destination ne contient aucune règle. »* s'affiche et les règles sont copiées telles quelles.
-- Si elle comporte déjà des règles de pare-feu, un avertissement vous indique que confirmer la copie supprimera les règles actuellement configurées sur l'IP de destination.
+- Si elle comporte déjà des règles de pare-feu, l'avertissement *« Confirmer la copie supprimera les règles existantes sur l'IP de destination. »* s'affiche.
 
 :::warning
 Copier des règles vers une adresse IP de destination qui comporte déjà des règles de pare-feu **remplace** sa configuration existante : les règles présentes sur l'IP de destination sont supprimées avant la copie des règles source.
 
 :::
 
-
-Cliquez sur le bouton <code className="action">Confirmer</code> pour lancer la copie. Si l'IP de destination ne dispose pas encore d'un pare-feu, celui-ci est créé automatiquement, en reprenant l'état activé ou désactivé du pare-feu source. Une fois la copie terminée, cliquez sur le bouton <code className="action">Fermer</code>.
+Cliquez sur le bouton <code className="action">Confirmer</code> pour lancer la copie. Si l'IP de destination ne dispose pas encore d'un pare-feu, celui-ci est créé automatiquement, en reprenant l'état activé ou désactivé du pare-feu source.
 
 ### Erreurs courantes et bonnes pratiques
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attivare e configurare Edge Network Firewall
 description: Scopri come configurare Edge Network Firewall per i tuoi servizi
-lastUpdated: 2026-05-28
+lastUpdated: 2026-08-11
 ---
 
 ## Obiettivo
@@ -165,6 +165,31 @@ Le configurazioni del firewall con solo regole in modalità `Accept` non sono af
 Dopo la convalida, il firewall verrà attivato o disattivato.
 
 Tieni presente che le regole sono disattivate fino al momento in cui viene rilevato un attacco, dopodiché vengono attivate. Questa logica può essere utilizzata per regole che sono attive solo quando arriva un attacco ripetuto noto.
+
+### Copiare le regole del firewall su un altro indirizzo IP
+
+Se hai già configurato delle regole di firewall su un indirizzo IP, puoi copiarle su un altro indirizzo IP invece di ricreare manualmente ogni regola. Questa operazione è utile quando diversi dei tuoi servizi richiedono la stessa configurazione dell'Edge Network Firewall.
+
+:::info
+Questa funzionalità è attualmente disponibile solo nella versione beta dello Spazio Cliente OVHcloud. L'indirizzo IP di origine deve contenere almeno una regola di firewall affinché l'opzione di copia sia disponibile.
+
+:::
+
+Dalla pagina di configurazione dell'Edge Network Firewall dell'indirizzo IP di cui vuoi copiare le regole, clicca sul pulsante <code className="action">Copia su un altro IP</code> situato accanto all'elenco delle regole.
+
+Nella finestra **Copia le regole del firewall su un altro IP**, il campo **Da** mostra l'indirizzo IP di origine. Nel campo <code className="action">A</code>, seleziona l'indirizzo IP di destinazione a cui applicare le regole.
+
+In base all'indirizzo IP di destinazione selezionato:
+
+- Se non contiene alcuna regola di firewall, viene visualizzato il messaggio *"L'IP di destinazione non contiene alcuna regola di firewall."* e le regole vengono copiate così come sono.
+- Se contiene già delle regole di firewall, viene visualizzato l'avviso *"Confermando la copia verranno eliminate le regole del firewall già presenti sull'IP di destinazione."*.
+
+:::warning
+Copiare regole su un IP di destinazione che contiene già regole di firewall **sostituisce** la sua configurazione esistente: le regole presenti sull'IP di destinazione vengono eliminate prima della copia delle regole di origine.
+
+:::
+
+Clicca sul pulsante <code className="action">Conferma</code> per avviare la copia. Se l'IP di destinazione non dispone ancora di un firewall, ne viene creato uno automaticamente, che riprende lo stato attivato o disattivato del firewall di origine.
 
 ### Errori comuni e buone pratiche
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aktywacja i konfiguracja Edge Network Firewall
 description: Dowiedz się, jak skonfigurować Edge Network Firewall dla Twoich usług
-lastUpdated: 2026-05-28
+lastUpdated: 2026-08-11
 ---
 
 ## Wprowadzenie
@@ -165,6 +165,31 @@ Konfiguracje zapory zawierające wyłącznie reguły trybu `Accept` nie są skut
 Po potwierdzeniu zapora zostanie włączona lub wyłączona.
 
 Reguły są nieaktywne do momentu wykrycia ataku — wtedy zostają aktywowane. Ta logika może być wykorzystywana dla reguł, które mają być aktywne tylko w przypadku znanego, powtarzającego się ataku.
+
+### Kopiowanie reguł zapory na inny adres IP
+
+Jeśli skonfigurowałeś już reguły zapory na jednym adresie IP, możesz skopiować je na inny adres IP zamiast ręcznie tworzyć każdą regułę od nowa. Jest to przydatne, gdy kilka Twoich usług wymaga tej samej konfiguracji Edge Network Firewall.
+
+:::info
+Ta funkcja jest obecnie dostępna wyłącznie w wersji beta panelu klienta OVHcloud. Źródłowy adres IP musi zawierać co najmniej jedną regułę zapory, aby opcja kopiowania była dostępna.
+
+:::
+
+Na stronie konfiguracji Edge Network Firewall dla adresu IP, którego reguły chcesz skopiować, kliknij przycisk <code className="action">Kopiuj na inny adres IP</code> znajdujący się obok listy reguł.
+
+W oknie **Kopiowanie reguł zapory na inny adres IP** pole **Od** wyświetla źródłowy adres IP. W polu <code className="action">Do</code> wybierz docelowy adres IP, do którego zostaną zastosowane reguły.
+
+W zależności od wybranego docelowego adresu IP:
+
+- Jeśli nie zawiera on żadnych reguł zapory, wyświetlany jest komunikat *"Docelowy adres IP nie zawiera żadnej reguły zapory."*, a reguły są kopiowane bez zmian.
+- Jeśli zawiera już reguły zapory, wyświetlane jest ostrzeżenie *"Potwierdzenie kopiowania spowoduje usunięcie reguł zapory już obecnych na docelowym adresie IP."*.
+
+:::warning
+Skopiowanie reguł na docelowy adres IP, który zawiera już reguły zapory, **zastępuje** jego istniejącą konfigurację: reguły obecne na docelowym adresie IP są usuwane przed skopiowaniem reguł źródłowych.
+
+:::
+
+Kliknij przycisk <code className="action">Potwierdź</code>, aby rozpocząć kopiowanie. Jeśli docelowy adres IP nie posiada jeszcze zapory, zostanie ona utworzona automatycznie, przejmując włączony lub wyłączony stan zapory źródłowej.
 
 ### Typowe błędy i najlepsze praktyki
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/firewall-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ativar e configurar o Edge Network Firewall
 description: Saiba como configurar o Edge Network Firewall para os seus serviços
-lastUpdated: 2026-05-28
+lastUpdated: 2026-08-11
 ---
 
 ## Objetivo
@@ -165,6 +165,31 @@ As configurações de firewall apenas com regras do modo "Aceitar" não são de 
 Após a validação, a firewall será ativada ou desativada.
 
 Tenha em conta que as regras são desativadas até ao momento em que um ataque é detetado, sendo depois ativadas. Esta lógica pode ser utilizada para regras que apenas ficam ativas quando um ataque repetido conhecido está a chegar.
+
+### Copiar as regras de firewall para outro endereço IP
+
+Se já configurou regras de firewall num endereço IP, pode copiá-las para outro endereço IP em vez de recriar cada regra manualmente. Isto é útil quando vários dos seus serviços requerem a mesma configuração da Edge Network Firewall.
+
+:::info
+Esta funcionalidade só está atualmente disponível na versão beta da área de cliente OVHcloud. O endereço IP de origem deve conter pelo menos uma regra de firewall para que a opção de cópia esteja disponível.
+
+:::
+
+Na página de configuração da Edge Network Firewall do endereço IP cujas regras pretende copiar, clique no botão <code className="action">Copiar para outro IP</code> situado junto à lista de regras.
+
+Na janela **Copiar as regras da firewall para outro IP**, o campo **De** apresenta o endereço IP de origem. No campo <code className="action">Para</code>, selecione o endereço IP de destino ao qual as regras serão aplicadas.
+
+Consoante o endereço IP de destino selecionado:
+
+- Se não contiver qualquer regra de firewall, é apresentada a mensagem *"O IP de destino não contém qualquer regra de firewall."* e as regras são copiadas tal como estão.
+- Se já contiver regras de firewall, é apresentado o aviso *"Ao confirmar a cópia serão eliminadas as regras de firewall já presentes no IP de destino."*.
+
+:::warning
+Copiar regras para um IP de destino que já contém regras de firewall **substitui** a sua configuração existente: as regras presentes no IP de destino são eliminadas antes da cópia das regras de origem.
+
+:::
+
+Clique no botão <code className="action">Confirmar</code> para iniciar a cópia. Se o IP de destino ainda não dispuser de uma firewall, esta é criada automaticamente, assumindo o estado ativado ou desativado da firewall de origem.
 
 ### Erros comuns e boas práticas
 


### PR DESCRIPTION
Introduces a new feature to the Edge Network Firewall : the ability to copy rulesets from one IP to another (beta manager only).

- Changes to an existing guide
- Tools used : Claude
- This can be merged as soon as possible.