### PR TITLE
docs(kms): add Cosign Sigstore docs link to third-party integrations

### DIFF
--- a/docs/de/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/de/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Offizielle Drittanbieter-Integrationen mit OVHcloud KMS
 description: Entdecken Sie Drittanwendungen, die offiziell mit OVHcloud KMS integriert sind, und finden Sie die Dokumentation zur Einrichtung jeder Integration
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-28
 ---
 
 ## Ziel
@@ -24,7 +24,7 @@ Die folgende Tabelle wird aktualisiert, sobald neue von OVHcloud gepflegte Integ
 | Drittanbieterprodukt | Integrationstyp | Dokumentation |
 | :------------------- | :-------------- | :------------ |
 | **Kubernetes** | ETCD-Verschlüsselung im Ruhezustand über `okms-k8s-encryption-provider` | [Kubernetes ETCD mit OVHcloud KMS verschlüsseln](/guides/manage-and-operate/kms/kms-etcd) · [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) |
-| **Cosign** | KMS-gestützte OCI-Image-Signierung (`ovhcloud://` URI) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) |
+| **Cosign** | KMS-gestützte OCI-Image-Signierung (`ovhcloud://` URI) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) · [Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-Unseal über das `ovhcloud` Seal | [OVHcloud KMS Seal (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
 
 :::info

--- a/docs/en/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/en/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Official third-party integrations with OVHcloud KMS
 description: Discover third-party applications officially integrated with OVHcloud KMS and find the documentation to set up each integration
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-28
 ---
 
 ## Objective
@@ -24,7 +24,7 @@ The table below is updated as new OVHcloud-maintained integrations are released.
 | Third-party product | Integration type | Documentation |
 | :------------------ | :--------------- | :------------ |
 | **Kubernetes** | ETCD encryption at rest via `okms-k8s-encryption-provider` | [Encrypt Kubernetes ETCD with OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) · [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) |
-| **Cosign** | KMS-backed OCI image signing (`ovhcloud://` URI) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) |
+| **Cosign** | KMS-backed OCI image signing (`ovhcloud://` URI) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) · [Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal via `ovhcloud` seal | [OVHcloud KMS seal (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
 
 :::info

--- a/docs/es/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/es/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integraciones oficiales de terceros con OVHcloud KMS
 description: Descubra las aplicaciones de terceros integradas oficialmente con OVHcloud KMS y acceda a la documentación para configurar cada integración
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-28
 ---
 
 ## Objetivo
@@ -24,7 +24,7 @@ La siguiente tabla se actualiza cada vez que se publica una nueva integración m
 | Producto de terceros | Tipo de integración | Documentación |
 | :------------------- | :------------------ | :------------ |
 | **Kubernetes** | Cifrado de ETCD en reposo mediante `okms-k8s-encryption-provider` | [Cifrar ETCD de Kubernetes con OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) · [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) |
-| **Cosign** | Firma de imágenes OCI mediante KMS (URI `ovhcloud://`) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) |
+| **Cosign** | Firma de imágenes OCI mediante KMS (URI `ovhcloud://`) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) · [Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal mediante el seal `ovhcloud` | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
 
 :::info

--- a/docs/fr/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/fr/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Intégrations tierces officielles avec OVHcloud KMS
 description: Découvrez les applications tierces officiellement intégrées à OVHcloud KMS et accédez à la documentation pour configurer chaque intégration
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-28
 ---
 
 ## Objectif
@@ -24,7 +24,7 @@ Le tableau ci-dessous est mis à jour à chaque nouvelle intégration maintenue 
 | Produit tiers | Type d'intégration | Documentation |
 | :------------ | :----------------- | :------------ |
 | **Kubernetes** | Chiffrement ETCD au repos via `okms-k8s-encryption-provider` | [Chiffrer ETCD de Kubernetes avec OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) · [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) |
-| **Cosign** | Signature d'images OCI via KMS (URI `ovhcloud://`) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) |
+| **Cosign** | Signature d'images OCI via KMS (URI `ovhcloud://`) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) · [Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal via le seal `ovhcloud` | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
 
 :::info

--- a/docs/it/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/it/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integrazioni ufficiali di terze parti con OVHcloud KMS
 description: Scopri le applicazioni di terze parti integrate ufficialmente con OVHcloud KMS e accedi alla documentazione per configurare ogni integrazione
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-28
 ---
 
 ## Obiettivo
@@ -24,7 +24,7 @@ La tabella seguente viene aggiornata a ogni nuova integrazione mantenuta da OVHc
 | Prodotto di terze parti | Tipo di integrazione | Documentazione |
 | :---------------------- | :------------------- | :------------- |
 | **Kubernetes** | Crittografia ETCD a riposo tramite `okms-k8s-encryption-provider` | [Crittografare ETCD di Kubernetes con OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) · [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) |
-| **Cosign** | Firma di immagini OCI tramite KMS (URI `ovhcloud://`) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) |
+| **Cosign** | Firma di immagini OCI tramite KMS (URI `ovhcloud://`) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) · [Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal tramite il seal `ovhcloud` | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
 
 :::info

--- a/docs/pl/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/pl/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Oficjalne integracje zewnętrzne z OVHcloud KMS
 description: Poznaj aplikacje zewnętrzne oficjalnie zintegrowane z OVHcloud KMS i znajdź dokumentację umożliwiającą skonfigurowanie każdej integracji
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-28
 ---
 
 ## Wprowadzenie
@@ -24,7 +24,7 @@ Poniższa tabela jest aktualizowana wraz z udostępnianiem nowych integracji utr
 | Produkt zewnętrzny | Typ integracji | Dokumentacja |
 | :----------------- | :------------- | :----------- |
 | **Kubernetes** | Szyfrowanie ETCD w spoczynku za pomocą `okms-k8s-encryption-provider` | [Szyfrowanie ETCD Kubernetes za pomocą OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) · [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) |
-| **Cosign** | Podpisywanie obrazów OCI za pomocą KMS (URI `ovhcloud://`) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) |
+| **Cosign** | Podpisywanie obrazów OCI za pomocą KMS (URI `ovhcloud://`) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) · [Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal za pomocą seal `ovhcloud` | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
 
 :::info

--- a/docs/pt/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/pt/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integrações oficiais de terceiros com o OVHcloud KMS
 description: Descubra as aplicações de terceiros oficialmente integradas com o OVHcloud KMS e aceda à documentação para configurar cada integração
-lastUpdated: 2026-07-17
+lastUpdated: 2026-07-28
 ---
 
 ## Objetivo
@@ -24,7 +24,7 @@ A tabela abaixo é atualizada sempre que é publicada uma nova integração mant
 | Produto de terceiros | Tipo de integração | Documentação |
 | :------------------- | :----------------- | :----------- |
 | **Kubernetes** | Encriptação ETCD em repouso através de `okms-k8s-encryption-provider` | [Encriptar o ETCD do Kubernetes com o OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) · [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) |
-| **Cosign** | Assinatura de imagens OCI através do KMS (URI `ovhcloud://`) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) |
+| **Cosign** | Assinatura de imagens OCI através do KMS (URI `ovhcloud://`) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/) · [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) · [Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal através do seal `ovhcloud` | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
 
 :::info


### PR DESCRIPTION
## Summary
- Add the official Sigstore Cosign key-management docs link for the OVHcloud KMS provider to the Cosign row on the KMS third-party integrations page