### PR TITLE
docs(otb): improve wireguard guide

### DIFF
--- a/docs/fr/guides/web-cloud/internet/overthebox/config-wireguard-client.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/config-wireguard-client.mdx
@@ -31,7 +31,7 @@ La configuration d'un client repose sur un échange d'informations entre l'appli
 - l'application génère une **paire de clés** (privée / publique) : la **clé publique du client** doit être déclarée sur votre service via l'API ;
 - votre service OverTheBox expose sa propre configuration (**clé publique du serveur**, **point de terminaison**) que vous reportez dans l'application.
 
-La procédure détaillée ci-dessous porte sur l'application mobile, mais le principe (échange de clés et déclaration du peer via l'API) reste identique pour un client sur ordinateur ou routeur.
+La procédure détaillée ci-dessous porte sur l'application mobile, mais le principe (échange de clés et déclaration du pair via l'API) reste identique pour un client sur ordinateur ou routeur.
 
 Tous les appels API de ce guide sont disponibles dans la <ApiLink section="/overTheBox">section */overTheBox*</ApiLink> de la console API.
 
@@ -50,7 +50,7 @@ Les champs suivants sont nécessaires pour configurer votre client :
 | `endpoint.ipv4` et `endpoint.port` | Point de terminaison du pair, au format `ipv4:port` |
 | `privateIpv4` | Plage d'adresses privées du serveur : choisissez-y une adresse libre à attribuer à votre client |
 
-### Déclarer votre client comme peer
+### Déclarer votre client comme pair
 
 Une fois la paire de clés générée dans l'application (voir l'étape de configuration ci-dessous), déclarez la **clé publique du client** sur votre service :
 
@@ -65,6 +65,12 @@ Une fois la paire de clés générée dans l'application (voir l'étape de confi
 | `publicKey` | Oui | La **clé publique** générée par l'application WireGuard du client |
 | `privateIpv4` | Oui | L'adresse IPv4 privée attribuée au client (comprise dans la plage `privateIpv4` du serveur) |
 
+:::info
+À sa création, un pair est **inactif** par défaut : vous devez l'activer explicitement (paramètre `active` à `true` via un appel `PUT`) pour établir la connexion. Consultez la section « Gérer les pairs WireGuard » du guide « [Comment configurer WireGuard sur OverTheBox](/guides/web-cloud/internet/overthebox/config-wireguard) ».
+
+:::
+
+
 ### Configurer l'application WireGuard sur smartphone
 
 <Tabs>
@@ -77,8 +83,9 @@ Si ce n'est pas déjà fait, installez l'application **WireGuard** en scannant l
 1. Ouvrez l'application **WireGuard**, appuyez sur le bouton <code className="action">+</code>, puis choisissez <code className="action">Créer à partir de zéro</code>.
 2. Dans la section **Interface** :
     - **Nom** : donnez un nom à votre tunnel (par exemple `MonServiceOTB`).
