### PR TITLE
fix(theme): correct sidebar keyboard handling

### DIFF
--- a/theme/components/Sidebar/SidebarItem.tsx
+++ b/theme/components/Sidebar/SidebarItem.tsx
@@ -108,7 +108,8 @@ export function SidebarItemRaw({
       onClick={onClick}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
-          onClick?.();
+          e.preventDefault();
+          e.currentTarget.click();
         }
       }}
     >

--- a/theme/layouts/ELearningCourseLayout/index.tsx
+++ b/theme/layouts/ELearningCourseLayout/index.tsx
@@ -76,7 +76,6 @@ function useELearningCourseSidebarMenu() {
             <button
               type="button"
               onClick={() => setIsSidebarOpen(false)}
-              onKeyUp={() => setIsSidebarOpen(false)}
               className="rp-sidebar-menu__mask"
               aria-label="Close sidebar"
             />,

--- a/theme/layouts/ELearningLayout/index.tsx
+++ b/theme/layouts/ELearningLayout/index.tsx
@@ -68,7 +68,6 @@ function useELearningSidebarMenu() {
             <button
               type="button"
               onClick={() => setIsSidebarOpen(false)}
-              onKeyUp={() => setIsSidebarOpen(false)}
               className="rp-sidebar-menu__mask"
               aria-label="Close sidebar"
             />,

--- a/theme/layouts/HomeLayout/HomeLayout.tsx
+++ b/theme/layouts/HomeLayout/HomeLayout.tsx
@@ -72,7 +72,6 @@ function useHomeSidebarMenu() {
             <button
               type="button"
               onClick={() => setIsSidebarOpen(false)}
-              onKeyUp={() => setIsSidebarOpen(false)}
               className="rp-sidebar-menu__mask"
               aria-label="Close sidebar"
             />,

--- a/theme/layouts/LandingLayout/index.tsx
+++ b/theme/layouts/LandingLayout/index.tsx
@@ -84,7 +84,6 @@ function useLandingSidebarMenu() {
             <button
               type="button"
               onClick={() => setIsSidebarOpen(false)}
-              onKeyUp={() => setIsSidebarOpen(false)}
               className="rp-sidebar-menu__mask"
               aria-label="Close sidebar"
             />,

--- a/theme/layouts/MigrationLayout/index.tsx
+++ b/theme/layouts/MigrationLayout/index.tsx
@@ -70,7 +70,6 @@ function useMigrationSidebarMenu() {
             <button
               type="button"
               onClick={() => setIsSidebarOpen(false)}
-              onKeyUp={() => setIsSidebarOpen(false)}
               className="rp-sidebar-menu__mask"
               aria-label="Close sidebar"
             />,

--- a/theme/layouts/OverviewLayout/index.tsx
+++ b/theme/layouts/OverviewLayout/index.tsx
@@ -93,9 +93,6 @@ function useOverviewSidebarMenu() {
             <button
               type="button"
               onClick={() => setIsSidebarOpen(false)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') setIsSidebarOpen(false);
-              }}
               className="rp-sidebar-menu__mask"
               aria-label="Close sidebar"
             />,


### PR DESCRIPTION
## Summary

- Remove custom keyboard handlers from native sidebar mask buttons so unrelated key releases no longer close the sidebar.
- Route Enter and Space activation for custom sidebar group buttons through a real click event.

## Details

Five sidebar masks used an unfiltered `onKeyUp` handler, so any key release could close an open sidebar. The overview mask also duplicated native Enter/Space activation with a custom `onKeyDown` handler. All six masks are native `button` elements, so their `onClick` handlers already provide the expected keyboard behavior.

Container-only sidebar groups use a custom `div[role="button"]`. Their keyboard handler called the row's mouse handler without an event, while the group handler calls `stopPropagation()`. Pressing Enter or Space therefore raised `TypeError: Cannot read properties of undefined (reading 'stopPropagation')` instead of toggling the group. Dispatching a real click supplies the expected mouse event; preventing the key's default action also avoids Space scrolling the page.

## Verification

- Browser RED/GREEN: Enter on a container-only group raised a `TypeError` and left it closed before the change; afterward Enter expands it and Space collapses it without console errors.
- Both Enter and Space report `defaultPrevented` after the change.
- Unrelated `KeyA` no longer closes the HomeLayout sidebar mask.
- Clicking the mask still closes the sidebar.
- Targeted Biome check across all seven changed files.
- `pnpm test` (9/9).
- `pnpm build:en`.
- `git diff --check`.

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
