### PR TITLE
FIX - WEB - Domains - Correct UI labels in the DNS zone and WHOIS guides

### DIFF
--- a/docs/de/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/de/guides/web-cloud/domains/domain-whois.mdx
@@ -30,7 +30,7 @@ Darüber hinaus können die Registrys, die diese Domainendungen verwalten, es de
 Mit den folgenden Schritten können Sie auf die WHOIS Einträge zugreifen, die einer Domain zugeordnet sind:
 
 1. Greifen Sie auf unser [WHOIS Tool](/links/web/domains-whois) zu.
-1. Geben Sie auf der angezeigten Seite den Domainnamen (zum Beispiel: *domain.tld*, **ohne** www) in das Feld <code className="action">Domainname</code> ein und geben Sie den `Sicherheitscode` im Feld <code className="action">Sicherheitscode eingeben *</code> ein.
+1. Geben Sie auf der angezeigten Seite den Domainnamen (zum Beispiel: *domain.tld*, **ohne** www) in das Feld <code className="action">Domainname</code> ein und geben Sie den `Sicherheitscode` im Feld <code className="action">Sicherheitscode eingeben</code> ein.
 1. Klicken Sie auf die Schaltfläche <code className="action">Whois</code>, um die Anfrage zu senden.
 1. Überprüfen Sie das Ergebnis der WHOIS Abfrage im neuen Abschnitt <code className="action">Whois search results :</code> unter der Schaltfläche <code className="action">Whois</code>.
 

--- a/docs/en/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/en/guides/web-cloud/domains/domain-whois.mdx
@@ -30,7 +30,7 @@ In addition, the registries that manage these extensions may allow domain name h
 The following steps will take you to the WHOIS records associated with a domain name:
 
 1. Access our [WHOIS online tool](/links/web/domains-whois).
-1. On the page that pops up, enter the domain name (for example: *domain.tld* **without** the *www*) in the <code className="action">Domain name</code> field, then enter the `Security code` in the <code className="action">Enter security code *</code> field.
+1. On the page that pops up, enter the domain name (for example: *domain.tld* **without** the *www*) in the <code className="action">Domain name</code> field, then enter the `Security code` in the <code className="action">Enter security code</code> field.
 1. Click the <code className="action">Whois</code> button to send the request.
 1. See the result of the WHOIS query in the new section titled <code className="action">Whois search results :</code> under the <code className="action">Whois</code> button.
 

--- a/docs/en/guides/web-cloud/domains/faq-domain-dns.mdx
+++ b/docs/en/guides/web-cloud/domains/faq-domain-dns.mdx
@@ -850,7 +850,7 @@ Click the tabs below to view each of the **4** steps in succession.
     Above the table, click <code className="action">Add an entry</code>, then select the <code className="action">NS</code> DNS record type to declare a DNS server.
   </Tab>
   <Tab label="Step 3">
-    In the form that opens, enter the subdomain in the <code className="action">Sub-domain</code> field (e.g., write **only** *www* if your domain name is *domain.tld* and your full subdomain is *www.domain.tld*). In the <code className="action">Target</code> field, enter **one** of the 2 DNS servers.
+    In the form that opens, enter the subdomain in the <code className="action">Subdomain</code> field (e.g., write **only** *www* if your domain name is *domain.tld* and your full subdomain is *www.domain.tld*). In the <code className="action">Target</code> field, enter **one** of the 2 DNS servers.
   </Tab>
   <Tab label="Step 4">
     Click <code className="action">Add</code>.
@@ -894,7 +894,7 @@ Click the tabs below to view each of the **4** steps in succession.
     Above the table, click <code className="action">Add an entry</code>, then select the <code className="action">A</code> DNS record type for an IPv4 (e.g., `203.0.113.0`) or the <code className="action">AAAA</code> DNS record type for an IPv6 (e.g., `2001:db8:1:1b00:203:0:113:0`).
   </Tab>
   <Tab label="Step 3">