-    - **Clé privée** / **Clé publique** : l'application génère automatiquement une paire de clés. Utilisez le bouton de régénération si nécessaire. Conservez la **Clé publique** affichée : c'est elle que vous déclarerez sur votre service (paramètre `publicKey` de l'appel de création de peer).
+    - **Clé privée** / **Clé publique** : l'application génère automatiquement une paire de clés. Utilisez le bouton de régénération si nécessaire. Conservez la **Clé publique** affichée : c'est elle que vous déclarerez sur votre service (paramètre `publicKey` de l'appel de création de pair).
     - **Adresses** : saisissez l'adresse IPv4 privée à attribuer à ce client (par exemple `10.100.0.2`), comprise dans la plage `privateIpv4` du serveur.
+    - **Serveurs DNS** (optionnel) : si vous n'avez pas de connectivité une fois le tunnel activé, renseignez un serveur DNS, par exemple `9.9.9.9` (Quad9) ou `91.121.61.147` (OVHcloud).
 
     <img className="thumbnail" alt="Configuration de l'interface WireGuard sur Android" src="/images/web-cloud/internet/overthebox/config-wireguard-client/android_clientConfig.png" loading="lazy" />
 
@@ -91,7 +98,7 @@ Si ce n'est pas déjà fait, installez l'application **WireGuard** en scannant l
     <img className="thumbnail" alt="Configuration du pair WireGuard sur Android" src="/images/web-cloud/internet/overthebox/config-wireguard-client/android_serverConfig.png" loading="lazy" />
 
 4. Enregistrez le tunnel à l'aide du bouton en haut à droite.
-5. Assurez-vous d'avoir déclaré votre client comme peer sur votre service (voir la section précédente), puis activez le tunnel pour établir la connexion.
+5. Assurez-vous d'avoir déclaré votre client comme pair sur votre service (voir la section précédente), puis activez le tunnel pour établir la connexion.
 
 </Tab>
 <Tab label="iOS">
@@ -103,8 +110,9 @@ Si ce n'est pas déjà fait, installez l'application **WireGuard** en scannant l
 1. Ouvrez l'application **WireGuard**, appuyez sur le bouton <code className="action">+</code>, puis choisissez <code className="action">Créer à partir de rien</code>.
 2. Dans la section **Interface** :
     - **Nom** : donnez un nom à votre tunnel (par exemple `MonServiceOTB`).
-    - **Clé privée** / **Clé publique** : appuyez sur <code className="action">Générer une paire de clés</code>. Conservez la **Clé publique** affichée : c'est elle que vous déclarerez sur votre service (paramètre `publicKey` de l'appel de création de peer).
+    - **Clé privée** / **Clé publique** : appuyez sur <code className="action">Générer une paire de clés</code>. Conservez la **Clé publique** affichée : c'est elle que vous déclarerez sur votre service (paramètre `publicKey` de l'appel de création de pair).
     - **Adresses** : saisissez l'adresse IPv4 privée à attribuer à ce client (par exemple `10.100.0.2`), comprise dans la plage `privateIpv4` du serveur.
+    - **Serveurs DNS** (optionnel) : si vous n'avez pas de connectivité une fois le tunnel activé, renseignez un serveur DNS, par exemple `9.9.9.9` (Quad9) ou `91.121.61.147` (OVHcloud).
 
     <img className="thumbnail" alt="Configuration de l'interface WireGuard sur iOS" src="/images/web-cloud/internet/overthebox/config-wireguard-client/ios_clientConfig.png" loading="lazy" />
 
@@ -117,7 +125,7 @@ Si ce n'est pas déjà fait, installez l'application **WireGuard** en scannant l
     <img className="thumbnail" alt="Configuration du pair WireGuard sur iOS" src="/images/web-cloud/internet/overthebox/config-wireguard-client/ios_serverConfig.png" loading="lazy" />
 
 4. Enregistrez le tunnel à l'aide du bouton <code className="action">Enregistrer</code>.
-5. Assurez-vous d'avoir déclaré votre client comme peer sur votre service (voir la section précédente), puis activez le tunnel pour établir la connexion.
+5. Assurez-vous d'avoir déclaré votre client comme pair sur votre service (voir la section précédente), puis activez le tunnel pour établir la connexion.
 
 </Tab>
 </Tabs>

--- a/docs/fr/guides/web-cloud/internet/overthebox/config-wireguard-client.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/config-wireguard-client.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comment configurer un client WireGuard
 description: Découvrez comment configurer un client WireGuard (application mobile, ordinateur, routeur) pour vous connecter à un service OverTheBox en mode WireGuard
-lastUpdated: 2026-07-24
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -66,7 +66,7 @@ Une fois la paire de clés générée dans l'application (voir l'étape de confi
 | `privateIpv4` | Oui | L'adresse IPv4 privée attribuée au client (comprise dans la plage `privateIpv4` du serveur) |
 
 :::info
-À sa création, un pair est **inactif** par défaut : vous devez l'activer explicitement (paramètre `active` à `true` via un appel `PUT`) pour établir la connexion. Consultez la section « Gérer les pairs WireGuard » du guide « [Comment configurer WireGuard sur OverTheBox](/guides/web-cloud/internet/overthebox/config-wireguard) ».
+À sa création, un pair est **inactif** par défaut : pour établir la connexion, vous devez l'activer en définissant son paramètre `active` sur `true` via un appel `PUT`. Consultez la section « Gérer les pairs WireGuard » du guide « [Comment configurer WireGuard sur OverTheBox](/guides/web-cloud/internet/overthebox/config-wireguard#gérer-les-pairs-wireguard) ».
 
 :::
 
