### PR TITLE
docs: add guide on importing an external DNS zone before an incoming transfer

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -1711,6 +1711,7 @@
             + [Migration](products/web-cloud-domains-domain-names-migration)
                 + [Incoming transfer to OVHcloud](web-cloud-domains-domain-names-migration-incoming-transfer-to-ovhcloud)
                     + [Transferring a domain name to OVHcloud](web-cloud/domains/transfer-incoming-generic-domain)
+                    + [Importing an external DNS zone to OVHcloud](web-cloud/domains/dns-zone-import)
                     + [Transferring a .uk domain name to OVHcloud](web-cloud/domains/transfer-incoming-couk)
                     + [Transferring a .pl domain name to OVHcloud](web-cloud/domains/transfer-pl)
                     + [Transferring a domain name from Hostinger to OVHcloud](web-cloud/domains/transfer-incoming-hostinger)

--- a/docs/de/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zone-import.mdx
@@ -11,7 +11,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Wenn Sie einen Domainnamen zu OVHcloud transferieren (*eingehender Transfer*), ändert sich nur der Registrar, der den Domainnamen verwaltet. Die **DNS-Zone** – also die Gesamtheit der *DNS-Einträge*, die Ihren Domainnamen mit Ihren Diensten (Website, E-Mails usw.) verbinden – wird **nicht** automatisch mit dem Domainnamen transferiert.
 
-Manche Anbieter löschen die bei ihnen gehostete DNS-Zone, sobald der Transfer des Domainnamens abgeschlossen ist. Wenn Sie sie nicht zuvor bei OVHcloud neu erstellt haben, können Ihre Dienste nicht verfügbar sein, bis Sie die DNS-Zone manuell neu konfigurieren.
+Manche Anbieter löschen die bei ihnen gehostete DNS-Zone, sobald der Transfer des Domainnamens abgeschlossen ist. Wenn Sie sie nicht zuvor bei OVHcloud neu erstellt haben, sind Ihre Dienste möglicherweise nicht mehr verfügbar, bis Sie die DNS-Zone manuell neu konfiguriert haben.
 
 **In dieser Anleitung erfahren Sie, wie Sie Ihre aktuelle DNS-Zone abrufen und bei OVHcloud identisch neu erstellen, bevor Sie den eingehenden Transfer Ihres Domainnamens starten.**
 
@@ -73,7 +73,7 @@ Kopieren Sie **nicht** die **NS**-Einträge Ihres früheren Anbieters oder desse
 
 Erstellen Sie anschließend eine OVHcloud DNS-Zone für Ihren Domainnamen. Diese Zone enthält die in Schritt 1 notierten DNS-Einträge.
 
-Folgen Sie dazu unserer Anleitung "[OVHcloud DNS-Zone für eine Domainnamen erstellen](/guides/web-cloud/domains/dns-zone-create)".
+Folgen Sie dazu unserer Anleitung "[OVHcloud DNS-Zone für einen Domainnamen erstellen](/guides/web-cloud/domains/dns-zone-create)".
 
 :::tip
 Wählen Sie beim Erstellen die Option **minimale Einträge**, wenn Sie die Zone vollständig selbst anpassen möchten. So vermeiden Sie, dass OVHcloud Einträge vorkonfiguriert, die Sie anschließend löschen müssten.
@@ -139,7 +139,7 @@ Je nach Ihrem aktuellen Registrar oder der Endung Ihres Domainnamens gibt es spe
 - [Einen .uk-Domainnamen transferieren](/guides/web-cloud/domains/transfer-incoming-couk)
 
 :::info
-Damit Ihre OVHcloud DNS-Zone aktiv wird, muss Ihr Domainname auf die DNS-Server von OVHcloud verweisen. Wenn Sie dies beim Starten des eingehenden Transfers noch nicht getan haben, geben Sie diese DNS-Server nach Abschluss des Transfers an. Dieses Verfahren wird in der Anleitung "[OVHcloud DNS-Zone für eine Domainnamen erstellen](/guides/web-cloud/domains/dns-zone-create)" beschrieben (Abschnitt "DNS-Server des Domainnamens ändern").
+Damit Ihre OVHcloud DNS-Zone aktiv wird, muss Ihr Domainname auf die DNS-Server von OVHcloud verweisen. Wenn Sie dies beim Starten des eingehenden Transfers noch nicht getan haben, geben Sie diese DNS-Server nach Abschluss des Transfers an. Dieses Verfahren wird in der Anleitung "[OVHcloud DNS-Zone für einen Domainnamen erstellen](/guides/web-cloud/domains/dns-zone-create)" beschrieben (Abschnitt "DNS-Server des Domainnamens ändern").
 
 :::
 
@@ -147,7 +147,7 @@ Damit Ihre OVHcloud DNS-Zone aktiv wird, muss Ihr Domainname auf die DNS-Server 
 
 [Domainnamen zu OVHcloud transferieren](/guides/web-cloud/domains/transfer-incoming-generic-domain)
 
-[OVHcloud DNS-Zone für eine Domainnamen erstellen](/guides/web-cloud/domains/dns-zone-create)
+[OVHcloud DNS-Zone für einen Domainnamen erstellen](/guides/web-cloud/domains/dns-zone-create)
 
 [Bearbeiten der OVHcloud DNS-Zone](/guides/web-cloud/domains/dns-zone-edit)
 

--- a/docs/de/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zone-import.mdx
@@ -1,0 +1,164 @@
+---
+title: Externe DNS-Zone zu OVHcloud importieren
+description: Erfahren Sie, wie Sie die DNS-Zone Ihres Domainnamens vor einem eingehenden Transfer bei OVHcloud neu erstellen, um Konfigurationsverluste zu vermeiden
+lastUpdated: 2026-07-30
+availableIn: [eu, ca, apac]
+---
+
+import { Tab, Tabs } from '@rspress/core/theme';
+
+## Ziel
+
+Wenn Sie einen Domainnamen zu OVHcloud transferieren (*eingehender Transfer*), ändert sich nur der Registrar, der den Domainnamen verwaltet. Die **DNS-Zone** – also die Gesamtheit der *DNS-Einträge*, die Ihren Domainnamen mit Ihren Diensten (Website, E-Mails usw.) verbinden – wird **nicht** automatisch mit dem Domainnamen transferiert.
+
+Manche Anbieter löschen die bei ihnen gehostete DNS-Zone, sobald der Transfer des Domainnamens abgeschlossen ist. Wenn Sie sie nicht zuvor bei OVHcloud neu erstellt haben, können Ihre Dienste nicht verfügbar sein, bis Sie die DNS-Zone manuell neu konfigurieren.
+
+**In dieser Anleitung erfahren Sie, wie Sie Ihre aktuelle DNS-Zone abrufen und bei OVHcloud identisch neu erstellen, bevor Sie den eingehenden Transfer Ihres Domainnamens starten.**
+
+:::warning
+Verwechseln Sie nicht die **DNS-Server** und die **DNS-Zone**:
+
+- die **DNS-Server** (*Nameserver*) geben an, *wo* die DNS-Konfiguration Ihres Domainnamens gehostet wird.
+- die **DNS-Zone** enthält die Konfiguration selbst (die *Einträge*: A, AAAA, MX, CNAME, TXT usw.).
+
+Diese Anleitung behandelt die **DNS-Zone und ihre DNS-Einträge**. Wenn Sie Ihre aktuellen externen DNS-Server zum Zeitpunkt des eingehenden Transfers des Domainnamens beibehalten, geben Sie diese direkt bei der Transfer-Bestellung an (siehe Schritt 3 der Anleitung "[Domainnamen zu OVHcloud transferieren](/guides/web-cloud/domains/transfer-incoming-generic-domain#step3)"): Die bei OVHcloud gehostete DNS-Zone wird dann erst verwendet, wenn Sie die DNS-Server ändern.
+
+:::
+
+## Voraussetzungen
+
+- Sie haben Zugriff auf die DNS-Verwaltungsoberfläche Ihres aktuellen Anbieters/Registrars, um Ihre DNS-Einträge abzurufen.
+- Sie verfügen über einen [OVHcloud Kunden-Account](/guides/account-and-service-management/account-information/ovhcloud-account-creation).
+- Der betreffende Domainname verfügt noch nicht über eine aktive DNS-Zone bei OVHcloud.
+- Planen Sie diesen Vorgang, **bevor** Sie den eingehenden Transfer des Domainnamens starten.
+
+## Einführung
+
+Bei der Transfer-Bestellung sind zwei Fälle möglich:
+
+- Sie geben die **externen DNS-Server** an, die der Domainname bereits verwendet: Die DNS-Konfiguration bleibt bei Ihrem aktuellen Anbieter unverändert und es kommt zum Zeitpunkt des Transfers zu keiner Unterbrechung, sofern dieser Ihre DNS-Zone nach Abschluss des Transfers nicht löscht.
+- Sie geben nichts an: Der Domainname wird mit einer **neuen, leeren DNS-Zone** auf den DNS-Servern von OVHcloud bereitgestellt, und Sie müssen Ihre DNS-Einträge anschließend selbst neu erstellen.
+
+In beiden Fällen empfehlen wir Ihnen, Ihre DNS-Zone bei OVHcloud **vor** dem Transfer Ihres Domainnamens neu zu erstellen, falls Sie sie langfristig bei OVHcloud hosten möchten. So können Sie ihre Konfiguration überprüfen und ohne Dienstunterbrechung umstellen, unabhängig von der DNS-Zone bei Ihrem früheren Anbieter (die gelöscht werden kann).
+
+## In der praktischen Anwendung
+
+### 1 - Ihre aktuelle DNS-Zone bei Ihrem externen Anbieter abrufen
+
+Notieren Sie zunächst alle DNS-Einträge, die für Ihren Domainnamen bei Ihrem aktuellen Anbieter/Registrar derzeit gültig sind.
+
+Die meisten Anbieter bieten eine der folgenden Methoden an:
+
+- einen **Export der Zone im Textformat** (häufig als "Zonendatei" bezeichnet).
+- eine **Liste der Einträge**, die in ihrer Oberfläche angezeigt wird und die Sie kopieren können.
+
+Achten Sie besonders auf die Einträge, die mit Ihren wesentlichen Diensten verbunden sind:
+
+- die **A**- und **AAAA**-Einträge (IPv4/IPv6-Adressen Ihrer Website).
+- die **MX**-Einträge (die E-Mail-Server, an die Ihre E-Mails weitergeleitet werden).
+- die **CNAME**-Einträge (ein Alias, der auf einen anderen Domainnamen verweist).
+- die Einträge für E-Mail-Sicherheit und -Authentifizierung (**SPF**, **DKIM**, **DMARC**), in der Regel als **TXT**-Einträge gespeichert.
+
+:::tip
+Um die verschiedenen Eintragstypen vor dem Kopieren besser zu verstehen, lesen Sie unsere Anleitung "[Alle Informationen zu DNS-Einträgen](/guides/web-cloud/domains/dns-zone-records)".
+
+:::
+
+:::warning
+Kopieren Sie **nicht** die **NS**-Einträge Ihres früheren Anbieters oder dessen **SOA**-Eintrag: Diese Werte sind spezifisch für den DNS-Host und werden für die neue bei OVHcloud gehostete Zone automatisch verwaltet.
+
+:::
+
+### 2 - Die DNS-Zone bei OVHcloud erstellen
+
+Erstellen Sie anschließend eine OVHcloud DNS-Zone für Ihren Domainnamen. Diese Zone enthält die in Schritt 1 notierten DNS-Einträge.
+
+Folgen Sie dazu unserer Anleitung "[OVHcloud DNS-Zone für eine Domainnamen erstellen](/guides/web-cloud/domains/dns-zone-create)".
+
+:::tip
+Wählen Sie beim Erstellen die Option **minimale Einträge**, wenn Sie die Zone vollständig selbst anpassen möchten. So vermeiden Sie, dass OVHcloud Einträge vorkonfiguriert, die Sie anschließend löschen müssten.
+
+:::
+
+### 3 - Ihre Einträge bei OVHcloud neu erstellen
+
+Sobald die OVHcloud DNS-Zone erstellt ist, übertragen Sie die in Schritt 1 abgerufenen DNS-Einträge in diese Zone. Es gibt zwei mögliche Vorgehensweisen.
+
+<Tabs>
+  <Tab label="Textmodus (empfohlen für einen Import)">
+    Der **Textmodus** ermöglicht es, die DNS-Zone direkt als Text zu bearbeiten. Dies ist die schnellste Methode, wenn Sie bereits über einen Export der DNS-Zone (im Textformat) verfügen: Sie können alle Ihre DNS-Einträge auf einmal einfügen.
+
+    Lesen Sie dazu den Abschnitt "Zone manuell im Textmodus bearbeiten" unserer Anleitung "[Bearbeiten der OVHcloud DNS-Zone](/guides/web-cloud/domains/dns-zone-edit#txtmod)".
+
+    :::warning
+    Diese Methode ist nur für erfahrene Benutzer bestimmt. Achten Sie sehr genau auf die Syntax. Ändern Sie die **NS**-Einträge der DNS-Zone nicht zugunsten von DNS-Servern außerhalb von OVHcloud: Diese DNS-Zone funktioniert **ausschließlich** mit DNS-Servern von OVHcloud.
+
+    :::
+  </Tab>
+  <Tab label="DNS-Einträge einzeln hinzufügen">
+    Wenn Sie nicht über einen Export der DNS-Zone verfügen, fügen Sie jeden DNS-Eintrag einzeln über die Konfigurationsassistenten von OVHcloud hinzu.
+
+    Folgen Sie dazu unserer Anleitung "[Bearbeiten der OVHcloud DNS-Zone](/guides/web-cloud/domains/dns-zone-edit)", die beschreibt, wie Sie einen DNS-Eintrag hinzufügen, ändern und löschen.
+
+    Für die gängigsten DNS-Eintragstypen gibt es außerdem eigene Anleitungen:
+
+    - [Einen A-Eintrag hinzufügen](/guides/web-cloud/domains/dns-zone-a-record-creation)
+    - [Einen CNAME-Eintrag hinzufügen](/guides/web-cloud/domains/dns-zone-cname-record-creation)
+    - [Einen MX-Eintrag konfigurieren](/guides/web-cloud/domains/dns-zone-mx)
+    - [Einen TXT-Eintrag hinzufügen](/guides/web-cloud/domains/dns-zone-txt-record-creation)
+  </Tab>
+</Tabs>
+
+### 4 - Die neu erstellte DNS-Zone überprüfen
+
+Bevor Sie den eingehenden Transfer Ihres Domainnamens starten, überprüfen Sie, ob die bei OVHcloud neu erstellte DNS-Zone vollständig und mit Ihrer ursprünglichen Konfiguration konsistent ist.
+
+- Vergleichen Sie die DNS-Einträge der OVHcloud-Zone einzeln mit der in Schritt 1 notierten Liste.
+- Stellen Sie sicher, dass alle Ihre wesentlichen Dienste (Website, E-Mails) abgedeckt sind.
+
+Sie können die Konfiguration auch mit dem Tool Zonemaster analysieren. Lesen Sie unsere Anleitung "[Verwendung von Zonemaster](/guides/web-cloud/domains/dns-zonemaster)".
+
+:::warning
+Zu diesem Zeitpunkt ist Ihre OVHcloud DNS-Zone bereit, aber **noch nicht aktiv**: Solange Ihr Domainname die DNS-Server Ihres früheren Anbieters verwendet, gilt die alte Konfiguration. Die Umstellung erfolgt zum Zeitpunkt des eingehenden Transfers oder wenn Sie die DNS-Server ändern.
+
+:::
+
+### 5 - Den eingehenden Transfer des Domainnamens starten
+
+Nachdem Ihre DNS-Zone bei OVHcloud neu erstellt und überprüft wurde, können Sie den eingehenden Transfer sicher starten.
+
+Folgen Sie dem Verfahren, das in unserer Anleitung "[Domainnamen zu OVHcloud transferieren](/guides/web-cloud/domains/transfer-incoming-generic-domain)" beschrieben ist.
+
+Je nach Ihrem aktuellen Registrar oder der Endung Ihres Domainnamens gibt es spezifische Anleitungen:
+
+- [Einen Domainnamen von Gandi transferieren](/guides/web-cloud/domains/transfer-incoming-gandi)
+- [Einen Domainnamen von GoDaddy transferieren](/guides/web-cloud/domains/transfer-incoming-godaddy)
+- [Einen Domainnamen von Ionos transferieren](/guides/web-cloud/domains/transfer-incoming-ionos)
+- [Einen Domainnamen von Hostinger transferieren](/guides/web-cloud/domains/transfer-incoming-hostinger)
+- [Einen Domainnamen von Wix transferieren](/guides/web-cloud/domains/transfer-incoming-wix)
+- [Einen .uk-Domainnamen transferieren](/guides/web-cloud/domains/transfer-incoming-couk)
+
+:::info
+Damit Ihre OVHcloud DNS-Zone aktiv wird, muss Ihr Domainname auf die DNS-Server von OVHcloud verweisen. Wenn Sie dies beim Starten des eingehenden Transfers noch nicht getan haben, geben Sie diese DNS-Server nach Abschluss des Transfers an. Dieses Verfahren wird in der Anleitung "[OVHcloud DNS-Zone für eine Domainnamen erstellen](/guides/web-cloud/domains/dns-zone-create)" beschrieben (Abschnitt "DNS-Server des Domainnamens ändern").
+
+:::
+
+## Weiterführende Informationen
+
+[Domainnamen zu OVHcloud transferieren](/guides/web-cloud/domains/transfer-incoming-generic-domain)
+
+[OVHcloud DNS-Zone für eine Domainnamen erstellen](/guides/web-cloud/domains/dns-zone-create)
+
+[Bearbeiten der OVHcloud DNS-Zone](/guides/web-cloud/domains/dns-zone-edit)
+
+[Alle Informationen zur DNS-Zone](/guides/web-cloud/domains/dns-zone-general-information)
+
+[Alle Informationen zu DNS-Einträgen](/guides/web-cloud/domains/dns-zone-records)
+
+[Migration Ihrer Website und zugehörigen Dienste zu OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
+
+Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](/links/partner).
+
+Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](/links/support).
+
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/web-cloud/domains/dns/landing-page-dns.mdx
+++ b/docs/de/guides/web-cloud/domains/dns/landing-page-dns.mdx
@@ -93,6 +93,7 @@ Jeder Eintrag ist eine Zeile der Zone, die einen Namen mit einem Wert verknüpft
         { title: 'Eine OVHcloud DNS-Zone für einen Domainnamen erstellen', link: '/guides/web-cloud/domains/dns-zone-create' },
         { title: 'Eine OVHcloud DNS-Zone für eine Subdomain erstellen', link: '/guides/web-cloud/domains/dns-zone-create-subdomain' },
         { title: 'Eine OVHcloud DNS-Zone bearbeiten', link: '/guides/web-cloud/domains/dns-zone-edit' },
