### PR TITLE
[SK-2655] WEB - Email - document the account-lockout / repeated password-prompt known issue

### DIFF
--- a/components/ProblemIcon/ProblemIcon.tsx
+++ b/components/ProblemIcon/ProblemIcon.tsx
@@ -5,7 +5,8 @@ export type Problem =
   | 'spam-blocked'
   | 'mailbox-full'
   | 'password'
-  | 'deleted';
+  | 'deleted'
+  | 'locked';
 
 interface ProblemIconProps {
   /** Which troubleshooting symptom this card is about. */
@@ -81,6 +82,17 @@ export function ProblemIcon({ name, size = 28, style }: ProblemIconProps) {
         <path d="M11.5 12H20" />
         <path d="M17 12v3" />
         <path d="M20 12v3" />
+      </svg>
+    );
+  }
+
+  if (name === 'locked') {
+    // Padlock — account locked / mail client repeatedly prompted for the password.
+    return (
+      <svg {...common} aria-hidden="true">
+        <rect x="4.5" y="10.5" width="15" height="9.5" rx="2" />
+        <path d="M7.5 10.5V7a4.5 4.5 0 0 1 9 0v3.5" />
+        <path d="M12 14v3" />
       </svg>
     );
   }

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ OVHcloud E-Mails
 description: Hier finden Sie die am häufigsten gestellten Fragen zu E-Mails
-lastUpdated: 2026-07-08
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -414,6 +414,23 @@ In der Anleitung "[Website und zugehörige Dienste zu OVHcloud migrieren](/guide
 
 </details>
 
