### PR TITLE
docs: fix S3 ACL shell placeholders

### DIFF
--- a/docs/de/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-10
 ---
 
 ## Overview

--- a/docs/de/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-03-06
+lastUpdated: 2026-07-30
 ---
 
 ## Overview
@@ -111,7 +111,7 @@ You can set the ACL on a bucket at its creation or afterwards, by calling the `p
 Example:
 
 ```bash
-aws s3api create-bucket --bucket `<bucket_name>` --region `<region>` --acl public-read
+aws s3api create-bucket --bucket <bucket_name> --region <region> --acl public-read
 ```
 
 In this example, we created a bucket named `<bucket_name>` using a predefined ACL `public-read`.
@@ -151,7 +151,7 @@ aws s3api get-bucket-acl --bucket <bucket_name>
 To change the ACL, you can call the `put-bucket-acl` endpoint by using the AWS CLI:
 
 ```bash
-aws s3api put-bucket-acl --bucket `<bucket_name>` --grant-write id=<project_name>:`<user_name>`
+aws s3api put-bucket-acl --bucket <bucket_name> --grant-write id=<project_name>:<user_name>
 ```
 
 Here, we change the ACL to give account user "user-yyyyyyyyyy" the permission to write in the bucket.
@@ -159,7 +159,7 @@ Here, we change the ACL to give account user "user-yyyyyyyyyy" the permission to
 Again, to verify that ACL are set correctly:
 
 ```bash
-aws s3api get-bucket-acl --bucket `<bucket_name>`
+aws s3api get-bucket-acl --bucket <bucket_name>
 ```
 
 ```json
@@ -188,7 +188,7 @@ Similar to bucket level, you can set the ACL on an object at its creation or aft
 Example:
 
 ```bash
-aws s3api put-object --bucket `<bucket_name>` --body <file_path> --key <object_key> --grant-full-control id=<project_name>:`<user_name>`
+aws s3api put-object --bucket <bucket_name> --body <file_path> --key <object_key> --grant-full-control id=<project_name>:<user_name>
 ```
 
 In this example, we created an object named `<object_key>` and we gave `FULL_CONTROL` on that object to the account user `<user_name>`.
@@ -229,7 +229,7 @@ aws s3api get-object-acl --bucket <bucket_name> --key <object_key>
 To change the ACL, you can call the `put-object-acl` endpoint by using the AWS CLI:
 
 ```bash
-aws s3api put-object-acl --bucket `<bucket_name>` --key <object_key> --grant-read id=<project_name>:`<user_name>`
+aws s3api put-object-acl --bucket <bucket_name> --key <object_key> --grant-read id=<project_name>:<user_name>
 ```
 
 Here, we changed our mind and decided to only give the account user `<user_name>` the permission to read instead of full control.

--- a/docs/en/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-10
 ---
 
 ## Overview

--- a/docs/en/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-03-06
+lastUpdated: 2026-07-30
 ---
 
 ## Overview
@@ -111,7 +111,7 @@ You can set the ACL on a bucket at its creation or afterwards, by calling the `p
 Example:
 
 ```bash
-aws s3api create-bucket --bucket `<bucket_name>` --region `<region>` --acl public-read
+aws s3api create-bucket --bucket <bucket_name> --region <region> --acl public-read
 ```
 
 In this example, we created a bucket named `<bucket_name>` using a predefined ACL `public-read`.
@@ -151,7 +151,7 @@ aws s3api get-bucket-acl --bucket <bucket_name>
 To change the ACL, you can call the `put-bucket-acl` endpoint by using the AWS CLI:
 
 ```bash
-aws s3api put-bucket-acl --bucket `<bucket_name>` --grant-write id=<project_name>:`<user_name>`
+aws s3api put-bucket-acl --bucket <bucket_name> --grant-write id=<project_name>:<user_name>
 ```
 
 Here, we change the ACL to give account user "user-yyyyyyyyyy" the permission to write in the bucket.
@@ -159,7 +159,7 @@ Here, we change the ACL to give account user "user-yyyyyyyyyy" the permission to
 Again, to verify that ACL are set correctly:
 
 ```bash
