### PR TITLE
SK-2665 - WEB - DNS - Update the DNS FAQ for the new Manager UX (4/6)

### DIFF
--- a/docs/de/guides/web-cloud/domains/faq-domain-dns.mdx
+++ b/docs/de/guides/web-cloud/domains/faq-domain-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ zu Domainnamen & DNS
 description: Hier finden Sie die Antworten auf die häufigsten Fragen zu Domainnamen, DNS-Servern und DNS-Zonen
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -444,21 +444,21 @@ Klicken Sie auf die unten stehenden Tabs, um die **2** Schritte nacheinander anz
 
 <Tabs>
   <Tab label="Schritt 1">
-    Gehen Sie auf die Seite <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink>, und wählen Sie den betreffenden Domainnamen aus.
-
-    <img className="thumbnail" alt="DNS-Zone" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Klicken Sie im Bereich `Web Cloud` auf <ManagerLink to="/#/web-domains/domain">Domainnamen</ManagerLink>, wählen Sie den betreffenden Domainnamen aus und öffnen Sie dann den Tab **DNS-Zone**.
+  
+    <img className="thumbnail" alt="Reiter DNS-Zone mit den Einträgen einer Domain" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Schritt 2">
-    Klicken Sie rechts oder unterhalb der Tabelle auf <code className="action">Eintrag hinzufügen</code>.
+    Klicken Sie oberhalb der Tabelle auf <code className="action">Eintrag hinzufügen</code>.
 
-    Sie sehen alle DNS-Einträge, die Sie über den OVHcloud Konfigurationsassistenten hinzufügen können:
+    Sie sehen alle DNS-Einträge, die Sie über das OVHcloud DNS-Zonen-Formular hinzufügen können:
 
     - **Pointer-Einträge**: `A`, `AAAA`, `NS`, `CNAME` und `DNAME`.
     - **Erweiterte Einträge**: `CAA`, `TXT`, `NAPTR`, `SRV`, `LOC`, `SSHFP`, `TLSA`, `RP`, `SVCB` und `HTTPS`.
     - **E-Mail-Einträge**: `MX`, `SPF`, `DKIM` und `DMARC`.
 
     :::info
-    Wenn Sie einen DNS-Eintrag hinzufügen möchten, der nicht aufgelistet ist, schließen Sie das nach dem Klick auf <code className="action">Eintrag hinzufügen</code> geöffnete Fenster und klicken Sie auf die Schaltfläche <code className="action">Im Textmodus bearbeiten</code> rechts oder unterhalb der Tabelle.
+    Wenn Sie einen DNS-Eintrag hinzufügen möchten, der nicht aufgelistet ist, schließen Sie das Formular, öffnen Sie dann das Menü <code className="action">Aktionen zu meiner Zone</code> und klicken Sie auf <code className="action">Im Textmodus bearbeiten</code>.
 
     Sie können dann Ihren gewählten DNS-Eintrag manuell hinzufügen.
 
@@ -592,15 +592,15 @@ Klicken Sie auf die unten stehenden Tabs, um die **3** Schritte nacheinander anz
 
 <Tabs>
   <Tab label="Schritt 1">
-    Gehen Sie auf die Seite <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink>, und wählen Sie den betreffenden Domainnamen aus.
-
-    <img className="thumbnail" alt="DNS-Zone" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Klicken Sie im Bereich `Web Cloud` auf <ManagerLink to="/#/web-domains/domain">Domainnamen</ManagerLink>, wählen Sie den betreffenden Domainnamen aus und öffnen Sie dann den Tab **DNS-Zone**.
+  
+    <img className="thumbnail" alt="Reiter DNS-Zone mit den Einträgen einer Domain" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Schritt 2">
-    Klicken Sie rechts oder unterhalb der Tabelle auf <code className="action">Standard-TTL ändern</code>.
+    Öffnen Sie oberhalb der Tabelle das Menü <code className="action">Aktionen zu meiner Zone</code> und klicken Sie auf <code className="action">Standard-TTL bearbeiten</code>.
   </Tab>
   <Tab label="Schritt 3">
-    Passen Sie im geöffneten Fenster den Wert unter der Bezeichnung `Standard-TTL` Ihren Bedürfnissen an und klicken Sie dann auf <code className="action">Ändern</code>.
+    Passen Sie in dem Bereich, der sich öffnet, den Wert unter der Bezeichnung `Standard-TTL` Ihren Bedürfnissen an und bestätigen Sie dann.
   </Tab>
 </Tabs>
 
@@ -651,7 +651,7 @@ Hier sind verschiedene Methoden zur Überprüfung Ihrer DNS-Zonen-Konfiguration:
 
 - **Der Befehl "nslookup"**: Der Befehl `nslookup` ist auf den meisten Betriebssystemen verfügbar und kann ebenfalls zur Überprüfung Ihrer DNS-Zonen-Konfiguration verwendet werden.
 
-- **Über Ihr OVHcloud Kundencenter**: Wenn die aktive DNS-Zone für Ihren Domainnamen von OVHcloud verwaltet wird, gehen Sie auf die Seite <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink>, um alle für Ihren Domainnamen deklarierten DNS-Einträge anzuzeigen.
+- **Über Ihr OVHcloud Kundencenter**: Wenn die aktive DNS-Zone für Ihren Domainnamen von OVHcloud verwaltet wird, klicken Sie im Bereich `Web Cloud` auf <ManagerLink to="/#/web-domains/domain">Domainnamen</ManagerLink>, wählen Sie den Domainnamen aus und öffnen Sie den Tab **DNS-Zone**, um alle für Ihren Domainnamen deklarierten DNS-Einträge anzuzeigen.
 
 :::tip
 Alle Details finden Sie in unserer Anleitung "[OVHcloud DNS-Zone bearbeiten](/guides/web-cloud/domains/dns-zone-edit)".
@@ -706,15 +706,15 @@ Klicken Sie nach Ermittlung der Seriennummer auf die unten stehenden Tabs, um di
 
 <Tabs>
   <Tab label="Schritt 1">
-    Gehen Sie auf die Seite <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink>, und wählen Sie den betreffenden Domainnamen aus.
-
-    <img className="thumbnail" alt="DNS-Zone" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Klicken Sie im Bereich `Web Cloud` auf <ManagerLink to="/#/web-domains/domain">Domainnamen</ManagerLink>, wählen Sie den betreffenden Domainnamen aus und öffnen Sie dann den Tab **DNS-Zone**.
+  
+    <img className="thumbnail" alt="Reiter DNS-Zone mit den Einträgen einer Domain" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Schritt 2">
-    Klicken Sie rechts oder unterhalb der Tabelle auf <code className="action">Im Textmodus bearbeiten</code>.
+    Öffnen Sie oberhalb der Tabelle das Menü <code className="action">Aktionen zu meiner Zone</code> und klicken Sie auf <code className="action">Im Textmodus bearbeiten</code>.
   </Tab>
   <Tab label="Schritt 3">
-    Suchen Sie im geöffneten Fenster die zweite Zeile, die in unserem Beispiel wie folgt lautet: `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
+    Suchen Sie in dem Texteditor, der sich öffnet, die zweite Zeile, die in unserem Beispiel wie folgt lautet: `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
   </Tab>
   <Tab label="Schritt 4">
     Vergleichen Sie die über das Terminal ermittelte Seriennummer mit der in Ihrem OVHcloud Kundencenter angezeigten.
@@ -728,7 +728,7 @@ Klicken Sie nach Ermittlung der Seriennummer auf die unten stehenden Tabs, um di
     Dies bedeutet entweder:
 
     - Die DNS-Propagation Ihrer Änderungen ist noch nicht abgeschlossen (Sie befinden sich noch im normalen Propagationszeitraum). Warten Sie in diesem Fall, bis die DNS-Propagation vollständig abgeschlossen ist (**24** Stunden für eine DNS-Zonen-Änderung und **48** Stunden für eine DNS-Server-Änderung), und wiederholen Sie dann den Vorgang.
-    - Die DNS-Propagation erfolgt nicht korrekt. Klicken Sie in diesem Fall im in Schritt **3** geöffneten Fenster <code className="action">Im Textmodus bearbeiten</code> direkt **ohne Änderungen vorzunehmen** auf <code className="action">Weiter</code> und dann auf <code className="action">Bestätigen</code>. Eine neue DNS-Propagation wird dann gestartet.
+    - Die DNS-Propagation erfolgt nicht korrekt. Folgen Sie in diesem Fall in dem in Schritt **3** geöffneten Bereich <code className="action">Im Textmodus bearbeiten</code> **ohne Änderungen vorzunehmen** den Schritten auf dem Bildschirm, um zu bestätigen. Eine neue DNS-Propagation wird dann gestartet.
   </Tab>
 </Tabs>
 
@@ -742,15 +742,15 @@ Klicken Sie auf die unten stehenden Tabs, um die **3** Schritte nacheinander anz
 
 <Tabs>
   <Tab label="Schritt 1">
-    Gehen Sie auf die Seite <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink>, und wählen Sie den betreffenden Domainnamen aus.
-
-    <img className="thumbnail" alt="DNS-Zone" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Klicken Sie im Bereich `Web Cloud` auf <ManagerLink to="/#/web-domains/domain">Domainnamen</ManagerLink>, wählen Sie den betreffenden Domainnamen aus und öffnen Sie dann den Tab **DNS-Zone**.
+  
+    <img className="thumbnail" alt="Reiter DNS-Zone mit den Einträgen einer Domain" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Schritt 2">
-    Klicken Sie rechts oder unterhalb der Tabelle auf <code className="action">Verlauf Ihrer DNS-Zone anzeigen</code>.
+    Öffnen Sie oberhalb der Tabelle das Menü <code className="action">Aktionen zu meiner Zone</code> und klicken Sie auf <code className="action">Historie meiner DNS-Zone anzeigen</code>.
   </Tab>
   <Tab label="Schritt 3">
-    Identifizieren Sie in der Tabelle auf der angezeigten Seite die Zeile, die der wiederherzustellenden DNS-Zonen-Sicherung entspricht, und klicken Sie auf das Symbol in der Spalte <code className="action">Wiederherstellen</code>. Die aktuelle Konfiguration der DNS-Zone wird durch die ausgewählte Sicherung ersetzt.
+    Identifizieren Sie in der Tabelle auf der angezeigten Seite die Zeile, die der wiederherzustellenden DNS-Zonen-Sicherung entspricht, und klicken Sie in der Spalte **Wiederherstellen** auf <code className="action">Wiederherstellen</code>. Die aktuelle Konfiguration der DNS-Zone wird durch die ausgewählte Sicherung ersetzt.
   </Tab>
 </Tabs>
 
@@ -774,15 +774,15 @@ Klicken Sie auf die unten stehenden Tabs, um die **3** Schritte nacheinander anz
 
 <Tabs>
   <Tab label="Schritt 1">
-    Gehen Sie auf die Seite <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink>, und wählen Sie den betreffenden Domainnamen aus.
-
-    <img className="thumbnail" alt="DNS-Zone" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Klicken Sie im Bereich `Web Cloud` auf <ManagerLink to="/#/web-domains/domain">Domainnamen</ManagerLink>, wählen Sie den betreffenden Domainnamen aus und öffnen Sie dann den Tab **DNS-Zone**.
+  
+    <img className="thumbnail" alt="Reiter DNS-Zone mit den Einträgen einer Domain" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Schritt 2">
-    Klicken Sie rechts oder unterhalb der Tabelle auf <code className="action">Verlauf Ihrer DNS-Zone anzeigen</code>.
+    Öffnen Sie oberhalb der Tabelle das Menü <code className="action">Aktionen zu meiner Zone</code> und klicken Sie auf <code className="action">Historie meiner DNS-Zone anzeigen</code>.
   </Tab>
   <Tab label="Schritt 3">
-    Identifizieren Sie in der Tabelle auf der angezeigten Seite die Zeile, die der gewünschten DNS-Zonen-Sicherung entspricht, und klicken Sie auf das Symbol in der Spalte <code className="action">Herunterladen</code>. Die Kopie der DNS-Zone wird im Format *.txt* heruntergeladen.
+    Identifizieren Sie in der Tabelle auf der angezeigten Seite die Zeile, die der gewünschten DNS-Zonen-Sicherung entspricht, und klicken Sie auf das Symbol in der Spalte <code className="action">Jetzt herunterladen</code>. Die Kopie der DNS-Zone wird im Format *.txt* heruntergeladen.
   </Tab>
 </Tabs>
 
@@ -803,7 +803,7 @@ Klicken Sie dazu auf die unten stehenden Tabs, um die **4** Schritte nacheinande
 
 <Tabs>
   <Tab label="Schritt 1">
-    Gehen Sie auf die Seite <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink>, und klicken Sie auf die Schaltfläche <code className="action">Bestellen</code> oben rechts in der angezeigten Tabelle.
+    Klicken Sie im Bereich `Web Cloud` auf die Schaltfläche <code className="action">Bestellen</code> und wählen Sie dann <code className="action">DNS-Zone</code> aus.
   </Tab>
   <Tab label="Schritt 2">
     Geben Sie auf der angezeigten Seite die Subdomain ein (z.B. *www.domain.tld*), für die Sie eine OVHcloud DNS-Zone erstellen möchten. Warten Sie einen Moment, während das Tool die Subdomain überprüft.
@@ -822,12 +822,12 @@ Um die Namen der 2 DNS-Server abzurufen, klicken Sie auf die unten stehenden Tab
 
 <Tabs>
   <Tab label="Schritt 1">
-    Gehen Sie auf die Seite <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink>, und wählen Sie die betreffende Subdomain aus.
-
-    <img className="thumbnail" alt="DNS-Zone" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Klicken Sie im Bereich `Web Cloud` auf <ManagerLink to="/#/web-domains/domain">Domainnamen</ManagerLink>, wählen Sie die betreffende Subdomain aus und öffnen Sie dann den Tab **DNS-Zone**.
+  
+    <img className="thumbnail" alt="Reiter DNS-Zone mit den Einträgen einer Domain" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Schritt 2">
-    Rufen Sie oben links auf der angezeigten Seite die 2 DNS-Server-Namen ab, die unter der Bezeichnung `Name Servers` aufgeführt sind. Diese haben eines der folgenden zwei Formate:
+    Suchen Sie in der Tabelle die beiden **NS**-Einträge und notieren Sie die beiden Werte in der Spalte **Ziel**. Diese haben eines der folgenden zwei Formate:
 
     - `dnsXXX.ovh.net` und `nsXXX.ovh.net` **oder** `dnsXXX.ovh.ca` und `nsXXX.ovh.ca` (wobei jedes `X` eine Ziffer zwischen `0` und `9` darstellt).
     - `dns200.ovh.me` und `ns200.anycast.me`.
@@ -842,18 +842,18 @@ Klicken Sie auf die unten stehenden Tabs, um die **4** Schritte nacheinander anz
 
 <Tabs>
   <Tab label="Schritt 1">
-    Gehen Sie auf die Seite <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink>, und wählen Sie den betreffenden Domainnamen aus.
-
-    <img className="thumbnail" alt="DNS-Zone" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Klicken Sie im Bereich `Web Cloud` auf <ManagerLink to="/#/web-domains/domain">Domainnamen</ManagerLink>, wählen Sie den betreffenden Domainnamen aus und öffnen Sie dann den Tab **DNS-Zone**.
+  
+    <img className="thumbnail" alt="Reiter DNS-Zone mit den Einträgen einer Domain" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Schritt 2">
-    Klicken Sie rechts oder unterhalb der Tabelle auf <code className="action">Eintrag hinzufügen</code> und wählen Sie den DNS-Eintragstyp <code className="action">NS</code> aus, um einen DNS-Server zu deklarieren.
+    Klicken Sie oberhalb der Tabelle auf <code className="action">Eintrag hinzufügen</code> und wählen Sie dann den DNS-Eintragstyp <code className="action">NS</code> aus, um einen DNS-Server zu deklarieren.
   </Tab>
   <Tab label="Schritt 3">
-    Geben Sie im geöffneten Fenster im Feld <code className="action">Sub-domain *</code> die Subdomain ein (z.B. schreiben Sie **nur** *www*, wenn Ihr Domainname *domain.tld* ist und Ihre vollständige Subdomain *www.domain.tld* lautet). Geben Sie im Feld <code className="action">Target *</code> **einen** der 2 DNS-Server ein.
+    Geben Sie in dem Formular, das sich öffnet, im Feld <code className="action">Subdomain</code> die Subdomain ein (z.B. schreiben Sie **nur** *www*, wenn Ihr Domainname *domain.tld* ist und Ihre vollständige Subdomain *www.domain.tld* lautet). Geben Sie im Feld <code className="action">Ziel</code> **einen** der 2 DNS-Server ein.
   </Tab>
   <Tab label="Schritt 4">
-    Klicken Sie auf <code className="action">Weiter</code> und dann auf <code className="action">Bestätigen</code>.
+    Klicken Sie auf <code className="action">Hinzufügen</code>.
 
     Wiederholen Sie den Vorgang für den zweiten zu deklarierenden DNS-Server.
   </Tab>
@@ -886,18 +886,18 @@ Klicken Sie auf die unten stehenden Tabs, um die **4** Schritte nacheinander anz
 
 <Tabs>
   <Tab label="Schritt 1">