-    In the form that opens and in the <code className="action">Sub-domain</code> field, enter the value `*`. The asterisk `*` will represent all subdomains (e.g., `www.domain.tld` or `ovhcloud.domain.tld`) of your domain name. Complete the <code className="action">Target</code> field with the desired IP address.
+    In the form that opens and in the <code className="action">Subdomain</code> field, enter the value `*`. The asterisk `*` will represent all subdomains (e.g., `www.domain.tld` or `ovhcloud.domain.tld`) of your domain name. Complete the <code className="action">Target</code> field with the desired IP address.
   </Tab>
   <Tab label="Step 4">
     Click <code className="action">Add</code>.
@@ -931,7 +931,7 @@ To do this, click the tabs below to view each of the **4** steps in succession.
     Above the table, click <code className="action">Add an entry</code>, then select the DNS record type for which you want to set up a wildcard.
   </Tab>
   <Tab label="Step 3">
-    In the form that opens and in the <code className="action">Sub-domain</code> field, enter the value `*`. The asterisk `*` will represent all subdomains (e.g., `www.domain.tld` or `ovhcloud.domain.tld`) of your domain name. Complete the other fields with the desired values.
+    In the form that opens and in the <code className="action">Subdomain</code> field, enter the value `*`. The asterisk `*` will represent all subdomains (e.g., `www.domain.tld` or `ovhcloud.domain.tld`) of your domain name. Complete the other fields with the desired values.
   </Tab>
   <Tab label="Step 4">
     Click <code className="action">Add</code>.

--- a/docs/es/guides/web-cloud/domains/dns-zone-edit.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-edit.mdx
@@ -1,7 +1,7 @@
 ---
 title: Editar una zona DNS de OVHcloud
 description: Descubra cómo editar una zona DNS desde el área de cliente de OVHcloud
-lastUpdated: 2026-07-30
+lastUpdated: 2026-07-31
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,8 +24,8 @@ Para más información, consulte nuestras guías "[Todo sobre los servidores DNS
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** <ManagerLink to="/#/web-domains/domain">Nombres de dominio</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Nombres de dominio</code> > seleccione su nombre de dominio > pestaña <code className="action">Zona DNS</code>
+- **Enlace directo:** <ManagerLink to="/#/web-domains/domain">Dominios</ManagerLink>
+- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Dominios</code> > seleccione su nombre de dominio > pestaña <code className="action">Zona DNS</code>
 
 ---
 {/* CP-NAV-END:web-dns-zone */}

--- a/docs/es/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/es/guides/web-cloud/domains/domain-whois.mdx
@@ -30,7 +30,7 @@ Además, los registros que gestionan estas extensiones pueden permitir a los tit
 Siga estos pasos para acceder a los registros WHOIS asociados a un dominio:
 
 1. Acceda a nuestra [herramienta WHOIS online](/links/web/domains-whois).
-1. Introduzca el nombre de dominio (por ejemplo:, *domain.tld* **sin** los *www*) en el campo <code className="action">Dominio</code> e introduzca el `Código de seguridad` que aparece en el campo <code className="action">Introduzca el código de seguridad *</code>.
+1. Introduzca el nombre de dominio (por ejemplo:, *domain.tld* **sin** los *www*) en el campo <code className="action">Dominio</code> e introduzca el `Código de seguridad` que aparece en el campo <code className="action">Introduzca el código de seguridad</code>.
 1. Haga clic en el botón <code className="action">Whois</code> para enviar la consulta.
 1. Consulte el resultado de la consulta WHOIS en la nueva sección titulada <code className="action">Whois search results:</code> situada debajo del botón <code className="action">Whois</code>.
 

--- a/docs/fr/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/fr/guides/web-cloud/domains/domain-whois.mdx
@@ -30,7 +30,7 @@ De plus, les registres qui gèrent ces extensions peuvent permettre aux titulair
 Les étapes suivantes permettent d’accéder aux enregistrements WHOIS associés à un nom de domaine :
 
 1. Accédez à notre [outil WHOIS en ligne](/links/web/domains-whois).
-1. Sur la page qui s’affiche, renseignez le nom de domaine (par exemple : *domain.tld* **sans** les *www*) dans le champ <code className="action">Nom de domaine</code>, puis saisissez le `Code de sécurité` qui s’affiche dans le champ <code className="action">Entrer le code de sécurité *</code>.
+1. Sur la page qui s’affiche, renseignez le nom de domaine (par exemple : *domain.tld* **sans** les *www*) dans le champ <code className="action">Nom de domaine</code>, puis saisissez le `Code de sécurité` qui s’affiche dans le champ <code className="action">Entrer le code de sécurité</code>.
 1. Cliquez sur le bouton <code className="action">Whois</code> pour envoyer la requête.
 1. Consultez le résultat de la requête WHOIS dans la nouvelle section intitulée <code className="action">Whois search results :</code> située sous le bouton <code className="action">Whois</code>.
 