+
+<a name="mail-password-prompt"></a>
+
+<details>
+
+<summary>Warum fragt mein E-Mail-Programm ständig nach meinem Passwort?</summary>
+
+Wenn Ihr E-Mail-Programm ständig nach Ihrem Passwort fragt – oder Ihr Account zeitweise gesperrt zu sein scheint –, liegt die Ursache häufig in der Account-Sperrung Ihrer E-Mail-Sicherheitsrichtlinie in Kombination mit einem E-Mail-Programm, das noch ein altes Passwort verwendet.
+
+Die Sperrrichtlinie sperrt einen E-Mail-Account vorübergehend, nachdem eine bestimmte Anzahl von Anmeldeversuchen fehlgeschlagen ist. Nachdem Sie das Passwort eines Accounts geändert haben, verbindet sich ein nicht aktualisiertes Zweitprogramm – ein Smartphone, ein selten neu gestarteter Computer, ein automatisiertes Skript – weiterhin mit dem **alten** Passwort. Diese wiederholten Fehlversuche lösen die Sperrung aus, und daraufhin fragt jedes Programm nach dem Passwort.
+
+**Lösung:**
+
+1. Ermitteln Sie jedes Gerät und jede Anwendung, die mit dieser Adresse konfiguriert sind, und geben Sie auf jedem einzelnen das **neue** Passwort ein (oder entfernen Sie diejenigen, die Sie nicht mehr verwenden). Das ist die eigentliche Lösung: Sie stoppt die Fehlversuche an der Quelle.
+2. Überprüfen Sie bei Bedarf die Einstellung **Schwelle für die Sperrung** in Ihrer Sicherheitsrichtlinie – siehe [Sicherheitseinstellungen eines E-Mail-Dienstes verwalten](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/security-policy#enhanced-security). Wenn Sie diese auf `0` setzen, wird die Sperrung vollständig deaktiviert, wodurch auch der Schutz vor Brute-Force-Versuchen entfällt. Beheben Sie daher zuerst das Problem mit dem veralteten Programm.
+
+</details>
 
 ## Weiterführende Informationen <a name="go-further"></a>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E-Mail-Diagnose und Fehlerbehebung - OVHcloud E-Mail-Dokumentation"
 description: "Lösen Sie Ihre OVHcloud-E-Mail-Probleme: Senden oder Empfangen nicht möglich, wegen Spam gesperrte Adresse, volles Postfach, vergessenes Passwort oder Wiederherstellung gelöschter E-Mails."
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-27
 pageType: landing
 banner: true
 tagline: "Erkennen und beheben Sie die häufigsten Probleme mit Ihrem OVHcloud-Postfach."
@@ -46,6 +46,7 @@ Sobald Sie die wahrscheinliche Ursache eingegrenzt haben, finden Sie unten Ihr *
   <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="Meine Adresse ist wegen Spam gesperrt" description="Ermitteln Sie die Ursache der verdächtigen Aktivität und entsperren Sie Ihre Adresse." />
   <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="Mein Postfach ist voll" description="Verwalten und optimieren Sie den Speicherplatz Ihres E-Mail-Kontos." />
   <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="Ich habe mein Passwort vergessen" description="Setzen Sie das Passwort einer E-Mail-Adresse zurück oder ändern Sie es." />
+  <LinkCard icon={<ProblemIcon name="locked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails#mail-password-prompt" title="Mein E-Mail-Programm fragt ständig nach meinem Passwort" description="Beheben Sie wiederholte Passwortabfragen und Kontosperrungen, die durch ein E-Mail-Programm mit einem alten Passwort verursacht werden." />
 </CardGrid>
 
 <Region zones={['eu', 'ca']}>

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ OVHcloud emails
 description: Find the most frequently asked questions about emails
-lastUpdated: 2026-07-08
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -418,6 +418,23 @@ Refer to our guide on [Migrating your website and associated services to OVHclou
 
 </details>
 
+
+<a name="mail-password-prompt"></a>
+
+<details>
+
+<summary>Why does my email client keep asking for my password?</summary>
+
+If your email client keeps prompting for your password — or your account appears to lock intermittently — the cause is often the account lockout of your email security policy, combined with a mail client still using an old password.
+
+The lockout policy temporarily locks an email account after a number of failed login attempts. After you change an account's password, a secondary client that was not updated — a smartphone, a rarely-restarted computer, an automated script — keeps connecting with the **old** password. These repeated failures trigger the lockout, and every client then prompts for the password.
+
+**Resolution:**
+
+1. Identify every device and application configured with this address and enter the **new** password on each one (or remove those you no longer use). This is the real fix: it stops the failed attempts at the source.
+2. If needed, review the **Lockout threshold** setting in your security policy — see [Managing the security policy of an email service](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/security-policy#enhanced-security). Setting it to `0` disables the lockout entirely, which also removes protection against brute-force attempts, so fix the outdated client first.
+
+</details>
 
 ## Go further <a name="go-further"></a>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Email diagnostics and troubleshooting - OVHcloud documentation"
 description: "Solve your OVHcloud email problems: cannot send or receive, address blocked for spam, full mailbox, forgotten password, or recovering deleted emails."
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-27
 pageType: landing
 banner: true
 tagline: "Identify and resolve the common problems with your OVHcloud mailbox."
@@ -46,6 +46,7 @@ Once you have identified the likely origin, find your **symptom** below: most co
   <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="My address is blocked for spam" description="Identify the cause of the suspicious activity and unblock your address." />
   <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="My mailbox is full" description="Manage and optimise the storage space of your email account." />
   <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="I forgot my password" description="Reset or change the password of an email address." />
+  <LinkCard icon={<ProblemIcon name="locked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails#mail-password-prompt" title="My email client keeps asking for my password" description="Fix repeated password prompts and account lockouts caused by a mail client using an old password." />
 </CardGrid>
 
 <Region zones={['eu', 'ca']}>

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ soluciones de correo electrónico de OVHcloud
 description: Encuentre las preguntas más frecuentes sobre el correo electrónico
-lastUpdated: 2026-07-08
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -415,6 +415,23 @@ Para más información, consulte la guía "[Migrar un sitio web y los servicios 
 
 </details>
 
+
+<a name="mail-password-prompt"></a>
+
+<details>
+
+<summary>¿Por qué mi cliente de correo me pide continuamente la contraseña?</summary>
+
+Si su cliente de correo le solicita continuamente la contraseña —o su cuenta parece bloquearse de forma intermitente—, la causa suele ser el bloqueo de cuenta de su política de seguridad de correo, combinado con un cliente de correo que sigue utilizando una contraseña antigua.
+
+La política de bloqueo bloquea temporalmente una cuenta de correo tras un número determinado de intentos de inicio de sesión fallidos. Después de cambiar la contraseña de una cuenta, un cliente secundario que no se ha actualizado —un smartphone, un ordenador que rara vez se reinicia, un script automatizado— sigue conectándose con la contraseña **antigua**. Estos fallos repetidos activan el bloqueo, y todos los clientes solicitan entonces la contraseña.
+
+**Resolución:**
+
+1. Identifique todos los dispositivos y aplicaciones configurados con esta dirección e introduzca la **nueva** contraseña en cada uno de ellos (o elimine los que ya no utilice). Esta es la verdadera solución: detiene los intentos fallidos en su origen.
+2. Si es necesario, revise el ajuste **Umbral de bloqueo** en su política de seguridad; consulte [Configurar la política de seguridad de un servicio de correo](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/security-policy#enhanced-security). Si lo establece en `0`, se desactiva por completo el bloqueo, lo que también elimina la protección frente a los intentos de fuerza bruta, por lo que conviene corregir primero el cliente desactualizado.
+
+</details>
 
 ## Más información <a name="go-further"></a>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnóstico y resolución de problemas de correo - Documentación de correo OVHcloud"
 description: "Resuelva sus problemas de correo de OVHcloud: no puede enviar ni recibir, dirección bloqueada por spam, buzón lleno, contraseña olvidada o recuperación de correos eliminados."
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-27
 pageType: landing
 banner: true
 tagline: "Identifique y resuelva los problemas habituales de su mensajería OVHcloud."
@@ -46,6 +46,7 @@ Una vez identificado el origen probable, localice su **síntoma** más abajo: la
   <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="Mi dirección está bloqueada por spam" description="Identifique la causa de la actividad sospechosa y desbloquee su dirección." />
   <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="Mi buzón está lleno" description="Gestione y optimice el espacio de almacenamiento de su cuenta de correo." />
   <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="He olvidado mi contraseña" description="Restablezca o cambie la contraseña de una dirección de correo." />
+  <LinkCard icon={<ProblemIcon name="locked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails#mail-password-prompt" title="Mi cliente de correo me pide continuamente la contraseña" description="Solucione las solicitudes repetidas de contraseña y los bloqueos de cuenta provocados por un cliente de correo que utiliza una contraseña antigua." />
 </CardGrid>
 
 <Region zones={['eu', 'ca']}>

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ e-mails OVHcloud
 description: Retrouvez les questions les plus fréquemment posées sur les e-mails
-lastUpdated: 2026-07-08
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -419,6 +419,23 @@ Consultez le guide « [Migrer son site web et ses services associés vers OVHclo
 
 </details>
 
+
+<a name="mail-password-prompt"></a>
+
+<details>
+
+<summary>Pourquoi mon client de messagerie me demande-t-il sans cesse mon mot de passe ?</summary>
+
+Si votre client de messagerie vous demande continuellement votre mot de passe — ou si votre compte semble se verrouiller de façon intermittente —, la cause est souvent le verrouillage de compte défini dans la politique de sécurité de votre service e-mail, combiné à un client de messagerie qui utilise encore un ancien mot de passe.
+
+La politique de verrouillage bloque temporairement un compte e-mail après un certain nombre de tentatives de connexion échouées. Après avoir modifié le mot de passe d'un compte, un client secondaire qui n'a pas été mis à jour — un smartphone, un ordinateur rarement redémarré, un script automatisé — continue de se connecter avec l'**ancien** mot de passe. Ces échecs répétés déclenchent le verrouillage, et chaque client demande alors le mot de passe.
+
+**Résolution :**
+
+1. Identifiez chaque appareil et chaque application configurés avec cette adresse et saisissez le **nouveau** mot de passe sur chacun d'eux (ou supprimez ceux que vous n'utilisez plus). C'est la véritable solution : elle arrête les tentatives échouées à la source.
+2. Si nécessaire, vérifiez le paramètre **Seuil de verrouillage** dans votre politique de sécurité — consultez [Gérer la politique de sécurité d'un service e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/security-policy#enhanced-security). Le définir sur `0` désactive entièrement le verrouillage, ce qui supprime également la protection contre les tentatives par force brute ; corrigez donc d'abord le client obsolète.
+
+</details>
 
 ## Aller plus loin <a name="go-further"></a>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnostic et dépannage e-mail OVHcloud"
 description: "Résolvez vos problèmes d'e-mail OVHcloud : envoi ou réception impossible, adresse bloquée pour spam, boîte pleine, mot de passe oublié ou récupération d'e-mails supprimés."
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-27
 pageType: landing
 banner: true
 tagline: "Identifiez et résolvez les problèmes courants de votre messagerie OVHcloud."
@@ -46,6 +46,7 @@ Une fois l'origine probable repérée, identifiez le **symptôme** ci-dessous :
   <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="Mon adresse est bloquée pour spam" description="Identifiez la cause de l'activité suspecte et débloquez votre adresse." />
   <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="Ma boîte e-mail est pleine" description="Gérez et optimisez l'espace de stockage de votre compte e-mail." />
   <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="J'ai oublié mon mot de passe" description="Réinitialisez ou modifiez le mot de passe d'une adresse e-mail." />
+  <LinkCard icon={<ProblemIcon name="locked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails#mail-password-prompt" title="Mon client de messagerie me demande sans cesse mon mot de passe" description="Résolvez les demandes répétées de mot de passe et les verrouillages de compte causés par un client de messagerie qui utilise un ancien mot de passe." />
 </CardGrid>
 
 <Region zones={['eu', 'ca']}>

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ email OVHcloud
 description: Rileggi le domande più frequenti sulle email
-lastUpdated: 2026-07-08
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -415,6 +415,23 @@ Consulta la guida "[Migrare il proprio sito Web e i servizi associati a OVHcloud
 
 </details>
 
+
+<a name="mail-password-prompt"></a>
+
+<details>
+
+<summary>Perché il mio client di posta continua a chiedermi la password?</summary>
+
+Se il tuo client di posta continua a richiederti la password — o se il tuo account sembra bloccarsi in modo intermittente — la causa è spesso il blocco dell'account previsto dalla politica di sicurezza della tua email, combinato con un client di posta che utilizza ancora una vecchia password.
+
+La politica di blocco blocca temporaneamente un account email dopo un certo numero di tentativi di accesso non riusciti. Dopo aver modificato la password di un account, un client secondario che non è stato aggiornato — uno smartphone, un computer riavviato raramente, uno script automatico — continua a connettersi con la **vecchia** password. Questi tentativi falliti ripetuti attivano il blocco e, di conseguenza, ogni client richiede la password.
+
+**Soluzione:**
+
+1. Individua tutti i dispositivi e le applicazioni configurati con questo indirizzo e inserisci la **nuova** password su ciascuno di essi (oppure rimuovi quelli che non utilizzi più). Questa è la vera soluzione: interrompe i tentativi falliti alla fonte.
+2. Se necessario, verifica l'impostazione **Limite di blocco** nella tua politica di sicurezza — consulta [Gestire la politica di sicurezza di un servizio di posta elettronica](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/security-policy#enhanced-security). Impostandolo su `0` si disabilita completamente il blocco, il che rimuove anche la protezione contro i tentativi di forza bruta, quindi correggi prima il client obsoleto.
+
+</details>
 
 ## Per saperne di più <a name="go-further"></a>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnostica e risoluzione dei problemi e-mail - Documentazione email OVHcloud"
 description: "Risolvete i vostri problemi e-mail OVHcloud: invio o ricezione impossibili, indirizzo bloccato per spam, casella piena, password dimenticata o recupero di e-mail eliminate."
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-27
 pageType: landing
 banner: true
 tagline: "Individuate e risolvete i problemi più comuni della vostra messaggistica OVHcloud."
@@ -46,6 +46,7 @@ Una volta individuata l'origine probabile, trovate qui sotto il vostro **sintomo
   <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="Il mio indirizzo è bloccato per spam" description="Individuate la causa dell'attività sospetta e sbloccate il vostro indirizzo." />
   <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="La mia casella è piena" description="Gestite e ottimizzate lo spazio di archiviazione del vostro account e-mail." />
   <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="Ho dimenticato la mia password" description="Reimpostate o modificate la password di un indirizzo e-mail." />
+  <LinkCard icon={<ProblemIcon name="locked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails#mail-password-prompt" title="Il mio client di posta continua a chiedermi la password" description="Risolvete le richieste ripetute di password e i blocchi dell'account causati da un client di posta che utilizza una vecchia password." />
 </CardGrid>
 
 <Region zones={['eu', 'ca']}>

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ e-mail OVHcloud
 description: Znajdź najczęściej zadawane pytania dotyczące kont e-mail
-lastUpdated: 2026-07-08
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -415,6 +415,23 @@ Wszystkie kolejne etapy znajdują się w przewodniku „[Przeniesienie strony WW
 
 </details>
 
+
+<a name="mail-password-prompt"></a>
+
+<details>
+
+<summary>Dlaczego mój klient poczty e-mail wciąż prosi o hasło?</summary>
+
+Jeśli Twój klient poczty e-mail wciąż prosi o hasło — lub Twoje konto co jakiś czas wydaje się blokować — przyczyną jest często blokada konta wynikająca z polityki bezpieczeństwa usługi e-mail, w połączeniu z klientem poczty, który nadal używa starego hasła.
+
+Polityka blokady tymczasowo blokuje konto e-mail po określonej liczbie nieudanych prób logowania. Po zmianie hasła do konta drugorzędny klient, który nie został zaktualizowany — smartfon, rzadko restartowany komputer, zautomatyzowany skrypt — nadal łączy się przy użyciu **starego** hasła. Te powtarzające się niepowodzenia uruchamiają blokadę, a następnie każdy klient prosi o hasło.
+
+**Rozwiązanie:**
+
+1. Zidentyfikuj każde urządzenie i aplikację skonfigurowane z tym adresem i wprowadź na każdym z nich **nowe** hasło (lub usuń te, których już nie używasz). To właściwe rozwiązanie: zatrzymuje nieudane próby u źródła.
+2. W razie potrzeby sprawdź ustawienie **Próg blokady** w polityce bezpieczeństwa — zobacz [Zarządzanie polityką bezpieczeństwa usługi e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/security-policy#enhanced-security). Ustawienie go na `0` całkowicie wyłącza blokadę, co usuwa również ochronę przed atakami metodą brute-force, dlatego najpierw napraw nieaktualnego klienta.
+
+</details>
 
 ## Sprawdź również <a name="go-further"></a>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnostyka i rozwiązywanie problemów z pocztą - Dokumentacja e-mail OVHcloud"
 description: "Rozwiąż problemy z pocztą OVHcloud: brak możliwości wysyłania lub odbierania, adres zablokowany z powodu spamu, pełna skrzynka, zapomniane hasło lub odzyskiwanie usuniętych wiadomości."
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-27
 pageType: landing
 banner: true
 tagline: "Zidentyfikuj i rozwiąż najczęstsze problemy ze swoją skrzynką OVHcloud."
@@ -46,6 +46,7 @@ Po ustaleniu prawdopodobnego źródła odszukaj poniżej swój **objaw**: więks
   <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="Mój adres jest zablokowany z powodu spamu" description="Ustal przyczynę podejrzanej aktywności i odblokuj swój adres." />
   <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="Moja skrzynka jest pełna" description="Zarządzaj przestrzenią dyskową swojego konta e-mail i optymalizuj ją." />
   <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="Zapomniałem hasła" description="Zresetuj lub zmień hasło do adresu e-mail." />
+  <LinkCard icon={<ProblemIcon name="locked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails#mail-password-prompt" title="Mój klient poczty e-mail wciąż prosi o hasło" description="Rozwiąż problem powtarzających się próśb o hasło i blokad konta spowodowanych przez klienta poczty używającego starego hasła." />
 </CardGrid>
 
 <Region zones={['eu', 'ca']}>

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ e-mails OVHcloud
 description: Consulte as perguntas mais frequentes sobre os e-mails
-lastUpdated: 2026-07-08
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -414,6 +414,23 @@ Para más información, consulte la guía "[Migrar un sitio web y los servicios 
 
 </details>
 
+
+<a name="mail-password-prompt"></a>
+
+<details>
+
+<summary>Porque é que o meu cliente de e-mail continua a pedir-me a palavra-passe?</summary>
+
+Se o seu cliente de e-mail continua a pedir a palavra-passe — ou se a sua conta parece bloquear-se de forma intermitente — a causa é, muitas vezes, o bloqueio de conta da política de segurança do seu serviço de e-mail, combinado com um cliente de correio que continua a utilizar uma palavra-passe antiga.
+
+A política de bloqueio bloqueia temporariamente uma conta de e-mail após um determinado número de tentativas de início de sessão falhadas. Depois de alterar a palavra-passe de uma conta, um cliente secundário que não foi atualizado — um smartphone, um computador raramente reiniciado, um script automatizado — continua a ligar-se com a palavra-passe **antiga**. Estas falhas repetidas desencadeiam o bloqueio, e todos os clientes passam então a pedir a palavra-passe.
+
+**Resolução:**
+
+1. Identifique todos os dispositivos e aplicações configurados com este endereço e introduza a palavra-passe **nova** em cada um deles (ou remova aqueles que já não utiliza). Esta é a verdadeira solução: interrompe as tentativas falhadas na origem.
+2. Se necessário, reveja a definição **Limite de bloqueio** na sua política de segurança — consulte [Gerir a política de segurança de um serviço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/security-policy#enhanced-security). Defini-la como `0` desativa completamente o bloqueio, o que também remove a proteção contra tentativas de força bruta, por isso corrija primeiro o cliente desatualizado.
+
+</details>
 
 ## Quer saber mais? <a name="go-further"></a>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/landing-page-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnóstico e resolução de problemas de e-mail - Documentação de e-mail OVHcloud"
 description: "Resolva os seus problemas de e-mail OVHcloud: envio ou receção impossível, endereço bloqueado por spam, caixa cheia, palavra-passe esquecida ou recuperação de e-mails eliminados."
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-27
 pageType: landing
 banner: true
 tagline: "Identifique e resolva os problemas comuns do seu serviço de e-mail OVHcloud."
@@ -46,6 +46,7 @@ Depois de identificar a origem provável, localize o seu **sintoma** abaixo: a m
   <LinkCard icon={<ProblemIcon name="spam-blocked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam" title="O meu endereço está bloqueado por spam" description="Identifique a causa da atividade suspeita e desbloqueie o seu endereço." />
   <LinkCard icon={<ProblemIcon name="mailbox-full" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/email-manage-quota" title="A minha caixa de e-mail está cheia" description="Faça a gestão e otimize o espaço de armazenamento da sua conta de e-mail." />
   <LinkCard icon={<ProblemIcon name="password" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password" title="Esqueci-me da minha palavra-passe" description="Reponha ou altere a palavra-passe de um endereço de e-mail." />
+  <LinkCard icon={<ProblemIcon name="locked" size={36} />} href="/guides/web-cloud/email-and-collaborative-solutions/mx-plan/faq-emails#mail-password-prompt" title="O meu cliente de e-mail continua a pedir-me a palavra-passe" description="Resolva os pedidos repetidos de palavra-passe e os bloqueios de conta causados por um cliente de correio que utiliza uma palavra-passe antiga." />
 </CardGrid>
 
 <Region zones={['eu', 'ca']}>


### PR DESCRIPTION
## What

Documents the first email "known issue": a mail client repeatedly prompting
for its password (and the account appearing to lock intermittently), caused by
the security-policy **account lockout** being triggered by a secondary client
still connecting with an **old** password after a password change.

It is documented in two places so users find it wherever they look:

- **FAQ entry** in the OVHcloud emails FAQ — *"Why does my email client keep
  asking for my password?"* (anchor `#mail-password-prompt`).
- **Troubleshooting hub card** in the "What is your problem?" grid, linking to
  that FAQ entry, with a new padlock icon.

## Why

Reported via SK-2655. The ask was a "known issues" reference guiding customers
to a resolution. Instead of a standalone single-entry page, the content is
placed in the existing FAQ + troubleshooting hub — better discoverability and a
reusable pattern for future known issues.

## How

- New FAQ `<details>` entry: explains the cause, then gives the resolution.
  1. **Real fix** — update/remove every device or app still using the old
     password (stops the failed attempts at the source).
  2. **Workaround** — review the **Lockout threshold** setting; links to
     *Managing the security policy of an email service*
     (`security-policy#enhanced-security`). Notes that setting it to `0`
     disables brute-force protection, so the outdated client should be fixed
     first.
- New `<LinkCard>` in `landing-page-troubleshooting.mdx` pointing at the FAQ
  anchor.
- New `locked` (padlock) variant added to the `ProblemIcon` component.

## Scope

7 locales: EN, FR, DE, ES, IT, PL, PT.

- `.../mx-plan/faq-emails.mdx` (×7)
- `.../troubleshooting/landing-page-troubleshooting.mdx` (×7)
- `components/ProblemIcon/ProblemIcon.tsx`

## Testing / QA

- Cross-references verified per locale against `security-policy.mdx` (link
  label = target title, setting name = actual UI label, `#enhanced-security`
  anchor exists).
- Diff-scoped proofread across all 7 locales (FR non-breaking spaces; DE
  `Account` terminology; IT formal register on the card).
- `content:lint` passes on all 14 guides.
