### PR TITLE
docs(web-hosting): fix Apache domain-blocking examples

### DIFF
--- a/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Wie kann ich den Zugang zu meiner Website für bestimmte IP-Adressen über eine .htaccess Datei sperren?
 description: Erfahren Sie hier die Möglichkeiten, um mit .htaccess Dateien den Zugriff auf Ihre Website für bestimmte IP-Adressen zu blockieren
-lastUpdated: 2026-07-23
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -101,6 +101,7 @@ Um eine Domain zu blockieren, tragen Sie den folgenden Code in Ihre ".htaccess"-
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain
 </RequireAll>
 ```
@@ -109,6 +110,7 @@ Require not host domain
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain.tld
 </RequireAll>
 ```

--- a/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Wie kann ich den Zugang zu meiner Website für bestimmte IP-Adressen über eine .htaccess Datei sperren?
 description: Erfahren Sie hier die Möglichkeiten, um mit .htaccess Dateien den Zugriff auf Ihre Website für bestimmte IP-Adressen zu blockieren
-lastUpdated: 2026-07-27
+lastUpdated: 2026-08-07
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - How do I block access to my website for certain IP addresses via a .htaccess file?
 description: Find out about the actions you can take via a .htaccess file to block access to your website for certain IP addresses
-lastUpdated: 2026-07-27
+lastUpdated: 2026-08-07
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - How do I block access to my website for certain IP addresses via a .htaccess file?
 description: Find out about the actions you can take via a .htaccess file to block access to your website for certain IP addresses
-lastUpdated: 2026-07-23
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -101,6 +101,7 @@ To block a domain, insert the following code into your ".htaccess" file:
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain
 </RequireAll>
 ```
@@ -109,6 +110,7 @@ Require not host domain
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain.tld
 </RequireAll>
 ```

--- a/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - ¿Cómo bloquear el acceso a mi sitio web para determinadas direcciones IP a través de un archivo .htaccess?
 description: Descubra las posibles acciones a través de un archivo .htaccess para bloquear el acceso a su sitio web a determinadas direcciones IP.
-lastUpdated: 2026-07-27
+lastUpdated: 2026-08-07
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - ¿Cómo bloquear el acceso a mi sitio web para determinadas direcciones IP a través de un archivo .htaccess?
 description: Descubra las posibles acciones a través de un archivo .htaccess para bloquear el acceso a su sitio web a determinadas direcciones IP.
-lastUpdated: 2026-07-23
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -101,6 +101,7 @@ Para bloquear un dominio, introduzca el siguiente código en el archivo ".htacce
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain
 </RequireAll>
 ```
@@ -109,6 +110,7 @@ Require not host domain
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain.tld
 </RequireAll>
 ```

--- a/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tutoriel - Comment bloquer l'accès à mon site pour certaines adresses IP via un fichier .htaccess ?"
 description: "Découvrez les actions possibles via un fichier .htaccess afin de bloquer l'accès à votre site à certaines adresses IP"
-lastUpdated: 2026-07-23
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -101,6 +101,7 @@ Pour bloquer un domaine, insérez le code suivant dans votre fichier « .htacce
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain
 </RequireAll>
 ```
@@ -109,6 +110,7 @@ Require not host domain
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain.tld
 </RequireAll>
 ```

--- a/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tutoriel - Comment bloquer l'accès à mon site pour certaines adresses IP via un fichier .htaccess ?"
 description: "Découvrez les actions possibles via un fichier .htaccess afin de bloquer l'accès à votre site à certaines adresses IP"
-lastUpdated: 2026-07-27
+lastUpdated: 2026-08-07
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Come bloccare l'accesso al mio sito per alcuni indirizzi IP tramite un file .htaccess?"
 description: "Scopri le azioni possibili tramite un file .htaccess per bloccare l'accesso al tuo sito ad alcuni indirizzi IP"
-lastUpdated: 2026-07-27
+lastUpdated: 2026-08-07
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Come bloccare l'accesso al mio sito per alcuni indirizzi IP tramite un file .htaccess?"
 description: "Scopri le azioni possibili tramite un file .htaccess per bloccare l'accesso al tuo sito ad alcuni indirizzi IP"
-lastUpdated: 2026-07-23
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -101,6 +101,7 @@ Per bloccare un dominio, inserisci il seguente codice nel tuo file ".htaccess":
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain
 </RequireAll>
 ```
@@ -109,6 +110,7 @@ Require not host domain
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain.tld
 </RequireAll>
 ```

--- a/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Jak zablokować dostęp do mojej strony dla niektórych adresów IP za pomocą pliku .htaccess?
 description: Odkryj operacje możliwe przy użyciu pliku .htaccess, w celu zablokowania dostępu do Twojej strony WWW dla niektórych adresów IP
-lastUpdated: 2026-07-27
+lastUpdated: 2026-08-07
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Jak zablokować dostęp do mojej strony dla niektórych adresów IP za pomocą pliku .htaccess?
 description: Odkryj operacje możliwe przy użyciu pliku .htaccess, w celu zablokowania dostępu do Twojej strony WWW dla niektórych adresów IP
-lastUpdated: 2026-07-23
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -101,6 +101,7 @@ Aby zablokować domenę, wprowadź poniższy kod do pliku ".htaccess":
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain
 </RequireAll>
 ```
@@ -109,6 +110,7 @@ Require not host domain
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain.tld
 </RequireAll>
 ```

--- a/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Como bloquear o acesso ao meu site para alguns endereços IP através de um ficheiro .htaccess ?
 description: Descubra as ações possíveis através de um ficheiro .htaccess para bloquear o acesso ao seu site a determinados endereços IP
-lastUpdated: 2026-07-23
+lastUpdated: 2026-07-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -101,6 +101,7 @@ Para bloquear um domínio, insira o seguinte código no seu ficheiro ".htaccess"
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain
 </RequireAll>
 ```
@@ -109,6 +110,7 @@ Require not host domain
 
 ```bash
 <RequireAll>
+Require all granted
 Require not host domain.tld
 </RequireAll>
 ```

--- a/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Como bloquear o acesso ao meu site para alguns endereços IP através de um ficheiro .htaccess ?
 description: Descubra as ações possíveis através de um ficheiro .htaccess para bloquear o acesso ao seu site a determinados endereços IP
-lastUpdated: 2026-07-27
+lastUpdated: 2026-08-07
 availableIn: [eu, ca, apac]
 ---
 


### PR DESCRIPTION
## Summary

- add the positive Apache 2.4 authorization provider required by the domain-blocking `<RequireAll>` examples
- keep the generic and concrete snippets consistent across all seven locales
- update the affected guides' `lastUpdated` date

## Why

The examples currently contain only a negated provider:

```apache
<RequireAll>
Require not host domain.tld
</RequireAll>
```

Apache documents that `<RequireAll>` needs at least one provider to grant access and that a negated `Require` directive cannot independently authorize a request. As written, the examples therefore do not implement “allow everyone except this host”. Adding `Require all granted` supplies the required positive provider while `Require not host` continues to deny the named host.

Reference: https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html#requireall

## Validation

- `pnpm content:lint`
- base/worktree invariant: 14 affected blocks changed from 0/14 to 14/14 with an immediately preceding `Require all granted`
- `git diff --check`
- independent review

A full site build was not run because the change only adds plain text inside existing fenced code blocks and does not alter MDX structure, links, or rendering components.

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
