### PR TITLE
docs: migrate WordPress tutorial to Docker Compose v2

### DIFF
--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "How to install WordPress with Docker on a VPS or a dedicated server"
 excerpt: "Find out how to quickly install WordPress with Docker on a VPS or an OVHcloud dedicated server"
-lastUpdated: 2026-07-31
+lastUpdated: 2026-08-10
 ---
 
 ## Objective

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -50,17 +50,17 @@ Add the Docker repository to your system:
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bullseye stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 ```
 
-Update the `apt` package index and install the Docker Engine:
+Update the `apt` package index and install Docker Engine and the Docker Compose plugin:
 
 ```sh
 sudo apt update
-sudo apt install docker-ce docker-ce-cli containerd.io -y
+sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y
 ```
 
 Verify that Docker is installed and configured:
 
 ```sh
-docker –version
+docker --version
 ```
 
 Test Docker with a simple command:
@@ -75,22 +75,12 @@ If the Docker installation is successful, you will receive a message like this:
 
 ### Install Docker Compose
 
-Download the latest version of Docker Compose (replace 1.29.2 with the latest available version):
-
-```sh
-sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-```
-
-Make the binary executable:
-
-```sh
-sudo chmod +x /usr/local/bin/docker-compose
-```
+The Docker Compose plugin was installed with Docker Engine in the previous step.
 
 Check the Docker Compose installation:
 
 ```sh
-docker-compose –version
+docker compose version
 ```
 
 If the Docker Compose installation is successful, you will receive a message like this:
@@ -114,8 +104,6 @@ nano docker-compose.yml
 Copy and paste the following configuration into the `docker-compose.yml` file:
 
 ```yaml
-version: '3.8'
-
 services:
   db:
     image: mysql:5.7
@@ -150,7 +138,7 @@ This Compose file creates a WordPress service and a MySQL service.
 Launch the services with Docker Compose:
 
 ```sh
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 The Docker image used in this example is the official version `wordpress:latest`. This specific image is designed to work with an Apache web server. The official WordPress images on [Docker Hub](https://hub.docker.com/) are regularly updated to include the latest stable PHP versions compatible with the current version of WordPress.
@@ -178,8 +166,6 @@ If you wish, you can use another Docker image.
 Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:5-php7.4-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:5-php7.4-fpm` image you have chosen. For example:
 
 ```yaml
-version: '3.8'
-
 services:
   wordpress:
     image: wordpress:5-php7.4-fpm
@@ -192,13 +178,13 @@ services:
 Launch or update your containers with Docker Compose. If this is your first time launching the project, use:
 
 ```sh
-docker-compose up -d
+docker compose up -d
 ```
 
 If your containers are already running and you want to apply the changes, use:
 
 ```sh
-docker-compose up -d --force-recreate
+docker compose up -d --force-recreate
 ```
 
 Check that everything is working as expected. You can check the logs of your WordPress container to ensure that it starts correctly and that there are no errors:

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -51,17 +51,17 @@ Add the Docker repository to your system:
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bullseye stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 ```
 
-Update the `apt` package index and install the Docker Engine:
+Update the `apt` package index and install Docker Engine and the Docker Compose plugin:
 
 ```sh
 sudo apt update
-sudo apt install docker-ce docker-ce-cli containerd.io -y
+sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y
 ```
 
 Verify that Docker is installed and configured:
 
 ```sh
-docker –version
+docker --version
 ```
 
 Test Docker with a simple command:
@@ -76,17 +76,7 @@ If the Docker installation is successful, you will receive a message like this:
 
 ### Install Docker Compose
 
-Download the latest version of Docker Compose (replace 1.29.2 with the latest available version):
-
-```sh
-sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-```
-
-Make the binary executable:
-
-```sh
-sudo chmod +x /usr/local/bin/docker-compose
-```
+The Docker Compose plugin was installed with Docker Engine in the previous step.
 
 Check the Docker Compose installation:
 
@@ -115,8 +105,6 @@ nano docker-compose.yml
 Copy and paste the following configuration into the `docker-compose.yml` file:
 
 ```yaml
-version: '3.8'
-
 services:
   db:
     image: mysql:5.7
@@ -179,8 +167,6 @@ If you wish, you can use another Docker image.
 Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:5-php7.4-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:5-php7.4-fpm` image you have chosen. For example:
 
 ```yaml
-version: '3.8'
-
 services:
   wordpress:
     image: wordpress:5-php7.4-fpm
@@ -193,13 +179,13 @@ services:
 Launch or update your containers with Docker Compose. If this is your first time launching the project, use:
 
 ```sh
