### PR TITLE
docs: replace deprecated nova boot command

### DIFF
--- a/docs/de/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Launching a script when an instance is created"
-updated: 2022-03-18
+updated: 2026-07-28
 ---
 
   
@@ -87,10 +87,10 @@ user.
 
 ### Create the instance
 
-After you have retrieved the list of images and instance templates, you can launch the script with Cloud-init via the **--user- data** argument:
+After you have retrieved the list of images and instance templates, you can launch the script with Cloud-init via the **--user-data** argument:
 
 ```sh
-root@server:~# nova boot --key_name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
+root@server:~# openstack server create --key-name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
 ```
 
 After we have double-checked the details, our user is correctly added after the instance has been created, and they have all of the permissions required:

--- a/docs/de/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Launching a script when an instance is created"
-updated: 2026-07-28
+updated: 2026-07-30
 ---
 
   

--- a/docs/en/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,6 +1,6 @@
 ---
 title: Launching a script when an instance is created
-lastUpdated: 2022-03-18
+lastUpdated: 2026-07-28
 ---
 
   
@@ -92,7 +92,7 @@ user.
 After you have retrieved the list of images and instance templates, you can launch the script with Cloud-init via the **--user-data** argument:
 
 ```bash
-root@server:~# nova boot --key_name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
+root@server:~# openstack server create --key-name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
 ```
 
 After we have double-checked the details, our user is correctly added after the instance has been created, and they have all of the permissions required:

--- a/docs/en/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,6 +1,6 @@
 ---
 title: Launching a script when an instance is created
-lastUpdated: 2026-07-28
+lastUpdated: 2026-07-30
 ---
 
   

--- a/docs/es/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Launching a script when an instance is created"
-updated: 2022-03-18
+updated: 2026-07-28
 ---
 
   
@@ -87,10 +87,10 @@ user.
 
 ### Create the instance
 
-After you have retrieved the list of images and instance templates, you can launch the script with Cloud-init via the **--user- data** argument:
+After you have retrieved the list of images and instance templates, you can launch the script with Cloud-init via the **--user-data** argument:
 
 ```sh
-root@server:~# nova boot --key_name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
+root@server:~# openstack server create --key-name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
 ```
 
 After we have double-checked the details, our user is correctly added after the instance has been created, and they have all of the permissions required:

--- a/docs/es/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Launching a script when an instance is created"
-updated: 2026-07-28
+updated: 2026-07-30
 ---
 
   

--- a/docs/fr/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,6 +1,6 @@
 ---
 title: Lancer un script lors de la création d’une instance
-lastUpdated: 2022-03-18
+lastUpdated: 2026-07-28
 ---
 
   
@@ -92,7 +92,7 @@ utilisateur.
 Après avoir récupéré la liste des images et des modèles d'instance, il est possible de lancer le script avec Cloud-init grâce à l'argument **--user-data** :
 
 ```bash
-root@server:~# nova boot --key_name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
+root@server:~# openstack server create --key-name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
 ```
 
 Après vérification, notre utilisateur est correctement ajouté après la création de l'instance avec les droits nécessaires :

--- a/docs/fr/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,6 +1,6 @@
 ---
 title: Lancer un script lors de la création d’une instance
-lastUpdated: 2026-07-28
+lastUpdated: 2026-07-30
 ---
 
   

--- a/docs/it/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Esegui uno script durante la creazione della tua istanza
 description: Esegui uno script durante la creazione della tua istanza
-lastUpdated: 2026-07-28
+lastUpdated: 2026-07-30
 ---
 
 ## Obiettivo

--- a/docs/it/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Esegui uno script durante la creazione della tua istanza
 description: Esegui uno script durante la creazione della tua istanza
-lastUpdated: 2022-03-18
+lastUpdated: 2026-07-28
 ---
 
 ## Obiettivo
@@ -90,7 +90,7 @@ L'utente "admin" non verrà creato, ma sarà sostituito dal tuo utente.
 Dopo aver recuperato la lista delle immagini e dei modelli di istanza, puoi eseguire lo script con Cloud-init utilizzando l'argomento --user-data:
 
 ```bash
-root@server:~# nova boot --key_name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
+root@server:~# openstack server create --key-name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
 ```
 
 Una volta verificata la correttezza dei dati inseriti, il tuo utente e i relativi permessi vengono aggiunti al termine della creazione dell'istanza:

--- a/docs/pl/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Uruchomienie skryptu podczas tworzenia instancji
 description: Uruchomienie skryptu podczas tworzenia instancji
-lastUpdated: 2022-03-18
+lastUpdated: 2026-07-28
 ---
 
 :::info
@@ -99,7 +99,7 @@ Użytkownik "admin" nie zostanie utworzony, ale zostanie zastąpiony Twoim użyt
 Po pobraniu listy obrazów i modeli instancji można uruchomić skrypt z Cloud-init korzystając z argumentu --user-data:
 
 ```bash
-root@server:~# nova boot --key_name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
+root@server:~# openstack server create --key-name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
 ```
 
 Nasz użytkownik został prawidłowo dodany po utworzeniu instancji z niezbędnymi uprawnieniami:

--- a/docs/pl/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Uruchomienie skryptu podczas tworzenia instancji
 description: Uruchomienie skryptu podczas tworzenia instancji
-lastUpdated: 2026-07-28
+lastUpdated: 2026-07-30
 ---
 
 :::info

--- a/docs/pt/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Launching a script when an instance is created"
-updated: 2022-03-18
+updated: 2026-07-28
 ---
 
   
@@ -87,10 +87,10 @@ user.
 
 ### Create the instance
 
-After you have retrieved the list of images and instance templates, you can launch the script with Cloud-init via the **--user- data** argument:
+After you have retrieved the list of images and instance templates, you can launch the script with Cloud-init via the **--user-data** argument:
 
 ```sh
-root@server:~# nova boot --key_name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
+root@server:~# openstack server create --key-name SSH_KEY --image bdcb5042-3548-40d0-b06f-79551d3b4377 --flavor 98c1e679-5f2c-4069-b4da-4a4f7179b758 --user-data ./adduser.sh Instance1
 ```
 
 After we have double-checked the details, our user is correctly added after the instance has been created, and they have all of the permissions required:

--- a/docs/pt/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/launching-script-when-creating-instance.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Launching a script when an instance is created"
-updated: 2026-07-28
+updated: 2026-07-30
 ---
 
   


### PR DESCRIPTION
## Summary

- replace the deprecated `nova boot` example with `openstack server create`
- update `--key_name` to the current `--key-name` option
- fix the adjacent `--user-data` spelling in the fallback locale copies
- apply the command update consistently across all seven locale files

## Why

The guide requires readers to prepare an OpenStack API environment using the OVHcloud prerequisite guide. That prerequisite installs `python-openstackclient` and teaches the unified `openstack` executable, but the instance-creation example then invokes the separate `nova` executable.

The current `python-novaclient` documentation states that the `nova` CLI has been deprecated since version 17.8.0 in favour of the unified `openstack` CLI. The current OpenStackClient command reference provides the equivalent `openstack server create` command and documents every option used by this example.

Official references:

- nova CLI deprecation: https://docs.openstack.org/python-novaclient/latest/cli/nova.html
- current server create command: https://docs.openstack.org/python-openstackclient/latest/cli/command-objects/compute/v2/index.html#server-create

<img width="1604" height="1070" alt="image" src="https://github.com/user-attachments/assets/8b751eeb-8cdb-44d7-9898-26b00bed9db0" />

## Validation

- `pnpm content:lint`
- `git diff --check`
- verified all seven locale siblings contain the current command and date
- verified no `nova boot`, `--key_name`, or malformed `--user- data` remains in the affected files
- verified the replacement preserves image, flavor, keypair, user-data file, and instance name arguments
- checked open/closed issues and PRs plus open PR file overlap; no duplicate found

The OpenStack CLI is not installed locally, so no parser or cloud API operation was attempted. The replacement syntax was checked against the current official OpenStackClient reference. A full site build was not run because this change only updates existing guide prose, code samples, and metadata—not MDX structure, routing, or rendering code.