-    Gehen Sie auf die Seite <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink>, und wählen Sie den betreffenden Domainnamen aus.
-
-    <img className="thumbnail" alt="DNS-Zone" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Klicken Sie im Bereich `Web Cloud` auf <ManagerLink to="/#/web-domains/domain">Domainnamen</ManagerLink>, wählen Sie den betreffenden Domainnamen aus und öffnen Sie dann den Tab **DNS-Zone**.
+  
+    <img className="thumbnail" alt="Reiter DNS-Zone mit den Einträgen einer Domain" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Schritt 2">
-    Klicken Sie rechts oder unterhalb der Tabelle auf <code className="action">Eintrag hinzufügen</code> und wählen Sie den DNS-Eintragstyp <code className="action">A</code> für eine IPv4 (z.B. `203.0.113.0`) oder den DNS-Eintragstyp <code className="action">AAAA</code> für eine IPv6 (z.B. `2001:db8:1:1b00:203:0:113:0`) aus.
+    Klicken Sie oberhalb der Tabelle auf <code className="action">Eintrag hinzufügen</code> und wählen Sie dann den DNS-Eintragstyp <code className="action">A</code> für eine IPv4 (z.B. `203.0.113.0`) oder den DNS-Eintragstyp <code className="action">AAAA</code> für eine IPv6 (z.B. `2001:db8:1:1b00:203:0:113:0`) aus.
   </Tab>
   <Tab label="Schritt 3">
-    Geben Sie im geöffneten Fenster im Feld <code className="action">Sub-domain *</code> den Wert `*` ein. Das Sternchen `*` steht für alle Subdomains (z.B. `www.domain.tld` oder `ovhcloud.domain.tld`) Ihres Domainnamens. Vervollständigen Sie das Feld <code className="action">Target *</code> mit der gewünschten IP-Adresse.
+    Geben Sie in dem Formular, das sich öffnet, im Feld <code className="action">Subdomain</code> den Wert `*` ein. Das Sternchen `*` steht für alle Subdomains (z.B. `www.domain.tld` oder `ovhcloud.domain.tld`) Ihres Domainnamens. Vervollständigen Sie das Feld <code className="action">Ziel</code> mit der gewünschten IP-Adresse.
   </Tab>
   <Tab label="Schritt 4">
-    Klicken Sie auf <code className="action">Weiter</code> und dann auf <code className="action">Bestätigen</code>.
+    Klicken Sie auf <code className="action">Hinzufügen</code>.
   </Tab>
 </Tabs>
 
@@ -923,18 +923,18 @@ Klicken Sie dazu auf die unten stehenden Tabs, um die **4** Schritte nacheinande
 
 <Tabs>
   <Tab label="Schritt 1">
-    Gehen Sie auf die Seite <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink>, und wählen Sie den betreffenden Domainnamen aus.
-
-    <img className="thumbnail" alt="DNS-Zone" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Klicken Sie im Bereich `Web Cloud` auf <ManagerLink to="/#/web-domains/domain">Domainnamen</ManagerLink>, wählen Sie den betreffenden Domainnamen aus und öffnen Sie dann den Tab **DNS-Zone**.
+  
+    <img className="thumbnail" alt="Reiter DNS-Zone mit den Einträgen einer Domain" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Schritt 2">
-    Klicken Sie rechts oder unterhalb der Tabelle auf <code className="action">Eintrag hinzufügen</code> und wählen Sie den DNS-Eintragstyp aus, für den Sie einen Wildcard einrichten möchten.
+    Klicken Sie oberhalb der Tabelle auf <code className="action">Eintrag hinzufügen</code> und wählen Sie dann den DNS-Eintragstyp aus, für den Sie einen Wildcard einrichten möchten.
   </Tab>
   <Tab label="Schritt 3">
-    Geben Sie im geöffneten Fenster im Feld <code className="action">Sub-domain *</code> den Wert `*` ein. Das Sternchen `*` steht für alle Subdomains (z.B. `www.domain.tld` oder `ovhcloud.domain.tld`) Ihres Domainnamens. Vervollständigen Sie die anderen Felder mit den gewünschten Werten.
+    Geben Sie in dem Formular, das sich öffnet, im Feld <code className="action">Subdomain</code> den Wert `*` ein. Das Sternchen `*` steht für alle Subdomains (z.B. `www.domain.tld` oder `ovhcloud.domain.tld`) Ihres Domainnamens. Vervollständigen Sie die anderen Felder mit den gewünschten Werten.
   </Tab>
   <Tab label="Schritt 4">
-    Klicken Sie auf <code className="action">Weiter</code> und dann auf <code className="action">Bestätigen</code>.
+    Klicken Sie auf <code className="action">Hinzufügen</code>.
   </Tab>
 </Tabs>
 
@@ -978,10 +978,10 @@ Klicken Sie auf die unten stehenden Tabs, um die **4** Schritte nacheinander anz
     Wählen Sie den Tab <code className="action">DNS-Zone</code> aus, sobald Sie sich auf dem betreffenden Domainnamen befinden. **Wenn die DNS-Zone inaktiv ist, aktivieren Sie sie über diesen Tab.**
   </Tab>
   <Tab label="Schritt 3">
-    Klicken Sie rechts oder unterhalb der Tabelle auf <code className="action">Im Textmodus bearbeiten</code>.
+    Öffnen Sie oberhalb der Tabelle das Menü <code className="action">Aktionen zu meiner Zone</code> und klicken Sie auf <code className="action">Im Textmodus bearbeiten</code>.
   </Tab>
   <Tab label="Schritt 4">
-    Ersetzen Sie im geöffneten Fenster den gesamten angezeigten Inhalt durch die Kopie der gelöschten DNS-Zone. Klicken Sie auf <code className="action">Weiter</code> und dann auf <code className="action">Bestätigen</code>.
+    Ersetzen Sie in dem Texteditor, der sich öffnet, den gesamten angezeigten Inhalt durch die Kopie der gelöschten DNS-Zone und folgen Sie dann den Schritten auf dem Bildschirm, um zu bestätigen.
   </Tab>
 </Tabs>
 
@@ -1023,10 +1023,10 @@ Klicken Sie auf die unten stehenden Tabs, um die **2** Schritte nacheinander anz
 
 <Tabs>
   <Tab label="Schritt 1">
-    Gehen Sie auf die Seite <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink>, und überprüfen Sie, ob der betreffende Domainname angezeigt wird.
-
-    <img className="thumbnail" alt="DNS-Zone" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Klicken Sie im Bereich `Web Cloud` auf <ManagerLink to="/#/web-domains/domain">Domainnamen</ManagerLink> und überprüfen Sie, ob der betreffende Domainname angezeigt wird.
+  
+    <img className="thumbnail" alt="Reiter DNS-Zone mit den Einträgen einer Domain" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Schritt 2">
     **Fall 1** – Der betreffende Domainname erscheint in der Liste:
 

--- a/docs/en/guides/web-cloud/domains/faq-domain-dns.mdx
+++ b/docs/en/guides/web-cloud/domains/faq-domain-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: Domain name & DNS FAQ
 description: Find the answers to the most frequently asked questions about domain names, DNS servers and DNS zones
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -444,21 +444,21 @@ Click the tabs below to view each of the **2** steps in succession.
 
 <Tabs>
   <Tab label="Step 1">
-    Go to the <ManagerLink to="/#/web/zone">DNS zones</ManagerLink> page, then choose the domain name concerned.
-
-    <img className="thumbnail" alt="DNS zones" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    In the `Web Cloud` section, click <ManagerLink to="/#/web-domains/domain">Domain names</ManagerLink>, select the domain name concerned, then open the **DNS zone** tab.
+  
+    <img className="thumbnail" alt="DNS zone tab listing the records of a domain name" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    On the right or below the table, click <code className="action">Add an entry</code>.
+    Above the table, click <code className="action">Add an entry</code>.
 
-    You will see all the DNS records you can add via the OVHcloud configuration assistant:
+    You will see all the DNS records you can add via the OVHcloud DNS zone form:
 
     - **Pointer records**: `A`, `AAAA`, `NS`, `CNAME`, and `DNAME`.
     - **Extended records**: `CAA`, `TXT`, `NAPTR`, `SRV`, `LOC`, `SSHFP`, `TLSA`, `RP`, `SVCB`, and `HTTPS`.
     - **Email records**: `MX`, `SPF`, `DKIM`, and `DMARC`.
 
     :::info
-    If you want to add a DNS record not listed, close the window that opened after clicking the <code className="action">Add an entry</code> button and click the <code className="action">Change to text mode</code> button on the right or below the table.
+    If you want to add a DNS record not listed, close the form, then open the <code className="action">Actions on my zone</code> menu and click <code className="action">Edit in text mode</code>.
 
     You can then manually add your chosen DNS record.
 
@@ -511,7 +511,7 @@ To do this, click the tabs below to view each of the **3** steps in succession.
     <img className="thumbnail" alt="Domain names" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-names.png" loading="lazy" />
   </Tab>
   <Tab label="Step 2">
-    Select the <code className="action">DNS Servers</code> tab once positioned on the concerned domain name.
+    Select the <code className="action">DNS servers</code> tab once positioned on the concerned domain name.
   </Tab>
   <Tab label="Step 3">
     Click the <code className="action">Modify DNS servers</code> button located to the right of the "DNS servers" table. Depending on your screen resolution, the button may be located below the table.
@@ -592,15 +592,15 @@ Click the tabs below to view each of the **3** steps in succession.
 
 <Tabs>
   <Tab label="Step 1">
-    Go to the <ManagerLink to="/#/web/zone">DNS zones</ManagerLink> page, then choose the domain name concerned.
-
-    <img className="thumbnail" alt="DNS zones" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    In the `Web Cloud` section, click <ManagerLink to="/#/web-domains/domain">Domain names</ManagerLink>, select the domain name concerned, then open the **DNS zone** tab.
+  
+    <img className="thumbnail" alt="DNS zone tab listing the records of a domain name" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    On the right or below the table, click <code className="action">Modify default TTL</code>.
+    Above the table, open the <code className="action">Actions on my zone</code> menu and click <code className="action">Edit the default TTL</code>.
   </Tab>
   <Tab label="Step 3">
-    In the window that opens, adjust the value under the `Default TTL` label according to your needs, then click <code className="action">Modify</code>.
+    In the panel that opens, adjust the value under the `Default TTL` label according to your needs, then confirm.
   </Tab>
 </Tabs>
 
@@ -651,7 +651,7 @@ Here are several methods to verify your DNS zone configuration:
 
 - **The "nslookup" command**: The `nslookup` command is available on most operating systems and can also be used to verify your DNS zone configuration.
 
-- **From your OVHcloud Control Panel**: If the active DNS zone for your domain name is managed by OVHcloud, go to the <ManagerLink to="/#/web/zone">DNS zones</ManagerLink> page to view all the DNS records declared for your domain name.
+- **From your OVHcloud Control Panel**: If the active DNS zone for your domain name is managed by OVHcloud, open the <ManagerLink to="/#/web-domains/domain">Domain names</ManagerLink> section, select the domain name and open the **DNS zone** tab to view all the DNS records declared for it.
 
 :::tip
 Find all the details in our guide "[Editing an OVHcloud DNS zone](/guides/web-cloud/domains/dns-zone-edit)".
@@ -706,15 +706,15 @@ Once the serial number is retrieved, click the tabs below to view each of the **
 
 <Tabs>
   <Tab label="Step 1">
-    Go to the <ManagerLink to="/#/web/zone">DNS zones</ManagerLink> page, then choose the domain name concerned.
-
-    <img className="thumbnail" alt="DNS zones" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    In the `Web Cloud` section, click <ManagerLink to="/#/web-domains/domain">Domain names</ManagerLink>, select the domain name concerned, then open the **DNS zone** tab.
+  
+    <img className="thumbnail" alt="DNS zone tab listing the records of a domain name" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    On the right or below the table, click <code className="action">Change to text mode</code>.
+    Above the table, open the <code className="action">Actions on my zone</code> menu and click <code className="action">Edit in text mode</code>.
   </Tab>
   <Tab label="Step 3">
-    In the window that opens, locate the second line, which in our example would be equivalent to: `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
+    In the text editor that opens, locate the second line, which in our example would be equivalent to: `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
   </Tab>
   <Tab label="Step 4">
     Compare the serial number retrieved via the terminal with the one displayed in your OVHcloud Control Panel.
@@ -728,7 +728,7 @@ Once the serial number is retrieved, click the tabs below to view each of the **
     This means either:
 
     - DNS propagation of your changes is not yet complete (you are still within the standard propagation time frame). In this case, wait until DNS propagation is fully completed (**24** hours for a DNS zone change and **48** hours for a DNS server change), then repeat the process.
-    - DNS propagation is not occurring correctly. In this case, from the <code className="action">Change to text mode</code> window opened in step **3**, click directly **without making any changes** on the <code className="action">Next</code> button, then on <code className="action">Confirm</code>. A new DNS propagation will then be initiated.
+    - DNS propagation is not occurring correctly. In this case, from the <code className="action">Edit in text mode</code> panel opened in step **3**, follow the on-screen steps to confirm **without making any changes**. A new DNS propagation will then be initiated.
   </Tab>
 </Tabs>
 
@@ -742,15 +742,15 @@ Click the tabs below to view each of the **3** steps in succession.
 
 <Tabs>
   <Tab label="Step 1">
-    Go to the <ManagerLink to="/#/web/zone">DNS zones</ManagerLink> page, then choose the domain name concerned.
-
-    <img className="thumbnail" alt="DNS zones" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    In the `Web Cloud` section, click <ManagerLink to="/#/web-domains/domain">Domain names</ManagerLink>, select the domain name concerned, then open the **DNS zone** tab.
+  
+    <img className="thumbnail" alt="DNS zone tab listing the records of a domain name" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    On the right or below the table, click <code className="action">View your DNS zone history</code>.
+    Above the table, open the <code className="action">Actions on my zone</code> menu and click <code className="action">View the history of my DNS zone</code>.
   </Tab>
   <Tab label="Step 3">
-    In the table on the displayed page, identify the line corresponding to the DNS zone backup you want to restore, then click the icon in the <code className="action">Restore</code> column. The current configuration of the DNS zone will be replaced by the selected backup.
+    In the table on the displayed page, identify the line corresponding to the DNS zone backup you want to restore, then click <code className="action">Retrieve</code> in the **Retrieve** column. The current configuration of the DNS zone will be replaced by the selected backup.
   </Tab>
 </Tabs>
 
@@ -774,12 +774,12 @@ Click the tabs below to view each of the **3** steps in succession.
 
 <Tabs>
   <Tab label="Step 1">
-    Go to the <ManagerLink to="/#/web/zone">DNS zones</ManagerLink> page, then choose the domain name concerned.
-
-    <img className="thumbnail" alt="DNS zones" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    In the `Web Cloud` section, click <ManagerLink to="/#/web-domains/domain">Domain names</ManagerLink>, select the domain name concerned, then open the **DNS zone** tab.
+  
+    <img className="thumbnail" alt="DNS zone tab listing the records of a domain name" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    On the right or below the table, click <code className="action">View your DNS zone history</code>.
+    Above the table, open the <code className="action">Actions on my zone</code> menu and click <code className="action">View the history of my DNS zone</code>.
   </Tab>
   <Tab label="Step 3">
     In the table on the displayed page, identify the line corresponding to the DNS zone backup you want to retrieve, then click the icon in the <code className="action">Download</code> column. The DNS zone copy will be downloaded in *.txt* format.
@@ -803,7 +803,7 @@ To do this, click the tabs below to view each of the **4** steps in succession.
 
 <Tabs>
   <Tab label="Step 1">
-    Go to the <ManagerLink to="/#/web/zone">DNS zones</ManagerLink> page, then click the <code className="action">Order</code> button in the top right corner of the displayed table.
+    In the `Web Cloud` section, click the <code className="action">Order</code> button, then select <code className="action">DNS zone</code>.
   </Tab>
   <Tab label="Step 2">
     On the page that appears, enter the subdomain (e.g., *www.domain.tld*) for which you want to create an OVHcloud DNS zone. Wait a few moments while the tool checks the subdomain.
@@ -822,12 +822,12 @@ To retrieve the names of the 2 DNS servers, click the tabs below to view each of
 
 <Tabs>
   <Tab label="Step 1">
-    Go to the <ManagerLink to="/#/web/zone">DNS zones</ManagerLink> page, then choose the subdomain concerned.
-
-    <img className="thumbnail" alt="DNS zones" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    In the `Web Cloud` section, click <ManagerLink to="/#/web-domains/domain">Domain names</ManagerLink>, select the subdomain concerned, then open the **DNS zone** tab.
+  
+    <img className="thumbnail" alt="DNS zone tab listing the records of a domain name" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    In the top left corner of the displayed page, retrieve the 2 DNS server names listed under the `Name Servers` label. These have one of the following two formats:
+    In the table, find the two **NS** records and note the two values in the **Target** column. These have one of the following two formats:
 
     - `dnsXXX.ovh.net` and `nsXXX.ovh.net` **or** `dnsXXX.ovh.ca` and `nsXXX.ovh.ca` (where each `X` represents a digit between `0` and `9`).
     - `dns200.ovh.me` and `ns200.anycast.me`.
@@ -842,18 +842,18 @@ Click the tabs below to view each of the **4** steps in succession.
 
 <Tabs>
   <Tab label="Step 1">
-    Go to the <ManagerLink to="/#/web/zone">DNS zones</ManagerLink> page, then choose the domain name concerned.
-
-    <img className="thumbnail" alt="DNS zones" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    In the `Web Cloud` section, click <ManagerLink to="/#/web-domains/domain">Domain names</ManagerLink>, select the domain name concerned, then open the **DNS zone** tab.
+  
+    <img className="thumbnail" alt="DNS zone tab listing the records of a domain name" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    On the right or below the table, click <code className="action">Add an entry</code>, then select the <code className="action">NS</code> DNS record type to declare a DNS server.
+    Above the table, click <code className="action">Add an entry</code>, then select the <code className="action">NS</code> DNS record type to declare a DNS server.
   </Tab>
   <Tab label="Step 3">
-    In the window that opens, enter the subdomain in the <code className="action">Sub-domain *</code> field (e.g., write **only** *www* if your domain name is *domain.tld* and your full subdomain is *www.domain.tld*). In the <code className="action">Target *</code> field, enter **one** of the 2 DNS servers.
+    In the form that opens, enter the subdomain in the <code className="action">Sub-domain</code> field (e.g., write **only** *www* if your domain name is *domain.tld* and your full subdomain is *www.domain.tld*). In the <code className="action">Target</code> field, enter **one** of the 2 DNS servers.
   </Tab>
   <Tab label="Step 4">
