### PR TITLE
fix(scripts): tolerate PDF cache transport failures

### DIFF
--- a/scripts/pdf/pdf-cache.ts
+++ b/scripts/pdf/pdf-cache.ts
@@ -87,9 +87,16 @@ export async function downloadCached(
   digest: string,
   outPath: string,
 ): Promise<boolean> {
-  const res = await fetch(cacheUrl(locale, productRef, digest), {
-    headers: { authorization: `Bearer ${ART.token}` },
-  });
+  let res: Response;
+  try {
+    res = await fetch(cacheUrl(locale, productRef, digest), {
+      headers: { authorization: `Bearer ${ART.token}` },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`⚠️  cache probe ${locale}/${productRef}: ${message}`);
+    return false;
+  }
   if (!res.ok) {
     if (res.status !== 404) {
       console.warn(
@@ -98,8 +105,16 @@ export async function downloadCached(
     }
     return false;
   }
+  let body: ArrayBuffer;
+  try {
+    body = await res.arrayBuffer();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`⚠️  cache probe ${locale}/${productRef}: ${message}`);
+    return false;
+  }
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, Buffer.from(await res.arrayBuffer()));
+  fs.writeFileSync(outPath, Buffer.from(body));
   return true;
 }
 
@@ -110,11 +125,19 @@ export async function uploadCached(
   digest: string,
   pdfPath: string,
 ): Promise<void> {
-  const res = await fetch(cacheUrl(locale, productRef, digest), {
-    method: 'PUT',
-    headers: { authorization: `Bearer ${ART.token}` },
-    body: new Uint8Array(fs.readFileSync(pdfPath)),
-  });
+  const body = new Uint8Array(fs.readFileSync(pdfPath));
+  let res: Response;
+  try {
+    res = await fetch(cacheUrl(locale, productRef, digest), {
+      method: 'PUT',
+      headers: { authorization: `Bearer ${ART.token}` },
+      body,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`⚠️  cache upload ${locale}/${productRef}: ${message}`);
+    return;
+  }
   if (!res.ok) {
     console.warn(`⚠️  cache upload ${locale}/${productRef}: HTTP ${res.status}`);
   }

--- a/scripts/pdf/pdf.test.ts
+++ b/scripts/pdf/pdf.test.ts
@@ -19,7 +19,7 @@ import {
   relinkCrossGuide,
   stripInteractiveWidgets,
 } from './assemble-book';
-import { computeDigest } from './pdf-cache';
+import { computeDigest, downloadCached, uploadCached } from './pdf-cache';
 import { readFrontmatterValue } from './resolve-product';
 
 test('extractArticle walks balanced <div> nesting to the article end', () => {
@@ -121,4 +121,90 @@ test('computeDigest folds referenced images and the footer logo into the key', (
   fs.writeFileSync(path.join(imageRoot, 'logo-ovhcloud-light.png'), 'logo-v2');
   assert.notEqual(computeDigest(html, imageRoot), b);
   fs.rmSync(imageRoot, { recursive: true, force: true });
+});
+
+test('uploadCached logs transport failures without rejecting', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pdf-test-cache-'));
+  const pdfPath = path.join(dir, 'guide.pdf');
+  fs.writeFileSync(pdfPath, 'rendered PDF');
+
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  globalThis.fetch = async () => {
+    throw new Error('simulated cache transport failure');
+  };
+  console.warn = (...args) => warnings.push(args.join(' '));
+
+  try {
+    await assert.doesNotReject(uploadCached('en', 'guide', 'digest', pdfPath));
+    assert.deepEqual(warnings, [
+      '⚠️  cache upload en/guide: simulated cache transport failure',
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('downloadCached treats transport failures as cache misses', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  globalThis.fetch = async () => {
+    throw new Error('simulated cache transport failure');
+  };
+  console.warn = (...args) => warnings.push(args.join(' '));
+
+  try {
+    assert.equal(
+      await downloadCached(
+        'en',
+        'guide',
+        'digest',
+        path.join(os.tmpdir(), 'unused.pdf'),
+      ),
+      false,
+    );
+    assert.deepEqual(warnings, [
+      '⚠️  cache probe en/guide: simulated cache transport failure',
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
+  }
+});
+
+test('downloadCached treats response body failures as cache misses', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  globalThis.fetch = async () =>
+    new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.error(new Error('simulated response transport failure'));
+        },
+      }),
+    );
+  console.warn = (...args) => warnings.push(args.join(' '));
+
+  try {
+    assert.equal(
+      await downloadCached(
+        'en',
+        'guide',
+        'digest',
+        path.join(os.tmpdir(), 'unused.pdf'),
+      ),
+      false,
+    );
+    assert.deepEqual(warnings, [
+      '⚠️  cache probe en/guide: simulated response transport failure',
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
+  }
 });


### PR DESCRIPTION
## Summary

- Treat PDF cache probe transport failures as cache misses so rendering can continue.
- Treat interrupted cache response bodies as cache misses.
- Keep successfully rendered PDFs when the subsequent cache upload fails at the transport layer.
- Preserve local PDF read failures as fatal errors.

## Details

The cache helpers already handled non-successful HTTP responses without aborting the PDF pipeline. However, a rejected `fetch()` from a DNS, connection, or timeout failure escaped both helpers:

- a failed cache probe stopped the job before a cache miss could be rendered;
- a failed cache upload stopped the job after the PDF had already been rendered successfully.

Transport failures now log the failure and follow the cache helpers' existing non-fatal result: probes return `false`, while uploads return without rejecting. This covers both the initial request and interruption while consuming a successful probe response. The upload reads the PDF before entering the recovery block, and probe filesystem operations happen afterward, so local filesystem failures are still reported to the caller.

## Verification

- Added RED/GREEN regression coverage for rejected cache probe and upload requests, plus interrupted probe response bodies.
- Confirmed a missing local PDF still rejects with `ENOENT` before `fetch()` is called.
- Confirmed a local cache write failure still rejects after a successful response.
- `pnpm test` (12/12).
- Targeted Biome check for both changed files.
- `git diff --check`.

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