@@ -85,7 +85,7 @@ Si ce n'est pas déjà fait, installez l'application **WireGuard** en scannant l
     - **Nom** : donnez un nom à votre tunnel (par exemple `MonServiceOTB`).
     - **Clé privée** / **Clé publique** : l'application génère automatiquement une paire de clés. Utilisez le bouton de régénération si nécessaire. Conservez la **Clé publique** affichée : c'est elle que vous déclarerez sur votre service (paramètre `publicKey` de l'appel de création de pair).
     - **Adresses** : saisissez l'adresse IPv4 privée à attribuer à ce client (par exemple `10.100.0.2`), comprise dans la plage `privateIpv4` du serveur.
-    - **Serveurs DNS** (optionnel) : si vous n'avez pas de connectivité une fois le tunnel activé, renseignez un serveur DNS, par exemple `9.9.9.9` (Quad9) ou `91.121.61.147` (OVHcloud).
+    - **Serveurs DNS** (facultatif) : en l'absence de connectivité après l'activation du tunnel, renseignez un serveur DNS, par exemple `9.9.9.9` (Quad9) ou `91.121.61.147` (OVHcloud).
 
     <img className="thumbnail" alt="Configuration de l'interface WireGuard sur Android" src="/images/web-cloud/internet/overthebox/config-wireguard-client/android_clientConfig.png" loading="lazy" />
 
@@ -98,7 +98,7 @@ Si ce n'est pas déjà fait, installez l'application **WireGuard** en scannant l
     <img className="thumbnail" alt="Configuration du pair WireGuard sur Android" src="/images/web-cloud/internet/overthebox/config-wireguard-client/android_serverConfig.png" loading="lazy" />
 
 4. Enregistrez le tunnel à l'aide du bouton en haut à droite.
-5. Assurez-vous d'avoir déclaré votre client comme pair sur votre service (voir la section précédente), puis activez le tunnel pour établir la connexion.
+5. Assurez-vous d'avoir [déclaré votre client comme pair](#déclarer-votre-client-comme-pair) sur votre service, puis activez le tunnel pour établir la connexion.
 
 </Tab>
 <Tab label="iOS">
@@ -112,7 +112,7 @@ Si ce n'est pas déjà fait, installez l'application **WireGuard** en scannant l
     - **Nom** : donnez un nom à votre tunnel (par exemple `MonServiceOTB`).
     - **Clé privée** / **Clé publique** : appuyez sur <code className="action">Générer une paire de clés</code>. Conservez la **Clé publique** affichée : c'est elle que vous déclarerez sur votre service (paramètre `publicKey` de l'appel de création de pair).
     - **Adresses** : saisissez l'adresse IPv4 privée à attribuer à ce client (par exemple `10.100.0.2`), comprise dans la plage `privateIpv4` du serveur.
-    - **Serveurs DNS** (optionnel) : si vous n'avez pas de connectivité une fois le tunnel activé, renseignez un serveur DNS, par exemple `9.9.9.9` (Quad9) ou `91.121.61.147` (OVHcloud).
+    - **Serveurs DNS** (facultatif) : en l'absence de connectivité après l'activation du tunnel, renseignez un serveur DNS, par exemple `9.9.9.9` (Quad9) ou `91.121.61.147` (OVHcloud).
 
     <img className="thumbnail" alt="Configuration de l'interface WireGuard sur iOS" src="/images/web-cloud/internet/overthebox/config-wireguard-client/ios_clientConfig.png" loading="lazy" />
 
@@ -125,7 +125,7 @@ Si ce n'est pas déjà fait, installez l'application **WireGuard** en scannant l
     <img className="thumbnail" alt="Configuration du pair WireGuard sur iOS" src="/images/web-cloud/internet/overthebox/config-wireguard-client/ios_serverConfig.png" loading="lazy" />
 
 4. Enregistrez le tunnel à l'aide du bouton <code className="action">Enregistrer</code>.