--- a/docs/it/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/it/guides/web-cloud/domains/domain-whois.mdx
@@ -30,7 +30,7 @@ Inoltre, i registri che gestiscono queste estensioni possono permettere ai titol
 Di seguito sono riportati gli step che permettono di accedere ai record WHOIS associati a un dominio:
 
 1. Accedi al nostro [strumento WHOIS online](/links/web/domains-whois).
-1. Nella nuova pagina, inserisci il nome del dominio (ad esempio: *domain.tld* **senza** i *www*) nel campo <code className="action">Domini</code>, quindi inserisci il `Codice di sicurezza` che appare nel campo <code className="action">Inserisci un codice di sicurezza *</code>.
+1. Nella nuova pagina, inserisci il nome del dominio (ad esempio: *domain.tld* **senza** i *www*) nel campo <code className="action">Domini</code>, quindi inserisci il `Codice di sicurezza` che appare nel campo <code className="action">Inserisci un codice di sicurezza</code>.
 1. Clicca sul pulsante <code className="action">Whois</code> per inviare la richiesta.
 1. Consulta il risultato della richiesta WHOIS nella nuova sezione intitolata <code className="action">Whois search results:</code> situata sotto il pulsante <code className="action">Whois</code>.
 

--- a/docs/pl/guides/web-cloud/domains/dns-zone-edit.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-edit.mdx
@@ -24,8 +24,8 @@ Aby uzyskać więcej informacji, zapoznaj się z naszymi przewodnikami "[Wszystk
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** <ManagerLink to="/#/web-domains/domain">Nazwy domen</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">Nazwy domen</code> > wybierz nazwę domeny > zakładka <code className="action">Strefa DNS</code>
+- **Link bezpośredni:** <ManagerLink to="/#/web-domains/domain">Domeny</ManagerLink>
+- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">Domeny</code> > wybierz nazwę domeny > zakładka <code className="action">Strefa DNS</code>
 
 ---
 {/* CP-NAV-END:web-dns-zone */}

--- a/docs/pl/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/pl/guides/web-cloud/domains/domain-whois.mdx
@@ -30,7 +30,7 @@ Ponadto rejestry zarządzające tymi rozszerzeniami mogą zezwalać właściciel
 Następujące etapy umożliwiają dostęp do rekordów WHOIS powiązanych z domeną:
 
 1. Przejdź do [narzędzia WHOIS online](/links/web/domains-whois).
-1. Na stronie, która się wyświetli, wpisz nazwę domeny (na przykład: *domain.tld* **bez znaków** *www*) w polu <code className="action">Domeny</code>, następnie wpisz `Kod zabezpieczeń`, który wyświetla się w polu <code className="action">Wprowadź kod zabezpieczeń *</code>.
+1. Na stronie, która się wyświetli, wpisz nazwę domeny (na przykład: *domain.tld* **bez znaków** *www*) w polu <code className="action">Domeny</code>, następnie wpisz `Kod zabezpieczeń`, który wyświetla się w polu <code className="action">Wprowadź kod zabezpieczeń</code>.
 1. Kliknij przycisk <code className="action">Whois</code>, aby wysłać zapytanie.
 1. Sprawdź wynik zapytania WHOIS w nowej sekcji zatytułowanej <code className="action">Whois search results:</code> znajdującej się pod przyciskiem <code className="action">Whois</code>.
 

--- a/docs/pt/guides/web-cloud/domains/domain-whois.mdx
+++ b/docs/pt/guides/web-cloud/domains/domain-whois.mdx
@@ -30,7 +30,7 @@ Além disso, os registos que gerem essas extensões podem permitir que os titula
 As seguintes etapas permitem aceder aos registos WHOIS associados a um domínio:
 
 1. Aceda à nossa [ferramenta WHOIS online](/links/web/domains-whois).