-    Click <code className="action">Next</code>, then <code className="action">Confirm</code>.
+    Click <code className="action">Add</code>.
 
     Repeat the process for the second DNS server to declare.
   </Tab>
@@ -886,18 +886,18 @@ Click the tabs below to view each of the **4** steps in succession.
 
 <Tabs>
   <Tab label="Step 1">
-    Go to the <ManagerLink to="/#/web/zone">DNS zones</ManagerLink> page, then choose the domain name concerned.
-
-    <img className="thumbnail" alt="DNS zones" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    In the `Web Cloud` section, click <ManagerLink to="/#/web-domains/domain">Domain names</ManagerLink>, select the domain name concerned, then open the **DNS zone** tab.
+  
+    <img className="thumbnail" alt="DNS zone tab listing the records of a domain name" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    On the right or below the table, click <code className="action">Add an entry</code>, then select the <code className="action">A</code> DNS record type for an IPv4 (e.g., `203.0.113.0`) or the <code className="action">AAAA</code> DNS record type for an IPv6 (e.g., `2001:db8:1:1b00:203:0:113:0`).
+    Above the table, click <code className="action">Add an entry</code>, then select the <code className="action">A</code> DNS record type for an IPv4 (e.g., `203.0.113.0`) or the <code className="action">AAAA</code> DNS record type for an IPv6 (e.g., `2001:db8:1:1b00:203:0:113:0`).
   </Tab>
   <Tab label="Step 3">
-    In the window that opens and in the <code className="action">Sub-domain *</code> field, enter the value `*`. The asterisk `*` will represent all subdomains (e.g., `www.domain.tld` or `ovhcloud.domain.tld`) of your domain name. Complete the <code className="action">Target *</code> field with the desired IP address.
+    In the form that opens and in the <code className="action">Sub-domain</code> field, enter the value `*`. The asterisk `*` will represent all subdomains (e.g., `www.domain.tld` or `ovhcloud.domain.tld`) of your domain name. Complete the <code className="action">Target</code> field with the desired IP address.
   </Tab>
   <Tab label="Step 4">
-    Click <code className="action">Next</code>, then <code className="action">Confirm</code>.
+    Click <code className="action">Add</code>.
   </Tab>
 </Tabs>
 
@@ -923,18 +923,18 @@ To do this, click the tabs below to view each of the **4** steps in succession.
 
 <Tabs>
   <Tab label="Step 1">
-    Go to the <ManagerLink to="/#/web/zone">DNS zones</ManagerLink> page, then choose the domain name concerned.
-
-    <img className="thumbnail" alt="DNS zones" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    In the `Web Cloud` section, click <ManagerLink to="/#/web-domains/domain">Domain names</ManagerLink>, select the domain name concerned, then open the **DNS zone** tab.
+  
+    <img className="thumbnail" alt="DNS zone tab listing the records of a domain name" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    On the right or below the table, click <code className="action">Add an entry</code>, then select the DNS record type for which you want to set up a wildcard.
+    Above the table, click <code className="action">Add an entry</code>, then select the DNS record type for which you want to set up a wildcard.
   </Tab>
   <Tab label="Step 3">
-    In the window that opens and in the <code className="action">Sub-domain *</code> field, enter the value `*`. The asterisk `*` will represent all subdomains (e.g., `www.domain.tld` or `ovhcloud.domain.tld`) of your domain name. Complete the other fields with the desired values.
+    In the form that opens and in the <code className="action">Sub-domain</code> field, enter the value `*`. The asterisk `*` will represent all subdomains (e.g., `www.domain.tld` or `ovhcloud.domain.tld`) of your domain name. Complete the other fields with the desired values.
   </Tab>
   <Tab label="Step 4">
-    Click <code className="action">Next</code>, then <code className="action">Confirm</code>.
+    Click <code className="action">Add</code>.
   </Tab>
 </Tabs>
 
@@ -975,13 +975,13 @@ Click the tabs below to view each of the **4** steps in succession.
     <img className="thumbnail" alt="Domain names" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-names.png" loading="lazy" />
   </Tab>
   <Tab label="Step 2">
-    Select the <code className="action">DNS Zone</code> tab once positioned on the concerned domain name. **If the DNS zone is inactive, activate it from this tab.**
+    Select the <code className="action">DNS zone</code> tab once positioned on the concerned domain name. **If the DNS zone is inactive, activate it from this tab.**
   </Tab>
   <Tab label="Step 3">
-    On the right or below the table, click <code className="action">Change to text mode</code>.
+    Above the table, open the <code className="action">Actions on my zone</code> menu and click <code className="action">Edit in text mode</code>.
   </Tab>
   <Tab label="Step 4">
-    In the window that opens, replace all the displayed content with the copy of the deleted DNS zone. Click <code className="action">Next</code>, then <code className="action">Confirm</code>.
+    In the text editor that opens, replace all the displayed content with the copy of the deleted DNS zone, then follow the on-screen steps to confirm.
   </Tab>
 </Tabs>
 
@@ -1023,10 +1023,10 @@ Click the tabs below to view each of the **2** steps in succession.
 
 <Tabs>
   <Tab label="Step 1">
-    Go to the <ManagerLink to="/#/web/zone">DNS zones</ManagerLink> page, then check if the concerned domain name appears.
-
-    <img className="thumbnail" alt="DNS zones" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    In the `Web Cloud` section, click <ManagerLink to="/#/web-domains/domain">Domain names</ManagerLink> and check if the concerned domain name appears.
+  
+    <img className="thumbnail" alt="DNS zone tab listing the records of a domain name" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
     **Case #1** - The concerned domain name appears in the list:
 
@@ -1078,7 +1078,7 @@ Click the tabs below to view each of the **3** steps in succession.
     <img className="thumbnail" alt="Domain names" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-names.png" loading="lazy" />
   </Tab>
   <Tab label="Step 2">
-    Select the <code className="action">DNS Servers</code> tab once positioned on the concerned domain name.
+    Select the <code className="action">DNS servers</code> tab once positioned on the concerned domain name.
   </Tab>
   <Tab label="Step 3">
     Click the <code className="action">Modify DNS servers</code> button located to the right of the "DNS servers" table. Depending on your screen resolution, the button may be located below the table.
@@ -1112,7 +1112,7 @@ Click the tabs below to view each of the **3** steps in succession.
     <img className="thumbnail" alt="Domain names" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-names.png" loading="lazy" />
   </Tab>
   <Tab label="Step 2">
-    Select the <code className="action">DNS Servers</code> tab once positioned on the concerned domain name.
+    Select the <code className="action">DNS servers</code> tab once positioned on the concerned domain name.
   </Tab>
   <Tab label="Step 3">
     Click the <code className="action">Modify DNS servers</code> button located to the right of the "DNS servers" table. Depending on your screen resolution, the button may be located below the table.
@@ -1146,7 +1146,7 @@ Click the tabs below to view each of the **3** steps in succession.
     <img className="thumbnail" alt="Domain names" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-names.png" loading="lazy" />
   </Tab>
   <Tab label="Step 2">
-    Select the <code className="action">DNS Servers</code> tab once positioned on the concerned domain name.
+    Select the <code className="action">DNS servers</code> tab once positioned on the concerned domain name.
   </Tab>
   <Tab label="Step 3">
     Click the <code className="action">Modify DNS servers</code> button located to the right of the "DNS servers" table. Depending on your screen resolution, the button may be located below the table.

--- a/docs/es/guides/web-cloud/domains/faq-domain-dns.mdx
+++ b/docs/es/guides/web-cloud/domains/faq-domain-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ sobre los nombres de dominio y DNS
 description: Encuentre las principales preguntas sobre los nombres de dominio, los servidores DNS y las zonas DNS
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -444,21 +444,21 @@ Haga clic en las pestañas de abajo para ver cada uno de los **2** pasos.
 
 <Tabs>
   <Tab label="Paso 1">
-    Acceda a la página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> y seleccione el dominio correspondiente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    En la sección `Web Cloud`, haga clic en <ManagerLink to="/#/web-domains/domain">Dominios</ManagerLink>, seleccione el nombre de dominio en cuestión y abra la pestaña **Zona DNS**.
+  
+    <img className="thumbnail" alt="Pestaña Zona DNS con los registros de un nombre de dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Paso 2">
-    A la derecha o debajo de la tabla, haga clic en <code className="action">Añadir un registro</code>.
+    Encima de la tabla, haga clic en <code className="action">Añadir una entrada</code>.
 
-    Visualizará todos los registros DNS que podrá añadir a través del asistente de configuración de OVHcloud:
+    Visualizará todos los registros DNS que podrá añadir a través del formulario de la zona DNS de OVHcloud:
 
     - **Campos de apuntado**: `A`, `AAAA`, `NS`, `CNAME` y `DNAME`.
     - **Campos extendidos**: `CAA`, `TXT`, `NAPTR`, `SRV`, `LOC`, `SSHFP`, `TLSA`, `RP`, `SVCB` y `HTTPS`.
     - **Campos mail**: `MX`, `SPF`, `DKIM` y `DMARC`.
 
     :::info
-    Si desea añadir un registro DNS que no aparece en la lista, cierre la ventana que se ha abierto tras hacer clic en el botón <code className="action">Añadir un registro</code> y haga clic en el botón <code className="action">Modificar en modo de texto</code> situado a la derecha o debajo de la tabla.
+    Si desea añadir un registro DNS que no aparece en la lista, cierre el formulario, abra el menú <code className="action">Acciones sobre mi zona</code> y haga clic en <code className="action">Modificar en modo textual</code>.
 
     Así podrá añadir manualmente el registro DNS de su elección.
 
@@ -592,15 +592,15 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
 
 <Tabs>
   <Tab label="Paso 1">
-    Acceda a la página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> y seleccione el dominio correspondiente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    En la sección `Web Cloud`, haga clic en <ManagerLink to="/#/web-domains/domain">Dominios</ManagerLink>, seleccione el nombre de dominio en cuestión y abra la pestaña **Zona DNS**.
+  
+    <img className="thumbnail" alt="Pestaña Zona DNS con los registros de un nombre de dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Paso 2">
-    A la derecha o debajo de la tabla, haga clic en <code className="action">Modificar el TTL predeterminado</code>.
+    Encima de la tabla, abra el menú <code className="action">Acciones sobre mi zona</code> y haga clic en <code className="action">Modificar el TTL por defecto</code>.
   </Tab>
   <Tab label="Paso 3">
-    En la ventana que se abre, ajuste el valor bajo la mención `TTL predeterminado` según sus necesidades y haga clic en <code className="action">Modificar</code>.
+    En el panel que aparece, ajuste el valor bajo la mención `TTL por defecto` según sus necesidades y confirme.
   </Tab>
 </Tabs>
 
@@ -651,7 +651,7 @@ Estas son diferentes soluciones para verificar la configuración de una zona DNS
 
 - **El comando "nslookup"**: El comando `nslookup` está disponible en la mayoría de los sistemas operativos y también permite verificar la configuración de su zona DNS.
 
-- **Desde su área de cliente de OVHcloud**: Si la zona DNS activa de su nombre de dominio se gestiona en OVHcloud, acceda a la página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> para visualizar todos los registros DNS declarados para su nombre de dominio.
+- **Desde su área de cliente de OVHcloud**: Si la zona DNS activa de su nombre de dominio se gestiona en OVHcloud, acceda a la sección <ManagerLink to="/#/web-domains/domain">Dominios</ManagerLink>, seleccione el nombre de dominio y abra la pestaña **Zona DNS** para visualizar todos los registros DNS declarados para su nombre de dominio.
 
 :::tip
 Consulte todos los detalles en nuestra guía "[Editar una zona DNS de OVHcloud](/guides/web-cloud/domains/dns-zone-edit)".
@@ -706,15 +706,15 @@ Una vez obtenido el número de serie, haga clic en las pestañas de abajo para v
 
 <Tabs>
   <Tab label="Paso 1">
-    Acceda a la página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> y seleccione el dominio correspondiente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    En la sección `Web Cloud`, haga clic en <ManagerLink to="/#/web-domains/domain">Dominios</ManagerLink>, seleccione el nombre de dominio en cuestión y abra la pestaña **Zona DNS**.
+  
+    <img className="thumbnail" alt="Pestaña Zona DNS con los registros de un nombre de dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Paso 2">
-    A la derecha o debajo de la tabla, haga clic en <code className="action">Modificar en modo de texto</code>.
+    Encima de la tabla, abra el menú <code className="action">Acciones sobre mi zona</code> y haga clic en <code className="action">Modificar en modo textual</code>.
   </Tab>
   <Tab label="Paso 3">
-    En la ventana que se abre, localice la segunda línea que, siguiendo nuestro ejemplo, sería equivalente a esta: `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
+    En el editor de texto que se abre, localice la segunda línea que, siguiendo nuestro ejemplo, sería equivalente a esta: `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
   </Tab>
   <Tab label="Paso 4">
     Compare el número de serie obtenido a través del terminal con el que aparece en su área de cliente de OVHcloud.
@@ -728,7 +728,7 @@ Una vez obtenido el número de serie, haga clic en las pestañas de abajo para v
     Esto significa que:
 
     - La propagación DNS de sus modificaciones aún no ha terminado completamente (todavía está dentro de los plazos estándar de propagación DNS). En este caso, espere a que la propagación DNS finalice completamente (**24** horas para una modificación de zona DNS y **48** horas para una modificación de servidores DNS) y repita la operación.
-    - La propagación DNS no se está realizando correctamente. En este caso, desde la ventana <code className="action">Modificar en modo de texto</code> que se abrió en el paso **3**, haga clic directamente **sin realizar modificaciones** en el botón <code className="action">Siguiente</code> y luego en <code className="action">Validar</code>. Se iniciará una nueva propagación DNS.
+    - La propagación DNS no se está realizando correctamente. En este caso, desde el panel <code className="action">Modificar en modo textual</code> abierto en el paso **3**, siga los pasos indicados en pantalla para confirmar **sin realizar ninguna modificación**. Se iniciará una nueva propagación DNS.
   </Tab>
 </Tabs>
 
@@ -742,12 +742,12 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
 
 <Tabs>
   <Tab label="Paso 1">
-    Acceda a la página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> y seleccione el dominio correspondiente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    En la sección `Web Cloud`, haga clic en <ManagerLink to="/#/web-domains/domain">Dominios</ManagerLink>, seleccione el nombre de dominio en cuestión y abra la pestaña **Zona DNS**.
+  
+    <img className="thumbnail" alt="Pestaña Zona DNS con los registros de un nombre de dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Paso 2">
-    A la derecha o debajo de la tabla, haga clic en <code className="action">Ver el historial de mi zona DNS</code>.
+    Encima de la tabla, abra el menú <code className="action">Acciones sobre mi zona</code> y haga clic en <code className="action">Ver el historial de mi zona DNS</code>.
   </Tab>
   <Tab label="Paso 3">
     En la tabla de la página que aparece, identifique la línea correspondiente a la copia de seguridad de la zona DNS que desea y haga clic en el icono presente en la columna <code className="action">Restaurar</code>. La configuración actual de la zona DNS será sustituida por la copia de seguridad elegida.
@@ -774,12 +774,12 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
 
 <Tabs>
   <Tab label="Paso 1">
-    Acceda a la página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> y seleccione el dominio correspondiente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    En la sección `Web Cloud`, haga clic en <ManagerLink to="/#/web-domains/domain">Dominios</ManagerLink>, seleccione el nombre de dominio en cuestión y abra la pestaña **Zona DNS**.
+  
+    <img className="thumbnail" alt="Pestaña Zona DNS con los registros de un nombre de dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Paso 2">
-    A la derecha o debajo de la tabla, haga clic en <code className="action">Ver el historial de mi zona DNS</code>.
+    Encima de la tabla, abra el menú <code className="action">Acciones sobre mi zona</code> y haga clic en <code className="action">Ver el historial de mi zona DNS</code>.
   </Tab>
   <Tab label="Paso 3">
     En la tabla de la página que aparece, identifique la línea correspondiente a la copia de seguridad de la zona DNS que desea y haga clic en el icono presente en la columna <code className="action">Descargar</code>. La copia de la zona DNS se descargará en formato *.txt*.
@@ -803,7 +803,7 @@ Para ello, haga clic en las pestañas de abajo para ver cada uno de los **4** pa
 
 <Tabs>
   <Tab label="Paso 1">
-    Acceda a la página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> y haga clic en el botón <code className="action">Contratar</code> en la parte superior derecha de la tabla que aparece.
+    En la sección `Web Cloud`, haga clic en el botón <code className="action">Contratar</code> y luego seleccione <code className="action">Zona DNS</code>.
   </Tab>
   <Tab label="Paso 2">
     En la página que aparece, introduzca el subdominio (por ejemplo: *www.domain.tld*) para el que desea crear una zona DNS de OVHcloud. Espere unos instantes mientras la herramienta realiza las verificaciones relativas al subdominio.
@@ -822,12 +822,12 @@ Para obtener los nombres de los 2 servidores DNS, haga clic en las pestañas de 
 
 <Tabs>
   <Tab label="Paso 1">
-    Acceda a la página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> y seleccione el subdominio correspondiente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    En la sección `Web Cloud`, haga clic en <ManagerLink to="/#/web-domains/domain">Dominios</ManagerLink>, seleccione el subdominio en cuestión y abra la pestaña **Zona DNS**.
+  
+    <img className="thumbnail" alt="Pestaña Zona DNS con los registros de un nombre de dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Paso 2">
-    En la parte superior izquierda de la página que aparece, obtenga los 2 nombres de los servidores DNS presentes bajo la mención `Name Servers`. Estos tienen una de las 2 formas siguientes:
+    En la tabla, localice los dos registros **NS** y anote los dos valores presentes en la columna **Destino**. Estos tienen una de las 2 formas siguientes:
 
     - `dnsXXX.ovh.net` y `nsXXX.ovh.net` **o** `dnsXXX.ovh.ca` y `nsXXX.ovh.ca` (donde cada `X` representa un dígito comprendido entre `0` y `9`).
     - `dns200.ovh.me` y `ns200.anycast.me`.
