### PR TITLE
docs(billing): add FR guide for unknown transaction or issuer

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -58,6 +58,7 @@
             + [Managing OVHcloud orders](account-and-service-management/managing-billing-payments-and-services/ovh-orders)
             + [Managing payment methods](account-and-service-management/managing-billing-payments-and-services/manage-payment-methods)
             + [Managing OVHcloud bills](account-and-service-management/managing-billing-payments-and-services/invoice-management)
+            + [Unknown transaction or issuer](account-and-service-management/managing-billing-payments-and-services/understand-unknown-invoice)
             + [Purchase Order (PO)](account-and-service-management/managing-billing-payments-and-services/purchase-order)
             + [Payer une commande en tant qu’administration publique](account-and-service-management/managing-billing-payments-and-services/public-administration)
             + [Correcting a bank details error](account-and-service-management/managing-billing-payments-and-services/correct-bank-details-error)

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/understand-unknown-invoice.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/understand-unknown-invoice.mdx
@@ -1,0 +1,53 @@
+---
+title: Comprendre une facture d'un émetteur ou service inconnu
+description: Vous avez reçu une facture OVHcloud mais n'arrivez pas à identifier le service concerné, ou bien vous ne reconnaissez pas OVHcloud comme faisant partie de vos fournisseurs
+lastUpdated: 2026-07-27
+---
+
+## Objectif
+
+**Ce guide vous aide à comprendre le contenu de votre facture ou à prendre contact avec OVHcloud.**
+
+Vous avez reçu une facture OVHcloud mais n'arrivez pas à identifier le service concerné, ou bien vous ne reconnaissez pas OVHcloud comme faisant partie de vos fournisseurs.
+
+## Prérequis
+
+- Être connecté à votre espace client OVHcloud.
+- Disposer du droit de visualiser les factures dans votre espace client.
+
+{/* CP-NAV-START:billing-invoices */}
+---
+
+### Accès à l'espace client OVHcloud
+
+- **Lien direct :** <ManagerLink to="/#/billing/history">Mes factures</ManagerLink>
+- **Pour y accéder :** Cliquez sur votre nom en haut à droite > <code className="action">Mes factures</code>
+
+---
+{/* CP-NAV-END:billing-invoices */}
+
+## En pratique
+
+Pour identifier le service concerné, voici comment lire nos références :
+
+- les serveurs commencent par la référence `NS` (exemple : `ns1234-ip12.34.56.net`) ou `VPS` (exemple : `vps12344678.vps.ovh.net`) ;
+- les adresses IP contiennent la référence `IP` (exemple : `ip-1234.5678.9`) ou `pn` (exemple : `pn-123.456.78`) ;
+- les autres services (projets Public Cloud, noms de domaine, licences, lignes de téléphone, etc.) affichent la nature du service à côté de leur référence technique (exemple : `Public Cloud projet référence 1234ABC12345`), afin d'indiquer clairement leur type.
+
+La durée (en jours ou en mois) ainsi que les quantités sont également indiquées de façon lisible sur nos factures.
+
+Nous vous invitons à consulter votre facture pour identifier les services qui vous ont été facturés. Pour cela, ouvrez la page <ManagerLink to="/#/billing/history">Mes factures</ManagerLink>, puis cliquez sur <code className="action">Voir la version PDF</code> pour afficher la facture concernée.
+
+Si, malgré cela, vous ne comprenez pas l'origine de cette facturation et ne reconnaissez pas OVHcloud comme faisant partie de vos fournisseurs, nous vous invitons à nous contacter en [créant un ticket d'assistance](https://help.ovhcloud.com/csm?id=csm_get_help) en précisant les références que vous ne parvenez pas à identifier sur votre facture.
+
+:::info
+Vous disposez de 30 jours pour contester une facture. Passé ce délai, votre réclamation pourrait ne plus être admissible.
+
+:::
+
+## Aller plus loin
+
+- [Comment résilier vos services OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/how-to-cancel-services)
+- [Mieux comprendre vos factures de Public Cloud](/guides/public-cloud/cross-functional/analyze-billing)
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/understand-unknown-invoice.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/understand-unknown-invoice.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comprendre une facture d'un émetteur ou service inconnu
 description: Vous avez reçu une facture OVHcloud mais n'arrivez pas à identifier le service concerné, ou bien vous ne reconnaissez pas OVHcloud comme faisant partie de vos fournisseurs
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-29
 ---
 
 ## Objectif

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/understand-unknown-invoice.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/understand-unknown-invoice.mdx
@@ -38,6 +38,8 @@ La durée (en jours ou en mois) ainsi que les quantités sont également indiqu�
 
 Nous vous invitons à consulter votre facture pour identifier les services qui vous ont été facturés. Pour cela, ouvrez la page <ManagerLink to="/#/billing/history">Mes factures</ManagerLink>, puis cliquez sur <code className="action">Voir la version PDF</code> pour afficher la facture concernée.
 
+Si vous avez l'impression d'avoir reçu une facture en doublon, vérifiez la période facturée ainsi que la référence du service sur chaque document : un même service peut apparaître sur deux factures distinctes correspondant à deux périodes de facturation différentes.
+
 Si, malgré cela, vous ne comprenez pas l'origine de cette facturation et ne reconnaissez pas OVHcloud comme faisant partie de vos fournisseurs, nous vous invitons à nous contacter en [créant un ticket d'assistance](https://help.ovhcloud.com/csm?id=csm_get_help) en précisant les références que vous ne parvenez pas à identifier sur votre facture.
 
 :::info


### PR DESCRIPTION
New France-only e-invoicing guide helping customers identify a service on an OVHcloud invoice or contact support when the issuer is unknown. Registered in the sidebar under Invoices, billing and payments.