### PR TITLE
docs: replace retired ingress-nginx guide with Traefik

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -1063,7 +1063,7 @@
                     + [Customizing CoreDNS on an OVHcloud Managed Kubernetes cluster](public-cloud/containers-orchestration/managed-kubernetes/customizing-coredns)
                     + [Customizing Cilium on an OVHcloud Managed Kubernetes cluster](public-cloud/containers-orchestration/managed-kubernetes/customizing-cilium)
                 + [Traffic Management](public-cloud-containers-orchestration-managed-kubernetes-k8s-configuration-traffic-management)
-                    + [Installing Nginx Ingress on OVHcloud Managed Kubernetes](public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress)
+                    + [Installing Traefik on OVHcloud Managed Kubernetes](public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress)
                     + [Expose your applications using OVHcloud Public Cloud Load Balancer](public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer)
                     + [Sticky sessions/Session Affinity based on Nginx Ingress on OVHcloud Managed Kubernetes](public-cloud/containers-orchestration/managed-kubernetes/sticky-session-nginx-ingress)
                     + [Secure a Nginx Ingress with cert-manager on OVHcloud Managed Kubernetes](public-cloud/containers-orchestration/managed-kubernetes/secure-nginx-ingress-cert-manager)

--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
@@ -1,184 +1,80 @@
 ---
-title: Installing Nginx Ingress on OVHcloud Managed Kubernetes
-description: Find out how to install Nginx Ingress on OVHcloud Managed Kubernetes
-lastUpdated: 2024-09-12
+title: Installing Traefik on OVHcloud Managed Kubernetes
+description: Find out how to install Traefik as an Ingress Controller on OVHcloud Managed Kubernetes
+lastUpdated: 2026-07-29
 ---
 
