### PR TITLE
docs(baremetal): document new install options

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Install an OS via the OVHcloud API on a Dedicated Server
 description: Use OVHcloud API to install or reinstall an OS on your dedicated server
-lastUpdated: 2025-06-06
+lastUpdated: 2026-07-30
 ---
 
 import Api from '@components/Api';
@@ -165,6 +165,19 @@ Each question has the following attributes:
 
 ¹ If a mandatory question without default value is not answered, the API will return an error.
 
+Some server ranges also expose an `enableLacpBonding` question. When set to `true`, LACP (IEEE 802.3ad) link aggregation is configured on the server's network interfaces during installation. This corresponds to the **Enable LACP to aggregate multiple network interfaces (if applicable)** option in the OVHcloud Control Panel.
+
+```json
+{
+    "name": "enableLacpBonding",
+    "description": "Enable LACP to aggregate multiple network interfaces (if applicable)",
+    "default": "false",
+    "mandatory": false,
+    "type": "boolean",
+    "enum": []
+}
+```
+
 ### Create an OS reinstallation task <a name="install-task"></a>
 
 When you have gathered all the information that you need, you can create the OS reinstallation task with the following API call:
@@ -219,6 +232,10 @@ date "+%Y-%m-%d %H:%M:%S" --utc >> /opt/coucou
 
 :::info
 For UNIX/Linux OS, you can provide scripts in any programming language (if running stack is installed on the target OS) that matches the provided shebang.
