### PR TITLE
refactor: Improvement to the ‘ISSUE_TEMPLATE’ template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,7 +1,6 @@
 name: Bug report
 description: Create a new issue for a bug.
 title: "bug: "
-labels: ["bug"]
 body:
   - type: markdown
     attributes:
@@ -16,6 +15,13 @@ body:
       options:
       - label: I have searched the existing issues
         required: true
+  - type: textarea
+    attributes:
+      label: Relevant guide(s)
+      description: Please let us know which guide(s) are concerned
+      placeholder: "- docs/{locale}/guides/{universe}/{product}/{slug}.mdx"
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Current Behavior

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,7 +1,5 @@
 name: New feature request
 description: Suggest an idea for the OVHcloud documentation.
-#title: ""
-#labels: ["bug"]
 body:
   - type: markdown
     attributes:
@@ -16,6 +14,15 @@ body:
       options:
       - label: I have searched the existing issues
         required: true
+  - type: textarea
+    attributes:
+      label: Relevant guide(s)
+      description: | 
+        Please let us know which guide(s) are concerned.    
+        If your request is to create a new guide, please let us know the relevant universe and product.  
+      placeholder: "- docs/{locale}/guides/{universe}/{product}/{slug}.mdx"
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Is your feature request related to a problem? Please describe.

--- a/.github/ISSUE_TEMPLATE/OUTDATED_INFORMATION.yml
+++ b/.github/ISSUE_TEMPLATE/OUTDATED_INFORMATION.yml
@@ -16,6 +16,13 @@ body:
         required: true
   - type: textarea
     attributes:
+      label: Relevant guide(s)
+      description: Please let us know which guide(s) are concerned
+      placeholder: "- docs/{locale}/guides/{universe}/{product}/{slug}.mdx"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
       label: Description
       description: A clear and concise description of the outdated information with the list of concerned file(s)/URL(s).
     validations:


### PR DESCRIPTION
Following on from feedback from @scraly, which was passed on to me by @Y0Coss when I published these issue templates on ovh/docs, I am responding to this request to improve the ‘ISSUE_TEMPLATE’ template by adding a mandatory ‘relevant guide(s)’ field