### PR TITLE
docs(dedicated-servers): typo fixes

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -76,7 +76,7 @@ Um sie zu aktivieren:
 Kein anderes Betriebssystem konfiguriert die Aggregate während der Installation, sodass Sie dies anschließend selbst tun müssen.
 
 :::info
-Die Option kann auf jedem Server gesetzt werden, hat aber nur dann eine Auswirkung, wenn der Server über Interfaces verfügt, die aggregiert werden können.
+Die Option kann auf jedem Server aktiviert werden, hat aber nur dann eine Auswirkung, wenn der Server über Interfaces verfügt, die aggregiert werden können.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/lacp-enable-ifupdown.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/lacp-enable-ifupdown.mdx
@@ -10,7 +10,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 ## Objective
 
 Link aggregation increases your server's availability and boosts the efficiency of your network connections. By bonding your network interfaces, you make your network links redundant: if one link goes down, traffic is automatically redirected to another available link. The available bandwidth is also increased thanks to aggregation.
-Aggregation uses Link Aggregation Control Protocol (LACP), defined by the IEEE 802.3ad standard.
+Aggregation uses the Link Aggregation Control Protocol (LACP), defined by the IEEE 802.3ad standard.
 
 **This guide explains how to configure LACP link aggregation on Debian 9 to 11 (ifupdown configuration).**
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/lacp-enable-sles15.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/lacp-enable-sles15.mdx
@@ -10,7 +10,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 ## Objective
 
 Link aggregation increases your server's availability and boosts the efficiency of your network connections. By bonding your network interfaces, you make your network links redundant: if one link goes down, traffic is automatically redirected to another available link. The available bandwidth is also increased thanks to aggregation.
-Aggregation uses Link Aggregation Control Protocol (LACP), defined by the IEEE 802.3ad standard.
+Aggregation uses the Link Aggregation Control Protocol (LACP), defined by the IEEE 802.3ad standard.
 
 **This guide explains how to configure LACP link aggregation on SLES 15.**
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2026-08-05
 
 ## Objective
 
-Link aggregation bonds several of your server's network interfaces together using Link Aggregation Control Protocol (LACP), defined by the IEEE 802.3ad standard. Available bandwidth increases, and your network links become redundant: if one link goes down, traffic is automatically redirected to another available link.
+Link aggregation bonds several of your server's network interfaces together using the Link Aggregation Control Protocol (LACP), defined by the IEEE 802.3ad standard. Available bandwidth increases, and your network links become redundant: if one link goes down, traffic is automatically redirected to another available link.
 
 Several guides cover link aggregation, depending on your server's range, its operating system, and whether it keeps public connectivity.
 
@@ -76,7 +76,7 @@ To enable it:
 No other operating system configures the bonds during the installation, so you have to do it yourself afterwards.
 
 :::info
-The option can be set on any server, but it only has an effect if the server has interfaces to bond.
+The option can be enabled on any server, but it only has an effect if the server has interfaces to bond.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/ola-enable-manager.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/ola-enable-manager.mdx
@@ -7,7 +7,7 @@ lastUpdated: 2026-07-01
 ## Objective
 
 OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.<br/>
-Aggregation uses Link Aggregation Control Protocol (LACP), defined by the IEEE 802.3ad standard.
+Aggregation uses the Link Aggregation Control Protocol (LACP), defined by the IEEE 802.3ad standard.
 
 **This guide explains how to configure OLA in the OVHcloud Control Panel.**
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/ola-enable-w2k19.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/ola-enable-w2k19.mdx
@@ -7,7 +7,7 @@ lastUpdated: 2026-07-01
 ## Objective
 
 OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server's availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link. The available bandwidth is also doubled thanks to aggregation.
-Aggregation uses Link Aggregation Control Protocol (LACP), defined by the IEEE 802.3ad standard.
+Aggregation uses the Link Aggregation Control Protocol (LACP), defined by the IEEE 802.3ad standard.
 
 **This guide explains how to configure NIC Teaming for OLA in Windows Server 2019.**
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -76,7 +76,7 @@ Para activarla:
 Ningún otro sistema operativo configura los agregados durante la instalación, por lo que deberá hacerlo usted mismo posteriormente.
 
 :::info
-La opción puede definirse en cualquier servidor, pero solo tiene efecto si el servidor dispone de interfaces que agregar.
+La opción puede activarse en cualquier servidor, pero solo tiene efecto si el servidor dispone de interfaces que agregar.
 
 :::
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -76,7 +76,7 @@ Pour l'activer :
 Aucun autre système d'exploitation ne configure les agrégats pendant l'installation : vous devez donc le faire vous-même ensuite.
 
 :::info
-L'option peut être définie sur n'importe quel serveur, mais elle n'a d'effet que si le serveur dispose d'interfaces à agréger.
+L'option peut être activée sur n'importe quel serveur, mais elle n'a d'effet que si le serveur dispose d'interfaces à agréger.
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -76,7 +76,7 @@ Per attivarla:
 Nessun altro sistema operativo configura gli aggregati durante l'installazione, per cui dovrai farlo tu successivamente.
 
 :::info
-L'opzione può essere impostata su qualsiasi server, ma ha effetto solo se il server dispone di interfacce da aggregare.
+L'opzione può essere attivata su qualsiasi server, ma ha effetto solo se il server dispone di interfacce da aggregare.
 
 :::
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -76,7 +76,7 @@ Aby ją aktywować:
 Żaden inny system operacyjny nie konfiguruje agregatów podczas instalacji, musisz więc zrobić to samodzielnie później.
 
 :::info
-Opcję można ustawić na każdym serwerze, ale przynosi ona efekt tylko wtedy, gdy serwer posiada interfejsy do zagregowania.
+Opcję można aktywować na każdym serwerze, ale przynosi ona efekt tylko wtedy, gdy serwer posiada interfejsy do zagregowania.
 
 :::
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -76,7 +76,7 @@ Para a ativar:
 Nenhum outro sistema operativo configura os agregados durante a instalação, pelo que terá de o fazer posteriormente.
 
 :::info
-A opção pode ser definida em qualquer servidor, mas só tem efeito se o servidor dispuser de interfaces para agregar.
+A opção pode ser ativada em qualquer servidor, mas só tem efeito se o servidor dispuser de interfaces para agregar.
 
 :::
 


### PR DESCRIPTION
Fix the LACP protocol name and align the opt…ion verb

- en: a spelled-out protocol name takes the definite article, so use "the Link Aggregation Control Protocol (LACP)" in the overview and in the four LACP/OLA guides. Reported by @sbraz on #536
- overview (7 locales): the info callout said the option could be "set", two lines after the step that says how to "enable" it. Use each locale's own activation verb instead