-aws s3api get-bucket-acl --bucket `<bucket_name>`
+aws s3api get-bucket-acl --bucket <bucket_name>
 ```
 
 ```json
@@ -188,7 +188,7 @@ Similar to bucket level, you can set the ACL on an object at its creation or aft
 Example:
 
 ```bash
-aws s3api put-object --bucket `<bucket_name>` --body <file_path> --key <object_key> --grant-full-control id=<project_name>:`<user_name>`
+aws s3api put-object --bucket <bucket_name> --body <file_path> --key <object_key> --grant-full-control id=<project_name>:<user_name>
 ```
 
 In this example, we created an object named `<object_key>` and we gave `FULL_CONTROL` on that object to the account user `<user_name>`.
@@ -229,7 +229,7 @@ aws s3api get-object-acl --bucket <bucket_name> --key <object_key>
 To change the ACL, you can call the `put-object-acl` endpoint by using the AWS CLI:
 
 ```bash
-aws s3api put-object-acl --bucket `<bucket_name>` --key <object_key> --grant-read id=<project_name>:`<user_name>`
+aws s3api put-object-acl --bucket <bucket_name> --key <object_key> --grant-read id=<project_name>:<user_name>
 ```
 
 Here, we changed our mind and decided to only give the account user `<user_name>` the permission to read instead of full control.

--- a/docs/es/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-10
 ---
 
 ## Overview

--- a/docs/es/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-03-06
+lastUpdated: 2026-07-30
 ---
 
 ## Overview
@@ -111,7 +111,7 @@ You can set the ACL on a bucket at its creation or afterwards, by calling the `p
 Example:
 
 ```bash
-aws s3api create-bucket --bucket `<bucket_name>` --region `<region>` --acl public-read
+aws s3api create-bucket --bucket <bucket_name> --region <region> --acl public-read
 ```
 
 In this example, we created a bucket named `<bucket_name>` using a predefined ACL `public-read`.
@@ -151,7 +151,7 @@ aws s3api get-bucket-acl --bucket <bucket_name>
 To change the ACL, you can call the `put-bucket-acl` endpoint by using the AWS CLI:
 
 ```bash
-aws s3api put-bucket-acl --bucket `<bucket_name>` --grant-write id=<project_name>:`<user_name>`
+aws s3api put-bucket-acl --bucket <bucket_name> --grant-write id=<project_name>:<user_name>
 ```
 
 Here, we change the ACL to give account user "user-yyyyyyyyyy" the permission to write in the bucket.
@@ -159,7 +159,7 @@ Here, we change the ACL to give account user "user-yyyyyyyyyy" the permission to
 Again, to verify that ACL are set correctly:
 
 ```bash
-aws s3api get-bucket-acl --bucket `<bucket_name>`
+aws s3api get-bucket-acl --bucket <bucket_name>
 ```
 
 ```json
@@ -188,7 +188,7 @@ Similar to bucket level, you can set the ACL on an object at its creation or aft
 Example:
 
 ```bash
-aws s3api put-object --bucket `<bucket_name>` --body <file_path> --key <object_key> --grant-full-control id=<project_name>:`<user_name>`
+aws s3api put-object --bucket <bucket_name> --body <file_path> --key <object_key> --grant-full-control id=<project_name>:<user_name>
 ```
 
 In this example, we created an object named `<object_key>` and we gave `FULL_CONTROL` on that object to the account user `<user_name>`.
@@ -229,7 +229,7 @@ aws s3api get-object-acl --bucket <bucket_name> --key <object_key>
 To change the ACL, you can call the `put-object-acl` endpoint by using the AWS CLI:
 
 ```bash
-aws s3api put-object-acl --bucket `<bucket_name>` --key <object_key> --grant-read id=<project_name>:`<user_name>`
+aws s3api put-object-acl --bucket <bucket_name> --key <object_key> --grant-read id=<project_name>:<user_name>
 ```
 
 Here, we changed our mind and decided to only give the account user `<user_name>` the permission to read instead of full control.

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-03-06
+lastUpdated: 2026-07-30
 ---
 
 ## Objectif
