### PR TITLE
Guide update - Configuring iptables on a dedicated server

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
@@ -1,7 +1,7 @@
 ---
 title: Dedicated Server - iptables unter Linux konfigurieren
-description: Sichern Sie Ihren Dedicated Server durch die Konfiguration von iptables-Firewallregeln zur Filterung des Netzwerkverkehrs unter Linux.
-lastUpdated: 2024-12-20
+description: Sichern Sie Ihren Dedicated Server durch die Konfiguration von iptables-Firewallregeln zur Filterung des Netzwerkverkehrs unter Linux
+lastUpdated: 2026-07-29
 ---
 
 :::info
@@ -19,13 +19,13 @@ Firewalls implementieren Regeln, die erlaubten und gesperrten Traffic verwalten.
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für die Sie die alleinige Verantwortung tragen. Da wir keinen Zugriff auf diese Dienste haben, können wir hierfür keinerlei Administrator-Aufgaben übernehmen oder sonstige Hilfeleistung anbieten. Es liegt daher in Ihrer Verantwortung, das Softwaremanagement und die tägliche Sicherheit zu gewährleisten.
 
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovh.com/en/) wenden, um sich mit anderen Benutzern auszutauschen.
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](/links/partner) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](/links/community) wenden, um sich mit anderen Benutzern auszutauschen.
 :::
 
 
 ## Voraussetzungen
 
