### PR TITLE
docs: update OpenStack CLI installation references

### DIFF
--- a/docs/de/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud IaaS Migration - Steps and Best Practices"
 excerpt: "Learn how to migrate your infrastructure to OVHcloud Public Cloud using IaaS services, Terraform automation, and resilient network design."
-updated: 2026-07-27
+updated: 2026-07-30
 ---
 
 ## Objective

--- a/docs/de/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/de/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud IaaS Migration - Steps and Best Practices"
 excerpt: "Learn how to migrate your infrastructure to OVHcloud Public Cloud using IaaS services, Terraform automation, and resilient network design."
-updated: 2025-06-16
+updated: 2026-07-27
 ---
 
 ## Objective
@@ -101,7 +101,7 @@ The Lift and Shift method allows you to migrate your existing virtual machines (
 
 To begin, export your source VMs from your current infrastructure. OVHcloud supports several image formats, including: ami, ari, aki, vhd, vmdk, raw, qcow2, vhdx, vdi, iso, and ploop.
 
-Once exported, you need to upload the VM image to your OVHcloud project. To do this, make sure you have a local Python environment ready and install the OpenStack CLI (to do this, follow this [installation guide](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html)). You'll also need your API credentials to authenticate.
+Once exported, you need to upload the VM image to your OVHcloud project. To do this, make sure you have a local Python environment ready and install the OpenStack CLI (to do this, follow this [installation guide](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)). You'll also need your API credentials to authenticate.
 
 After uploading the image, you can deploy a new instance from it using the OVHcloud Control Panel, OpenStack CLI, or via Terraform/OpenTofu. You'll find step-by-step instructions on how to import a VM image in our guide "[Uploading your own image](/guides/public-cloud/compute/upload-own-image)".
 

--- a/docs/de/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/de/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/de/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/de/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -20,7 +20,7 @@ Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/publ
 
 - A [Public Cloud project](/guides/public-cloud/cross-functional/create-a-public-cloud-project) in your OVHcloud account
 - Access to the <ApiLink>OVHcloud API</ApiLink> or the OpenStack command line environment ([Tutorial](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment))
-- The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment (optional)
+- The [OpenStack Command Line Interface](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) tool installed on your working environment (optional)
 
 ## Understanding the Floating IP service
 

--- a/docs/en/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud IaaS Migration - Steps and Best Practices
 description: Learn how to migrate your infrastructure to OVHcloud Public Cloud using IaaS services, Terraform automation, and resilient network design.
-lastUpdated: 2025-06-16
+lastUpdated: 2026-07-27
 ---
 
 ## Objective
@@ -113,7 +113,7 @@ The Lift and Shift method allows you to migrate your existing virtual machines (
 
 To begin, export your source VMs from your current infrastructure. OVHcloud supports several image formats, including: ami, ari, aki, vhd, vmdk, raw, qcow2, vhdx, vdi, iso, and ploop.
 
-Once exported, you need to upload the VM image to your OVHcloud project. To do this, make sure you have a local Python environment ready and install the OpenStack CLI (to do this, follow this [installation guide](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html)). You’ll also need your API credentials to authenticate.
+Once exported, you need to upload the VM image to your OVHcloud project. To do this, make sure you have a local Python environment ready and install the OpenStack CLI (to do this, follow this [installation guide](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)). You’ll also need your API credentials to authenticate.
 
 After uploading the image, you can deploy a new instance from it using the OVHcloud Control Panel, OpenStack CLI, or via Terraform/OpenTofu. You’ll find step-by-step instructions on how to import a VM image in our guide "[Uploading your own image](/guides/public-cloud/compute/upload-own-image)".
 

--- a/docs/en/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud IaaS Migration - Steps and Best Practices
 description: Learn how to migrate your infrastructure to OVHcloud Public Cloud using IaaS services, Terraform automation, and resilient network design.
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 ---
 
 ## Objective

--- a/docs/en/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/en/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/en/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/en/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -20,7 +20,7 @@ Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/publ
 
 - A [Public Cloud project](/guides/public-cloud/cross-functional/create-a-public-cloud-project) in your OVHcloud account
 - Access to the <ApiLink>OVHcloud API</ApiLink> or the OpenStack command line environment ([Tutorial](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment))
-- The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment (optional)
+- The [OpenStack Command Line Interface](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) tool installed on your working environment (optional)
 
 ## Understanding the Floating IP service
 

--- a/docs/en/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
+++ b/docs/en/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
@@ -1,7 +1,7 @@
 ---
 title: Changing the MTU size for existing networks using OpenStack CLI/API
 description: Find out how to change the MTU size for an existing public cloud network using OpenStack CLI/API
-lastUpdated: 2023-05-24
+lastUpdated: 2026-07-27
 ---
 
 ## Objective
@@ -16,7 +16,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 - A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
-- The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
+- The [OpenStack Command Line Interface](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) tool installed on your working environment
 
 Before proceeding, it is recommended that you read these guides:
 

--- a/docs/en/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
+++ b/docs/en/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
@@ -1,7 +1,7 @@
 ---
 title: Changing the MTU size for existing networks using OpenStack CLI/API
 description: Find out how to change the MTU size for an existing public cloud network using OpenStack CLI/API
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 ---
 
 ## Objective

--- a/docs/en/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
+++ b/docs/en/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: L3 services SNAT configuration
 description: Find out how to configure the SNAT service on Public CLoud
-lastUpdated: 2022-11-02
+lastUpdated: 2026-07-27
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 ## Requirements
 
 - A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
-- The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
+- The [Openstack Command Line Interface](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) tool installed on your working environment
 - A [Public Cloud Floating IP](/guides/public-cloud/network-services/attach-floating-ip-to-instance)
 
 ## Concepts

--- a/docs/en/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
+++ b/docs/en/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: L3 services SNAT configuration
 description: Find out how to configure the SNAT service on Public CLoud
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 ---
 
 ## Objective

--- a/docs/es/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud IaaS Migration - Steps and Best Practices"
 excerpt: "Learn how to migrate your infrastructure to OVHcloud Public Cloud using IaaS services, Terraform automation, and resilient network design."
-updated: 2026-07-27
+updated: 2026-07-30
 ---
 
 ## Objective

--- a/docs/es/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/es/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud IaaS Migration - Steps and Best Practices"
 excerpt: "Learn how to migrate your infrastructure to OVHcloud Public Cloud using IaaS services, Terraform automation, and resilient network design."
-updated: 2025-06-16
+updated: 2026-07-27
 ---
 
 ## Objective
@@ -101,7 +101,7 @@ The Lift and Shift method allows you to migrate your existing virtual machines (
 
 To begin, export your source VMs from your current infrastructure. OVHcloud supports several image formats, including: ami, ari, aki, vhd, vmdk, raw, qcow2, vhdx, vdi, iso, and ploop.
 
-Once exported, you need to upload the VM image to your OVHcloud project. To do this, make sure you have a local Python environment ready and install the OpenStack CLI (to do this, follow this [installation guide](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html)). You'll also need your API credentials to authenticate.
+Once exported, you need to upload the VM image to your OVHcloud project. To do this, make sure you have a local Python environment ready and install the OpenStack CLI (to do this, follow this [installation guide](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)). You'll also need your API credentials to authenticate.
 
 After uploading the image, you can deploy a new instance from it using the OVHcloud Control Panel, OpenStack CLI, or via Terraform/OpenTofu. You'll find step-by-step instructions on how to import a VM image in our guide "[Uploading your own image](/guides/public-cloud/compute/upload-own-image)".
 

--- a/docs/es/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/es/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/es/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/es/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -20,7 +20,7 @@ Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/publ
 
 - A [Public Cloud project](/guides/public-cloud/cross-functional/create-a-public-cloud-project) in your OVHcloud account
 - Access to the <ApiLink>OVHcloud API</ApiLink> or the OpenStack command line environment ([Tutorial](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment))
-- The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment (optional)
+- The [OpenStack Command Line Interface](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) tool installed on your working environment (optional)
 
 ## Understanding the Floating IP service
 

--- a/docs/fr/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migration IaaS vers le Public Cloud - Étapes et bonnes pratiques
 description: Découvrez comment migrer votre infrastructure vers le Public Cloud OVHcloud en utilisant les services IaaS, l’automatisation Terraform et une architecture réseau résiliente
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 ---
 
 ## Objectif

--- a/docs/fr/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/fr/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migration IaaS vers le Public Cloud - Étapes et bonnes pratiques
 description: Découvrez comment migrer votre infrastructure vers le Public Cloud OVHcloud en utilisant les services IaaS, l’automatisation Terraform et une architecture réseau résiliente
-lastUpdated: 2025-06-16
+lastUpdated: 2026-07-27
 ---
 
 ## Objectif
@@ -113,7 +113,7 @@ La méthode Lift and Shift vous permet de migrer vos machines virtuelles (VMs) e
 
 Pour commencer, exportez vos VMs sources depuis votre infrastructure actuelle. OVHcloud supporte plusieurs formats d’images, notamment : ami, ari, aki, vhd, vmdk, raw, qcow2, vhdx, vdi, iso, et ploop.
 
-Une fois exportée, vous devrez téléverser l'image de la VM dans votre projet OVHcloud. Pour cela, assurez-vous d’avoir un environnement Python local prêt et installez le client OpenStack CLI (pour ce faire, suivez ce [guide d’installation](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html)). Vous aurez également besoin de vos identifiants API pour vous authentifier.
+Une fois exportée, vous devrez téléverser l'image de la VM dans votre projet OVHcloud. Pour cela, assurez-vous d’avoir un environnement Python local prêt et installez le client OpenStack CLI (pour ce faire, suivez ce [guide d’installation](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)). Vous aurez également besoin de vos identifiants API pour vous authentifier.
 
 Après avoir téléversé l'image, vous pourrez déployer une nouvelle instance à partir de celle-ci via le tableau de bord OVHcloud, la CLI OpenStack ou via Terraform/OpenTofu. Retrouvez les instructions détaillées pour importer une image de VM dans notre guide « [Importez votre propre image](/guides/public-cloud/compute/upload-own-image) ».
 

--- a/docs/fr/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/fr/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attacher une adresse Floating IP à une instance Public Cloud
 description: "Comprendre qu'est-ce qu’une Floating IP des services L3 et comment la configurer"
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/fr/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/fr/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attacher une adresse Floating IP à une instance Public Cloud
 description: "Comprendre qu'est-ce qu’une Floating IP des services L3 et comment la configurer"
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -20,7 +20,7 @@ Les Floating IP sont des adresses IP publiques sur [Public Cloud](/links/public-
 
 - Un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) existant sur votre compte OVHcloud
 - Avoir accès à <ApiLink>l’API OVHcloud</ApiLink> ou à l’environnement OpenStack en ligne de commande (si besoin, consultez notre [tutoriel](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment))
-- L’outil [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) installé sur votre environnement de travail (facultatif)
+- L’outil [OpenStack Command Line Interface](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) installé sur votre environnement de travail (facultatif)
 
 ## Comprendre le service Floating IP
 

--- a/docs/fr/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
+++ b/docs/fr/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Modifier la taille de la MTU pour les réseaux existants à l'aide des API/CLI OpenStack"
 description: "Découvrez comment modifier la taille de la MTU pour un réseau Public Cloud existant à l'aide des API/CLI OpenStack"
-lastUpdated: 2023-05-24
+lastUpdated: 2026-07-27
 ---
 
 ## Objectif
@@ -16,7 +16,7 @@ La taille de MTU sera la même pour tous les services utilisant des IPs sur le m
 
 - Un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
 - Utiliser l'[environnement de ligne de commande OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)
-- L’outil [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) installé sur votre environnement de travail
+- L’outil [OpenStack Command Line Interface](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) installé sur votre environnement de travail
 
 Avant de poursuivre, il est recommandé de consulter ces guides :
 

--- a/docs/fr/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
+++ b/docs/fr/guides/public-cloud/network-services/configuration-change-mtu-size.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Modifier la taille de la MTU pour les réseaux existants à l'aide des API/CLI OpenStack"
 description: "Découvrez comment modifier la taille de la MTU pour un réseau Public Cloud existant à l'aide des API/CLI OpenStack"
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 ---
 
 ## Objectif

--- a/docs/fr/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
+++ b/docs/fr/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuration SNAT pour services L3
 description: "Comprendre qu'est-ce que le service SNAT et comment le configurer"
-lastUpdated: 2022-11-02
+lastUpdated: 2026-07-27
 ---
 
 ## Objectif
@@ -11,7 +11,7 @@ L'objectif de ce guide est d'expliquer ce qu'est le service SNAT fourni par les 
 ## Prérequis
 
 - Un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
-- L'outil [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) installé sur votre environnement (local)
+- L'outil [Openstack Command Line Interface](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) installé sur votre environnement (local)
 - Une [Floating IP des services L3](/guides/public-cloud/network-services/attach-floating-ip-to-instance)
 
 ## Concepts

--- a/docs/fr/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
+++ b/docs/fr/guides/public-cloud/network-services/l3-services-snat-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuration SNAT pour services L3
 description: "Comprendre qu'est-ce que le service SNAT et comment le configurer"
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 ---
 
 ## Objectif

--- a/docs/it/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud IaaS Migration - Steps and Best Practices"
 excerpt: "Learn how to migrate your infrastructure to OVHcloud Public Cloud using IaaS services, Terraform automation, and resilient network design."
-updated: 2026-07-27
+updated: 2026-07-30
 ---
 
 ## Objective

--- a/docs/it/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/it/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud IaaS Migration - Steps and Best Practices"
 excerpt: "Learn how to migrate your infrastructure to OVHcloud Public Cloud using IaaS services, Terraform automation, and resilient network design."
-updated: 2025-06-16
+updated: 2026-07-27
 ---
 
 ## Objective
@@ -101,7 +101,7 @@ The Lift and Shift method allows you to migrate your existing virtual machines (
 
 To begin, export your source VMs from your current infrastructure. OVHcloud supports several image formats, including: ami, ari, aki, vhd, vmdk, raw, qcow2, vhdx, vdi, iso, and ploop.
 
-Once exported, you need to upload the VM image to your OVHcloud project. To do this, make sure you have a local Python environment ready and install the OpenStack CLI (to do this, follow this [installation guide](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html)). You'll also need your API credentials to authenticate.
+Once exported, you need to upload the VM image to your OVHcloud project. To do this, make sure you have a local Python environment ready and install the OpenStack CLI (to do this, follow this [installation guide](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)). You'll also need your API credentials to authenticate.
 
 After uploading the image, you can deploy a new instance from it using the OVHcloud Control Panel, OpenStack CLI, or via Terraform/OpenTofu. You'll find step-by-step instructions on how to import a VM image in our guide "[Uploading your own image](/guides/public-cloud/compute/upload-own-image)".
 

--- a/docs/it/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/it/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/it/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/it/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -20,7 +20,7 @@ Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/publ
 
 - A [Public Cloud project](/guides/public-cloud/cross-functional/create-a-public-cloud-project) in your OVHcloud account
 - Access to the <ApiLink>OVHcloud API</ApiLink> or the OpenStack command line environment ([Tutorial](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment))
-- The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment (optional)
+- The [OpenStack Command Line Interface](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) tool installed on your working environment (optional)
 
 ## Understanding the Floating IP service
 

--- a/docs/pl/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud IaaS Migration - Steps and Best Practices"
 excerpt: "Learn how to migrate your infrastructure to OVHcloud Public Cloud using IaaS services, Terraform automation, and resilient network design."
-updated: 2026-07-27
+updated: 2026-07-30
 ---
 
 ## Objective

--- a/docs/pl/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/pl/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud IaaS Migration - Steps and Best Practices"
 excerpt: "Learn how to migrate your infrastructure to OVHcloud Public Cloud using IaaS services, Terraform automation, and resilient network design."
-updated: 2025-06-16
+updated: 2026-07-27
 ---
 
 ## Objective
@@ -101,7 +101,7 @@ The Lift and Shift method allows you to migrate your existing virtual machines (
 
 To begin, export your source VMs from your current infrastructure. OVHcloud supports several image formats, including: ami, ari, aki, vhd, vmdk, raw, qcow2, vhdx, vdi, iso, and ploop.
 
-Once exported, you need to upload the VM image to your OVHcloud project. To do this, make sure you have a local Python environment ready and install the OpenStack CLI (to do this, follow this [installation guide](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html)). You'll also need your API credentials to authenticate.
+Once exported, you need to upload the VM image to your OVHcloud project. To do this, make sure you have a local Python environment ready and install the OpenStack CLI (to do this, follow this [installation guide](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)). You'll also need your API credentials to authenticate.
 
 After uploading the image, you can deploy a new instance from it using the OVHcloud Control Panel, OpenStack CLI, or via Terraform/OpenTofu. You'll find step-by-step instructions on how to import a VM image in our guide "[Uploading your own image](/guides/public-cloud/compute/upload-own-image)".
 

--- a/docs/pl/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/pl/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/pl/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/pl/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -20,7 +20,7 @@ Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/publ
 
 - A [Public Cloud project](/guides/public-cloud/cross-functional/create-a-public-cloud-project) in your OVHcloud account
 - Access to the <ApiLink>OVHcloud API</ApiLink> or the OpenStack command line environment ([Tutorial](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment))
-- The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment (optional)
+- The [OpenStack Command Line Interface](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) tool installed on your working environment (optional)
 
 ## Understanding the Floating IP service
 

--- a/docs/pt/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud IaaS Migration - Steps and Best Practices"
 excerpt: "Learn how to migrate your infrastructure to OVHcloud Public Cloud using IaaS services, Terraform automation, and resilient network design."
-updated: 2026-07-27
+updated: 2026-07-30
 ---
 
 ## Objective

--- a/docs/pt/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/pt/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud IaaS Migration - Steps and Best Practices"
 excerpt: "Learn how to migrate your infrastructure to OVHcloud Public Cloud using IaaS services, Terraform automation, and resilient network design."
-updated: 2025-06-16
+updated: 2026-07-27
 ---
 
 ## Objective
@@ -101,7 +101,7 @@ The Lift and Shift method allows you to migrate your existing virtual machines (
 
 To begin, export your source VMs from your current infrastructure. OVHcloud supports several image formats, including: ami, ari, aki, vhd, vmdk, raw, qcow2, vhdx, vdi, iso, and ploop.
 
-Once exported, you need to upload the VM image to your OVHcloud project. To do this, make sure you have a local Python environment ready and install the OpenStack CLI (to do this, follow this [installation guide](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html)). You'll also need your API credentials to authenticate.
+Once exported, you need to upload the VM image to your OVHcloud project. To do this, make sure you have a local Python environment ready and install the OpenStack CLI (to do this, follow this [installation guide](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)). You'll also need your API credentials to authenticate.
 
 After uploading the image, you can deploy a new instance from it using the OVHcloud Control Panel, OpenStack CLI, or via Terraform/OpenTofu. You'll find step-by-step instructions on how to import a VM image in our guide "[Uploading your own image](/guides/public-cloud/compute/upload-own-image)".
 

--- a/docs/pt/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/pt/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/pt/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
+++ b/docs/pt/guides/public-cloud/network-services/attach-floating-ip-to-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attaching a Floating IP to a Public Cloud instance
 description: Find out how a Floating IP address functions and how to configure it
-lastUpdated: 2026-07-16
+lastUpdated: 2026-07-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -20,7 +20,7 @@ Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/publ
 
 - A [Public Cloud project](/guides/public-cloud/cross-functional/create-a-public-cloud-project) in your OVHcloud account
 - Access to the <ApiLink>OVHcloud API</ApiLink> or the OpenStack command line environment ([Tutorial](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment))
-- The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment (optional)
+- The [OpenStack Command Line Interface](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) tool installed on your working environment (optional)
 
 ## Understanding the Floating IP service
 


### PR DESCRIPTION
## Summary

- replace OpenStack Newton CLI installation links with the maintained OVHcloud OpenStack environment guide
- update every occurrence across the IaaS migration, Floating IP, MTU, and SNAT guides
- keep the seven locale variants and EN/FR canonical guides consistent

## Why

The linked OpenStack Newton documentation belongs to a release from 2016 whose components are marked End of Life. Its archived installation page still recommends Python 2.7, states that the clients do not support Python 3, and includes obsolete `easy_install`/`python-pip` workflows.

The replacement OVHcloud guide is available in all seven locales, uses Python 3, virtual environments, and `python-openstackclient`, and links onward to the current OpenStackClient documentation. Using the internal guide also avoids pinning current installation instructions to a historical OpenStack release URL.

Official references:

- Newton release status: https://releases.openstack.org/newton/
- archived Newton installation page: https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html
- current OpenStackClient documentation: https://docs.openstack.org/python-openstackclient/latest/
- current package metadata: https://pypi.org/project/python-openstackclient/

## Validation

- `pnpm content:lint`
- `git diff --check`
- exact invariant: 18 Newton links removed and 18 internal guide links added
- exact invariant: only the link and existing date field changed in each of the 18 files
- verified that the replacement guide exists in all seven locales
- checked open and closed issues/PRs and current open PR file overlap; no duplicate found

A full site build was not run because this change only updates Markdown links and frontmatter dates; it does not alter MDX structure, routing, or rendering code.