@@ -111,7 +111,7 @@ Vous pouvez configurer les ACLS sur un bucket à la création de celui-ci ou apr
 Exemple:
 
 ```bash
-aws s3api create-bucket --bucket `<bucket_name>` --region `<region>` --acl public-read
+aws s3api create-bucket --bucket <bucket_name> --region <region> --acl public-read
 ```
 
 Dans cet exemple, nous avons créé un bucket nommé `<bucket_name>` qui utilise l'ACL prédéfinie `public-read`.
@@ -151,7 +151,7 @@ aws s3api get-bucket-acl --bucket <bucket_name>
 Pour changer les ACL, vous pouvez appeler la commande `put-bucket-acl` en utilisant l'AWS CLI :
 
 ```bash
-aws s3api put-bucket-acl --bucket `<bucket_name>` --grant-write id=<project_name>:`<user_name>`
+aws s3api put-bucket-acl --bucket <bucket_name> --grant-write id=<project_name>:<user_name>
 ```
 
 Ici, nous avons changé l'ACL pour donner à l'utilisateur "user-yyyyyyyyyy" la permission d'écrire dans le bucket.
@@ -159,7 +159,7 @@ Ici, nous avons changé l'ACL pour donner à l'utilisateur "user-yyyyyyyyyy" la 
 A nouveau, pour vérifier que les ACL sont correctement configurées :
 
 ```bash
-aws s3api get-bucket-acl --bucket `<bucket_name>`
+aws s3api get-bucket-acl --bucket <bucket_name>
 ```
 
 ```json
@@ -188,7 +188,7 @@ Tout comme au niveau du bucket, vous pouvez configurer les ACLs sur un objet ind
 Exemple:
 
 ```bash
-aws s3api put-object --bucket `<bucket_name>` --body <file_path> --key <object_key> --grant-full-control id=<project_name>:`<user_name>`
+aws s3api put-object --bucket <bucket_name> --body <file_path> --key <object_key> --grant-full-control id=<project_name>:<user_name>
 ```
 
 Dans cet exemple, nous avons créé un objet nommé `<object_key>` et nous avons accordé à l'utilisateur `<user_name>` la permission `FULL_CONTROL` dessus.
@@ -229,7 +229,7 @@ aws s3api get-object-acl --bucket <bucket_name> --key <object_key>
 Pour modifier l'ACL, vous pouvez appeler le point de terminaison `put-object-acl` à l'aide de l'AWS CLI :
 
 ```bash
-aws s3api put-object-acl --bucket `<bucket_name>` --key <object_key> --grant-read id=<project_name>:`<user_name>`
+aws s3api put-object-acl --bucket <bucket_name> --key <object_key> --grant-read id=<project_name>:<user_name>
 ```
 
 Ici, nous avons changé d'avis et décidé de donner uniquement à l'utilisateur `<user_name>` l'autorisation *read*, au lieu de la permission « FULL_CONTROL ».

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-10
 ---
 
 ## Objectif

--- a/docs/it/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-10
 ---
 
 ## Overview

--- a/docs/it/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-03-06
+lastUpdated: 2026-07-30
 ---
 
 ## Overview
@@ -111,7 +111,7 @@ You can set the ACL on a bucket at its creation or afterwards, by calling the `p
 Example:
 
 ```bash
-aws s3api create-bucket --bucket `<bucket_name>` --region `<region>` --acl public-read
+aws s3api create-bucket --bucket <bucket_name> --region <region> --acl public-read
 ```
 
 In this example, we created a bucket named `<bucket_name>` using a predefined ACL `public-read`.
@@ -151,7 +151,7 @@ aws s3api get-bucket-acl --bucket <bucket_name>
 To change the ACL, you can call the `put-bucket-acl` endpoint by using the AWS CLI:
 
 ```bash
-aws s3api put-bucket-acl --bucket `<bucket_name>` --grant-write id=<project_name>:`<user_name>`
+aws s3api put-bucket-acl --bucket <bucket_name> --grant-write id=<project_name>:<user_name>
 ```
 
 Here, we change the ACL to give account user "user-yyyyyyyyyy" the permission to write in the bucket.