-5. Assurez-vous d'avoir déclaré votre client comme pair sur votre service (voir la section précédente), puis activez le tunnel pour établir la connexion.
+5. Assurez-vous d'avoir [déclaré votre client comme pair](#déclarer-votre-client-comme-pair) sur votre service, puis activez le tunnel pour établir la connexion.
 
 </Tab>
 </Tabs>

--- a/docs/fr/guides/web-cloud/internet/overthebox/config-wireguard.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/config-wireguard.mdx
@@ -109,14 +109,14 @@ La réponse contient les informations à reporter dans la configuration de vos c
 | `endpoint.port` | Port de connexion du serveur WireGuard |
 | `publicKey` | Clé publique du serveur WireGuard |
 | `privateIpv4` | Plage d'adresses IPv4 privées du serveur WireGuard |
-| `maxPeerActive` | Nombre maximum de peers actifs simultanément |
-| `maxPeerAllowed` | Nombre maximum de peers configurables |
+| `maxPeerActive` | Nombre maximum de pairs actifs simultanément |
+| `maxPeerAllowed` | Nombre maximum de pairs configurables |
 
-### Gérer les peers WireGuard
+### Gérer les pairs WireGuard
 
-Un *peer* représente un client autorisé à se connecter au serveur WireGuard de votre OverTheBox.
+Un *pair* (*peer*) représente un client autorisé à se connecter au serveur WireGuard de votre OverTheBox.
 
-#### Lister les peers
+#### Lister les pairs
 
 <Api version="v1" section="/overTheBox" method="GET" route={"/overTheBox/\{serviceName\}/wireguard/peers"} />
 
@@ -125,7 +125,7 @@ Un *peer* représente un client autorisé à se connecter au serveur WireGuard d
 |-----------|----------|-------------|
 | `serviceName` | Oui | Le nom interne de votre service OverTheBox |
 
-#### Créer un peer
+#### Créer un pair
 
 Générez d'abord une paire de clés WireGuard sur votre client, puis transmettez sa clé publique à l'aide de l'appel suivant :
 
@@ -135,12 +135,18 @@ Générez d'abord une paire de clés WireGuard sur votre client, puis transmette
 | Paramètre | Obligatoire | Description |
 |-----------|----------|-------------|
 | `serviceName` | Oui | Le nom interne de votre service OverTheBox |
-| `name` | Oui | Un nom pour identifier le peer |
-| `description` | Oui | Une description du peer |
+| `name` | Oui | Un nom pour identifier le pair |
+| `description` | Oui | Une description du pair |
 | `publicKey` | Oui | La clé publique WireGuard du client |
-| `privateIpv4` | Oui | L'adresse IPv4 privée à attribuer au peer (dans la plage `privateIpv4` du serveur) |
+| `privateIpv4` | Oui | L'adresse IPv4 privée à attribuer au pair (dans la plage `privateIpv4` du serveur) |
 
-#### Consulter un peer
+:::info
+À sa création, un pair est **inactif** par défaut. Pour l'activer, effectuez un appel `PUT` sur la route `/overTheBox/{serviceName}/wireguard/peers/{peerId}` (voir « [Modifier un pair](#modifier-un-pair) ») en passant le paramètre `active` à `true`.
+
+:::
+
+
+#### Consulter un pair
 
 <Api version="v1" section="/overTheBox" method="GET" route={"/overTheBox/\{serviceName\}/wireguard/peers/\{peerId\}"} />
 
@@ -148,9 +154,9 @@ Générez d'abord une paire de clés WireGuard sur votre client, puis transmette
 | Paramètre | Obligatoire | Description |
 |-----------|----------|-------------|
 | `serviceName` | Oui | Le nom interne de votre service OverTheBox |
-| `peerId` | Oui | L'identifiant du peer |
+| `peerId` | Oui | L'identifiant du pair |
 