@@ -842,18 +842,18 @@ Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
 
 <Tabs>
   <Tab label="Paso 1">
-    Acceda a la página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> y seleccione el dominio correspondiente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    En la sección `Web Cloud`, haga clic en <ManagerLink to="/#/web-domains/domain">Dominios</ManagerLink>, seleccione el nombre de dominio en cuestión y abra la pestaña **Zona DNS**.
+  
+    <img className="thumbnail" alt="Pestaña Zona DNS con los registros de un nombre de dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Paso 2">
-    A la derecha o debajo de la tabla, haga clic en <code className="action">Añadir un registro</code> y seleccione el tipo de registro DNS <code className="action">NS</code> para declarar un servidor DNS.
+    Encima de la tabla, haga clic en <code className="action">Añadir una entrada</code> y seleccione el tipo de registro DNS <code className="action">NS</code> para declarar un servidor DNS.
   </Tab>
   <Tab label="Paso 3">
-    En la ventana que se abre, introduzca el subdominio en cuestión en el campo <code className="action">Subdominio *</code> (por ejemplo, escriba **únicamente** *www* si su nombre de dominio es *domain.tld* y su subdominio completo es *www.domain.tld*). En el campo <code className="action">Destino *</code>, introduzca **solo uno** de los 2 servidores DNS.
+    En el formulario que aparece, introduzca el subdominio en el campo <code className="action">Subdominio</code> (por ejemplo, escriba **únicamente** *www* si su nombre de dominio es *domain.tld* y su subdominio completo es *www.domain.tld*). En el campo <code className="action">Objetivo</code>, introduzca **uno** de los 2 servidores DNS.
   </Tab>
   <Tab label="Paso 4">
-    Haga clic en <code className="action">Siguiente</code> y luego en <code className="action">Validar</code>.
+    Haga clic en <code className="action">Añadir</code>.
 
     Repita la operación para el segundo servidor DNS restante.
   </Tab>
@@ -886,18 +886,18 @@ Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
 
 <Tabs>
   <Tab label="Paso 1">
-    Acceda a la página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> y seleccione el dominio correspondiente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    En la sección `Web Cloud`, haga clic en <ManagerLink to="/#/web-domains/domain">Dominios</ManagerLink>, seleccione el nombre de dominio en cuestión y abra la pestaña **Zona DNS**.
+  
+    <img className="thumbnail" alt="Pestaña Zona DNS con los registros de un nombre de dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Paso 2">
-    A la derecha o debajo de la tabla, haga clic en <code className="action">Añadir un registro</code> y seleccione el tipo de registro DNS <code className="action">A</code> para una IPv4 (por ejemplo: `203.0.113.0`) o <code className="action">AAAA</code> para una IPv6 (por ejemplo: `2001:db8:1:1b00:203:0:113:0`).
+    Encima de la tabla, haga clic en <code className="action">Añadir una entrada</code> y seleccione el tipo de registro DNS <code className="action">A</code> para una IPv4 (por ejemplo: `203.0.113.0`) o <code className="action">AAAA</code> para una IPv6 (por ejemplo: `2001:db8:1:1b00:203:0:113:0`).
   </Tab>
   <Tab label="Paso 3">
-    En la ventana que se abre, en el campo de entrada <code className="action">Subdominio *</code>, introduzca el valor `*`. El asterisco `*` representará todos los subdominios (por ejemplo: `www.domain.tld` o `ovhcloud.domain.tld`) de su nombre de dominio. Complete el campo <code className="action">Destino *</code> con la dirección IP deseada.
+    En el formulario que aparece, en el campo <code className="action">Subdominio</code>, introduzca el valor `*`. El asterisco `*` representará todos los subdominios (por ejemplo: `www.domain.tld` o `ovhcloud.domain.tld`) de su nombre de dominio. Complete el campo <code className="action">Objetivo</code> con la dirección IP deseada.
   </Tab>
   <Tab label="Paso 4">
-    Haga clic en <code className="action">Siguiente</code> y luego en <code className="action">Validar</code>.
+    Haga clic en <code className="action">Añadir</code>.
   </Tab>
 </Tabs>
 
@@ -923,18 +923,18 @@ Para ello, haga clic en las pestañas de abajo para ver cada uno de los **4** pa
 
 <Tabs>
   <Tab label="Paso 1">
-    Acceda a la página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> y seleccione el dominio correspondiente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    En la sección `Web Cloud`, haga clic en <ManagerLink to="/#/web-domains/domain">Dominios</ManagerLink>, seleccione el nombre de dominio en cuestión y abra la pestaña **Zona DNS**.
+  
+    <img className="thumbnail" alt="Pestaña Zona DNS con los registros de un nombre de dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Paso 2">
-    A la derecha o debajo de la tabla, haga clic en <code className="action">Añadir un registro</code> y seleccione el tipo de registro DNS para el que desea configurar un wildcard.
+    Encima de la tabla, haga clic en <code className="action">Añadir una entrada</code> y seleccione el tipo de registro DNS para el que desea configurar un wildcard.
   </Tab>
   <Tab label="Paso 3">
-    En la ventana que se abre, en el campo de entrada <code className="action">Subdominio *</code>, introduzca el valor `*`. El asterisco `*` representará todos los subdominios (por ejemplo: `www.domain.tld` o `ovhcloud.domain.tld`) de su nombre de dominio. Complete los demás campos con los valores deseados.
+    En el formulario que aparece, en el campo <code className="action">Subdominio</code>, introduzca el valor `*`. El asterisco `*` representará todos los subdominios (por ejemplo: `www.domain.tld` o `ovhcloud.domain.tld`) de su nombre de dominio. Complete los demás campos con los valores deseados.
   </Tab>
   <Tab label="Paso 4">
-    Haga clic en <code className="action">Siguiente</code> y luego en <code className="action">Validar</code>.
+    Haga clic en <code className="action">Añadir</code>.
   </Tab>
 </Tabs>
 
@@ -978,10 +978,10 @@ Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
     Seleccione la pestaña <code className="action">Zona DNS</code> una vez posicionado en el nombre de dominio en cuestión. **Si la zona DNS está inactiva, actívela desde esta pestaña.**
   </Tab>
   <Tab label="Paso 3">
-    A la derecha o debajo de la tabla, haga clic en <code className="action">Modificar en modo de texto</code>.
+    Encima de la tabla, abra el menú <code className="action">Acciones sobre mi zona</code> y haga clic en <code className="action">Modificar en modo textual</code>.
   </Tab>
   <Tab label="Paso 4">
-    En la ventana que se abre, sustituya todo el contenido que aparece por la copia de la zona DNS eliminada. A continuación, haga clic en <code className="action">Siguiente</code> y luego en <code className="action">Validar</code>.
+    En el editor de texto que se abre, sustituya todo el contenido que aparece por la copia de la zona DNS eliminada. A continuación, siga los pasos indicados en pantalla para confirmar.
   </Tab>
 </Tabs>
 
@@ -1023,10 +1023,10 @@ Haga clic en las pestañas de abajo para ver cada uno de los **2** pasos.
 
 <Tabs>
   <Tab label="Paso 1">
-    Acceda a la página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> y compruebe si el nombre de dominio en cuestión aparece.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    En la sección `Web Cloud`, haga clic en <ManagerLink to="/#/web-domains/domain">Dominios</ManagerLink> y compruebe si el nombre de dominio en cuestión aparece.
+  
+    <img className="thumbnail" alt="Pestaña Zona DNS con los registros de un nombre de dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Paso 2">
     **Caso n.º 1** - El nombre de dominio en cuestión aparece en la lista:
 

--- a/docs/fr/guides/web-cloud/domains/faq-domain-dns.mdx
+++ b/docs/fr/guides/web-cloud/domains/faq-domain-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ sur les noms de domaine & DNS
 description: Retrouvez les principales questions posées sur les noms de domaine, les serveurs DNS et les zones DNS
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -444,21 +444,21 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2*
 
 <Tabs>
   <Tab label="Étape 1">
-    Accédez à la page <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink>, puis choisissez le nom de domaine concerné.
-
-    <img className="thumbnail" alt="Zones DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Dans la section `Web Cloud`, cliquez sur <ManagerLink to="/#/web-domains/domain">Noms de domaine</ManagerLink>, sélectionnez le nom de domaine concerné, puis ouvrez l’onglet **Zone DNS**.
+  
+    <img className="thumbnail" alt="Onglet Zone DNS listant les enregistrements d’un nom de domaine" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Étape 2">
-    Sur la droite ou en dessous du tableau, cliquez sur <code className="action">Ajouter une entrée</code>.
+    Au-dessus du tableau, cliquez sur <code className="action">Ajouter une entrée</code>.
 
-    Vous visualiserez l’ensemble des enregistrements DNS que vous pourrez ajouter via l’assistant de configuration OVHcloud :
+    Vous visualiserez l’ensemble des enregistrements DNS que vous pourrez ajouter via le formulaire de zone DNS OVHcloud :
 
     - **Champs de pointage** : `A`, `AAAA`, `NS`, `CNAME` et `DNAME`.
     - **Champs étendus** : `CAA`, `TXT`, `NAPTR`, `SRV`, `LOC`, `SSHFP`, `TLSA`, `RP`, `SVCB` et `HTTPS`.
     - **Champs mail** : `MX`, `SPF`, `DKIM` et `DMARC`.
 
     :::info
-    Si vous souhaitez ajouter un enregistrement DNS qui n’est pas présent dans la liste, fermez la fenêtre qui s’est ouverte après avoir cliqué sur le bouton <code className="action">Ajouter une entrée</code> et cliquez sur le bouton <code className="action">Modifier en mode textuel</code> situé sur la droite ou en dessous du tableau.
+    Si vous souhaitez ajouter un enregistrement DNS qui n’est pas présent dans la liste, fermez le formulaire, puis ouvrez le menu <code className="action">Actions sur ma zone</code> et cliquez sur <code className="action">Modifier en mode textuel</code>.
 
     Vous pourrez ainsi ajouter manuellement l’enregistrement DNS de votre choix.
 
@@ -592,15 +592,15 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 
 <Tabs>
   <Tab label="Étape 1">
-    Accédez à la page <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink>, puis choisissez le nom de domaine concerné.
-
-    <img className="thumbnail" alt="Zones DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Dans la section `Web Cloud`, cliquez sur <ManagerLink to="/#/web-domains/domain">Noms de domaine</ManagerLink>, sélectionnez le nom de domaine concerné, puis ouvrez l’onglet **Zone DNS**.
+  
+    <img className="thumbnail" alt="Onglet Zone DNS listant les enregistrements d’un nom de domaine" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Étape 2">
-    Sur la droite ou en dessous du tableau, cliquez sur <code className="action">Modifier le TTL par défaut</code>.
+    Au-dessus du tableau, ouvrez le menu <code className="action">Actions sur ma zone</code> et cliquez sur <code className="action">Modifier le TTL par défaut</code>.
   </Tab>
   <Tab label="Étape 3">
-    Dans la fenêtre qui s’ouvre, ajustez la valeur sous la mention `TTL par défaut` en fonction de vos besoins, puis cliquez sur <code className="action">Modifier</code>.
+    Dans le panneau qui s’ouvre, ajustez la valeur sous la mention `TTL par défaut` en fonction de vos besoins, puis confirmez.
   </Tab>
 </Tabs>
 
@@ -647,11 +647,11 @@ Voici différentes solutions pour vérifier la configuration d’une zone DNS :
 
 - **Un outil de vérification en ligne** : Plusieurs outils en ligne permettent de vérifier la configuration de votre zone DNS. Retrouvez-les directement grâce à un navigateur Internet (Chrome, Edge, Firefox, Safari, etc.) en saisissant les mots-clés adéquats (par exemple : « vérifier propagation DNS ») dans un moteur de recherche.
 
-- **La commande « dig »** : Si vous avez accès à un *terminal* depuis un système d’exploitation Linux ou macOS, vous pouvez utiliser la commande `dig` pour vérifier la configuration de votre zone DNS sur le réseau DNS.
+- **La commande « dig »** : Si vous avez accès à un *terminal* depuis un système d’exploitation Linux ou macOS, vous pouvez utiliser la commande `dig` pour vérifier la configuration de votre zone DNS sur le réseau DNS.
 
 - **La commande « nslookup »** : La commande `nslookup` est disponible sur la plupart des systèmes d’exploitation et permet également de vérifier la configuration de votre zone DNS.
 
-- **Depuis votre espace client OVHcloud** : Si la zone DNS active de votre nom de domaine est gérée chez OVHcloud, accédez à la page <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink> pour visualiser l’ensemble des enregistrements DNS déclarés pour votre nom de domaine.
+- **Depuis votre espace client OVHcloud** : Si la zone DNS active de votre nom de domaine est gérée chez OVHcloud, ouvrez la section <ManagerLink to="/#/web-domains/domain">Noms de domaine</ManagerLink>, sélectionnez le nom de domaine et ouvrez l’onglet **Zone DNS** pour visualiser l’ensemble des enregistrements DNS déclarés pour votre nom de domaine.
 
 :::tip
 Retrouvez tous les détails dans notre guide « [Éditer une zone DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit) ».
@@ -706,15 +706,15 @@ Une fois le numéro de série récupéré, cliquez sur les onglets ci-dessous po
 
 <Tabs>
   <Tab label="Étape 1">
-    Accédez à la page <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink>, puis choisissez le nom de domaine concerné.
-
-    <img className="thumbnail" alt="Zones DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Dans la section `Web Cloud`, cliquez sur <ManagerLink to="/#/web-domains/domain">Noms de domaine</ManagerLink>, sélectionnez le nom de domaine concerné, puis ouvrez l’onglet **Zone DNS**.
+  
+    <img className="thumbnail" alt="Onglet Zone DNS listant les enregistrements d’un nom de domaine" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Étape 2">
-    Sur la droite ou en dessous du tableau, cliquez sur <code className="action">Modifier en mode textuel</code>.
+    Au-dessus du tableau, ouvrez le menu <code className="action">Actions sur ma zone</code> et cliquez sur <code className="action">Modifier en mode textuel</code>.
   </Tab>
   <Tab label="Étape 3">
-    Dans la fenêtre qui s’ouvre, repérez la deuxième ligne qui, pour reprendre notre exemple, serait équivalente à celle-ci : `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
+    Dans l’éditeur de texte qui s’ouvre, repérez la deuxième ligne qui, pour reprendre notre exemple, serait équivalente à celle-ci : `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
   </Tab>
   <Tab label="Étape 4">
     Comparez le numéro de série récupéré via le terminal avec celui qui s’affiche dans votre espace client OVHcloud.
@@ -728,7 +728,7 @@ Une fois le numéro de série récupéré, cliquez sur les onglets ci-dessous po
     Cela signifie que soit :
 
     - La propagation DNS de vos modifications n’est pas totalement terminée (vous êtes encore dans les délais standards de propagation DNS). Dans ce cas, patientez le temps que la propagation DNS soit totalement terminée (**24** heures pour une modification de zone DNS et **48** heures pour une modification des serveurs DNS), puis réitérez l’opération.
-    - La propagation DNS ne s’effectue pas correctement. Dans ce cas, depuis la fenêtre <code className="action">Modifier en mode textuel</code> qui s’est ouverte à l’étape **3**, cliquez directement **sans effectuer de modifications** sur le bouton <code className="action">Suivant</code>, puis sur <code className="action">Valider</code>. Une nouvelle propagation DNS sera alors initiée.
+    - La propagation DNS ne s’effectue pas correctement. Dans ce cas, depuis le panneau <code className="action">Modifier en mode textuel</code> ouvert à l’étape **3**, suivez les étapes affichées à l’écran pour valider **sans effectuer de modifications**. Une nouvelle propagation DNS sera alors initiée.
   </Tab>
 </Tabs>
 
@@ -736,21 +736,21 @@ Une fois le numéro de série récupéré, cliquez sur les onglets ci-dessous po
 
 <details>
 
-<summary>Comment restaurer une zone DNS ?</summary>
+<summary>Comment restaurer une zone DNS ?</summary>
 
 Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
 <Tabs>
   <Tab label="Étape 1">
-    Accédez à la page <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink>, puis choisissez le nom de domaine concerné.
-
-    <img className="thumbnail" alt="Zones DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Dans la section `Web Cloud`, cliquez sur <ManagerLink to="/#/web-domains/domain">Noms de domaine</ManagerLink>, sélectionnez le nom de domaine concerné, puis ouvrez l’onglet **Zone DNS**.
+  
+    <img className="thumbnail" alt="Onglet Zone DNS listant les enregistrements d’un nom de domaine" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Étape 2">
-    Sur la droite ou en dessous du tableau, cliquez sur <code className="action">Voir l'historique de ma zone DNS</code>.
+    Au-dessus du tableau, ouvrez le menu <code className="action">Actions sur ma zone</code> et cliquez sur <code className="action">Voir l'historique de ma zone DNS</code>.
   </Tab>
   <Tab label="Étape 3">
-    Dans le tableau de la page qui s’affiche, identifiez la ligne correspondant à la sauvegarde de la zone DNS de votre choix, puis cliquez sur l’icône présente dans la colonne <code className="action">Restaurer</code>. La configuration actuelle de la zone DNS sera remplacée par la sauvegarde choisie.
+    Dans le tableau de la page qui s’affiche, identifiez la ligne correspondant à la sauvegarde de la zone DNS que vous souhaitez restaurer, puis cliquez sur <code className="action">Restaurer</code> dans la colonne **Restaurer**. La configuration actuelle de la zone DNS sera remplacée par la sauvegarde choisie.
   </Tab>
 </Tabs>
 
@@ -774,12 +774,12 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 
 <Tabs>
   <Tab label="Étape 1">