-1. Na página que se abrir, introduza o domínio (por exemplo: *domain.tld* **sem** os *www*) no campo <code className="action">Nome de domínio</code> e, em seguida, introduza o `Código de segurança` que aparece no campo <code className="action">Introduzir o código de segurança *</code>.
+1. Na página que se abrir, introduza o domínio (por exemplo: *domain.tld* **sem** os *www*) no campo <code className="action">Nome de domínio</code> e, em seguida, introduza o `Código de segurança` que aparece no campo <code className="action">Introduzir o código de segurança</code>.
 1. Clique no botão <code className="action">Whois</code> para enviar o pedido.
 1. Consulte o resultado do pedido WHOIS na nova secção intitulada <code className="action">Whois search results:</code> situado abaixo do botão <code className="action">Whois</code>.
 


### PR DESCRIPTION
## Description

Corrects four UI label defects found while auditing the SK-2665 DNS zone series
after it was merged. Every label is now backed by its source of truth.

### 1. Control Panel navigation label (ES, PL)

`dns-zone-edit.mdx` was the only guide out of 18 carrying a wrong navigation
label in its Control Panel block:

| Locale | Was | Now | Key |
|---|---|---|---|
| ES | `Nombres de dominio` | `Dominios` | `sidebar_domain` |
| PL | `Nazwy domen` | `Domeny` | `sidebar_domain` |

The other 17 guides already used the correct value in both locales, and the
remaining 5 locales were correct in this guide too — a single mistyped template.
Both the direct link text and the navigation path are fixed.

### 2. Subdomain field label (EN)

Three occurrences in `faq-domain-dns.mdx` read `Sub-domain`, while the DNS zone
form displays `Subdomain` (`zone_page_form_subdomain`). In the zone app,
`Sub-domain` is only used for the DKIM subdomain-restriction label, which is not
the field these steps describe. The six other locales already matched their own
key and are unchanged.

### 3. Required-field asterisk in the WHOIS guide (all 7 locales)

`domain-whois.mdx` labelled the security-code field with a trailing `*`. That
asterisk is the required-field marker, not part of the label.

Verified against the live tool the guide links to — `/links/web/domains-whois`
resolves to `ovhcloud.com/{locale}/domains/whois/`, the public website, not the
Control Panel. All seven pages were fetched and their `<label>` elements read:
the field is `Enter security code` / `Entrer le code de sécurité` /
`Sicherheitscode eingeben` / `Introduzca el código de seguridad` /
`Inserisci un codice di sicurezza` / `Wprowadź kod zabezpieczeń` /
`Introduzir o código de segurança` — no asterisk in any locale.

Every other label in these steps already matched the live page and is untouched.

## Checks

- `content:lint` passes on all 10 files
- No `<Api>`/`<ApiLink>`, external link, zoned product or `<Region>` on any
  changed line
- No file added, deleted or renamed — no `301.map` entry required
- All 10 files are regular files, not English-fallback symlinks
- Locale coverage reconciled per guide: no translation propagation needed

## Known issues left out of scope

Found during the same audit, pre-existing and unrelated to the labels above:

- `dns-zone-dkim.mdx` (DE): the `internal-dkim` section carries one `<Region>`
  where EN carries three, so Canadian readers of the German guide see EU-only
  content. Two sections also share the same German title — the `enable-switch`
  heading is mistranslated — and one tab reads `E-Mails und Zimbra` instead of
  `MX Plan und Zimbra`.
- `dns-zone-dkim.mdx`: `Email Pro` / `E-mail Pro` are mixed against the
  terminology reference, 22 occurrences across EN, FR, ES, IT, PL and PT.
- `multisites-website-not-installed.mdx` (ES): a `&#123;.thumbnail` artifact left
  over from the legacy conversion, plus an alt text equal to the file name.
- `web-hosting/faq.mdx` (DE): a `> [!tip]` GitHub-alert block that survived the
  migration.
- The WordPress VPS guides reference images under `/images/guides/…` in DE, ES,
  IT, PL and PT but `/images/…` in EN and FR, so the files are duplicated on disk.
- 42 orphaned screenshots (604 KB) remain in the DNS zone image folder.
- `dns-dynhost.mdx` (EN) also uses `Sub-domain`, but it describes a different
  form and was left alone pending verification.
