### PR TITLE
FIX - WEB - Domains - Fix factual, label and zone errors in the domains guides

### DIFF
--- a/docs/de/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Sicherheit durch DKIM-Eintrag verbessern
 description: Erfahren Sie hier, wie Sie einen DKIM-Eintrag für Domainnamen und E-Mail-Dienste bei OVHcloud einrichten
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -66,9 +66,13 @@ Wenn Ihr Domainname bei OVHcloud registriert ist, können Sie im <ManagerLink to
     - [Beispiel einer unter Verwendung von DKIM gesendeten E-Mail](#example)
     - [Was ist ein DKIM-Selektor?](#selector)
 - [DKIM automatisch für ein E-Mail-Angebot von OVHcloud konfigurieren](#auto-dkim)
+<Region zones={['eu', 'ca']}>
 - [DKIM manuell für OVHcloud Exchange oder E-Mail Pro konfigurieren](#internal-dkim)
+</Region>
     - [API - Vollständige Konfiguration von DKIM](#firststep)
+        <Region zones={['eu']}>
         - [Für MX Plan und Zimbra](#confemail)
+        </Region>
         <Region zones={['eu', 'ca']}>
         - [Für Exchange](#confex)
         </Region>
@@ -184,7 +188,7 @@ Die automatische DKIM-Konfiguration ist für alle unsere E-Mail-Angebote verfüg
 - [Exchange](/links/web/emails-exchange)
 </Region>
 <Region zones={['eu']}>
-- [E-mail Pro](/links/web/email-pro)
+- [E-Mail Pro](/links/web/email-pro)
 </Region>
 <Region zones={['eu']}>
 - [Zimbra](/links/web/zimbra)
@@ -270,7 +274,13 @@ Klicken Sie auf das unten stehende Registerblatt, das zu Ihrem Angebot passt.
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
 Die automatische DKIM-Aktivierung dauert zwischen 30 Minuten und 24 Stunden. Um zu prüfen, ob Ihr DKIM funktioniert, kehren Sie einfach in den Bereich zur Domainverwaltung zurück, der in den oben genannten Tabs erwähnt wird, und stellen Sie sicher, dass die Schaltfläche `DKIM` grün ist oder für Zimbra, dass `DKIM` keine Warnung mehr anzeigt.
+</Region>
+
+<Region zones={['ca', 'apac']}>
+Die automatische DKIM-Aktivierung dauert zwischen 30 Minuten und 24 Stunden. Um zu prüfen, ob Ihr DKIM funktioniert, kehren Sie einfach in den Bereich zur Domainverwaltung zurück, der in den oben genannten Tabs erwähnt wird, und stellen Sie sicher, dass die Schaltfläche `DKIM` grün ist.
+</Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
@@ -328,12 +338,18 @@ Um DKIM zu konfigurieren, besuchen Sie die <ApiLink>OVHcloud API-Seite</ApiLink>
 Nutzen Sie unsere Anleitung „[Erste Schritte mit der OVHcloud API](/guides/manage-and-operate/api/first-steps)“, falls Sie die API noch nie verwendet haben.
 :::
 
-Gehen Sie im API-Interface zum Bereich `/email/domain/` (Angebote MX Plan und Zimbra), `/email/exchange` (Angebot Exchange) oder `/email/pro` (Angebot E-mail Pro) und geben Sie „dkim“ in das Feld `Filter` ein, um nur die API-Funktionen anzuzeigen, die sich auf DKIM beziehen.
+<Region zones={['eu']}>
+Gehen Sie im API-Interface zum Bereich `/email/domain/` (Angebote MX Plan und Zimbra), `/email/exchange` (Angebot Exchange) oder `/email/pro` (Angebot E-Mail Pro) und geben Sie "dkim" in das Feld `Filter` ein, um nur die API-Funktionen anzuzeigen, die sich auf DKIM beziehen.
+</Region>
+
+<Region zones={['ca']}>
+Gehen Sie im API-Interface zum Bereich `/email/exchange` (Angebot Exchange) und geben Sie "dkim" in das Feld `Filter` ein, um nur die API-Funktionen anzuzeigen, die sich auf DKIM beziehen.
+</Region>
 
 Klicken Sie auf den Tab für Ihren Dienst:
 
 <ZoneTabs>
-  <Tab label="MX Plan und Zimbra">
+  <Tab label="MX Plan und Zimbra" availableIn={['eu']}>
     <img className="thumbnail" alt="email" src="/images/assets/screens/api/get-email-domain-domain-dkim.png" loading="lazy" />
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
@@ -344,6 +360,7 @@ Klicken Sie auf den Tab für Ihren Dienst:
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
 ##### **Für MX Plan und Zimbra** <a name="confemail"></a>
 
 Folgen Sie den **5 Schritten**, indem Sie nacheinander auf die Tabs klicken:
@@ -511,6 +528,7 @@ Folgen Sie den **5 Schritten**, indem Sie nacheinander auf die Tabs klicken:
     :::
   </Tab>
 </Tabs>
+</Region>
 
 <Region zones={['eu', 'ca']}>
 
@@ -828,7 +846,7 @@ Folgen Sie den **5 Schritten**, indem Sie auf jeden Tab klicken.
 Klicken Sie auf den Tab für Ihren Dienst:
 
 <ZoneTabs>
-  <Tab label="MX Plan und Zimbra">
+  <Tab label="MX Plan und Zimbra" availableIn={['eu']}>
     Überprüfen Sie bei DKIM-Operationen den aktuellen DKIM-Status mithilfe des folgenden API-Aufrufs.
 
     <Api version="v1" section="/email/domain" method="GET" route={"/email/domain/\\{domain\\}/dkim"} regions={["eu"]} />
@@ -913,7 +931,7 @@ Der DKIM-Selektor muss den Status `inProduction` oder `ready` haben, bevor er de
 Wählen Sie das relevante E-Mail-Angebot aus:
 
 <ZoneTabs>
-  <Tab label="MX Plan und Zimbra">
+  <Tab label="MX Plan und Zimbra" availableIn={['eu']}>
     Um DKIM zu aktivieren, verwenden Sie folgenden API-Aufruf:
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/enable"} regions={["eu"]} />
@@ -968,7 +986,7 @@ Der DKIM-Selektor muss den Status `inProduction` haben, bevor er deaktiviert wer
 Klicken Sie auf den Tab für Ihren Dienst:
 
 <ZoneTabs>
-  <Tab label="MX Plan und Zimbra">
+  <Tab label="MX Plan und Zimbra" availableIn={['eu']}>
     Wenn Sie DKIM deaktivieren möchten, ohne die Selektoren und deren Schlüsselpaare zu löschen, verwenden Sie folgenden API-Aufruf:
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/disable"} regions={["eu"]} />

--- a/docs/de/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Sicherheit durch DMARC-Eintrag verbessern
 description: Erfahren Sie hier, wie DMARC funktioniert und für Ihren E-Mail-Dienst eingerichtet wird
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -162,7 +162,7 @@ Alle gesendeten E-Mails (**pct=100**) werden mit den SPF- und/oder DKIM-Authenti
 Für das zweite Beispiel wurde ein [TXT-Eintrag](#txt-record) erstellt, um Tags zu verwenden, die nicht über den vereinfachten [DMARC-Eintrag](#dmarc-record) verfügbar sind. Das Ergebnis lautet:
 
 ```
-"v=DMARC1; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; adkim=r; ri=86400"
+"v=DMARC1; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; ri=86400"
 ```
 
 - **p=quarantine**: E-Mails, die die DMARC-Tests nicht bestehen, werden als „verdächtig“ behandelt.
@@ -176,8 +176,6 @@ Für das zweite Beispiel wurde ein [TXT-Eintrag](#txt-record) erstellt, um Tags 
 - **adkim=r**: Der vom Domaininhaber angeforderte Alignment-Modus für DKIM ID ist „relaxed“ (flexibler Modus). In diesem Modus muss DKIM eine gültige Signatur bereitstellen, und der Identifier „From“ im Header kann teilweise abgestimmt sein.
 
 - **aspf=s**: Der erforderliche Alignment-Modus für SPF ist „strict“. Das bedeutet, dass die SPF-Kennung der abgestimmten Domain exakt mit der IP-Adresse übereinstimmen muss, die die Nachricht sendet.
-
-- **adkim=r**: Der vom Domaininhaber angeforderte Alignment-Modus für DKIM ID ist „relaxed“ (flexibler Modus). In diesem Modus muss DKIM eine gültige Signatur bereitstellen, und der Identifier „From“ im Header kann teilweise abgestimmt sein.
 
 - **ri=86400**: Legt das angeforderte Intervall zwischen den aggregierten Berichten in Sekunden fest. In diesem Fall muss ein aggregierter Bericht mindestens alle 86400 Sekunden (einmal täglich) generiert werden.
 

--- a/docs/de/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/de/guides/web-cloud/domains/domain-whois.mdx
@@ -1,7 +1,7 @@
 ---
 title: WHOIS Informationen eines Domainnamens abrufen
 description: Erfahren Sie, wie Sie mit dem WHOIS Tool verfügbare Details zu einem Domainname erhalten
-lastUpdated: 2025-07-04
+lastUpdated: 2026-07-31
 availableIn: [eu]
 ---
 
@@ -30,7 +30,7 @@ Darüber hinaus können die Registrys, die diese Domainendungen verwalten, es de
 Mit den folgenden Schritten können Sie auf die WHOIS Einträge zugreifen, die einer Domain zugeordnet sind:
 
 1. Greifen Sie auf unser [WHOIS Tool](/links/web/domains-whois) zu.
-1. Geben Sie auf der angezeigten Seite den Domainnamen (zum Beispiel: *domain.tld*, **ohne** www) in das Feld <code className="action">Domainname *</code> ein und geben Sie den `Sicherheitscode` im Feld <code className="action">Sicherheitscode eingeben *</code> ein.
+1. Geben Sie auf der angezeigten Seite den Domainnamen (zum Beispiel: *domain.tld*, **ohne** www) in das Feld <code className="action">Domainname</code> ein und geben Sie den `Sicherheitscode` im Feld <code className="action">Sicherheitscode eingeben *</code> ein.
 1. Klicken Sie auf die Schaltfläche <code className="action">Whois</code>, um die Anfrage zu senden.
 1. Überprüfen Sie das Ergebnis der WHOIS Abfrage im neuen Abschnitt <code className="action">Whois search results :</code> unter der Schaltfläche <code className="action">Whois</code>.
 

--- a/docs/en/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to improve email security with a DKIM record
 description: Find out how to configure a DKIM record on your OVHcloud domain name and email service
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -66,9 +66,13 @@ If your domain name is registered with OVHcloud, you can check if it is using th
     - [Example of an email sent using DKIM](#example)
     - [What is a DKIM selector?](#selector)
 - [Automatically configure DKIM for an OVHcloud email offer](#auto-dkim)
+<Region zones={['eu', 'ca']}>
 - [Configure DKIM via API for an OVHcloud email offer](#internal-dkim)
+</Region>
     - [API - Full DKIM configuration](#firststep)
+        <Region zones={['eu']}>
         - [For MX Plan and Zimbra](#confemail)
+        </Region>
         <Region zones={['eu', 'ca']}>
         - [For Exchange](#confex)
         </Region>
@@ -273,7 +277,13 @@ Open the <code className="action">DNS zone</code> tab, then click <code classNam
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
 Automatic DKIM activation takes between 30 minutes and a maximum of 24 hours. To check that your DKIM is working, simply return to the domain management section mentioned in the tabs above and check that the `DKIM` badge is green, or for a Zimbra offer, that the `DKIM` tab no longer displays the warning icon.
+</Region>
+
+<Region zones={['ca', 'apac']}>
+Automatic DKIM activation takes between 30 minutes and a maximum of 24 hours. To check that your DKIM is working, simply return to the domain management section mentioned in the tabs above and check that the `DKIM` badge is green.
+</Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
@@ -335,12 +345,18 @@ To configure DKIM, go to the <ApiLink>OVHcloud API page</ApiLink> and log in:
 Refer to our guide "[Getting started with OVHcloud APIs](/guides/manage-and-operate/api/first-steps)" if you have never used APIs before.
 :::
 
+<Region zones={['eu']}>
 Go to the API section `/email/domain/` (MX Plan and Zimbra offers), `/email/exchange` (Exchange offer) or `/email/pro` (E-mail Pro offer) and enter "dkim" in the `Filter` field to display only the API functions related to DKIM.
+</Region>
+
+<Region zones={['ca']}>
+Go to the API section `/email/exchange` (Exchange offer) and enter "dkim" in the `Filter` field to display only the API functions related to DKIM.
+</Region>
 
 Click on the tab corresponding to your offer:
 
 <ZoneTabs>
-  <Tab label="MX Plan and Zimbra">
+  <Tab label="MX Plan and Zimbra" availableIn={['eu']}>
     <img className="thumbnail" alt="email" src="/images/assets/screens/api/get-email-domain-domain-dkim.png" loading="lazy" />
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
@@ -351,6 +367,7 @@ Click on the tab corresponding to your offer:
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
 ##### **For MX Plan and Zimbra** <a name="confemail"></a>
 
 Follow the **5 steps** by clicking on each of the 5 tabs below:
@@ -521,6 +538,7 @@ Go to the <code className="action">DNS zone</code> tab, then click <code classNa
     :::
   </Tab>
 </Tabs>
+</Region>
 
 <Region zones={['eu', 'ca']}>
 
@@ -842,7 +860,7 @@ Go to the <code className="action">DNS zone</code> tab, then click <code classNa
 Select the email solution concerned in the following tabs:
 
 <ZoneTabs>
-  <Tab label="MX Plan and Zimbra">
+  <Tab label="MX Plan and Zimbra" availableIn={['eu']}>
     When performing operations on your E-mail platform's DKIM, use the API call below to check the current DKIM status.
 
     <Api version="v1" section="/email/domain" method="GET" route={"/email/domain/\\{domain\\}/dkim"} regions={["eu"]} />
@@ -925,7 +943,7 @@ The DKIM selector must be in `ready` status before it can be enabled.
 Select the email solution concerned in the following tabs:
 
 <ZoneTabs>
-  <Tab label="MX Plan and Zimbra">
+  <Tab label="MX Plan and Zimbra" availableIn={['eu']}>
     To enable DKIM, use the following API call:
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/enable"} regions={["eu"]} />
@@ -980,7 +998,7 @@ The DKIM selector must be in `inProduction` or `ready` status before it can be d
 Select the email solution concerned in the following tabs:
 
 <ZoneTabs>
-  <Tab label="MX Plan and Zimbra">
+  <Tab label="MX Plan and Zimbra" availableIn={['eu']}>
     If you want to disable the DKIM without removing the selectors and their key pair, use the following API call:
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/disable"} regions={["eu"]} />
@@ -1269,7 +1287,7 @@ Below, you will find the states that may block your DKIM from working, and the a
     - `disabling`: DKIM is being disabled. Once you have done this, you can activate the selector by going to [API - Activate or change a DKIM selector](#enable-switch).
     - `todo`: The task has been initialised, it must be launched. After 24 hours, if your selector is still in this state, please open a [support ticket](/links/support-contact), specifying the number of the selector concerned.
   </Tab>
-  <Tab label="MX Plan and Zimbra">
+  <Tab label="MX Plan and Zimbra" availableIn={['eu']}>
     - `disabled`: DKIM is disabled, has not yet been configured, or has been disabled by API. <br/>
     - `modifying`: The DKIM configuration is in progress, you will need to wait for the process to complete.<br/>
     - `toConfigure`: DKIM configuration is pending domain name DNS settings. You must manually enter the DNS records in the domain name zone. To do this, see the step “[API - Full DKIM configuration](#confemail)” in this guide. <br/>

--- a/docs/en/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to improve email security with a DMARC record
 description: Find out how DMARC works, and how to set it up for your email service
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -165,7 +165,7 @@ To illustrate this first example, we used the [DMARC record](#dmarc-record) in t
 For this second example, we used a [TXT record](#txt-record) to use tags that are not available through the simplified [DMARC record](#dmarc-record). The result is:
 
 ```
-"v=DMARC1; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; adkim=r; ri=86400"
+"v=DMARC1; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; ri=86400"
 ```
 
 - **p=quarantine**: Emails that do not pass the DMARC tests are treated as “suspicious”.
@@ -179,8 +179,6 @@ For this second example, we used a [TXT record](#txt-record) to use tags that ar
 - **adkim=r**: The DKIM ID alignment mode required by the domain holder is "relaxed" (flexible mode). In this mode, DKIM must provide a valid signature and the identifier of the "From" header can be partially aligned.
 
 - **aspf=s**: The SPF identifier alignment mode required is "strict". This means that the SPF identifier of the aligned domain must exactly match the sending IP address of the message.
-
-- **adkim=r**: The DKIM ID alignment mode required by the domain holder is "relaxed". In this mode, DKIM must provide a valid signature and the "From" header identifier can be partially aligned.
 
 - **ri=86400**: Sets the requested interval between aggregated reports, in seconds. In this case, an aggregated report must be generated at least once every 86400 seconds (i.e. once per day).
 

--- a/docs/en/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/en/guides/web-cloud/domains/domain-whois.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to get information about a domain name with WHOIS
 description: Find out how to use the WHOIS tool to get details on a domain name
-lastUpdated: 2025-07-04
+lastUpdated: 2026-07-31
 availableIn: [eu]
 ---
 
@@ -30,7 +30,7 @@ In addition, the registries that manage these extensions may allow domain name h
 The following steps will take you to the WHOIS records associated with a domain name:
 
 1. Access our [WHOIS online tool](/links/web/domains-whois).
-1. On the page that pops up, enter the domain name (for example: *domain.tld* **without** the *www*) in the <code className="action">Domain name *</code> field, then enter the `Security code` in the <code className="action">Enter security code *</code> field.
+1. On the page that pops up, enter the domain name (for example: *domain.tld* **without** the *www*) in the <code className="action">Domain name</code> field, then enter the `Security code` in the <code className="action">Enter security code *</code> field.
 1. Click the <code className="action">Whois</code> button to send the request.
 1. See the result of the WHOIS query in the new section titled <code className="action">Whois search results :</code> under the <code className="action">Whois</code> button.
 

--- a/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mejorar la seguridad del correo electrónico mediante un registro DKIM
 description: Cómo configurar un registro DKIM en un nombre de dominio y una plataforma de correo electrónico de OVHcloud
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -66,9 +66,13 @@ Si el dominio está registrado en OVHcloud, puede comprobar si utiliza nuestra c
     - [Ejemplo de un email enviado utilizando DKIM](#example)
     - [¿Qué es un selector DKIM?](#selector)
 - [Configurar el DKIM automáticamente para una solución de correo electrónico de OVHcloud](#auto-dkim)
+<Region zones={['eu', 'ca']}>
 - [Configurar el DKIM mediante API para una solución de correo electrónico de OVHcloud](#internal-dkim)
+</Region>
     - [API - Configuración completa del DKIM](#firststep)
+        <Region zones={['eu']}>
         - [Para MX Plan y Zimbra](#confemail)
+        </Region>
         <Region zones={['eu', 'ca']}>
         - [Para Exchange](#confex)
         </Region>
@@ -274,7 +278,13 @@ Para activar el DKIM, haga clic en la etiqueta rojo `DKIM` y seleccione <code cl
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto02.png" loading="lazy" />
 
+<Region zones={['eu']}>
 La activación automática del DKIM dura entre 30 minutos y 24 horas como máximo. Para verificar que su DKIM funciona correctamente, simplemente vaya a la sección de gestión del dominio mencionada en las pestañas anteriores y verifique que el indicador `DKIM` es verde o, para una oferta Zimbra, que la pestaña `DKIM` no muestra más el icono de advertencia.
+</Region>
+
+<Region zones={['ca', 'apac']}>
+La activación automática del DKIM dura entre 30 minutos y 24 horas como máximo. Para verificar que su DKIM funciona correctamente, simplemente vaya a la sección de gestión del dominio mencionada en las pestañas anteriores y verifique que el indicador `DKIM` es verde.
+</Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
@@ -336,12 +346,18 @@ Para configurar el DKIM, vaya a la <ApiLink>página de las API de OVHcloud</ApiL
 Consulte nuestro guía "[Primeros pasos con las API de OVHcloud](/guides/manage-and-operate/api/first-steps)" si nunca ha utilizado las API.
 :::
 
+<Region zones={['eu']}>
 Vaya a la sección `/email/domain/` (ofertas MX Plan y Zimbra), `/email/exchange` (oferta Exchange) o `/email/pro` (oferta E-mail Pro) de las API y escriba "dkim" en el campo `Filter` para mostrar únicamente las funciones API relacionadas con el DKIM.
+</Region>
+
+<Region zones={['ca']}>
+Vaya a la sección `/email/exchange` (oferta Exchange) de las API y escriba "dkim" en el campo `Filter` para mostrar únicamente las funciones API relacionadas con el DKIM.
+</Region>
 
 Haga clic en la pestaña correspondiente a su oferta:
 
 <ZoneTabs>
-  <Tab label="MX Plan y Zimbra">
+  <Tab label="MX Plan y Zimbra" availableIn={['eu']}>
     <img className="thumbnail" alt="email" src="/images/assets/screens/api/get-email-domain-domain-dkim.png" loading="lazy" />
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
@@ -352,6 +368,7 @@ Haga clic en la pestaña correspondiente a su oferta:
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
 ##### **Para MX Plan y Zimbra** <a name="confemail"></a>
 
 Siga los **5 pasos** haciendo clic en cada una de las 5 pestañas siguientes:
@@ -521,6 +538,7 @@ Siga los **5 pasos** haciendo clic en cada una de las 5 pestañas siguientes:
     :::
   </Tab>
 </Tabs>
+</Region>
 
 <Region zones={['eu', 'ca']}>
 
@@ -840,7 +858,7 @@ Siga los **5 pasos** que se indican a continuación haciendo clic en cada una de
 Seleccione el servicio de correo en las siguientes pestañas:
 
 <ZoneTabs>
-  <Tab label="MX Plan y Zimbra">
+  <Tab label="MX Plan y Zimbra" availableIn={['eu']}>
     Durante sus operaciones en el DKIM de su plataforma E-mail, utilice la llamada API que aparece a continuación para comprobar el estado actual del DKIM.
 
     <Api version="v1" section="/email/domain" method="GET" route={"/email/domain/\\{domain\\}/dkim"} regions={["eu"]} />
@@ -923,7 +941,7 @@ El selector DKIM debe estar en estado de `ready` antes de poder activarlo.
 Seleccione el servicio de correo en las siguientes pestañas:
 
 <ZoneTabs>
-  <Tab label="MX Plan y Zimbra">
+  <Tab label="MX Plan y Zimbra" availableIn={['eu']}>
     Para activar el DKIM, utilice la siguiente llamada a la API:
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/enable"} regions={["eu"]} />
@@ -978,7 +996,7 @@ El selector DKIM debe estar en estado `inProduction` o `ready` antes de poder de
 Seleccione el servicio de correo en las siguientes pestañas:
 
 <ZoneTabs>
-  <Tab label="MX Plan y Zimbra">
+  <Tab label="MX Plan y Zimbra" availableIn={['eu']}>
     Si desea desactivar el DKIM sin eliminar los selectores y su par de claves, utilice la siguiente llamada a la API:
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/disable"} regions={["eu"]} />
@@ -1267,7 +1285,7 @@ A continuación, encontrará los estados que pueden bloquear el funcionamiento d
     - `disabling`: se está desactivando el DKIM. Una vez hecho esto, puede activar el selector en la sección "[API - Activar o cambiar un selector DKIM](#enable-switch)".
     - `todo`: la tarea se ha inicializado y debe iniciarse. Una vez transcurridas 24 horas, si el selector sigue en este estado, le invitamos a abrir un [tíquet con el soporte](/links/support-contact) indicando el número del selector correspondiente.
   </Tab>
-  <Tab label="MX Plan y Zimbra">
+  <Tab label="MX Plan y Zimbra" availableIn={['eu']}>
     - `disabled`: El DKIM está desactivado, todavía no se ha configurado o ha sido desactivado por API. <br/>
     - `modifying`: La configuración del DKIM está en curso, es necesario esperar hasta que el proceso haya finalizado.<br/>
     - `toConfigure`: La configuración del DKIM está pendiente de los parámetros DNS del dominio. Debe introducir manualmente los registros DNS en la zona del nombre de dominio. Para ello, consulte el paso "[Configuración completa del DKIM](#confemail)" de esta guía. <br/>

--- a/docs/es/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mejorar la seguridad del correo electrónico mediante el registro DMARC
 description: Descubra cómo funciona DMARC y cómo implementarlo para su servicio de correo
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -160,7 +160,7 @@ Todos los mensajes de correo enviados (**pct=100**) se procesan mediante los mec
 En este segundo ejemplo, se ha utilizado un [registro TXT](#txt-record) para utilizar etiquetas que no están disponibles a través del [registro DMARC](#dmarc-record) simplificado. Obtenemos el siguiente resultado:
 
 ```
-"v=DMARC1; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; adkim=r; ri=86400"
+"v=DMARC1; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; ri=86400"
 ```
 
 - **p=quarantine**: los mensajes de correo electrónico que no superan las pruebas DMARC se tratan como "sospechosos".
@@ -174,8 +174,6 @@ En este segundo ejemplo, se ha utilizado un [registro TXT](#txt-record) para uti
 - **adkim=r**: el modo de alineación de ID de DKIM requerido por el titular del nombre de dominio es "relaxed" (modo flexible). En este modo, DKIM debe proporcionar una firma válida y el identificador del encabezado "From" se puede alinear parcialmente.
 
 - **aspf=s**: el modo de alineación del identificador SPF requerido es "strict". Esto significa que el SPF del nombre de dominio alineado debe coincidir exactamente con la dirección IP remitente del mensaje.
-
-- **adkim=r**: el modo de alineación de ID de DKIM requerido por el titular del nombre de dominio es «relaxed» (modo flexible). En este modo, DKIM debe proporcionar una firma válida y el identificador del encabezado 'From' se puede alinear parcialmente.
 
 - **ri=86400**: Establece el intervalo solicitado entre informes agregados, en segundos. En este caso, debe generarse un informe agregado al menos una vez cada 86400 segundos (una vez al día).
 

--- a/docs/es/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/es/guides/web-cloud/domains/domain-whois.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cómo obtener información relativa a un dominio con el WHOIS
 description: Descubra cómo utilizar la herramienta WHOIS para obtener detalles sobre un dominio
-lastUpdated: 2025-07-04
+lastUpdated: 2026-07-31
 availableIn: [eu]
 ---
 
@@ -30,7 +30,7 @@ Además, los registros que gestionan estas extensiones pueden permitir a los tit
 Siga estos pasos para acceder a los registros WHOIS asociados a un dominio:
 
 1. Acceda a nuestra [herramienta WHOIS online](/links/web/domains-whois).
-1. Introduzca el nombre de dominio (por ejemplo:, *domain.tld* **sin** los *www*) en el campo <code className="action">Dominio *</code> e introduzca el `Código de seguridad` que aparece en el campo <code className="action">Introduzca el código de seguridad *</code>.
+1. Introduzca el nombre de dominio (por ejemplo:, *domain.tld* **sin** los *www*) en el campo <code className="action">Dominio</code> e introduzca el `Código de seguridad` que aparece en el campo <code className="action">Introduzca el código de seguridad *</code>.
 1. Haga clic en el botón <code className="action">Whois</code> para enviar la consulta.
 1. Consulte el resultado de la consulta WHOIS en la nueva sección titulada <code className="action">Whois search results:</code> situada debajo del botón <code className="action">Whois</code>.
 

--- a/docs/fr/guides/web-cloud/domains/dns-anycast-enable.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-anycast-enable.mdx
@@ -1,7 +1,7 @@
 ---
 title: Activer les DNS Anycast pour votre nom de domaine
 description: "Découvrez comment accélérer l'accès à vos services web grâce à la vitesse de résolution DNS offerte par l’option DNS Anycast de votre nom de domaine"
-lastUpdated: 2025-06-18
+lastUpdated: 2026-07-31
 availableIn: [eu]
 ---
 
@@ -53,7 +53,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4*
   <Tab label="Étape 4">
     Sur la nouvelle page qui s’affiche :
 
-    - Choisissez la durée proposée dans la section `1` et cliquez sur <code className="action">suivant</code>.
+    - Choisissez la durée proposée dans la section `1` et cliquez sur <code className="action">Suivant</code>.
     - Sélectionnez votre moyen de paiement puis cliquez sur <code className="action">Payer</code> pour poursuivre l’activation des DNS Anycast.
 
     <img className="thumbnail" alt="Order Anycast DNS step 2" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-servers/order-anycast-dns-step-2.png" loading="lazy" />

--- a/docs/fr/guides/web-cloud/domains/dns-dnssec.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-dnssec.mdx
@@ -1,7 +1,7 @@
 ---
 title: Sécuriser votre nom de domaine avec DNSSEC
 description: Découvrez comment protéger votre nom de domaine du Cache Poisoning en activant le DNSSEC
-lastUpdated: 2026-06-08
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -112,7 +112,7 @@ Une fois ces 4 paramètres récupérés, cliquez sur les onglets ci-dessous pour
     <img className="thumbnail" alt="Domain Names" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-names.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 2">
-    Sur la page qui s’affiche, cliquez sur l’onglet <code className="action">DS records</code>. **Cet onglet n’apparaît que si votre nom de domaine utilise des serveurs DNS externes**.
+    Sur la page qui s’affiche, cliquez sur l’onglet <code className="action">DS Records</code>. **Cet onglet n’apparaît que si votre nom de domaine utilise des serveurs DNS externes**.
   </Tab>
   <Tab label="Étape 3">
     Dans la nouvelle page qui apparaît, cliquez sur le bouton <code className="action">Ajouter</code>.

--- a/docs/fr/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Améliorer la sécurité des e-mails via un enregistrement DKIM
 description: Découvrez comment configurer un enregistrement DKIM sur votre nom de domaine et votre plateforme e-mail OVHcloud
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -66,9 +66,13 @@ Si votre nom de domaine est déposé chez OVHcloud, vous pouvez vérifier si ce 
     - [Exemple d’un e-mail envoyé en utilisant le DKIM](#example)
     - [Qu’est-ce qu’un sélecteur DKIM ?](#selector)
 - [Configurer le DKIM automatiquement pour une offre e-mail OVHcloud](#auto-dkim)
+<Region zones={['eu', 'ca']}>
 - [Configurer le DKIM par API pour une offre e-mail OVHcloud](#internal-dkim)
+</Region>
     - [API - Configuration complète du DKIM](#firststep)
+        <Region zones={['eu']}>
         - [Pour MX Plan et Zimbra](#confemail)
+        </Region>
         <Region zones={['eu', 'ca']}>
         - [Pour Exchange](#confex)
         </Region>
@@ -270,7 +274,13 @@ Cliquez sur l’onglet ci-dessous correspondant à votre offre.
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
 L’activation automatique du DKIM dure entre 30 minutes et 24 heures maximum. Pour vérifier que votre DKIM est fonctionnel, il vous suffit de retourner dans la rubrique de gestion du domaine mentionnée dans les onglets ci-dessus et de vérifier que la pastille `DKIM` est verte ou, pour une offre Zimbra, que l’onglet `DKIM` ne présente plus l’icône d’avertissement.
+</Region>
+
+<Region zones={['ca', 'apac']}>
+L’activation automatique du DKIM dure entre 30 minutes et 24 heures maximum. Pour vérifier que votre DKIM est fonctionnel, il vous suffit de retourner dans la rubrique de gestion du domaine mentionnée dans les onglets ci-dessus et de vérifier que la pastille `DKIM` est verte.
+</Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
@@ -332,12 +342,18 @@ Pour configurer le DKIM, rendez-vous sur la <ApiLink>page des API OVHcloud</ApiL
 Appuyez-vous sur notre guide « [Premiers pas avec les API OVHcloud](/guides/manage-and-operate/api/first-steps) » si vous n’avez jamais utilisé les API.
 :::
 
+<Region zones={['eu']}>
 Dirigez-vous vers la section `/email/domain/` (offres MX Plan et Zimbra), `/email/exchange` (offre Exchange) ou `/email/pro` (offre E-mail Pro) des API et renseignez « dkim » dans le champ `Filter` pour faire apparaître uniquement les fonctions API relatives au DKIM.
+</Region>
+
+<Region zones={['ca']}>
+Dirigez-vous vers la section `/email/exchange` (offre Exchange) des API et renseignez « dkim » dans le champ `Filter` pour faire apparaître uniquement les fonctions API relatives au DKIM.
+</Region>
 
 Cliquez sur l’onglet correspondant à votre offre :
 
 <ZoneTabs>
-  <Tab label="MX Plan et Zimbra">
+  <Tab label="MX Plan et Zimbra" availableIn={['eu']}>
     <img className="thumbnail" alt="email" src="/images/assets/screens/api/get-email-domain-domain-dkim.png" loading="lazy" />
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
@@ -348,6 +364,7 @@ Cliquez sur l’onglet correspondant à votre offre :
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
 ##### **Pour MX Plan et Zimbra** <a name="confemail"></a>
 
 Suivez les **5 étapes** en cliquant successivement sur chacun des 5 onglets ci-dessous :
@@ -517,6 +534,7 @@ Suivez les **5 étapes** en cliquant successivement sur chacun des 5 onglets ci-
     :::
   </Tab>
 </Tabs>
+</Region>
 
 <Region zones={['eu', 'ca']}>
 
@@ -836,7 +854,7 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
 Sélectionnez l’offre e-mail concernée dans les onglets suivants :
 
 <ZoneTabs>
-  <Tab label="MX Plan et Zimbra">
+  <Tab label="MX Plan et Zimbra" availableIn={['eu']}>
     Lors de vos opérations sur le DKIM de votre plateforme E-mail, utilisez l’appel API ci-dessous pour vérifier le statut actuel du DKIM.
 
     <Api version="v1" section="/email/domain" method="GET" route={"/email/domain/\\{domain\\}/dkim"} regions={["eu"]} />
@@ -919,7 +937,7 @@ Le sélecteur DKIM doit être en statut `ready` avant de pouvoir être activé.
 Sélectionnez l’offre e-mail concernée parmi les onglets suivants :
 
 <ZoneTabs>
-  <Tab label="MX Plan et Zimbra">
+  <Tab label="MX Plan et Zimbra" availableIn={['eu']}>
     Pour activer le DKIM, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/enable"} regions={["eu"]} />
@@ -974,7 +992,7 @@ Le sélecteur DKIM doit être en statut `inProduction` ou `ready` avant de pouvo
 Sélectionnez l’offre e-mail concernée parmi les onglets suivants :
 
 <ZoneTabs>
-  <Tab label="MX Plan et Zimbra">
+  <Tab label="MX Plan et Zimbra" availableIn={['eu']}>
     Si vous souhaitez désactiver le DKIM sans supprimer les sélecteurs et leur paire de clés, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/disable"} regions={["eu"]} />
@@ -1263,7 +1281,7 @@ Retrouvez ci-dessous les états qui peuvent bloquer le fonctionnement de votre D
     - `disabling` : Le DKIM est en cours de désactivation. Après cette opération, vous pourrez activer le sélecteur en vous appuyant sur la section « [API - Activer ou changer un sélecteur DKIM](#enable-switch) ».
     - `todo` : La tâche a été initialisée, elle doit se lancer. Au-delà de 24 heures, si votre sélecteur est toujours dans cet état, nous vous invitons à ouvrir un [ticket auprès du support](/links/support-contact) en précisant le numéro du sélecteur concerné.
   </Tab>
-  <Tab label="MX Plan et Zimbra">
+  <Tab label="MX Plan et Zimbra" availableIn={['eu']}>
     - `disabled` : Le DKIM est désactivé, il n’a pas encore été configuré ou il a été désactivé par API. <br/>
     - `modifying` : La configuration du DKIM est en cours, il est nécessaire de patienter jusqu’à la fin du processus.<br/>
     - `toConfigure` : La configuration du DKIM est en attente des paramètres DNS du nom de domaine. Vous devez renseigner manuellement les enregistrements DNS dans la zone du nom de domaine. Pour cela; appuyez-vous sur l’étape « [Configuration complète du DKIM](#confemail) » de ce guide. <br/>

--- a/docs/fr/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -1,7 +1,7 @@
 ---
 title: Améliorer la sécurité des e-mails via un enregistrement DMARC
 description: Découvrez comment fonctionne DMARC et comment le mettre en place pour votre service e-mail
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -164,7 +164,7 @@ Pour illustrer ce premier exemple, nous avons utilisé l’[enregistrement DMARC
 Pour ce deuxième exemple, nous avons utilisé un [enregistrement TXT](#txt-record) pour utiliser des balises qui ne sont pas disponibles via l’[enregistrement DMARC](#dmarc-record) simplifié. Nous obtenons le résultat suivant :
 
 ```
-"v=DMARC1; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; adkim=r; ri=86400"
+"v=DMARC1; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; ri=86400"
 ```
 
 - **p=quarantine** : les e-mails qui ne passent pas les tests DMARC sont traités comme « suspects ».
@@ -178,8 +178,6 @@ Pour ce deuxième exemple, nous avons utilisé un [enregistrement TXT](#txt-reco
 - **adkim=r** : le mode d’alignement d’identifiant DKIM requis par le titulaire du nom de domaine est "relaxed" (mode souple). Dans ce mode, DKIM doit fournir une signature valide et l’identifiant de l’en-tête "From" peut être partiellement aligné.
 
 - **aspf=s** : le mode d’alignement d’identifiant SPF requis est « strict ». Cela signifie que l’identifiant SPF du nom de domaine aligné doit correspondre exactement à l’adresse IP émettrice du message.
-
-- **adkim=r** : le mode d’alignement d’identifiant DKIM requis par le titulaire du nom de domaine est « relaxed » (mode souple). Dans ce mode, DKIM doit fournir une signature valide et l’identifiant de l’en-tête « From » peut être partiellement aligné.
 
 - **ri=86400** : définit l’intervalle demandé entre les rapports agrégés, en secondes. Dans ce cas, un rapport agrégé doit être généré au moins une fois toutes les 86400 secondes (soit une fois par jour).
 

--- a/docs/fr/guides/web-cloud/domains/dns-zone-edit.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-edit.mdx
@@ -1,7 +1,7 @@
 ---
 title: Éditer une zone DNS OVHcloud
 description: Découvrez comment éditer une zone DNS OVHcloud via votre espace client OVHcloud
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -171,7 +171,7 @@ Vous pouvez aussi modifier le TTL d’un enregistrement DNS individuel lors de s
 
 ## Aller plus loin
 
-[Qu’est ce qu’un serveur DNS?](/guides/web-cloud/domains/dns-server-general-information)
+[Qu’est-ce qu’un serveur DNS ?](/guides/web-cloud/domains/dns-server-general-information)
 
 [Qu’est ce qu’une zone DNS?](/guides/web-cloud/domains/dns-zone-general-information)
 
@@ -179,7 +179,7 @@ Vous pouvez aussi modifier le TTL d’un enregistrement DNS individuel lors de s
 
 [Gérer l’historique d’une zone DNS](/guides/web-cloud/domains/dns-zone-history)
 
-[Ajouter un champ SPF à la configuration de son nom de domaine](/guides/web-cloud/domains/dns-zone-spf)
+[Améliorer la sécurité des e-mails via un enregistrement SPF](/guides/web-cloud/domains/dns-zone-spf)
 
 [Protégez votre nom de domaine contre le Cache Poisoning avec le DNSSEC](/links/web/domains-dnssec)
 

--- a/docs/fr/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/fr/guides/web-cloud/domains/domain-whois.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comment obtenir des informations relatives à un nom de domaine avec le WHOIS
 description: "Découvrez comment utiliser l'outil WHOIS pour obtenir des détails sur un nom de domaine"
-lastUpdated: 2025-07-04
+lastUpdated: 2026-07-31
 availableIn: [eu]
 ---
 
@@ -30,7 +30,7 @@ De plus, les registres qui gèrent ces extensions peuvent permettre aux titulair
 Les étapes suivantes permettent d’accéder aux enregistrements WHOIS associés à un nom de domaine :
 
 1. Accédez à notre [outil WHOIS en ligne](/links/web/domains-whois).
-1. Sur la page qui s’affiche, renseignez le nom de domaine (par exemple : *domain.tld* **sans** les *www*) dans le champ <code className="action">Nom de domaine *</code>, puis saisissez le `Code de sécurité` qui s’affiche dans le champ <code className="action">Entrer le code de sécurité *</code>.
+1. Sur la page qui s’affiche, renseignez le nom de domaine (par exemple : *domain.tld* **sans** les *www*) dans le champ <code className="action">Nom de domaine</code>, puis saisissez le `Code de sécurité` qui s’affiche dans le champ <code className="action">Entrer le code de sécurité *</code>.
 1. Cliquez sur le bouton <code className="action">Whois</code> pour envoyer la requête.
 1. Consultez le résultat de la requête WHOIS dans la nouvelle section intitulée <code className="action">Whois search results :</code> située sous le bouton <code className="action">Whois</code>.
 

--- a/docs/it/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migliora la sicurezza delle email con un record DKIM
 description: Come configurare un record DKIM sul tuo nome di dominio e sulla tua piattaforma email OVHcloud
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -66,9 +66,13 @@ Se il tuo dominio è registrato presso OVHcloud, verifica che utilizzi la config
     - [Esempio di un'email inviata utilizzando il DKIM](#example)
     - [Cos'è un selettore DKIM?](#selector)
 - [Configurare automaticamente il DKIM per un'offerta e-mail OVHcloud](#auto-dkim)
+<Region zones={['eu', 'ca']}>
 - [Configurare il DKIM tramite API per un'offerta e-mail OVHcloud](#internal-dkim)
+</Region>
     - [API - Configurazione completa del DKIM](#firststep)
+        <Region zones={['eu']}>
         - [Per Email (MX Plan) e Zimbra](#confemail)
+        </Region>
         <Region zones={['eu', 'ca']}>
         - [Per Exchange](#confex)
         </Region>
@@ -271,7 +275,13 @@ Clicca sulla scheda qui sotto corrispondente alla tua offerta.
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
 L'attivazione automatica del DKIM richiede tra i 30 minuti e un massimo di 24 ore. Per verificare che il tuo DKIM funzioni correttamente, torna alla sezione di gestione del dominio indicata nelle schede precedenti e controlla che il badge `DKIM` sia verde oppure, per un'offerta Zimbra, che la scheda `DKIM` non mostri più l'icona di avviso.
+</Region>
+
+<Region zones={['ca', 'apac']}>
+L'attivazione automatica del DKIM richiede tra i 30 minuti e un massimo di 24 ore. Per verificare che il tuo DKIM funzioni correttamente, torna alla sezione di gestione del dominio indicata nelle schede precedenti e controlla che il badge `DKIM` sia verde.
+</Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
@@ -333,12 +343,18 @@ Per configurare il DKIM, recatevi sulla <ApiLink>pagina delle API OVHcloud</ApiL
 Riferitevi alla nostra guida "[Primi passi con le API OVHcloud](/guides/manage-and-operate/api/first-steps)" se non avete mai utilizzato le API.
 :::
 
+<Region zones={['eu']}>
 Recatevi nella sezione `/email/domain/` (offerte MX Plan e Zimbra), `/email/exchange` (offerta Exchange) o `/email/pro` (offerta E-mail Pro) delle API e digitate "dkim" nel campo `Filter` per far apparire solo le funzioni API relative al DKIM.
+</Region>
+
+<Region zones={['ca']}>
+Recatevi nella sezione `/email/exchange` (offerta Exchange) delle API e digitate "dkim" nel campo `Filter` per far apparire solo le funzioni API relative al DKIM.
+</Region>
 
 Clicca sulla scheda corrispondente alla tua offerta:
 
 <ZoneTabs>
-  <Tab label="Email (MX Plan) e Zimbra">
+  <Tab label="Email (MX Plan) e Zimbra" availableIn={['eu']}>
     <img className="thumbnail" alt="email" src="/images/assets/screens/api/get-email-domain-domain-dkim.png" loading="lazy" />
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
@@ -349,6 +365,7 @@ Clicca sulla scheda corrispondente alla tua offerta:
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
 ##### **Per MX Plan e Zimbra** <a name="confemail"></a>
 
 Segui i **5 step** cliccando su ognuna delle 5 schede qui sotto:
@@ -518,6 +535,7 @@ Segui i **5 step** cliccando su ognuna delle 5 schede qui sotto:
     :::
   </Tab>
 </Tabs>
+</Region>
 
 <Region zones={['eu', 'ca']}>
 
@@ -837,7 +855,7 @@ Clicca sui **5 step** seguenti, cliccando su ciascuna scheda.
 Seleziona il servizio di posta in questione nelle seguenti schede:
 
 <ZoneTabs>
-  <Tab label="MX Plan e Zimbra">
+  <Tab label="MX Plan e Zimbra" availableIn={['eu']}>
     Durante le operazioni sulla DKIM del tuo servizio Email, utilizza la chiamata API qui sotto per verificare lo stato attuale della DKIM.
 
     <Api version="v1" section="/email/domain" method="GET" route={"/email/domain/\\{domain\\}/dkim"} regions={["eu"]} />
@@ -920,7 +938,7 @@ Il selettore DKIM deve essere in stato `ready` prima di poter essere attivato.
 Seleziona il servizio di posta in questione nelle seguenti schede:
 
 <ZoneTabs>
-  <Tab label="MX Plan e Zimbra">
+  <Tab label="MX Plan e Zimbra" availableIn={['eu']}>
     Per attivare il DKIM, utilizza questa chiamata API:
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/enable"} regions={["eu"]} />
@@ -975,7 +993,7 @@ Il selettore DKIM deve trovarsi nello stato `inProduction` o `ready` prima di po
 Seleziona il servizio di posta in questione nelle seguenti schede:
 
 <ZoneTabs>
-  <Tab label="MX Plan e Zimbra">
+  <Tab label="MX Plan e Zimbra" availableIn={['eu']}>
     Per disattivare il DKIM senza eliminare i selettori e le relative coppie di chiavi, utilizza questa chiamata API:
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/disable"} regions={["eu"]} />
@@ -1264,7 +1282,7 @@ Di seguito sono riportati gli stati che possono bloccare il funzionamento della 
     - `disabling`: disattivazione del DKIM in corso. Dopo questa operazione, è possibile attivare il selettore dalla sezione "[API - Attivare o cambiare un selettore DKIM](#enable-switch)".
     - `todo`: l’operazione è stata inizializzata, deve essere avviata. Oltre le 24 ore, se il selettore è ancora in questo stato, ti invitiamo ad aprire un [ticket presso il supporto](/links/support-contact) precisando il numero del selettore in questione.
   </Tab>
-  <Tab label="MX Plan e Zimbra">
+  <Tab label="MX Plan e Zimbra" availableIn={['eu']}>
     - `disabled`: il DKIM è disattivato, non è stato ancora configurato o è stato disattivato tramite API. <br/>
     - `modifying`: La configurazione del DKIM è in corso, è necessario attendere il completamento del processo.<br/>
     - `toConfigure`: la configurazione del DKIM è in attesa delle impostazioni DNS del nome di dominio. È necessario inserire manualmente i record DNS nella zona del nome di dominio. Per farlo, clicca sul passaggio "[Configurazione completa del DKIM](#confemail)" di questa guida. <br/>

--- a/docs/it/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migliora la sicurezza delle email con un record DMARC
 description: Questa guida ti mostra come funziona DMARC e come configurarlo per il tuo servizio di posta
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -162,7 +162,7 @@ Tutte le email inviate (**pct=100**) vengono gestite dai meccanismi di autentica
 In questo secondo esempio, è stato utilizzato un [record TXT](#txt-record) per utilizzare tag non disponibili nel [record DMARC](#dmarc-record) semplificato. Otteniamo il seguente risultato:
 
 ```
-"v=DMARC1; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; adkim=r; ri=86400"
+"v=DMARC1; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; ri=86400"
 ```
 
 - **p=quarantine**: le email che non superano i test DMARC vengono trattate come "sospette".
@@ -176,8 +176,6 @@ In questo secondo esempio, è stato utilizzato un [record TXT](#txt-record) per 
 - **adkim=r**: la modalità di allineamento dell'identificativo DKIM richiesta dall'intestatario del dominio è "relaxed" (modalità flessibile). In questa modalità, DKIM deve fornire una firma valida e l'identificativo dell'intestazione "From" può essere parzialmente allineato.
 
 - **aspf=s** - La modalità di allineamento dell'identificativo SPF richiesto è "strict". L'identificativo SPF del nome di dominio allineato deve corrispondere esattamente all'indirizzo IP che invia il messaggio.
-
-- **adkim=r**: la modalità di allineamento dell’identificativo DKIM richiesta dall'intestatario del nome di dominio è "relaxed" (modalità flessibile). In questa modalità DKIM deve fornire una firma valida e l'identificativo dell'intestazione "From" può essere parzialmente allineato.
 
 - **ri=86400** - Imposta l'intervallo richiesto tra i rapporti aggregati, in secondi. In questo caso, il report aggregato deve essere generato almeno una volta ogni 86400 secondi (cioè una volta al giorno).
 

--- a/docs/it/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/it/guides/web-cloud/domains/domain-whois.mdx
@@ -1,7 +1,7 @@
 ---
 title: Come ottenere informazioni relative a un dominio con il WHOIS
 description: Scopri come utilizzare lo strumento WHOIS per ottenere informazioni su un dominio
-lastUpdated: 2025-07-04
+lastUpdated: 2026-07-31
 availableIn: [eu]
 ---
 
@@ -30,7 +30,7 @@ Inoltre, i registri che gestiscono queste estensioni possono permettere ai titol
 Di seguito sono riportati gli step che permettono di accedere ai record WHOIS associati a un dominio:
 
 1. Accedi al nostro [strumento WHOIS online](/links/web/domains-whois).
-1. Nella nuova pagina, inserisci il nome del dominio (ad esempio: *domain.tld* **senza** i *www*) nel campo <code className="action">Domini *</code>, quindi inserisci il `Codice di sicurezza` che appare nel campo <code className="action">Inserisci un codice di sicurezza *</code>.
+1. Nella nuova pagina, inserisci il nome del dominio (ad esempio: *domain.tld* **senza** i *www*) nel campo <code className="action">Domini</code>, quindi inserisci il `Codice di sicurezza` che appare nel campo <code className="action">Inserisci un codice di sicurezza *</code>.
 1. Clicca sul pulsante <code className="action">Whois</code> per inviare la richiesta.
 1. Consulta il risultato della richiesta WHOIS nella nuova sezione intitolata <code className="action">Whois search results:</code> situata sotto il pulsante <code className="action">Whois</code>.
 

--- a/docs/pl/guides/web-cloud/domains/autorenew-domain-name.mdx
+++ b/docs/pl/guides/web-cloud/domains/autorenew-domain-name.mdx
@@ -1,7 +1,7 @@
 ---
 title: Odnowienie domen OVHcloud
 description: Dowiedz się, dlaczego i jak odnawiać domeny OVHcloud
-lastUpdated: 2026-03-13
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -99,14 +99,14 @@ Kliknij zakładki poniżej, aby wyświetlić każdy z **2** kroków.
 
     - Kliknij przycisk <code className="action">...</code> po prawej stronie linii.
     - Kliknij na akcję <code className="action">Skonfiguruj odnowienie</code>.
-    - Skonfiguruj odnowienie <code className="action">Ręcznie</code> lub <code className="action">Automaticznie</code>.
+    - Skonfiguruj odnowienie <code className="action">Ręcznie</code> lub <code className="action">Automatycznie</code>.
     - Jeśli wybrałeś automatyczne odnawianie, wybierz częstotliwość automatycznego odnawiania.
     - Zatwierdź i zapłać.
 
     **Dla kilku domen:**
 
     - Wybierz odpowiednie wiersze w tabeli, zaznaczając pola wyboru na początku wiersza.
-    - Kliknij przycisk <code className="action">Actions</code> w lewym górnym rogu tabeli.
+    - Kliknij przycisk <code className="action">Operacje</code> w lewym górnym rogu tabeli.
     - Wybierz <code className="action">Włącz płatność automatyczną</code> lub <code className="action">Wyłącz płatność automatyczną</code>.
   </Tab>
 </Tabs>

--- a/docs/pl/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Poprawa bezpieczeństwa e-maili dzięki rejestracji DKIM
 description: Dowiedz się, jak skonfigurować rekord DKIM w Twojej nazwy domeny i platformie e-mail OVHcloud
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -67,9 +67,13 @@ Jeśli Twoja domena jest zarejestrowana w OVHcloud, możesz sprawdzić, czy uży
     - [Przykład e-maila wysłanego z wykorzystaniem DKIM](#example)
     - [Co to jest selekcja DKIM?](#selector)
 - [Automatyczna konfiguracja DKIM dla oferty e-mail OVHcloud](#auto-dkim)
+<Region zones={['eu', 'ca']}>
 - [Konfiguracja DKIM przez API dla oferty e-mail OVHcloud](#internal-dkim)
+</Region>
     - [API - Kompletna konfiguracja DKIM](#firststep)
+        <Region zones={['eu']}>
         - [Dla MX Plan i Zimbra](#confemail)
+        </Region>
         <Region zones={['eu', 'ca']}>
         - [Dla usługi Exchange](#confex)
         </Region>
@@ -271,7 +275,13 @@ Kliknij na zakładkę poniżej odpowiadającą Twojej ofercie.
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
 Automatyczna aktywacja DKIM trwa od 30 minut do maksymalnie 24 godzin. Aby sprawdzić, czy Twój DKIM działa poprawnie, wróć do sekcji zarządzania domeną, jak w powyższych zakładkach, i sprawdź, czy guzik `DKIM` jest zielony, lub, w przypadku oferty Zimbra, czy zakładka `DKIM` nie zawiera już ikony ostrzeżenia.
+</Region>
+
+<Region zones={['ca', 'apac']}>
+Automatyczna aktywacja DKIM trwa od 30 minut do maksymalnie 24 godzin. Aby sprawdzić, czy Twój DKIM działa poprawnie, wróć do sekcji zarządzania domeną, jak w powyższych zakładkach, i sprawdź, czy guzik `DKIM` jest zielony.
+</Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
@@ -333,12 +343,18 @@ Aby skonfigurować DKIM, przejdź na <ApiLink>stronę API OVHcloud</ApiLink> i z
 Skorzystaj z naszego przewodnika "[Pierwsze kroki z API OVHcloud](/guides/manage-and-operate/api/first-steps)", jeśli nigdy wcześniej nie korzystałeś z API.
 :::
 
+<Region zones={['eu']}>
 Przejdź do sekcji `/email/domain/` (oferty MX Plan i Zimbra), `/email/exchange` (oferta Exchange) lub `/email/pro` (oferta E-mail Pro) API i wpisz "dkim" w polu `Filter`, aby wyświetlić tylko funkcje API związane z DKIM.
+</Region>
+
+<Region zones={['ca']}>
+Przejdź do sekcji `/email/exchange` (oferta Exchange) API i wpisz "dkim" w polu `Filter`, aby wyświetlić tylko funkcje API związane z DKIM.
+</Region>
 
 Kliknij zakładkę odnoszącą się do Twojej oferty:
 
 <ZoneTabs>
-  <Tab label="MX Plan i Zimbra">
+  <Tab label="MX Plan i Zimbra" availableIn={['eu']}>
     <img className="thumbnail" alt="email" src="/images/assets/screens/api/get-email-domain-domain-dkim.png" loading="lazy" />
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
@@ -349,6 +365,7 @@ Kliknij zakładkę odnoszącą się do Twojej oferty:
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
 ##### **Dla MX Plan i Zimbra** <a name="confemail"></a>
 
 Postępuj zgodnie z instrukcjami **5 kroków**, klikając kolejno na 5 poniższych zakładek:
@@ -518,6 +535,7 @@ Postępuj zgodnie z instrukcjami **5 kroków**, klikając kolejno na 5 poniższy
     :::
   </Tab>
 </Tabs>
+</Region>
 
 <Region zones={['eu', 'ca']}>
 
@@ -837,7 +855,7 @@ Postępuj zgodnie z **5 krokami** poniżej, klikając na każdą z zakładek.
 Wybierz odpowiednią ofertę e-mail w następujących zakładkach:
 
 <ZoneTabs>
-  <Tab label="MX Plan i Zimbra">
+  <Tab label="MX Plan i Zimbra" availableIn={['eu']}>
     Podczas operacji na DKIM Twojej platformy Email użyj poniższego wywołania API, aby sprawdzić aktualny status DKIM.
 
     <Api version="v1" section="/email/domain" method="GET" route={"/email/domain/\\{domain\\}/dkim"} regions={["eu"]} />
@@ -920,7 +938,7 @@ Wybieracz DKIM musi mieć status `ready`, zanim zostanie włączony.
 Wybierz odpowiednią ofertę e-mail w następujących zakładkach:
 
 <ZoneTabs>
-  <Tab label="MX Plan i Zimbra">
+  <Tab label="MX Plan i Zimbra" availableIn={['eu']}>
     Aby wyłączyć DKIM bez usuwania selektorów i ich par kluczy, należy użyć następującego wywołania API:
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/enable"} regions={["eu"]} />
@@ -975,7 +993,7 @@ Wybieracz DKIM musi mieć status `inProduction` lub `ready`, zanim zostanie wył
 Wybierz odpowiednią ofertę e-mail w następujących zakładkach:
 
 <ZoneTabs>
-  <Tab label="MX Plan i Zimbra">
+  <Tab label="MX Plan i Zimbra" availableIn={['eu']}>
     Aby wyłączyć DKIM bez usuwania selektorów i ich par kluczy, należy użyć następującego wywołania API:
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/disable"} regions={["eu"]} />
@@ -1264,7 +1282,7 @@ Poniżej znajdziesz statusy, które mogą blokować działanie DKIM i odpowiedni
     - `disabling`: trwa wyłączanie DKIM. Po tej operacji możesz aktywować selektor, naciskając sekcję "[API - Włącz lub zmień selektor DKIM](#enable-switch)".
     - `todo`: Zadanie zostało zainicjowane, musi zostać uruchomione. Po upływie 24 godzin, jeśli selektor nadal jest w tym stanie, prosimy o otwarcie [zgłoszenia w dziale obsługi klienta](/links/support-contact) i podanie numeru selektora zgłoszeń.
   </Tab>
-  <Tab label="E-maile (MX Plan) i Zimbra">
+  <Tab label="E-maile (MX Plan) i Zimbra" availableIn={['eu']}>
     - `disabled`: DKIM jest wyłączony, nie został jeszcze skonfigurowany lub został wyłączony przez API. <br/>
     - `modifying`: Konfiguracja DKIM jest w trakcie, należy poczekać na zakończenie procesu.<br/>
     - `toConfigure`: Konfiguracja DKIM oczekuje na ustawienia DNS domeny. Wprowadź ręcznie rekordy DNS w strefie nazwy domeny. W tym celu przejdź do etapu "[Pełna konfiguracja DKIM](#confemail)" niniejszego przewodnika. <br/>

--- a/docs/pl/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -1,7 +1,7 @@
 ---
 title: Poprawa bezpieczeństwa e-maili dzięki rejestracji DMARC
 description: Dowiedz się, jak działa DMARC i jak wdrożyć go dla Twojej usługi e-mail
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -150,7 +150,7 @@ Konfiguracja parametru `p=` może mieć duży wpływ na dostarczalność e-maili
 Aby zilustrować ten pierwszy przykład, użyliśmy [rekordu DMARC](#dmarc-record) w strefie DNS i zastosowaliśmy do niego następujące ustawienia. Otrzymujemy następujący wynik:
 
 ```
-"v=;p=quarantine;pct=100;rua=mailto:report@mydomain.ovh;aspf=s;"
+"v=DMARC1;p=quarantine;pct=100;rua=mailto:report@mydomain.ovh;aspf=s;"
 ```
 
 Wszystkie wysłane e-maile (**pct=100**) są przetwarzane przez mechanizmy uwierzytelniania SPF i/lub DKIM. E-maile, które nie przeszły testu SPF są automatycznie odrzucane, ponieważ "**aspf=s**" (mechanizm SPF w trybie ścisłym). Raport o błędach mechanizmów uwierzytelniania SPF i/lub DKIM jest wysyłany na adres `report@mydomain.ovh` (**rua=mailto:report@mydomain.ovh**).
@@ -160,7 +160,7 @@ Wszystkie wysłane e-maile (**pct=100**) są przetwarzane przez mechanizmy uwier
 W tym drugim przykładzie użyliśmy [rekordu TXT](#txt-record), aby użyć tagów, które nie są dostępne za pośrednictwem uproszczonego [rekordu DMARC](#dmarc-record). Otrzymujemy następujący wynik:
 
 ```
-"v=; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; adkim=r; ri=86400"
+"v=DMARC1; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; ri=86400"
 ```
 
 - **p=quarantine**: e-maile, które nie przeszły testu DMARC są traktowane jako "podejrzane".
@@ -174,8 +174,6 @@ W tym drugim przykładzie użyliśmy [rekordu TXT](#txt-record), aby użyć tag�
 - **adkim=r**: tryb wyrównania identyfikatora DKIM wymagany przez abonenta nazwy domeny to "relaxed" (tryb elastyczny). W tym trybie DKIM musi dostarczyć prawidłowy podpis, a identyfikator nagłówka może być częściowo wyrównany.
 
 - **aspf=s**: wymagany tryb wyrównania identyfikatora SPF to "strict". Oznacza to, że identyfikator SPF przypisanej nazwy domeny musi dokładnie odpowiadać adresowi IP nadawcy wiadomości.
-
-- **adkim=r**: tryb wyrównania identyfikatora DKIM wymagany przez abonenta nazwy domeny to "relaxed" (tryb elastyczny). W tym trybie DKIM musi dostarczyć prawidłowy podpis, a identyfikator nagłówka "From" może być częściowo wyrównany.
 
 - **RI=86400**: Ustawia żądany interwał między raportami zagregowanymi w sekundach. W tym przypadku zagregowany raport musi być generowany co najmniej raz na 86 400 sekund (czyli raz dziennie).
 

--- a/docs/pl/guides/web-cloud/domains/dns-zone-edit.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-edit.mdx
@@ -1,7 +1,7 @@
 ---
 title: Modyfikacja strefy DNS
 description: Dowiedz się, jak edytować strefę DNS w Panelu klienta
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -178,7 +178,7 @@ Możesz również zmienić TTL pojedynczego rekordu podczas jego dodawania lub e
 
 [Zarządzanie historią strefy DNS](/guides/web-cloud/domains/dns-zone-history)
 
-[Dodawanie rekordu SPF podczas konfiguracji domeny](/guides/web-cloud/domains/dns-zone-spf).
+[Poprawa bezpieczeństwa e-maili poprzez rekord SPF](/guides/web-cloud/domains/dns-zone-spf).
 
 [Zabezpieczenie domeny przed Cache Poisoning za pomocą DNSSEC](/guides/web-cloud/domains/dns-dnssec).
 

--- a/docs/pl/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/pl/guides/web-cloud/domains/domain-whois.mdx
@@ -1,7 +1,7 @@
 ---
 title: Jak uzyskać informacje związane z domeną w bazie WHOIS
 description: Dowiedz się, jak korzystać z narzędzia WHOIS, aby uzyskać szczegółowe informacje na temat nazwy domeny
-lastUpdated: 2025-07-04
+lastUpdated: 2026-07-31
 availableIn: [eu]
 ---
 
@@ -30,7 +30,7 @@ Ponadto rejestry zarządzające tymi rozszerzeniami mogą zezwalać właściciel
 Następujące etapy umożliwiają dostęp do rekordów WHOIS powiązanych z domeną:
 
 1. Przejdź do [narzędzia WHOIS online](/links/web/domains-whois).
-1. Na stronie, która się wyświetli, wpisz nazwę domeny (na przykład: *domain.tld* **bez znaków** *www*) w polu <code className="action">Domeny *</code>, następnie wpisz `Kod zabezpieczeń`, który wyświetla się w polu <code className="action">Wprowadź kod zabezpieczeń *</code>.
+1. Na stronie, która się wyświetli, wpisz nazwę domeny (na przykład: *domain.tld* **bez znaków** *www*) w polu <code className="action">Domeny</code>, następnie wpisz `Kod zabezpieczeń`, który wyświetla się w polu <code className="action">Wprowadź kod zabezpieczeń *</code>.
 1. Kliknij przycisk <code className="action">Whois</code>, aby wysłać zapytanie.
 1. Sprawdź wynik zapytania WHOIS w nowej sekcji zatytułowanej <code className="action">Whois search results:</code> znajdującej się pod przyciskiem <code className="action">Whois</code>.
 

--- a/docs/pt/guides/web-cloud/domains/dns-dnssec.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-dnssec.mdx
@@ -1,7 +1,7 @@
 ---
 title: Proteger o seu nome de domínio com DNSSEC
 description: Saiba como proteger o seu domínio do Cache Poisoning ativando o DNSSEC
-lastUpdated: 2026-06-08
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -112,7 +112,7 @@ Quando tiver concluído a obtenção destes 4 parâmetros, clique nos separadore
     <img className="thumbnail" alt="Domain Names" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-names.png" loading="lazy" />
   </Tab>
   <Tab label="Etapa 2">
-    Na página que vai aparecer, clique no separador <code className="action">DS records</code>. **Esta janela só é apresentada se o domínio utilizar servidores DNS externos**.
+    Na página que vai aparecer, clique no separador <code className="action">DS Records</code>. **Esta janela só é apresentada se o domínio utilizar servidores DNS externos**.
   </Tab>
   <Tab label="Etapa 3">
     Na nova página que aparece, clique no botão <code className="action">Alterar</code> à direita e, a seguir, no botão <code className="action">+</code>.

--- a/docs/pt/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Melhorar a segurança dos e-mails através do registo DKIM
 description: Saiba como configurar um registo DKIM no seu nome de domínio e na sua plataforma de e-mail OVHcloud
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -66,9 +66,13 @@ Se o seu nome de domínio estiver registado na OVHcloud, pode verificar se este 
     - [Exemplo de um e-mail enviado utilizando o DKIM](#example)
     - [O que é um seletor DKIM?](#selector)
 - [Configurar o DKIM automaticamente para uma oferta de correio eletrónico OVHcloud](#auto-dkim)
+<Region zones={['eu', 'ca']}>
 - [Configurar o DKIM através da API para uma oferta de correio eletrónico OVHcloud](#internal-dkim)
+</Region>
     - [API - Configuração completa do DKIM](#firststep)
+        <Region zones={['eu']}>
         - [Para MX Plan e Zimbra](#confemail)
+        </Region>
         <Region zones={['eu', 'ca']}>
         - [Para Exchange](#confex)
         </Region>
@@ -270,7 +274,13 @@ Clique no separador seguinte da sua oferta.
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
 A ativação automática do DKIM dura entre 30 minutos e 24 horas no máximo. Para verificar que o seu DKIM está funcional, basta voltar à rubrica de gestão do domínio mencionada nos separadores acima e verificar que o botão `DKIM` está verde ou, para uma oferta Zimbra, que o separador `DKIM` não apresenta mais o ícone de aviso.
+</Region>
+
+<Region zones={['ca', 'apac']}>
+A ativação automática do DKIM dura entre 30 minutos e 24 horas no máximo. Para verificar que o seu DKIM está funcional, basta voltar à rubrica de gestão do domínio mencionada nos separadores acima e verificar que o botão `DKIM` está verde.
+</Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
@@ -332,12 +342,18 @@ Para configurar o DKIM, dirija-se à <ApiLink>página das API OVHcloud</ApiLink>
 Consulte o nosso guia "[Primeiros passos com as API OVHcloud](/guides/manage-and-operate/api/first-steps)" se nunca utilizou as API.
 :::
 
+<Region zones={['eu']}>
 Dirija-se à secção `/email/domain/` (ofertas MX Plan e Zimbra), `/email/exchange` (oferta Exchange) ou `/email/pro` (oferta E-mail Pro) das API e preencha "dkim" no campo `Filter` para mostrar apenas as funções API relativas ao DKIM.
+</Region>
+
+<Region zones={['ca']}>
+Dirija-se à secção `/email/exchange` (oferta Exchange) das API e preencha "dkim" no campo `Filter` para mostrar apenas as funções API relativas ao DKIM.
+</Region>
 
 Clique no separador da sua oferta:
 
 <ZoneTabs>
-  <Tab label="MX Plan e Zimbra">
+  <Tab label="MX Plan e Zimbra" availableIn={['eu']}>
     <img className="thumbnail" alt="email" src="/images/assets/screens/api/get-email-domain-domain-dkim.png" loading="lazy" />
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
@@ -348,6 +364,7 @@ Clique no separador da sua oferta:
   </Tab>
 </ZoneTabs>
 
+<Region zones={['eu']}>
 ##### **Para MX Plan e Zimbra** <a name="confemail"></a>
 
 Siga os **5 passos** clicando sucessivamente em cada um dos 5 separadores seguintes:
@@ -517,6 +534,7 @@ Siga os **5 passos** clicando sucessivamente em cada um dos 5 separadores seguin
     :::
   </Tab>
 </Tabs>
+</Region>
 
 <Region zones={['eu', 'ca']}>
 
@@ -836,7 +854,7 @@ Siga os **5 passos** abaixo ao clicar em cada separador.
 Selecione a oferta de e-mail em questão nos separadores seguintes:
 
 <ZoneTabs>
-  <Tab label="MX Plan e Zimbra">
+  <Tab label="MX Plan e Zimbra" availableIn={['eu']}>
     Quando efetuar as operações no DKIM da sua plataforma Email, utilize a chamada API abaixo para verificar o estado atual do DKIM.
 
     <Api version="v1" section="/email/domain" method="GET" route={"/email/domain/\\{domain\\}/dkim"} regions={["eu"]} />
@@ -919,7 +937,7 @@ O seletor DKIM deve estar no estado `ready` antes de poder ser ativado.
 Selecione a oferta de e-mail em questão nos separadores seguintes:
 
 <ZoneTabs>
-  <Tab label="MX Plan et Zimbra">
+  <Tab label="MX Plan et Zimbra" availableIn={['eu']}>
     Para ativar o DKIM, utilize a seguinte chamada API:
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/enable"} regions={["eu"]} />
@@ -974,7 +992,7 @@ O seletor DKIM deve estar no estado `in Production` ou `ready` antes de poder se
 Selecione a oferta de e-mail em questão nos separadores seguintes:
 
 <ZoneTabs>
-  <Tab label="MX Plan e Zimbra">
+  <Tab label="MX Plan e Zimbra" availableIn={['eu']}>
     Se deseja desativar o DKIM sem eliminar os seletores e o seu par de chaves, utilize a seguinte chamada API:
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/disable"} regions={["eu"]} />
@@ -1263,7 +1281,7 @@ Abaixo irá encontrar os estados que podem bloquear o funcionamento do seu DKIM 
     - `disabling`: o DKIM está em curso de desativação. Após esta operação, poderá ativar o seletor recorrendo à secção "[API - Ativar ou alterar um seletor DKIM](#enable-switch)".
     - `todo`: a tarefa foi inicializada e deverá iniciar-se. Acima das 24 horas, se o seletor ainda estiver nesse estado, convidamo-lo a abrir um [ticket junto do suporte](/links/support-contact) especificando o número do seletor em causa.
   </Tab>
-  <Tab label="MX Plan e Zimbra">
+  <Tab label="MX Plan e Zimbra" availableIn={['eu']}>
     - `disabled`: O DKIM está desativado, ainda não foi configurado ou foi desativado pela API. <br/>
     - `modifying`: A configuração do DKIM está em curso, é necessário aguardar até ao fim do processo.<br/>
     - `toConfigure`: A configuração do DKIM está aguardando os parâmetros DNS do domínio. Os registos DNS devem ser preenchidos manualmente na zona do domínio. Para isso, clique na etapa "[API - Configuração completa do DKIM](#confemail)" deste guia. <br/>

--- a/docs/pt/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -1,7 +1,7 @@
 ---
 title: Melhorar a segurança dos e-mails através do registo DMARC
 description: Saiba como o DMARC funciona e como configurá-lo para o seu serviço de e-mail
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -164,7 +164,7 @@ Para ilustrar este primeiro exemplo, utilizámos o [registo DMARC](#dmarc-record
 Neste segundo exemplo, usamos um [registo TXT](#txt-record) para usar etiquetas que não estão disponíveis através do [registo DMARC](#dmarc-record) simplificado. Obtemos o seguinte resultado:
 
 ```
-"v=DMARC1; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; adkim=r; ri=86400"
+"v=DMARC1; p=quarantine; pct=100; ruf=mailto:report@mydomain.ovh; fo=0; adkim=r; aspf=s; ri=86400"
 ```
 
 - **p=quarantine**: As mensagens de correio eletrónico que não passem os testes DMARC são tratadas como « suspeitas ».
@@ -178,8 +178,6 @@ Neste segundo exemplo, usamos um [registo TXT](#txt-record) para usar etiquetas 
 - **adkim=r**: o modo de alinhamento do identificador DKIM requerido pelo titular do nome de domínio é "relaxed" (modo flexível). Neste modo, o DKIM deve fornecer uma assinatura válida e o identificador do cabeçalho "From" pode ser parcialmente alinhado.
 
 - **aspf=s**: O modo de alinhamento do SPF é « strict ». Isto significa que o nome de utilizador do nome de domínio alinhado deve corresponder exatamente ao endereço IP de origem da mensagem.
-
-- **adkim=r**: o modo de alinhamento do identificador DKIM requerido pelo titular do nome de domínio é « relaxed » (modo flexível). Neste modo, o DKIM deve fornecer uma assinatura válida e o identificador do cabeçalho « From » pode ser parcialmente alinhado.
 
 - **ri=86400** : define o intervalo solicitado entre as relações agregadas, em segundos. Neste caso, deve ser gerada, pelo menos, uma relação de transmissão agregada a cada 86400 segundos (ou seja, uma vez por dia).
 

--- a/docs/pt/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/pt/guides/web-cloud/domains/domain-whois.mdx
@@ -1,7 +1,7 @@
 ---
 title: Como obter informações relativas a um domínio com o WHOIS
 description: Saiba como utilizar a ferramenta WHOIS para obter detalhes sobre um domínio
-lastUpdated: 2025-07-04
+lastUpdated: 2026-07-31
 availableIn: [eu]
 ---
 
@@ -30,7 +30,7 @@ Além disso, os registos que gerem essas extensões podem permitir que os titula
 As seguintes etapas permitem aceder aos registos WHOIS associados a um domínio:
 
 1. Aceda à nossa [ferramenta WHOIS online](/links/web/domains-whois).
-1. Na página que se abrir, introduza o domínio (por exemplo: *domain.tld* **sem** os *www*) no campo <code className="action">Nome de domínio *</code> e, em seguida, introduza o `Código de segurança` que aparece no campo <code className="action">Introduzir o código de segurança *</code>.
+1. Na página que se abrir, introduza o domínio (por exemplo: *domain.tld* **sem** os *www*) no campo <code className="action">Nome de domínio</code> e, em seguida, introduza o `Código de segurança` que aparece no campo <code className="action">Introduzir o código de segurança *</code>.
 1. Clique no botão <code className="action">Whois</code> para enviar o pedido.
 1. Consulte o resultado do pedido WHOIS na nova secção intitulada <code className="action">Whois search results:</code> situado abaixo do botão <code className="action">Whois</code>.
 


### PR DESCRIPTION
Four unrelated defect families found while auditing the domains guides after the
SK-2665 DNS zone series. None of them was introduced by that series — all
predate it. Grouped here because they are the same kind of work: correcting what
the guides state.

## 1. Invalid DMARC example record (7 locales)

The second example repeated the `adkim` tag:

    "v=DMARC1; …; fo=0; adkim=r; aspf=s; adkim=r; ri=86400"

A DMARC record must not repeat a tag, and this snippet is meant to be copied
verbatim. The duplicate is removed, along with the duplicated `**adkim=r**`
bullet that mirrored it — the two bullets were near-identical restatements of
the same value, not an `aspf` mix-up.

Both Polish examples had also lost their version value — `"v=;p=quarantine…"`
instead of `"v=DMARC1;p=quarantine…"` — leaving the file without a single valid
`v=` tag. Restored to match the six other locales.

## 2. Spurious required-field marker in the whois guide (7 locales)

`Domain name *` → `Domain name`, and its equivalent in each language. The
asterisk is drawn by the form to mark a required field; it is not part of the
label. Each target value was checked against `Messages_{locale}.json` before
being applied.

The `Enter security code` label is left untouched: it is absent from the Manager
translations in all seven languages even without the asterisk, so the correct
string cannot be established from the current snapshot.

## 3. EU-only DKIM sections shown in every zone (7 locales)

`dns-zone-dkim` is served in `[eu, ca, apac]`, but its "MX Plan and Zimbra" API
section was not zone-gated — while Zimbra is EU-only and all eight
`/email/domain` operations in that section already declare `regions={["eu"]}`.

The guide already held the answer: its two sibling sections are wrapped in a
`<Region>`, and only this one was not. Restoring the wrapper makes the three
sections structurally identical — no duplicated content, and no label surgery,
since the label "MX Plan and Zimbra" becomes accurate once the section renders
in the EU only.

Also gated in the same pass: the overview entry, the five offer tabs
(`availableIn={['eu']}`), the API intro sentence — which leaked Email Pro to
Canada too — and the automatic-configuration sentence. The "Configure DKIM via
API" overview entry is now gated to `[eu, ca]` to match the heading it points
to; it was a dead link in APAC.

Readers outside the EU keep a working path: the Control Panel section above has
an ungated `MX Plan` tab.

Two smaller German fixes on touched lines: `E-mail Pro` → `E-Mail Pro` (2 of 44
occurrences; the terminology CSV and the file's own usage agree) and the
`„dkim"` filter value aligned on the file's 567 straight quotes.

## 4. Stale labels and typography in four more guides

| Guide | Fix |
|---|---|
| `fr/dns-zone-edit` | `Qu'est ce qu'un serveur DNS?` → `Qu'est-ce qu'un serveur DNS ?` (missing hyphen, missing non-breaking space) |
| `fr` + `pl/dns-zone-edit` | link labels quoted the SPF guide's **former** title; replaced with its current one |
| `fr` + `pt/dns-dnssec` | `DS records` → `DS Records` (key `domain_tab_name_ds_records`) |
| `fr/dns-anycast-enable` | `suivant` → `Suivant` |
| `pl/autorenew-domain-name` | `Actions` → `Operacje`, and the typo `Automaticznie` → `Automatycznie` |

Polish was the only locale still quoting that button in English — the other six
localise it (`Aktionen`, `Acciones`, `Azioni`, `Ações`). `Automaticznie` exists
in no Manager translation.

Deliberately left alone: the redirection labels in `redirect-domain-name`. They
look like casing errors, but the Manager keys
(`domain_tab_REDIRECTION_type_301`, `…_add_step2_web`) are sentence fragments
composed at render time, so the guides are making an incomplete citation rather
than a casing mistake. Settling it needs an observation of the live redirection
form.

## Checks

- `content:lint` 27/27; tags balanced in every locale
- DMARC: locale-agnostic corpus scan finds no malformed record left
- DKIM rendered in all three commercial zones by switching the
  `ovhcloud-docs:commercial-zone` key: 0 dead anchors, no Zimbra left in the
  article body outside the EU, API section absent in APAC
- every replacement label re-checked against `Messages_{locale}.json` before
  being written
- no file overlap with #506, #507 or #508 (verified against each branch's
  merge-base)
- diff-scoped pre-pass: the only remaining flag is a pre-existing house pattern
  (14 bullets per locale sit directly under a `<Region>` with no blank line)