-    Accédez à la page <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink>, puis choisissez le nom de domaine concerné.
-
-    <img className="thumbnail" alt="Zones DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Dans la section `Web Cloud`, cliquez sur <ManagerLink to="/#/web-domains/domain">Noms de domaine</ManagerLink>, sélectionnez le nom de domaine concerné, puis ouvrez l’onglet **Zone DNS**.
+  
+    <img className="thumbnail" alt="Onglet Zone DNS listant les enregistrements d’un nom de domaine" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Étape 2">
-    Sur la droite ou en dessous du tableau, cliquez sur <code className="action">Voir l'historique de ma zone DNS</code>.
+    Au-dessus du tableau, ouvrez le menu <code className="action">Actions sur ma zone</code> et cliquez sur <code className="action">Voir l'historique de ma zone DNS</code>.
   </Tab>
   <Tab label="Étape 3">
     Dans le tableau de la page qui s’affiche, identifiez la ligne correspondant à la sauvegarde de la zone DNS de votre choix, puis cliquez sur l’icône présente dans la colonne <code className="action">Télécharger</code>. La copie de la zone DNS sera téléchargée au format *.txt*.
@@ -803,7 +803,7 @@ Pour ce faire, cliquez sur les onglets ci-dessous pour afficher successivement c
 
 <Tabs>
   <Tab label="Étape 1">
-    Accédez à la page <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink>, puis cliquez sur le bouton <code className="action">Commander</code> en haut à droite du tableau qui s’affiche.
+    Dans la section `Web Cloud`, cliquez sur le bouton <code className="action">Commander</code>, puis sélectionnez <code className="action">Zone DNS</code>.
   </Tab>
   <Tab label="Étape 2">
     Sur la page qui apparaît, renseignez le sous-domaine (par exemple : *www.domain.tld*) pour lequel vous souhaitez créer une zone DNS OVHcloud. Patientez quelques instants le temps que l’outil effectue des vérifications concernant le sous-domaine.
@@ -822,12 +822,12 @@ Pour récupérer les noms des 2 serveurs DNS, cliquez sur les onglets ci-dessous
 
 <Tabs>
   <Tab label="Étape 1">
-    Accédez à la page <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink>, puis choisissez le sous-domaine concerné.
-
-    <img className="thumbnail" alt="Zones DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Dans la section `Web Cloud`, cliquez sur <ManagerLink to="/#/web-domains/domain">Noms de domaine</ManagerLink>, sélectionnez le sous-domaine concerné, puis ouvrez l’onglet **Zone DNS**.
+  
+    <img className="thumbnail" alt="Onglet Zone DNS listant les enregistrements d’un nom de domaine" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Étape 2">
-    En haut à gauche de la page qui s’affiche, récupérez les 2 noms des serveurs DNS présents sous la mention `Name Servers`. Ces derniers ont l’une des 2 formes suivantes :
+    Dans le tableau, repérez les deux enregistrements **NS** et notez les deux valeurs présentes dans la colonne **Cible**. Ces derniers ont l’une des 2 formes suivantes :
 
     - `dnsXXX.ovh.net` et `nsXXX.ovh.net` **ou** `dnsXXX.ovh.ca` et `nsXXX.ovh.ca` (où chaque `X` représente un chiffre compris entre `0` et `9`).
     - `dns200.ovh.me` et `ns200.anycast.me`.
@@ -836,24 +836,24 @@ Pour récupérer les noms des 2 serveurs DNS, cliquez sur les onglets ci-dessous
 
 Une fois les 2 serveurs DNS en votre possession, déclarez-les à l’aide de deux enregistrements de type NS dans la zone DNS active du nom de domaine dont provient votre sous-domaine.
 
-Cas n°1 - La zone DNS active du nom de domaine dont provient votre sous-domaine est chez OVHcloud :
+Cas n°1 - La zone DNS active du nom de domaine dont provient votre sous-domaine est chez OVHcloud :
 
 Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4** étapes.
 
 <Tabs>
   <Tab label="Étape 1">
-    Accédez à la page <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink>, puis choisissez le nom de domaine concerné.
-
-    <img className="thumbnail" alt="Zones DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Dans la section `Web Cloud`, cliquez sur <ManagerLink to="/#/web-domains/domain">Noms de domaine</ManagerLink>, sélectionnez le nom de domaine concerné, puis ouvrez l’onglet **Zone DNS**.
+  
+    <img className="thumbnail" alt="Onglet Zone DNS listant les enregistrements d’un nom de domaine" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Étape 2">
-    Sur la droite ou en dessous du tableau, cliquez sur <code className="action">Ajouter une entrée</code>, puis sélectionnez le type d’enregistrement DNS de type <code className="action">NS</code> pour déclarer un serveur DNS.
+    Au-dessus du tableau, cliquez sur <code className="action">Ajouter une entrée</code>, puis sélectionnez le type d’enregistrement DNS de type <code className="action">NS</code> pour déclarer un serveur DNS.
   </Tab>
   <Tab label="Étape 3">
-    Dans la fenêtre qui s’ouvre, renseignez le sous-domaine concerné dans le champ <code className="action">Sous-domaine *</code> (par exemple, écrivez **uniquement** *www* si votre nom de domaine est *domain.tld* et que votre sous-domaine complet est *www.domain.tld*). Dans le champ <code className="action">Cible *</code>, renseignez **un seul** des 2 serveurs DNS.
+    Dans le formulaire qui s’ouvre, renseignez le sous-domaine concerné dans le champ <code className="action">Sous-domaine</code> (par exemple, écrivez **uniquement** *www* si votre nom de domaine est *domain.tld* et que votre sous-domaine complet est *www.domain.tld*). Dans le champ <code className="action">Cible</code>, renseignez **un seul** des 2 serveurs DNS.
   </Tab>
   <Tab label="Étape 4">
-    Cliquez sur <code className="action">Suivant</code>, puis sur <code className="action">Valider</code>.
+    Cliquez sur <code className="action">Ajouter</code>.
 
     Réitérez l’opération pour le second serveur DNS restant à déclarer.
   </Tab>
@@ -886,18 +886,18 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4*
 
 <Tabs>
   <Tab label="Étape 1">
-    Accédez à la page <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink>, puis choisissez le nom de domaine concerné.
-
-    <img className="thumbnail" alt="Zones DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Dans la section `Web Cloud`, cliquez sur <ManagerLink to="/#/web-domains/domain">Noms de domaine</ManagerLink>, sélectionnez le nom de domaine concerné, puis ouvrez l’onglet **Zone DNS**.
+  
+    <img className="thumbnail" alt="Onglet Zone DNS listant les enregistrements d’un nom de domaine" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Étape 2">
-    Sur la droite ou en dessous du tableau, cliquez sur <code className="action">Ajouter une entrée</code>, puis sélectionnez le type d’enregistrement DNS de type <code className="action">A</code> pour une IPv4 (par exemple : `203.0.113.0`) ou de type <code className="action">AAAA</code> pour une IPv6 (par exemple : `2001:db8:1:1b00:203:0:113:0`).
+    Au-dessus du tableau, cliquez sur <code className="action">Ajouter une entrée</code>, puis sélectionnez le type d’enregistrement DNS de type <code className="action">A</code> pour une IPv4 (par exemple : `203.0.113.0`) ou de type <code className="action">AAAA</code> pour une IPv6 (par exemple : `2001:db8:1:1b00:203:0:113:0`).
   </Tab>
   <Tab label="Étape 3">
-    Dans la fenêtre qui s’ouvre et dans le champ de saisie intitulé <code className="action">Sous-domaine *</code>, renseignez la valeur `*`. L’astérisque `*` représentera l’ensemble des sous-domaines (par exemple : `www.domain.tld` ou encore `ovhcloud.domain.tld`) de votre nom de domaine. Complétez le champ <code className="action">Cible *</code> par l’adresse IP désirée.
+    Dans le formulaire qui s’ouvre et dans le champ de saisie intitulé <code className="action">Sous-domaine</code>, renseignez la valeur `*`. L’astérisque `*` représentera l’ensemble des sous-domaines (par exemple : `www.domain.tld` ou encore `ovhcloud.domain.tld`) de votre nom de domaine. Complétez le champ <code className="action">Cible</code> par l’adresse IP désirée.
   </Tab>
   <Tab label="Étape 4">
-    Cliquez sur <code className="action">Suivant</code>, puis sur <code className="action">Valider</code>.
+    Cliquez sur <code className="action">Ajouter</code>.
   </Tab>
 </Tabs>
 
@@ -923,18 +923,18 @@ Pour cela, cliquez sur les onglets ci-dessous pour afficher successivement chacu
 
 <Tabs>
   <Tab label="Étape 1">
-    Accédez à la page <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink>, puis choisissez le nom de domaine concerné.
-
-    <img className="thumbnail" alt="Zones DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Dans la section `Web Cloud`, cliquez sur <ManagerLink to="/#/web-domains/domain">Noms de domaine</ManagerLink>, sélectionnez le nom de domaine concerné, puis ouvrez l’onglet **Zone DNS**.
+  
+    <img className="thumbnail" alt="Onglet Zone DNS listant les enregistrements d’un nom de domaine" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Étape 2">
-    Sur la droite ou en dessous du tableau, cliquez sur <code className="action">Ajouter une entrée</code>, puis sélectionnez le type d’enregistrement DNS pour lequel vous souhaitez mettre en place un wildcard.
+    Au-dessus du tableau, cliquez sur <code className="action">Ajouter une entrée</code>, puis sélectionnez le type d’enregistrement DNS pour lequel vous souhaitez mettre en place un wildcard.
   </Tab>
   <Tab label="Étape 3">
-    Dans la fenêtre qui s’ouvre et dans le champ de saisie intitulé <code className="action">Sous-domaine *</code>, renseignez la valeur `*`. L’astérisque `*` représentera l’ensemble des sous-domaines (par exemple : `www.domain.tld` ou encore `ovhcloud.domain.tld`) de votre nom de domaine. Complétez les autres champs par les valeurs désirées.
+    Dans le formulaire qui s’ouvre et dans le champ de saisie intitulé <code className="action">Sous-domaine</code>, renseignez la valeur `*`. L’astérisque `*` représentera l’ensemble des sous-domaines (par exemple : `www.domain.tld` ou encore `ovhcloud.domain.tld`) de votre nom de domaine. Complétez les autres champs par les valeurs désirées.
   </Tab>
   <Tab label="Étape 4">
-    Cliquez sur <code className="action">Suivant</code>, puis sur <code className="action">Valider</code>.
+    Cliquez sur <code className="action">Ajouter</code>.
   </Tab>
 </Tabs>
 
@@ -978,10 +978,10 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4*
     Sélectionnez l’onglet <code className="action">Zone DNS</code> une fois positionné sur le nom de domaine concerné. **Si la zone DNS est inactive, activez-la depuis cet onglet.**
   </Tab>
   <Tab label="Étape 3">
-    Sur la droite ou en dessous du tableau, cliquez sur <code className="action">Modifier en mode textuel</code>.
+    Au-dessus du tableau, ouvrez le menu <code className="action">Actions sur ma zone</code> et cliquez sur <code className="action">Modifier en mode textuel</code>.
   </Tab>
   <Tab label="Étape 4">
-    Dans la fenêtre qui s’ouvre, remplacez tout le contenu qui s’affiche par la copie de la zone DNS supprimée. Cliquez ensuite sur <code className="action">Suivant</code>, puis sur <code className="action">Valider</code>.
+    Dans l’éditeur de texte qui s’ouvre, remplacez tout le contenu qui s’affiche par la copie de la zone DNS supprimée, puis suivez les étapes affichées à l’écran pour valider.
   </Tab>
 </Tabs>
 
@@ -1023,10 +1023,10 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2*
 
 <Tabs>
   <Tab label="Étape 1">
-    Accédez à la page <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink>, puis vérifiez si le nom de domaine concerné apparaît.
-
-    <img className="thumbnail" alt="Zones DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Dans la section `Web Cloud`, cliquez sur <ManagerLink to="/#/web-domains/domain">Noms de domaine</ManagerLink> et vérifiez si le nom de domaine concerné apparaît.
+  
+    <img className="thumbnail" alt="Onglet Zone DNS listant les enregistrements d’un nom de domaine" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Étape 2">
     **Cas n°1** - Le nom de domaine concerné apparaît dans la liste :
 

--- a/docs/it/guides/web-cloud/domains/faq-domain-dns.mdx
+++ b/docs/it/guides/web-cloud/domains/faq-domain-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ sui nomi di dominio & DNS
 description: Ritrova le principali domande sui nomi di dominio, i server DNS e le zone DNS
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -444,21 +444,21 @@ Clicca sulle schede qui sotto per visualizzare i **2** step in sequenza.
 
 <Tabs>
   <Tab label="Step 1">
-    Accedi alla pagina <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink>, poi seleziona il dominio interessato.
-
-    <img className="thumbnail" alt="Zone DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Nella sezione `Web Cloud`, clicca su <ManagerLink to="/#/web-domains/domain">Domini</ManagerLink>, seleziona il dominio interessato, poi apri la scheda **Zona DNS**.
+  
+    <img className="thumbnail" alt="Tab Zona DNS con i record di un dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    A destra o sotto la tabella, clicca su <code className="action">Aggiungi un record</code>.
+    Sopra la tabella, clicca su <code className="action">Aggiungi una voce</code>.
 
-    Visualizzerai tutti i record DNS che potrai aggiungere tramite la procedura guidata di configurazione OVHcloud:
+    Visualizzerai tutti i record DNS che potrai aggiungere tramite il modulo per la zona DNS OVHcloud:
 
     - **Campi di puntamento**: `A`, `AAAA`, `NS`, `CNAME` e `DNAME`.
     - **Campi estesi**: `CAA`, `TXT`, `NAPTR`, `SRV`, `LOC`, `SSHFP`, `TLSA`, `RP`, `SVCB` e `HTTPS`.
     - **Campi mail**: `MX`, `SPF`, `DKIM` e `DMARC`.
 
     :::info
-    Se desideri aggiungere un record DNS non presente nella lista, chiudi la finestra che si è aperta dopo aver cliccato sul pulsante <code className="action">Aggiungi un record</code> e clicca sul pulsante <code className="action">Modifica in modalità testo</code> situato a destra o sotto la tabella.
+    Se desideri aggiungere un record DNS non presente nella lista, chiudi il modulo, poi apri il menu <code className="action">Azioni sulla mia zona</code> e clicca su <code className="action">Modifica in modalità testuale</code>.
 
     Potrai così aggiungere manualmente il record DNS di tua scelta.
 
@@ -592,15 +592,15 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
 
 <Tabs>
   <Tab label="Step 1">
-    Accedi alla pagina <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink>, poi seleziona il dominio interessato.
-
-    <img className="thumbnail" alt="Zone DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Nella sezione `Web Cloud`, clicca su <ManagerLink to="/#/web-domains/domain">Domini</ManagerLink>, seleziona il dominio interessato, poi apri la scheda **Zona DNS**.
+  
+    <img className="thumbnail" alt="Tab Zona DNS con i record di un dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    A destra o sotto la tabella, clicca su <code className="action">Modifica il TTL predefinito</code>.
+    Sopra la tabella, apri il menu <code className="action">Azioni sulla mia zona</code> e clicca su <code className="action">Modifica il TTL predefinito</code>.
   </Tab>
   <Tab label="Step 3">
-    Nella finestra che si apre, regola il valore sotto la menzione `TTL predefinito` in base alle tue esigenze, poi clicca su <code className="action">Modifica</code>.
+    Nel pannello che si apre, regola il valore sotto la menzione `TTL predefinito` in base alle tue esigenze, poi conferma.
   </Tab>
 </Tabs>
 
@@ -651,7 +651,7 @@ Ecco diverse soluzioni per verificare la configurazione di una zona DNS:
 
 - **Il comando "nslookup"**: Il comando `nslookup` è disponibile sulla maggior parte dei sistemi operativi e consente anche di verificare la configurazione della tua zona DNS.
 
-- **Dal tuo Spazio Cliente OVHcloud**: Se la zona DNS attiva del tuo nome di dominio è gestita su OVHcloud, accedi alla pagina <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink> per visualizzare tutti i record DNS dichiarati per il tuo nome di dominio.
+- **Dal tuo Spazio Cliente OVHcloud**: Se la zona DNS attiva del tuo nome di dominio è gestita su OVHcloud, accedi alla sezione <ManagerLink to="/#/web-domains/domain">Domini</ManagerLink>, seleziona il nome di dominio e apri la scheda **Zona DNS** per visualizzare tutti i record DNS dichiarati per quest'ultimo.
 
 :::tip
 Consulta tutti i dettagli nella nostra guida "[Modificare una zona DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit)".
@@ -706,15 +706,15 @@ Una volta recuperato il numero di serie, clicca sulle schede qui sotto per visua
 
 <Tabs>
   <Tab label="Step 1">
-    Accedi alla pagina <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink>, poi seleziona il dominio interessato.
-
-    <img className="thumbnail" alt="Zone DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Nella sezione `Web Cloud`, clicca su <ManagerLink to="/#/web-domains/domain">Domini</ManagerLink>, seleziona il dominio interessato, poi apri la scheda **Zona DNS**.
+  
+    <img className="thumbnail" alt="Tab Zona DNS con i record di un dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    A destra o sotto la tabella, clicca su <code className="action">Modifica in modalità testo</code>.
+    Sopra la tabella, apri il menu <code className="action">Azioni sulla mia zona</code> e clicca su <code className="action">Modifica in modalità testuale</code>.
   </Tab>
   <Tab label="Step 3">
-    Nella finestra che si apre, individua la seconda riga che, riprendendo il nostro esempio, sarebbe equivalente a questa: `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
+    Nell'editor di testo che si apre, individua la seconda riga che, riprendendo il nostro esempio, sarebbe equivalente a questa: `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
   </Tab>
   <Tab label="Step 4">
     Confronta il numero di serie recuperato tramite il terminale con quello visualizzato nel tuo Spazio Cliente OVHcloud.
