### PR TITLE
fix(theme): use semantic fieldsets for search filters

### DIFF
--- a/theme/components/PagefindSearch/index.css
+++ b/theme/components/PagefindSearch/index.css
@@ -149,6 +149,10 @@
 }
 
 .pagefind-filter-row {
+  min-inline-size: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
   display: flex;
   flex-wrap: wrap;
   gap: 6px;

--- a/theme/components/PagefindSearch/index.tsx
+++ b/theme/components/PagefindSearch/index.tsx
@@ -1025,9 +1025,8 @@ export function PagefindSearch() {
               </div>
 
               <div className="pagefind-filters">
-                <div
+                <fieldset
                   className="pagefind-filter-row"
-                  role="group"
                   aria-label={t.filterByUniverse}
                 >
                   <button
@@ -1077,11 +1076,10 @@ export function PagefindSearch() {
                       </button>
                     );
                   })}
-                </div>
+                </fieldset>
                 {productOptions.length > 0 && (
-                  <div
+                  <fieldset
                     className="pagefind-filter-row pagefind-filter-row--products"
-                    role="group"
                     aria-label={t.filterByProduct}
                   >
                     {productOptions.map((p) => (
@@ -1097,7 +1095,7 @@ export function PagefindSearch() {
                         {p.label}
                       </button>
                     ))}
-                  </div>
+                  </fieldset>
                 )}
               </div>
 


### PR DESCRIPTION
Replace the Pagefind universe and product filter wrappers with native `fieldset` elements so assistive technologies get semantic grouping without relying on generic `role="group"` containers.

The scoped CSS reset removes browser-default fieldset spacing and sizing while preserving the existing pill layout and product-row divider.

Verified with:
- `pnpm exec biome check theme/components/PagefindSearch/index.tsx theme/components/PagefindSearch/index.css`
- `pnpm test` (9/9)
- `pnpm content:lint`
- `pnpm sidebar:check`
- all seven locale outputs built and combined
- `pnpm retrievability:check` (56 guides across 7 locales)
- browser comparison before/after, including identical computed row dimensions

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