+        { title: 'Externe DNS-Zone importieren', link: '/guides/web-cloud/domains/dns-zone-import' },
         { title: 'Den Verlauf einer DNS-Zone verwalten', link: '/guides/web-cloud/domains/dns-zone-history' },
         { title: 'Eine DNS-Zone löschen', link: '/guides/web-cloud/domains/dns-zone-deletion' },
       ],

--- a/docs/en/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-import.mdx
@@ -1,7 +1,7 @@
 ---
 title: Importing an external DNS zone to OVHcloud
 description: Find out how to prepare and recreate your domain name's DNS zone at OVHcloud before an incoming transfer, to avoid losing any DNS configuration
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/en/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-import.mdx
@@ -1,6 +1,6 @@
 ---
 title: Importing an external DNS zone to OVHcloud
-description: Prepare and recreate your domain name's DNS zone at OVHcloud before an incoming transfer to avoid losing any DNS configuration
+description: Find out how to prepare and recreate your domain name's DNS zone at OVHcloud before an incoming transfer, to avoid losing any DNS configuration
 lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
@@ -9,37 +9,37 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objective
 
-When you transfer a domain name to OVHcloud (*incoming transfer*), only the management of the domain name changes registrar. The **DNS zone**, that is, the set of *DNS records* that link your domain name to your services (website, emails, etc.), is **not** transferred automatically with the domain name.
+When you transfer a domain name to OVHcloud (*incoming transfer*), only the registrar managing the domain name changes. The **DNS zone** — the set of *DNS records* linking your domain name to your services (website, emails, etc.) — is **not** transferred automatically with the domain name.
 
-Some providers delete the DNS zone hosted on their side as soon as the domain name transfer is complete. If you have not recreated it beforehand at OVHcloud, your services may become unavailable until you have manually reconfigured the DNS zone.
+Some providers delete the DNS zone hosted on their side as soon as the domain name transfer is complete. If you have not recreated it beforehand at OVHcloud, your services may become unavailable until you manually reconfigure the DNS zone.
 
-**This guide explains how to retrieve your current DNS zone and recreate it identically at OVHcloud, before starting the incoming transfer of your domain name.**
+**This guide explains how to retrieve your current DNS zone and recreate an identical copy at OVHcloud, before starting the incoming transfer of your domain name.**
 
 :::warning
 Do not confuse **DNS servers** and the **DNS zone**:
 
-- **DNS servers** (*nameservers*) indicate *where* your domain name's DNS configuration is hosted;
+- **DNS servers** (*nameservers*) indicate *where* your domain name's DNS configuration is hosted.
 - the **DNS zone** contains the configuration itself (the *records*: A, AAAA, MX, CNAME, TXT, etc.).
 