@@ -728,7 +728,7 @@ Una volta recuperato il numero di serie, clicca sulle schede qui sotto per visua
     Ciò significa che:
 
     - La propagazione DNS delle tue modifiche non è ancora completamente terminata (sei ancora nei tempi standard di propagazione DNS). In questo caso, attendi che la propagazione DNS sia completamente terminata (**24** ore per una modifica di zona DNS e **48** ore per una modifica dei server DNS), poi ripeti l'operazione.
-    - La propagazione DNS non si sta effettuando correttamente. In questo caso, dalla finestra <code className="action">Modifica in modalità testo</code> che si è aperta allo step **3**, clicca direttamente **senza effettuare modifiche** sul pulsante <code className="action">Avanti</code>, poi su <code className="action">Conferma</code>. Verrà avviata una nuova propagazione DNS.
+    - La propagazione DNS non si sta effettuando correttamente. In questo caso, dal pannello <code className="action">Modifica in modalità testuale</code> che si è aperto allo step **3**, segui gli step visualizzati per confermare **senza effettuare modifiche**. Verrà avviata una nuova propagazione DNS.
   </Tab>
 </Tabs>
 
@@ -742,15 +742,15 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
 
 <Tabs>
   <Tab label="Step 1">
-    Accedi alla pagina <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink>, poi seleziona il dominio interessato.
-
-    <img className="thumbnail" alt="Zone DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Nella sezione `Web Cloud`, clicca su <ManagerLink to="/#/web-domains/domain">Domini</ManagerLink>, seleziona il dominio interessato, poi apri la scheda **Zona DNS**.
+  
+    <img className="thumbnail" alt="Tab Zona DNS con i record di un dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    A destra o sotto la tabella, clicca su <code className="action">Visualizza lo storico della mia zona DNS</code>.
+    Sopra la tabella, apri il menu <code className="action">Azioni sulla mia zona</code> e clicca su <code className="action">Visualizza la cronologia della mia zona DNS</code>.
   </Tab>
   <Tab label="Step 3">
-    Nella tabella della pagina visualizzata, identifica la riga corrispondente al backup della zona DNS desiderato, poi clicca sull'icona presente nella colonna <code className="action">Ripristina</code>. La configurazione attuale della zona DNS sarà sostituita dal backup scelto.
+    Nella tabella della pagina visualizzata, identifica la riga corrispondente al backup della zona DNS che desideri ripristinare, poi clicca su <code className="action">Ripristina</code> nella colonna **Ripristina**. La configurazione attuale della zona DNS sarà sostituita dal backup scelto.
   </Tab>
 </Tabs>
 
@@ -774,12 +774,12 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
 
 <Tabs>
   <Tab label="Step 1">
-    Accedi alla pagina <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink>, poi seleziona il dominio interessato.
-
-    <img className="thumbnail" alt="Zone DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Nella sezione `Web Cloud`, clicca su <ManagerLink to="/#/web-domains/domain">Domini</ManagerLink>, seleziona il dominio interessato, poi apri la scheda **Zona DNS**.
+  
+    <img className="thumbnail" alt="Tab Zona DNS con i record di un dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    A destra o sotto la tabella, clicca su <code className="action">Visualizza lo storico della mia zona DNS</code>.
+    Sopra la tabella, apri il menu <code className="action">Azioni sulla mia zona</code> e clicca su <code className="action">Visualizza la cronologia della mia zona DNS</code>.
   </Tab>
   <Tab label="Step 3">
     Nella tabella della pagina visualizzata, identifica la riga corrispondente al backup della zona DNS desiderato, poi clicca sull'icona presente nella colonna <code className="action">Scarica</code>. La copia della zona DNS sarà scaricata in formato *.txt*.
@@ -803,7 +803,7 @@ Per farlo, clicca sulle schede qui sotto per visualizzare i **4** step in sequen
 
 <Tabs>
   <Tab label="Step 1">
-    Accedi alla pagina <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink>, poi clicca sul pulsante <code className="action">Ordina</code> in alto a destra della tabella visualizzata.
+    Nella sezione `Web Cloud`, clicca sul pulsante <code className="action">Ordina</code>, poi seleziona <code className="action">Zona DNS</code>.
   </Tab>
   <Tab label="Step 2">
     Nella pagina visualizzata, inserisci il sottodominio (ad esempio: *www.domain.tld*) per il quale desideri creare una zona DNS OVHcloud. Attendi qualche istante mentre lo strumento effettua le verifiche relative al sottodominio.
@@ -822,12 +822,12 @@ Per recuperare i nomi dei 2 server DNS, clicca sulle schede qui sotto per visual
 
 <Tabs>
   <Tab label="Step 1">
-    Accedi alla pagina <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink>, poi seleziona il sottodominio interessato.
-
-    <img className="thumbnail" alt="Zone DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Nella sezione `Web Cloud`, clicca su <ManagerLink to="/#/web-domains/domain">Domini</ManagerLink>, seleziona il sottodominio interessato, poi apri la scheda **Zona DNS**.
+  
+    <img className="thumbnail" alt="Tab Zona DNS con i record di un dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    In alto a sinistra della pagina visualizzata, recupera i 2 nomi dei server DNS presenti sotto la menzione `Name Servers`. Questi ultimi hanno una delle 2 forme seguenti:
+    Nella tabella, individua i due record **NS** e prendi nota dei due valori presenti nella colonna **Destinazione**. Questi ultimi hanno una delle 2 forme seguenti:
 
     - `dnsXXX.ovh.net` e `nsXXX.ovh.net` **o** `dnsXXX.ovh.ca` e `nsXXX.ovh.ca` (dove ogni `X` rappresenta una cifra compresa tra `0` e `9`).
     - `dns200.ovh.me` e `ns200.anycast.me`.
@@ -842,18 +842,18 @@ Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
 
 <Tabs>
   <Tab label="Step 1">
-    Accedi alla pagina <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink>, poi seleziona il dominio interessato.
-
-    <img className="thumbnail" alt="Zone DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Nella sezione `Web Cloud`, clicca su <ManagerLink to="/#/web-domains/domain">Domini</ManagerLink>, seleziona il dominio interessato, poi apri la scheda **Zona DNS**.
+  
+    <img className="thumbnail" alt="Tab Zona DNS con i record di un dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    A destra o sotto la tabella, clicca su <code className="action">Aggiungi un record</code>, poi seleziona il tipo di record DNS <code className="action">NS</code> per dichiarare un server DNS.
+    Sopra la tabella, clicca su <code className="action">Aggiungi una voce</code>, poi seleziona il tipo di record DNS <code className="action">NS</code> per dichiarare un server DNS.
   </Tab>
   <Tab label="Step 3">
-    Nella finestra che si apre, inserisci il sottodominio in questione nel campo <code className="action">Sottodominio *</code> (ad esempio, scrivi **unicamente** *www* se il tuo nome di dominio è *domain.tld* e il tuo sottodominio completo è *www.domain.tld*). Nel campo <code className="action">Destinazione *</code>, inserisci **uno solo** dei 2 server DNS.
+    Nel modulo che si apre, inserisci il sottodominio in questione nel campo <code className="action">Sottodominio</code> (ad esempio, scrivi **unicamente** *www* se il tuo nome di dominio è *domain.tld* e il tuo sottodominio completo è *www.domain.tld*). Nel campo <code className="action">Destinazione</code>, inserisci **uno solo** dei 2 server DNS.
   </Tab>
   <Tab label="Step 4">
-    Clicca su <code className="action">Avanti</code>, poi su <code className="action">Conferma</code>.
+    Clicca su <code className="action">Aggiungi</code>.
 
     Ripeti l'operazione per il secondo server DNS restante da dichiarare.
   </Tab>
@@ -886,18 +886,18 @@ Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
 
 <Tabs>
   <Tab label="Step 1">
-    Accedi alla pagina <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink>, poi seleziona il dominio interessato.
-
-    <img className="thumbnail" alt="Zone DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Nella sezione `Web Cloud`, clicca su <ManagerLink to="/#/web-domains/domain">Domini</ManagerLink>, seleziona il dominio interessato, poi apri la scheda **Zona DNS**.
+  
+    <img className="thumbnail" alt="Tab Zona DNS con i record di un dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    A destra o sotto la tabella, clicca su <code className="action">Aggiungi un record</code>, poi seleziona il tipo di record DNS <code className="action">A</code> per un IPv4 (ad esempio: `203.0.113.0`) o <code className="action">AAAA</code> per un IPv6 (ad esempio: `2001:db8:1:1b00:203:0:113:0`).
+    Sopra la tabella, clicca su <code className="action">Aggiungi una voce</code>, poi seleziona il tipo di record DNS <code className="action">A</code> per un IPv4 (ad esempio: `203.0.113.0`) o <code className="action">AAAA</code> per un IPv6 (ad esempio: `2001:db8:1:1b00:203:0:113:0`).
   </Tab>
   <Tab label="Step 3">
-    Nella finestra che si apre, nel campo di inserimento <code className="action">Sottodominio *</code>, inserisci il valore `*`. L'asterisco `*` rappresenterà l'insieme dei sottodomini (ad esempio: `www.domain.tld` o `ovhcloud.domain.tld`) del tuo nome di dominio. Completa il campo <code className="action">Destinazione *</code> con l'indirizzo IP desiderato.
+    Nel modulo che si apre, nel campo <code className="action">Sottodominio</code>, inserisci il valore `*`. L'asterisco `*` rappresenterà l'insieme dei sottodomini (ad esempio: `www.domain.tld` o `ovhcloud.domain.tld`) del tuo nome di dominio. Completa il campo <code className="action">Destinazione</code> con l'indirizzo IP desiderato.
   </Tab>
   <Tab label="Step 4">
-    Clicca su <code className="action">Avanti</code>, poi su <code className="action">Conferma</code>.
+    Clicca su <code className="action">Aggiungi</code>.
   </Tab>
 </Tabs>
 
@@ -923,18 +923,18 @@ Per farlo, clicca sulle schede qui sotto per visualizzare i **4** step in sequen
 
 <Tabs>
   <Tab label="Step 1">
-    Accedi alla pagina <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink>, poi seleziona il dominio interessato.
-
-    <img className="thumbnail" alt="Zone DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Nella sezione `Web Cloud`, clicca su <ManagerLink to="/#/web-domains/domain">Domini</ManagerLink>, seleziona il dominio interessato, poi apri la scheda **Zona DNS**.
+  
+    <img className="thumbnail" alt="Tab Zona DNS con i record di un dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
-    A destra o sotto la tabella, clicca su <code className="action">Aggiungi un record</code>, poi seleziona il tipo di record DNS per il quale desideri configurare un wildcard.
+    Sopra la tabella, clicca su <code className="action">Aggiungi una voce</code>, poi seleziona il tipo di record DNS per il quale desideri configurare un wildcard.
   </Tab>
   <Tab label="Step 3">
-    Nella finestra che si apre, nel campo di inserimento <code className="action">Sottodominio *</code>, inserisci il valore `*`. L'asterisco `*` rappresenterà l'insieme dei sottodomini (ad esempio: `www.domain.tld` o `ovhcloud.domain.tld`) del tuo nome di dominio. Completa gli altri campi con i valori desiderati.
+    Nel modulo che si apre, nel campo <code className="action">Sottodominio</code>, inserisci il valore `*`. L'asterisco `*` rappresenterà l'insieme dei sottodomini (ad esempio: `www.domain.tld` o `ovhcloud.domain.tld`) del tuo nome di dominio. Completa gli altri campi con i valori desiderati.
   </Tab>
   <Tab label="Step 4">
-    Clicca su <code className="action">Avanti</code>, poi su <code className="action">Conferma</code>.
+    Clicca su <code className="action">Aggiungi</code>.
   </Tab>
 </Tabs>
 
@@ -978,10 +978,10 @@ Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
     Seleziona la scheda <code className="action">Zona DNS</code> una volta posizionato sul nome di dominio in questione. **Se la zona DNS è inattiva, attivala da questa scheda.**
   </Tab>
   <Tab label="Step 3">
-    A destra o sotto la tabella, clicca su <code className="action">Modifica in modalità testo</code>.
+    Sopra la tabella, apri il menu <code className="action">Azioni sulla mia zona</code> e clicca su <code className="action">Modifica in modalità testuale</code>.
   </Tab>
   <Tab label="Step 4">
-    Nella finestra che si apre, sostituisci tutto il contenuto visualizzato con la copia della zona DNS eliminata. Poi clicca su <code className="action">Avanti</code>, quindi su <code className="action">Conferma</code>.
+    Nell'editor di testo che si apre, sostituisci tutto il contenuto visualizzato con la copia della zona DNS eliminata, poi segui gli step visualizzati per confermare.
   </Tab>
 </Tabs>
 
@@ -1023,10 +1023,10 @@ Clicca sulle schede qui sotto per visualizzare i **2** step in sequenza.
 
 <Tabs>
   <Tab label="Step 1">
-    Accedi alla pagina <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink> e verifica se il nome di dominio in questione appare.
-
-    <img className="thumbnail" alt="Zone DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Nella sezione `Web Cloud`, clicca su <ManagerLink to="/#/web-domains/domain">Domini</ManagerLink> e verifica se il nome di dominio in questione appare.
+  
+    <img className="thumbnail" alt="Tab Zona DNS con i record di un dominio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Step 2">
     **Caso n°1** - Il nome di dominio in questione appare nella lista:
 

--- a/docs/pl/guides/web-cloud/domains/faq-domain-dns.mdx
+++ b/docs/pl/guides/web-cloud/domains/faq-domain-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ dotyczący nazw domen i DNS
 description: Znajdź odpowiedzi na najczęściej zadawane pytania dotyczące nazw domen, serwerów DNS i stref DNS
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -444,21 +444,21 @@ Kliknij poniższe karty, aby wyświetlić kolejne **2** kroki.
 
 <Tabs>
   <Tab label="Krok 1">
-    Przejdź na stronę <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>, następnie wybierz odpowiednią nazwę domeny.
-
-    <img className="thumbnail" alt="Strefy DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    W sekcji `Web Cloud` kliknij <ManagerLink to="/#/web-domains/domain">Domeny</ManagerLink>, wybierz odpowiednią nazwę domeny, następnie otwórz zakładkę **Strefa DNS**.
+  
+    <img className="thumbnail" alt="Zakładka Strefa DNS z rekordami nazwy domeny" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Krok 2">
-    Po prawej stronie lub poniżej tabeli kliknij <code className="action">Dodaj rekord</code>.
+    Nad tabelą kliknij <code className="action">Dodaj wpis</code>.
 
-    Zobaczysz wszystkie rekordy DNS, które możesz dodać za pomocą asystenta konfiguracji OVHcloud:
+    Zobaczysz wszystkie rekordy DNS, które możesz dodać za pomocą formularza strefy DNS OVHcloud:
 
     - **Rekordy wskaźnikowe**: `A`, `AAAA`, `NS`, `CNAME` i `DNAME`.
     - **Rekordy rozszerzone**: `CAA`, `TXT`, `NAPTR`, `SRV`, `LOC`, `SSHFP`, `TLSA`, `RP`, `SVCB` i `HTTPS`.
     - **Rekordy e-mail**: `MX`, `SPF`, `DKIM` i `DMARC`.
 
     :::info
-    Jeśli chcesz dodać rekord DNS, który nie jest wymieniony na liście, zamknij okno otwarte po kliknięciu przycisku <code className="action">Dodaj rekord</code> i kliknij przycisk <code className="action">Zmień w trybie tekstowym</code> po prawej stronie lub poniżej tabeli.
+    Jeśli chcesz dodać rekord DNS, którego nie ma na liście, zamknij formularz, następnie otwórz menu <code className="action">Akcje na mojej strefie</code> i kliknij <code className="action">Edytuj w trybie tekstowym</code>.
 
     Możesz następnie ręcznie dodać wybrany rekord DNS.
 
@@ -592,15 +592,15 @@ Kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
 
 <Tabs>
   <Tab label="Krok 1">
-    Przejdź na stronę <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>, następnie wybierz odpowiednią nazwę domeny.
-
-    <img className="thumbnail" alt="Strefy DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    W sekcji `Web Cloud` kliknij <ManagerLink to="/#/web-domains/domain">Domeny</ManagerLink>, wybierz odpowiednią nazwę domeny, następnie otwórz zakładkę **Strefa DNS**.
+  
+    <img className="thumbnail" alt="Zakładka Strefa DNS z rekordami nazwy domeny" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Krok 2">
-    Po prawej stronie lub poniżej tabeli kliknij <code className="action">Zmień domyślny TTL</code>.
+    Nad tabelą otwórz menu <code className="action">Akcje na mojej strefie</code> i kliknij <code className="action">Zmień domyślny TTL</code>.
   </Tab>
   <Tab label="Krok 3">
-    W otwartym oknie dostosuj wartość pod etykietą `Domyślny TTL` do swoich potrzeb, a następnie kliknij <code className="action">Zmień</code>.
+    W otwartym panelu dostosuj wartość pod etykietą `Domyślny TTL` do swoich potrzeb, a następnie potwierdź.
   </Tab>
 </Tabs>
 
@@ -651,7 +651,7 @@ Oto kilka metod weryfikacji konfiguracji strefy DNS:
 
 - **Polecenie "nslookup"**: Polecenie `nslookup` jest dostępne w większości systemów operacyjnych i może być również używane do weryfikacji konfiguracji strefy DNS.
 
-- **Z Panelu klienta OVHcloud**: Jeśli aktywna strefa DNS Twojej nazwy domeny jest zarządzana przez OVHcloud, przejdź na stronę <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>, aby wyświetlić wszystkie rekordy DNS zadeklarowane dla Twojej nazwy domeny.
+- **Z Panelu klienta OVHcloud**: Jeśli aktywna strefa DNS Twojej nazwy domeny jest zarządzana przez OVHcloud, otwórz sekcję <ManagerLink to="/#/web-domains/domain">Domeny</ManagerLink>, wybierz nazwę domeny i otwórz zakładkę **Strefa DNS**, aby wyświetlić wszystkie rekordy DNS zadeklarowane dla Twojej nazwy domeny.
 
 :::tip
 Wszystkie szczegóły znajdziesz w naszym przewodniku "[Edycja strefy DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit)".