-- Sie verfügen über einen [Dedicated Server](https://www.ovhcloud.com/de/bare-metal/) in Ihrem Kunden-Account.
+- Sie verfügen über einen [Dedicated Server](/links/bare-metal/bare-metal) in Ihrem Kunden-Account.
 - Sie haben administrativen Zugriff (root/sudo) über SSH auf Ihren Server. 
 
 ## In der praktischen Anwendung
@@ -56,13 +56,7 @@ Um *iptables* für IPv6 zu konfigurieren müssen Sie das Dienstprogramm *iptable
 *iptables* ist standardmäßig für die meisten Linux-Systeme installiert. Um zu bestätigen, dass *iptables* installiert ist, verwenden Sie folgenden Befehl:
 
 ```bash
-sudo apt-get install iptables
-```
-
-Um sicherzustellen, dass Ihre *iptables*-Regeln nach dem Neustart persistent sind, installieren Sie das Paket *iptables-persistent* mit dem folgenden Befehl:
-
-```bash
-sudo apt-get install iptables-persistent
+sudo apt install iptables
 ```
 
 Sobald dieses Paket installiert ist, wird der *iptables*-Ordner zwei Dateien für die IPV4- und IPV6-Regeln enthalten:
@@ -78,15 +72,15 @@ sudo iptables [option] CHAIN_rule [-j target]
 
 Diese Liste enthält einige der üblichen Optionen:
 
-- -A -—append: Füge eine Regel zu einer Kette (*Chain*) hinzu (am Ende).
-- -C -—check: Suche nach einer Regel, die den Anforderungen der Kette entspricht.
-- -D —-delete: Die spezifizierten Regeln einer Kette löschen.
-- -F —-flush: Löscht alle Regeln.
-- -I —-insert: Füge eine Regel an einer bestimmten Position hinzu.
-- -L —-list: Zeigt alle Regeln einer Kette an.
-- -N -new-chain: Erstelle eine neue Kette.
-- -v —-verbose Zeigt bei der Verwendung einer Listenoption mehr Informationen an.
-- -X —-delete-chain: Die gegebene Kette löschen.
+- -A --append: Füge eine Regel zu einer Kette (*Chain*) hinzu (am Ende).
+- -C --check: Suche nach einer Regel, die den Anforderungen der Kette entspricht.
+- -D --delete: Die spezifizierten Regeln einer Kette löschen.
+- -F --flush: Löscht alle Regeln.
+- -I --insert: Füge eine Regel an einer bestimmten Position hinzu.
+- -L --list: Zeigt alle Regeln einer Kette an.
+- -N --new-chain: Erstelle eine neue Kette.
+- -v --verbose: Zeigt bei der Verwendung einer Listenoption mehr Informationen an.
+- -X --delete-chain: Die gegebene Kette löschen.
 
 ### Schritt 3: Den aktuellen Zustand von iptables überprüfen
 
@@ -120,25 +114,25 @@ Ein Port ist ein Kommunikationsendpunkt für einen bestimmten Datentyp.
 Um HTTP-Web-Traffic zu erlauben geben Sie folgenden Befehl ein:
 
 ```bash
-sudo iptables -A INPUT -p tcp -—dport 80 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 80 -j ACCEPT
 ```
 
 Um eingehenden SSH-Traffic (Secure Shell) zu erlauben, geben Sie Folgendes ein. (Beachten Sie dabei, dass der Standardport 22 im Beispiel verwendet wird. Wenn Sie eine andere Portnummer nutzen, müssen die Befehle entsprechend angepasst werden.)
 
 ```bash
-sudo iptables -A INPUT -p tcp -—dport 22 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 22 -j ACCEPT
 ```
 
 Um HTTPS-Web-Traffic zu erlauben geben Sie folgenden Befehl ein:
 
 ```bash
-sudo iptables -A INPUT -p tcp —-dport 443 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 443 -j ACCEPT
 ```
 
 Die Optionen funktionieren wie folgt:
 
 - -p: Überprüft das angegebene Protokoll (TCP).
-- -—dport: Gibt den Zielport an.
+- --dport: Gibt den Zielport an.
 - -j (jump): Führt die Aktion aus.
 
 :::warning
@@ -153,7 +147,7 @@ Weitere Informationen zum Zugriff auf dieses Tool finden Sie in [dieser Anleitun
 Verwenden Sie folgenden Befehl, um den Traffic von einer bestimmten IP-Adresse zu akzeptieren.
 
 ```bash
-sudo iptables -A INPUT -s IP-Adresse -j ACCEPT
+sudo iptables -A INPUT -s IP_Adresse -j ACCEPT
 ```
 
 Ersetzen Sie IP_Adresse im Befehl mit der IP-Adresse, die Sie autorisieren möchten.
@@ -169,14 +163,14 @@ Ersetzen Sie die IP_Adresse im Befehl mit der IP-Adresse, die Sie blockieren mö
 Sie können den Traffic aus einem IP-Adressbereich mit folgendem Befehl zurückweisen:
 
 ```bash
-sudo iptables -A INPUT -m iprange —-src-range Start_IP-End_IP -j REJECT
+sudo iptables -A INPUT -m iprange --src-range Start_IP-End_IP -j REJECT
 ```
 
 Die in den Beispielen verwendeten Optionen funktionieren wie folgt:
 
 - -m: Entspricht der angegebenen Option.
 - -iprange: Teilt dem System mit, einen IP-Adressbereich zu erwarten statt einer einzelnen IP-Adresse.
-- —-src-range: Identifiziert den IP-Adressbereich.
+- --src-range: Identifiziert den IP-Adressbereich.
 
 ### Schritt 7: Unerwünschten Traffic ablehnen
 
@@ -221,18 +215,23 @@ Ersetzen Sie `Nummer` mit der Zeilennummer, die Sie löschen möchten.
 Beim Neustart des Systems werden Regeln, die Sie für *iptables* erstellt haben, nicht beibehalten.
 Jedes Mal, wenn Sie *iptables* unter Linux konfigurieren, greifen alle von Ihnen vorgenommenen Änderungen nur bis zum nächsten Neustart.
 
-Um die Regeln auf Ubuntu-basierten Systemen zu sichern, müssen Sie sich zunächst als Benutzer root mit dem Befehl `sudo su` anmelden:
+Auf Ubuntu-basierten Systemen übernimmt das Paket `iptables-persistent` das Wiederherstellen Ihrer Regeln beim Systemstart. Installieren Sie es mit folgendem Befehl:
 
 ```bash
-ubuntu@server:~$ sudo su
-root@server:/home/ubuntu#
+sudo apt install iptables-persistent
 ```
 
-Führen Sie dann den folgenden Befehl aus: 
+:::info
+Während der Installation werden Sie gefragt, ob die aktuellen IPv4- und IPv6-Regeln gespeichert werden sollen. Antworten Sie mit `Yes`, um die Regeln beizubehalten, die Sie gerade erstellt haben.
+:::
+
+Anschließend können Sie Ihre Regeln jederzeit mit folgendem Befehl speichern:
 
 ```bash
-iptables-save > /etc/iptables/rules.v4
+sudo netfilter-persistent save
 ```
+
+Ihre IPv4-Regeln werden in die Datei `/etc/iptables/rules.v4` geschrieben (und Ihre IPv6-Regeln in die Datei `/etc/iptables/rules.v6`).
 
 Dadurch werden die Regeln direkt im IPV4-Ordner gespeichert.
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure iptables on a Linux Dedicated Server
-description: Secure your dedicated server by configuring iptables firewall rules to filter network traffic on Linux.
-lastUpdated: 2024-12-20
+description: Secure your dedicated server by configuring iptables firewall rules to filter network traffic on Linux
+lastUpdated: 2026-07-29
 ---
 
 ## Objective
@@ -14,13 +14,13 @@ Firewalls work by defining rules that govern both authorised and blocked traffic
 :::warning
 OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](/links/community) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 :::
 
 
 ## Requirements
 
-- A [dedicated server](https://www.ovhcloud.com/en-gb/bare-metal/) in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - Administrative access (root/sudo) to your server via SSH
 
 ## Instructions
@@ -51,13 +51,7 @@ To configure *iptables* for IPv6, you must use the *iptables* utility. These two
 *iptables* is installed by default on most Linux systems. To confirm that *iptables* is installed, use the following command:
 
 ```bash
-sudo apt-get install iptables
-```
-
-To make sure that your iptables rules are persistent after reboot, you must install the iptables persistent package using the following command:
-
-```bash
-sudo apt-get install iptables-persistent
+sudo apt install iptables
 ```
 
 Once this is installed, the iptables folder will contain two files for IPV4 and IPV6 rules:
@@ -73,15 +67,15 @@ sudo iptables [option] CHAIN_rule [-j target]
 
 Here is a list of some common *iptables* options:
 
-- -A --append: Adds a rule to a string (at the end).
-- -C --check: Finds a rule that matches the requirements of the string.
-- -D --delete: Removes the specified rules from a string.
+- -A --append: Adds a rule to a chain (at the end).
+- -C --check: Finds a rule that matches the requirements of the chain.
+- -D --delete: Removes the specified rules from a chain.
 - -F --flush: Deletes all rules.
-- -I --insert: Adds a rule to a string at a given position.
-- -L --list: Displays all rules in a string.
-- -N -new chain: Creates a new string.
+- -I --insert: Adds a rule to a chain at a given position.
+- -L --list: Displays all rules in a chain.
+- -N --new-chain: Creates a new chain.
 - -v --verbose: Displays more information when using a list option.
-- -X --delete-chain: Deletes the supplied string.
+- -X --delete-chain: Deletes the supplied chain.
 
 ### Step 3: Check the current status of iptables
 
@@ -91,14 +85,15 @@ To display all of the current rules on your server, enter the following command 
 sudo iptables -L
 ```
 
-The system displays the status of your channels.<br/>
-The output will list three strings:
+The system displays the status of your channels.
+
+The output will list three chains:
 
 <img className="thumbnail" alt="Check-Current-iptables" src="/images/bare-metal-cloud/dedicated-servers/firewall-Linux-iptable/Check-Current-iptables.PNG" loading="lazy" />
 
 ### Step 4: Allow traffic on localhost
 
-To allow traffic from your own system (the *localhost*), add the input string by entering the following:
+To allow traffic from your own system (the *localhost*), add the input chain by entering the following:
 
 ```bash
 sudo iptables -A INPUT -i lo -j ACCEPT
@@ -181,7 +176,7 @@ If you are defining *iptables* firewall rules, you must prevent unauthorised acc
 sudo iptables -A INPUT -j DROP
 ```
 
-The -A option adds a new rule to the string. If a connection goes through ports other than those you have defined, it will be discontinued.
+The -A option adds a new rule to the chain. If a connection goes through ports other than those you have defined, it will be discontinued.
 
 :::warning
 If you type this command before performing [step 5](#step5), you will block all access including the current one, SSH access. This is particularly problematic on a machine you access remotely. 
@@ -217,20 +212,23 @@ Replace `Number` with the rule line number you want to delete.
 When the system is restarted, *iptables* does not keep the rules you created.
 Whenever you configure *iptables* on Linux, any changes you make apply only until the next reboot.
 
-To save rules to Ubuntu-based systems, first, you must log in as the root user using the `sudo su` command:
+On Ubuntu-based systems, the `iptables-persistent` package takes care of restoring your rules at boot. Install it with:
 
 ```bash
-ubuntu@server:~$ sudo su
-root@server:/home/ubuntu#
+sudo apt install iptables-persistent
 ```
 
-Next, run the following command: 
+:::info
+During installation, you are asked whether to save the current IPv4 and IPv6 rules. Answer `Yes` to keep the rules you have just created.
+:::
+
+Afterwards, save your rules at any time with:
 
 ```bash
-iptables-save > /etc/iptables/rules.v4
+sudo netfilter-persistent save
 ```
 
-This will save the rules directly to the IPV4 folder.
+Your IPv4 rules are written to the file `/etc/iptables/rules.v4` (and your IPv6 rules to `/etc/iptables/rules.v6`).
 
 The next time your system boots, *iptables* will automatically reload the firewall rules.
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar iptables en un servidor dedicado Linux
 description: Proteja su servidor dedicado configurando reglas de firewall iptables para filtrar el tráfico de red en Linux
-lastUpdated: 2024-12-20
+lastUpdated: 2026-07-29
 ---
 
 :::info
@@ -19,13 +19,13 @@ Los cortafuegos funcionan estableciendo reglas que regulan el tráfico autorizad
 :::warning
 La responsabilidad sobre los servicios que OVHcloud pone a su disposición recae íntegramente en usted. Nuestros técnicos no son los administradores de las máquinas, ya que no tienen acceso a ellas. Por lo tanto, la gestión del software y la seguridad le corresponde a usted.
 
-Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene dificultades o dudas con respecto a la administración, el uso o la seguridad de un servidor, le recomendamos que contacte con un proveedor de servicios especializado. Para más información, consulte el apartado «Más información» de esta guía.
+Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene dificultades o dudas con respecto a la administración, el uso o la seguridad de un servidor, le recomendamos que contacte con un [proveedor de servicios especializado](/links/partner). Para más información, consulte el apartado "Más información" de esta guía.
 :::
 
 
 ## Requisitos
 
-- Tener un [servidor dedicado](https://www.ovhcloud.com/es-es/bare-metal/) en su cuenta de OVHcloud.
+- Tener un [servidor dedicado](/links/bare-metal/bare-metal) en su cuenta de OVHcloud.
 - Tener acceso de administrador (root/sudo) a su servidor por SSH.
 
 ## Procedimiento
@@ -54,22 +54,11 @@ Para configurar iptables para IPv6, debe utilizar la utilidad iptables6. Estos d
 :::
 
 
-iptables instalados por defecto en la mayoría de sistemas Linux. Para confirmar que iptables está instalado, utilice el siguiente comando:
+iptables está instalado por defecto en la mayoría de sistemas Linux. Para confirmar que iptables está instalado, utilice el siguiente comando:
 
 ```bash
-sudo apt-get install iptables
+sudo apt install iptables
 ```
-
-Para asegurar que sus reglas iptables son persistentes después de reiniciar, necesita instalar el paquete iptables persistent usando el siguiente comando:
-
-```bash
-sudo apt-get install iptables-persistent
-```
-
-Una vez instalado este paquete, la carpeta iptables contendrá dos archivos para las reglas IPV4 e IPV6:
-
-- /etc/iptables/rules.v4
-- /etc/iptables/rules.v6
 
 Por lo general, el comando iptables es el siguiente:
 
@@ -77,17 +66,17 @@ Por lo general, el comando iptables es el siguiente:
 sudo iptables [option] CHAIN_rule [-j target]
 ```
 
-A continuación le ofrecemos una lista de algunas de las opciones de iftables habituales:
+A continuación le ofrecemos una lista de algunas de las opciones de iptables habituales:
 
-- -A —append: Añade una regla a una cadena (al final).
-- -C —check : Busca una regla que coincida con los requerimientos de la cadena.
-- -D —delete: Borra las reglas especificadas de una cadena.
-- -F —flush: Elimina todas las reglas.
-- -I —insert: Añade una regla a una cadena en una posición dada.
-- -L —list : Muestra todas las reglas de una cadena.
-- -N -new-chain: Crea una nueva cadena.
-- -v —verbose: Muestra más información cuando se usa una opción de lista.
-- -X —delete-chain: Elimina la cadena proporcionada.
+- -A --append: Añade una regla a una cadena (al final).
+- -C --check: Busca una regla que coincida con los requerimientos de la cadena.
+- -D --delete: Borra las reglas especificadas de una cadena.
+- -F --flush: Elimina todas las reglas.
+- -I --insert: Añade una regla a una cadena en una posición dada.
+- -L --list: Muestra todas las reglas de una cadena.
+- -N --new-chain: Crea una nueva cadena.
+- -v --verbose: Muestra más información cuando se usa una opción de lista.
+- -X --delete-chain: Elimina la cadena proporcionada.
 
 ### 3. Comprobar el estado actual de iptables
 
@@ -97,7 +86,8 @@ Para ver todas las reglas actuales en su servidor, introduzca el siguiente coman
 sudo iptables -L
 ```
 
-El sistema muestra el estado de sus cadenas.<br/>
+El sistema muestra el estado de sus cadenas.
+
 La salida listará tres cadenas:
 
 <img className="thumbnail" alt="Check-Current-iptables" src="/images/bare-metal-cloud/dedicated-servers/firewall-Linux-iptable/Check-Current-iptables.PNG" loading="lazy" />
@@ -139,7 +129,7 @@ sudo iptables -A INPUT -p tcp --dport 443 -j ACCEPT
 Las opciones funcionan de la siguiente forma:
 
 - -p: Comprueba el protocolo especificado (tcp).
-- —dport : Especifica el puerto de destino.
+- --dport: Especifica el puerto de destino.
 - -j jump: Realiza la acción 
 
 :::warning
@@ -177,7 +167,7 @@ Las opciones iptables que hemos utilizado en los ejemplos funcionan de la siguie
 
 - -m: Coincide con la opción especificada.
 - -iprange: Indica que el sistema espere un rango de direcciones IP en lugar de una.
-- —src-range: Identifica el rango de direcciones IP.
+- --src-range: Identifica el rango de direcciones IP.
 
 ### 7. Eliminar el tráfico no deseado
 
@@ -222,20 +212,21 @@ Sustituya `Number` por el número de línea de la regla que quiera eliminar.
 Al reiniciar el sistema, iptables no conserva las reglas que había creado.
 Cada vez que configure iptables en Linux, todos los cambios que realice se aplicarán únicamente hasta el siguiente reinicio.
 
-Para guardar reglas en sistemas basados en Ubuntu, primero debe iniciar sesión como root mediante el comando `sudo su` ``:
+En los sistemas basados en Ubuntu, el paquete `iptables-persistent` se encarga de restaurar sus reglas al arrancar. Instálelo con el siguiente comando:
 
 ```bash
-ubuntu@server:~$ sudo su
-root@server:/home/ubuntu#
+sudo apt install iptables-persistent
 ```
 
-A continuación, ejecute el siguiente comando: 
+:::info Durante la instalación, se le preguntará si desea guardar las reglas IPv4 e IPv6 actuales. Responda Yes para conservar las reglas que acaba de crear. :::
+
+Después podrá guardar sus reglas en cualquier momento con el siguiente comando:
 
 ```bash
-iptables-save > /etc/iptables/rules.v4
+sudo netfilter-persistent save
 ```
 
-Esta operación guarda las reglas directamente en la carpeta IPV4.
+Sus reglas IPv4 se escriben en el archivo `/etc/iptables/rules.v4` (y sus reglas IPv6 en el archivo `/etc/iptables/rules.v6`).
 
 La próxima vez que inicie el sistema, iptables recargará automáticamente las reglas del firewall.
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer iptables sur un serveur dédié Linux
 description: Sécurisez votre serveur dédié en configurant des règles de pare-feu iptables pour filtrer le trafic réseau sous Linux
-lastUpdated: 2024-12-20
+lastUpdated: 2026-07-29
 ---
 
 ## Objectif
@@ -14,13 +14,13 @@ Les pare-feux fonctionnent en définissant des règles qui régissent le trafic 
 :::warning
 OVHcloud met à votre disposition des services dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d'assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.
 
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
+Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
 :::
 
 
 ## Prérequis
 
-- Disposer d’un [serveur dédié](https://www.ovhcloud.com/fr/bare-metal/) dans votre compte OVHcloud
+- Disposer d’un [serveur dédié](/links/bare-metal/bare-metal) dans votre compte OVHcloud
 - Disposer d'un accès administrateur (root/sudo) à votre serveur via SSH
 
 ## En pratique
@@ -34,13 +34,13 @@ La plupart des règles décrites dans ce guide supposent que votre iptables est 
 :::
 
 
-### Etape 1 : mettre à jour votre système
+### Étape 1 : mettre à jour votre système
 
 Les développeurs de systèmes de distribution et d'exploitation proposent des mises à jour fréquentes de progiciels, très souvent pour des raisons de sécurité. **Garder votre distribution ou votre système d'exploitation à jour est primordial pour la sécurisation de votre serveur.**
 
 Consultez notre guide sur la [sécurisation d'un serveur dédié](/guides/bare-metal-cloud/dedicated-servers/securing-a-dedicated-server) pour plus d'informations.
 
-### Etape 2 : installer le pare-feu Iptables sous Ubuntu
+### Étape 2 : installer le pare-feu Iptables sous Ubuntu
 
 :::info
 Il existe deux versions différentes d'iptables, pour IPv4 et IPv6. Les règles que nous couvrons dans ce tutoriel Linux Iptables concernent IPv4.
@@ -48,56 +48,46 @@ Pour configurer Iptables pour IPv6, vous devez utiliser l'utilitaire iptables6. 
 :::
 
 
-Iptables est installé par défaut sur la plupart des systèmes Linux. Pour confirmer que Iptables est installé, utilisez la commande suivante :
+Iptables est installé par défaut sur la plupart des systèmes Linux. Pour confirmer que Iptables est installé, utilisez la commande suivante :
 
 ```bash
-sudo apt-get install iptables
+sudo apt install iptables
 ```
 
-Pour vous assurer que vos règles Iptables sont persistantes après le redémarrage, vous devez installer le paquet `iptables persistent` en utilisant la commande suivante :
-
-```bash
-sudo apt-get install iptables-persistent
-```
-
-Une fois ce paquet installé, le dossier iptables contiendra deux fichiers pour les règles IPV4 et IPV6 :
-
-- /etc/iptables/rules.v4
-- /etc/iptables/rules.v6
-
-En général, une commande Iptables se présente comme suit :
+En général, une commande Iptables se présente comme suit :
 
 ```bash
 sudo iptables [option] CHAIN_rule [-j target]
 ```
 
-Voici une liste de quelques options Iptables courantes :
+Voici une liste de quelques options Iptables courantes :
 
-- -A --append : Ajoute une règle à une chaîne (à la fin).
-- -C --check : Recherche une règle qui correspond aux exigences de la chaîne.
-- -D --delete : Supprime les règles spécifiées d'une chaîne.
-- -F --flush : Supprime toutes les règles.
-- -I --insert : Ajoute une règle à une chaîne à une position donnée.
-- -L --list : Affiche toutes les règles d'une chaîne.
-- -N -new-chain : Crée une nouvelle chaîne.
-- -v --verbose : Affiche plus d'informations lors de l'utilisation d'une option de liste.
-- -X --delete-chain : Supprime la chaîne fournie.
+- -A --append : Ajoute une règle à une chaîne (à la fin).
+- -C --check : Recherche une règle qui correspond aux exigences de la chaîne.
+- -D --delete : Supprime les règles spécifiées d'une chaîne.
+- -F --flush : Supprime toutes les règles.
+- -I --insert : Ajoute une règle à une chaîne à une position donnée.
+- -L --list : Affiche toutes les règles d'une chaîne.
+- -N -new-chain : Crée une nouvelle chaîne.
+- -v --verbose : Affiche plus d'informations lors de l'utilisation d'une option de liste.
+- -X --delete-chain : Supprime la chaîne fournie.
 
-### Etape 3 : vérifier l'état actuel d'iptables
+### Étape 3 : vérifier l'état actuel d'iptables
 
-Pour afficher l'ensemble des règles actuelles sur votre serveur, saisissez la commande suivante dans la fenêtre du terminal :
+Pour afficher l'ensemble des règles actuelles sur votre serveur, saisissez la commande suivante dans la fenêtre du terminal :
 
 ```bash
 sudo iptables -L
 ```
-Le système affiche le statut de vos chaînes.<br/>
-La sortie répertoriera trois chaînes :
+Le système affiche le statut de vos chaînes.
+
+La sortie répertoriera trois chaînes :
 
 <img className="thumbnail" alt="Check-Current-iptables" src="/images/bare-metal-cloud/dedicated-servers/firewall-Linux-iptable/Check-Current-iptables.PNG" loading="lazy" />
 
-### Etape 4 : autoriser le trafic sur localhost
+### Étape 4 : autoriser le trafic sur localhost
 
-Pour autoriser le trafic de votre propre système (le localhost), ajoutez la chaîne d'entrée en saisissant ce qui suit :
+Pour autoriser le trafic de votre propre système (le localhost), ajoutez la chaîne d'entrée en saisissant ce qui suit :
 
 ```bash
 sudo iptables -A INPUT -i lo -j ACCEPT
@@ -106,34 +96,34 @@ sudo iptables -A INPUT -i lo -j ACCEPT
 Cette commande configure le pare-feu pour accepter le trafic pour l'interface localhost (lo) (-i). Désormais, tout ce qui provient de votre système passera par votre pare-feu.
 Vous devez définir cette règle pour permettre aux applications de communiquer avec l'interface localhost.
 
-### Etape 5 : autoriser le trafic sur des ports spécifiques <a name="step5"></a>
+### Étape 5 : autoriser le trafic sur des ports spécifiques <a name="step5"></a>
 
 Ces règles autorisent le trafic sur les différents ports que vous spécifiez à l'aide des commandes répertoriées ci-dessous. 
 Un port est un point de terminaison de communication spécifié pour un type spécifique de données.
 
-Pour autoriser le trafic Web HTTP, saisissez la commande suivante :
+Pour autoriser le trafic Web HTTP, saisissez la commande suivante :
 
 ```bash
 sudo iptables -A INPUT -p tcp --dport 80 -j ACCEPT
 ```
 
-Pour autoriser uniquement le trafic SSH (Secure Shell) entrant, saisissez ce qui suit (veuillez noter que nous utilisons le port 22, qui est le numéro du port SSH par défaut. Si votre numéro de port est différent, veillez à ajuster les commandes suivantes en fonction) :
+Pour autoriser uniquement le trafic SSH (Secure Shell) entrant, saisissez ce qui suit (veuillez noter que nous utilisons le port 22, qui est le numéro du port SSH par défaut. Si votre numéro de port est différent, veillez à ajuster les commandes suivantes en fonction) :
 
 ```bash
 sudo iptables -A INPUT -p tcp --dport 22 -j ACCEPT
 ```
 
-Pour autoriser le trafic Internet HTTPS, saisissez la commande suivante :
+Pour autoriser le trafic Internet HTTPS, saisissez la commande suivante :
 
 ```bash
 sudo iptables -A INPUT -p tcp --dport 443 -j ACCEPT
 ```
 
-Les options fonctionnent ainsi :
+Les options fonctionnent ainsi :
 
-- -p : Vérifie le protocole spécifié (tcp).
-- --dport : Spécifie le port de destination.
-- -j jump : Effectue l'action 
+- -p : Vérifie le protocole spécifié (tcp).
+- --dport : Spécifie le port de destination.
+- -j jump : Effectue l'action 
 
 :::warning
 En cas de perte d'accès à votre serveur, vous pouvez toujours utiliser l'outil KVM/IPMI pour y accéder à nouveau et modifier votre configuration ou supprimer vos règles.
@@ -142,7 +132,7 @@ Pour plus d'informations sur l'accès à cet outil, veuillez consulter [ce guide
 :::
 
 
-### Etape 6 : contrôler le trafic par adresse IP
+### Étape 6 : contrôler le trafic par adresse IP
 
 Utilisez la commande suivante pour accepter le trafic à partir d'une adresse IP spécifique.
 
@@ -160,21 +150,21 @@ sudo iptables -A INPUT -s votre_adresse_IP_à_bloquer -j DROP
 
 Remplacez l'adresse IP dans la commande par l'adresse IP que vous souhaitez bloquer.
 
-Vous pouvez rejeter le trafic à partir d'une plage d'adresses IP, avec la commande suivante :
+Vous pouvez rejeter le trafic à partir d'une plage d'adresses IP, avec la commande suivante :
 
 ```bash
 sudo iptables -A INPUT -m iprange --src-range votre_adresse_IP_debut-votre_adresse_IP_fin -j REJECT
 ```
 
-Les options iptables que nous avons utilisées dans les exemples fonctionnent ainsi :
+Les options iptables que nous avons utilisées dans les exemples fonctionnent ainsi :
 
-- -m : Correspond à l'option spécifiée.
-- -iprange : Indique au système d'attendre une plage d'adresses IP au lieu d'une seule.
-- --src-range : Identifie la plage d'adresses IP.
+- -m : Correspond à l'option spécifiée.
+- -iprange : Indique au système d'attendre une plage d'adresses IP au lieu d'une seule.
+- --src-range : Identifie la plage d'adresses IP.
 
-### Etape 7 : supprimer le trafic indésirable
+### Étape 7 : supprimer le trafic indésirable
 
-Si vous définissez des règles de pare-feu Iptables, vous devez empêcher les accès non autorisés en supprimant tout trafic provenant d'autres ports :
+Si vous définissez des règles de pare-feu Iptables, vous devez empêcher les accès non autorisés en supprimant tout trafic provenant d'autres ports :
 
 ```bash
 sudo iptables -A INPUT -j DROP
@@ -186,7 +176,7 @@ L'option -A ajoute une nouvelle règle à la chaîne. Si une connexion passe par
 Attention, si vous tapez cette commande avant d'effectuer [l'étape 5](#step5), vous bloquerez tous les accès y compris celui en cours, l'accès SSH. Ceci est particulièrement problématique sur une machine sur laquelle vous accédez à distance. 
 :::
 
-### Etape 8 : supprimer une règle
+### Étape 8 : supprimer une règle
 
 Une méthode plus précise consiste à supprimer le numéro de ligne d'une règle.
 
@@ -194,7 +184,7 @@ Une méthode plus précise consiste à supprimer le numéro de ligne d'une règl
 sudo iptables -P INPUT DROP 
 ```
 
-Tout d'abord, répertoriez toutes les règles en saisissant ce qui suit :
+Tout d'abord, répertoriez toutes les règles en saisissant ce qui suit :
 
 ```bash
 sudo iptables -L --line-numbers
@@ -202,32 +192,35 @@ sudo iptables -L --line-numbers
 
 <img className="thumbnail" alt="line-numbers" src="/images/bare-metal-cloud/dedicated-servers/firewall-Linux-iptable/Step7-all-rules.PNG" loading="lazy" />
 
-Recherchez la ligne de la règle de pare-feu que vous souhaitez supprimer et exécutez cette commande :
+Recherchez la ligne de la règle de pare-feu que vous souhaitez supprimer et exécutez cette commande :
 
 ```bash
 sudo iptables -D INPUT <Number>
 ```
 Remplacez `Number` par le numéro de ligne de règle que vous souhaitez supprimer.
 
-### Etape 9 : enregistrer vos modifications
+### Étape 9 : enregistrer vos modifications
 
 Lors du redémarrage du système, Iptables ne conserve pas les règles que vous aviez créées. 
 Chaque fois que vous configurez Iptables sous Linux, toutes les modifications que vous apportez s'appliquent uniquement jusqu'au prochain redémarrage.
 
-Pour sauvegarder les règles sur les systèmes basés sur Ubuntu, vous devez d'abord vous connecter en tant qu'utilisateur root en utilisant la commande `sudo su` :
+Sur les systèmes basés sur Ubuntu, le paquet `iptables-persistent` se charge de restaurer vos règles au démarrage. Installez-le avec la commande suivante :
 
 ```bash
-ubuntu@server:~$ sudo su
-root@server:/home/ubuntu#
+sudo apt install iptables-persistent
 ```
 
-Ensuite, exécutez la commande suivante : 
+:::info
+Lors de l'installation, il vous est demandé si vous souhaitez enregistrer les règles IPv4 et IPv6 actuelles. Répondez `Yes` pour conserver les règles que vous venez de créer.
+:::
+
+Vous pouvez ensuite enregistrer vos règles à tout moment avec la commande suivante :
 
 ```bash
-iptables-save > /etc/iptables/rules.v4
+sudo netfilter-persistent save
 ```
 
-Cette opération permet d'enregistrer les règles directement dans le dossier IPV4.
+Vos règles IPv4 sont écrites dans le fichier `/etc/iptables/rules.v4` (et vos règles IPv6 dans le fichier `/etc/iptables/rules.v6`).
 
 Au prochain démarrage de votre système, Iptables rechargera automatiquement les règles du pare-feu.
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurare iptables su un server dedicato Linux
 description: Proteggi il tuo server dedicato configurando regole firewall iptables per filtrare il traffico di rete su Linux
-lastUpdated: 2024-12-20
+lastUpdated: 2026-07-29
 ---
 
 :::info
@@ -17,15 +17,15 @@ I firewall funzionano definendo regole che disciplinano il traffico autorizzato 
 **Questa guida ti mostra come proteggere un server dedicato grazie agli iptables.**
 
 :::warning
-OVHcloud mette a tua disposizione servizi di cui sei responsabile. ma non è autorizzata ad accedervi e non si occupa quindi della loro amministrazione. Garantire quotidianamente la gestione software e la sicurezza di queste macchine è quindi responsabilità dell’utente.
+OVHcloud mette a tua disposizione servizi di cui sei responsabile, ma non è autorizzata ad accedervi e non si occupa quindi della loro amministrazione. Garantire quotidianamente la gestione software e la sicurezza di queste macchine è quindi responsabilità dell’utente.
 
-Questa guida ti aiuta a realizzare le operazioni più ricorrenti. Tuttavia, in caso di difficoltà o dubbi relativi all'amministrazione, all'utilizzo o alla sicurezza di un server, ti consigliamo di contattare un [provider specializzato](https://partner.ovhcloud.com/it/directory/). Per maggiori informazioni consulta la sezione “Per saperne di più” di questa guida.
+Questa guida ti aiuta a realizzare le operazioni più ricorrenti. Tuttavia, in caso di difficoltà o dubbi relativi all'amministrazione, all'utilizzo o alla sicurezza di un server, ti consigliamo di contattare un [provider specializzato](/links/partner). Per maggiori informazioni consulta la sezione "Per saperne di più" di questa guida.
 :::
 
 
 ## Prerequisiti
 
-- Disporre di un [server dedicato](https://www.ovhcloud.com/it/bare-metal/) nel proprio account OVHcloud
+- Disporre di un [server dedicato](/links/bare-metal/bare-metal) nel proprio account OVHcloud
 - Avere accesso amministratore (root/sudo) al server via SSH
 
 ## Procedura
@@ -56,19 +56,8 @@ Per configurare iptables per IPv6, utilizza il programma iptables6. Questi due d
 iptables è installato di default sulla maggior parte dei sistemi Linux. Per confermare l'installazione di iptables, utilizza il comando:
 
 ```bash
-sudo apt-get install iptables
+sudo apt install iptables
 ```
-
-Per assicurarsi che le regole di iptables siano persistenti dopo il riavvio, è necessario installare il pacchetto `iptables persistent` usando il seguente comando:
-
-```bash
-sudo apt-get install iptables-persistent
-```
-
-Una volta installato questo pacchetto, la cartella iptables conterrà due file per le regole IPV4 e IPV6:
-
-- /etc/iptables/rules.v4
-- /etc/iptables/rules.v6
 
 In genere, esegui il comando iptables come segue:
 
@@ -78,15 +67,15 @@ sudo iptables [option] CHAIN_rule [-j target]
 
 Ecco una lista di alcune opzioni iptables comuni:
 
-- -A —append: Aggiungi una regola a una catena (alla fine).
-- -C —check : Ricerca una regola che corrisponde alle esigenze della catena.
-- -D —delete: Elimina le regole specificate di una catena.
-- -F -flush: Elimina tutte le regole.
-- -I —insert: Aggiungi una regola a una catena in una determinata posizione.
-- -L —list: Mostra tutte le regole di un canale.
-- -N -new-chain : Crea un nuovo canale.
-- -v —verbose: Indica maggiori informazioni durante l'utilizzo di un'opzione di lista.
-- -X —delete-chain: Elimina la catena fornita.
+- -A --append: Aggiungi una regola a una catena (alla fine).
+- -C --check: Ricerca una regola che corrisponde alle esigenze della catena.
+- -D --delete: Elimina le regole specificate di una catena.
+- -F --flush: Elimina tutte le regole.
+- -I --insert: Aggiungi una regola a una catena in una determinata posizione.
+- -L --list: Mostra tutte le regole di una catena.
+- -N --new-chain: Crea una nuova catena.
+- -v --verbose: Indica maggiori informazioni durante l'utilizzo di un'opzione di lista.
+- -X --delete-chain: Elimina la catena fornita.
 
 ### Step 3: verificare lo stato attuale degli iptables
 
@@ -96,8 +85,9 @@ Per visualizzare tutte le regole attuali sul tuo server, inserisci questo comand
 sudo iptables -L
 ```
 
-Il sistema mostra lo stato delle tue catene.<br/>
-L'uscita elenca tre canali:
+Il sistema mostra lo stato delle tue catene.
+
+L'uscita elenca tre catene:
 
 <img className="thumbnail" alt="Check-Current-iptables" src="/images/bare-metal-cloud/dedicated-servers/firewall-Linux-iptable/Check-Current-iptables.PNG" loading="lazy" />
 
@@ -109,7 +99,7 @@ Per autorizzare il traffico del tuo sistema (il localhost), aggiungi la catena d
 sudo iptables -A INPUT -i lo -j ACCEPT
 ```
 
-Questo comando configura il firewall per accettare il traffico per l'interfaccia localhost (lo) (-i). Tutto quello che viene dal vostro sistema passerà attraverso il vostro firewall.
+Questo comando configura il firewall per accettare il traffico per l'interfaccia localhost (lo) (-i). Tutto quello che viene dal tuo sistema passerà attraverso il tuo firewall.
 Devi definire questa regola per permettere alle applicazioni di comunicare con l'interfaccia localhost.
 
 ### Step 5: autorizzare il traffico su porti specifici <a name="step5"></a>
@@ -120,25 +110,25 @@ Una porta è un punto terminale di comunicazione specificato per un tipo specifi
 Per autorizzare il traffico Web HTTP, inserisci questo comando:
 
 ```bash
-sudo iptables -A INPUT -p tcp —dport 80 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 80 -j ACCEPT
 ```
 
-Per autorizzare solo il traffico SSH (Secure Shell) in entrata, inserisci (notare che si utilizza la porta 22, che è il numero di porta SSH predefinito. Se il vostro numero di porta è diverso, assicuratevi di adattare di conseguenza i comandi seguenti):
+Per autorizzare solo il traffico SSH (Secure Shell) in entrata, inserisci (notare che si utilizza la porta 22, che è il numero di porta SSH predefinito. Se il tuo numero di porta è diverso, assicurati di adattare di conseguenza i comandi seguenti):
 
 ```bash
-sudo iptables -A INPUT -p tcp —dport 22 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 22 -j ACCEPT
 ```
 
 Per autorizzare il traffico Internet HTTPS, inserisci questo comando:
 
 ```bash
-sudo iptables -A INPUT -p tcp —dport 443 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 443 -j ACCEPT
 ```
 
 Le opzioni funzionano in questo modo:
 
 - -p: Verifica il protocollo specificato (tcp).
-- —dport: Specifica il porto di destinazione.
+- --dport: Specifica il porto di destinazione.
 - -j jump : Effettua l'azione 
 
 :::warning
@@ -153,7 +143,7 @@ Per maggiori informazioni sull'accesso a questo tool, consulta [questa guida](/g
 Per accettare il traffico da un indirizzo IP specifico, utilizza questo comando:
 
 ```bash
-sudo iptables -A INPUT -s il tuo_indirizzo_IP_da_autorizzare -j ACCEPT
+sudo iptables -A INPUT -s il_tuo_indirizzo_IP_da_autorizzare -j ACCEPT
 ```
 
 Sostituisci l'indirizzo IP nel comando con l'indirizzo IP che vuoi autorizzare.
@@ -161,7 +151,7 @@ Sostituisci l'indirizzo IP nel comando con l'indirizzo IP che vuoi autorizzare.
 Puoi anche bloccare il traffico a partire da un indirizzo IP 
 
 ```bash
-sudo iptables -A INPUT -s il vostro_indirizzo_IP_a_bloccare -j DROP
+sudo iptables -A INPUT -s il_tuo_indirizzo_IP_a_bloccare -j DROP
 ```
 
 Sostituisci l'indirizzo IP nel comando con l'indirizzo IP che vuoi bloccare.
@@ -169,14 +159,14 @@ Sostituisci l'indirizzo IP nel comando con l'indirizzo IP che vuoi bloccare.
 Puoi rifiutare il traffico a partire da una gamma di indirizzi IP, con il seguente comando:
 
 ```bash
-sudo iptables -A INPUT -m iprange —src-ordina il tuo_indirizzo_IP_di_inizio_il_tuo_indirizzo_IP_fine -j REJECT
+sudo iptables -A INPUT -m iprange --src-range il_tuo_indirizzo_IP_di_inizio-il_tuo_indirizzo_IP_di_fine -j REJECT
 ```
 
 Le opzioni iptables che abbiamo utilizzato negli esempi funzionano in questo modo:
 
 - -m: Corrisponde all'opzione specificata.
 - -iprange: Indica al sistema di attendere una gamma di indirizzi IP invece di una sola.
-- —src-range: Identifica la gamma di indirizzi IP.
+- --src-range: Identifica la gamma di indirizzi IP.
 
 ### Step 7: eliminare il traffico indesiderato
 
@@ -186,7 +176,7 @@ Se definisci regole di firewall iptables, è necessario impedire gli accessi non
 sudo iptables -A INPUT -j DROP
 ```
 
-L'opzione -A aggiunge una nuova regola al canale. Se una connessione passa attraverso porti diversi da quelli da voi definiti, sarà abbandonata.
+L'opzione -A aggiunge una nuova regola alla catena. Se una connessione passa attraverso porti diversi da quelli da te definiti, sarà abbandonata.
 
 :::warning
 Attenzione: se digiti questo ordine prima di effettuare [lo Step 5](#step5), bloccherai tutti gli accessi, incluso quello in corso, l'accesso SSH. Questo è particolarmente problematico per una macchina su cui puoi accedere a distanza. 
@@ -221,20 +211,23 @@ Sostituisci `Number` con il numero di riga che vuoi eliminare.
 Durante il riavvio del sistema, iptables non mantiene le regole che hai creato.
 Ogni volta che configuri iptables su Linux, le modifiche apportate si applicano solo fino al prossimo riavvio.
 
-Per salvare le regole sui sistemi basati su Ubuntu, è necessario prima accedere come root utilizzando il comando `sudo su` :
+Sui sistemi basati su Ubuntu, il pacchetto `iptables-persistent` si occupa di ripristinare le tue regole all'avvio. Installalo con il comando seguente:
 
 ```bash
-ubuntu@server:~$ sudo su
-root@server:/home/ubuntu#
+sudo apt install iptables-persistent
 ```
 
-Quindi, eseguite il seguente comando: 
+:::info
+Durante l'installazione ti viene chiesto se salvare le regole IPv4 e IPv6 attuali. Rispondi `Yes` per conservare le regole che hai appena creato.
+:::
+
+In seguito puoi salvare le tue regole in qualsiasi momento con il comando seguente:
 
 ```bash
-iptables-save > /etc/iptables/rules.v4
+sudo netfilter-persistent save
 ```
 
-Questa operazione salva le regole direttamente nella cartella IPV4.
+Le tue regole IPv4 vengono scritte nel file `/etc/iptables/rules.v4` (e le tue regole IPv6 nel file `/etc/iptables/rules.v6`).
 
 Al prossimo avvio del sistema, gli iptables ricariceranno automaticamente le regole del firewall.
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja zapory iptables na serwerze dedykowanym z systemem Linux
-description: Skonfiguruj reguły zapory iptables na serwerze dedykowanym OVHcloud z systemem Linux, aby zabezpieczyć ruch sieciowy.
-lastUpdated: 2024-12-20
+description: Skonfiguruj reguły zapory iptables na serwerze dedykowanym OVHcloud z systemem Linux, aby zabezpieczyć ruch sieciowy
+lastUpdated: 2026-07-29
 ---
 
 :::info
@@ -17,15 +17,15 @@ Firewall działa poprzez określenie zasad regulujących dozwolony ruch i zablok
 **Dowiedz się, jak zabezpieczyć serwer dedykowany korzystając z iptables.**
 
 :::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, za które przejmujesz odpowiedzialność. Firma OVH nie ma dostępu do Twoich serwerów, nie pełni funkcji administratora i w związku z tym nie będzie mogła udzielić Ci wsparcia. Zarządzanie oprogramowaniem i wdrażanie środków bezpieczeństwa należy do klienta.
+OVHcloud oddaje do Twojej dyspozycji usługi, za które przejmujesz odpowiedzialność. Firma OVHcloud nie ma dostępu do Twoich serwerów, nie pełni funkcji administratora i w związku z tym nie będzie mogła udzielić Ci wsparcia. Zarządzanie oprogramowaniem i wdrażanie środków bezpieczeństwa należy do klienta.
 
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności lub wątpliwości związanych z administrowaniem, użytkowaniem lub zabezpieczeniem serwera rekomendujemy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](https://partner.ovhcloud.com/pl/directory/). Więcej informacji znajduje się w sekcji “Sprawdź również”.
+Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności lub wątpliwości związanych z administrowaniem, użytkowaniem lub zabezpieczeniem serwera rekomendujemy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Więcej informacji znajduje się w sekcji "Sprawdź również".
 :::
 
 
 ## Wymagania początkowe
 
-- Posiadanie [serwera dedykowanego](https://www.ovhcloud.com/pl/bare-metal/) na koncie OVHcloud
+- Posiadanie [serwera dedykowanego](/links/bare-metal/bare-metal) na koncie OVHcloud
 - Dostęp administratora (root/sudo) do serwera przez SSH
 
 ## W praktyce
@@ -56,19 +56,8 @@ Aby skonfigurować IPv6, użyj narzędzia iptables6. Te dwa różne protokoły n
 iptables jest domyślnie zainstalowany na większości systemów Linux. Aby potwierdzić, że usługa iptables jest zainstalowana, wpisz następujące polecenie:
 
 ```bash
-sudo apt-get install iptables
+sudo apt install iptables
 ```
-
-Aby zapewnić trwałość reguł iptables po ponownym uruchomieniu komputera, należy zainstalować pakiet `iptables persistent` przy użyciu następującego polecenia:
-
-```bash
-sudo apt-get install iptables-persistent
-```
-
-Po zainstalowaniu tego pakietu folder iptables będzie zawierał dwa pliki dla reguł IPV4 i IPV6:
-
-- /etc/iptables/rules.v4
-- /etc/iptables/rules.v6
 
 Zwykle polecenie iptables jest następujące:
 
@@ -78,15 +67,15 @@ sudo iptables [option] CHAIN_rule [-j target]
 
 Poniżej znajduje się lista kilku opcji Do wyboru:
 
-- -A -—append: Dodaj regułę do łańcucha (na końcu).
-- -C —-check: Wyszukiwanie reguły, która odpowiada wymaganiom łańcucha.
-- -D —-delete: Usuwa określone reguły łańcucha.
-- -F —-flush: Usuń wszystkie reguły.
-- -I —-insert: Dodaje regułę do danego łańcucha.
-- -L —-list: Wyświetl wszystkie reguły łańcucha.
-- -N -new-chain: Stwórz nowy kanał.
-- -v —-verbose: Wyświetla więcej informacji podczas korzystania z opcji listy.
-- -X —-delete-chain: Usuń ciąg.
+- -A --append: Dodaj regułę do łańcucha (na końcu).
+- -C --check: Wyszukiwanie reguły, która odpowiada wymaganiom łańcucha.
+- -D --delete: Usuwa określone reguły łańcucha.
+- -F --flush: Usuń wszystkie reguły.
+- -I --insert: Dodaje regułę do danego łańcucha.
+- -L --list: Wyświetl wszystkie reguły łańcucha.
+- -N --new-chain: Stwórz nowy łańcuch.
+- -v --verbose: Wyświetla więcej informacji podczas korzystania z opcji listy.
+- -X --delete-chain: Usuń łańcuch.
 
 ### Etap 3: sprawdź obecny stan iptables
 
@@ -96,14 +85,15 @@ Aby wyświetlić wszystkie aktualne reguły na Twoim serwerze, wprowadź następ
 sudo iptables -L
 ```
 
-System wyświetla status twoich kanałów.<br/>
-Wyjście będzie zawierać trzy kanały:
+System wyświetla status twoich łańcuchów.
+
+Wyjście będzie zawierać trzy łańcuchy:
 
 <img className="thumbnail" alt="Check-Current-iptables" src="/images/bare-metal-cloud/dedicated-servers/firewall-Linux-iptable/Check-Current-iptables.PNG" loading="lazy" />
 
 ### Etap 4: zezwalaj na ruch na localhost
 
-Aby zezwolić na ruch z własnego systemu (localhost), dodaj ciąg wejściowy, wprowadzając następujące elementy:
+Aby zezwolić na ruch z własnego systemu (localhost), dodaj łańcuch wejściowy, wprowadzając następujące elementy:
 
 ```bash
 sudo iptables -A INPUT -i lo -j ACCEPT
@@ -138,7 +128,7 @@ sudo iptables -A INPUT -p tcp --dport 443 -j ACCEPT
 Opcje działają następująco:
 
 - -p : Sprawdź określony protokół (tcp).
-- —-dport: Określa port docelowy.
+- --dport: Określa port docelowy.
 - -j jump: Wykonaj czynność 
 
 :::warning
@@ -176,7 +166,7 @@ Opcje iptables, których używaliśmy w przykładach działają następująco:
 
 - -m : Odpowiada określonej opcji.
 - -iprange: Wskazuje, że system będzie czekać na określony zakres adresów IP zamiast na jeden.
-- —-src-range: Określa zakres adresów IP.
+- --src-range: Określa zakres adresów IP.
 
 ### Etap 7: usuń niepożądany ruch
 
@@ -221,20 +211,23 @@ Zastąp `Number` numerem linii reguły, którą chcesz usunąć.
 Podczas restartu systemu, iptables nie zachowuje reguł, które utworzyłeś.
 Za każdym razem, gdy skonfigurujesz iptables w Linuxie, wszystkie wprowadzone przez Ciebie zmiany dotyczą tylko do kolejnego restartu.
 
-Aby zapisać reguły w systemach opartych na Ubuntu, należy najpierw zalogować się jako root za pomocą polecenia `sudo su` :
+W systemach opartych na Ubuntu pakiet `iptables-persistent` odpowiada za przywracanie reguł przy uruchamianiu systemu. Zainstaluj go za pomocą następującego polecenia:
 
 ```bash
-ubuntu@server:~$ sudo su
-root@server:/home/ubuntu#
+sudo apt install iptables-persistent
 ```
 
-Następnie uruchom następujące polecenie: 
+:::info
+Podczas instalacji zostaniesz zapytany, czy zapisać aktualne reguły IPv4 i IPv6. Odpowiedz `Yes`, aby zachować reguły, które właśnie utworzyłeś.
+:::
+
+Następnie możesz zapisać reguły w dowolnym momencie za pomocą następującego polecenia:
 
 ```bash
-iptables-save > /etc/iptables/rules.v4
+sudo netfilter-persistent save
 ```
 
-Ta operacja zapisuje reguły bezpośrednio w folderze IPV4.
+Reguły IPv4 są zapisywane w pliku `/etc/iptables/rules.v4` (a reguły IPv6 w pliku `/etc/iptables/rules.v6`).
 
 Po kolejnym uruchomieniu systemu iptables automatycznie przeładuje reguły firewalla.
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/firewall-linux-iptable.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar iptables num servidor dedicado Linux
 description: Proteja o seu servidor dedicado configurando regras de firewall iptables para filtrar o tráfego de rede em Linux
-lastUpdated: 2024-12-20
+lastUpdated: 2026-07-29
 ---
 
 :::info
@@ -19,13 +19,13 @@ As firewalls funcionam definindo regras que regulem o tráfego autorizado e o qu
 :::warning
 A OVHcloud oferece-lhe serviços que são da sua responsabilidade. Uma vez que não temos acesso a estas máquinas, não podemos administrá-las nem fornecer-lhe assistência. O cliente é o único responsável pela gestão e pela segurança do serviço.
 
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou tiver dúvidas quanto à administração, utilização ou segurança de um servidor, recomendamos que recorra a um [prestador de serviços especializado](https://partner.ovhcloud.com/pt/directory/). Para mais informações, aceda à secção “Quer saber mais?” deste manual.
+Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou tiver dúvidas quanto à administração, utilização ou segurança de um servidor, recomendamos que recorra a um [prestador de serviços especializado](/links/partner). Para mais informações, aceda à secção "Quer saber mais?" deste manual.
 :::
 
 
 ## Requisitos
 
-- Ter um [servidor dedicado](https://www.ovhcloud.com/pt/bare-metal/) na sua conta OVHcloud
+- Ter um [servidor dedicado](/links/bare-metal/bare-metal) na sua conta OVHcloud
 - Dispor de um acesso administrador (root/sudo) ao seu servidor através de SSH
 
 ## Instruções
@@ -56,19 +56,8 @@ Para configurar iptables para IPv6, deve utilizar o utilitário iptables6. Estes
 O iptables é instalado de forma padrão na maior parte dos sistemas Linux. Para confirmar que o iptables está instalado, utilize o seguinte comando:
 
 ```bash
-sudo apt-get install iptables
+sudo apt install iptables
 ```
-
-Para garantir que suas regras do iptables sejam persistentes após a reinicialização, é necessário instalar o pacote `iptables persistent` usando o seguinte comando:
-
-```bash
-sudo apt-get install iptables-persistent
-```
-
-Uma vez que este pacote tenha sido instalado, a pasta iptables conterá dois arquivos para regras IPV4 e IPV6:
-
-- /etc/iptables/rules.v4
-- /etc/iptables/rules.v6
 
 Geralmente, um comando iptables é o seguinte:
 
@@ -78,15 +67,15 @@ sudo iptables [option] CHAIN_rule [-j target]
 
 Eis uma lista de algumas opções iptables comuns:
 
-- -A —append: Adiciona uma regra a uma cadeia (no fim).
-- -C —check: Procura uma regra que corresponda às exigências da cadeia.
-- -D —delete: Eliminar as regras especificadas de uma cadeia.
-- -F —flush: Elimina todas as regras.
-- -I —insert: Adiciona uma regra a uma cadeia numa determinada posição.
-- -L —list: Indica todas as regras de um canal.
-- -N -new-chain: Crie uma nova cadeia.
-- -v —verbose: Afixar mais informações aquando da utilização de uma opção de lista.
-- -X —delete-chain: Eliminar a cadeia fornecida.
+- -A --append: Adiciona uma regra a uma cadeia (no fim).
+- -C --check: Procura uma regra que corresponda às exigências da cadeia.
+- -D --delete: Eliminar as regras especificadas de uma cadeia.
+- -F --flush: Elimina todas as regras.
+- -I --insert: Adiciona uma regra a uma cadeia numa determinada posição.
+- -L --list: Indica todas as regras de uma cadeia.
+- -N --new-chain: Crie uma nova cadeia.
+- -v --verbose: Afixar mais informações aquando da utilização de uma opção de lista.
+- -X --delete-chain: Eliminar a cadeia fornecida.
 
 ### Etapa 3: verificar o estado atual dos itens
 
@@ -96,8 +85,9 @@ Para apresentar o conjunto das regras atuais no seu servidor, introduza o seguin
 sudo iptables -L
 ```
 
-O sistema apresenta o estado das suas cadeias.<br/>
-A saída irá listar três canais:
+O sistema apresenta o estado das suas cadeias.
+
+A saída irá listar três cadeias:
 
 <img className="thumbnail" alt="Check-Current-iptables" src="/images/bare-metal-cloud/dedicated-servers/firewall-Linux-iptable/Check-Current-iptables.PNG" loading="lazy" />
 
@@ -120,19 +110,19 @@ Uma porta é um ponto de terminação de comunicação especificado para um tipo
 Para autorizar o tráfego Web HTTP, introduza o seguinte comando:
 
 ```bash
-sudo iptables -A INPUT -p tcp —dport 80 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 80 -j ACCEPT
 ```
 
 Para autorizar apenas o tráfego SSH (Secure Shell) de entrada, introduza o seguinte (note que utilizamos a porta 22, que é o número padrão da porta SSH. Se o seu número de porta for diferente, certifique-se de ajustar os seguintes comandos em conformidade):
 
 ```bash
-sudo iptables -A INPUT -p tcp —dport 22 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 22 -j ACCEPT
 ```
 
 Para autorizar o tráfego Internet HTTPS, introduza o seguinte comando:
 
 ```bash
-sudo iptables -A INPUT -p tcp —dport 443 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 443 -j ACCEPT
 ```
 
 As opções funcionam da seguinte forma:
@@ -169,14 +159,14 @@ Substitua o endereço IP na encomenda pelo endereço IP que pretende bloquear.
 Pode rejeitar o tráfego a partir de um intervalo de endereços IP, com o seguinte comando:
 
 ```bash
-sudo iptables -A INPUT -m iprange —selecione o seu_endereço_IP_inicio-o_o_endereço_IP_fin -j REJECT
+sudo iptables -A INPUT -m iprange --src-range o_seu_endereço_IP_inicial-o_seu_endereço_IP_final -j REJECT
 ```
 
 As opções essenciais que utilizámos nos exemplos funcionam da seguinte forma:
 
 - -m: Corresponde à opção especificada.
 - -iprange: Indica ao sistema esperar um intervalo de endereços de IP em vez de um só.
-- —-src-range: Identifique o intervalo de endereços IP.
+- --src-range: Identifique o intervalo de endereços IP.
 
 ### Etapa 7: eliminar o tráfego indesejável
 
@@ -220,20 +210,23 @@ Substitua o `Number` pelo número de linha de regra que pretende eliminar.
 Ao reiniciar o sistema, o iptables não mantém as regras que criou.
 Cada vez que configura o iptables sob Linux, todas as modificações que efetuar aplicam-se apenas até ao próximo reboot.
 
-Para salvar as regras em sistemas baseados no Ubuntu, é preciso primeiro fazer o login como root usando o comando `sudo su` :
+Nos sistemas baseados em Ubuntu, o pacote `iptables-persistent` encarrega-se de restaurar as suas regras no arranque. Instale-o com o seguinte comando:
 
 ```bash
-ubuntu@servidor:~$ sudo su
-root@server:/home/ubuntu#
+sudo apt install iptables-persistent
 ```
 
-Em seguida, execute o seguinte comando: 
+:::info
+Durante a instalação, é-lhe perguntado se deseja guardar as regras IPv4 e IPv6 atuais. Responda `Yes` para conservar as regras que acabou de criar.
+:::
+
+Em seguida, pode guardar as suas regras em qualquer momento com o seguinte comando:
 
 ```bash
-iptables-save > /etc/iptables/rules.v4
+sudo netfilter-persistent save
 ```
 
-Esta operação guarda as regras diretamente na pasta IPV4.
+As suas regras IPv4 são escritas no ficheiro `/etc/iptables/rules.v4` (e as suas regras IPv6 no ficheiro `/etc/iptables/rules.v6`).
 
 Quando iniciar o seu sistema, iptables recarregará automaticamente as regras da firewall.
 


### PR DESCRIPTION
- Following an update on the VPS guide, updating the firewall rules in the SD guide as well.
- Broken links: dead legacy community URL (404), a broken /links/bare-metal/ key, hardcoded per-locale marketing URLs → all centralized/repaired
- Real command bugs: --dport/--src-range corrupted into em-dashes in several locales — some inside runnable code blocks, meaning copy-pasted commands would have failed
- Terminology drift: "chain" got mistranslated as "string" (EN), "channel" (IT/PT), or lost entirely (PL) — fixed for technical accuracy
- IT: 3 code blocks had a stray space splitting a placeholder into two shell arguments — genuinely broken commands, now fixed
- Plus: quote styles, missing accents/NBSP (FR), a dropped hyperlink (ES), typos, register mismatches (formal/informal mixing), etc.