-#### Modifier un peer
+#### Modifier un pair
 
 <Api version="v1" section="/overTheBox" method="PUT" route={"/overTheBox/\{serviceName\}/wireguard/peers/\{peerId\}"} />
 
@@ -158,14 +164,14 @@ Générez d'abord une paire de clés WireGuard sur votre client, puis transmette
 | Paramètre | Obligatoire | Description |
 |-----------|----------|-------------|
 | `serviceName` | Oui | Le nom interne de votre service OverTheBox |
-| `peerId` | Oui | L'identifiant du peer |
-| `name` |  | Un nom pour identifier le peer |
-| `description` |  | Une description du peer |
+| `peerId` | Oui | L'identifiant du pair |
+| `name` |  | Un nom pour identifier le pair |
+| `description` |  | Une description du pair |
 | `publicKey` |  | La clé publique WireGuard du client |
-| `privateIpv4` |  | L'adresse IPv4 privée attribuée au peer |
-| `active` |  | Active (`true`) ou désactive (`false`) le peer |
+| `privateIpv4` |  | L'adresse IPv4 privée attribuée au pair |
+| `active` |  | Active (`true`) ou désactive (`false`) le pair |
 
-#### Supprimer un peer
+#### Supprimer un pair
 
 <Api version="v1" section="/overTheBox" method="DELETE" route={"/overTheBox/\{serviceName\}/wireguard/peers/\{peerId\}"} />
 
@@ -173,7 +179,7 @@ Générez d'abord une paire de clés WireGuard sur votre client, puis transmette
 | Paramètre | Obligatoire | Description |
 |-----------|----------|-------------|
 | `serviceName` | Oui | Le nom interne de votre service OverTheBox |
-| `peerId` | Oui | L'identifiant du peer |
+| `peerId` | Oui | L'identifiant du pair |
 
 ### Régénérer la configuration WireGuard
 
@@ -204,7 +210,7 @@ Cette opération réinitialise la configuration WireGuard du service :
 | `serviceName` | Oui | Le nom interne de votre service OverTheBox |
 
 :::warning
-La réinitialisation est une opération destructive : elle supprime les peers configurés et restaure la configuration WireGuard par défaut.
+La réinitialisation est une opération destructive : elle supprime les pairs configurés et restaure la configuration WireGuard par défaut.
 
 :::
 

--- a/docs/fr/guides/web-cloud/internet/overthebox/config-wireguard.mdx
+++ b/docs/fr/guides/web-cloud/internet/overthebox/config-wireguard.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comment configurer WireGuard sur OverTheBox
 description: Découvrez comment basculer votre service OverTheBox en mode WireGuard et le configurer via l'API OVHcloud
-lastUpdated: 2026-07-24
+lastUpdated: 2026-07-30
 ---
 
 import Api from '@components/Api';
@@ -114,7 +114,7 @@ La réponse contient les informations à reporter dans la configuration de vos c
 
 ### Gérer les pairs WireGuard
 
-Un *pair* (*peer*) représente un client autorisé à se connecter au serveur WireGuard de votre OverTheBox.
+Un *pair* (*peer* dans l'API) représente un client autorisé à se connecter au serveur WireGuard de votre OverTheBox.
 
 #### Lister les pairs
 
@@ -141,7 +141,7 @@ Générez d'abord une paire de clés WireGuard sur votre client, puis transmette
 | `privateIpv4` | Oui | L'adresse IPv4 privée à attribuer au pair (dans la plage `privateIpv4` du serveur) |
 
 :::info
-À sa création, un pair est **inactif** par défaut. Pour l'activer, effectuez un appel `PUT` sur la route `/overTheBox/{serviceName}/wireguard/peers/{peerId}` (voir « [Modifier un pair](#modifier-un-pair) ») en passant le paramètre `active` à `true`.
+À sa création, un pair est **inactif** par défaut. Pour l'activer, définissez son paramètre `active` sur `true` à l'aide de l'appel `PUT` décrit dans la section « [Modifier un pair](#modifier-un-pair) ».
 
 :::
 


### PR DESCRIPTION
- add mention that dns might be needed in client config
- add mention that a peer need to be activated after creation
- localise peers to french "pairs"