@@ -706,15 +706,15 @@ Po pobraniu numeru seryjnego kliknij poniższe karty, aby wyświetlić kolejne *
 
 <Tabs>
   <Tab label="Krok 1">
-    Przejdź na stronę <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>, następnie wybierz odpowiednią nazwę domeny.
-
-    <img className="thumbnail" alt="Strefy DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    W sekcji `Web Cloud` kliknij <ManagerLink to="/#/web-domains/domain">Domeny</ManagerLink>, wybierz odpowiednią nazwę domeny, następnie otwórz zakładkę **Strefa DNS**.
+  
+    <img className="thumbnail" alt="Zakładka Strefa DNS z rekordami nazwy domeny" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Krok 2">
-    Po prawej stronie lub poniżej tabeli kliknij <code className="action">Zmień w trybie tekstowym</code>.
+    Nad tabelą otwórz menu <code className="action">Akcje na mojej strefie</code> i kliknij <code className="action">Edytuj w trybie tekstowym</code>.
   </Tab>
   <Tab label="Krok 3">
-    W otwartym oknie znajdź drugi wiersz, który w naszym przykładzie odpowiadałby: `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
+    W otwartym edytorze tekstu znajdź drugi wiersz, który w naszym przykładzie odpowiadałby: `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
   </Tab>
   <Tab label="Krok 4">
     Porównaj numer seryjny pobrany z terminala z numerem wyświetlonym w Panelu klienta OVHcloud.
@@ -728,7 +728,7 @@ Po pobraniu numeru seryjnego kliknij poniższe karty, aby wyświetlić kolejne *
     Oznacza to, że:
 
     - Propagacja DNS Twoich zmian nie została jeszcze zakończona (jesteś w standardowym okresie propagacji). W takim przypadku poczekaj, aż propagacja DNS zostanie w pełni zakończona (**24** godziny na zmianę strefy DNS i **48** godzin na zmianę serwera DNS), a następnie powtórz procedurę.
-    - Propagacja DNS nie przebiega prawidłowo. W takim przypadku, w oknie <code className="action">Zmień w trybie tekstowym</code> otwartym w kroku **3**, kliknij bezpośrednio **bez dokonywania żadnych zmian** na <code className="action">Dalej</code>, a następnie na <code className="action">Potwierdź</code>. Zostanie wówczas zainicjowana nowa propagacja DNS.
+    - Propagacja DNS nie przebiega prawidłowo. W takim przypadku, w panelu <code className="action">Edytuj w trybie tekstowym</code> otwartym w kroku **3**, postępuj zgodnie z instrukcjami na ekranie, aby potwierdzić **bez dokonywania żadnych zmian**. Zostanie wówczas zainicjowana nowa propagacja DNS.
   </Tab>
 </Tabs>
 
@@ -742,15 +742,15 @@ Kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
 
 <Tabs>
   <Tab label="Krok 1">
-    Przejdź na stronę <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>, następnie wybierz odpowiednią nazwę domeny.
-
-    <img className="thumbnail" alt="Strefy DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    W sekcji `Web Cloud` kliknij <ManagerLink to="/#/web-domains/domain">Domeny</ManagerLink>, wybierz odpowiednią nazwę domeny, następnie otwórz zakładkę **Strefa DNS**.
+  
+    <img className="thumbnail" alt="Zakładka Strefa DNS z rekordami nazwy domeny" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Krok 2">
-    Po prawej stronie lub poniżej tabeli kliknij <code className="action">Wyświetl historię strefy DNS</code>.
+    Nad tabelą otwórz menu <code className="action">Akcje na mojej strefie</code> i kliknij <code className="action">Zobacz historię mojej strefy DNS</code>.
   </Tab>
   <Tab label="Krok 3">
-    W tabeli na wyświetlonej stronie zidentyfikuj wiersz odpowiadający kopii zapasowej strefy DNS, którą chcesz przywrócić, a następnie kliknij ikonę w kolumnie <code className="action">Przywróć</code>. Bieżąca konfiguracja strefy DNS zostanie zastąpiona wybraną kopią zapasową.
+    W tabeli na wyświetlonej stronie zidentyfikuj wiersz odpowiadający kopii zapasowej strefy DNS, którą chcesz przywrócić, a następnie kliknij <code className="action">Przywracanie dostępu</code> w kolumnie **Przywracanie dostępu**. Bieżąca konfiguracja strefy DNS zostanie zastąpiona wybraną kopią zapasową.
   </Tab>
 </Tabs>
 
@@ -774,12 +774,12 @@ Kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
 
 <Tabs>
   <Tab label="Krok 1">
-    Przejdź na stronę <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>, następnie wybierz odpowiednią nazwę domeny.
-
-    <img className="thumbnail" alt="Strefy DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    W sekcji `Web Cloud` kliknij <ManagerLink to="/#/web-domains/domain">Domeny</ManagerLink>, wybierz odpowiednią nazwę domeny, następnie otwórz zakładkę **Strefa DNS**.
+  
+    <img className="thumbnail" alt="Zakładka Strefa DNS z rekordami nazwy domeny" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Krok 2">
-    Po prawej stronie lub poniżej tabeli kliknij <code className="action">Wyświetl historię strefy DNS</code>.
+    Nad tabelą otwórz menu <code className="action">Akcje na mojej strefie</code> i kliknij <code className="action">Zobacz historię mojej strefy DNS</code>.
   </Tab>
   <Tab label="Krok 3">
     W tabeli na wyświetlonej stronie zidentyfikuj wiersz odpowiadający kopii zapasowej strefy DNS, którą chcesz pobrać, a następnie kliknij ikonę w kolumnie <code className="action">Pobierz</code>. Kopia strefy DNS zostanie pobrana w formacie *.txt*.
@@ -803,7 +803,7 @@ W tym celu kliknij poniższe karty, aby wyświetlić kolejne **4** kroki.
 
 <Tabs>
   <Tab label="Krok 1">
-    Przejdź na stronę <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>, następnie kliknij przycisk <code className="action">Zamów</code> w prawym górnym rogu wyświetlonej tabeli.
+    W sekcji `Web Cloud` kliknij przycisk <code className="action">Zamów</code>, a następnie wybierz <code className="action">Strefa DNS</code>.
   </Tab>
   <Tab label="Krok 2">
     Na wyświetlonej stronie wpisz subdomenę (np. *www.domain.tld*), dla której chcesz utworzyć strefę DNS OVHcloud. Poczekaj chwilę, aż narzędzie zweryfikuje subdomenę.
@@ -822,12 +822,12 @@ Aby pobrać nazwy 2 serwerów DNS, kliknij poniższe karty, aby wyświetlić kol
 
 <Tabs>
   <Tab label="Krok 1">
-    Przejdź na stronę <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>, następnie wybierz odpowiednią subdomenę.
-
-    <img className="thumbnail" alt="Strefy DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    W sekcji `Web Cloud` kliknij <ManagerLink to="/#/web-domains/domain">Domeny</ManagerLink>, wybierz odpowiednią subdomenę, następnie otwórz zakładkę **Strefa DNS**.
+  
+    <img className="thumbnail" alt="Zakładka Strefa DNS z rekordami nazwy domeny" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Krok 2">
-    W lewym górnym rogu wyświetlonej strony pobierz 2 nazwy serwerów DNS wymienione pod etykietą `Name Servers`. Mają one jeden z dwóch następujących formatów:
+    W tabeli znajdź dwa rekordy **NS** i zanotuj dwie wartości w kolumnie **Cel**. Mają one jeden z dwóch następujących formatów:
 
     - `dnsXXX.ovh.net` i `nsXXX.ovh.net` **lub** `dnsXXX.ovh.ca` i `nsXXX.ovh.ca` (gdzie każde `X` oznacza cyfrę od `0` do `9`).
     - `dns200.ovh.me` i `ns200.anycast.me`.
@@ -842,18 +842,18 @@ Kliknij poniższe karty, aby wyświetlić kolejne **4** kroki.
 
 <Tabs>
   <Tab label="Krok 1">
-    Przejdź na stronę <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>, następnie wybierz odpowiednią nazwę domeny.
-
-    <img className="thumbnail" alt="Strefy DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    W sekcji `Web Cloud` kliknij <ManagerLink to="/#/web-domains/domain">Domeny</ManagerLink>, wybierz odpowiednią nazwę domeny, następnie otwórz zakładkę **Strefa DNS**.
+  
+    <img className="thumbnail" alt="Zakładka Strefa DNS z rekordami nazwy domeny" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Krok 2">
-    Po prawej stronie lub poniżej tabeli kliknij <code className="action">Dodaj rekord</code>, a następnie wybierz typ rekordu DNS <code className="action">NS</code>, aby zadeklarować serwer DNS.
+    Nad tabelą kliknij <code className="action">Dodaj wpis</code>, a następnie wybierz typ rekordu DNS <code className="action">NS</code>, aby zadeklarować serwer DNS.
   </Tab>
   <Tab label="Krok 3">
-    W otwartym oknie wpisz subdomenę w polu <code className="action">Sub-domain *</code> (np. wpisz **tylko** *www*, jeśli Twoja nazwa domeny to *domain.tld*, a pełna subdomena to *www.domain.tld*). W polu <code className="action">Target *</code> wpisz **jeden** z 2 serwerów DNS.
+    W otwartym formularzu wpisz subdomenę w polu <code className="action">Subdomena</code> (np. wpisz **tylko** *www*, jeśli Twoja nazwa domeny to *domain.tld*, a pełna subdomena to *www.domain.tld*). W polu <code className="action">Cel</code> wpisz **jeden** z 2 serwerów DNS.
   </Tab>
   <Tab label="Krok 4">
-    Kliknij <code className="action">Dalej</code>, a następnie <code className="action">Potwierdź</code>.
+    Kliknij <code className="action">Dodaj</code>.
 
     Powtórz procedurę dla drugiego serwera DNS do zadeklarowania.
   </Tab>
@@ -886,18 +886,18 @@ Kliknij poniższe karty, aby wyświetlić kolejne **4** kroki.
 
 <Tabs>
   <Tab label="Krok 1">
-    Przejdź na stronę <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>, następnie wybierz odpowiednią nazwę domeny.
-
-    <img className="thumbnail" alt="Strefy DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    W sekcji `Web Cloud` kliknij <ManagerLink to="/#/web-domains/domain">Domeny</ManagerLink>, wybierz odpowiednią nazwę domeny, następnie otwórz zakładkę **Strefa DNS**.
+  
+    <img className="thumbnail" alt="Zakładka Strefa DNS z rekordami nazwy domeny" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Krok 2">
-    Po prawej stronie lub poniżej tabeli kliknij <code className="action">Dodaj rekord</code>, a następnie wybierz typ rekordu DNS <code className="action">A</code> dla adresu IPv4 (np. `203.0.113.0`) lub typ rekordu DNS <code className="action">AAAA</code> dla adresu IPv6 (np. `2001:db8:1:1b00:203:0:113:0`).
+    Nad tabelą kliknij <code className="action">Dodaj wpis</code>, a następnie wybierz typ rekordu DNS <code className="action">A</code> dla adresu IPv4 (np. `203.0.113.0`) lub typ rekordu DNS <code className="action">AAAA</code> dla adresu IPv6 (np. `2001:db8:1:1b00:203:0:113:0`).
   </Tab>
   <Tab label="Krok 3">
-    W otwartym oknie, w polu <code className="action">Sub-domain *</code>, wpisz wartość `*`. Gwiazdka `*` reprezentuje wszystkie subdomeny (np. `www.domain.tld` lub `ovhcloud.domain.tld`) Twojej nazwy domeny. Uzupełnij pole <code className="action">Target *</code> żądanym adresem IP.
+    W otwartym formularzu, w polu <code className="action">Subdomena</code>, wpisz wartość `*`. Gwiazdka `*` reprezentuje wszystkie subdomeny (np. `www.domain.tld` lub `ovhcloud.domain.tld`) Twojej nazwy domeny. Uzupełnij pole <code className="action">Cel</code> żądanym adresem IP.
   </Tab>
   <Tab label="Krok 4">
-    Kliknij <code className="action">Dalej</code>, a następnie <code className="action">Potwierdź</code>.
+    Kliknij <code className="action">Dodaj</code>.
   </Tab>
 </Tabs>
 
@@ -923,18 +923,18 @@ W tym celu kliknij poniższe karty, aby wyświetlić kolejne **4** kroki.
 
 <Tabs>
   <Tab label="Krok 1">
-    Przejdź na stronę <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>, następnie wybierz odpowiednią nazwę domeny.
-
-    <img className="thumbnail" alt="Strefy DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    W sekcji `Web Cloud` kliknij <ManagerLink to="/#/web-domains/domain">Domeny</ManagerLink>, wybierz odpowiednią nazwę domeny, następnie otwórz zakładkę **Strefa DNS**.
+  
+    <img className="thumbnail" alt="Zakładka Strefa DNS z rekordami nazwy domeny" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Krok 2">
-    Po prawej stronie lub poniżej tabeli kliknij <code className="action">Dodaj rekord</code>, a następnie wybierz typ rekordu DNS, dla którego chcesz skonfigurować wildcard.
+    Nad tabelą kliknij <code className="action">Dodaj wpis</code>, a następnie wybierz typ rekordu DNS, dla którego chcesz skonfigurować wildcard.
   </Tab>
   <Tab label="Krok 3">
-    W otwartym oknie, w polu <code className="action">Sub-domain *</code>, wpisz wartość `*`. Gwiazdka `*` reprezentuje wszystkie subdomeny (np. `www.domain.tld` lub `ovhcloud.domain.tld`) Twojej nazwy domeny. Uzupełnij pozostałe pola żądanymi wartościami.
+    W otwartym formularzu, w polu <code className="action">Subdomena</code>, wpisz wartość `*`. Gwiazdka `*` reprezentuje wszystkie subdomeny (np. `www.domain.tld` lub `ovhcloud.domain.tld`) Twojej nazwy domeny. Uzupełnij pozostałe pola żądanymi wartościami.
   </Tab>
   <Tab label="Krok 4">
-    Kliknij <code className="action">Dalej</code>, a następnie <code className="action">Potwierdź</code>.
+    Kliknij <code className="action">Dodaj</code>.
   </Tab>
 </Tabs>
 
@@ -978,10 +978,10 @@ Kliknij poniższe karty, aby wyświetlić kolejne **4** kroki.
     Wybierz zakładkę <code className="action">Strefa DNS</code> po przejściu na odpowiednią nazwę domeny. **Jeśli strefa DNS jest nieaktywna, aktywuj ją z tej zakładki.**
   </Tab>
   <Tab label="Krok 3">
-    Po prawej stronie lub poniżej tabeli kliknij <code className="action">Zmień w trybie tekstowym</code>.
+    Nad tabelą otwórz menu <code className="action">Akcje na mojej strefie</code> i kliknij <code className="action">Edytuj w trybie tekstowym</code>.
   </Tab>
   <Tab label="Krok 4">
-    W otwartym oknie zastąp całą wyświetloną zawartość kopią usuniętej strefy DNS. Kliknij <code className="action">Dalej</code>, a następnie <code className="action">Potwierdź</code>.
+    W otwartym edytorze tekstu zastąp całą wyświetloną zawartość kopią usuniętej strefy DNS, a następnie postępuj zgodnie z instrukcjami na ekranie, aby potwierdzić.
   </Tab>
 </Tabs>
 
@@ -1023,10 +1023,10 @@ Kliknij poniższe karty, aby wyświetlić kolejne **2** kroki.
 
 <Tabs>
   <Tab label="Krok 1">
-    Przejdź na stronę <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>, a następnie sprawdź, czy odpowiednia nazwa domeny jest wyświetlana.
-
-    <img className="thumbnail" alt="Strefy DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    W sekcji `Web Cloud` kliknij <ManagerLink to="/#/web-domains/domain">Domeny</ManagerLink> i sprawdź, czy odpowiednia nazwa domeny jest wyświetlana.
+  
+    <img className="thumbnail" alt="Zakładka Strefa DNS z rekordami nazwy domeny" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Krok 2">
     **Przypadek 1** — Odpowiednia nazwa domeny pojawia się na liście:
 

--- a/docs/pt/guides/web-cloud/domains/faq-domain-dns.mdx
+++ b/docs/pt/guides/web-cloud/domains/faq-domain-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ sobre os nomes de domínio & DNS
 description: Encontre as principais questões sobre os nomes de domínio, os servidores DNS e as zonas DNS
-lastUpdated: 2026-03-27
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -444,21 +444,21 @@ Clique nos separadores abaixo para ver cada um dos **2** passos.
 
 <Tabs>
   <Tab label="Passo 1">
-    Aceda à página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> e escolha o domínio correspondente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Na secção `Web Cloud`, clique em <ManagerLink to="/#/web-domains/domain">Nomes de domínio</ManagerLink>, selecione o nome de domínio em questão e abra o separador **Zona DNS**.
+  
+    <img className="thumbnail" alt="Separador Zona DNS com os registos de um nome de domínio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Passo 2">
-    À direita ou abaixo da tabela, clique em <code className="action">Adicionar um registo</code>.
+    Acima da tabela, clique em <code className="action">Adicionar uma entrada</code>.
 
-    Visualizará todos os registos DNS que poderá adicionar através do assistente de configuração OVHcloud:
+    Visualizará todos os registos DNS que poderá adicionar através do formulário de zona DNS OVHcloud:
 
     - **Campos de apontamento**: `A`, `AAAA`, `NS`, `CNAME` e `DNAME`.
     - **Campos alargados**: `CAA`, `TXT`, `NAPTR`, `SRV`, `LOC`, `SSHFP`, `TLSA`, `RP`, `SVCB` e `HTTPS`.
     - **Campos mail**: `MX`, `SPF`, `DKIM` e `DMARC`.
 
     :::info