@@ -159,7 +159,7 @@ Here, we change the ACL to give account user "user-yyyyyyyyyy" the permission to
 Again, to verify that ACL are set correctly:
 
 ```bash
-aws s3api get-bucket-acl --bucket `<bucket_name>`
+aws s3api get-bucket-acl --bucket <bucket_name>
 ```
 
 ```json
@@ -188,7 +188,7 @@ Similar to bucket level, you can set the ACL on an object at its creation or aft
 Example:
 
 ```bash
-aws s3api put-object --bucket `<bucket_name>` --body <file_path> --key <object_key> --grant-full-control id=<project_name>:`<user_name>`
+aws s3api put-object --bucket <bucket_name> --body <file_path> --key <object_key> --grant-full-control id=<project_name>:<user_name>
 ```
 
 In this example, we created an object named `<object_key>` and we gave `FULL_CONTROL` on that object to the account user `<user_name>`.
@@ -229,7 +229,7 @@ aws s3api get-object-acl --bucket <bucket_name> --key <object_key>
 To change the ACL, you can call the `put-object-acl` endpoint by using the AWS CLI:
 
 ```bash
-aws s3api put-object-acl --bucket `<bucket_name>` --key <object_key> --grant-read id=<project_name>:`<user_name>`
+aws s3api put-object-acl --bucket <bucket_name> --key <object_key> --grant-read id=<project_name>:<user_name>
 ```
 
 Here, we changed our mind and decided to only give the account user `<user_name>` the permission to read instead of full control.

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-10
 ---
 
 ## Overview

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-03-06
+lastUpdated: 2026-07-30
 ---
 
 ## Overview
@@ -111,7 +111,7 @@ You can set the ACL on a bucket at its creation or afterwards, by calling the `p
 Example:
 
 ```bash
-aws s3api create-bucket --bucket `<bucket_name>` --region `<region>` --acl public-read
+aws s3api create-bucket --bucket <bucket_name> --region <region> --acl public-read
 ```
 
 In this example, we created a bucket named `<bucket_name>` using a predefined ACL `public-read`.
@@ -151,7 +151,7 @@ aws s3api get-bucket-acl --bucket <bucket_name>
 To change the ACL, you can call the `put-bucket-acl` endpoint by using the AWS CLI:
 
 ```bash
-aws s3api put-bucket-acl --bucket `<bucket_name>` --grant-write id=<project_name>:`<user_name>`
+aws s3api put-bucket-acl --bucket <bucket_name> --grant-write id=<project_name>:<user_name>
 ```
 
 Here, we change the ACL to give account user "user-yyyyyyyyyy" the permission to write in the bucket.
@@ -159,7 +159,7 @@ Here, we change the ACL to give account user "user-yyyyyyyyyy" the permission to
 Again, to verify that ACL are set correctly:
 
 ```bash
-aws s3api get-bucket-acl --bucket `<bucket_name>`
+aws s3api get-bucket-acl --bucket <bucket_name>
 ```
 
 ```json
@@ -188,7 +188,7 @@ Similar to bucket level, you can set the ACL on an object at its creation or aft
 Example:
 
 ```bash
-aws s3api put-object --bucket `<bucket_name>` --body <file_path> --key <object_key> --grant-full-control id=<project_name>:`<user_name>`
+aws s3api put-object --bucket <bucket_name> --body <file_path> --key <object_key> --grant-full-control id=<project_name>:<user_name>
 ```
 
 In this example, we created an object named `<object_key>` and we gave `FULL_CONTROL` on that object to the account user `<user_name>`.
@@ -229,7 +229,7 @@ aws s3api get-object-acl --bucket <bucket_name> --key <object_key>
 To change the ACL, you can call the `put-object-acl` endpoint by using the AWS CLI:
 
 ```bash