-docker-compose up -d
+docker compose up -d
 ```
 
 If your containers are already running and you want to apply the changes, use:
 
 ```sh
-docker-compose up -d --force-recreate
+docker compose up -d --force-recreate
 ```
 
 Check that everything is working as expected. You can check the logs of your WordPress container to ensure that it starts correctly and that there are no errors:

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to install WordPress with Docker on a VPS or a dedicated server
 description: Find out how to quickly install WordPress with Docker on a VPS or an OVHcloud dedicated server
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-10
 ---
 
 ## Objective

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "How to install WordPress with Docker on a VPS or a dedicated server"
 description: "Find out how to quickly install WordPress with Docker on a VPS or an OVHcloud dedicated server"
-lastUpdated: 2026-07-31
+lastUpdated: 2026-08-10
 ---
 
 ## Objective

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -50,17 +50,17 @@ Add the Docker repository to your system:
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bullseye stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 ```
 
-Update the `apt` package index and install the Docker Engine:
+Update the `apt` package index and install Docker Engine and the Docker Compose plugin:
 
 ```sh
 sudo apt update
-sudo apt install docker-ce docker-ce-cli containerd.io -y
+sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y
 ```
 
 Verify that Docker is installed and configured:
 
 ```sh
-docker –version
+docker --version
 ```
 
 Test Docker with a simple command:
@@ -75,22 +75,12 @@ If the Docker installation is successful, you will receive a message like this:
 
 ### Install Docker Compose
 
-Download the latest version of Docker Compose (replace 1.29.2 with the latest available version):
-
-```sh
-sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-```
-
-Make the binary executable:
-
-```sh
-sudo chmod +x /usr/local/bin/docker-compose
-```
+The Docker Compose plugin was installed with Docker Engine in the previous step.
 
 Check the Docker Compose installation:
 
 ```sh
-docker-compose –version
+docker compose version
 ```
 
 If the Docker Compose installation is successful, you will receive a message like this:
@@ -114,8 +104,6 @@ nano docker-compose.yml
 Copy and paste the following configuration into the `docker-compose.yml` file:
 
 ```yaml
-version: '3.8'
-
 services:
   db:
     image: mysql:5.7
@@ -150,7 +138,7 @@ This Compose file creates a WordPress service and a MySQL service.
 Launch the services with Docker Compose:
 
 ```sh
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 The Docker image used in this example is the official version `wordpress:latest`. This specific image is designed to work with an Apache web server. The official WordPress images on [Docker Hub](https://hub.docker.com/) are regularly updated to include the latest stable PHP versions compatible with the current version of WordPress.
@@ -178,8 +166,6 @@ If you wish, you can use another Docker image.
 Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:5-php7.4-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:5-php7.4-fpm` image you have chosen. For example:
 
 ```yaml
-version: '3.8'
-
 services:
   wordpress:
     image: wordpress:5-php7.4-fpm
@@ -192,13 +178,13 @@ services:
 Launch or update your containers with Docker Compose. If this is your first time launching the project, use:
 
 ```sh
-docker-compose up -d
+docker compose up -d
 ```
 
 If your containers are already running and you want to apply the changes, use:
 
 ```sh
-docker-compose up -d --force-recreate
+docker compose up -d --force-recreate
 ```
 
 Check that everything is working as expected. You can check the logs of your WordPress container to ensure that it starts correctly and that there are no errors:

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -1,7 +1,7 @@
 ---
 title: Installer WordPress avec Docker sur un VPS ou un serveur dédié
 description: Découvrez comment installer WordPress rapidement avec Docker sur un VPS ou un serveur dédié OVHcloud
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-10
 ---
 
 ## Objectif

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -53,17 +53,17 @@ Ajoutez le dépôt Docker à votre système :
 ~$ echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bullseye stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 ```
 
-Mettez à jour l'index des paquets `apt` et installez Docker Engine :
+Mettez à jour l'index des paquets `apt`, puis installez Docker Engine et le plugin Docker Compose :
 
 ```sh
 ~$ sudo apt update
-sudo apt install docker-ce docker-ce-cli containerd.io -y
+sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y
 ```
 
 Vérifiez que Docker est bien installé et configuré :
 
 ```sh
-~$ docker –version
+~$ docker --version
 ```
 
 Testez Docker avec une commande simple :
@@ -78,17 +78,7 @@ Si l'installation de Docker s'est bien déroulée, vous obtenez un message de ce
 
 ### Installer Docker Compose
 
-Téléchargez la dernière version de Docker Compose (remplacez 1.29.2 par la dernière version disponible) :
-
-```sh
-~$ sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-```
-
-Rendez le binaire exécutable :
-
-```sh
-~$ sudo chmod +x /usr/local/bin/docker-compose
-```
+Le plugin Docker Compose a été installé avec Docker Engine à l'étape précédente.
 
 Vérifiez l'installation de Docker Compose :
 
@@ -117,8 +107,6 @@ Créez un fichier `docker-compose.yml` avec votre éditeur de texte préféré :
 Copiez et collez la configuration suivante dans le fichier `docker-compose.yml` :
 
 ```sh
-version: '3.8'
-
 services:
   db:
     image: mysql:5.7
@@ -181,8 +169,6 @@ Si vous le souhaitez, vous pouvez utiliser une autre image Docker.
 Dirigez-vous dans la [section WordPress de Docker Hub](https://hub.docker.com/_/wordpress) et identifiez l'image qui correspond à vos besoins. Par exemple, si vous choisissez d'utiliser l'image `wordpress:5-php7.4-fpm`, vous devrez modifier votre fichier `docker-compose.yml` avec un éditeur de texte. Une fois le fichier ouvert, trouvez la section du service `wordpress` et modifiez la ligne `image:` pour utiliser le tag spécifique de l'image `wordpress:5-php7.4-fpm` que vous avez choisi. Par exemple :
 
 ```sh
-version: '3.8'
-
 services:
   wordpress:
     image: wordpress:5-php7.4-fpm
@@ -195,13 +181,13 @@ services:
 Lancez ou mettez à jour vos conteneurs avec Docker Compose. Si c'est la première fois que vous lancez le projet, utilisez :
 
 ```sh
-~$ docker-compose up -d
+~$ docker compose up -d
 ```
 
 Si vos conteneurs sont déjà en cours d'exécution et que vous souhaitez appliquer les modifications, utilisez :
 
 ```sh
-~$ docker-compose up -d --force-recreate
+~$ docker compose up -d --force-recreate
 ```
 
 Vérifiez que tout fonctionne comme prévu. Vous pouvez vérifier les logs de votre conteneur WordPress pour vous assurer qu'il démarre correctement et qu'il n'y a pas d'erreurs :

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "How to install WordPress with Docker on a VPS or a dedicated server"
 description: "Find out how to quickly install WordPress with Docker on a VPS or an OVHcloud dedicated server"
-lastUpdated: 2026-07-31
+lastUpdated: 2026-08-10
 ---
 
 ## Objective

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -50,17 +50,17 @@ Add the Docker repository to your system:
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bullseye stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 ```
 
-Update the `apt` package index and install the Docker Engine:
+Update the `apt` package index and install Docker Engine and the Docker Compose plugin:
 
 ```sh
 sudo apt update
-sudo apt install docker-ce docker-ce-cli containerd.io -y
+sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y
 ```
 
 Verify that Docker is installed and configured:
 
 ```sh
-docker –version
+docker --version
 ```
 
 Test Docker with a simple command:
@@ -75,22 +75,12 @@ If the Docker installation is successful, you will receive a message like this:
 
 ### Install Docker Compose
 
-Download the latest version of Docker Compose (replace 1.29.2 with the latest available version):
-
-```sh
-sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-```
-
-Make the binary executable:
-
-```sh
-sudo chmod +x /usr/local/bin/docker-compose
-```
+The Docker Compose plugin was installed with Docker Engine in the previous step.
 
 Check the Docker Compose installation:
 
 ```sh
-docker-compose –version
+docker compose version
 ```
 
 If the Docker Compose installation is successful, you will receive a message like this:
@@ -114,8 +104,6 @@ nano docker-compose.yml
 Copy and paste the following configuration into the `docker-compose.yml` file:
 
 ```yaml
-version: '3.8'
-
 services:
   db:
     image: mysql:5.7
@@ -150,7 +138,7 @@ This Compose file creates a WordPress service and a MySQL service.
 Launch the services with Docker Compose:
 
 ```sh
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 The Docker image used in this example is the official version `wordpress:latest`. This specific image is designed to work with an Apache web server. The official WordPress images on [Docker Hub](https://hub.docker.com/) are regularly updated to include the latest stable PHP versions compatible with the current version of WordPress.
@@ -178,8 +166,6 @@ If you wish, you can use another Docker image.
 Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:5-php7.4-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:5-php7.4-fpm` image you have chosen. For example:
 
 ```yaml
-version: '3.8'
-
 services:
   wordpress:
     image: wordpress:5-php7.4-fpm
@@ -192,13 +178,13 @@ services:
 Launch or update your containers with Docker Compose. If this is your first time launching the project, use:
 
 ```sh
-docker-compose up -d
+docker compose up -d
 ```
 
 If your containers are already running and you want to apply the changes, use:
 
 ```sh
-docker-compose up -d --force-recreate
+docker compose up -d --force-recreate
 ```
 
 Check that everything is working as expected. You can check the logs of your WordPress container to ensure that it starts correctly and that there are no errors:

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "How to install WordPress with Docker on a VPS or a dedicated server"
 description: "Find out how to quickly install WordPress with Docker on a VPS or an OVHcloud dedicated server"
-lastUpdated: 2026-07-31
+lastUpdated: 2026-08-10
 ---
 
 ## Objective

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -50,17 +50,17 @@ Add the Docker repository to your system:
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bullseye stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 ```
 
-Update the `apt` package index and install the Docker Engine:
+Update the `apt` package index and install Docker Engine and the Docker Compose plugin:
 
 ```sh
 sudo apt update
-sudo apt install docker-ce docker-ce-cli containerd.io -y
+sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y
 ```
 
 Verify that Docker is installed and configured:
 
 ```sh
-docker –version
+docker --version
 ```
 
 Test Docker with a simple command:
@@ -75,22 +75,12 @@ If the Docker installation is successful, you will receive a message like this:
 
 ### Install Docker Compose
 
-Download the latest version of Docker Compose (replace 1.29.2 with the latest available version):
-
-```sh
-sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-```
-
-Make the binary executable:
-
-```sh
-sudo chmod +x /usr/local/bin/docker-compose
-```
+The Docker Compose plugin was installed with Docker Engine in the previous step.
 
 Check the Docker Compose installation:
 
 ```sh
-docker-compose –version
+docker compose version
 ```
 
 If the Docker Compose installation is successful, you will receive a message like this:
@@ -114,8 +104,6 @@ nano docker-compose.yml
 Copy and paste the following configuration into the `docker-compose.yml` file:
 
 ```yaml
-version: '3.8'
-
 services:
   db:
     image: mysql:5.7
@@ -150,7 +138,7 @@ This Compose file creates a WordPress service and a MySQL service.
 Launch the services with Docker Compose:
 
 ```sh
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 The Docker image used in this example is the official version `wordpress:latest`. This specific image is designed to work with an Apache web server. The official WordPress images on [Docker Hub](https://hub.docker.com/) are regularly updated to include the latest stable PHP versions compatible with the current version of WordPress.
@@ -178,8 +166,6 @@ If you wish, you can use another Docker image.
 Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:5-php7.4-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:5-php7.4-fpm` image you have chosen. For example:
 
 ```yaml
-version: '3.8'
-
 services:
   wordpress:
     image: wordpress:5-php7.4-fpm
@@ -192,13 +178,13 @@ services:
 Launch or update your containers with Docker Compose. If this is your first time launching the project, use:
 
 ```sh
-docker-compose up -d
+docker compose up -d
 ```
 
 If your containers are already running and you want to apply the changes, use:
 
 ```sh
-docker-compose up -d --force-recreate
+docker compose up -d --force-recreate
 ```
 
 Check that everything is working as expected. You can check the logs of your WordPress container to ensure that it starts correctly and that there are no errors:

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "How to install WordPress with Docker on a VPS or a dedicated server"
 excerpt: "Find out how to quickly install WordPress with Docker on a VPS or an OVHcloud dedicated server"
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-10
 ---
 
 ## Objective

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -50,17 +50,17 @@ Add the Docker repository to your system:
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bullseye stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 ```
 
-Update the `apt` package index and install the Docker Engine:
+Update the `apt` package index and install Docker Engine and the Docker Compose plugin:
 
 ```sh
 sudo apt update
-sudo apt install docker-ce docker-ce-cli containerd.io -y
+sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y
 ```
 
 Verify that Docker is installed and configured:
 
 ```sh
-docker –version
+docker --version
 ```
 
 Test Docker with a simple command:
@@ -75,22 +75,12 @@ If the Docker installation is successful, you will receive a message like this:
 
 ### Install Docker Compose
 
-Download the latest version of Docker Compose (replace 1.29.2 with the latest available version):
-
-```sh
-sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-```
-
-Make the binary executable:
-
-```sh
-sudo chmod +x /usr/local/bin/docker-compose
-```
+The Docker Compose plugin was installed with Docker Engine in the previous step.
 
 Check the Docker Compose installation:
 
 ```sh
-docker-compose –version
+docker compose version
 ```
 
 If the Docker Compose installation is successful, you will receive a message like this:
@@ -114,8 +104,6 @@ nano docker-compose.yml
 Copy and paste the following configuration into the `docker-compose.yml` file:
 
 ```yaml
-version: '3.8'
-
 services:
   db:
     image: mysql:5.7
@@ -150,7 +138,7 @@ This Compose file creates a WordPress service and a MySQL service.
 Launch the services with Docker Compose:
 
 ```sh
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 The Docker image used in this example is the official version `wordpress:latest`. This specific image is designed to work with an Apache web server. The official WordPress images on [Docker Hub](https://hub.docker.com/) are regularly updated to include the latest stable PHP versions compatible with the current version of WordPress.
@@ -178,8 +166,6 @@ If you wish, you can use another Docker image.
 Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:5-php7.4-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:5-php7.4-fpm` image you have chosen. For example:
 
 ```yaml
-version: '3.8'
-
 services:
   wordpress:
     image: wordpress:5-php7.4-fpm
@@ -192,13 +178,13 @@ services:
 Launch or update your containers with Docker Compose. If this is your first time launching the project, use:
 
 ```sh
-docker-compose up -d
+docker compose up -d
 ```
 
 If your containers are already running and you want to apply the changes, use:
 
 ```sh
-docker-compose up -d --force-recreate
+docker compose up -d --force-recreate
 ```
 
 Check that everything is working as expected. You can check the logs of your WordPress container to ensure that it starts correctly and that there are no errors:


### PR DESCRIPTION
## Summary

- install the Docker Compose plugin together with Docker Engine
- remove the legacy standalone Compose 1.29.2 download workflow
- standardize the WordPress tutorial on `docker compose` across all seven locales
- remove obsolete Compose file `version` fields and fix the malformed `docker --version` command

## Why

The guide currently downloads the standalone Docker Compose 1.29.2 binary but mixes the legacy `docker-compose` command with the Compose v2 `docker compose` syntax. On a clean system, the package installation does not provide the plugin required by the v2 commands shown in the guide.

Docker marks the standalone installation as **Legacy**, not recommended, and supported only for backward compatibility. The current repository-based installation uses the `docker-compose-plugin` package and the `docker compose` command. Docker also marks the top-level Compose file `version` property as obsolete and warns when it is present.

Official references:

- Compose plugin installation: https://docs.docker.com/compose/install/linux/
- standalone Compose status: https://docs.docker.com/compose/install/standalone/
- obsolete `version` field: https://docs.docker.com/reference/compose-file/version-and-name/

## Validation

- `pnpm content:lint`
- `git diff --check`
- parsed both Compose YAML fragments in every locale (14 fragments total)
- verified expected `db` and `wordpress` service structures after removing `version`
- exact invariant: no standalone 1.29.2 URL, legacy executable command, Unicode dash, or obsolete `version` field remains
- exact invariant: seven plugin package installs, seven Compose version checks, and consistent v2 `up` commands
- verified current upstream frontmatter was retained and the existing locale equivalence groups were preserved (`es` and `it` remain byte-identical)
- checked open/closed issues and PRs plus open PR file overlap; no duplicate found

Docker CLI was not available locally, so no package installation or runtime container test was attempted. A full site build was not run because this change only updates guide prose and code samples, not MDX structure, routing, or rendering code.

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