-    Se deseja adicionar um registo DNS que não aparece na lista, feche a janela que se abriu após ter clicado no botão <code className="action">Adicionar um registo</code> e clique no botão <code className="action">Modificar em modo de texto</code> situado à direita ou abaixo da tabela.
+    Se deseja adicionar um registo DNS que não aparece na lista, feche o formulário, abra o menu <code className="action">Ações na minha zona</code> e clique em <code className="action">Modificar em modo textual</code>.
 
     Poderá assim adicionar manualmente o registo DNS à sua escolha.
 
@@ -592,15 +592,15 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
 
 <Tabs>
   <Tab label="Passo 1">
-    Aceda à página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> e escolha o domínio correspondente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Na secção `Web Cloud`, clique em <ManagerLink to="/#/web-domains/domain">Nomes de domínio</ManagerLink>, selecione o nome de domínio em questão e abra o separador **Zona DNS**.
+  
+    <img className="thumbnail" alt="Separador Zona DNS com os registos de um nome de domínio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Passo 2">
-    À direita ou abaixo da tabela, clique em <code className="action">Modificar o TTL predefinido</code>.
+    Acima da tabela, abra o menu <code className="action">Ações na minha zona</code> e clique em <code className="action">Modificar o TTL por defeito</code>.
   </Tab>
   <Tab label="Passo 3">
-    Na janela que se abre, ajuste o valor sob a menção `TTL predefinido` conforme as suas necessidades e clique em <code className="action">Modificar</code>.
+    No painel que se abre, ajuste o valor sob a menção `TTL por defeito` conforme as suas necessidades e confirme.
   </Tab>
 </Tabs>
 
@@ -651,7 +651,7 @@ Eis diferentes soluções para verificar a configuração de uma zona DNS:
 
 - **O comando "nslookup"**: O comando `nslookup` está disponível na maioria dos sistemas operativos e também permite verificar a configuração da sua zona DNS.
 
-- **A partir da sua Área de Cliente OVHcloud**: Se a zona DNS ativa do seu nome de domínio for gerida na OVHcloud, aceda à página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> para visualizar todos os registos DNS declarados para o seu nome de domínio.
+- **A partir da sua Área de Cliente OVHcloud**: Se a zona DNS ativa do seu nome de domínio for gerida na OVHcloud, aceda à secção <ManagerLink to="/#/web-domains/domain">Nomes de domínio</ManagerLink>, selecione o nome de domínio e abra o separador **Zona DNS** para visualizar todos os registos DNS declarados para o mesmo.
 
 :::tip
 Consulte todos os detalhes no nosso manual "[Editar uma zona DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit)".
@@ -706,15 +706,15 @@ Uma vez recuperado o número de série, clique nos separadores abaixo para ver c
 
 <Tabs>
   <Tab label="Passo 1">
-    Aceda à página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> e escolha o domínio correspondente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Na secção `Web Cloud`, clique em <ManagerLink to="/#/web-domains/domain">Nomes de domínio</ManagerLink>, selecione o nome de domínio em questão e abra o separador **Zona DNS**.
+  
+    <img className="thumbnail" alt="Separador Zona DNS com os registos de um nome de domínio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Passo 2">
-    À direita ou abaixo da tabela, clique em <code className="action">Modificar em modo de texto</code>.
+    Acima da tabela, abra o menu <code className="action">Ações na minha zona</code> e clique em <code className="action">Modificar em modo textual</code>.
   </Tab>
   <Tab label="Passo 3">
-    Na janela que se abre, localize a segunda linha que, retomando o nosso exemplo, seria equivalente a esta: `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
+    No editor de texto que se abre, localize a segunda linha que, retomando o nosso exemplo, seria equivalente a esta: `@	IN SOA dns200.anycast.me. tech.ovh.net. (2025091801 86400 3600 3600000 60)`.
   </Tab>
   <Tab label="Passo 4">
     Compare o número de série recuperado através do terminal com o que aparece na sua Área de Cliente OVHcloud.
@@ -728,7 +728,7 @@ Uma vez recuperado o número de série, clique nos separadores abaixo para ver c
     Isto significa que:
 
     - A propagação DNS das suas alterações ainda não terminou completamente (ainda se encontra dentro dos prazos normais de propagação DNS). Nesse caso, aguarde até que a propagação DNS termine completamente (**24** horas para uma alteração de zona DNS e **48** horas para uma alteração de servidores DNS) e repita a operação.
-    - A propagação DNS não está a decorrer corretamente. Nesse caso, a partir da janela <code className="action">Modificar em modo de texto</code> que se abriu no passo **3**, clique diretamente **sem efetuar alterações** no botão <code className="action">Seguinte</code> e depois em <code className="action">Validar</code>. Uma nova propagação DNS será então iniciada.
+    - A propagação DNS não está a decorrer corretamente. Nesse caso, a partir do painel <code className="action">Modificar em modo textual</code> aberto no passo **3**, siga os passos apresentados no ecrã para confirmar **sem efetuar qualquer alteração**. Uma nova propagação DNS será então iniciada.
   </Tab>
 </Tabs>
 
@@ -742,15 +742,15 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
 
 <Tabs>
   <Tab label="Passo 1">
-    Aceda à página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> e escolha o domínio correspondente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Na secção `Web Cloud`, clique em <ManagerLink to="/#/web-domains/domain">Nomes de domínio</ManagerLink>, selecione o nome de domínio em questão e abra o separador **Zona DNS**.
+  
+    <img className="thumbnail" alt="Separador Zona DNS com os registos de um nome de domínio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Passo 2">
-    À direita ou abaixo da tabela, clique em <code className="action">Ver o histórico da minha zona DNS</code>.
+    Acima da tabela, abra o menu <code className="action">Ações na minha zona</code> e clique em <code className="action">Ver o histórico da minha zona DNS</code>.
   </Tab>
   <Tab label="Passo 3">
-    Na tabela da página apresentada, identifique a linha correspondente à cópia de segurança da zona DNS pretendida e clique no ícone presente na coluna <code className="action">Restaurar</code>. A configuração atual da zona DNS será substituída pela cópia de segurança escolhida.
+    Na tabela da página apresentada, identifique a linha correspondente à cópia de segurança da zona DNS que pretende restaurar e clique em <code className="action">Restaurar</code> na coluna **Restaurar**. A configuração atual da zona DNS será substituída pela cópia de segurança selecionada.
   </Tab>
 </Tabs>
 
@@ -774,15 +774,15 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
 
 <Tabs>
   <Tab label="Passo 1">
-    Aceda à página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> e escolha o domínio correspondente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Na secção `Web Cloud`, clique em <ManagerLink to="/#/web-domains/domain">Nomes de domínio</ManagerLink>, selecione o nome de domínio em questão e abra o separador **Zona DNS**.
+  
+    <img className="thumbnail" alt="Separador Zona DNS com os registos de um nome de domínio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Passo 2">
-    À direita ou abaixo da tabela, clique em <code className="action">Ver o histórico da minha zona DNS</code>.
+    Acima da tabela, abra o menu <code className="action">Ações na minha zona</code> e clique em <code className="action">Ver o histórico da minha zona DNS</code>.
   </Tab>
   <Tab label="Passo 3">
-    Na tabela da página apresentada, identifique a linha correspondente à cópia de segurança da zona DNS pretendida e clique no ícone presente na coluna <code className="action">Descarregar</code>. A cópia da zona DNS será descarregada no formato *.txt*.
+    Na tabela da página apresentada, identifique a linha correspondente à cópia de segurança da zona DNS que pretende obter e clique no ícone presente na coluna <code className="action">Descarregar</code>. A cópia da zona DNS será descarregada no formato *.txt*.
   </Tab>
 </Tabs>
 
@@ -803,7 +803,7 @@ Para isso, clique nos separadores abaixo para ver cada um dos **4** passos.
 
 <Tabs>
   <Tab label="Passo 1">
-    Aceda à página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> e clique no botão <code className="action">Encomendar</code> no canto superior direito da tabela apresentada.
+    Na secção `Web Cloud`, clique no botão <code className="action">Encomendar</code> e selecione <code className="action">Zona DNS</code>.
   </Tab>
   <Tab label="Passo 2">
     Na página que aparece, introduza o subdomínio (por exemplo: *www.domain.tld*) para o qual deseja criar uma zona DNS OVHcloud. Aguarde alguns instantes enquanto a ferramenta efetua verificações relativas ao subdomínio.
@@ -822,12 +822,12 @@ Para recuperar os nomes dos 2 servidores DNS, clique nos separadores abaixo para
 
 <Tabs>
   <Tab label="Passo 1">
-    Aceda à página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> e escolha o subdomínio correspondente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Na secção `Web Cloud`, clique em <ManagerLink to="/#/web-domains/domain">Nomes de domínio</ManagerLink>, selecione o subdomínio em questão e abra o separador **Zona DNS**.
+  
+    <img className="thumbnail" alt="Separador Zona DNS com os registos de um nome de domínio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Passo 2">
-    No canto superior esquerdo da página apresentada, recupere os 2 nomes dos servidores DNS presentes sob a menção `Name Servers`. Estes últimos têm uma das 2 formas seguintes:
+    Na tabela, localize os dois registos **NS** e anote os dois valores presentes na coluna **Destino**. Estes últimos têm uma das 2 formas seguintes:
 
     - `dnsXXX.ovh.net` e `nsXXX.ovh.net` **ou** `dnsXXX.ovh.ca` e `nsXXX.ovh.ca` (onde cada `X` representa um algarismo compreendido entre `0` e `9`).
     - `dns200.ovh.me` e `ns200.anycast.me`.
@@ -842,18 +842,18 @@ Clique nos separadores abaixo para ver cada um dos **4** passos.
 
 <Tabs>
   <Tab label="Passo 1">
-    Aceda à página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> e escolha o domínio correspondente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Na secção `Web Cloud`, clique em <ManagerLink to="/#/web-domains/domain">Nomes de domínio</ManagerLink>, selecione o nome de domínio em questão e abra o separador **Zona DNS**.
+  
+    <img className="thumbnail" alt="Separador Zona DNS com os registos de um nome de domínio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Passo 2">
-    À direita ou abaixo da tabela, clique em <code className="action">Adicionar um registo</code> e selecione o tipo de registo DNS <code className="action">NS</code> para declarar um servidor DNS.
+    Acima da tabela, clique em <code className="action">Adicionar uma entrada</code> e selecione o tipo de registo DNS <code className="action">NS</code> para declarar um servidor DNS.
   </Tab>
   <Tab label="Passo 3">
-    Na janela que se abre, introduza o subdomínio em questão no campo <code className="action">Subdomínio *</code> (por exemplo, escreva **unicamente** *www* se o seu nome de domínio for *domain.tld* e o seu subdomínio completo for *www.domain.tld*). No campo <code className="action">Destino *</code>, introduza **apenas um** dos 2 servidores DNS.
+    No formulário que aparece, introduza o subdomínio em questão no campo <code className="action">Subdomínio</code> (por exemplo, escreva **unicamente** *www* se o seu nome de domínio for *domain.tld* e o seu subdomínio completo for *www.domain.tld*). No campo <code className="action">Alvo</code>, introduza **apenas um** dos 2 servidores DNS.
   </Tab>
   <Tab label="Passo 4">
-    Clique em <code className="action">Seguinte</code> e depois em <code className="action">Validar</code>.
+    Clique em <code className="action">Adicionar</code>.
 
     Repita a operação para o segundo servidor DNS que falta declarar.
   </Tab>
@@ -886,18 +886,18 @@ Clique nos separadores abaixo para ver cada um dos **4** passos.
 
 <Tabs>
   <Tab label="Passo 1">
-    Aceda à página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> e escolha o domínio correspondente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Na secção `Web Cloud`, clique em <ManagerLink to="/#/web-domains/domain">Nomes de domínio</ManagerLink>, selecione o nome de domínio em questão e abra o separador **Zona DNS**.
+  
+    <img className="thumbnail" alt="Separador Zona DNS com os registos de um nome de domínio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Passo 2">
-    À direita ou abaixo da tabela, clique em <code className="action">Adicionar um registo</code> e selecione o tipo de registo DNS <code className="action">A</code> para um IPv4 (por exemplo: `203.0.113.0`) ou <code className="action">AAAA</code> para um IPv6 (por exemplo: `2001:db8:1:1b00:203:0:113:0`).
+    Acima da tabela, clique em <code className="action">Adicionar uma entrada</code> e selecione o tipo de registo DNS <code className="action">A</code> para um IPv4 (por exemplo: `203.0.113.0`) ou <code className="action">AAAA</code> para um IPv6 (por exemplo: `2001:db8:1:1b00:203:0:113:0`).
   </Tab>
   <Tab label="Passo 3">
-    Na janela que se abre, no campo de introdução <code className="action">Subdomínio *</code>, introduza o valor `*`. O asterisco `*` representará todos os subdomínios (por exemplo: `www.domain.tld` ou `ovhcloud.domain.tld`) do seu nome de domínio. Preencha o campo <code className="action">Destino *</code> com o endereço IP pretendido.
+    No formulário que aparece, no campo de introdução <code className="action">Subdomínio</code>, introduza o valor `*`. O asterisco `*` representará todos os subdomínios (por exemplo: `www.domain.tld` ou `ovhcloud.domain.tld`) do seu nome de domínio. Preencha o campo <code className="action">Alvo</code> com o endereço IP pretendido.
   </Tab>
   <Tab label="Passo 4">
-    Clique em <code className="action">Seguinte</code> e depois em <code className="action">Validar</code>.
+    Clique em <code className="action">Adicionar</code>.
   </Tab>
 </Tabs>
 
@@ -923,18 +923,18 @@ Para isso, clique nos separadores abaixo para ver cada um dos **4** passos.
 
 <Tabs>
   <Tab label="Passo 1">
-    Aceda à página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> e escolha o domínio correspondente.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Na secção `Web Cloud`, clique em <ManagerLink to="/#/web-domains/domain">Nomes de domínio</ManagerLink>, selecione o nome de domínio em questão e abra o separador **Zona DNS**.
+  
+    <img className="thumbnail" alt="Separador Zona DNS com os registos de um nome de domínio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Passo 2">
-    À direita ou abaixo da tabela, clique em <code className="action">Adicionar um registo</code> e selecione o tipo de registo DNS para o qual deseja configurar um wildcard.
+    Acima da tabela, clique em <code className="action">Adicionar uma entrada</code> e selecione o tipo de registo DNS para o qual deseja configurar um wildcard.
   </Tab>
   <Tab label="Passo 3">
-    Na janela que se abre, no campo de introdução <code className="action">Subdomínio *</code>, introduza o valor `*`. O asterisco `*` representará todos os subdomínios (por exemplo: `www.domain.tld` ou `ovhcloud.domain.tld`) do seu nome de domínio. Preencha os restantes campos com os valores pretendidos.
+    No formulário que aparece, no campo de introdução <code className="action">Subdomínio</code>, introduza o valor `*`. O asterisco `*` representará todos os subdomínios (por exemplo: `www.domain.tld` ou `ovhcloud.domain.tld`) do seu nome de domínio. Preencha os restantes campos com os valores pretendidos.
   </Tab>
   <Tab label="Passo 4">
-    Clique em <code className="action">Seguinte</code> e depois em <code className="action">Validar</code>.
+    Clique em <code className="action">Adicionar</code>.
   </Tab>
 </Tabs>
 
@@ -978,10 +978,10 @@ Clique nos separadores abaixo para ver cada um dos **4** passos.
     Selecione o separador <code className="action">Zona DNS</code> uma vez posicionado no nome de domínio em questão. **Se a zona DNS estiver inativa, ative-a a partir deste separador.**
   </Tab>
   <Tab label="Passo 3">
-    À direita ou abaixo da tabela, clique em <code className="action">Modificar em modo de texto</code>.
+    Acima da tabela, abra o menu <code className="action">Ações na minha zona</code> e clique em <code className="action">Modificar em modo textual</code>.
   </Tab>
   <Tab label="Passo 4">
-    Na janela que se abre, substitua todo o conteúdo apresentado pela cópia da zona DNS eliminada. Em seguida, clique em <code className="action">Seguinte</code> e depois em <code className="action">Validar</code>.
+    No editor de texto que se abre, substitua todo o conteúdo apresentado pela cópia da zona DNS eliminada. Em seguida, siga os passos apresentados no ecrã para confirmar.
   </Tab>
 </Tabs>
 
@@ -1023,10 +1023,10 @@ Clique nos separadores abaixo para ver cada um dos **2** passos.
 
 <Tabs>
   <Tab label="Passo 1">
-    Aceda à página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> e verifique se o nome de domínio em questão aparece.
-
-    <img className="thumbnail" alt="Zonas DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
-  </Tab>
+    Na secção `Web Cloud`, clique em <ManagerLink to="/#/web-domains/domain">Nomes de domínio</ManagerLink> e verifique se o nome de domínio em questão aparece.
+  
+    <img className="thumbnail" alt="Separador Zona DNS com os registos de um nome de domínio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-zone/nx-zone-overview.png" loading="lazy" />
+</Tab>
   <Tab label="Passo 2">
     **Caso n.º 1** - O nome de domínio em questão aparece na lista:
 


### PR DESCRIPTION
Part 4/6 of the SK-2665 series (new DNS zone UX).

## What changed
Updated every DNS-zone answer in the domains FAQ to the new UI: new access path (`Domain names` > **DNS zone** tab), inline add form (`Add`), `⋮` row actions (`Edit the entry`), and the `Actions on my zone` menu (`Edit in text mode`, `Edit the default TTL`, `View the history of my DNS zone`). Obsolete "DNS zones" navigation screenshots removed. The `<Tabs>` structure is preserved. The domain-purchase order funnel is intentionally left untouched.

## Guide updated
`faq-domain-dns`.

## Scope
- 7 locales (en, fr, de, es, it, pl, pt).
- Passed `/proofread-pr` and `content:lint`.
