### PR TITLE
FIX - WEB - DNS - Correct the Spanish order button label

### DIFF
--- a/docs/es/guides/web-cloud/domains/dns-zone-create-subdomain.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-create-subdomain.mdx
@@ -58,7 +58,7 @@ Si desea crear una zona DNS para un nombre de dominio, consulte directamente [es
 
 ### 1 - Crear la zona DNS desde el área de cliente de OVHcloud
 
-En el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, abra la sección `Web Cloud`. Haga clic en el botón <code className="action">Solicitar</code> y, a continuación, seleccione <code className="action">Zona DNS</code>.
+En el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, abra la sección `Web Cloud`. Haga clic en el botón <code className="action">Contratar</code> y, a continuación, seleccione <code className="action">Zona DNS</code>.
 
 En la página que aparece, indique el subdominio (por ejemplo: *sub.domain.tld*) para el que desea crear una zona DNS de OVHcloud. Espere unos instantes mientras la herramienta realiza comprobaciones sobre el subdominio.
 

--- a/docs/es/guides/web-cloud/domains/dns-zone-create.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-create.mdx
@@ -53,7 +53,7 @@ Por lo tanto, antes de cambiar los **servidores DNS** declarados con su dominio,
 
 ### 1 - Crear la zona DNS desde el área de cliente de OVHcloud
 
-En el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, abra la sección `Web Cloud`. Haga clic en el botón <code className="action">Solicitar</code> y, a continuación, seleccione <code className="action">Zona DNS</code>.
+En el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, abra la sección `Web Cloud`. Haga clic en el botón <code className="action">Contratar</code> y, a continuación, seleccione <code className="action">Zona DNS</code>.
 
 En la página que aparece, indique el dominio (por ejemplo: *domain.tld*) para el que desea crear una zona DNS de OVHcloud. Espere unos instantes mientras la herramienta realiza comprobaciones sobre el dominio.
 


### PR DESCRIPTION
## What

Replaces the `Solicitar` action label with `Contratar` in two Spanish DNS zone
guides:

- `es/guides/web-cloud/domains/dns-zone-create.mdx`
- `es/guides/web-cloud/domains/dns-zone-create-subdomain.mdx`

Two lines in total. Spanish only — the other six locales already used the
correct label.

## Why

`Solicitar` is not a Control Panel label. It appears in no
`Messages_es_ES.json` file in the Manager repository, so a Spanish reader was
being told to click a button that does not exist under that name.

The correct label is `Contratar`, established two independent ways:

- it is the value of the key whose English is `Order` and whose French is
  `Commander`;
- it is already used 14 times across the rest of the Spanish documentation
  (SSL Gateway, web hosting, dedicated servers).

`Solicitar` appeared exactly three times in the Spanish corpus, and all three
were in guides from the SK-2665 DNS zone series. This PR fixes two of them; the
third, in the DNS FAQ, is fixed in #506.

## Checks

- `content:lint` passes on both files
- no `Solicitar` action label left anywhere in `docs/es`
- `lastUpdated` already carried the series' date, so no bump was needed