-This guide covers the **DNS zone and its DNS records**. If you keep your current external DNS servers at the time of the incoming transfer of the domain name, enter them directly when placing the transfer order (see part 3 of the [Transferring a domain name to OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain) guide): the DNS zone hosted at OVHcloud will then not be used until you change the DNS servers.
+This guide covers the **DNS zone and its DNS records**. If you keep your current external DNS servers at the time of the incoming transfer of the domain name, enter them directly when placing the transfer order (see Step 3 of the [Transferring a domain name to OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain#step3) guide): the DNS zone hosted at OVHcloud will then not be used until you change the DNS servers.
 
 :::
 
 ## Requirements
 
-- Have access to the DNS management interface of your current provider/registrar, in order to retrieve your DNS records.
-- Have an [OVHcloud account](/guides/account-and-service-management/account-information/ovhcloud-account-creation).
+- Access to the DNS management interface of your current provider/registrar, to retrieve your DNS records.
+- An [OVHcloud account](/guides/account-and-service-management/account-information/ovhcloud-account-creation).
 - The domain name concerned must not already have an active DNS zone at OVHcloud.
 - Plan this operation **before** starting the incoming transfer of the domain name.
 
 ## Introduction
 
-During an incoming transfer, two scenarios arise when placing the order:
+When you place the transfer order, two scenarios are possible:
 
-- you enter the **external DNS servers** that the domain name already uses: the DNS configuration remains unchanged at your current provider and no interruption occurs at the time of transfer, provided that this provider does not delete your DNS zone after finalising the transfer;
+- you enter the **external DNS servers** that the domain name already uses: the DNS configuration remains unchanged at your current provider and no interruption occurs at the time of transfer, provided it does not delete your DNS zone once the transfer is complete.
 - you enter nothing: the domain name is provided with a **new, empty DNS zone** on the OVHcloud DNS servers, and you must then recreate your DNS records yourself.
 
-In both cases, if you plan to eventually host your DNS zone at OVHcloud, we recommend recreating it at OVHcloud **before** transferring your domain name. This way, you can check its configuration and switch over without any service interruption, independently of the DNS zone hosted at your former provider (which may be deleted).
+In both cases, if you plan to eventually host your DNS zone at OVHcloud, we recommend recreating it at OVHcloud **before** transferring your domain name. You can then check its configuration and switch over with no service interruption, regardless of the DNS zone at your former provider (which may be deleted).
 
 ## Instructions
 
@@ -49,15 +49,15 @@ First, note down all the DNS records currently in effect for your domain name at
 
 Most providers offer one of the following methods:
 
-- a **text-format export of the zone** (often called a "zone file");
-- a **display of the record list** in their interface, which you can copy.
+- a **text-format export of the zone** (often called a "zone file").
+- a **list of the records** displayed in their interface, which you can copy.
 
 Pay particular attention to the records linked to your essential services:
 
-- **A** and **AAAA** records (IPv4/IPv6 addresses of your website);
-- **MX** records (the email servers to which your emails are redirected);
-- **CNAME** records (an alias pointing to another domain name);
-- email security and authentication records (**SPF**, **DKIM**, **DMARC**), usually set as **TXT** fields.
+- **A** and **AAAA** records (IPv4/IPv6 addresses of your website).
+- **MX** records (the email servers to which your emails are redirected).
+- **CNAME** records (an alias pointing to another domain name).
+- email security and authentication records (**SPF**, **DKIM**, **DMARC**), usually stored as **TXT** records.
 
 :::tip
 To better understand the different record types before copying them, read our guide on [Everything you need to know about DNS records](/guides/web-cloud/domains/dns-zone-records).
@@ -71,12 +71,12 @@ Do **not** copy the **NS** records of your former provider or its **SOA** record
 
 ### 2 - Create the DNS zone at OVHcloud
 
-Next, create an OVHcloud DNS zone for your domain name. This zone will hold the DNS records you noted down in the previous part.
+Next, create an OVHcloud DNS zone for your domain name. This zone will hold the DNS records you noted down in part 1.
 
 To do this, follow our guide on [Creating an OVHcloud DNS zone for a domain name](/guides/web-cloud/domains/dns-zone-create).
 
 :::tip
-When creating it, choose the **minimum records** option if you plan to fully customise the zone yourself. This avoids OVHcloud preconfiguring records that you would then have to delete.
+When creating it, choose the **minimal records** option if you plan to fully customise the zone yourself. This avoids OVHcloud preconfiguring records that you would then have to delete.
 
 :::
 
@@ -102,18 +102,18 @@ Once the OVHcloud DNS zone is created, transfer the DNS records retrieved in par
 
     Dedicated guides also exist for the most common DNS record types:
 
-    - [Add a DNS A record](/guides/web-cloud/domains/dns-zone-a-record-creation)
+    - [Add an A record](/guides/web-cloud/domains/dns-zone-a-record-creation)
     - [Add a CNAME record](/guides/web-cloud/domains/dns-zone-cname-record-creation)
-    - [Add an MX record](/guides/web-cloud/domains/dns-zone-mx)
-    - [Add a DNS TXT record](/guides/web-cloud/domains/dns-zone-txt-record-creation)
+    - [Configure an MX record](/guides/web-cloud/domains/dns-zone-mx)
+    - [Add a TXT record](/guides/web-cloud/domains/dns-zone-txt-record-creation)
   </Tab>
 </Tabs>
 
 ### 4 - Check the recreated DNS zone
 
-Before starting the incoming transfer of your domain name, check that the DNS zone recreated at OVHcloud is complete and consistent with your original configuration.
+Before starting the incoming transfer of your domain name, check that the DNS zone you recreated at OVHcloud is complete and matches your original configuration.
 
-- Compare, one by one, the DNS records of the OVHcloud zone with the list you noted down in part 1.
+- Compare the OVHcloud zone's DNS records one by one with the list you noted down in part 1.
 - Make sure all your essential services (website, emails) are covered.
 
 You can also analyse the configuration using the Zonemaster tool. Read our guide on [Using Zonemaster](/guides/web-cloud/domains/dns-zonemaster).
@@ -125,11 +125,11 @@ At this stage, your OVHcloud DNS zone is ready but **not yet active**: as long a
 
 ### 5 - Start the incoming transfer of the domain name
 
-With your DNS zone recreated and checked at OVHcloud, you can now start the incoming transfer safely.
+Now that your DNS zone is recreated and checked at OVHcloud, you can start the incoming transfer safely.
 
 Follow the procedure described in our guide on [Transferring a domain name to OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain).
 
-Specific guides exist depending on your current registrar:
+Specific guides exist depending on your current registrar or your domain name's extension:
 
 - [Transferring a domain name from Gandi](/guides/web-cloud/domains/transfer-incoming-gandi)
 - [Transferring a domain name from GoDaddy](/guides/web-cloud/domains/transfer-incoming-godaddy)
@@ -139,7 +139,7 @@ Specific guides exist depending on your current registrar:
 - [Transferring a .uk domain name](/guides/web-cloud/domains/transfer-incoming-couk)
 
 :::info
-For your OVHcloud DNS zone to become active, your domain name must point to the OVHcloud DNS servers. If you have not already done so when initiating the incoming transfer, declare these DNS servers once the incoming transfer is complete. This procedure is described in the [Creating an OVHcloud DNS zone for a domain name](/guides/web-cloud/domains/dns-zone-create) guide (section "Modify the domain name's DNS servers").
+For your OVHcloud DNS zone to become active, your domain name must point to the OVHcloud DNS servers. If you have not already done so when initiating the incoming transfer, declare these DNS servers once the incoming transfer is complete. This procedure is described in the [Creating an OVHcloud DNS zone for a domain name](/guides/web-cloud/domains/dns-zone-create) guide (section "Modify the domain name’s DNS servers").
 
 :::
 

--- a/docs/en/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-import.mdx
@@ -1,0 +1,166 @@
+---
+title: Importing an external DNS zone to OVHcloud
+description: Prepare and recreate your domain name's DNS zone at OVHcloud before an incoming transfer to avoid losing any DNS configuration
+lastUpdated: 2026-07-27
+availableIn: [eu, ca, apac]
+---
+
+import { Tab, Tabs } from '@rspress/core/theme';
+
+## Objective
+
+When you transfer a domain name to OVHcloud (*incoming transfer*), only the management of the domain name changes registrar. The **DNS zone** — the set of *DNS records* that link your domain name to your services (website, emails, etc.) — is **not** transferred automatically with the domain name.
+
+Some providers delete the DNS zone hosted on their side as soon as the domain name transfer is complete. If you have not recreated it beforehand at OVHcloud, your services may become unavailable while you manually reconfigure the DNS zone.
+
+**This guide explains how to retrieve your current DNS zone and recreate it identically at OVHcloud, before starting the incoming transfer of your domain name.**
+
+:::warning
+Do not confuse **DNS servers** and the **DNS zone**:
+
+- **DNS servers** (*nameservers*) indicate *where* your domain name's DNS configuration is hosted;
+- the **DNS zone** contains the configuration itself (the *records*: A, AAAA, MX, CNAME, TXT, etc.).
+
+This guide covers the **DNS zone and its records**. If you keep your current external DNS servers at the time of transfer, enter them directly when placing the transfer order (see part 3 of the [Transferring a domain name to OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain) guide): the DNS zone hosted at OVHcloud will then not be used until you change the DNS servers.
+
+:::
+
+## Requirements
+
+- Have access to the DNS management interface of your current provider/registrar, in order to retrieve your DNS records.
+- Have an [OVHcloud account](/links/manager).
+- The domain name concerned must not already have an active DNS zone at OVHcloud.
+- Plan this operation **before** starting the incoming transfer of the domain name.
+
+## Introduction
+
+A domain name's active DNS zone contains the DNS configuration applied to it. It is what links your domain name to your services such as your email addresses or your website.
+
+During an incoming transfer, two scenarios arise when placing the order:
+
+- you enter the **external DNS servers** that the domain name already uses: the DNS configuration remains unchanged at your current provider and no interruption occurs at the time of transfer, provided that this provider does not delete your DNS zone after finalising the transfer;
+- you enter nothing: the domain name is provided with a **new, empty DNS zone** on the OVHcloud DNS servers, and you must then recreate your DNS records yourself.
+
+In both cases, if you plan to eventually host your DNS zone at OVHcloud, we recommend recreating it at OVHcloud **before** transferring your domain name. This way, you can check its configuration and switch over without any service interruption, independently of the DNS zone hosted at your former provider (which may be deleted).
+
+## Instructions
+
+### 1 - Retrieve your current DNS zone from your external provider
+
+First, note down all the DNS records currently in effect for your domain name at your current provider/registrar.
+
+Most providers offer one of the following methods:
+
+- a **text-format export of the zone** (often called a "zone file" or "BIND format");
+- a **display of the record list** in their interface, which you can copy.
+
+Pay particular attention to the records linked to your essential services:
+
+- **A** and **AAAA** records (IPv4/IPv6 addresses of your website);
+- **MX** records (mail servers);
+- **CNAME** records (aliases, subdomains);
+- **TXT** records (SPF, DKIM, DMARC, ownership verification, etc.).
+
+:::tip
+To better understand the different record types before copying them, read our guide on [Everything you need to know about DNS records](/guides/web-cloud/domains/dns-zone-records).
+
+:::
+
+:::warning
+Do **not** copy the **NS** records of your former provider or its **SOA** record: these values are specific to the DNS host and will be managed automatically for the new zone hosted at OVHcloud.
+
+:::
+
+### 2 - Create the DNS zone at OVHcloud
+
+Next, create an OVHcloud DNS zone for your domain name. This zone will hold the DNS records you noted down in the previous part.
+
+To do this, follow our guide on [Creating an OVHcloud DNS zone for a domain name](/guides/web-cloud/domains/dns-zone-create).
+
+:::tip
+When creating it, choose the **minimum records** option if you plan to fully customise the zone yourself. This avoids OVHcloud preconfiguring records that you would then have to delete.
+
+:::
+
+### 3 - Recreate your records at OVHcloud
+
+Once the OVHcloud DNS zone is created, transfer the DNS records retrieved in part 1 into it. Two approaches are possible.
+
+<Tabs>
+  <Tab label="Text mode (recommended for an import)">
+    **Text mode** lets you edit the DNS zone directly as text. This is the fastest method when you already have a DNS zone export (BIND or text format): you can paste all your DNS records at once.
+
+    To do this, refer to the "Manually edit the zone in text mode" section of our guide on [Editing an OVHcloud DNS zone](/guides/web-cloud/domains/dns-zone-edit#txtmod).
+
+    :::warning
+    This method is for advanced users only. Be very careful with the syntax. Do not change the **NS** records of the DNS zone in favour of DNS servers external to OVHcloud: this DNS zone works **only** with OVHcloud DNS servers.
+
+    :::
+  </Tab>
+  <Tab label="Adding DNS records one by one">
+    If you do not have a DNS zone export, add each DNS record individually using OVHcloud's configuration assistants.
+
+    To do this, follow our guide on [Editing an OVHcloud DNS zone](/guides/web-cloud/domains/dns-zone-edit), which describes how to add, modify and delete a DNS record.
+
+    Dedicated guides also exist for the most common DNS record types:
+
+    - [Add a DNS A record](/guides/web-cloud/domains/dns-zone-a-record-creation)
+    - [Add a CNAME record](/guides/web-cloud/domains/dns-zone-cname-record-creation)
+    - [Add an MX record](/guides/web-cloud/domains/dns-zone-mx)
+    - [Add a DNS TXT record](/guides/web-cloud/domains/dns-zone-txt-record-creation)
+  </Tab>
+</Tabs>
+
+### 4 - Check the recreated DNS zone
+
+Before starting the incoming transfer of your domain name, check that the DNS zone recreated at OVHcloud is complete and consistent with your original configuration.
+
+- Compare, one by one, the DNS records of the OVHcloud zone with the list you noted down in part 1.
+- Make sure all your essential services (website, emails) are covered.
+
+You can also analyse the configuration using the Zonemaster tool. Read our guide on [Using Zonemaster](/guides/web-cloud/domains/dns-zonemaster).
+
+:::warning
+At this stage, your OVHcloud DNS zone is ready but **not yet active**: as long as your domain name uses the DNS servers of your former provider, the old configuration applies. The switch will take place at the time of the incoming transfer or when you change the DNS servers.
+
+:::
+
+### 5 - Start the incoming transfer of the domain name
+
+With your DNS zone recreated and checked at OVHcloud, you can now start the incoming transfer safely.
+
+Follow the procedure described in our guide on [Transferring a domain name to OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain).
+
+Specific guides exist depending on your current registrar:
+
+- [Transferring a domain name from Gandi](/guides/web-cloud/domains/transfer-incoming-gandi)
+- [Transferring a domain name from GoDaddy](/guides/web-cloud/domains/transfer-incoming-godaddy)
+- [Transferring a domain name from Ionos](/guides/web-cloud/domains/transfer-incoming-ionos)
+- [Transferring a domain name from Hostinger](/guides/web-cloud/domains/transfer-incoming-hostinger)
+- [Transferring a domain name from Wix](/guides/web-cloud/domains/transfer-incoming-wix)
+- [Transferring a .uk domain name](/guides/web-cloud/domains/transfer-incoming-couk)
+
+:::info
+For your OVHcloud DNS zone to become active, your domain name must point to the OVHcloud DNS servers. If you have not already done so when initiating the incoming transfer, declare these DNS servers once the incoming transfer is complete. This procedure is described in the [Creating an OVHcloud DNS zone for a domain name](/guides/web-cloud/domains/dns-zone-create) guide (section "Modify the domain name's DNS servers").
+
+:::
+
+## Go further
+
+[Transferring a domain name to OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain)
+
+[Creating an OVHcloud DNS zone for a domain name](/guides/web-cloud/domains/dns-zone-create)
+
+[Editing an OVHcloud DNS zone](/guides/web-cloud/domains/dns-zone-edit)
+
+[Everything you need to know about DNS zone](/guides/web-cloud/domains/dns-zone-general-information)
+
+[Everything you need to know about DNS records](/guides/web-cloud/domains/dns-zone-records)
+
+[Migrating your website and associated services to OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
+
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
+
+Join our [community of users](/links/community).

--- a/docs/en/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-import.mdx
@@ -9,9 +9,9 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objective
 
-When you transfer a domain name to OVHcloud (*incoming transfer*), only the management of the domain name changes registrar. The **DNS zone** — the set of *DNS records* that link your domain name to your services (website, emails, etc.) — is **not** transferred automatically with the domain name.
+When you transfer a domain name to OVHcloud (*incoming transfer*), only the management of the domain name changes registrar. The **DNS zone**, that is, the set of *DNS records* that link your domain name to your services (website, emails, etc.), is **not** transferred automatically with the domain name.
 
-Some providers delete the DNS zone hosted on their side as soon as the domain name transfer is complete. If you have not recreated it beforehand at OVHcloud, your services may become unavailable while you manually reconfigure the DNS zone.
+Some providers delete the DNS zone hosted on their side as soon as the domain name transfer is complete. If you have not recreated it beforehand at OVHcloud, your services may become unavailable until you have manually reconfigured the DNS zone.
 
 **This guide explains how to retrieve your current DNS zone and recreate it identically at OVHcloud, before starting the incoming transfer of your domain name.**
 
@@ -21,7 +21,7 @@ Do not confuse **DNS servers** and the **DNS zone**:
 - **DNS servers** (*nameservers*) indicate *where* your domain name's DNS configuration is hosted;
 - the **DNS zone** contains the configuration itself (the *records*: A, AAAA, MX, CNAME, TXT, etc.).
 
-This guide covers the **DNS zone and its records**. If you keep your current external DNS servers at the time of transfer, enter them directly when placing the transfer order (see part 3 of the [Transferring a domain name to OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain) guide): the DNS zone hosted at OVHcloud will then not be used until you change the DNS servers.
+This guide covers the **DNS zone and its DNS records**. If you keep your current external DNS servers at the time of the incoming transfer of the domain name, enter them directly when placing the transfer order (see part 3 of the [Transferring a domain name to OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain) guide): the DNS zone hosted at OVHcloud will then not be used until you change the DNS servers.
 
 :::
 

--- a/docs/en/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-import.mdx
@@ -28,7 +28,7 @@ This guide covers the **DNS zone and its DNS records**. If you keep your current
 ## Requirements
 
 - Have access to the DNS management interface of your current provider/registrar, in order to retrieve your DNS records.
-- Have an [OVHcloud account](/links/manager).
+- Have an [OVHcloud account](/guides/account-and-service-management/account-information/ovhcloud-account-creation).
 - The domain name concerned must not already have an active DNS zone at OVHcloud.
 - Plan this operation **before** starting the incoming transfer of the domain name.
 

--- a/docs/en/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-import.mdx
@@ -34,8 +34,6 @@ This guide covers the **DNS zone and its records**. If you keep your current ext
 
 ## Introduction
 
-A domain name's active DNS zone contains the DNS configuration applied to it. It is what links your domain name to your services such as your email addresses or your website.
-
 During an incoming transfer, two scenarios arise when placing the order:
 
 - you enter the **external DNS servers** that the domain name already uses: the DNS configuration remains unchanged at your current provider and no interruption occurs at the time of transfer, provided that this provider does not delete your DNS zone after finalising the transfer;
@@ -51,15 +49,15 @@ First, note down all the DNS records currently in effect for your domain name at
 
 Most providers offer one of the following methods:
 
-- a **text-format export of the zone** (often called a "zone file" or "BIND format");
+- a **text-format export of the zone** (often called a "zone file");
 - a **display of the record list** in their interface, which you can copy.
 
 Pay particular attention to the records linked to your essential services:
 
 - **A** and **AAAA** records (IPv4/IPv6 addresses of your website);
-- **MX** records (mail servers);
-- **CNAME** records (aliases, subdomains);
-- **TXT** records (SPF, DKIM, DMARC, ownership verification, etc.).
+- **MX** records (the email servers to which your emails are redirected);
+- **CNAME** records (an alias pointing to another domain name);
+- email security and authentication records (**SPF**, **DKIM**, **DMARC**), usually set as **TXT** fields.
 
 :::tip
 To better understand the different record types before copying them, read our guide on [Everything you need to know about DNS records](/guides/web-cloud/domains/dns-zone-records).
@@ -88,7 +86,7 @@ Once the OVHcloud DNS zone is created, transfer the DNS records retrieved in par
 
 <Tabs>
   <Tab label="Text mode (recommended for an import)">
-    **Text mode** lets you edit the DNS zone directly as text. This is the fastest method when you already have a DNS zone export (BIND or text format): you can paste all your DNS records at once.
+    **Text mode** lets you edit the DNS zone directly as text. This is the fastest method when you already have a DNS zone export (in text format): you can paste all your DNS records at once.
 
     To do this, refer to the "Manually edit the zone in text mode" section of our guide on [Editing an OVHcloud DNS zone](/guides/web-cloud/domains/dns-zone-edit#txtmod).
 

--- a/docs/en/guides/web-cloud/domains/dns/landing-page-dns.mdx
+++ b/docs/en/guides/web-cloud/domains/dns/landing-page-dns.mdx
@@ -93,6 +93,7 @@ Each record is a line in the zone that associates a name with a value: an IP add
         { title: 'Create an OVHcloud DNS zone for a domain name', link: '/guides/web-cloud/domains/dns-zone-create' },
         { title: 'Create an OVHcloud DNS zone for a subdomain', link: '/guides/web-cloud/domains/dns-zone-create-subdomain' },
         { title: 'Edit an OVHcloud DNS zone', link: '/guides/web-cloud/domains/dns-zone-edit' },
+        { title: 'Import an external DNS zone', link: '/guides/web-cloud/domains/dns-zone-import' },
         { title: 'Manage the history of a DNS zone', link: '/guides/web-cloud/domains/dns-zone-history' },
         { title: 'Delete a DNS zone', link: '/guides/web-cloud/domains/dns-zone-deletion' },
       ],

--- a/docs/es/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-import.mdx
@@ -1,0 +1,164 @@
+---
+title: Importar una zona DNS externa a OVHcloud
+description: Descubra cómo recrear en OVHcloud la zona DNS de su dominio antes de una transferencia entrante, para evitar cualquier pérdida de configuración DNS
+lastUpdated: 2026-07-30
+availableIn: [eu, ca, apac]
+---
+
+import { Tab, Tabs } from '@rspress/core/theme';
+
+## Objetivo
+
+Cuando transfiere un nombre de dominio a OVHcloud (*transferencia entrante*), solo cambia el registrador que gestiona el dominio. La **zona DNS**, es decir, el conjunto de *registros DNS* que vinculan su dominio a sus servicios (sitio web, correos electrónicos, etc.), **no** se transfiere automáticamente con el dominio.
+
+Algunos proveedores eliminan la zona DNS alojada en su plataforma en cuanto se completa la transferencia del dominio. Si no la ha recreado previamente en OVHcloud, sus servicios pueden quedar no disponibles hasta que reconfigure manualmente la zona DNS.
+
+**Descubra cómo recuperar su zona DNS actual y recrearla de forma idéntica en OVHcloud, antes de iniciar la transferencia entrante de su dominio.**
+
+:::warning
+No confunda los **servidores DNS** con la **zona DNS**:
+
+- los **servidores DNS** (*nameservers*) indican *dónde* está alojada la configuración DNS de su dominio.
+- la **zona DNS** contiene la propia configuración (los *registros*: A, AAAA, MX, CNAME, TXT, etc.).
+
+Esta guía trata sobre la **zona DNS y sus registros DNS**. Si conserva sus servidores DNS externos actuales en el momento de la transferencia entrante del dominio, indíquelos directamente al realizar el pedido de transferencia (consulte el paso 3 de la guía [Transferir un nombre de dominio a OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain#step3)): la zona DNS alojada en OVHcloud no se utilizará hasta que modifique los servidores DNS.
+
+:::
+
+## Requisitos
+
+- Tener acceso a la interfaz de gestión DNS de su proveedor/registrador actual, para recuperar sus registros DNS.
+- Disponer de una [cuenta de cliente de OVHcloud](/guides/account-and-service-management/account-information/ovhcloud-account-creation).
+- El dominio en cuestión no debe tener ya una zona DNS activa en OVHcloud.
+- Prever esta operación **antes** de iniciar la transferencia entrante del dominio.
+
+## Introducción
+
+En el momento de realizar el pedido de una transferencia entrante, hay dos posibilidades:
+
+- indica los **servidores DNS externos** que el dominio ya utiliza: la configuración DNS permanece sin cambios en su proveedor actual y no se produce ninguna interrupción en el momento de la transferencia, siempre que este no elimine su zona DNS una vez completada la transferencia.
+- no indica nada: el dominio se entrega con una **nueva zona DNS vacía** en los servidores DNS de OVHcloud, y usted deberá recrear sus registros DNS por su cuenta.
+
+En ambos casos, si prevé alojar a largo plazo su zona DNS en OVHcloud, le recomendamos recrearla en OVHcloud **antes** de transferir su dominio. Así podrá comprobar su configuración y realizar el cambio sin interrupción del servicio, con independencia de la zona DNS de su antiguo proveedor (que puede ser eliminada).
+
+## Procedimiento
+
+### 1 - Recuperar su zona DNS actual en su proveedor externo
+
+Anote primero todos los registros DNS actualmente vigentes para su dominio en su proveedor/registrador actual.
+
+La mayoría de los proveedores ofrecen uno de los siguientes métodos:
+
+- una **exportación de la zona en formato de texto** (a menudo llamada "archivo de zona").
+- una **lista de los registros** mostrada en su interfaz, que puede copiar.
+
+Preste especial atención a los registros vinculados a sus servicios esenciales:
+
+- los registros **A** y **AAAA** (direcciones IPv4/IPv6 de su sitio web).
+- los registros **MX** (los servidores de correo a los que se redirigen sus correos electrónicos).
+- los registros **CNAME** (un alias que apunta a otro dominio).
+- los registros de seguridad y autenticación de correo (**SPF**, **DKIM**, **DMARC**), normalmente almacenados como registros **TXT**.
+
+:::tip
+Para comprender mejor los distintos tipos de registros antes de copiarlos, consulte nuestra guía [Todo sobre los registros DNS](/guides/web-cloud/domains/dns-zone-records).
+
+:::
+
+:::warning
+**No** copie los registros **NS** de su antiguo proveedor ni su registro **SOA**: estos valores son propios del proveedor de alojamiento DNS y se gestionarán automáticamente para la nueva zona alojada en OVHcloud.
+
+:::
+
+### 2 - Crear la zona DNS en OVHcloud
+
+A continuación, cree una zona DNS de OVHcloud para su dominio. Esta zona alojará los registros DNS que anotó en el paso 1.
+
+Para ello, siga nuestra guía [Crear una zona DNS de OVHcloud para un dominio](/guides/web-cloud/domains/dns-zone-create).
+
+:::tip
+Al crearla, elija la opción de **registros mínimos** si prevé personalizar completamente la zona usted mismo. Así evitará que OVHcloud preconfigure registros que después tendría que eliminar.
+
+:::
+
+### 3 - Recrear sus registros en OVHcloud
+
+Una vez creada la zona DNS de OVHcloud, transfiera a ella los registros DNS recuperados en el paso 1. Existen dos enfoques posibles.
+
+<Tabs>
+  <Tab label="Modo de texto (recomendado para una importación)">
+    El **modo de texto** permite editar la zona DNS directamente como texto. Es el método más rápido cuando ya dispone de una exportación de la zona DNS (en formato de texto): puede pegar todos sus registros DNS de una sola vez.
+
+    Para ello, consulte la sección "Editar manualmente el área en modo de texto" de nuestra guía [Editar una zona DNS de OVHcloud](/guides/web-cloud/domains/dns-zone-edit#txtmod).
+
+    :::warning
+    Este método está reservado a usuarios avanzados. Preste mucha atención a la sintaxis. No modifique los registros **NS** de la zona DNS en favor de servidores DNS externos a OVHcloud: esta zona DNS funciona **únicamente** con servidores DNS de OVHcloud.
+
+    :::
+  </Tab>
+  <Tab label="Añadir los registros DNS uno por uno">
+    Si no dispone de una exportación de la zona DNS, añada cada registro DNS individualmente mediante los asistentes de configuración de OVHcloud.
+
+    Para ello, siga nuestra guía [Editar una zona DNS de OVHcloud](/guides/web-cloud/domains/dns-zone-edit), que describe cómo añadir, modificar y eliminar un registro DNS.
+
+    También existen guías dedicadas para los tipos de registros DNS más habituales:
+
+    - [Añadir un registro A](/guides/web-cloud/domains/dns-zone-a-record-creation)
+    - [Añadir un registro CNAME](/guides/web-cloud/domains/dns-zone-cname-record-creation)
+    - [Configurar un registro MX](/guides/web-cloud/domains/dns-zone-mx)
+    - [Añadir un registro TXT](/guides/web-cloud/domains/dns-zone-txt-record-creation)
+  </Tab>
+</Tabs>
+
+### 4 - Comprobar la zona DNS recreada
+
+Antes de iniciar la transferencia entrante de su dominio, compruebe que la zona DNS recreada en OVHcloud está completa y es coherente con su configuración original.
+
+- Compare uno por uno los registros DNS de la zona de OVHcloud con la lista que anotó en el paso 1.
+- Asegúrese de que todos sus servicios esenciales (sitio web, correos electrónicos) están cubiertos.
+
+También puede analizar la configuración con la herramienta Zonemaster. Consulte nuestra guía [Utilización de Zonemaster](/guides/web-cloud/domains/dns-zonemaster).
+
+:::warning
+En esta fase, su zona DNS de OVHcloud está lista pero **aún no activa**: mientras su dominio utilice los servidores DNS de su antiguo proveedor, se aplicará la configuración anterior. El cambio se producirá en el momento de la transferencia entrante o al modificar los servidores DNS.
+
+:::
+
+### 5 - Iniciar la transferencia entrante del dominio
+
+Ahora que su zona DNS está recreada y comprobada en OVHcloud, puede iniciar la transferencia entrante con total seguridad.
+
+Siga el procedimiento descrito en nuestra guía [Transferir un nombre de dominio a OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain).
+
+Existen guías específicas según su registrador actual o la extensión de su dominio:
+
+- [Transferir un nombre de dominio desde Gandi](/guides/web-cloud/domains/transfer-incoming-gandi)
+- [Transferir un nombre de dominio desde GoDaddy](/guides/web-cloud/domains/transfer-incoming-godaddy)
+- [Transferir un nombre de dominio desde Ionos](/guides/web-cloud/domains/transfer-incoming-ionos)
+- [Transferir un nombre de dominio desde Hostinger](/guides/web-cloud/domains/transfer-incoming-hostinger)
+- [Transferir un nombre de dominio desde Wix](/guides/web-cloud/domains/transfer-incoming-wix)
+- [Transferir un nombre de dominio .uk](/guides/web-cloud/domains/transfer-incoming-couk)
+
+:::info
+Para que su zona DNS de OVHcloud se active, su dominio debe apuntar a los servidores DNS de OVHcloud. Si aún no lo ha hecho al iniciar la transferencia entrante, indique estos servidores DNS una vez completada la transferencia. Este procedimiento se describe en la guía [Crear una zona DNS de OVHcloud para un dominio](/guides/web-cloud/domains/dns-zone-create) (sección "Cambiar los servidores DNS del dominio").
+
+:::
+
+## Más información
+
+[Transferir un nombre de dominio a OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain)
+
+[Crear una zona DNS de OVHcloud para un dominio](/guides/web-cloud/domains/dns-zone-create)
+
+[Editar una zona DNS de OVHcloud](/guides/web-cloud/domains/dns-zone-edit)
+
+[Todo sobre la zona DNS](/guides/web-cloud/domains/dns-zone-general-information)
+
+[Todo sobre los registros DNS](/guides/web-cloud/domains/dns-zone-records)
+
+[Migrar un sitio web y los servicios asociados a OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
+
+Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con [partners de OVHcloud](/links/partner).
+
+Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas [opciones de soporte](/links/support).
+
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/web-cloud/domains/dns/landing-page-dns.mdx
+++ b/docs/es/guides/web-cloud/domains/dns/landing-page-dns.mdx
@@ -93,6 +93,7 @@ Cada registro es una línea de la zona que asocia un nombre a un valor: una dire
         { title: 'Crear una zona DNS de OVHcloud para un nombre de dominio', link: '/guides/web-cloud/domains/dns-zone-create' },
         { title: 'Crear una zona DNS de OVHcloud para un subdominio', link: '/guides/web-cloud/domains/dns-zone-create-subdomain' },
         { title: 'Editar una zona DNS de OVHcloud', link: '/guides/web-cloud/domains/dns-zone-edit' },
+        { title: 'Importar una zona DNS externa', link: '/guides/web-cloud/domains/dns-zone-import' },
         { title: 'Gestionar el historial de una zona DNS', link: '/guides/web-cloud/domains/dns-zone-history' },
         { title: 'Eliminar una zona DNS', link: '/guides/web-cloud/domains/dns-zone-deletion' },
       ],

--- a/docs/fr/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-import.mdx
@@ -1,7 +1,7 @@
 ---
 title: Importer une zone DNS externe chez OVHcloud
 description: Découvrez comment recréer chez OVHcloud la zone DNS de votre nom de domaine avant un transfert entrant, pour éviter toute perte de configuration DNS
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/fr/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-import.mdx
@@ -1,0 +1,166 @@
+---
+title: Importer une zone DNS externe chez OVHcloud
+description: Préparez et recréez chez OVHcloud la zone DNS de votre nom de domaine avant un transfert entrant, pour éviter toute perte de configuration DNS
+lastUpdated: 2026-07-27
+availableIn: [eu, ca, apac]
+---
+
+import { Tab, Tabs } from '@rspress/core/theme';
+
+## Objectif
+
+Lorsque vous transférez un nom de domaine vers OVHcloud (*transfert entrant*), seule la gestion du nom de domaine change de *bureau d’enregistrement*. La **zone DNS** — l’ensemble des *enregistrements DNS* qui relient votre nom de domaine à vos services (site web, e-mails, etc.) — n’est **pas** transférée automatiquement avec le nom de domaine.
+
+Certains fournisseurs suppriment la zone DNS hébergée chez eux dès que le transfert du nom de domaine est terminé. Si vous ne l’avez pas reconstituée au préalable chez OVHcloud, vos services peuvent devenir indisponibles le temps de reconfigurer manuellement la zone DNS.
+
+**Découvrez comment récupérer votre zone DNS actuelle et la recréer à l’identique chez OVHcloud, avant de lancer le transfert entrant de votre nom de domaine.**
+
+:::warning
+Ne confondez pas les **serveurs DNS** et la **zone DNS** :
+
+- les **serveurs DNS** (*nameservers*) indiquent *où* est hébergée la configuration DNS de votre nom de domaine ;
+- la **zone DNS** contient la configuration elle-même (les *enregistrements* A, AAAA, MX, CNAME, TXT, etc.).
+
+Ce guide traite de la **zone DNS et de ses enregistrements**. Si vous conservez vos serveurs DNS externes actuels au moment du transfert, renseignez-les directement lors de la commande de transfert (consultez la partie 3 du guide « [Transférer son nom de domaine vers OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain) ») : la zone DNS hébergée chez OVHcloud ne sera alors pas utilisée tant que vous n’aurez pas modifié les serveurs DNS.
+
+:::
+
+## Prérequis
+
+- Disposer d’un accès à l’interface de gestion DNS de votre fournisseur/*bureau d’enregistrement* actuel, afin de récupérer vos enregistrements DNS.
+- Disposer d’un [compte client OVHcloud](/links/manager).
+- Le nom de domaine concerné ne doit pas déjà disposer d’une zone DNS active chez OVHcloud.
+- Prévoir cette opération **avant** de démarrer le transfert entrant du nom de domaine.
+
+## Introduction
+
+La zone DNS active d’un nom de domaine contient la configuration DNS appliquée à ce dernier. C’est elle qui lie votre nom de domaine à vos services tels que vos adresses e-mail ou votre site web.
+
+Lors d’un transfert entrant, deux cas se présentent au moment de la commande :
+
+- vous renseignez les **serveurs DNS externes** que le nom de domaine utilise déjà : la configuration DNS reste inchangée chez votre fournisseur actuel et aucune coupure n’a lieu au moment du transfert, sous réserve que ce fournisseur ne supprime pas votre zone DNS après avoir finalisé le transfert ;
+- vous ne renseignez rien : le nom de domaine est fourni avec une **nouvelle zone DNS vierge** sur les serveurs DNS OVHcloud, et vous devez alors reconstituer vous-même vos enregistrements DNS.
+
+Dans les deux cas, si vous prévoyez d’héberger à terme votre zone DNS chez OVHcloud, il est recommandé de la reconstituer **avant** de transférer votre nom de domaine. Vous pourrez ainsi vérifier sa configuration et basculer sans interruption de service, indépendamment de la zone DNS hébergée chez votre ancien fournisseur (qui peut être supprimée).
+
+## En pratique
+
+### 1 - Récupérer votre zone DNS actuelle chez votre fournisseur externe
+
+Avant toute chose, relevez l’intégralité des enregistrements DNS actuellement en vigueur pour votre nom de domaine chez votre fournisseur/*bureau d’enregistrement* actuel.
+
+La plupart des fournisseurs proposent l’une des méthodes suivantes :
+
+- un **export de la zone au format texte** (souvent appelé « fichier de zone » ou « format BIND ») ;
+- un **affichage de la liste des enregistrements** dans leur interface, que vous pouvez recopier.
+
+Notez en particulier les enregistrements liés à vos services essentiels :
+
+- les enregistrements **A** et **AAAA** (adresses IPv4/IPv6 de votre site web) ;
+- les enregistrements **MX** (serveurs de messagerie) ;
+- les enregistrements **CNAME** (alias, sous-domaines) ;
+- les enregistrements **TXT** (SPF, DKIM, DMARC, vérifications de propriété, etc.).
+
+:::tip
+Pour mieux comprendre les différents types d’enregistrements avant de les recopier, consultez notre guide « [Tout savoir sur les enregistrements DNS](/guides/web-cloud/domains/dns-zone-records) ».
+
+:::
+
+:::warning
+Ne recopiez **pas** les enregistrements **NS** de votre ancien fournisseur ni son enregistrement **SOA** : ces valeurs sont propres à l’hébergeur DNS et seront gérées automatiquement pour la nouvelle zone hébergée chez OVHcloud.
+
+:::
+
+### 2 - Créer la zone DNS chez OVHcloud
+
+Créez ensuite une zone DNS OVHcloud pour votre nom de domaine. Cette zone accueillera les enregistrements DNS que vous avez relevés dans la partie précédente.
+
+Pour cela, suivez notre guide « [Créer une zone DNS OVHcloud pour un nom de domaine](/guides/web-cloud/domains/dns-zone-create) ».
+
+:::tip
+Lors de la création, choisissez l’option des **entrées minimales** si vous prévoyez de personnaliser entièrement la zone vous-même. Vous éviterez ainsi qu’OVHcloud ne préconfigure des enregistrements DNS que vous devrez ensuite supprimer.
+
+:::
+
+### 3 - Reconstituer vos enregistrements chez OVHcloud
+
+Une fois la zone DNS OVHcloud créée, reportez-y les enregistrements DNS récupérés dans la partie 1. Deux approches sont possibles.
+
+<Tabs>
+  <Tab label="Mode textuel (recommandé pour un import)">
+    Le **mode textuel** permet d’éditer la zone DNS directement sous forme de texte. C’est la méthode la plus rapide lorsque vous disposez déjà d’un export de zone DNS (format BIND ou texte) : vous pouvez y coller vos enregistrements DNS en une seule fois.
+
+    Pour cela, reportez-vous à la section « Modifier manuellement la zone DNS en mode textuel » de notre guide « [Éditer une zone DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit#txtmod) ».
+
+    :::warning
+    Cette méthode est réservée aux utilisateurs avertis. Soyez très vigilant sur la syntaxe. Ne modifiez pas les enregistrements **NS** de la zone DNS au profit de serveurs DNS externes à OVHcloud : cette zone DNS fonctionne **uniquement** avec des serveurs DNS OVHcloud.
+
+    :::
+  </Tab>
+  <Tab label="Ajout des enregistrements DNS un par un">
+    Si vous ne disposez pas d’un export de zone DNS, ajoutez chaque enregistrement DNS individuellement via les assistants de configuration d’OVHcloud.
+
+    Suivez pour cela notre guide « [Éditer une zone DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit) », qui décrit l’ajout, la modification et la suppression d’un enregistrement DNS.
+
+    Des guides dédiés existent également pour les types d’enregistrements DNS les plus courants :
+
+    - [Ajouter un enregistrement A](/guides/web-cloud/domains/dns-zone-a-record-creation)
+    - [Ajouter un enregistrement CNAME](/guides/web-cloud/domains/dns-zone-cname-record-creation)
+    - [Ajouter un enregistrement MX](/guides/web-cloud/domains/dns-zone-mx)
+    - [Ajouter un enregistrement TXT](/guides/web-cloud/domains/dns-zone-txt-record-creation)
+  </Tab>
+</Tabs>
+
+### 4 - Vérifier la zone DNS reconstituée
+
+Avant de lancer le transfert entrant de votre nom de domaine, vérifiez que la zone DNS recréée chez OVHcloud est complète et cohérente avec votre configuration d’origine.
+
+- Comparez, un par un, les enregistrements DNS de la zone OVHcloud avec le relevé effectué dans la partie 1.
+- Assurez-vous que tous vos services essentiels (site web, e-mails) sont bien couverts.
+
+Vous pouvez également analyser la configuration à l’aide de l’outil Zonemaster. Consultez notre guide « [Utilisation de Zonemaster](/guides/web-cloud/domains/dns-zonemaster) ».
+
+:::warning
+À ce stade, votre zone DNS OVHcloud est prête mais **pas encore active** : tant que votre nom de domaine utilise les serveurs DNS de votre ancien fournisseur, c’est l’ancienne configuration qui s’applique. La bascule s’effectuera au moment du transfert entrant ou lors de la modification des serveurs DNS.
+
+:::
+
+### 5 - Lancer le transfert entrant du nom de domaine
+
+Votre zone DNS étant reconstituée et vérifiée chez OVHcloud, vous pouvez maintenant lancer le transfert entrant en toute sécurité.
+
+Suivez la procédure décrite dans notre guide « [Transférer son nom de domaine vers OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain) ».
+
+Des guides spécifiques existent selon votre *bureau d’enregistrement* actuel :
+
+- [Transférer un nom de domaine depuis Gandi](/guides/web-cloud/domains/transfer-incoming-gandi)
+- [Transférer un nom de domaine depuis GoDaddy](/guides/web-cloud/domains/transfer-incoming-godaddy)
+- [Transférer un nom de domaine depuis Ionos](/guides/web-cloud/domains/transfer-incoming-ionos)
+- [Transférer un nom de domaine depuis Hostinger](/guides/web-cloud/domains/transfer-incoming-hostinger)
+- [Transférer un nom de domaine depuis Wix](/guides/web-cloud/domains/transfer-incoming-wix)
+- [Transférer un nom de domaine .uk](/guides/web-cloud/domains/transfer-incoming-couk)
+
+:::info
+Pour que votre zone DNS OVHcloud devienne active, votre nom de domaine doit pointer vers les serveurs DNS OVHcloud. Si vous ne l’avez pas déjà fait lors de l’initialisation du transfert entrant, déclarez ces serveurs DNS une fois le transfert entrant terminé. Cette procédure est décrite dans le guide « [Créer une zone DNS OVHcloud pour un nom de domaine](/guides/web-cloud/domains/dns-zone-create) » (section « Modifier les serveurs DNS du nom de domaine »).
+
+:::
+
+## Aller plus loin
+
+[Transférer son nom de domaine vers OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain)
+
+[Créer une zone DNS OVHcloud pour un nom de domaine](/guides/web-cloud/domains/dns-zone-create)
+
+[Éditer une zone DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit)
+
+[Tout savoir sur la zone DNS](/guides/web-cloud/domains/dns-zone-general-information)
+
+[Tout savoir sur les enregistrements DNS](/guides/web-cloud/domains/dns-zone-records)
+
+[Migration de votre site Web et de vos e-mails vers OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
+
+Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner).
+
+Si vous souhaitez bénéficier d’une assistance à l’usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).
+
+Échangez avec notre [communauté d’utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-import.mdx
@@ -9,9 +9,9 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objectif
 
-Lorsque vous transférez un nom de domaine vers OVHcloud (*transfert entrant*), seule la gestion du nom de domaine change de *bureau d’enregistrement*. La **zone DNS** — l’ensemble des *enregistrements DNS* qui relient votre nom de domaine à vos services (site web, e-mails, etc.) — n’est **pas** transférée automatiquement avec le nom de domaine.
+Lorsque vous transférez un nom de domaine vers OVHcloud (*transfert entrant*), seule la gestion du nom de domaine change de *bureau d’enregistrement*. La **zone DNS**, c’est-à-dire l’ensemble des *enregistrements DNS* qui relient votre nom de domaine à vos services (site web, e-mails, etc.), n’est **pas** transférée automatiquement avec le nom de domaine.
 
-Certains fournisseurs suppriment la zone DNS hébergée chez eux dès que le transfert du nom de domaine est terminé. Si vous ne l’avez pas reconstituée au préalable chez OVHcloud, vos services peuvent devenir indisponibles le temps de reconfigurer manuellement la zone DNS.
+Certains fournisseurs suppriment la zone DNS hébergée chez eux dès que le transfert du nom de domaine est terminé. Si vous ne l’avez pas reconstituée au préalable chez OVHcloud, vos services peuvent devenir indisponibles tant que vous n’aurez pas reconfiguré manuellement la zone DNS.
 
 **Découvrez comment récupérer votre zone DNS actuelle et la recréer à l’identique chez OVHcloud, avant de lancer le transfert entrant de votre nom de domaine.**
 
@@ -21,7 +21,7 @@ Ne confondez pas les **serveurs DNS** et la **zone DNS** :
 - les **serveurs DNS** (*nameservers*) indiquent *où* est hébergée la configuration DNS de votre nom de domaine ;
 - la **zone DNS** contient la configuration elle-même (les *enregistrements* A, AAAA, MX, CNAME, TXT, etc.).
 
-Ce guide traite de la **zone DNS et de ses enregistrements**. Si vous conservez vos serveurs DNS externes actuels au moment du transfert, renseignez-les directement lors de la commande de transfert (consultez la partie 3 du guide « [Transférer son nom de domaine vers OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain) ») : la zone DNS hébergée chez OVHcloud ne sera alors pas utilisée tant que vous n’aurez pas modifié les serveurs DNS.
+Ce guide traite de la **zone DNS et de ses enregistrements DNS**. Si vous conservez vos serveurs DNS externes actuels au moment du transfert entrant du nom de domaine, renseignez-les directement lors de la commande de transfert (consultez la partie 3 du guide « [Transférer son nom de domaine vers OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain) ») : la zone DNS hébergée chez OVHcloud ne sera alors pas utilisée tant que vous n’aurez pas modifié les serveurs DNS.
 
 :::
 

--- a/docs/fr/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-import.mdx
@@ -34,8 +34,6 @@ Ce guide traite de la **zone DNS et de ses enregistrements**. Si vous conservez 
 
 ## Introduction
 
-La zone DNS active d’un nom de domaine contient la configuration DNS appliquée à ce dernier. C’est elle qui lie votre nom de domaine à vos services tels que vos adresses e-mail ou votre site web.
-
 Lors d’un transfert entrant, deux cas se présentent au moment de la commande :
 
 - vous renseignez les **serveurs DNS externes** que le nom de domaine utilise déjà : la configuration DNS reste inchangée chez votre fournisseur actuel et aucune coupure n’a lieu au moment du transfert, sous réserve que ce fournisseur ne supprime pas votre zone DNS après avoir finalisé le transfert ;
@@ -51,15 +49,15 @@ Avant toute chose, relevez l’intégralité des enregistrements DNS actuellemen
 
 La plupart des fournisseurs proposent l’une des méthodes suivantes :
 
-- un **export de la zone au format texte** (souvent appelé « fichier de zone » ou « format BIND ») ;
+- un **export de la zone au format texte** (souvent appelé « fichier de zone ») ;
 - un **affichage de la liste des enregistrements** dans leur interface, que vous pouvez recopier.
 
 Notez en particulier les enregistrements liés à vos services essentiels :
 
 - les enregistrements **A** et **AAAA** (adresses IPv4/IPv6 de votre site web) ;
-- les enregistrements **MX** (serveurs de messagerie) ;
-- les enregistrements **CNAME** (alias, sous-domaines) ;
-- les enregistrements **TXT** (SPF, DKIM, DMARC, vérifications de propriété, etc.).
+- les enregistrements **MX** (serveurs e-mail vers lesquels sont redirigés les e-mails reçus) ;
+- les enregistrements **CNAME** (alias pointant vers un autre nom de domaine) ;
+- les enregistrements de sécurité et d’authentification e-mail (**SPF**, **DKIM**, **DMARC**), généralement sous forme de champs **TXT**.
 
 :::tip
 Pour mieux comprendre les différents types d’enregistrements avant de les recopier, consultez notre guide « [Tout savoir sur les enregistrements DNS](/guides/web-cloud/domains/dns-zone-records) ».
@@ -88,7 +86,7 @@ Une fois la zone DNS OVHcloud créée, reportez-y les enregistrements DNS récup
 
 <Tabs>
   <Tab label="Mode textuel (recommandé pour un import)">
-    Le **mode textuel** permet d’éditer la zone DNS directement sous forme de texte. C’est la méthode la plus rapide lorsque vous disposez déjà d’un export de zone DNS (format BIND ou texte) : vous pouvez y coller vos enregistrements DNS en une seule fois.
+    Le **mode textuel** permet d’éditer la zone DNS directement sous forme de texte. C’est la méthode la plus rapide lorsque vous disposez déjà d’un export de zone DNS (au format texte) : vous pouvez y coller vos enregistrements DNS en une seule fois.
 
     Pour cela, reportez-vous à la section « Modifier manuellement la zone DNS en mode textuel » de notre guide « [Éditer une zone DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit#txtmod) ».
 

--- a/docs/fr/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-import.mdx
@@ -1,6 +1,6 @@
 ---
 title: Importer une zone DNS externe chez OVHcloud
-description: Préparez et recréez chez OVHcloud la zone DNS de votre nom de domaine avant un transfert entrant, pour éviter toute perte de configuration DNS
+description: Découvrez comment recréer chez OVHcloud la zone DNS de votre nom de domaine avant un transfert entrant, pour éviter toute perte de configuration DNS
 lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
@@ -9,55 +9,55 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objectif
 
-Lorsque vous transférez un nom de domaine vers OVHcloud (*transfert entrant*), seule la gestion du nom de domaine change de *bureau d’enregistrement*. La **zone DNS**, c’est-à-dire l’ensemble des *enregistrements DNS* qui relient votre nom de domaine à vos services (site web, e-mails, etc.), n’est **pas** transférée automatiquement avec le nom de domaine.
+Lorsque vous transférez un nom de domaine vers OVHcloud (*transfert entrant*), seul le *bureau d’enregistrement* qui gère le nom de domaine change. La **zone DNS**, l’ensemble des *enregistrements DNS* reliant votre nom de domaine à vos services (site web, e-mails, etc.), n’est **pas** transférée automatiquement avec le nom de domaine.
 
-Certains fournisseurs suppriment la zone DNS hébergée chez eux dès que le transfert du nom de domaine est terminé. Si vous ne l’avez pas reconstituée au préalable chez OVHcloud, vos services peuvent devenir indisponibles tant que vous n’aurez pas reconfiguré manuellement la zone DNS.
+Certains fournisseurs suppriment la zone DNS hébergée chez eux dès que le transfert du nom de domaine est terminé. Si vous ne l’avez pas recréée au préalable chez OVHcloud, vos services peuvent devenir indisponibles tant que vous n’aurez pas reconfiguré manuellement la zone DNS.
 
 **Découvrez comment récupérer votre zone DNS actuelle et la recréer à l’identique chez OVHcloud, avant de lancer le transfert entrant de votre nom de domaine.**
 
 :::warning
 Ne confondez pas les **serveurs DNS** et la **zone DNS** :
 
-- les **serveurs DNS** (*nameservers*) indiquent *où* est hébergée la configuration DNS de votre nom de domaine ;
+- les **serveurs DNS** (*nameservers*) indiquent *où* est hébergée la configuration DNS de votre nom de domaine.
 - la **zone DNS** contient la configuration elle-même (les *enregistrements* A, AAAA, MX, CNAME, TXT, etc.).
 
-Ce guide traite de la **zone DNS et de ses enregistrements DNS**. Si vous conservez vos serveurs DNS externes actuels au moment du transfert entrant du nom de domaine, renseignez-les directement lors de la commande de transfert (consultez la partie 3 du guide « [Transférer son nom de domaine vers OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain) ») : la zone DNS hébergée chez OVHcloud ne sera alors pas utilisée tant que vous n’aurez pas modifié les serveurs DNS.
+Ce guide traite de la **zone DNS et de ses enregistrements DNS**. Si vous conservez vos serveurs DNS externes actuels au moment du transfert entrant du nom de domaine, renseignez-les directement lors de la commande de transfert (consultez l’étape 3 du guide « [Transférer son nom de domaine vers OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain#step3) ») : la zone DNS hébergée chez OVHcloud ne sera alors pas utilisée tant que vous n’aurez pas modifié les serveurs DNS.
 
 :::
 
 ## Prérequis
 
-- Disposer d’un accès à l’interface de gestion DNS de votre fournisseur/*bureau d’enregistrement* actuel, afin de récupérer vos enregistrements DNS.
+- Disposer d’un accès à l’interface de gestion DNS de votre fournisseur/*bureau d’enregistrement* actuel, pour récupérer vos enregistrements DNS.
 - Disposer d’un [compte OVHcloud](/guides/account-and-service-management/account-information/ovhcloud-account-creation).
-- Le nom de domaine concerné ne doit pas déjà disposer d’une zone DNS active chez OVHcloud.
+- Le nom de domaine concerné ne doit pas déjà avoir de zone DNS active chez OVHcloud.
 - Prévoir cette opération **avant** de démarrer le transfert entrant du nom de domaine.
 
 ## Introduction
 
-Lors d’un transfert entrant, deux cas se présentent au moment de la commande :
+Au moment de la commande d’un transfert entrant, deux cas sont possibles :
 
-- vous renseignez les **serveurs DNS externes** que le nom de domaine utilise déjà : la configuration DNS reste inchangée chez votre fournisseur actuel et aucune coupure n’a lieu au moment du transfert, sous réserve que ce fournisseur ne supprime pas votre zone DNS après avoir finalisé le transfert ;
-- vous ne renseignez rien : le nom de domaine est fourni avec une **nouvelle zone DNS vierge** sur les serveurs DNS OVHcloud, et vous devez alors reconstituer vous-même vos enregistrements DNS.
+- vous renseignez les **serveurs DNS externes** que le nom de domaine utilise déjà : la configuration DNS reste inchangée chez votre fournisseur actuel et aucune coupure n’a lieu au moment du transfert, sous réserve qu’il ne supprime pas votre zone DNS une fois le transfert finalisé.
+- vous ne renseignez rien : le nom de domaine est fourni avec une **nouvelle zone DNS vierge** sur les serveurs DNS OVHcloud, et vous devez alors recréer vous-même vos enregistrements DNS.
 
-Dans les deux cas, si vous prévoyez d’héberger à terme votre zone DNS chez OVHcloud, il est recommandé de la reconstituer **avant** de transférer votre nom de domaine. Vous pourrez ainsi vérifier sa configuration et basculer sans interruption de service, indépendamment de la zone DNS hébergée chez votre ancien fournisseur (qui peut être supprimée).
+Dans les deux cas, si vous prévoyez d’héberger à terme votre zone DNS chez OVHcloud, nous vous recommandons de la recréer **avant** de transférer votre nom de domaine. Vous pouvez ainsi vérifier sa configuration et basculer sans interruption de service, indépendamment de la zone DNS de votre ancien fournisseur (qui peut être supprimée).
 
 ## En pratique
 
 ### 1 - Récupérer votre zone DNS actuelle chez votre fournisseur externe
 
-Avant toute chose, relevez l’intégralité des enregistrements DNS actuellement en vigueur pour votre nom de domaine chez votre fournisseur/*bureau d’enregistrement* actuel.
+Relevez d’abord tous les enregistrements DNS actuellement en vigueur pour votre nom de domaine chez votre fournisseur/*bureau d’enregistrement* actuel.
 
 La plupart des fournisseurs proposent l’une des méthodes suivantes :
 
-- un **export de la zone au format texte** (souvent appelé « fichier de zone ») ;
-- un **affichage de la liste des enregistrements** dans leur interface, que vous pouvez recopier.
+- un **export de la zone au format texte** (souvent appelé « fichier de zone »).
+- une **liste des enregistrements** affichée dans leur interface, que vous pouvez recopier.
 
 Notez en particulier les enregistrements liés à vos services essentiels :
 
-- les enregistrements **A** et **AAAA** (adresses IPv4/IPv6 de votre site web) ;
-- les enregistrements **MX** (serveurs e-mail vers lesquels sont redirigés les e-mails reçus) ;
-- les enregistrements **CNAME** (alias pointant vers un autre nom de domaine) ;
-- les enregistrements de sécurité et d’authentification e-mail (**SPF**, **DKIM**, **DMARC**), généralement sous forme de champs **TXT**.
+- les enregistrements **A** et **AAAA** (adresses IPv4/IPv6 de votre site web).
+- les enregistrements **MX** (serveurs e-mail vers lesquels sont redirigés les e-mails reçus).
+- les enregistrements **CNAME** (alias pointant vers un autre nom de domaine).
+- les enregistrements de sécurité et d’authentification e-mail (**SPF**, **DKIM**, **DMARC**), généralement sous forme d’enregistrements **TXT**.
 
 :::tip
 Pour mieux comprendre les différents types d’enregistrements avant de les recopier, consultez notre guide « [Tout savoir sur les enregistrements DNS](/guides/web-cloud/domains/dns-zone-records) ».
@@ -71,7 +71,7 @@ Ne recopiez **pas** les enregistrements **NS** de votre ancien fournisseur ni so
 
 ### 2 - Créer la zone DNS chez OVHcloud
 
-Créez ensuite une zone DNS OVHcloud pour votre nom de domaine. Cette zone accueillera les enregistrements DNS que vous avez relevés dans la partie précédente.
+Créez ensuite une zone DNS OVHcloud pour votre nom de domaine. Cette zone accueillera les enregistrements DNS relevés dans la partie 1.
 
 Pour cela, suivez notre guide « [Créer une zone DNS OVHcloud pour un nom de domaine](/guides/web-cloud/domains/dns-zone-create) ».
 
@@ -80,7 +80,7 @@ Lors de la création, choisissez l’option des **entrées minimales** si vous p
 
 :::
 
-### 3 - Reconstituer vos enregistrements chez OVHcloud
+### 3 - Recréer vos enregistrements chez OVHcloud
 
 Une fois la zone DNS OVHcloud créée, reportez-y les enregistrements DNS récupérés dans la partie 1. Deux approches sont possibles.
 
@@ -88,12 +88,12 @@ Une fois la zone DNS OVHcloud créée, reportez-y les enregistrements DNS récup
   <Tab label="Mode textuel (recommandé pour un import)">
     Le **mode textuel** permet d’éditer la zone DNS directement sous forme de texte. C’est la méthode la plus rapide lorsque vous disposez déjà d’un export de zone DNS (au format texte) : vous pouvez y coller vos enregistrements DNS en une seule fois.
 
-    Pour cela, reportez-vous à la section « Modifier manuellement la zone DNS en mode textuel » de notre guide « [Éditer une zone DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit#txtmod) ».
+    Pour cela, reportez-vous à la section « Modifier manuellement la zone en mode textuel » de notre guide « [Éditer une zone DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit#txtmod) ».
 
-    :::warning
+    :::warning
     Cette méthode est réservée aux utilisateurs avertis. Soyez très vigilant sur la syntaxe. Ne modifiez pas les enregistrements **NS** de la zone DNS au profit de serveurs DNS externes à OVHcloud : cette zone DNS fonctionne **uniquement** avec des serveurs DNS OVHcloud.
 
-    :::
+    :::
   </Tab>
   <Tab label="Ajout des enregistrements DNS un par un">
     Si vous ne disposez pas d’un export de zone DNS, ajoutez chaque enregistrement DNS individuellement via les assistants de configuration d’OVHcloud.
@@ -104,16 +104,16 @@ Une fois la zone DNS OVHcloud créée, reportez-y les enregistrements DNS récup
 
     - [Ajouter un enregistrement A](/guides/web-cloud/domains/dns-zone-a-record-creation)
     - [Ajouter un enregistrement CNAME](/guides/web-cloud/domains/dns-zone-cname-record-creation)
-    - [Ajouter un enregistrement MX](/guides/web-cloud/domains/dns-zone-mx)
+    - [Configurer un enregistrement MX](/guides/web-cloud/domains/dns-zone-mx)
     - [Ajouter un enregistrement TXT](/guides/web-cloud/domains/dns-zone-txt-record-creation)
   </Tab>
 </Tabs>
 
-### 4 - Vérifier la zone DNS reconstituée
+### 4 - Vérifier la zone DNS recréée
 
 Avant de lancer le transfert entrant de votre nom de domaine, vérifiez que la zone DNS recréée chez OVHcloud est complète et cohérente avec votre configuration d’origine.
 
-- Comparez, un par un, les enregistrements DNS de la zone OVHcloud avec le relevé effectué dans la partie 1.
+- Comparez un par un les enregistrements DNS de la zone OVHcloud avec le relevé de la partie 1.
 - Assurez-vous que tous vos services essentiels (site web, e-mails) sont bien couverts.
 
 Vous pouvez également analyser la configuration à l’aide de l’outil Zonemaster. Consultez notre guide « [Utilisation de Zonemaster](/guides/web-cloud/domains/dns-zonemaster) ».
@@ -125,11 +125,11 @@ Vous pouvez également analyser la configuration à l’aide de l’outil Zonema
 
 ### 5 - Lancer le transfert entrant du nom de domaine
 
-Votre zone DNS étant reconstituée et vérifiée chez OVHcloud, vous pouvez maintenant lancer le transfert entrant en toute sécurité.
+Maintenant que votre zone DNS est recréée et vérifiée chez OVHcloud, vous pouvez lancer le transfert entrant en toute sécurité.
 
 Suivez la procédure décrite dans notre guide « [Transférer son nom de domaine vers OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain) ».
 
-Des guides spécifiques existent selon votre *bureau d’enregistrement* actuel :
+Des guides spécifiques existent selon votre *bureau d’enregistrement* actuel ou l’extension de votre nom de domaine :
 
 - [Transférer un nom de domaine depuis Gandi](/guides/web-cloud/domains/transfer-incoming-gandi)
 - [Transférer un nom de domaine depuis GoDaddy](/guides/web-cloud/domains/transfer-incoming-godaddy)
@@ -155,9 +155,9 @@ Pour que votre zone DNS OVHcloud devienne active, votre nom de domaine doit poin
 
 [Tout savoir sur les enregistrements DNS](/guides/web-cloud/domains/dns-zone-records)
 
-[Migration de votre site Web et de vos e-mails vers OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
+[Migrer son site web et ses services associés vers OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner).
+Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](/links/partner).
 
 Si vous souhaitez bénéficier d’une assistance à l’usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).
 

--- a/docs/fr/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-import.mdx
@@ -28,7 +28,7 @@ Ce guide traite de la **zone DNS et de ses enregistrements DNS**. Si vous conser
 ## Prérequis
 
 - Disposer d’un accès à l’interface de gestion DNS de votre fournisseur/*bureau d’enregistrement* actuel, afin de récupérer vos enregistrements DNS.
-- Disposer d’un [compte client OVHcloud](/links/manager).
+- Disposer d’un [compte OVHcloud](/guides/account-and-service-management/account-information/ovhcloud-account-creation).
 - Le nom de domaine concerné ne doit pas déjà disposer d’une zone DNS active chez OVHcloud.
 - Prévoir cette opération **avant** de démarrer le transfert entrant du nom de domaine.
 

--- a/docs/fr/guides/web-cloud/domains/dns/landing-page-dns.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns/landing-page-dns.mdx
@@ -93,6 +93,7 @@ Chaque enregistrement est une ligne de la zone qui relie un nom à une valeur : 
         { title: 'Créer une zone DNS pour un nom de domaine', link: '/guides/web-cloud/domains/dns-zone-create' },
         { title: 'Créer une zone DNS pour un sous-domaine', link: '/guides/web-cloud/domains/dns-zone-create-subdomain' },
         { title: 'Éditer une zone DNS', link: '/guides/web-cloud/domains/dns-zone-edit' },
+        { title: 'Importer une zone DNS externe', link: '/guides/web-cloud/domains/dns-zone-import' },
         { title: "Gérer l'historique d'une zone DNS", link: '/guides/web-cloud/domains/dns-zone-history' },
         { title: 'Supprimer une zone DNS', link: '/guides/web-cloud/domains/dns-zone-deletion' },
       ],

--- a/docs/it/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zone-import.mdx
@@ -1,0 +1,164 @@
+---
+title: Importare una zona DNS esterna in OVHcloud
+description: Scopri come ricreare in OVHcloud la zona DNS del tuo dominio prima di un trasferimento in entrata, per evitare qualsiasi perdita di configurazione DNS
+lastUpdated: 2026-07-30
+availableIn: [eu, ca, apac]
+---
+
+import { Tab, Tabs } from '@rspress/core/theme';
+
+## Obiettivo
+
+Quando trasferisci un nome di dominio in OVHcloud (*trasferimento in entrata*), cambia solo il Registrar che gestisce il nome di dominio. La **zona DNS**, ovvero l'insieme dei *record DNS* che collegano il tuo nome di dominio ai tuoi servizi (sito web, e-mail, ecc.), **non** viene trasferita automaticamente con il nome di dominio.
+
+Alcuni provider eliminano la zona DNS ospitata sui loro server non appena il trasferimento del nome di dominio viene completato. Se non l'hai ricreata in anticipo in OVHcloud, i tuoi servizi potrebbero diventare non disponibili finché non riconfiguri manualmente la zona DNS.
+
+**Questa guida ti mostra come recuperare la tua zona DNS attuale e ricrearla in modo identico in OVHcloud, prima di avviare il trasferimento in entrata del tuo nome di dominio.**
+
+:::warning
+Non confondere i **server DNS** con la **zona DNS**:
+
+- i **server DNS** (*nameserver*) indicano *dove* è ospitata la configurazione DNS del tuo nome di dominio.
+- la **zona DNS** contiene la configurazione stessa (i *record*: A, AAAA, MX, CNAME, TXT, ecc.).
+
+Questa guida tratta la **zona DNS e i suoi record DNS**. Se mantieni i tuoi server DNS esterni attuali al momento del trasferimento in entrata del nome di dominio, indicali direttamente al momento dell'ordine di trasferimento (consulta il passaggio 3 della guida "[Trasferire un nome di dominio in OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain#step3)"): la zona DNS ospitata in OVHcloud non verrà quindi utilizzata finché non modifichi i server DNS.
+
+:::
+
+## Prerequisiti
+
+- Avere accesso all'interfaccia di gestione DNS del tuo provider/Registrar attuale, per recuperare i tuoi record DNS.
+- Avere un [account cliente OVHcloud](/guides/account-and-service-management/account-information/ovhcloud-account-creation).
+- Il nome di dominio in questione non deve già avere una zona DNS attiva in OVHcloud.
+- Prevedere questa operazione **prima** di avviare il trasferimento in entrata del nome di dominio.
+
+## Introduzione
+
+Al momento dell'ordine di un trasferimento in entrata, sono possibili due casi:
+
+- indichi i **server DNS esterni** che il nome di dominio già utilizza: la configurazione DNS resta invariata presso il tuo provider attuale e non si verifica alcuna interruzione al momento del trasferimento, a condizione che questo non elimini la tua zona DNS una volta completato il trasferimento.
+- non indichi nulla: il nome di dominio viene fornito con una **nuova zona DNS vuota** sui server DNS di OVHcloud, e dovrai quindi ricreare tu stesso i tuoi record DNS.
+
+In entrambi i casi, se prevedi di ospitare a lungo termine la tua zona DNS in OVHcloud, ti consigliamo di ricrearla in OVHcloud **prima** di trasferire il tuo nome di dominio. In questo modo potrai verificare la sua configurazione ed effettuare il passaggio senza interruzione del servizio, indipendentemente dalla zona DNS del tuo precedente provider (che può essere eliminata).
+
+## Procedura
+
+### 1 - Recuperare la tua zona DNS attuale presso il tuo provider esterno
+
+Prima di tutto, annota tutti i record DNS attualmente in vigore per il tuo nome di dominio presso il tuo provider/Registrar attuale.
+
+La maggior parte dei provider offre uno dei seguenti metodi:
+
+- un'**esportazione della zona in formato testo** (spesso chiamata "file di zona").
+- un **elenco dei record** visualizzato nella loro interfaccia, che puoi copiare.
+
+Presta particolare attenzione ai record collegati ai tuoi servizi essenziali:
+
+- i record **A** e **AAAA** (indirizzi IPv4/IPv6 del tuo sito web).
+- i record **MX** (i server e-mail verso cui vengono reindirizzate le tue e-mail).
+- i record **CNAME** (un alias che punta a un altro nome di dominio).
+- i record di sicurezza e autenticazione e-mail (**SPF**, **DKIM**, **DMARC**), generalmente memorizzati come record **TXT**.
+
+:::tip
+Per comprendere meglio i diversi tipi di record prima di copiarli, consulta la nostra guida "[Scopri tutto sui record DNS](/guides/web-cloud/domains/dns-zone-records)".
+
+:::
+
+:::warning
+**Non** copiare i record **NS** del tuo precedente provider né il suo record **SOA**: questi valori sono specifici dell'host DNS e verranno gestiti automaticamente per la nuova zona ospitata in OVHcloud.
+
+:::
+
+### 2 - Creare la zona DNS in OVHcloud
+
+Crea quindi una zona DNS OVHcloud per il tuo nome di dominio. Questa zona conterrà i record DNS annotati nel passaggio 1.
+
+Per farlo, segui la nostra guida "[Creare una zona DNS OVHcloud per un dominio](/guides/web-cloud/domains/dns-zone-create)".
+
+:::tip
+Al momento della creazione, scegli l'opzione dei **record minimi** se prevedi di personalizzare interamente la zona da solo. In questo modo eviterai che OVHcloud preconfiguri record che dovresti poi eliminare.
+
+:::
+
+### 3 - Ricreare i tuoi record in OVHcloud
+
+Una volta creata la zona DNS OVHcloud, riporta al suo interno i record DNS recuperati nel passaggio 1. Sono possibili due approcci.
+
+<Tabs>
+  <Tab label="Modalità testuale (consigliata per un'importazione)">
+    La **modalità testuale** consente di modificare la zona DNS direttamente come testo. È il metodo più rapido quando disponi già di un'esportazione della zona DNS (in formato testo): puoi incollare tutti i tuoi record DNS in una sola volta.
+
+    Per farlo, consulta la sezione "Modifica manualmente la zona in modalità testuale" della nostra guida "[Modificare una zona DNS di OVHcloud](/guides/web-cloud/domains/dns-zone-edit#txtmod)".
+
+    :::warning
+    Questo metodo è riservato agli utenti esperti. Presta molta attenzione alla sintassi. Non modificare i record **NS** della zona DNS a favore di server DNS esterni a OVHcloud: questa zona DNS funziona **unicamente** con i server DNS di OVHcloud.
+
+    :::
+  </Tab>
+  <Tab label="Aggiungere i record DNS uno per uno">
+    Se non disponi di un'esportazione della zona DNS, aggiungi ogni record DNS singolarmente tramite gli assistenti di configurazione di OVHcloud.
+
+    Per farlo, segui la nostra guida "[Modificare una zona DNS di OVHcloud](/guides/web-cloud/domains/dns-zone-edit)", che descrive come aggiungere, modificare ed eliminare un record DNS.
+
+    Esistono anche guide dedicate per i tipi di record DNS più comuni:
+
+    - [Aggiungere un record A](/guides/web-cloud/domains/dns-zone-a-record-creation)
+    - [Aggiungere un record CNAME](/guides/web-cloud/domains/dns-zone-cname-record-creation)
+    - [Configurare un record MX](/guides/web-cloud/domains/dns-zone-mx)
+    - [Aggiungere un record TXT](/guides/web-cloud/domains/dns-zone-txt-record-creation)
+  </Tab>
+</Tabs>
+
+### 4 - Verificare la zona DNS ricreata
+
+Prima di avviare il trasferimento in entrata del tuo nome di dominio, verifica che la zona DNS ricreata in OVHcloud sia completa e coerente con la tua configurazione originale.
+
+- Confronta uno per uno i record DNS della zona OVHcloud con l'elenco annotato nel passaggio 1.
+- Assicurati che tutti i tuoi servizi essenziali (sito web, e-mail) siano coperti.
+
+Puoi anche analizzare la configurazione con lo strumento Zonemaster. Consulta la nostra guida "[Utilizzo di Zonemaster](/guides/web-cloud/domains/dns-zonemaster)".
+
+:::warning
+A questo punto, la tua zona DNS OVHcloud è pronta ma **non ancora attiva**: finché il tuo nome di dominio utilizza i server DNS del tuo precedente provider, si applica la configurazione precedente. Il passaggio avverrà al momento del trasferimento in entrata o quando modifichi i server DNS.
+
+:::
+
+### 5 - Avviare il trasferimento in entrata del nome di dominio
+
+Ora che la tua zona DNS è ricreata e verificata in OVHcloud, puoi avviare il trasferimento in entrata in tutta sicurezza.
+
+Segui la procedura descritta nella nostra guida "[Trasferire un nome di dominio in OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain)".
+
+Esistono guide specifiche a seconda del tuo Registrar attuale o dell'estensione del tuo nome di dominio:
+
+- [Trasferire un nome di dominio da Gandi](/guides/web-cloud/domains/transfer-incoming-gandi)
+- [Trasferire un nome di dominio da GoDaddy](/guides/web-cloud/domains/transfer-incoming-godaddy)
+- [Trasferire un nome di dominio da Ionos](/guides/web-cloud/domains/transfer-incoming-ionos)
+- [Trasferire un nome di dominio da Hostinger](/guides/web-cloud/domains/transfer-incoming-hostinger)
+- [Trasferire un nome di dominio da Wix](/guides/web-cloud/domains/transfer-incoming-wix)
+- [Trasferire un nome di dominio .uk](/guides/web-cloud/domains/transfer-incoming-couk)
+
+:::info
+Affinché la tua zona DNS OVHcloud diventi attiva, il tuo nome di dominio deve puntare ai server DNS di OVHcloud. Se non l'hai già fatto durante l'avvio del trasferimento in entrata, indica questi server DNS una volta completato il trasferimento. Questa procedura è descritta nella guida "[Creare una zona DNS OVHcloud per un dominio](/guides/web-cloud/domains/dns-zone-create)" (sezione "Modifica i server DNS del dominio").
+
+:::
+
+## Per saperne di più
+
+[Trasferire un nome di dominio in OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain)
+
+[Creare una zona DNS OVHcloud per un dominio](/guides/web-cloud/domains/dns-zone-create)
+
+[Modificare una zona DNS di OVHcloud](/guides/web-cloud/domains/dns-zone-edit)
+
+[Sapere tutto sulla zona DNS](/guides/web-cloud/domains/dns-zone-general-information)
+
+[Scopri tutto sui record DNS](/guides/web-cloud/domains/dns-zone-records)
+
+[Migrare un sito Web e i servizi associati a OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
+
+Per prestazioni specializzate (referenziamento, sviluppo, ecc...), contatta i [partner OVHcloud](/links/partner).
+
+Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, consulta le nostre [offerte di supporto](/links/support).
+
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zone-import.mdx
@@ -9,7 +9,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Obiettivo
 
-Quando trasferisci un nome di dominio in OVHcloud (*trasferimento in entrata*), cambia solo il Registrar che gestisce il nome di dominio. La **zona DNS**, ovvero l'insieme dei *record DNS* che collegano il tuo nome di dominio ai tuoi servizi (sito web, e-mail, ecc.), **non** viene trasferita automaticamente con il nome di dominio.
+Quando trasferisci un nome di dominio in OVHcloud (*trasferimento in entrata*), cambia solo il Registrar che gestisce il nome di dominio. La **zona DNS**, ovvero l'insieme dei *record DNS* che collegano il tuo nome di dominio ai tuoi servizi (sito web, email, ecc.), **non** viene trasferita automaticamente con il nome di dominio.
 
 Alcuni provider eliminano la zona DNS ospitata sui loro server non appena il trasferimento del nome di dominio viene completato. Se non l'hai ricreata in anticipo in OVHcloud, i tuoi servizi potrebbero diventare non disponibili finché non riconfiguri manualmente la zona DNS.
 
@@ -55,9 +55,9 @@ La maggior parte dei provider offre uno dei seguenti metodi:
 Presta particolare attenzione ai record collegati ai tuoi servizi essenziali:
 
 - i record **A** e **AAAA** (indirizzi IPv4/IPv6 del tuo sito web).
-- i record **MX** (i server e-mail verso cui vengono reindirizzate le tue e-mail).
+- i record **MX** (i server email verso cui vengono reindirizzate le tue email).
 - i record **CNAME** (un alias che punta a un altro nome di dominio).
-- i record di sicurezza e autenticazione e-mail (**SPF**, **DKIM**, **DMARC**), generalmente memorizzati come record **TXT**.
+- i record di sicurezza e autenticazione email (**SPF**, **DKIM**, **DMARC**), generalmente memorizzati come record **TXT**.
 
 :::tip
 Per comprendere meglio i diversi tipi di record prima di copiarli, consulta la nostra guida "[Scopri tutto sui record DNS](/guides/web-cloud/domains/dns-zone-records)".
@@ -114,7 +114,7 @@ Una volta creata la zona DNS OVHcloud, riporta al suo interno i record DNS recup
 Prima di avviare il trasferimento in entrata del tuo nome di dominio, verifica che la zona DNS ricreata in OVHcloud sia completa e coerente con la tua configurazione originale.
 
 - Confronta uno per uno i record DNS della zona OVHcloud con l'elenco annotato nel passaggio 1.
-- Assicurati che tutti i tuoi servizi essenziali (sito web, e-mail) siano coperti.
+- Assicurati che tutti i tuoi servizi essenziali (sito web, email) siano coperti.
 
 Puoi anche analizzare la configurazione con lo strumento Zonemaster. Consulta la nostra guida "[Utilizzo di Zonemaster](/guides/web-cloud/domains/dns-zonemaster)".
 

--- a/docs/it/guides/web-cloud/domains/dns/landing-page-dns.mdx
+++ b/docs/it/guides/web-cloud/domains/dns/landing-page-dns.mdx
@@ -93,6 +93,7 @@ Ogni record è una riga della zona che associa un nome a un valore: un indirizzo
         { title: 'Creare una zona DNS di OVHcloud per un nome a dominio', link: '/guides/web-cloud/domains/dns-zone-create' },
         { title: 'Creare una zona DNS di OVHcloud per un sottodominio', link: '/guides/web-cloud/domains/dns-zone-create-subdomain' },
         { title: 'Modificare una zona DNS di OVHcloud', link: '/guides/web-cloud/domains/dns-zone-edit' },
+        { title: 'Importare una zona DNS esterna', link: '/guides/web-cloud/domains/dns-zone-import' },
         { title: 'Gestire lo storico di una zona DNS', link: '/guides/web-cloud/domains/dns-zone-history' },
         { title: 'Eliminare una zona DNS', link: '/guides/web-cloud/domains/dns-zone-deletion' },
       ],

--- a/docs/pl/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-import.mdx
@@ -1,0 +1,164 @@
+---
+title: Importowanie zewnętrznej strefy DNS do OVHcloud
+description: Dowiedz się, jak odtworzyć w OVHcloud strefę DNS Twojej domeny przed transferem przychodzącym, aby uniknąć utraty konfiguracji DNS
+lastUpdated: 2026-07-30
+availableIn: [eu, ca, apac]
+---
+
+import { Tab, Tabs } from '@rspress/core/theme';
+
+## Wprowadzenie
+
+Gdy przenosisz nazwę domeny do OVHcloud (*transfer przychodzący*), zmienia się jedynie rejestrator zarządzający nazwą domeny. **Strefa DNS** – czyli zbiór *rekordów DNS* łączących Twoją nazwę domeny z Twoimi usługami (strona WWW, adresy e-mail itd.) – **nie** jest przenoszona automatycznie wraz z nazwą domeny.
+
+Niektórzy dostawcy usuwają strefę DNS hostowaną po swojej stronie, gdy tylko transfer nazwy domeny zostanie zakończony. Jeśli nie odtworzysz jej wcześniej w OVHcloud, Twoje usługi mogą stać się niedostępne do czasu ręcznego skonfigurowania strefy DNS.
+
+**Z tego przewodnika dowiesz się, jak pobrać bieżącą strefę DNS i odtworzyć ją identycznie w OVHcloud, zanim rozpoczniesz transfer przychodzący Twojej nazwy domeny.**
+
+:::warning
+Nie myl **serwerów DNS** ze **strefą DNS**:
+
+- **serwery DNS** (*nameservery*) wskazują, *gdzie* hostowana jest konfiguracja DNS Twojej nazwy domeny.
+- **strefa DNS** zawiera samą konfigurację (*rekordy*: A, AAAA, MX, CNAME, TXT itd.).
+
+Ten przewodnik dotyczy **strefy DNS i jej rekordów DNS**. Jeśli w momencie transferu przychodzącego nazwy domeny zachowasz swoje obecne zewnętrzne serwery DNS, wskaż je bezpośrednio podczas składania zamówienia transferu (zobacz krok 3 przewodnika "[Transfer nazwy domeny do OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain#step3)"): strefa DNS hostowana w OVHcloud nie będzie wówczas używana, dopóki nie zmienisz serwerów DNS.
+
+:::
+
+## Wymagania początkowe
+
+- Posiadanie dostępu do interfejsu zarządzania DNS u Twojego obecnego dostawcy/rejestratora, aby pobrać rekordy DNS.
+- Posiadanie [konta klienta OVHcloud](/guides/account-and-service-management/account-information/ovhcloud-account-creation).
+- Domena, której to dotyczy, nie może już posiadać aktywnej strefy DNS w OVHcloud.
+- Zaplanowanie tej operacji **przed** rozpoczęciem transferu przychodzącego nazwy domeny.
+
+## Wstęp
+
+Podczas składania zamówienia transferu przychodzącego możliwe są dwa przypadki:
+
+- wskazujesz **zewnętrzne serwery DNS**, których nazwa domeny już używa: konfiguracja DNS pozostaje bez zmian u Twojego obecnego dostawcy i w momencie transferu nie następuje żadna przerwa, pod warunkiem że nie usunie on Twojej strefy DNS po zakończeniu transferu.
+- nie wskazujesz nic: nazwa domeny zostaje dostarczona z **nową, pustą strefą DNS** na serwerach DNS OVHcloud, a Ty musisz następnie samodzielnie odtworzyć swoje rekordy DNS.
+
+W obu przypadkach, jeśli planujesz docelowo hostować swoją strefę DNS w OVHcloud, zalecamy jej odtworzenie w OVHcloud **przed** transferem nazwy domeny. Dzięki temu możesz sprawdzić jej konfigurację i przełączyć się bez przerwy w działaniu usługi, niezależnie od strefy DNS u Twojego poprzedniego dostawcy (która może zostać usunięta).
+
+## W praktyce
+
+### 1 - Pobierz bieżącą strefę DNS u zewnętrznego dostawcy
+
+Najpierw spisz wszystkie rekordy DNS aktualnie obowiązujące dla Twojej nazwy domeny u Twojego obecnego dostawcy/rejestratora.
+
+Większość dostawców udostępnia jedną z następujących metod:
+
+- **eksport strefy w formacie tekstowym** (często nazywany "plikiem strefy").
+- **listę rekordów** wyświetlaną w ich interfejsie, którą możesz skopiować.
+
+Zwróć szczególną uwagę na rekordy związane z Twoimi najważniejszymi usługami:
+
+- rekordy **A** i **AAAA** (adresy IPv4/IPv6 Twojej strony WWW).
+- rekordy **MX** (serwery e-mail, do których przekierowywane są Twoje wiadomości).
+- rekordy **CNAME** (alias wskazujący na inną nazwę domeny).
+- rekordy zabezpieczeń i uwierzytelniania poczty (**SPF**, **DKIM**, **DMARC**), zwykle przechowywane jako rekordy **TXT**.
+
+:::tip
+Aby lepiej zrozumieć poszczególne typy rekordów przed ich skopiowaniem, zapoznaj się z naszym przewodnikiem "[Wszystko o rekordach DNS](/guides/web-cloud/domains/dns-zone-records)".
+
+:::
+
+:::warning
+**Nie** kopiuj rekordów **NS** Twojego poprzedniego dostawcy ani jego rekordu **SOA**: te wartości są właściwe dla hosta DNS i będą zarządzane automatycznie dla nowej strefy hostowanej w OVHcloud.
+
+:::
+
+### 2 - Utwórz strefę DNS w OVHcloud
+
+Następnie utwórz strefę DNS OVHcloud dla Twojej nazwy domeny. Strefa ta będzie zawierać rekordy DNS spisane w kroku 1.
+
+W tym celu skorzystaj z naszego przewodnika "[Tworzenie strefy DNS OVHcloud dla domeny](/guides/web-cloud/domains/dns-zone-create)".
+
+:::tip
+Podczas tworzenia wybierz opcję **wpisów minimalnych**, jeśli planujesz w pełni samodzielnie dostosować strefę. Dzięki temu unikniesz sytuacji, w której OVHcloud wstępnie skonfiguruje rekordy, które następnie trzeba by usunąć.
+
+:::
+
+### 3 - Odtwórz swoje rekordy w OVHcloud
+
+Po utworzeniu strefy DNS OVHcloud przenieś do niej rekordy DNS pobrane w kroku 1. Możliwe są dwa podejścia.
+
+<Tabs>
+  <Tab label="Tryb tekstowy (zalecany do importu)">
+    **Tryb tekstowy** umożliwia edycję strefy DNS bezpośrednio jako tekstu. Jest to najszybsza metoda, gdy dysponujesz już eksportem strefy DNS (w formacie tekstowym): możesz wkleić wszystkie swoje rekordy DNS za jednym razem.
+
+    W tym celu zapoznaj się z sekcją "Ręczna zmiana strefy w trybie tekstowym" naszego przewodnika "[Modyfikacja strefy DNS](/guides/web-cloud/domains/dns-zone-edit#txtmod)".
+
+    :::warning
+    Ta metoda jest przeznaczona wyłącznie dla zaawansowanych użytkowników. Zachowaj szczególną ostrożność w kwestii składni. Nie zmieniaj rekordów **NS** strefy DNS na rzecz serwerów DNS zewnętrznych wobec OVHcloud: ta strefa DNS działa **wyłącznie** z serwerami DNS OVHcloud.
+
+    :::
+  </Tab>
+  <Tab label="Dodawanie rekordów DNS pojedynczo">
+    Jeśli nie dysponujesz eksportem strefy DNS, dodaj każdy rekord DNS indywidualnie za pomocą asystentów konfiguracji OVHcloud.
+
+    W tym celu skorzystaj z naszego przewodnika "[Modyfikacja strefy DNS](/guides/web-cloud/domains/dns-zone-edit)", który opisuje, jak dodać, zmodyfikować i usunąć rekord DNS.
+
+    Istnieją również dedykowane przewodniki dla najczęściej używanych typów rekordów DNS:
+
+    - [Dodawanie rekordu A](/guides/web-cloud/domains/dns-zone-a-record-creation)
+    - [Dodawanie rekordu CNAME](/guides/web-cloud/domains/dns-zone-cname-record-creation)
+    - [Konfiguracja rekordu MX](/guides/web-cloud/domains/dns-zone-mx)
+    - [Dodawanie rekordu TXT](/guides/web-cloud/domains/dns-zone-txt-record-creation)
+  </Tab>
+</Tabs>
+
+### 4 - Sprawdź odtworzoną strefę DNS
+
+Przed rozpoczęciem transferu przychodzącego Twojej nazwy domeny sprawdź, czy strefa DNS odtworzona w OVHcloud jest kompletna i zgodna z Twoją pierwotną konfiguracją.
+
+- Porównaj pojedynczo rekordy DNS strefy OVHcloud z listą spisaną w kroku 1.
+- Upewnij się, że wszystkie Twoje najważniejsze usługi (strona WWW, adresy e-mail) są uwzględnione.
+
+Możesz również przeanalizować konfigurację za pomocą narzędzia Zonemaster. Zapoznaj się z naszym przewodnikiem "[Korzystanie z Zonemaster](/guides/web-cloud/domains/dns-zonemaster)".
+
+:::warning
+Na tym etapie Twoja strefa DNS OVHcloud jest gotowa, ale **jeszcze nieaktywna**: dopóki Twoja nazwa domeny używa serwerów DNS Twojego poprzedniego dostawcy, obowiązuje poprzednia konfiguracja. Przełączenie nastąpi w momencie transferu przychodzącego lub gdy zmienisz serwery DNS.
+
+:::
+
+### 5 - Rozpocznij transfer przychodzący nazwy domeny
+
+Teraz, gdy Twoja strefa DNS jest odtworzona i sprawdzona w OVHcloud, możesz bezpiecznie rozpocząć transfer przychodzący.
+
+Postępuj zgodnie z procedurą opisaną w naszym przewodniku "[Transfer nazwy domeny do OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain)".
+
+W zależności od Twojego obecnego rejestratora lub rozszerzenia Twojej nazwy domeny istnieją specjalne przewodniki:
+
+- [Transfer nazwy domeny z Gandi](/guides/web-cloud/domains/transfer-incoming-gandi)
+- [Transfer nazwy domeny z GoDaddy](/guides/web-cloud/domains/transfer-incoming-godaddy)
+- [Transfer nazwy domeny z Ionos](/guides/web-cloud/domains/transfer-incoming-ionos)
+- [Transfer nazwy domeny z Hostinger](/guides/web-cloud/domains/transfer-incoming-hostinger)
+- [Transfer nazwy domeny z Wix](/guides/web-cloud/domains/transfer-incoming-wix)
+- [Transfer nazwy domeny .uk](/guides/web-cloud/domains/transfer-incoming-couk)
+
+:::info
+Aby Twoja strefa DNS OVHcloud stała się aktywna, Twoja nazwa domeny musi wskazywać na serwery DNS OVHcloud. Jeśli nie zrobiłeś tego już podczas inicjowania transferu przychodzącego, wskaż te serwery DNS po zakończeniu transferu. Procedura ta jest opisana w przewodniku "[Tworzenie strefy DNS OVHcloud dla domeny](/guides/web-cloud/domains/dns-zone-create)" (sekcja "Zmień serwery DNS domeny").
+
+:::
+
+## Sprawdź również
+
+[Transfer nazwy domeny do OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain)
+
+[Tworzenie strefy DNS OVHcloud dla domeny](/guides/web-cloud/domains/dns-zone-create)
+
+[Modyfikacja strefy DNS](/guides/web-cloud/domains/dns-zone-edit)
+
+[Wszystko o strefie DNS](/guides/web-cloud/domains/dns-zone-general-information)
+
+[Wszystko o rekordach DNS](/guides/web-cloud/domains/dns-zone-records)
+
+[Przeniesienie strony WWW i powiązanych z nią usług do OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
+
+W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj się z [partnerami OVHcloud](/links/partner).
+
+Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](/links/support).
+
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/web-cloud/domains/dns/landing-page-dns.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns/landing-page-dns.mdx
@@ -93,6 +93,7 @@ Każdy rekord to wiersz strefy, który łączy nazwę z wartością: adres IP, s
         { title: 'Utwórz strefę DNS OVHcloud dla nazwy domeny', link: '/guides/web-cloud/domains/dns-zone-create' },
         { title: 'Utwórz strefę DNS OVHcloud dla subdomeny', link: '/guides/web-cloud/domains/dns-zone-create-subdomain' },
         { title: 'Edytuj strefę DNS OVHcloud', link: '/guides/web-cloud/domains/dns-zone-edit' },
+        { title: 'Importowanie zewnętrznej strefy DNS', link: '/guides/web-cloud/domains/dns-zone-import' },
         { title: 'Zarządzaj historią strefy DNS', link: '/guides/web-cloud/domains/dns-zone-history' },
         { title: 'Usuń strefę DNS', link: '/guides/web-cloud/domains/dns-zone-deletion' },
       ],

--- a/docs/pt/guides/web-cloud/domains/dns-zone-import.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zone-import.mdx
@@ -1,0 +1,164 @@
+---
+title: Importar uma zona DNS externa para a OVHcloud
+description: Saiba como recriar na OVHcloud a zona DNS do seu domínio antes de uma transferência de entrada, para evitar qualquer perda de configuração DNS
+lastUpdated: 2026-07-30
+availableIn: [eu, ca, apac]
+---
+
+import { Tab, Tabs } from '@rspress/core/theme';
+
+## Objetivo
+
+Quando transfere um nome de domínio para a OVHcloud (*transferência de entrada*), apenas muda o registrar que gere o nome de domínio. A **zona DNS**, ou seja, o conjunto de *registos DNS* que ligam o seu nome de domínio aos seus serviços (site, e-mails, etc.), **não** é transferida automaticamente com o nome de domínio.
+
+Alguns fornecedores eliminam a zona DNS alojada do seu lado assim que a transferência do nome de domínio é concluída. Se não a recriou previamente na OVHcloud, os seus serviços podem ficar indisponíveis até reconfigurar manualmente a zona DNS.
+
+**Saiba como recuperar a sua zona DNS atual e recriá-la de forma idêntica na OVHcloud, antes de iniciar a transferência de entrada do seu nome de domínio.**
+
+:::warning
+Não confunda os **servidores DNS** com a **zona DNS**:
+
+- os **servidores DNS** (*nameservers*) indicam *onde* está alojada a configuração DNS do seu nome de domínio.
+- a **zona DNS** contém a própria configuração (os *registos*: A, AAAA, MX, CNAME, TXT, etc.).
+
+Este guia aborda a **zona DNS e os seus registos DNS**. Se mantiver os seus servidores DNS externos atuais no momento da transferência de entrada do nome de domínio, indique-os diretamente ao efetuar a encomenda de transferência (consulte o passo 3 do guia "[Transferir o nome de domínio para a OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain#step3)"): a zona DNS alojada na OVHcloud não será então utilizada enquanto não alterar os servidores DNS.
+
+:::
+
+## Requisitos
+
+- Ter acesso à interface de gestão DNS do seu fornecedor/registrar atual, para recuperar os seus registos DNS.
+- Dispor de uma [conta de cliente OVHcloud](/guides/account-and-service-management/account-information/ovhcloud-account-creation).
+- O nome de domínio em questão não deve ter já uma zona DNS ativa na OVHcloud.
+- Prever esta operação **antes** de iniciar a transferência de entrada do nome de domínio.
+
+## Introdução
+
+No momento da encomenda de uma transferência de entrada, há dois casos possíveis:
+
+- indica os **servidores DNS externos** que o nome de domínio já utiliza: a configuração DNS permanece inalterada no seu fornecedor atual e não ocorre qualquer interrupção no momento da transferência, desde que este não elimine a sua zona DNS assim que a transferência estiver concluída.
+- não indica nada: o nome de domínio é fornecido com uma **nova zona DNS vazia** nos servidores DNS da OVHcloud, e terá então de recriar os seus registos DNS por conta própria.
+
+Em ambos os casos, se pretender alojar a longo prazo a sua zona DNS na OVHcloud, recomendamos que a recrie na OVHcloud **antes** de transferir o seu nome de domínio. Assim, poderá verificar a sua configuração e efetuar a mudança sem interrupção do serviço, independentemente da zona DNS do seu antigo fornecedor (que pode ser eliminada).
+
+## Instruções
+
+### 1 - Recuperar a sua zona DNS atual no seu fornecedor externo
+
+Registe primeiro todos os registos DNS atualmente em vigor para o seu nome de domínio no seu fornecedor/registrar atual.
+
+A maioria dos fornecedores oferece um dos seguintes métodos:
+
+- uma **exportação da zona em formato de texto** (frequentemente designada por "ficheiro de zona").
+- uma **lista dos registos** apresentada na sua interface, que pode copiar.
+
+Preste especial atenção aos registos associados aos seus serviços essenciais:
+
+- os registos **A** e **AAAA** (endereços IPv4/IPv6 do seu site).
+- os registos **MX** (os servidores de e-mail para os quais os seus e-mails são reencaminhados).
+- os registos **CNAME** (um alias que aponta para outro nome de domínio).
+- os registos de segurança e autenticação de e-mail (**SPF**, **DKIM**, **DMARC**), geralmente armazenados como registos **TXT**.
+
+:::tip
+Para compreender melhor os diferentes tipos de registos antes de os copiar, consulte o nosso guia "[Saber tudo sobre os registos DNS](/guides/web-cloud/domains/dns-zone-records)".
+
+:::
+
+:::warning
+**Não** copie os registos **NS** do seu antigo fornecedor nem o seu registo **SOA**: estes valores são próprios do alojador DNS e serão geridos automaticamente para a nova zona alojada na OVHcloud.
+
+:::
+
+### 2 - Criar a zona DNS na OVHcloud
+
+Em seguida, crie uma zona DNS da OVHcloud para o seu nome de domínio. Esta zona irá alojar os registos DNS que registou no passo 1.
+
+Para tal, siga o nosso guia "[Criar uma zona DNS da OVHcloud para um domínio](/guides/web-cloud/domains/dns-zone-create)".
+
+:::tip
+Ao criá-la, escolha a opção de **entradas mínimas** se pretender personalizar totalmente a zona por si mesmo. Assim, evitará que a OVHcloud pré-configure registos que teria depois de eliminar.
+
+:::
+
+### 3 - Recriar os seus registos na OVHcloud
+
+Assim que a zona DNS da OVHcloud estiver criada, transfira para ela os registos DNS recuperados no passo 1. Existem duas abordagens possíveis.
+
+<Tabs>
+  <Tab label="Modo de texto (recomendado para uma importação)">
+    O **modo de texto** permite editar a zona DNS diretamente como texto. É o método mais rápido quando já dispõe de uma exportação da zona DNS (em formato de texto): pode colar todos os seus registos DNS de uma só vez.
+
+    Para tal, consulte a secção "Modificar manualmente a zona em modo de texto" do nosso guia "[Editar uma zona DNS da OVHcloud](/guides/web-cloud/domains/dns-zone-edit#txtmod)".
+
+    :::warning
+    Este método está reservado a utilizadores avançados. Preste muita atenção à sintaxe. Não modifique os registos **NS** da zona DNS a favor de servidores DNS externos à OVHcloud: esta zona DNS funciona **unicamente** com servidores DNS da OVHcloud.
+
+    :::
+  </Tab>
+  <Tab label="Adicionar os registos DNS um a um">
+    Se não dispuser de uma exportação da zona DNS, adicione cada registo DNS individualmente através dos assistentes de configuração da OVHcloud.
+
+    Para tal, siga o nosso guia "[Editar uma zona DNS da OVHcloud](/guides/web-cloud/domains/dns-zone-edit)", que descreve como adicionar, modificar e eliminar um registo DNS.
+
+    Existem igualmente guias dedicados para os tipos de registos DNS mais comuns:
+
+    - [Adicionar um registo A](/guides/web-cloud/domains/dns-zone-a-record-creation)
+    - [Adicionar um registo CNAME](/guides/web-cloud/domains/dns-zone-cname-record-creation)
+    - [Configurar um registo MX](/guides/web-cloud/domains/dns-zone-mx)
+    - [Adicionar um registo TXT](/guides/web-cloud/domains/dns-zone-txt-record-creation)
+  </Tab>
+</Tabs>
+
+### 4 - Verificar a zona DNS recriada
+
+Antes de iniciar a transferência de entrada do seu nome de domínio, verifique se a zona DNS recriada na OVHcloud está completa e coerente com a sua configuração de origem.
+
+- Compare um a um os registos DNS da zona da OVHcloud com a lista que registou no passo 1.
+- Certifique-se de que todos os seus serviços essenciais (site, e-mails) estão abrangidos.
+
+Pode também analisar a configuração com a ferramenta Zonemaster. Consulte o nosso guia "[Utilização do Zonemaster](/guides/web-cloud/domains/dns-zonemaster)".
+
+:::warning
+Nesta fase, a sua zona DNS da OVHcloud está pronta mas **ainda não ativa**: enquanto o seu nome de domínio utilizar os servidores DNS do seu antigo fornecedor, aplica-se a configuração anterior. A mudança ocorrerá no momento da transferência de entrada ou quando alterar os servidores DNS.
+
+:::
+
+### 5 - Iniciar a transferência de entrada do nome de domínio
+
+Agora que a sua zona DNS está recriada e verificada na OVHcloud, pode iniciar a transferência de entrada com toda a segurança.
+
+Siga o procedimento descrito no nosso guia "[Transferir o nome de domínio para a OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain)".
+
+Existem guias específicos consoante o seu registrar atual ou a extensão do seu nome de domínio:
+
+- [Transferir um nome de domínio a partir da Gandi](/guides/web-cloud/domains/transfer-incoming-gandi)
+- [Transferir um nome de domínio a partir da GoDaddy](/guides/web-cloud/domains/transfer-incoming-godaddy)
+- [Transferir um nome de domínio a partir da Ionos](/guides/web-cloud/domains/transfer-incoming-ionos)
+- [Transferir um nome de domínio a partir da Hostinger](/guides/web-cloud/domains/transfer-incoming-hostinger)
+- [Transferir um nome de domínio a partir da Wix](/guides/web-cloud/domains/transfer-incoming-wix)
+- [Transferir um nome de domínio .uk](/guides/web-cloud/domains/transfer-incoming-couk)
+
+:::info
+Para que a sua zona DNS da OVHcloud fique ativa, o seu nome de domínio deve apontar para os servidores DNS da OVHcloud. Se ainda não o fez ao iniciar a transferência de entrada, indique estes servidores DNS assim que a transferência estiver concluída. Este procedimento está descrito no guia "[Criar uma zona DNS da OVHcloud para um domínio](/guides/web-cloud/domains/dns-zone-create)" (secção "Alterar os servidores DNS do domínio").
+
+:::
+
+## Quer saber mais?
+
+[Transferir o nome de domínio para a OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain)
+
+[Criar uma zona DNS da OVHcloud para um domínio](/guides/web-cloud/domains/dns-zone-create)
+
+[Editar uma zona DNS da OVHcloud](/guides/web-cloud/domains/dns-zone-edit)
+
+[Saber tudo sobre a zona DNS](/guides/web-cloud/domains/dns-zone-general-information)
+
+[Saber tudo sobre os registos DNS](/guides/web-cloud/domains/dns-zone-records)
+
+[Migrar o seu website e os seus serviços associados para a OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
+
+Para serviços especializados (referenciamento, desenvolvimento, etc), contacte os [parceiros OVHcloud](/links/partner).
+
+Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
+
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/web-cloud/domains/dns/landing-page-dns.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns/landing-page-dns.mdx
@@ -93,6 +93,7 @@ Cada registo é uma linha da zona que associa um nome a um valor: um endereço I
         { title: 'Criar uma zona DNS da OVHcloud para um nome de domínio', link: '/guides/web-cloud/domains/dns-zone-create' },
         { title: 'Criar uma zona DNS da OVHcloud para um subdomínio', link: '/guides/web-cloud/domains/dns-zone-create-subdomain' },
         { title: 'Editar uma zona DNS da OVHcloud', link: '/guides/web-cloud/domains/dns-zone-edit' },
+        { title: 'Importar uma zona DNS externa', link: '/guides/web-cloud/domains/dns-zone-import' },
         { title: 'Gerir o histórico de uma zona DNS', link: '/guides/web-cloud/domains/dns-zone-history' },
         { title: 'Eliminar uma zona DNS', link: '/guides/web-cloud/domains/dns-zone-deletion' },
       ],


### PR DESCRIPTION
## 🆕 Nouveau guide — Importer une zone DNS externe chez OVHcloud (en vue d'un transfert entrant)

### Contexte / besoin comblé
Aucun guide existant n'expliquait comment reconstituer chez OVHcloud la zone DNS d'un domaine avant un transfert entrant. Le besoin était pourtant explicitement mentionné dans plusieurs guides de transfert (Gandi, GoDaddy, Ionos, Hostinger, Wix : « recréez à l'identique votre zone DNS chez OVHcloud avant de démarrer le transfert ») mais renvoyait uniquement, sans méthode, vers dns-zone-create / dns-zone-edit. Le guide générique de transfert ne traitait que des serveurs DNS, en indiquant qu'une « zone DNS vierge » serait créée sans expliquer comment préserver ses enregistrements.

### Contenu
- Distinction claire serveurs DNS != zone DNS
- Parcours en 5 étapes : récupérer la zone chez le fournisseur externe -> créer la zone OVHcloud -> reconstituer les enregistrements (mode textuel ou ajout un par un) -> vérifier (Zonemaster) -> lancer le transfert entrant
- Liens croisés avec dns-zone-create, dns-zone-edit#txtmod, dns-zone-records, dns-zonemaster et tous les transfer-incoming-*

### Fichiers
- docs/fr/guides/web-cloud/domains/dns-zone-import.mdx (nouveau)
- docs/en/guides/web-cloud/domains/dns-zone-import.mdx (nouveau)
- config/sidebar/index.md : enregistré sous Domain names > Migration > Incoming transfer to OVHcloud

### Qualité
- OK pnpm sidebar:validate
- OK Proofread FR + EN (typographie FR, cohérence, reformulations)
- OK Véracité : import via mode textuel uniquement (pas de bouton d'import BIND dédié dans le Manager - confirmé)
- OK Définitions calées sur la terminologie interne (dns-zone-general-information, dns-zone-records)

### A finaliser avant merge
- [ ] Relecture par paire + relecture technique (nouveau guide)
- [ ] Traductions de / es / it / pl / pt (routing : de/pl <- EN, es/it/pt <- FR)
- [ ] Référencer le guide dans la/les landing pages Domaine (landing-page-domain-names et/ou dns/landing-page-dns) - en une passe sur les 7 locales, une fois les traductions faites

Locales livrées dans cette PR : FR + EN uniquement (les autres viendront après relecture).