-aws s3api put-object-acl --bucket `<bucket_name>` --key <object_key> --grant-read id=<project_name>:`<user_name>`
+aws s3api put-object-acl --bucket <bucket_name> --key <object_key> --grant-read id=<project_name>:<user_name>
 ```
 
 Here, we changed our mind and decided to only give the account user `<user_name>` the permission to read instead of full control.

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-10
 ---
 
 ## Overview

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object Storage - Bucket ACL
-lastUpdated: 2026-03-06
+lastUpdated: 2026-07-30
 ---
 
 ## Overview
@@ -111,7 +111,7 @@ You can set the ACL on a bucket at its creation or afterwards, by calling the `p
 Example:
 
 ```bash
-aws s3api create-bucket --bucket `<bucket_name>` --region `<region>` --acl public-read
+aws s3api create-bucket --bucket <bucket_name> --region <region> --acl public-read
 ```
 
 In this example, we created a bucket named `<bucket_name>` using a predefined ACL `public-read`.
@@ -151,7 +151,7 @@ aws s3api get-bucket-acl --bucket <bucket_name>
 To change the ACL, you can call the `put-bucket-acl` endpoint by using the AWS CLI:
 
 ```bash
-aws s3api put-bucket-acl --bucket `<bucket_name>` --grant-write id=<project_name>:`<user_name>`
+aws s3api put-bucket-acl --bucket <bucket_name> --grant-write id=<project_name>:<user_name>
 ```
 
 Here, we change the ACL to give account user "user-yyyyyyyyyy" the permission to write in the bucket.
@@ -159,7 +159,7 @@ Here, we change the ACL to give account user "user-yyyyyyyyyy" the permission to
 Again, to verify that ACL are set correctly:
 
 ```bash
-aws s3api get-bucket-acl --bucket `<bucket_name>`
+aws s3api get-bucket-acl --bucket <bucket_name>
 ```
 
 ```json
@@ -188,7 +188,7 @@ Similar to bucket level, you can set the ACL on an object at its creation or aft
 Example:
 
 ```bash
-aws s3api put-object --bucket `<bucket_name>` --body <file_path> --key <object_key> --grant-full-control id=<project_name>:`<user_name>`
+aws s3api put-object --bucket <bucket_name> --body <file_path> --key <object_key> --grant-full-control id=<project_name>:<user_name>
 ```
 
 In this example, we created an object named `<object_key>` and we gave `FULL_CONTROL` on that object to the account user `<user_name>`.
@@ -229,7 +229,7 @@ aws s3api get-object-acl --bucket <bucket_name> --key <object_key>
 To change the ACL, you can call the `put-object-acl` endpoint by using the AWS CLI:
 
 ```bash
-aws s3api put-object-acl --bucket `<bucket_name>` --key <object_key> --grant-read id=<project_name>:`<user_name>`
+aws s3api put-object-acl --bucket <bucket_name> --key <object_key> --grant-read id=<project_name>:<user_name>
 ```
 
 Here, we changed our mind and decided to only give the account user `<user_name>` the permission to read instead of full control.


### PR DESCRIPTION
## Summary

- remove literal shell backticks from placeholders in the S3 Bucket ACL AWS CLI examples
- keep the existing placeholder convention consistent across all five affected commands
- update the guide metadata across all seven locale variants

## Why

The affected commands are inside fenced `bash` blocks, where backticks are interpreted by the shell as command substitution rather than Markdown formatting. After replacing a placeholder such as `<bucket_name>` with a concrete value, the remaining backticks make Bash attempt to execute that value as a command and pass an empty argument to the AWS CLI.

This change removes only those shell backticks; the surrounding commands and explanatory prose remain unchanged.

## Validation

- reproduced the failure with a local fake `aws` function and no network requests
- verified all 35 affected command lines across seven locales
- verified that all 63 backtick-wrapped command placeholders were removed
- verified concrete bucket and region values reach the fake AWS command unchanged
- `pnpm content:lint`
- `git diff --check`

A full site build was not run because this is a command-text and metadata-only change.

## References

- https://docs.aws.amazon.com/cli/latest/reference/s3api/create-bucket.html
- https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-acl.html
- https://www.gnu.org/software/bash/manual/html_node/Command-Substitution.html

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