+:::
+
+:::info
+When a Backup Agent is linked to your server, the OVHcloud Control Panel can automatically append the OVHcloud Backup Agent installation command to your `postInstallationScript` (the **Install Backup Agent** option). You can reproduce the same behaviour by adding the installation command to your own post-installation script. For more information, refer to [Back up a Bare Metal Linux Server with Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
 :::
 
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Erste Schritte mit einem Dedicated Server
 description: Erfahren Sie hier, wie Sie einen Dedicated Server in Ihrem OVHcloud Kundencenter verwalten und wie Sie mit der Konfiguration und Sicherung eines Servers starten
-lastUpdated: 2025-04-29
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -97,6 +97,8 @@ Dort finden Sie außerdem Optionen zu dem von Ihnen ausgewählten Betriebssystem
 
 <img className="thumbnail" alt="server options" src="/images/assets/screens/control-panel/product-selection/bare-metal-cloud/dedicated-servers/general-information/reinstalling-your-server-05.png" loading="lazy" />
 
+**Pre-installing an SSH key**
+
 Wenn Sie ein kompatibles Betriebssystem ausgewählt haben, können Sie einen **öffentlichen Schlüssel** angeben, der automatisch installiert werden soll. Sie haben zwei Möglichkeiten:
 
 - Kopieren Sie die Schlüsselzeichenfolge manuell und fügen Sie sie in das Feld `Ihr öffentlicher SSH-Schlüssel` ein.
@@ -108,6 +110,24 @@ Weitere Informationen zu diesem Thema finden Sie in unseren Anleitungen:
 
 - [Erstellen und verwenden von Schlüsseln für die SSH-Authentifizierung](/guides/bare-metal-cloud/dedicated-servers/creating-ssh-keys)
 - [Erstellen und verwenden von Schlüsseln für die SSH-Authentifizierung mit PuTTY](/guides/web-cloud/web-hosting/ssh-using-putty-on-windows)
+
+**Enabling LACP link aggregation**
+
+For compatible operating systems, you can tick the <code className="action">Enable LACP to aggregate multiple network interfaces (if applicable)</code> checkbox. When this option is enabled, LACP (IEEE 802.3ad) link aggregation is configured on your server's network interfaces directly during the operating system installation, so that the interfaces are bonded automatically once the server boots. This checkbox is only displayed for operating system templates that support it.
+
+To aggregate your server's interfaces on the OVHcloud side, or to configure link aggregation manually afterwards, refer to the following guides:
+
+- [Configuring OVHcloud Link Aggregation (OLA) in the OVHcloud Control Panel](/guides/bare-metal-cloud/dedicated-servers/ola-enable-manager)
+- [How to configure Link Aggregation with LACP in Debian 12 or newer / Ubuntu 24.04 or newer](/guides/bare-metal-cloud/dedicated-servers/lacp-enable-netplan)
+
+**Installing the Backup Agent (Linux)**
+
+If you have selected a Linux operating system, a **Backup Agent** option is available:
+
+- If a Backup Agent is already linked to your server, tick the <code className="action">Install Backup Agent</code> checkbox. The corresponding installation command is added to your post-installation script, so the agent is installed automatically once the operating system installation is complete.
+- If no Backup Agent is linked to your server yet, click <code className="action">Link a Backup Agent</code> to order or associate one first.
+
+For more information about backing up a Linux server, refer to [Back up a Bare Metal Linux Server with Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
 
 Klicken Sie anschließend auf <code className="action">Bestätigen</code>, um die Installation des Betriebssystems auf Ihrem Dedicated Server zu starten.
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Install an OS via the OVHcloud API on a Dedicated Server
 description: Use OVHcloud API to install or reinstall an OS on your dedicated server
-lastUpdated: 2025-06-06
+lastUpdated: 2026-07-30
 ---
 
 import Api from '@components/Api';
@@ -165,6 +165,19 @@ Each question has the following attributes:
 
 ¹ If a mandatory question without default value is not answered, the API will return an error.
 
+Some server ranges also expose an `enableLacpBonding` question. When set to `true`, LACP (IEEE 802.3ad) link aggregation is configured on the server's network interfaces during installation.
+
+```json
+{
+    "name": "enableLacpBonding",
+    "description": "Enable LACP to aggregate multiple network interfaces (if applicable)",
+    "default": "false",
+    "mandatory": false,
+    "type": "boolean",
+    "enum": []
+}
+```
+
 ### Create an OS reinstallation task <a name="install-task"></a>
 
 When you have gathered all the information that you need, you can create the OS reinstallation task with the following API call:
@@ -219,6 +232,11 @@ date "+%Y-%m-%d %H:%M:%S" --utc >> /opt/coucou
 
 :::info
 For UNIX/Linux OS, you can provide scripts in any programming language (if running stack is installed on the target OS) that matches the provided shebang.
+:::
+
+
+:::info
+To install the OVHcloud Backup Agent automatically, add its installation command to your `postInstallationScript`. For more information, refer to [Back up a Bare Metal Linux Server with Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
 :::
 
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to get started with a dedicated server
 description: Find out how to manage a dedicated server in the OVHcloud Control Panel and how to start with configuring and securing a server
-lastUpdated: 2025-04-29
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -96,6 +96,8 @@ You will find additional options that are specific to the chosen operating syste
 
 <img className="thumbnail" alt="server options" src="/images/assets/screens/control-panel/product-selection/bare-metal-cloud/dedicated-servers/general-information/reinstalling-your-server-05.png" loading="lazy" />
 
+**Pre-installing an SSH key**
+
 If you have selected a compatible operating system, you can provide a **public key** to be installed automatically. You have two options:
 
 - Manually copy the key string and paste it into the field `Your Public SSH key`.
@@ -108,7 +110,25 @@ To find out more about this topic, consult our guides:
 - [How to create and use keys for SSH authentication](/guides/bare-metal-cloud/dedicated-servers/creating-ssh-keys)
 - [How to create and use keys for SSH authentication with PuTTY](/guides/web-cloud/web-hosting/ssh-using-putty-on-windows)
 
-Finally, click <code className="action">Confirm</code> to trigger the operating system installation on your dedicated server.
+**Enabling LACP link aggregation**
+
+For compatible operating systems, you can tick the <code className="action">Enable LACP to aggregate multiple network interfaces (if applicable)</code> checkbox. When this option is enabled, LACP (IEEE 802.3ad) link aggregation is configured on your server's network interfaces directly during the operating system installation, so that the interfaces are bonded automatically once the server boots. This checkbox is only displayed for operating system templates that support it.
+
+To aggregate your server's interfaces on the OVHcloud side, or to configure link aggregation manually afterwards, refer to the following guides:
+
+- [Configuring OVHcloud Link Aggregation (OLA) in the OVHcloud Control Panel](/guides/bare-metal-cloud/dedicated-servers/ola-enable-manager)
+- [How to configure Link Aggregation with LACP in Debian 12 or newer / Ubuntu 24.04 or newer](/guides/bare-metal-cloud/dedicated-servers/lacp-enable-netplan)
+
+**Installing the Backup Agent (Linux)**
+
+If you have selected a Linux operating system, a **Backup Agent** option is available:
+
+- If a Backup Agent is already linked to your server, tick the <code className="action">Install Backup Agent</code> checkbox. The corresponding installation command is added to your post-installation script, so the agent is installed automatically once the operating system installation is complete.
+- If no Backup Agent is linked to your server yet, click <code className="action">Link a Backup Agent</code> to order or associate one first.
+
+For more information about backing up a Linux server, refer to [Back up a Bare Metal Linux Server with Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
+
+**Once you have reviewed the additional options**, click <code className="action">Confirm</code> to trigger the operating system installation on your dedicated server.
 
 <a name="connect"></a>
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Install an OS via the OVHcloud API on a Dedicated Server
 description: Use OVHcloud API to install or reinstall an OS on your dedicated server
-lastUpdated: 2025-06-06
+lastUpdated: 2026-07-30
 ---
 
 import Api from '@components/Api';
@@ -165,6 +165,19 @@ Each question has the following attributes:
 
 ¹ If a mandatory question without default value is not answered, the API will return an error.
 
+Some server ranges also expose an `enableLacpBonding` question. When set to `true`, LACP (IEEE 802.3ad) link aggregation is configured on the server's network interfaces during installation. This corresponds to the **Enable LACP to aggregate multiple network interfaces (if applicable)** option in the OVHcloud Control Panel.
+
+```json
+{
+    "name": "enableLacpBonding",
+    "description": "Enable LACP to aggregate multiple network interfaces (if applicable)",
+    "default": "false",
+    "mandatory": false,
+    "type": "boolean",
+    "enum": []
+}
+```
+
 ### Create an OS reinstallation task <a name="install-task"></a>
 
 When you have gathered all the information that you need, you can create the OS reinstallation task with the following API call:
@@ -219,6 +232,10 @@ date "+%Y-%m-%d %H:%M:%S" --utc >> /opt/coucou
 
 :::info
 For UNIX/Linux OS, you can provide scripts in any programming language (if running stack is installed on the target OS) that matches the provided shebang.
+:::
+
+:::info
+When a Backup Agent is linked to your server, the OVHcloud Control Panel can automatically append the OVHcloud Backup Agent installation command to your `postInstallationScript` (the **Install Backup Agent** option). You can reproduce the same behaviour by adding the installation command to your own post-installation script. For more information, refer to [Back up a Bare Metal Linux Server with Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
 :::
 
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Primeros pasos con un servidor dedicado
 description: Cómo gestionar un servidor dedicado en su área de cliente y cómo empezar con la configuración y la seguridad de un servidor
-lastUpdated: 2025-04-29
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -97,6 +97,8 @@ Esto incluye preguntas adicionales específicas para el sistema operativo selecc
 
 <img className="thumbnail" alt="server options" src="/images/assets/screens/control-panel/product-selection/bare-metal-cloud/dedicated-servers/general-information/reinstalling-your-server-05.png" loading="lazy" />
 
+**Pre-installing an SSH key**
+
 Si ha seleccionado un sistema operativo compatible, puede proporcionar una **clave pública** para su instalación automática. Puede elegir entre dos opciones:
 
 - Copie manualmente la cadena de llave y péguela en el campo `Su llave SSH pública`.
@@ -108,6 +110,24 @@ Para más información, consulte nuestras guías:
 
 - [Cómo crear y utilizar claves para la autenticación SSH](/guides/bare-metal-cloud/dedicated-servers/creating-ssh-keys)
 - [Cómo crear y utilizar claves para la autenticación SSH con PuTTY](/guides/web-cloud/web-hosting/ssh-using-putty-on-windows)
+
+**Enabling LACP link aggregation**
+
+For compatible operating systems, you can tick the <code className="action">Enable LACP to aggregate multiple network interfaces (if applicable)</code> checkbox. When this option is enabled, LACP (IEEE 802.3ad) link aggregation is configured on your server's network interfaces directly during the operating system installation, so that the interfaces are bonded automatically once the server boots. This checkbox is only displayed for operating system templates that support it.
+
+To aggregate your server's interfaces on the OVHcloud side, or to configure link aggregation manually afterwards, refer to the following guides:
+
+- [Configuring OVHcloud Link Aggregation (OLA) in the OVHcloud Control Panel](/guides/bare-metal-cloud/dedicated-servers/ola-enable-manager)
+- [How to configure Link Aggregation with LACP in Debian 12 or newer / Ubuntu 24.04 or newer](/guides/bare-metal-cloud/dedicated-servers/lacp-enable-netplan)
+
+**Installing the Backup Agent (Linux)**
+
+If you have selected a Linux operating system, a **Backup Agent** option is available:
+
+- If a Backup Agent is already linked to your server, tick the <code className="action">Install Backup Agent</code> checkbox. The corresponding installation command is added to your post-installation script, so the agent is installed automatically once the operating system installation is complete.
+- If no Backup Agent is linked to your server yet, click <code className="action">Link a Backup Agent</code> to order or associate one first.
+
+For more information about backing up a Linux server, refer to [Back up a Bare Metal Linux Server with Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
 
 Por último, haga clic en <code className="action">Confirmar</code> para instalar el sistema operativo en su servidor dedicado.
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Installer un OS via l'API OVHcloud sur un serveur dédié"
 description: "Utilisez l'API OVHcloud pour installer ou réinstaller un OS sur votre serveur dédié"
-lastUpdated: 2025-06-06
+lastUpdated: 2026-07-30
 ---
 
 import Api from '@components/Api';
@@ -162,6 +162,19 @@ Chaque question a les attributs suivants :
 
 ¹ Si une question obligatoire ne possédant pas de valeur par défaut est laissée sans réponse, alors l'API retournera une erreur.
 
+Certaines gammes de serveurs proposent également une question `enableLacpBonding`. Lorsqu'elle est définie sur `true`, l'agrégation de liens LACP (IEEE 802.3ad) est configurée sur les interfaces réseau du serveur pendant l'installation.
+
+```json
+{
+    "name": "enableLacpBonding",
+    "description": "Enable LACP to aggregate multiple network interfaces (if applicable)",
+    "default": "false",
+    "mandatory": false,
+    "type": "boolean",
+    "enum": []
+}
+```
+
 ### Lancer et suivre la demande de réinstallation <a name="install-task"></a>
 
 Lorsque vous avez rassemblé toutes les informations nécessaires, vous pouvez lancer la réinstallation de l'OS, en utilisant l'appel suivant :
@@ -216,6 +229,11 @@ date "+%Y-%m-%d %H:%M:%S" --utc >> /opt/coucou
 
 :::info
 Pour les OS UNIX/Linux, vous pouvez fournir des scripts dans le language de programmation de votre choix (sous réserve que l'environnement d'exécution soit installé sur l'OS cible), à condition de mettre le shebang approprié.
+:::
+
+
+:::info
+Pour installer automatiquement l'OVHcloud Backup Agent, ajoutez sa commande d'installation à votre `postInstallationScript`. Pour en savoir plus, consultez le guide [Sauvegarder un serveur Bare Metal Linux avec Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
 :::
 
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Premiers pas avec un serveur dédié
 description: "Découvrez comment gérer un serveur dédié dans votre espace client OVHcloud et comment démarrer avec la configuration et la sécurisation d'un serveur"
-lastUpdated: 2025-04-29
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -97,6 +97,8 @@ Vous y trouverez notamment des questions complémentaires spécifiques au systè
 
 <img className="thumbnail" alt="server options" src="/images/assets/screens/control-panel/product-selection/bare-metal-cloud/dedicated-servers/general-information/reinstalling-your-server-05.png" loading="lazy" />
 
+**Pré-installation d'une clé SSH**
+
 Si vous avez sélectionné un système d'exploitation compatible, vous pouvez fournir une **clé publique** à installer automatiquement. Deux possibilités s'offrent à vous :
 
 - Copiez manuellement la chaîne de clé et collez-la dans le champ `Votre clé SSH Publique`.
@@ -109,7 +111,25 @@ Pour en savoir plus sur ce sujet, consultez nos guides :
 - [Comment créer et utiliser des clés pour l'authentification SSH](/guides/bare-metal-cloud/dedicated-servers/creating-ssh-keys)
 - [Comment créer et utiliser des clés pour l'authentification SSH avec PuTTY](/guides/web-cloud/web-hosting/ssh-using-putty-on-windows)
 
-Cliquez enfin sur <code className="action">Confirmer</code> pour lancer l'installation du système d'exploitation sur votre serveur dédié.
+**Activer l'agrégation de liens LACP**
+
+Pour les systèmes d'exploitation compatibles, vous pouvez cocher la case <code className="action">Enable LACP to aggregate multiple network interfaces (if applicable)</code>. Lorsque cette option est activée, l'agrégation de liens LACP (IEEE 802.3ad) est configurée sur les interfaces réseau de votre serveur directement pendant l'installation du système d'exploitation ; les interfaces sont ainsi agrégées automatiquement au démarrage du serveur. Cette case n'apparaît que pour les modèles de système d'exploitation qui prennent en charge cette fonctionnalité.
+
+Pour agréger les interfaces de votre serveur du côté OVHcloud, ou pour configurer l'agrégation de liens manuellement par la suite, consultez les guides suivants :
+
+- [Configurer l'agrégation de liens OLA dans votre espace client](/guides/bare-metal-cloud/dedicated-servers/ola-enable-manager)
+- [Comment configurer l'agrégation de liens avec LACP dans Debian 12 ou plus récent / Ubuntu 24.04 ou plus récent](/guides/bare-metal-cloud/dedicated-servers/lacp-enable-netplan)
+
+**Installer le Backup Agent (Linux)**
+
+Si vous avez sélectionné un système d'exploitation Linux, une option **Backup Agent** est disponible :
+
+- Si un Backup Agent est déjà lié à votre serveur, cochez la case <code className="action">Installer Backup Agent</code>. La commande d'installation correspondante est ajoutée à votre script de post-installation, de sorte que l'agent est installé automatiquement une fois l'installation du système d'exploitation terminée.
+- Si aucun Backup Agent n'est encore lié à votre serveur, cliquez sur <code className="action">Lier un Backup Agent</code> pour en commander un ou en associer un au préalable.
+
+Pour en savoir plus sur la sauvegarde d'un serveur Linux, consultez le guide [Sauvegarder un serveur Bare Metal Linux avec Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
+
+**Après avoir examiné les options supplémentaires**, cliquez sur <code className="action">Confirmer</code> pour lancer l'installation du système d'exploitation sur votre serveur dédié.
 
 <a name="connect"></a>
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Install an OS via the OVHcloud API on a Dedicated Server
 description: Use OVHcloud API to install or reinstall an OS on your dedicated server
-lastUpdated: 2025-06-06
+lastUpdated: 2026-07-30
 ---
 
 import Api from '@components/Api';
@@ -165,6 +165,19 @@ Each question has the following attributes:
 
 ¹ If a mandatory question without default value is not answered, the API will return an error.
 
+Some server ranges also expose an `enableLacpBonding` question. When set to `true`, LACP (IEEE 802.3ad) link aggregation is configured on the server's network interfaces during installation. This corresponds to the **Enable LACP to aggregate multiple network interfaces (if applicable)** option in the OVHcloud Control Panel.
+
+```json
+{
+    "name": "enableLacpBonding",
+    "description": "Enable LACP to aggregate multiple network interfaces (if applicable)",
+    "default": "false",
+    "mandatory": false,
+    "type": "boolean",
+    "enum": []
+}
+```
+
 ### Create an OS reinstallation task <a name="install-task"></a>
 
 When you have gathered all the information that you need, you can create the OS reinstallation task with the following API call:
@@ -219,6 +232,10 @@ date "+%Y-%m-%d %H:%M:%S" --utc >> /opt/coucou
 
 :::info
 For UNIX/Linux OS, you can provide scripts in any programming language (if running stack is installed on the target OS) that matches the provided shebang.
+:::
+
+:::info
+When a Backup Agent is linked to your server, the OVHcloud Control Panel can automatically append the OVHcloud Backup Agent installation command to your `postInstallationScript` (the **Install Backup Agent** option). You can reproduce the same behaviour by adding the installation command to your own post-installation script. For more information, refer to [Back up a Bare Metal Linux Server with Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
 :::
 
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Iniziare a utilizzare un server dedicato
 description: Come gestire un server dedicato nello Spazio Cliente e come iniziare a utilizzare la configurazione e la protezione di un server
-lastUpdated: 2025-04-29
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -97,6 +97,8 @@ In particolare, sono disponibili domande complementari specifiche per il sistema
 
 <img className="thumbnail" alt="server options" src="/images/assets/screens/control-panel/product-selection/bare-metal-cloud/dedicated-servers/general-information/reinstalling-your-server-05.png" loading="lazy" />
 
+**Pre-installing an SSH key**
+
 Se è stato selezionato un sistema operativo compatibile, è possibile fornire una **chiave pubblica** da installare automaticamente. Le opzioni disponibili sono due:
 
 - Copia manualmente la stringa di chiave e incollala nel campo `La tua chiave SSH pubblica`.
@@ -108,6 +110,24 @@ Per saperne di più, consulta le nostre guide:
 
 - [Come creare e utilizzare le chiavi per l’autenticazione SSH](/guides/bare-metal-cloud/dedicated-servers/creating-ssh-keys)
 - [Come creare e utilizzare chiavi per l’autenticazione SSH con PuTTY](/guides/web-cloud/web-hosting/ssh-using-putty-on-windows)
+
+**Enabling LACP link aggregation**
+
+For compatible operating systems, you can tick the <code className="action">Enable LACP to aggregate multiple network interfaces (if applicable)</code> checkbox. When this option is enabled, LACP (IEEE 802.3ad) link aggregation is configured on your server's network interfaces directly during the operating system installation, so that the interfaces are bonded automatically once the server boots. This checkbox is only displayed for operating system templates that support it.
+
+To aggregate your server's interfaces on the OVHcloud side, or to configure link aggregation manually afterwards, refer to the following guides:
+
+- [Configuring OVHcloud Link Aggregation (OLA) in the OVHcloud Control Panel](/guides/bare-metal-cloud/dedicated-servers/ola-enable-manager)
+- [How to configure Link Aggregation with LACP in Debian 12 or newer / Ubuntu 24.04 or newer](/guides/bare-metal-cloud/dedicated-servers/lacp-enable-netplan)
+
+**Installing the Backup Agent (Linux)**
+
+If you have selected a Linux operating system, a **Backup Agent** option is available:
+
+- If a Backup Agent is already linked to your server, tick the <code className="action">Install Backup Agent</code> checkbox. The corresponding installation command is added to your post-installation script, so the agent is installed automatically once the operating system installation is complete.
+- If no Backup Agent is linked to your server yet, click <code className="action">Link a Backup Agent</code> to order or associate one first.
+
+For more information about backing up a Linux server, refer to [Back up a Bare Metal Linux Server with Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
 
 Clicca su <code className="action">Conferma</code> per avviare l’installazione del sistema operativo sul tuo server dedicato.
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Install an OS via the OVHcloud API on a Dedicated Server
 description: Use OVHcloud API to install or reinstall an OS on your dedicated server
-lastUpdated: 2025-06-06
+lastUpdated: 2026-07-30
 ---
 
 import Api from '@components/Api';
@@ -165,6 +165,19 @@ Each question has the following attributes:
 
 ¹ If a mandatory question without default value is not answered, the API will return an error.
 
+Some server ranges also expose an `enableLacpBonding` question. When set to `true`, LACP (IEEE 802.3ad) link aggregation is configured on the server's network interfaces during installation. This corresponds to the **Enable LACP to aggregate multiple network interfaces (if applicable)** option in the OVHcloud Control Panel.
+
+```json
+{
+    "name": "enableLacpBonding",
+    "description": "Enable LACP to aggregate multiple network interfaces (if applicable)",
+    "default": "false",
+    "mandatory": false,
+    "type": "boolean",
+    "enum": []
+}
+```
+
 ### Create an OS reinstallation task <a name="install-task"></a>
 
 When you have gathered all the information that you need, you can create the OS reinstallation task with the following API call:
@@ -219,6 +232,10 @@ date "+%Y-%m-%d %H:%M:%S" --utc >> /opt/coucou
 
 :::info
 For UNIX/Linux OS, you can provide scripts in any programming language (if running stack is installed on the target OS) that matches the provided shebang.
+:::
+
+:::info
+When a Backup Agent is linked to your server, the OVHcloud Control Panel can automatically append the OVHcloud Backup Agent installation command to your `postInstallationScript` (the **Install Backup Agent** option). You can reproduce the same behaviour by adding the installation command to your own post-installation script. For more information, refer to [Back up a Bare Metal Linux Server with Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
 :::
 
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pierwsze kroki z serwerem dedykowanym
 description: Dowiedz się, jak zarządzać serwerem dedykowanym w Panelu klienta i jak rozpocząć konfigurację oraz zabezpieczenie serwera
-lastUpdated: 2025-04-29
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -97,6 +97,8 @@ W dokumentacji tej znajdziesz pytania dodatkowe specyficzne dla wybranego system
 
 <img className="thumbnail" alt="server options" src="/images/assets/screens/control-panel/product-selection/bare-metal-cloud/dedicated-servers/general-information/reinstalling-your-server-05.png" loading="lazy" />
 
+**Pre-installing an SSH key**
+
 Jeśli wybrano kompatybilny system operacyjny, możesz automatycznie zainstalować **klucz publiczny**. Masz dwie możliwości:
 
 - [Ręcznie skopiuj ciąg](/guides/bare-metal-cloud/dedicated-servers/import-keys-control-panel) klucza i wklej go w polu `Twój publiczny klucz SSH`.
@@ -108,6 +110,24 @@ Więcej na ten temat znajdziesz w naszych przewodnikach:
 
 - [Jak tworzyć i używać kluczy do uwierzytelniania SSH](/guides/bare-metal-cloud/dedicated-servers/creating-ssh-keys)
 - [Jak tworzyć i używać kluczy do uwierzytelniania SSH za pomocą PuTTY](/guides/web-cloud/web-hosting/ssh-using-putty-on-windows)
+
+**Enabling LACP link aggregation**
+
+For compatible operating systems, you can tick the <code className="action">Enable LACP to aggregate multiple network interfaces (if applicable)</code> checkbox. When this option is enabled, LACP (IEEE 802.3ad) link aggregation is configured on your server's network interfaces directly during the operating system installation, so that the interfaces are bonded automatically once the server boots. This checkbox is only displayed for operating system templates that support it.
+
+To aggregate your server's interfaces on the OVHcloud side, or to configure link aggregation manually afterwards, refer to the following guides:
+
+- [Configuring OVHcloud Link Aggregation (OLA) in the OVHcloud Control Panel](/guides/bare-metal-cloud/dedicated-servers/ola-enable-manager)
+- [How to configure Link Aggregation with LACP in Debian 12 or newer / Ubuntu 24.04 or newer](/guides/bare-metal-cloud/dedicated-servers/lacp-enable-netplan)
+
+**Installing the Backup Agent (Linux)**
+
+If you have selected a Linux operating system, a **Backup Agent** option is available:
+
+- If a Backup Agent is already linked to your server, tick the <code className="action">Install Backup Agent</code> checkbox. The corresponding installation command is added to your post-installation script, so the agent is installed automatically once the operating system installation is complete.
+- If no Backup Agent is linked to your server yet, click <code className="action">Link a Backup Agent</code> to order or associate one first.
+
+For more information about backing up a Linux server, refer to [Back up a Bare Metal Linux Server with Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
 
 Kliknij przycisk <code className="action">Potwierdź</code>, aby rozpocząć instalację systemu operacyjnego na Twoim serwerze dedykowanym.
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/api-os-installation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Install an OS via the OVHcloud API on a Dedicated Server
 description: Use OVHcloud API to install or reinstall an OS on your dedicated server
-lastUpdated: 2025-06-06
+lastUpdated: 2026-07-30
 ---
 
 import Api from '@components/Api';
@@ -165,6 +165,19 @@ Each question has the following attributes:
 
 ¹ If a mandatory question without default value is not answered, the API will return an error.
 
+Some server ranges also expose an `enableLacpBonding` question. When set to `true`, LACP (IEEE 802.3ad) link aggregation is configured on the server's network interfaces during installation. This corresponds to the **Enable LACP to aggregate multiple network interfaces (if applicable)** option in the OVHcloud Control Panel.
+
+```json
+{
+    "name": "enableLacpBonding",
+    "description": "Enable LACP to aggregate multiple network interfaces (if applicable)",
+    "default": "false",
+    "mandatory": false,
+    "type": "boolean",
+    "enum": []
+}
+```
+
 ### Create an OS reinstallation task <a name="install-task"></a>
 
 When you have gathered all the information that you need, you can create the OS reinstallation task with the following API call:
@@ -219,6 +232,10 @@ date "+%Y-%m-%d %H:%M:%S" --utc >> /opt/coucou
 
 :::info
 For UNIX/Linux OS, you can provide scripts in any programming language (if running stack is installed on the target OS) that matches the provided shebang.
+:::
+
+:::info
+When a Backup Agent is linked to your server, the OVHcloud Control Panel can automatically append the OVHcloud Backup Agent installation command to your `postInstallationScript` (the **Install Backup Agent** option). You can reproduce the same behaviour by adding the installation command to your own post-installation script. For more information, refer to [Back up a Bare Metal Linux Server with Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
 :::
 
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Primeiros passos com um servidor dedicado
 description: Descubra como gerir um servidor dedicado na sua Área de Cliente e como começar com a configuração e a segurança de um servidor
-lastUpdated: 2025-04-29
+lastUpdated: 2026-07-30
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -97,6 +97,8 @@ Encontrará questões complementares específicas ao sistema operativo seleciona
 
 <img className="thumbnail" alt="server options" src="/images/assets/screens/control-panel/product-selection/bare-metal-cloud/dedicated-servers/general-information/reinstalling-your-server-05.png" loading="lazy" />
 
+**Pre-installing an SSH key**
+
 Se tiver selecionado um sistema operativo compatível, poderá fornecer uma **chave pública** para instalação automática. Tem duas possibilidades ao seu dispor:
 
 - Copie manualmente a cadeia de chaves e cole-a no campo `A sua chave SSH pública`.
@@ -108,6 +110,24 @@ Para saber mais sobre este assumpto, consulte os nossos manuais:
 
 - [Como criar e utilizar chaves para a autenticação SSH](/guides/bare-metal-cloud/dedicated-servers/creating-ssh-keys)
 - [Como criar e utilizar chaves para a autenticação SSH com PuTTY](/guides/web-cloud/web-hosting/ssh-using-putty-on-windows)
+
+**Enabling LACP link aggregation**
+
+For compatible operating systems, you can tick the <code className="action">Enable LACP to aggregate multiple network interfaces (if applicable)</code> checkbox. When this option is enabled, LACP (IEEE 802.3ad) link aggregation is configured on your server's network interfaces directly during the operating system installation, so that the interfaces are bonded automatically once the server boots. This checkbox is only displayed for operating system templates that support it.
+
+To aggregate your server's interfaces on the OVHcloud side, or to configure link aggregation manually afterwards, refer to the following guides:
+
+- [Configuring OVHcloud Link Aggregation (OLA) in the OVHcloud Control Panel](/guides/bare-metal-cloud/dedicated-servers/ola-enable-manager)
+- [How to configure Link Aggregation with LACP in Debian 12 or newer / Ubuntu 24.04 or newer](/guides/bare-metal-cloud/dedicated-servers/lacp-enable-netplan)
+
+**Installing the Backup Agent (Linux)**
+
+If you have selected a Linux operating system, a **Backup Agent** option is available:
+
+- If a Backup Agent is already linked to your server, tick the <code className="action">Install Backup Agent</code> checkbox. The corresponding installation command is added to your post-installation script, so the agent is installed automatically once the operating system installation is complete.
+- If no Backup Agent is linked to your server yet, click <code className="action">Link a Backup Agent</code> to order or associate one first.
+
+For more information about backing up a Linux server, refer to [Back up a Bare Metal Linux Server with Veeam Enterprise](/guides/bare-metal-cloud/dedicated-servers/veeam-enterprise-server-backup-linux).
 
 Por fim, clique em <code className="action">Confirmar</code> para lançar a instalação do sistema operativo no seu servidor dedicado.
 


### PR DESCRIPTION
Add the two new OS installation options to the dedicated server guides:

- getting-started: describe the "Enable LACP" and "Install Backup Agent" checkboxes on the install wizard's Options step, and label the existing SSH-key option for consistency
- api-os-installation: document the enableLacpBonding customization and the Backup Agent post-installation-script behaviour