-In this tutorial we are going to guide you with the setup of [Nginx Ingress](https://github.com/kubernetes/ingress-nginx) on your OVHcloud Managed Kubernetes Service.
+This tutorial explains how to install [Traefik](https://github.com/traefik/traefik) as an Ingress Controller on your OVHcloud Managed Kubernetes Service.
 
 ## Before you begin
 
-This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
+This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster and some basic knowledge of how to operate it. If you want to know more about these topics, please refer to the [OVHcloud Managed Kubernetes Service Quickstart](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
 
-You also need to have [Helm](https://docs.helm.sh/) installer on your workstation and your cluster. Please refer to the [How to install Helm on OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) tutorial.
+You also need to have [Helm](https://helm.sh/docs/intro/install/) installed on your workstation. Please refer to the [How to install Helm on OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) tutorial.
 
-## Ingress resources and Nginx Ingress Controller
+## Ingress resources and Traefik
 
-In Kubernetes, an Ingress resource allows you to access your Services from outside the cluster. The goal is to avoid creating a Load Balancer per Service but only one per Ingress.
+In Kubernetes, an Ingress resource allows you to access your Services from outside the cluster. The goal is to avoid creating one Load Balancer per Service and use a single Load Balancer for the Ingress Controller instead.
 
 ![Kubernetes Ingress](/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/ingress.png)
 
-An Ingress is implemented by a 3rd party: an Ingress Controller that extends specs to support additional features.
+An Ingress is implemented by a third-party Ingress Controller that watches the Kubernetes API for new and updated Ingress resources.
 
-In this tutorial, you will install an Nginx Ingress Controller.  
-It is an Ingress controller for Kubernetes using an Nginx web server as a reverse proxy and Load Balancer.
+In this tutorial, you will install Traefik Proxy. Traefik routes incoming requests to backend Services according to the rules defined in your Ingress resources.
 
-Specifically, when you are deploying and running an Nginx Ingress Controller, you will have a Pod that runs Nginx and watches the Kubernetes Control Plane for new and updated Ingress Resource objects.
-
-Imagine an Ingress Resource as a list of traffic routing rules for backend Services.
-
-After deploying the Nginx Ingress Controller, you will also have an OVHcloud Load Balancer. Thanks to this Load Balancer, the external traffic will be routed to the Ingress Controller Pod running Nginx, which then forwards traffic to the appropriate backend Services you will configure in Ingress resources.
+After deploying Traefik, you will also have an OVHcloud Public Cloud Load Balancer. The Load Balancer routes external traffic to Traefik, which then forwards each request to the appropriate backend Service.
 
 :::warning
-**Important:** There are two different Ingress controllers for Nginx:
+The Kubernetes community [retired ingress-nginx in March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/). The project no longer receives releases, bug fixes, or security updates and should not be deployed for new workloads.
 
-- [Nginx Inc Ingress Controller](https://github.com/nginxinc/kubernetes-ingress)
-- [Kubernetes Ingress Nginx Controller](https://github.com/kubernetes/ingress-nginx) (the one covered in this guide)
-
-If you opt to install the first controller, please follow the instructions provided in the [Nginx Inc Ingress Controller documentation](https://github.com/nginxinc/kubernetes-ingress/tree/v3.3.2/examples/shared-examples/proxy-protocol) and use the OVH proxy protocol v1 by adding the following annotation to your service:
-
-```yaml
-service:
-  annotations:
-    service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: v1
-```
+This guide previously covered ingress-nginx and now uses Traefik. Existing ingress-nginx users should follow the [Traefik migration guide](https://doc.traefik.io/traefik/migrate/nginx-to-traefik/), review their controller-specific annotations, and test the migration before removing their current controller.
 :::
 
+## Installing the Traefik Helm chart
 
-## Installing the Nginx Ingress Controller Helm chart
-
-For this tutorial, we are using the [Nginx Ingress Controller Helm chart](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) found on its own Helm repository.
-
-The chart is fully configurable, but here we are using the default configuration.
+For this tutorial, we are using the official [Traefik Helm chart](https://github.com/traefik/traefik-helm-chart) with its default configuration.
 
 ```bash
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-```
-The install process will begin:
-
-```console
-$ helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-NAME: ingress-nginx
-LAST DEPLOYED: Mon Sep 10 09:20:44 2024
-NAMESPACE: ingress-nginx
-STATUS: deployed
-REVISION: 1
-TEST SUITE: None
-NOTES:
+helm repo add traefik https://traefik.github.io/charts
+helm repo update traefik
+helm upgrade --install traefik traefik/traefik \
+  --version 41.0.2 \
+  --namespace traefik \
+  --create-namespace \
+  --wait --timeout 3m
 ```
 
-At the end of the install, as usual with most Helm charts, you get the configuration information and some tips to test your `nginx-ingress`:
-
-```console
-NOTES:
-The ingress-nginx controller has been installed.
-It may take a few minutes for the LoadBalancer IP to be available.
-You can watch the status by running 'kubectl --namespace ingress-nginx get services -o wide -w ingress-nginx-controller'
-
-An example Ingress that makes use of the controller:
-  apiVersion: networking.k8s.io/v1
-  kind: Ingress
-  metadata:
-    name: example
-    namespace: foo
-  spec:
-    ingressClassName: nginx
-    rules:
-      - host: www.example.com
-        http:
-          paths:
-            - pathType: Prefix
-              backend:
-                service:
-                  name: exampleService
-                  port:
-                    number: 80
-              path: /
-    # This section is only required if TLS is to be enabled for the Ingress
-    tls:
-      - hosts:
-        - www.example.com
-        secretName: example-tls
-
-If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:
-
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: example-tls
-    namespace: foo
-  data:
-    tls.crt: <base64 encoded cert>
-    tls.key: <base64 encoded key>
-  type: kubernetes.io/tls
-```
-
-As the `LoadBalancer` creation is asynchronous, and the provisioning of the load balancer can take several minutes, you will surely get a `<pending>` `EXTERNAL-IP`.
-
-If you try again in a few minutes you should get an `EXTERNAL-IP`:
-
-```console
-$ kubectl get svc -n ingress-nginx ingress-nginx-controller
-NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP       PORT(S)                      AGE
-ingress-nginx-controller   LoadBalancer   10.3.232.157   51.178.69.190     80:30903/TCP,443:31546/TCP   19h
-```
-You can then access your `nginx-ingress` at `http://[YOUR_LOAD_BALANCER_IP]` via HTTP or `https://[YOUR_LOAD_BALANCER_IP]` via HTTPS.
-
-Enter the following command to retrieve it:
+Check that the Traefik Deployment is available:
 
 ```bash
-export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
+kubectl rollout status deployment/traefik -n traefik
 ```
 
-You should have a content like this:
+The `LoadBalancer` creation is asynchronous and can take several minutes. Check the Service until an address appears in the `EXTERNAL-IP` column:
 
-```console
-$ export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
-echo Ingress URL: http://$INGRESS_URL/
-Ingress URL: http://51.178.69.190/
+```bash
+kubectl get service traefik -n traefik --watch
 ```
-In order to test your `nginx-ingress`, you can, for example, [install a WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) on your cluster, and then create a YAML file for the Ingress that uses the controller:
+
+Press `Ctrl+C` to stop watching the Service, then retrieve its external IP address:
+
+```bash
+export INGRESS_URL=$(kubectl get service traefik -n traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+echo "Ingress URL: http://$INGRESS_URL/"
+```
+
+## Testing Traefik with an Ingress
+
+To test Traefik, you can, for example, [install WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) on your cluster. Then create an `ingress.yml` file with the following content:
 
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
   name: ingress
   namespace: default
 spec:
-  rules:
-  - http:
-      paths:
-      - backend:
-          service:
-            name: [YOUR_WORDPRESS_SERVICE_NAME]
-            port:
-              number: 80
-        path: /
-        pathType: Prefix
-
-```
-
-:::info
-Don't forget to replace `[YOUR_WORDPRESS_SERVICE_NAME]`.
-:::
-
-
-In our example, the `ingress.yaml` produces this result:
-
-```yaml
-**apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
-  name: ingress
-  namespace: default
-spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:
@@ -186,27 +82,35 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: my-first-k8s-wordpress
+                name: [YOUR_WORDPRESS_SERVICE_NAME]
                 port:
                   number: 80
 ```
+
+:::info
+Replace `[YOUR_WORDPRESS_SERVICE_NAME]` with the name of your WordPress Service.
+:::
+
 Apply the file:
 
-```yaml
+```bash
 kubectl apply -f ingress.yml
 ```
-And the Ingress is created.
 
-```console
-$ kubectl apply -f ingress.yml 
-ingress.extensions/ingress created
+Check that the Ingress has an address:
+
+```bash
+kubectl get ingress ingress
 ```
 
-So now if you point your browser to `http://$INGRESS_URL/`, you will see your WordPress:
+If you point your browser to `http://$INGRESS_URL/`, you will see your WordPress:
 
 <img className="thumbnail" alt="WordPress using Ingress" src="/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/installing-ingress-01.png" loading="lazy" />
 
 ## Go further
+
+- Read the [Traefik Kubernetes Ingress documentation](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress/).
+- Learn how to [use the OVHcloud Public Cloud Load Balancer with MKS](/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
@@ -1,184 +1,80 @@
 ---
-title: Installing Nginx Ingress on OVHcloud Managed Kubernetes
-description: Find out how to install Nginx Ingress on OVHcloud Managed Kubernetes
-lastUpdated: 2024-09-12
+title: Installing Traefik on OVHcloud Managed Kubernetes
+description: Find out how to install Traefik as an Ingress Controller on OVHcloud Managed Kubernetes
+lastUpdated: 2026-07-29
 ---
 
-In this tutorial we are going to guide you with the setup of [Nginx Ingress](https://github.com/kubernetes/ingress-nginx) on your OVHcloud Managed Kubernetes Service.
+This tutorial explains how to install [Traefik](https://github.com/traefik/traefik) as an Ingress Controller on your OVHcloud Managed Kubernetes Service.
 
 ## Before you begin
 
-This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
+This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster and some basic knowledge of how to operate it. If you want to know more about these topics, please refer to the [OVHcloud Managed Kubernetes Service Quickstart](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
 
-You also need to have [Helm](https://docs.helm.sh/) installer on your workstation and your cluster. Please refer to the [How to install Helm on OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) tutorial.
+You also need to have [Helm](https://helm.sh/docs/intro/install/) installed on your workstation. Please refer to the [How to install Helm on OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) tutorial.
 
-## Ingress resources and Nginx Ingress Controller
+## Ingress resources and Traefik
 
-In Kubernetes, an Ingress resource allows you to access your Services from outside the cluster. The goal is to avoid creating a Load Balancer per Service but only one per Ingress.
+In Kubernetes, an Ingress resource allows you to access your Services from outside the cluster. The goal is to avoid creating one Load Balancer per Service and use a single Load Balancer for the Ingress Controller instead.
 
 ![Kubernetes Ingress](/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/ingress.png)
 
-An Ingress is implemented by a 3rd party: an Ingress Controller that extends specs to support additional features.
+An Ingress is implemented by a third-party Ingress Controller that watches the Kubernetes API for new and updated Ingress resources.
 
-In this tutorial, you will install an Nginx Ingress Controller.  
-It is an Ingress controller for Kubernetes using an Nginx web server as a reverse proxy and Load Balancer.
+In this tutorial, you will install Traefik Proxy. Traefik routes incoming requests to backend Services according to the rules defined in your Ingress resources.
 
-Specifically, when you are deploying and running an Nginx Ingress Controller, you will have a Pod that runs Nginx and watches the Kubernetes Control Plane for new and updated Ingress Resource objects.
-
-Imagine an Ingress Resource as a list of traffic routing rules for backend Services.
-
-After deploying the Nginx Ingress Controller, you will also have an OVHcloud Load Balancer. Thanks to this Load Balancer, the external traffic will be routed to the Ingress Controller Pod running Nginx, which then forwards traffic to the appropriate backend Services you will configure in Ingress resources.
+After deploying Traefik, you will also have an OVHcloud Public Cloud Load Balancer. The Load Balancer routes external traffic to Traefik, which then forwards each request to the appropriate backend Service.
 
 :::warning
-**Important:** There are two different Ingress controllers for Nginx:
+The Kubernetes community [retired ingress-nginx in March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/). The project no longer receives releases, bug fixes, or security updates and should not be deployed for new workloads.
 
-- [Nginx Inc Ingress Controller](https://github.com/nginxinc/kubernetes-ingress)
-- [Kubernetes Ingress Nginx Controller](https://github.com/kubernetes/ingress-nginx) (the one covered in this guide)
-
-If you opt to install the first controller, please follow the instructions provided in the [Nginx Inc Ingress Controller documentation](https://github.com/nginxinc/kubernetes-ingress/tree/v3.3.2/examples/shared-examples/proxy-protocol) and use the OVH proxy protocol v1 by adding the following annotation to your service:
-
-```yaml
-service:
-  annotations:
-    service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: v1
-```
+This guide previously covered ingress-nginx and now uses Traefik. Existing ingress-nginx users should follow the [Traefik migration guide](https://doc.traefik.io/traefik/migrate/nginx-to-traefik/), review their controller-specific annotations, and test the migration before removing their current controller.
 :::
 
+## Installing the Traefik Helm chart
 
-## Installing the Nginx Ingress Controller Helm chart
-
-For this tutorial, we are using the [Nginx Ingress Controller Helm chart](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) found on its own Helm repository.
-
-The chart is fully configurable, but here we are using the default configuration.
+For this tutorial, we are using the official [Traefik Helm chart](https://github.com/traefik/traefik-helm-chart) with its default configuration.
 
 ```bash
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-```
-The install process will begin:
-
-```console
-$ helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-NAME: ingress-nginx
-LAST DEPLOYED: Mon Sep 10 09:20:44 2024
-NAMESPACE: ingress-nginx
-STATUS: deployed
-REVISION: 1
-TEST SUITE: None
-NOTES:
+helm repo add traefik https://traefik.github.io/charts
+helm repo update traefik
+helm upgrade --install traefik traefik/traefik \
+  --version 41.0.2 \
+  --namespace traefik \
+  --create-namespace \
+  --wait --timeout 3m
 ```
 
-At the end of the install, as usual with most Helm charts, you get the configuration information and some tips to test your `nginx-ingress`:
-
-```console
-NOTES:
-The ingress-nginx controller has been installed.
-It may take a few minutes for the LoadBalancer IP to be available.
-You can watch the status by running 'kubectl --namespace ingress-nginx get services -o wide -w ingress-nginx-controller'
-
-An example Ingress that makes use of the controller:
-  apiVersion: networking.k8s.io/v1
-  kind: Ingress
-  metadata:
-    name: example
-    namespace: foo
-  spec:
-    ingressClassName: nginx
-    rules:
-      - host: www.example.com
-        http:
-          paths:
-            - pathType: Prefix
-              backend:
-                service:
-                  name: exampleService
-                  port:
-                    number: 80
-              path: /
-    # This section is only required if TLS is to be enabled for the Ingress
-    tls:
-      - hosts:
-        - www.example.com
-        secretName: example-tls
-
-If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:
-
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: example-tls
-    namespace: foo
-  data:
-    tls.crt: <base64 encoded cert>
-    tls.key: <base64 encoded key>
-  type: kubernetes.io/tls
-```
-
-As the `LoadBalancer` creation is asynchronous, and the provisioning of the load balancer can take several minutes, you will surely get a `<pending>` `EXTERNAL-IP`.
-
-If you try again in a few minutes you should get an `EXTERNAL-IP`:
-
-```console
-$ kubectl get svc -n ingress-nginx ingress-nginx-controller
-NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP       PORT(S)                      AGE
-ingress-nginx-controller   LoadBalancer   10.3.232.157   51.178.69.190     80:30903/TCP,443:31546/TCP   19h
-```
-You can then access your `nginx-ingress` at `http://[YOUR_LOAD_BALANCER_IP]` via HTTP or `https://[YOUR_LOAD_BALANCER_IP]` via HTTPS.
-
-Enter the following command to retrieve it:
+Check that the Traefik Deployment is available:
 
 ```bash
-export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
+kubectl rollout status deployment/traefik -n traefik
 ```
 
-You should have a content like this:
+The `LoadBalancer` creation is asynchronous and can take several minutes. Check the Service until an address appears in the `EXTERNAL-IP` column:
 
-```console
-$ export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
-echo Ingress URL: http://$INGRESS_URL/
-Ingress URL: http://51.178.69.190/
+```bash
+kubectl get service traefik -n traefik --watch
 ```
-In order to test your `nginx-ingress`, you can, for example, [install a WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) on your cluster, and then create a YAML file for the Ingress that uses the controller:
+
+Press `Ctrl+C` to stop watching the Service, then retrieve its external IP address:
+
+```bash
+export INGRESS_URL=$(kubectl get service traefik -n traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+echo "Ingress URL: http://$INGRESS_URL/"
+```
+
+## Testing Traefik with an Ingress
+
+To test Traefik, you can, for example, [install WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) on your cluster. Then create an `ingress.yml` file with the following content:
 
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
   name: ingress
   namespace: default
 spec:
-  rules:
-  - http:
-      paths:
-      - backend:
-          service:
-            name: [YOUR_WORDPRESS_SERVICE_NAME]
-            port:
-              number: 80
-        path: /
-        pathType: Prefix
-
-```
-
-:::info
-Don't forget to replace `[YOUR_WORDPRESS_SERVICE_NAME]`.
-:::
-
-
-In our example, the `ingress.yaml` produces this result:
-
-```yaml
-**apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
-  name: ingress
-  namespace: default
-spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:
@@ -186,27 +82,35 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: my-first-k8s-wordpress
+                name: [YOUR_WORDPRESS_SERVICE_NAME]
                 port:
                   number: 80
 ```
+
+:::info
+Replace `[YOUR_WORDPRESS_SERVICE_NAME]` with the name of your WordPress Service.
+:::
+
 Apply the file:
 
-```yaml
+```bash
 kubectl apply -f ingress.yml
 ```
-And the Ingress is created.
 
-```console
-$ kubectl apply -f ingress.yml 
-ingress.extensions/ingress created
+Check that the Ingress has an address:
+
+```bash
+kubectl get ingress ingress
 ```
 
-So now if you point your browser to `http://$INGRESS_URL/`, you will see your WordPress:
+If you point your browser to `http://$INGRESS_URL/`, you will see your WordPress:
 
 <img className="thumbnail" alt="WordPress using Ingress" src="/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/installing-ingress-01.png" loading="lazy" />
 
 ## Go further
+
+- Read the [Traefik Kubernetes Ingress documentation](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress/).
+- Learn how to [use the OVHcloud Public Cloud Load Balancer with MKS](/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
@@ -1,184 +1,80 @@
 ---
-title: Installing Nginx Ingress on OVHcloud Managed Kubernetes
-description: Find out how to install Nginx Ingress on OVHcloud Managed Kubernetes
-lastUpdated: 2024-09-12
+title: Installing Traefik on OVHcloud Managed Kubernetes
+description: Find out how to install Traefik as an Ingress Controller on OVHcloud Managed Kubernetes
+lastUpdated: 2026-07-29
 ---
 
-In this tutorial we are going to guide you with the setup of [Nginx Ingress](https://github.com/kubernetes/ingress-nginx) on your OVHcloud Managed Kubernetes Service.
+This tutorial explains how to install [Traefik](https://github.com/traefik/traefik) as an Ingress Controller on your OVHcloud Managed Kubernetes Service.
 
 ## Before you begin
 
-This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
+This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster and some basic knowledge of how to operate it. If you want to know more about these topics, please refer to the [OVHcloud Managed Kubernetes Service Quickstart](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
 
-You also need to have [Helm](https://docs.helm.sh/) installer on your workstation and your cluster. Please refer to the [How to install Helm on OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) tutorial.
+You also need to have [Helm](https://helm.sh/docs/intro/install/) installed on your workstation. Please refer to the [How to install Helm on OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) tutorial.
 
-## Ingress resources and Nginx Ingress Controller
+## Ingress resources and Traefik
 
-In Kubernetes, an Ingress resource allows you to access your Services from outside the cluster. The goal is to avoid creating a Load Balancer per Service but only one per Ingress.
+In Kubernetes, an Ingress resource allows you to access your Services from outside the cluster. The goal is to avoid creating one Load Balancer per Service and use a single Load Balancer for the Ingress Controller instead.
 
 ![Kubernetes Ingress](/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/ingress.png)
 
-An Ingress is implemented by a 3rd party: an Ingress Controller that extends specs to support additional features.
+An Ingress is implemented by a third-party Ingress Controller that watches the Kubernetes API for new and updated Ingress resources.
 
-In this tutorial, you will install an Nginx Ingress Controller.  
-It is an Ingress controller for Kubernetes using an Nginx web server as a reverse proxy and Load Balancer.
+In this tutorial, you will install Traefik Proxy. Traefik routes incoming requests to backend Services according to the rules defined in your Ingress resources.
 
-Specifically, when you are deploying and running an Nginx Ingress Controller, you will have a Pod that runs Nginx and watches the Kubernetes Control Plane for new and updated Ingress Resource objects.
-
-Imagine an Ingress Resource as a list of traffic routing rules for backend Services.
-
-After deploying the Nginx Ingress Controller, you will also have an OVHcloud Load Balancer. Thanks to this Load Balancer, the external traffic will be routed to the Ingress Controller Pod running Nginx, which then forwards traffic to the appropriate backend Services you will configure in Ingress resources.
+After deploying Traefik, you will also have an OVHcloud Public Cloud Load Balancer. The Load Balancer routes external traffic to Traefik, which then forwards each request to the appropriate backend Service.
 
 :::warning
-**Important:** There are two different Ingress controllers for Nginx:
+The Kubernetes community [retired ingress-nginx in March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/). The project no longer receives releases, bug fixes, or security updates and should not be deployed for new workloads.
 
-- [Nginx Inc Ingress Controller](https://github.com/nginxinc/kubernetes-ingress)
-- [Kubernetes Ingress Nginx Controller](https://github.com/kubernetes/ingress-nginx) (the one covered in this guide)
-
-If you opt to install the first controller, please follow the instructions provided in the [Nginx Inc Ingress Controller documentation](https://github.com/nginxinc/kubernetes-ingress/tree/v3.3.2/examples/shared-examples/proxy-protocol) and use the OVH proxy protocol v1 by adding the following annotation to your service:
-
-```yaml
-service:
-  annotations:
-    service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: v1
-```
+This guide previously covered ingress-nginx and now uses Traefik. Existing ingress-nginx users should follow the [Traefik migration guide](https://doc.traefik.io/traefik/migrate/nginx-to-traefik/), review their controller-specific annotations, and test the migration before removing their current controller.
 :::
 
+## Installing the Traefik Helm chart
 
-## Installing the Nginx Ingress Controller Helm chart
-
-For this tutorial, we are using the [Nginx Ingress Controller Helm chart](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) found on its own Helm repository.
-
-The chart is fully configurable, but here we are using the default configuration.
+For this tutorial, we are using the official [Traefik Helm chart](https://github.com/traefik/traefik-helm-chart) with its default configuration.
 
 ```bash
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-```
-The install process will begin:
-
-```console
-$ helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-NAME: ingress-nginx
-LAST DEPLOYED: Mon Sep 10 09:20:44 2024
-NAMESPACE: ingress-nginx
-STATUS: deployed
-REVISION: 1
-TEST SUITE: None
-NOTES:
+helm repo add traefik https://traefik.github.io/charts
+helm repo update traefik
+helm upgrade --install traefik traefik/traefik \
+  --version 41.0.2 \
+  --namespace traefik \
+  --create-namespace \
+  --wait --timeout 3m
 ```
 
-At the end of the install, as usual with most Helm charts, you get the configuration information and some tips to test your `nginx-ingress`:
-
-```console
-NOTES:
-The ingress-nginx controller has been installed.
-It may take a few minutes for the LoadBalancer IP to be available.
-You can watch the status by running 'kubectl --namespace ingress-nginx get services -o wide -w ingress-nginx-controller'
-
-An example Ingress that makes use of the controller:
-  apiVersion: networking.k8s.io/v1
-  kind: Ingress
-  metadata:
-    name: example
-    namespace: foo
-  spec:
-    ingressClassName: nginx
-    rules:
-      - host: www.example.com
-        http:
-          paths:
-            - pathType: Prefix
-              backend:
-                service:
-                  name: exampleService
-                  port:
-                    number: 80
-              path: /
-    # This section is only required if TLS is to be enabled for the Ingress
-    tls:
-      - hosts:
-        - www.example.com
-        secretName: example-tls
-
-If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:
-
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: example-tls
-    namespace: foo
-  data:
-    tls.crt: <base64 encoded cert>
-    tls.key: <base64 encoded key>
-  type: kubernetes.io/tls
-```
-
-As the `LoadBalancer` creation is asynchronous, and the provisioning of the load balancer can take several minutes, you will surely get a `<pending>` `EXTERNAL-IP`.
-
-If you try again in a few minutes you should get an `EXTERNAL-IP`:
-
-```console
-$ kubectl get svc -n ingress-nginx ingress-nginx-controller
-NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP       PORT(S)                      AGE
-ingress-nginx-controller   LoadBalancer   10.3.232.157   51.178.69.190     80:30903/TCP,443:31546/TCP   19h
-```
-You can then access your `nginx-ingress` at `http://[YOUR_LOAD_BALANCER_IP]` via HTTP or `https://[YOUR_LOAD_BALANCER_IP]` via HTTPS.
-
-Enter the following command to retrieve it:
+Check that the Traefik Deployment is available:
 
 ```bash
-export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
+kubectl rollout status deployment/traefik -n traefik
 ```
 
-You should have a content like this:
+The `LoadBalancer` creation is asynchronous and can take several minutes. Check the Service until an address appears in the `EXTERNAL-IP` column:
 
-```console
-$ export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
-echo Ingress URL: http://$INGRESS_URL/
-Ingress URL: http://51.178.69.190/
+```bash
+kubectl get service traefik -n traefik --watch
 ```
-In order to test your `nginx-ingress`, you can, for example, [install a WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) on your cluster, and then create a YAML file for the Ingress that uses the controller:
+
+Press `Ctrl+C` to stop watching the Service, then retrieve its external IP address:
+
+```bash
+export INGRESS_URL=$(kubectl get service traefik -n traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+echo "Ingress URL: http://$INGRESS_URL/"
+```
+
+## Testing Traefik with an Ingress
+
+To test Traefik, you can, for example, [install WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) on your cluster. Then create an `ingress.yml` file with the following content:
 
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
   name: ingress
   namespace: default
 spec:
-  rules:
-  - http:
-      paths:
-      - backend:
-          service:
-            name: [YOUR_WORDPRESS_SERVICE_NAME]
-            port:
-              number: 80
-        path: /
-        pathType: Prefix
-
-```
-
-:::info
-Don't forget to replace `[YOUR_WORDPRESS_SERVICE_NAME]`.
-:::
-
-
-In our example, the `ingress.yaml` produces this result:
-
-```yaml
-**apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
-  name: ingress
-  namespace: default
-spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:
@@ -186,27 +82,35 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: my-first-k8s-wordpress
+                name: [YOUR_WORDPRESS_SERVICE_NAME]
                 port:
                   number: 80
 ```
+
+:::info
+Replace `[YOUR_WORDPRESS_SERVICE_NAME]` with the name of your WordPress Service.
+:::
+
 Apply the file:
 
-```yaml
+```bash
 kubectl apply -f ingress.yml
 ```
-And the Ingress is created.
 
-```console
-$ kubectl apply -f ingress.yml 
-ingress.extensions/ingress created
+Check that the Ingress has an address:
+
+```bash
+kubectl get ingress ingress
 ```
 
-So now if you point your browser to `http://$INGRESS_URL/`, you will see your WordPress:
+If you point your browser to `http://$INGRESS_URL/`, you will see your WordPress:
 
 <img className="thumbnail" alt="WordPress using Ingress" src="/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/installing-ingress-01.png" loading="lazy" />
 
 ## Go further
+
+- Read the [Traefik Kubernetes Ingress documentation](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress/).
+- Learn how to [use the OVHcloud Public Cloud Load Balancer with MKS](/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
@@ -1,184 +1,80 @@
 ---
-title: Installer Nginx Ingress sur OVHcloud Managed Kubernetes
-description: Découvrez comment installer Nginx Ingress sur OVHcloud Managed Kubernetes
-lastUpdated: 2024-09-12
+title: Installing Traefik on OVHcloud Managed Kubernetes
+description: Find out how to install Traefik as an Ingress Controller on OVHcloud Managed Kubernetes
+lastUpdated: 2026-07-29
 ---
 
-Ce tutoriel vous guide dans la mise en place de [Nginx Ingress](https://github.com/kubernetes/ingress-nginx) sur votre OVHcloud Managed Kubernetes Service.
+This tutorial explains how to install [Traefik](https://github.com/traefik/traefik) as an Ingress Controller on your OVHcloud Managed Kubernetes Service.
 
-## Avant de commencer
+## Before you begin
 
-Ce tutoriel suppose que vous disposez déjà d'un cluster OVHcloud Managed Kubernetes fonctionnel, ainsi que de connaissances de base sur son utilisation. Pour en savoir plus sur ces sujets, consultez le [guide de démarrage rapide OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
+This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster and some basic knowledge of how to operate it. If you want to know more about these topics, please refer to the [OVHcloud Managed Kubernetes Service Quickstart](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
 
-Vous devez également avoir [Helm](https://docs.helm.sh/) installé sur votre poste de travail et sur votre cluster. Reportez-vous au tutoriel [Comment installer Helm sur OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm).
+You also need to have [Helm](https://helm.sh/docs/intro/install/) installed on your workstation. Please refer to the [How to install Helm on OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) tutorial.
 
-## Ressources Ingress et Nginx Ingress Controller
+## Ingress resources and Traefik
 
-Dans Kubernetes, une ressource Ingress permet d'accéder à vos Services depuis l'extérieur du cluster. L'objectif est d'éviter de créer un Load Balancer par Service, en n'en créant qu'un seul par Ingress.
+In Kubernetes, an Ingress resource allows you to access your Services from outside the cluster. The goal is to avoid creating one Load Balancer per Service and use a single Load Balancer for the Ingress Controller instead.
 
-![Ingress Kubernetes](/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/ingress.png)
+![Kubernetes Ingress](/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/ingress.png)
 
-Une Ingress est mise en œuvre par un composant tiers : un Ingress Controller, qui étend les spécifications pour prendre en charge des fonctionnalités supplémentaires.
+An Ingress is implemented by a third-party Ingress Controller that watches the Kubernetes API for new and updated Ingress resources.
 
-Dans ce tutoriel, vous allez installer un Nginx Ingress Controller.  
-Il s'agit d'un Ingress Controller pour Kubernetes, qui utilise un serveur web Nginx comme reverse proxy et Load Balancer.
+In this tutorial, you will install Traefik Proxy. Traefik routes incoming requests to backend Services according to the rules defined in your Ingress resources.
 
-Plus précisément, lorsque vous déployez et exécutez un Nginx Ingress Controller, vous disposez d'un Pod qui exécute Nginx et surveille le Control Plane Kubernetes pour détecter les objets Ingress Resource nouveaux ou mis à jour.
-
-Une Ingress Resource peut être vue comme une liste de règles de routage du trafic vers des Services backend.
-
-Après avoir déployé le Nginx Ingress Controller, vous disposerez également d'un Load Balancer OVHcloud. Grâce à ce Load Balancer, le trafic externe est routé vers le Pod de l'Ingress Controller exécutant Nginx, qui transmet ensuite le trafic aux Services backend appropriés que vous configurez dans les ressources Ingress.
+After deploying Traefik, you will also have an OVHcloud Public Cloud Load Balancer. The Load Balancer routes external traffic to Traefik, which then forwards each request to the appropriate backend Service.
 
 :::warning
-**Important :** il existe deux Ingress Controllers différents pour Nginx :
+The Kubernetes community [retired ingress-nginx in March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/). The project no longer receives releases, bug fixes, or security updates and should not be deployed for new workloads.
 
-- l'[Ingress Controller de Nginx Inc](https://github.com/nginxinc/kubernetes-ingress) ;
-- le [Kubernetes Ingress Nginx Controller](https://github.com/kubernetes/ingress-nginx) (celui présenté dans ce guide).
-
-Si vous choisissez d'installer le premier controller, suivez les instructions fournies dans la [documentation de l'Ingress Controller de Nginx Inc](https://github.com/nginxinc/kubernetes-ingress/tree/v3.3.2/examples/shared-examples/proxy-protocol) et utilisez le proxy protocol OVH v1 en ajoutant l'annotation suivante à votre service :
-
-```yaml
-service:
-  annotations:
-    service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: v1
-```
+This guide previously covered ingress-nginx and now uses Traefik. Existing ingress-nginx users should follow the [Traefik migration guide](https://doc.traefik.io/traefik/migrate/nginx-to-traefik/), review their controller-specific annotations, and test the migration before removing their current controller.
 :::
 
+## Installing the Traefik Helm chart
 
-## Installer le chart Helm du Nginx Ingress Controller
-
-Pour ce tutoriel, nous utilisons le [chart Helm du Nginx Ingress Controller](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) disponible sur son propre repository Helm.
-
-Le chart est entièrement configurable, mais nous utilisons ici la configuration par défaut.
+For this tutorial, we are using the official [Traefik Helm chart](https://github.com/traefik/traefik-helm-chart) with its default configuration.
 
 ```bash
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-```
-Le processus d'installation démarre :
-
-```console
-$ helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-NAME: ingress-nginx
-LAST DEPLOYED: Mon Sep 10 09:20:44 2024
-NAMESPACE: ingress-nginx
-STATUS: deployed
-REVISION: 1
-TEST SUITE: None
-NOTES:
+helm repo add traefik https://traefik.github.io/charts
+helm repo update traefik
+helm upgrade --install traefik traefik/traefik \
+  --version 41.0.2 \
+  --namespace traefik \
+  --create-namespace \
+  --wait --timeout 3m
 ```
 
-À la fin de l'installation, comme pour la plupart des charts Helm, vous obtenez les informations de configuration ainsi que quelques conseils pour tester votre `nginx-ingress` :
-
-```console
-NOTES:
-The ingress-nginx controller has been installed.
-It may take a few minutes for the LoadBalancer IP to be available.
-You can watch the status by running 'kubectl --namespace ingress-nginx get services -o wide -w ingress-nginx-controller'
-
-An example Ingress that makes use of the controller:
-  apiVersion: networking.k8s.io/v1
-  kind: Ingress
-  metadata:
-    name: example
-    namespace: foo
-  spec:
-    ingressClassName: nginx
-    rules:
-      - host: www.example.com
-        http:
-          paths:
-            - pathType: Prefix
-              backend:
-                service:
-                  name: exampleService
-                  port:
-                    number: 80
-              path: /
-    # This section is only required if TLS is to be enabled for the Ingress
-    tls:
-      - hosts:
-        - www.example.com
-        secretName: example-tls
-
-If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:
-
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: example-tls
-    namespace: foo
-  data:
-    tls.crt: <base64 encoded cert>
-    tls.key: <base64 encoded key>
-  type: kubernetes.io/tls
-```
-
-La création du `LoadBalancer` étant asynchrone et son provisionnement pouvant prendre plusieurs minutes, vous obtiendrez certainement un `EXTERNAL-IP` à l'état `<pending>`.
-
-Si vous réessayez quelques minutes plus tard, vous devriez obtenir un `EXTERNAL-IP` :
-
-```console
-$ kubectl get svc -n ingress-nginx ingress-nginx-controller
-NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP       PORT(S)                      AGE
-ingress-nginx-controller   LoadBalancer   10.3.232.157   51.178.69.190     80:30903/TCP,443:31546/TCP   19h
-```
-Vous pouvez ensuite accéder à votre `nginx-ingress` à l'adresse `http://[YOUR_LOAD_BALANCER_IP]` en HTTP ou `https://[YOUR_LOAD_BALANCER_IP]` en HTTPS.
-
-Saisissez la commande suivante pour la récupérer :
+Check that the Traefik Deployment is available:
 
 ```bash
-export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
+kubectl rollout status deployment/traefik -n traefik
 ```
 
-Vous devriez obtenir un résultat de ce type :
+The `LoadBalancer` creation is asynchronous and can take several minutes. Check the Service until an address appears in the `EXTERNAL-IP` column:
 
-```console
-$ export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
-echo Ingress URL: http://$INGRESS_URL/
-Ingress URL: http://51.178.69.190/
+```bash
+kubectl get service traefik -n traefik --watch
 ```
-Pour tester votre `nginx-ingress`, vous pouvez par exemple [installer un WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) sur votre cluster, puis créer un fichier YAML pour l'Ingress utilisant le controller :
+
+Press `Ctrl+C` to stop watching the Service, then retrieve its external IP address:
+
+```bash
+export INGRESS_URL=$(kubectl get service traefik -n traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+echo "Ingress URL: http://$INGRESS_URL/"
+```
+
+## Testing Traefik with an Ingress
+
+To test Traefik, you can, for example, [install WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) on your cluster. Then create an `ingress.yml` file with the following content:
 
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
   name: ingress
   namespace: default
 spec:
-  rules:
-  - http:
-      paths:
-      - backend:
-          service:
-            name: [YOUR_WORDPRESS_SERVICE_NAME]
-            port:
-              number: 80
-        path: /
-        pathType: Prefix
-
-```
-
-:::info
-N'oubliez pas de remplacer `[YOUR_WORDPRESS_SERVICE_NAME]`.
-:::
-
-
-Dans notre exemple, le fichier `ingress.yaml` produit ce résultat :
-
-```yaml
-**apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
-  name: ingress
-  namespace: default
-spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:
@@ -186,28 +82,36 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: my-first-k8s-wordpress
+                name: [YOUR_WORDPRESS_SERVICE_NAME]
                 port:
                   number: 80
 ```
-Appliquez le fichier :
 
-```yaml
+:::info
+Replace `[YOUR_WORDPRESS_SERVICE_NAME]` with the name of your WordPress Service.
+:::
+
+Apply the file:
+
+```bash
 kubectl apply -f ingress.yml
 ```
-Et l'Ingress est créée.
 
-```console
-$ kubectl apply -f ingress.yml 
-ingress.extensions/ingress created
+Check that the Ingress has an address:
+
+```bash
+kubectl get ingress ingress
 ```
 
-Maintenant, si vous pointez votre navigateur vers `http://$INGRESS_URL/`, vous verrez votre WordPress :
+If you point your browser to `http://$INGRESS_URL/`, you will see your WordPress:
 
-<img className="thumbnail" alt="WordPress via Ingress" src="/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/installing-ingress-01.png" loading="lazy" />
+<img className="thumbnail" alt="WordPress using Ingress" src="/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/installing-ingress-01.png" loading="lazy" />
 
-## Aller plus loin
+## Go further
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+- Read the [Traefik Kubernetes Ingress documentation](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress/).
+- Learn how to [use the OVHcloud Public Cloud Load Balancer with MKS](/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer).
 
-- Échangez avec notre [communauté d'utilisateurs](/links/community).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
+
+- Join our [community of users](/links/community).

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
@@ -1,184 +1,80 @@
 ---
-title: Installing Nginx Ingress on OVHcloud Managed Kubernetes
-description: Find out how to install Nginx Ingress on OVHcloud Managed Kubernetes
-lastUpdated: 2024-09-12
+title: Installing Traefik on OVHcloud Managed Kubernetes
+description: Find out how to install Traefik as an Ingress Controller on OVHcloud Managed Kubernetes
+lastUpdated: 2026-07-29
 ---
 
-In this tutorial we are going to guide you with the setup of [Nginx Ingress](https://github.com/kubernetes/ingress-nginx) on your OVHcloud Managed Kubernetes Service.
+This tutorial explains how to install [Traefik](https://github.com/traefik/traefik) as an Ingress Controller on your OVHcloud Managed Kubernetes Service.
 
 ## Before you begin
 
-This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
+This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster and some basic knowledge of how to operate it. If you want to know more about these topics, please refer to the [OVHcloud Managed Kubernetes Service Quickstart](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
 
-You also need to have [Helm](https://docs.helm.sh/) installer on your workstation and your cluster. Please refer to the [How to install Helm on OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) tutorial.
+You also need to have [Helm](https://helm.sh/docs/intro/install/) installed on your workstation. Please refer to the [How to install Helm on OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) tutorial.
 
-## Ingress resources and Nginx Ingress Controller
+## Ingress resources and Traefik
 
-In Kubernetes, an Ingress resource allows you to access your Services from outside the cluster. The goal is to avoid creating a Load Balancer per Service but only one per Ingress.
+In Kubernetes, an Ingress resource allows you to access your Services from outside the cluster. The goal is to avoid creating one Load Balancer per Service and use a single Load Balancer for the Ingress Controller instead.
 
 ![Kubernetes Ingress](/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/ingress.png)
 
-An Ingress is implemented by a 3rd party: an Ingress Controller that extends specs to support additional features.
+An Ingress is implemented by a third-party Ingress Controller that watches the Kubernetes API for new and updated Ingress resources.
 
-In this tutorial, you will install an Nginx Ingress Controller.  
-It is an Ingress controller for Kubernetes using an Nginx web server as a reverse proxy and Load Balancer.
+In this tutorial, you will install Traefik Proxy. Traefik routes incoming requests to backend Services according to the rules defined in your Ingress resources.
 
-Specifically, when you are deploying and running an Nginx Ingress Controller, you will have a Pod that runs Nginx and watches the Kubernetes Control Plane for new and updated Ingress Resource objects.
-
-Imagine an Ingress Resource as a list of traffic routing rules for backend Services.
-
-After deploying the Nginx Ingress Controller, you will also have an OVHcloud Load Balancer. Thanks to this Load Balancer, the external traffic will be routed to the Ingress Controller Pod running Nginx, which then forwards traffic to the appropriate backend Services you will configure in Ingress resources.
+After deploying Traefik, you will also have an OVHcloud Public Cloud Load Balancer. The Load Balancer routes external traffic to Traefik, which then forwards each request to the appropriate backend Service.
 
 :::warning
-**Important:** There are two different Ingress controllers for Nginx:
+The Kubernetes community [retired ingress-nginx in March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/). The project no longer receives releases, bug fixes, or security updates and should not be deployed for new workloads.
 
-- [Nginx Inc Ingress Controller](https://github.com/nginxinc/kubernetes-ingress)
-- [Kubernetes Ingress Nginx Controller](https://github.com/kubernetes/ingress-nginx) (the one covered in this guide)
-
-If you opt to install the first controller, please follow the instructions provided in the [Nginx Inc Ingress Controller documentation](https://github.com/nginxinc/kubernetes-ingress/tree/v3.3.2/examples/shared-examples/proxy-protocol) and use the OVH proxy protocol v1 by adding the following annotation to your service:
-
-```yaml
-service:
-  annotations:
-    service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: v1
-```
+This guide previously covered ingress-nginx and now uses Traefik. Existing ingress-nginx users should follow the [Traefik migration guide](https://doc.traefik.io/traefik/migrate/nginx-to-traefik/), review their controller-specific annotations, and test the migration before removing their current controller.
 :::
 
+## Installing the Traefik Helm chart
 
-## Installing the Nginx Ingress Controller Helm chart
-
-For this tutorial, we are using the [Nginx Ingress Controller Helm chart](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) found on its own Helm repository.
-
-The chart is fully configurable, but here we are using the default configuration.
+For this tutorial, we are using the official [Traefik Helm chart](https://github.com/traefik/traefik-helm-chart) with its default configuration.
 
 ```bash
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-```
-The install process will begin:
-
-```console
-$ helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-NAME: ingress-nginx
-LAST DEPLOYED: Mon Sep 10 09:20:44 2024
-NAMESPACE: ingress-nginx
-STATUS: deployed
-REVISION: 1
-TEST SUITE: None
-NOTES:
+helm repo add traefik https://traefik.github.io/charts
+helm repo update traefik
+helm upgrade --install traefik traefik/traefik \
+  --version 41.0.2 \
+  --namespace traefik \
+  --create-namespace \
+  --wait --timeout 3m
 ```
 
-At the end of the install, as usual with most Helm charts, you get the configuration information and some tips to test your `nginx-ingress`:
-
-```console
-NOTES:
-The ingress-nginx controller has been installed.
-It may take a few minutes for the LoadBalancer IP to be available.
-You can watch the status by running 'kubectl --namespace ingress-nginx get services -o wide -w ingress-nginx-controller'
-
-An example Ingress that makes use of the controller:
-  apiVersion: networking.k8s.io/v1
-  kind: Ingress
-  metadata:
-    name: example
-    namespace: foo
-  spec:
-    ingressClassName: nginx
-    rules:
-      - host: www.example.com
-        http:
-          paths:
-            - pathType: Prefix
-              backend:
-                service:
-                  name: exampleService
-                  port:
-                    number: 80
-              path: /
-    # This section is only required if TLS is to be enabled for the Ingress
-    tls:
-      - hosts:
-        - www.example.com
-        secretName: example-tls
-
-If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:
-
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: example-tls
-    namespace: foo
-  data:
-    tls.crt: <base64 encoded cert>
-    tls.key: <base64 encoded key>
-  type: kubernetes.io/tls
-```
-
-As the `LoadBalancer` creation is asynchronous, and the provisioning of the load balancer can take several minutes, you will surely get a `<pending>` `EXTERNAL-IP`.
-
-If you try again in a few minutes you should get an `EXTERNAL-IP`:
-
-```console
-$ kubectl get svc -n ingress-nginx ingress-nginx-controller
-NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP       PORT(S)                      AGE
-ingress-nginx-controller   LoadBalancer   10.3.232.157   51.178.69.190     80:30903/TCP,443:31546/TCP   19h
-```
-You can then access your `nginx-ingress` at `http://[YOUR_LOAD_BALANCER_IP]` via HTTP or `https://[YOUR_LOAD_BALANCER_IP]` via HTTPS.
-
-Enter the following command to retrieve it:
+Check that the Traefik Deployment is available:
 
 ```bash
-export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
+kubectl rollout status deployment/traefik -n traefik
 ```
 
-You should have a content like this:
+The `LoadBalancer` creation is asynchronous and can take several minutes. Check the Service until an address appears in the `EXTERNAL-IP` column:
 
-```console
-$ export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
-echo Ingress URL: http://$INGRESS_URL/
-Ingress URL: http://51.178.69.190/
+```bash
+kubectl get service traefik -n traefik --watch
 ```
-In order to test your `nginx-ingress`, you can, for example, [install a WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) on your cluster, and then create a YAML file for the Ingress that uses the controller:
+
+Press `Ctrl+C` to stop watching the Service, then retrieve its external IP address:
+
+```bash
+export INGRESS_URL=$(kubectl get service traefik -n traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+echo "Ingress URL: http://$INGRESS_URL/"
+```
+
+## Testing Traefik with an Ingress
+
+To test Traefik, you can, for example, [install WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) on your cluster. Then create an `ingress.yml` file with the following content:
 
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
   name: ingress
   namespace: default
 spec:
-  rules:
-  - http:
-      paths:
-      - backend:
-          service:
-            name: [YOUR_WORDPRESS_SERVICE_NAME]
-            port:
-              number: 80
-        path: /
-        pathType: Prefix
-
-```
-
-:::info
-Don't forget to replace `[YOUR_WORDPRESS_SERVICE_NAME]`.
-:::
-
-
-In our example, the `ingress.yaml` produces this result:
-
-```yaml
-**apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
-  name: ingress
-  namespace: default
-spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:
@@ -186,27 +82,35 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: my-first-k8s-wordpress
+                name: [YOUR_WORDPRESS_SERVICE_NAME]
                 port:
                   number: 80
 ```
+
+:::info
+Replace `[YOUR_WORDPRESS_SERVICE_NAME]` with the name of your WordPress Service.
+:::
+
 Apply the file:
 
-```yaml
+```bash
 kubectl apply -f ingress.yml
 ```
-And the Ingress is created.
 
-```console
-$ kubectl apply -f ingress.yml 
-ingress.extensions/ingress created
+Check that the Ingress has an address:
+
+```bash
+kubectl get ingress ingress
 ```
 
-So now if you point your browser to `http://$INGRESS_URL/`, you will see your WordPress:
+If you point your browser to `http://$INGRESS_URL/`, you will see your WordPress:
 
 <img className="thumbnail" alt="WordPress using Ingress" src="/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/installing-ingress-01.png" loading="lazy" />
 
 ## Go further
+
+- Read the [Traefik Kubernetes Ingress documentation](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress/).
+- Learn how to [use the OVHcloud Public Cloud Load Balancer with MKS](/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
@@ -1,184 +1,80 @@
 ---
-title: Installing Nginx Ingress on OVHcloud Managed Kubernetes
-description: Find out how to install Nginx Ingress on OVHcloud Managed Kubernetes
-lastUpdated: 2024-09-12
+title: Installing Traefik on OVHcloud Managed Kubernetes
+description: Find out how to install Traefik as an Ingress Controller on OVHcloud Managed Kubernetes
+lastUpdated: 2026-07-29
 ---
 
-In this tutorial we are going to guide you with the setup of [Nginx Ingress](https://github.com/kubernetes/ingress-nginx) on your OVHcloud Managed Kubernetes Service.
+This tutorial explains how to install [Traefik](https://github.com/traefik/traefik) as an Ingress Controller on your OVHcloud Managed Kubernetes Service.
 
 ## Before you begin
 
-This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
+This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster and some basic knowledge of how to operate it. If you want to know more about these topics, please refer to the [OVHcloud Managed Kubernetes Service Quickstart](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
 
-You also need to have [Helm](https://docs.helm.sh/) installer on your workstation and your cluster. Please refer to the [How to install Helm on OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) tutorial.
+You also need to have [Helm](https://helm.sh/docs/intro/install/) installed on your workstation. Please refer to the [How to install Helm on OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) tutorial.
 
-## Ingress resources and Nginx Ingress Controller
+## Ingress resources and Traefik
 
-In Kubernetes, an Ingress resource allows you to access your Services from outside the cluster. The goal is to avoid creating a Load Balancer per Service but only one per Ingress.
+In Kubernetes, an Ingress resource allows you to access your Services from outside the cluster. The goal is to avoid creating one Load Balancer per Service and use a single Load Balancer for the Ingress Controller instead.
 
 ![Kubernetes Ingress](/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/ingress.png)
 
-An Ingress is implemented by a 3rd party: an Ingress Controller that extends specs to support additional features.
+An Ingress is implemented by a third-party Ingress Controller that watches the Kubernetes API for new and updated Ingress resources.
 
-In this tutorial, you will install an Nginx Ingress Controller.  
-It is an Ingress controller for Kubernetes using an Nginx web server as a reverse proxy and Load Balancer.
+In this tutorial, you will install Traefik Proxy. Traefik routes incoming requests to backend Services according to the rules defined in your Ingress resources.
 
-Specifically, when you are deploying and running an Nginx Ingress Controller, you will have a Pod that runs Nginx and watches the Kubernetes Control Plane for new and updated Ingress Resource objects.
-
-Imagine an Ingress Resource as a list of traffic routing rules for backend Services.
-
-After deploying the Nginx Ingress Controller, you will also have an OVHcloud Load Balancer. Thanks to this Load Balancer, the external traffic will be routed to the Ingress Controller Pod running Nginx, which then forwards traffic to the appropriate backend Services you will configure in Ingress resources.
+After deploying Traefik, you will also have an OVHcloud Public Cloud Load Balancer. The Load Balancer routes external traffic to Traefik, which then forwards each request to the appropriate backend Service.
 
 :::warning
-**Important:** There are two different Ingress controllers for Nginx:
+The Kubernetes community [retired ingress-nginx in March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/). The project no longer receives releases, bug fixes, or security updates and should not be deployed for new workloads.
 
-- [Nginx Inc Ingress Controller](https://github.com/nginxinc/kubernetes-ingress)
-- [Kubernetes Ingress Nginx Controller](https://github.com/kubernetes/ingress-nginx) (the one covered in this guide)
-
-If you opt to install the first controller, please follow the instructions provided in the [Nginx Inc Ingress Controller documentation](https://github.com/nginxinc/kubernetes-ingress/tree/v3.3.2/examples/shared-examples/proxy-protocol) and use the OVH proxy protocol v1 by adding the following annotation to your service:
-
-```yaml
-service:
-  annotations:
-    service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: v1
-```
+This guide previously covered ingress-nginx and now uses Traefik. Existing ingress-nginx users should follow the [Traefik migration guide](https://doc.traefik.io/traefik/migrate/nginx-to-traefik/), review their controller-specific annotations, and test the migration before removing their current controller.
 :::
 
+## Installing the Traefik Helm chart
 
-## Installing the Nginx Ingress Controller Helm chart
-
-For this tutorial, we are using the [Nginx Ingress Controller Helm chart](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) found on its own Helm repository.
-
-The chart is fully configurable, but here we are using the default configuration.
+For this tutorial, we are using the official [Traefik Helm chart](https://github.com/traefik/traefik-helm-chart) with its default configuration.
 
 ```bash
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-```
-The install process will begin:
-
-```console
-$ helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-NAME: ingress-nginx
-LAST DEPLOYED: Mon Sep 10 09:20:44 2024
-NAMESPACE: ingress-nginx
-STATUS: deployed
-REVISION: 1
-TEST SUITE: None
-NOTES:
+helm repo add traefik https://traefik.github.io/charts
+helm repo update traefik
+helm upgrade --install traefik traefik/traefik \
+  --version 41.0.2 \
+  --namespace traefik \
+  --create-namespace \
+  --wait --timeout 3m
 ```
 
-At the end of the install, as usual with most Helm charts, you get the configuration information and some tips to test your `nginx-ingress`:
-
-```console
-NOTES:
-The ingress-nginx controller has been installed.
-It may take a few minutes for the LoadBalancer IP to be available.
-You can watch the status by running 'kubectl --namespace ingress-nginx get services -o wide -w ingress-nginx-controller'
-
-An example Ingress that makes use of the controller:
-  apiVersion: networking.k8s.io/v1
-  kind: Ingress
-  metadata:
-    name: example
-    namespace: foo
-  spec:
-    ingressClassName: nginx
-    rules:
-      - host: www.example.com
-        http:
-          paths:
-            - pathType: Prefix
-              backend:
-                service:
-                  name: exampleService
-                  port:
-                    number: 80
-              path: /
-    # This section is only required if TLS is to be enabled for the Ingress
-    tls:
-      - hosts:
-        - www.example.com
-        secretName: example-tls
-
-If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:
-
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: example-tls
-    namespace: foo
-  data:
-    tls.crt: <base64 encoded cert>
-    tls.key: <base64 encoded key>
-  type: kubernetes.io/tls
-```
-
-As the `LoadBalancer` creation is asynchronous, and the provisioning of the load balancer can take several minutes, you will surely get a `<pending>` `EXTERNAL-IP`.
-
-If you try again in a few minutes you should get an `EXTERNAL-IP`:
-
-```console
-$ kubectl get svc -n ingress-nginx ingress-nginx-controller
-NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP       PORT(S)                      AGE
-ingress-nginx-controller   LoadBalancer   10.3.232.157   51.178.69.190     80:30903/TCP,443:31546/TCP   19h
-```
-You can then access your `nginx-ingress` at `http://[YOUR_LOAD_BALANCER_IP]` via HTTP or `https://[YOUR_LOAD_BALANCER_IP]` via HTTPS.
-
-Enter the following command to retrieve it:
+Check that the Traefik Deployment is available:
 
 ```bash
-export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
+kubectl rollout status deployment/traefik -n traefik
 ```
 
-You should have a content like this:
+The `LoadBalancer` creation is asynchronous and can take several minutes. Check the Service until an address appears in the `EXTERNAL-IP` column:
 
-```console
-$ export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
-echo Ingress URL: http://$INGRESS_URL/
-Ingress URL: http://51.178.69.190/
+```bash
+kubectl get service traefik -n traefik --watch
 ```
-In order to test your `nginx-ingress`, you can, for example, [install a WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) on your cluster, and then create a YAML file for the Ingress that uses the controller:
+
+Press `Ctrl+C` to stop watching the Service, then retrieve its external IP address:
+
+```bash
+export INGRESS_URL=$(kubectl get service traefik -n traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+echo "Ingress URL: http://$INGRESS_URL/"
+```
+
+## Testing Traefik with an Ingress
+
+To test Traefik, you can, for example, [install WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) on your cluster. Then create an `ingress.yml` file with the following content:
 
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
   name: ingress
   namespace: default
 spec:
-  rules:
-  - http:
-      paths:
-      - backend:
-          service:
-            name: [YOUR_WORDPRESS_SERVICE_NAME]
-            port:
-              number: 80
-        path: /
-        pathType: Prefix
-
-```
-
-:::info
-Don't forget to replace `[YOUR_WORDPRESS_SERVICE_NAME]`.
-:::
-
-
-In our example, the `ingress.yaml` produces this result:
-
-```yaml
-**apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
-  name: ingress
-  namespace: default
-spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:
@@ -186,27 +82,35 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: my-first-k8s-wordpress
+                name: [YOUR_WORDPRESS_SERVICE_NAME]
                 port:
                   number: 80
 ```
+
+:::info
+Replace `[YOUR_WORDPRESS_SERVICE_NAME]` with the name of your WordPress Service.
+:::
+
 Apply the file:
 
-```yaml
+```bash
 kubectl apply -f ingress.yml
 ```
-And the Ingress is created.
 
-```console
-$ kubectl apply -f ingress.yml 
-ingress.extensions/ingress created
+Check that the Ingress has an address:
+
+```bash
+kubectl get ingress ingress
 ```
 
-So now if you point your browser to `http://$INGRESS_URL/`, you will see your WordPress:
+If you point your browser to `http://$INGRESS_URL/`, you will see your WordPress:
 
 <img className="thumbnail" alt="WordPress using Ingress" src="/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/installing-ingress-01.png" loading="lazy" />
 
 ## Go further
+
+- Read the [Traefik Kubernetes Ingress documentation](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress/).
+- Learn how to [use the OVHcloud Public Cloud Load Balancer with MKS](/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
@@ -1,184 +1,80 @@
 ---
-title: Installing Nginx Ingress on OVHcloud Managed Kubernetes
-description: Find out how to install Nginx Ingress on OVHcloud Managed Kubernetes
-lastUpdated: 2024-09-12
+title: Installing Traefik on OVHcloud Managed Kubernetes
+description: Find out how to install Traefik as an Ingress Controller on OVHcloud Managed Kubernetes
+lastUpdated: 2026-07-29
 ---
 
-In this tutorial we are going to guide you with the setup of [Nginx Ingress](https://github.com/kubernetes/ingress-nginx) on your OVHcloud Managed Kubernetes Service.
+This tutorial explains how to install [Traefik](https://github.com/traefik/traefik) as an Ingress Controller on your OVHcloud Managed Kubernetes Service.
 
 ## Before you begin
 
-This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
+This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster and some basic knowledge of how to operate it. If you want to know more about these topics, please refer to the [OVHcloud Managed Kubernetes Service Quickstart](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
 
-You also need to have [Helm](https://docs.helm.sh/) installer on your workstation and your cluster. Please refer to the [How to install Helm on OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) tutorial.
+You also need to have [Helm](https://helm.sh/docs/intro/install/) installed on your workstation. Please refer to the [How to install Helm on OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) tutorial.
 
-## Ingress resources and Nginx Ingress Controller
+## Ingress resources and Traefik
 
-In Kubernetes, an Ingress resource allows you to access your Services from outside the cluster. The goal is to avoid creating a Load Balancer per Service but only one per Ingress.
+In Kubernetes, an Ingress resource allows you to access your Services from outside the cluster. The goal is to avoid creating one Load Balancer per Service and use a single Load Balancer for the Ingress Controller instead.
 
 ![Kubernetes Ingress](/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/ingress.png)
 
-An Ingress is implemented by a 3rd party: an Ingress Controller that extends specs to support additional features.
+An Ingress is implemented by a third-party Ingress Controller that watches the Kubernetes API for new and updated Ingress resources.
 
-In this tutorial, you will install an Nginx Ingress Controller.  
-It is an Ingress controller for Kubernetes using an Nginx web server as a reverse proxy and Load Balancer.
+In this tutorial, you will install Traefik Proxy. Traefik routes incoming requests to backend Services according to the rules defined in your Ingress resources.
 
-Specifically, when you are deploying and running an Nginx Ingress Controller, you will have a Pod that runs Nginx and watches the Kubernetes Control Plane for new and updated Ingress Resource objects.
-
-Imagine an Ingress Resource as a list of traffic routing rules for backend Services.
-
-After deploying the Nginx Ingress Controller, you will also have an OVHcloud Load Balancer. Thanks to this Load Balancer, the external traffic will be routed to the Ingress Controller Pod running Nginx, which then forwards traffic to the appropriate backend Services you will configure in Ingress resources.
+After deploying Traefik, you will also have an OVHcloud Public Cloud Load Balancer. The Load Balancer routes external traffic to Traefik, which then forwards each request to the appropriate backend Service.
 
 :::warning
-**Important:** There are two different Ingress controllers for Nginx:
+The Kubernetes community [retired ingress-nginx in March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/). The project no longer receives releases, bug fixes, or security updates and should not be deployed for new workloads.
 
-- [Nginx Inc Ingress Controller](https://github.com/nginxinc/kubernetes-ingress)
-- [Kubernetes Ingress Nginx Controller](https://github.com/kubernetes/ingress-nginx) (the one covered in this guide)
-
-If you opt to install the first controller, please follow the instructions provided in the [Nginx Inc Ingress Controller documentation](https://github.com/nginxinc/kubernetes-ingress/tree/v3.3.2/examples/shared-examples/proxy-protocol) and use the OVH proxy protocol v1 by adding the following annotation to your service:
-
-```yaml
-service:
-  annotations:
-    service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: v1
-```
+This guide previously covered ingress-nginx and now uses Traefik. Existing ingress-nginx users should follow the [Traefik migration guide](https://doc.traefik.io/traefik/migrate/nginx-to-traefik/), review their controller-specific annotations, and test the migration before removing their current controller.
 :::
 
+## Installing the Traefik Helm chart
 
-## Installing the Nginx Ingress Controller Helm chart
-
-For this tutorial, we are using the [Nginx Ingress Controller Helm chart](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) found on its own Helm repository.
-
-The chart is fully configurable, but here we are using the default configuration.
+For this tutorial, we are using the official [Traefik Helm chart](https://github.com/traefik/traefik-helm-chart) with its default configuration.
 
 ```bash
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-```
-The install process will begin:
-
-```console
-$ helm -n ingress-nginx install ingress-nginx ingress-nginx/ingress-nginx --create-namespace
-NAME: ingress-nginx
-LAST DEPLOYED: Mon Sep 10 09:20:44 2024
-NAMESPACE: ingress-nginx
-STATUS: deployed
-REVISION: 1
-TEST SUITE: None
-NOTES:
+helm repo add traefik https://traefik.github.io/charts
+helm repo update traefik
+helm upgrade --install traefik traefik/traefik \
+  --version 41.0.2 \
+  --namespace traefik \
+  --create-namespace \
+  --wait --timeout 3m
 ```
 
-At the end of the install, as usual with most Helm charts, you get the configuration information and some tips to test your `nginx-ingress`:
-
-```console
-NOTES:
-The ingress-nginx controller has been installed.
-It may take a few minutes for the LoadBalancer IP to be available.
-You can watch the status by running 'kubectl --namespace ingress-nginx get services -o wide -w ingress-nginx-controller'
-
-An example Ingress that makes use of the controller:
-  apiVersion: networking.k8s.io/v1
-  kind: Ingress
-  metadata:
-    name: example
-    namespace: foo
-  spec:
-    ingressClassName: nginx
-    rules:
-      - host: www.example.com
-        http:
-          paths:
-            - pathType: Prefix
-              backend:
-                service:
-                  name: exampleService
-                  port:
-                    number: 80
-              path: /
-    # This section is only required if TLS is to be enabled for the Ingress
-    tls:
-      - hosts:
-        - www.example.com
-        secretName: example-tls
-
-If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:
-
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: example-tls
-    namespace: foo
-  data:
-    tls.crt: <base64 encoded cert>
-    tls.key: <base64 encoded key>
-  type: kubernetes.io/tls
-```
-
-As the `LoadBalancer` creation is asynchronous, and the provisioning of the load balancer can take several minutes, you will surely get a `<pending>` `EXTERNAL-IP`.
-
-If you try again in a few minutes you should get an `EXTERNAL-IP`:
-
-```console
-$ kubectl get svc -n ingress-nginx ingress-nginx-controller
-NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP       PORT(S)                      AGE
-ingress-nginx-controller   LoadBalancer   10.3.232.157   51.178.69.190     80:30903/TCP,443:31546/TCP   19h
-```
-You can then access your `nginx-ingress` at `http://[YOUR_LOAD_BALANCER_IP]` via HTTP or `https://[YOUR_LOAD_BALANCER_IP]` via HTTPS.
-
-Enter the following command to retrieve it:
+Check that the Traefik Deployment is available:
 
 ```bash
-export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
+kubectl rollout status deployment/traefik -n traefik
 ```
 
-You should have a content like this:
+The `LoadBalancer` creation is asynchronous and can take several minutes. Check the Service until an address appears in the `EXTERNAL-IP` column:
 
-```console
-$ export INGRESS_URL=$(kubectl get svc ingress-nginx-controller -n ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[].ip}')
-echo Ingress URL: http://$INGRESS_URL/
-Ingress URL: http://51.178.69.190/
+```bash
+kubectl get service traefik -n traefik --watch
 ```
-In order to test your `nginx-ingress`, you can, for example, [install a WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) on your cluster, and then create a YAML file for the Ingress that uses the controller:
+
+Press `Ctrl+C` to stop watching the Service, then retrieve its external IP address:
+
+```bash
+export INGRESS_URL=$(kubectl get service traefik -n traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+echo "Ingress URL: http://$INGRESS_URL/"
+```
+
+## Testing Traefik with an Ingress
+
+To test Traefik, you can, for example, [install WordPress](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress) on your cluster. Then create an `ingress.yml` file with the following content:
 
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
   name: ingress
   namespace: default
 spec:
-  rules:
-  - http:
-      paths:
-      - backend:
-          service:
-            name: [YOUR_WORDPRESS_SERVICE_NAME]
-            port:
-              number: 80
-        path: /
-        pathType: Prefix
-
-```
-
-:::info
-Don't forget to replace `[YOUR_WORDPRESS_SERVICE_NAME]`.
-:::
-
-
-In our example, the `ingress.yaml` produces this result:
-
-```yaml
-**apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
-  name: ingress
-  namespace: default
-spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:
@@ -186,27 +82,35 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: my-first-k8s-wordpress
+                name: [YOUR_WORDPRESS_SERVICE_NAME]
                 port:
                   number: 80
 ```
+
+:::info
+Replace `[YOUR_WORDPRESS_SERVICE_NAME]` with the name of your WordPress Service.
+:::
+
 Apply the file:
 
-```yaml
+```bash
 kubectl apply -f ingress.yml
 ```
-And the Ingress is created.
 
-```console
-$ kubectl apply -f ingress.yml 
-ingress.extensions/ingress created
+Check that the Ingress has an address:
+
+```bash
+kubectl get ingress ingress
 ```
 
-So now if you point your browser to `http://$INGRESS_URL/`, you will see your WordPress:
+If you point your browser to `http://$INGRESS_URL/`, you will see your WordPress:
 
 <img className="thumbnail" alt="WordPress using Ingress" src="/images/public-cloud/containers-orchestration/managed-kubernetes/installing-nginx-ingress/installing-ingress-01.png" loading="lazy" />
 
 ## Go further
+
+- Read the [Traefik Kubernetes Ingress documentation](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress/).
+- Learn how to [use the OVHcloud Public Cloud Load Balancer with MKS](/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer).
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 

--- a/i18n.json
+++ b/i18n.json
@@ -3105,13 +3105,13 @@
     "pt": "Enforcing policy management on OVHcloud Managed Kubernetes with Kyverno"
   },
   "sidebar.containers.orchestration.managed.kubernetes.installingNginxIngress": {
-    "fr": "Installing Nginx Ingress on OVHcloud Managed Kubernetes",
-    "en": "Installing Nginx Ingress on OVHcloud Managed Kubernetes",
-    "de": "Installing Nginx Ingress on OVHcloud Managed Kubernetes",
-    "es": "Installing Nginx Ingress on OVHcloud Managed Kubernetes",
-    "it": "Installing Nginx Ingress on OVHcloud Managed Kubernetes",
-    "pl": "Installing Nginx Ingress on OVHcloud Managed Kubernetes",
-    "pt": "Installing Nginx Ingress on OVHcloud Managed Kubernetes"
+    "fr": "Installing Traefik on OVHcloud Managed Kubernetes",
+    "en": "Installing Traefik on OVHcloud Managed Kubernetes",
+    "de": "Installing Traefik on OVHcloud Managed Kubernetes",
+    "es": "Installing Traefik on OVHcloud Managed Kubernetes",
+    "it": "Installing Traefik on OVHcloud Managed Kubernetes",
+    "pl": "Installing Traefik on OVHcloud Managed Kubernetes",
+    "pt": "Installing Traefik on OVHcloud Managed Kubernetes"
   },
   "sidebar.containers.orchestration.managed.kubernetes.installingOpenfaas": {
     "fr": "How to install OpenFaaS CE on OVHcloud Managed Kubernetes",


### PR DESCRIPTION
## Summary

- replace the retired ingress-nginx installation flow with Traefik
- use Traefik Helm chart 41.0.2 and the current `networking.k8s.io/v1` Ingress API
- update all seven locale fallback files while preserving the existing guide route and localized footer links
- update the active sidebar and i18n labels to advertise Traefik instead of Nginx Ingress

## Why

The Kubernetes project retired ingress-nginx in March 2026. The controller no longer receives releases, bug fixes, or security updates, but this guide still instructed users to deploy it for new workloads.

Traefik is actively maintained and already used in the OVHcloud `public-cloud-examples` repository for Managed Kubernetes workloads. Keeping the existing route avoids breaking inbound links while replacing the obsolete installation procedure.

This PR is deliberately limited to the canonical installation guide. The separate source-IP, cert-manager, sticky-session, and Keycloak workflows require controller-specific migration steps and should be reviewed independently.

This complements #103, which adds a dedicated NGINX-to-Traefik migration guide. The two changes do not modify any of the same files: this PR fixes the installation path for new deployments, while #103 covers existing deployments.

## Validation

- `pnpm content:lint`
- `pnpm sidebar:validate`
- `git diff --check`
- parsed the embedded Ingress manifest as YAML and verified `networking.k8s.io/v1` with `ingressClassName: traefik`
- `helm lint` for `traefik/traefik` chart 41.0.2
- `helm template` for chart 41.0.2 and verified the rendered `Service/traefik`, `Deployment/traefik`, and `IngressClass/traefik`
- verified all seven locale files are identical after normalizing the localized Professional Services URL

## References

- https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/
- https://github.com/traefik/traefik-helm-chart/releases/tag/v41.0.2
- https://github.com/ovh/public-cloud-examples/commit/41719e89c08a47193b669571acd32207a279be44

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
