### PR TITLE
docs(web-cloud): align action-button labels in Web Cloud guide tabs with the Manager (de, en, es, it, pl, pt)

### DIFF
--- a/docs/de/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/de/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -137,7 +137,7 @@ Klicken Sie auf die unten stehenden Tabs, um die **3** Schritte nacheinander anz
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 2">
-    Im standardmäßig angezeigten Tab **Allgemeine Informationen** klicken Sie auf <code className="action">...</code> rechts neben "RAM" und dann auf <code className="action">RAM-Größe ändern</code>, um zur Bestellung für diese Änderung geleitet zu werden.
+    Im standardmäßig angezeigten Tab **Allgemeine Informationen** klicken Sie auf <code className="action">...</code> rechts neben "RAM" und dann auf <code className="action">RAM-Menge ändern</code>, um zur Bestellung für diese Änderung geleitet zu werden.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/general-information/change-the-amount-of-ram.png" loading="lazy" />
   </Tab>
@@ -281,7 +281,7 @@ Klicken Sie auf die unten stehenden Tabs, um die **3** Schritte nacheinander anz
     Im Tab **Allgemeine Informationen** wird die aktuelle Version in der Zeile **Version** angezeigt.
   </Tab>
   <Tab label="Schritt 3">
-    Um die Version zu ändern, klicken Sie auf <code className="action">Version aktualisieren</code>.
+    Um die Version zu ändern, klicken Sie auf <code className="action">Die Version ändern</code>.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/general-information/postgre-12-update-version.png" loading="lazy" />
   </Tab>

--- a/docs/de/guides/web-cloud/databases/db-retrieve-logs.mdx
+++ b/docs/de/guides/web-cloud/databases/db-retrieve-logs.mdx
@@ -177,7 +177,7 @@ Klicken Sie auf die unten stehenden Tabs, um die **4** Schritte nacheinander anz
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/logs/tab-subscribe.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 3">
-    Wenn Sie über mehrere Logs Data Platform Dienste verfügen, wählen Sie die gewünschte Referenz aus der Dropdown-Liste unterhalb des Buttons <code className="action">Datenstream hinzufügen</code> aus.
+    Wenn Sie über mehrere Logs Data Platform Dienste verfügen, wählen Sie die gewünschte Referenz aus der Dropdown-Liste unterhalb des Buttons <code className="action">Stream hinzufügen</code> aus.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/logs/data-stream.png" loading="lazy" />
   </Tab>
@@ -208,12 +208,12 @@ Klicken Sie auf die unten stehenden Tabs, um die **5** Schritte nacheinander anz
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/logs/tab-subscribe.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 3">
-    Wenn Sie über mehrere Logs Data Platform Dienste verfügen, wählen Sie die gewünschte Referenz aus der Dropdown-Liste unterhalb des Buttons <code className="action">Datenstream hinzufügen</code> aus.
+    Wenn Sie über mehrere Logs Data Platform Dienste verfügen, wählen Sie die gewünschte Referenz aus der Dropdown-Liste unterhalb des Buttons <code className="action">Stream hinzufügen</code> aus.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/logs/data-stream.png" loading="lazy" />
   </Tab>
   <Tab label="Schritt 4">
-    Da der Datenstream noch nicht existiert, klicken Sie auf den Button <code className="action">Datenstream hinzufügen</code>. Sie werden auf eine Seite weitergeleitet, auf der Sie einen neuen Datenstream auf Ihrem Logs Data Platform Dienst erstellen können.
+    Da der Datenstream noch nicht existiert, klicken Sie auf den Button <code className="action">Stream hinzufügen</code>. Sie werden auf eine Seite weitergeleitet, auf der Sie einen neuen Datenstream auf Ihrem Logs Data Platform Dienst erstellen können.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/bare-metal-cloud/logs-data-platform/data-stream/add-data-stream.png" loading="lazy" />
 

--- a/docs/de/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -79,7 +79,7 @@ Klicken Sie auf die nachfolgenden Tabs, um die **2** Schritte nacheinander anzuz
     Klicken Sie auf den Tab <code className="action">1-Klick-Module</code>.
   </Tab>
   <Tab label="Schritt 2">
-    Klicken Sie auf den Button <code className="action">...</code> rechts neben der Zeile für Ihr Modul und dann auf <code className="action">Zum Verwaltungsinterface des Moduls</code>.
+    Klicken Sie auf den Button <code className="action">...</code> rechts neben der Zeile für Ihr Modul und dann auf <code className="action">Auf das Verwaltungsinterface des Moduls zugreifen</code>.
   </Tab>
 </Tabs>
 

--- a/docs/de/guides/web-cloud/web-hosting/enable-ldp-web-hosting.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/enable-ldp-web-hosting.mdx
@@ -199,7 +199,7 @@ Klicken Sie auf die untenstehenden Reiter, um nacheinander jeden der **6** Schri
   <Tab label="Schritt 6">
     Sobald die Formulare ausgefüllt sind, klicken Sie auf die Schaltfläche <code className="action">Speichern</code>.
 
-    Sie werden anschließend zum Reiter <code className="action">Datenstream</code> Ihrer Logs Data Platform Lösung weitergeleitet.
+    Sie werden anschließend zum Reiter <code className="action">Streams</code> Ihrer Logs Data Platform Lösung weitergeleitet.
 
     Es bleibt nur noch, Ihr Webhosting für Ihren neu erstellten Stream auf Ihrer Logs Data Platform Lösung zu abonnieren.
 

--- a/docs/de/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
@@ -70,7 +70,7 @@ Um Ihr Abonnement zu ändern, klicken Sie auf die Tabs, um die **2** Schritte an
 
     <img className="thumbnail" alt="change_plan" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/general-information/pro-change-plan.png" loading="lazy" />
 
-    Wählen Sie anschließend Ihr neues Abonnement und dessen Laufzeit aus. Bestätigen Sie die entsprechenden Verträge und klicken Sie auf <code className="action">Senden</code>.
+    Wählen Sie anschließend Ihr neues Abonnement und dessen Laufzeit aus. Bestätigen Sie die entsprechenden Verträge und klicken Sie auf <code className="action">Absenden</code>.
   </Tab>
 </Tabs>
 

--- a/docs/de/guides/web-cloud/web-hosting/sql-create-database.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/sql-create-database.mdx
@@ -189,7 +189,7 @@ OVHcloud stellt Ihnen ein Online-Tool für das Datenbankmanagement zur Verfügun
     Klicken Sie in der angezeigten Tabelle auf <code className="action">...</code> rechts neben der betreffenden Datenbank und dann im Drop-down-Menü auf <code className="action">Zugang zu phpMyAdmin</code>.
   </Tab>
   <Tab label="Schritt 4">
-    Geben Sie die Zugangsdaten für Ihre Datenbank ein und klicken Sie auf <code className="action">Anmelden</code>.
+    Geben Sie die Zugangsdaten für Ihre Datenbank ein und klicken Sie auf <code className="action">Anmeldung</code>.
 
     <img className="thumbnail" alt="phpMyAdmin Login-Seite" src="/images/assets/screens/other/web-tools/phpmyadmin/pma-interface-login.png" loading="lazy" />
 

--- a/docs/en/guides/web-cloud/databases/db-restore-import-database.mdx
+++ b/docs/en/guides/web-cloud/databases/db-restore-import-database.mdx
@@ -95,7 +95,7 @@ Click on the tabs below to view each of the **4** steps.
 
     Click on **"Import a new file"**, then on <code className="action">Next</code>.
 
-    Enter a name for your imported file, click <code className="action">Browse</code> to select it, then <code className="action">Submit</code>, and finally click <code className="action">Next</code>.
+    Enter a name for your imported file, click <code className="action">Browse</code> to select it, then <code className="action">Send</code>, and finally click <code className="action">Next</code>.
 
     :::warning
     The file must be in ".sql", ".txt" or ".gz" format.

--- a/docs/en/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -230,7 +230,7 @@ To complete the removal of your module, click on the tabs below to display each 
     Click on the <code className="action">...</code> button to the right of the line for your database, then click on <code className="action">Delete database</code>.
   </Tab>
   <Tab label="Step 3">
-    Before attempting to install a new module again, verify that the previously requested removal tasks have been completed in the <code className="action">Ongoing jobs</code> tab.
+    Before attempting to install a new module again, verify that the previously requested removal tasks have been completed in the <code className="action">Ongoing tasks</code> tab.
   </Tab>
 </Tabs>
 

--- a/docs/en/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
@@ -135,7 +135,7 @@ Click on the tabs below to view each of the **5** steps.
     <img className="thumbnail" alt="FTP - SSH" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh.png" loading="lazy" />
   </Tab>
   <Tab label="Step 3">
-    On the new page that appears, click <code className="action">Retrieve backup</code>.
+    On the new page that appears, click <code className="action">Restore backup</code>.
 
     <img className="thumbnail" alt="backupftp" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/restore-backup.png" loading="lazy" />
   </Tab>

--- a/docs/en/guides/web-cloud/web-hosting/resolve-anomalous-activity.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/resolve-anomalous-activity.mdx
@@ -94,13 +94,13 @@ Click on the tabs below to view each of the **4** steps.
     Go to the <ManagerLink to="/#/web/hosting">Hosting plans</ManagerLink> page, then select the web hosting plan concerned.
   </Tab>
   <Tab label="Step 2">
-    An **alert window** appears: `"Abnormal Activity on Your Hosting"`. If you click the <code className="action">Later</code> button, an **alert banner** `"Abnormal Activity Detected"` appears at the top of the page. Click <code className="action">Learn More</code> to reopen the alert window.
+    An **alert window** appears: `"Abnormal Activity on Your Hosting"`. If you click the <code className="action">Later</code> button, an **alert banner** `"Abnormal Activity Detected"` appears at the top of the page. Click <code className="action">Find out more</code> to reopen the alert window.
   </Tab>
   <Tab label="Step 3">
     **Check** the box: `I confirm I have performed all necessary actions to resolve the issue`, then click <code className="action">Lift Security Measures</code>.
   </Tab>
   <Tab label="Step 4">
-    A **confirmation banner** appears at the top of the page: `Your hosting is being analyzed to lift the security measures.` Track progress by clicking the link <code className="action">View Ongoing Tasks</code> or directly from the <code className="action">Ongoing Tasks</code> tab.
+    A **confirmation banner** appears at the top of the page: `Your hosting is being analyzed to lift the security measures.` Track progress by clicking the link <code className="action">View tasks in progress</code> or directly from the <code className="action">Ongoing Tasks</code> tab.
   </Tab>
 </Tabs>
 {/* CP-STEPS-END:lift-security-measures */}

--- a/docs/es/guides/web-cloud/databases/db-backup-export-database-server.mdx
+++ b/docs/es/guides/web-cloud/databases/db-backup-export-database-server.mdx
@@ -63,7 +63,7 @@ Haga clic en las pestañas siguientes para ver cada uno de los **3** pasos.
     En la columna **Copias de seguridad**, la cifra corresponde al número de copias de seguridad disponibles para su base de datos.
   </Tab>
   <Tab label="Paso 3">
-    Haga clic en el botón <code className="action">...</code> a la derecha de la base de datos y, a continuación, en <code className="action">Guardar</code>.
+    Haga clic en el botón <code className="action">...</code> a la derecha de la base de datos y, a continuación, en <code className="action">Realizar una copia de seguridad ahora</code>.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/databases/back-up-now.png" loading="lazy" />
   </Tab>

--- a/docs/es/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/es/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -80,7 +80,7 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 2">
-    Haga clic en la pestaña <code className="action">IPs autorizadas</code> y, a continuación, en el botón <code className="action">Añadir una dirección IP / máscara</code>.
+    Haga clic en la pestaña <code className="action">IP autorizadas</code> y, a continuación, en el botón <code className="action">Añadir una dirección IP / máscara</code>.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask.png" loading="lazy" />
   </Tab>
@@ -106,7 +106,7 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 2">
-    Haga clic en la pestaña <code className="action">IPs autorizadas</code>.
+    Haga clic en la pestaña <code className="action">IP autorizadas</code>.
   </Tab>
   <Tab label="Paso 3">
     Marque <code className="action">Autorizar a los alojamientos web de OVHcloud a acceder a la base de datos</code>.

--- a/docs/es/guides/web-cloud/databases/db-create-databases-users.mdx
+++ b/docs/es/guides/web-cloud/databases/db-create-databases-users.mdx
@@ -153,7 +153,7 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
     Haga clic en la pestaña <code className="action">Bases de datos</code>.
   </Tab>
   <Tab label="Paso 3">
-    Haga clic en el botón <code className="action">...</code> a la derecha de la base de datos correspondiente y luego en <code className="action">Eliminar la base de datos</code>.
+    Haga clic en el botón <code className="action">...</code> a la derecha de la base de datos correspondiente y luego en <code className="action">Eliminar la BD</code>.
 
     <img className="thumbnail" alt="web-cloud-databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/databases/delete-the-database.png" loading="lazy" />
   </Tab>

--- a/docs/es/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/es/guides/web-cloud/databases/db-getting-started.mdx
@@ -195,7 +195,7 @@ Para ello, haga clic en las pestañas de abajo para ver cada uno de los **4** pa
     <img className="thumbnail" alt="Interfaz de IP autorizadas" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/tab-0000-sftp-hosting-enabled.png" loading="lazy" />
 
     :::tip
-    Si desea modificar una dirección IP o un rango de IP ya autorizado, haga clic en el botón <code className="action">...</code> a la derecha de la línea correspondiente en la tabla y luego en <code className="action">Editar la whitelist</code>.
+    Si desea modificar una dirección IP o un rango de IP ya autorizado, haga clic en el botón <code className="action">...</code> a la derecha de la línea correspondiente en la tabla y luego en <code className="action">Editar la lista blanca</code>.
 
     :::
 

--- a/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -641,7 +641,7 @@ Siga los **5 pasos** que se indican a continuación haciendo clic en cada una de
     :::
   </Tab>
   <Tab label="4. Configurar el registro DNS">
-    Desde <ManagerLink to="/">el área de clientes de OVHcloud</ManagerLink> donde el nombre de dominio de su Exchange, en la pestaña <code className="action">Web Cloud</code>, haga clic en <code className="action">Domain name</code> en la columna de la izquierda y seleccione el nombre de dominio correspondiente.<br/>
+    Desde <ManagerLink to="/">el área de clientes de OVHcloud</ManagerLink> donde el nombre de dominio de su Exchange, en la pestaña <code className="action">Web Cloud</code>, haga clic en <code className="action">Dominios</code> en la columna de la izquierda y seleccione el nombre de dominio correspondiente.<br/>
     Acceda a la pestaña <code className="action">Zona DNS</code> y, a continuación, haga clic en <code className="action">Añadir una entrada</code> encima de la tabla. En el formulario que se abre, seleccione el tipo `CNAME` y complete los campos según los valores que haya anotado.
 
     Si se toman los valores del ejemplo en el paso "**3. Obtener el registro DNS**":
@@ -798,7 +798,7 @@ Siga los **5 pasos** que se indican a continuación haciendo clic en cada una de
     :::
   </Tab>
   <Tab label="4.Configurar el registro DNS">
-    Desde <ManagerLink to="/">el área de clientes de OVHcloud</ManagerLink> donde el nombre de dominio de su Exchange, en la pestaña <code className="action">Web Cloud</code>, haga clic en <code className="action">Domain name</code> en la columna de la izquierda y seleccione el nombre de dominio correspondiente.<br/>
+    Desde <ManagerLink to="/">el área de clientes de OVHcloud</ManagerLink> donde el nombre de dominio de su Exchange, en la pestaña <code className="action">Web Cloud</code>, haga clic en <code className="action">Dominios</code> en la columna de la izquierda y seleccione el nombre de dominio correspondiente.<br/>
     Acceda a la pestaña <code className="action">Zona DNS</code> y, a continuación, haga clic en <code className="action">Añadir una entrada</code> encima de la tabla. En el formulario que se abre, seleccione el tipo `CNAME` y complete los campos según los valores que haya anotado.
 
     Si se toman los valores del ejemplo en el paso "**3. Obtener el registro DNS**":

--- a/docs/es/guides/web-cloud/domains/redirect-domain-name.mdx
+++ b/docs/es/guides/web-cloud/domains/redirect-domain-name.mdx
@@ -123,7 +123,7 @@ Haga clic en <code className="action">Siguiente</code>.
 Haga clic en <code className="action">Siguiente</code>.
   </Tab>
   <Tab label="Paso 6">
-    Seleccione <code className="action">Permanente (301)</code> entre las dos opciones indicadas e introduzca el nombre de dominio o la URL de destino de la redirección en el formulario <code className="action">Dirección web</code> que aparece.
+    Seleccione <code className="action">Permanente (301)</code> entre las dos opciones indicadas e introduzca el nombre de dominio o la URL de destino de la redirección en el formulario <code className="action">Dirección de internet</code> que aparece.
 
     <img className="thumbnail" alt="Paso 6" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-4-permanent.png" loading="lazy" />
 
@@ -201,7 +201,7 @@ Haga clic en <code className="action">Siguiente</code>.
 Haga clic en <code className="action">Siguiente</code>.
   </Tab>
   <Tab label="Paso 6">
-    Seleccione <code className="action">Temporal (302)</code> entre las dos opciones indicadas e introduzca el nombre de dominio o la URL de destino de la redirección en el formulario <code className="action">Dirección web</code> que aparece.
+    Seleccione <code className="action">Temporal (302)</code> entre las dos opciones indicadas e introduzca el nombre de dominio o la URL de destino de la redirección en el formulario <code className="action">Dirección de internet</code> que aparece.
 
     <img className="thumbnail" alt="Paso 6" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-4-temporary.png" loading="lazy" />
 
@@ -286,7 +286,7 @@ Haga clic en <code className="action">Siguiente</code>.
 Haga clic en <code className="action">Siguiente</code>.
   </Tab>
   <Tab label="Paso 6">
-    Seleccione <code className="action">Temporal (iframe)</code> entre las dos opciones indicadas e introduzca el nombre de dominio o la URL de destino de la redirección en el formulario <code className="action">Dirección web</code> que aparece.
+    Seleccione <code className="action">Temporal (iframe)</code> entre las dos opciones indicadas e introduzca el nombre de dominio o la URL de destino de la redirección en el formulario <code className="action">Dirección de internet</code> que aparece.
 
     <img className="thumbnail" alt="Paso 6" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-4-iframe.png" loading="lazy" />
 

--- a/docs/es/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -79,7 +79,7 @@ Para acceder al apartado «Scripts de correo electrónico», haga clic en las fi
     A la derecha, varios botones permiten gestionar el envío de mensajes de correo automatizados desde el alojamiento web. En función del estado del servicio, algunas opciones pueden no estar disponibles.
 
     - **Purgar los mensajes de correo**: borra los emails que haya en la cola de espera y desbloquea el envío de emails. Por motivos de confidencialidad, OVHcloud no puede acceder a los mensajes de correo electrónico que se encuentren en la cola. Solo podrá visualizar estos mensajes de correo electrónico si han sido previamente registrados en la base de datos de su sitio web antes de ser enviados.
-    - **Mensajes en error**: permite el acceso a los logs de los últimos mensajes de correo electrónico que se hayan encontrado en error de envío. Encontrará las direcciones de correo electrónico afectadas con el error asociado. Atención: este historial no se restablecerá aunque decida <code className="action">Purgar los mensajes de correo</code> o <code className="action">Desbloquear el envío</code>.
+    - **Mensajes en error**: permite el acceso a los logs de los últimos mensajes de correo electrónico que se hayan encontrado en error de envío. Encontrará las direcciones de correo electrónico afectadas con el error asociado. Atención: este historial no se restablecerá aunque decida <code className="action">Eliminar los mensajes</code> o <code className="action">Desbloquear el envío</code>.
     - **Bloquear el envío**: bloquea la distribución de los envíos de mensajes de correo automatizados de su alojamiento web. Los emails generados por sus scripts después del bloqueo no se enviarán, sino que se conservarán en una cola de espera durante un máximo de 72 horas.
     - **Desbloquear el envío**: desbloquea el envío de los emails automatizados de su alojamiento web. Los mensajes de correo presentes en la cola de espera también se reenviarán.
 
@@ -175,7 +175,7 @@ Para desbloquear la situación, haga clic en las fichas siguientes para ver cada
     Existen dos opciones:
 
     - Si hace clic en <code className="action">Desbloquear el envío</code>, el estado del servicio pasará a *«Force»*. El ratio **e-mails devueltos a error / número total de mensajes enviados** autorizado antes de un bloqueo se duplicará. El envío volverá a estar operativo unos minutos después del desbloqueo.
-    - Si hace clic en <code className="action">Purgar los mensajes de correo</code>, se borrarán todos los mensajes de la cola de espera y el estado del servicio pasará a *«Activo»* sin duplicar la relación.
+    - Si hace clic en <code className="action">Eliminar los mensajes</code>, se borrarán todos los mensajes de la cola de espera y el estado del servicio pasará a *«Activo»* sin duplicar la relación.
   </Tab>
 </Tabs>
 
@@ -203,7 +203,7 @@ Acceda a continuación al apartado «Scripts de correo electrónico» de su aloj
     En la nueva página, haga clic en la pestaña <code className="action">Más</code> y haga clic en <code className="action">Scripts de correo electrónico</code>.
   </Tab>
   <Tab label="Etapa 3">
-    Haga clic en <code className="action">Purgar los mensajes de correo</code>. Esto borrará todos los mensajes de la cola de espera y el estado del servicio pasará a *«Activo»*. En este caso, es obligatorio realizar una purga para eliminar los spam pendientes de envío.
+    Haga clic en <code className="action">Eliminar los mensajes</code>. Esto borrará todos los mensajes de la cola de espera y el estado del servicio pasará a *«Activo»*. En este caso, es obligatorio realizar una purga para eliminar los spam pendientes de envío.
   </Tab>
 </Tabs>
 
@@ -229,7 +229,7 @@ Una vez que haya asegurado su alojamiento, haga clic en las fichas siguientes pa
     En la nueva página, haga clic en la pestaña <code className="action">Más</code> y haga clic en <code className="action">Scripts de correo electrónico</code>.
   </Tab>
   <Tab label="Etapa 3">
-    Haga clic en <code className="action">Purgar los mensajes de correo</code>. Esto borrará todos los mensajes de la cola de espera y el estado del servicio pasará a *«Activo»*.
+    Haga clic en <code className="action">Eliminar los mensajes</code>. Esto borrará todos los mensajes de la cola de espera y el estado del servicio pasará a *«Activo»*.
   </Tab>
 </Tabs>
 

--- a/docs/es/guides/web-cloud/web-hosting/sql-create-database.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/sql-create-database.mdx
@@ -189,7 +189,7 @@ OVHcloud ofrece una herramienta en línea para la gestión de bases de datos lla
     En la tabla que se abre, haga clic en el botón <code className="action">...</code> a la derecha de la base de datos correspondiente y, a continuación, haga clic en <code className="action">Acceder a phpMyAdmin</code> en el menú desplegable.
   </Tab>
   <Tab label="Etapa 4">
-    Introduzca los datos de acceso a la base de datos y haga clic en <code className="action">Conectarse</code>.
+    Introduzca los datos de acceso a la base de datos y haga clic en <code className="action">Iniciar sesión</code>.
 
     <img className="thumbnail" alt="Página de conexión a phpMyAdmin" src="/images/assets/screens/other/web-tools/phpmyadmin/pma-interface-login.png" loading="lazy" />
 

--- a/docs/es/guides/web-cloud/web-hosting/sql-database-export.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/sql-database-export.mdx
@@ -97,7 +97,7 @@ Para realizar una nueva copia de seguridad, haga clic en las fichas siguientes p
     <img className="thumbnail" alt="databasedump" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/databases/create-a-backup.png" loading="lazy" />
   </Tab>
   <Tab label="Paso 4">
-    Se abrirá una ventana en la que deberá seleccionar la fecha de la copia de seguridad deseada y pulsar el botón <code className="action">Siguiente</code>. Asegúrese de que la información introducida en el resumen es correcta y haga clic en <code className="action">Validar</code> para iniciar la operación.
+    Se abrirá una ventana en la que deberá seleccionar la fecha de la copia de seguridad deseada y pulsar el botón <code className="action">Siguiente</code>. Asegúrese de que la información introducida en el resumen es correcta y haga clic en <code className="action">Aceptar</code> para iniciar la operación.
 
     <img className="thumbnail" alt="databasedump" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/databases/create-a-database-backup-step-1.png" loading="lazy" />
 

--- a/docs/es/guides/web-cloud/web-hosting/sql-overquota-database.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/sql-overquota-database.mdx
@@ -93,7 +93,7 @@ Anote el `Nombre de usuario` y la `Dirección del servidor` **de su base de dato
   <Tab label="Etapa 4">
     <img className="thumbnail" alt="phpMyAdmin Login interface" src="/images/assets/screens/other/web-tools/phpmyadmin/pma-interface-login.png" loading="lazy" />
 
-Introduzca los datos de acceso a la base de datos y haga clic en <code className="action">Conexión</code>.
+Introduzca los datos de acceso a la base de datos y haga clic en <code className="action">Iniciar sesión</code>.
   </Tab>
 </Tabs>
 

--- a/docs/it/guides/web-cloud/databases/db-backup-export-database-server.mdx
+++ b/docs/it/guides/web-cloud/databases/db-backup-export-database-server.mdx
@@ -63,7 +63,7 @@ Clicca sulle schede qui di seguito per visualizzare ciascuno dei **3** passaggi.
     Nella colonna **Backup**, il numero corrisponde al numero di backup disponibili per il tuo database.
   </Tab>
   <Tab label="Passaggio 3">
-    Clicca sul pulsante <code className="action">...</code> a destra del database, poi su <code className="action">Salva adesso</code>.
+    Clicca sul pulsante <code className="action">...</code> a destra del database, poi su <code className="action">Esegui un backup adesso</code>.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/databases/back-up-now.png" loading="lazy" />
   </Tab>

--- a/docs/it/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/it/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -80,7 +80,7 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases.png" loading="lazy" />
   </Tab>
   <Tab label="Step 2">
-    Clicca sulla scheda <code className="action">IP autorizzati</code>, poi sul pulsante <code className="action">Aggiungi un indirizzo IP / maschera</code>.
+    Clicca sulla scheda <code className="action">IP autorizzati</code>, poi sul pulsante <code className="action">Aggiungi un indirizzo IP/mask</code>.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask.png" loading="lazy" />
   </Tab>
@@ -142,7 +142,7 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/general-information/change-the-amount-of-ram.png" loading="lazy" />
   </Tab>
   <Tab label="Step 3">
-    Scegli la quantità di RAM desiderata, poi clicca su <code className="action">Seguente</code>. Potrai quindi scegliere la durata desiderata.
+    Scegli la quantità di RAM desiderata, poi clicca su <code className="action">Continua</code>. Potrai quindi scegliere la durata desiderata.
 
     :::info
     Il periodo residuo fino alla scadenza sarà calcolato proporzionalmente. Questo calcolo proporzionale si baserà sulla data di scadenza della tua istanza Web Cloud Databases, non sulla data del buono d'ordine.

--- a/docs/it/guides/web-cloud/databases/db-restore-import-database.mdx
+++ b/docs/it/guides/web-cloud/databases/db-restore-import-database.mdx
@@ -93,9 +93,9 @@ Clicca sulle schede qui sotto per visualizzare ciascuno dei **4** passaggi.
 
     **1 - Importare un nuovo file**
 
-    Clicca su **"Importa un nuovo file"**, poi su <code className="action">Seguente</code>.
+    Clicca su **"Importa un nuovo file"**, poi su <code className="action">Continua</code>.
 
-    Inserisci un nome per il file importato, clicca su <code className="action">Sfoglia</code> per selezionarlo, poi su <code className="action">Invia</code> e infine su <code className="action">Seguente</code>.
+    Inserisci un nome per il file importato, clicca su <code className="action">Sfoglia</code> per selezionarlo, poi su <code className="action">Invia</code> e infine su <code className="action">Continua</code>.
 
     :::warning
     Il file deve essere in formato ".sql", ".txt" o ".gz".
@@ -110,7 +110,7 @@ Se lo desideri, seleziona **"Svuota il database attuale"** prima dell'importazio
 
     Se hai già importato un file in precedenza, puoi scegliere l'opzione **"Importa un file esistente"**.
 
-    Seleziona il file nel menu a tendina e clicca su <code className="action">Seguente</code>.
+    Seleziona il file nel menu a tendina e clicca su <code className="action">Continua</code>.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/databases/database-import-existing-file-step-2.png" loading="lazy" />
 

--- a/docs/it/guides/web-cloud/domains/dns-anycast-enable.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-anycast-enable.mdx
@@ -58,7 +58,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** pa
 
     <img className="thumbnail" alt="Order Anycast DNS step 2" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dns-servers/order-anycast-dns-step-2.png" loading="lazy" />
 
-Nel messaggio visualizzato in verde, clicca sul pulsante <code className="action">Buono d'ordine</code> per essere reindirizzato al buono d’ordine per l’attivazione dell’opzione DNS Anycast.
+Nel messaggio visualizzato in verde, clicca sul pulsante <code className="action">Buono d’ordine</code> per essere reindirizzato al buono d’ordine per l’attivazione dell’opzione DNS Anycast.
 
     Dal momento in cui visualizzi il buono d’ordine, continua fino alla sua convalida utilizzando un metodo di pagamento per finalizzare la presa in carico dell’ordine.
   </Tab>

--- a/docs/it/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -638,7 +638,7 @@ Clicca sui **5 step** seguenti, cliccando su ciascuna scheda.
     :::
   </Tab>
   <Tab label="4. Configura il record DNS">
-    Da <ManagerLink to="/">l'area clienti OVHcloud</ManagerLink> dove il nome del dominio del tuo Piattaforma Exchange, nella scheda <code className="action">Web Cloud</code>, fai clic su <code className="action">Nomi di dominio</code> nella colonna di sinistra e seleziona il nome di dominio pertinente.<br/>
+    Da <ManagerLink to="/">l'area clienti OVHcloud</ManagerLink> dove il nome del dominio del tuo Piattaforma Exchange, nella scheda <code className="action">Web Cloud</code>, fai clic su <code className="action">Domini</code> nella colonna di sinistra e seleziona il nome di dominio pertinente.<br/>
     Vai alla scheda <code className="action">Zona DNS</code>, poi clicca su <code className="action">Aggiungi una voce</code> sopra la tabella. Nel modulo che si apre, seleziona il tipo `CNAME` e completa i campi in base ai valori annotati.
 
     Se prendiamo i valori dell'esempio nello step "**3. Recupera il record DNS**":
@@ -795,7 +795,7 @@ Clicca sui **5 step** seguenti, cliccando su ciascuna scheda.
     :::
   </Tab>
   <Tab label="4. Configura il record DNS">
-    Da <ManagerLink to="/">l'area clienti OVHcloud</ManagerLink> dove il nome del dominio del tuo Piattaforma Email Pro, nella scheda <code className="action">Web Cloud</code>, fai clic su <code className="action">Nomi di dominio</code> nella colonna di sinistra e seleziona il nome di dominio pertinente.<br/>
+    Da <ManagerLink to="/">l'area clienti OVHcloud</ManagerLink> dove il nome del dominio del tuo Piattaforma Email Pro, nella scheda <code className="action">Web Cloud</code>, fai clic su <code className="action">Domini</code> nella colonna di sinistra e seleziona il nome di dominio pertinente.<br/>
     Vai alla scheda <code className="action">Zona DNS</code>, poi clicca su <code className="action">Aggiungi una voce</code> sopra la tabella. Nel modulo che si apre, seleziona il tipo `CNAME` e completa i campi in base ai valori annotati.
 
     Se prendiamo i valori dell'esempio nello step "**3. Recupera il record DNS**":

--- a/docs/it/guides/web-cloud/domains/domain-configure-whois-listing.mdx
+++ b/docs/it/guides/web-cloud/domains/domain-configure-whois-listing.mdx
@@ -66,7 +66,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** pa
 
     <img className="thumbnail" alt="Configure listing in WHOIS" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/general-information/configure-data-protection/configure-data-protection-in-drawer.png" loading="lazy" />
 
-Una volta effettuate le scelte, clicca sul pulsante <code className="action">Registrare le modifiche</code>.
+Una volta effettuate le scelte, clicca sul pulsante <code className="action">Confermare</code>.
 
     Per l'applicazione delle modifiche potrebbe essere necessario un massimo di **48** ore. Le modifiche saranno applicate **solo se autorizzate dal Registro che gestisce l’estensione del nome di dominio**.
   </Tab>

--- a/docs/it/guides/web-cloud/domains/glue-registry.mdx
+++ b/docs/it/guides/web-cloud/domains/glue-registry.mdx
@@ -128,7 +128,7 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
     <img className="thumbnail" alt="Domini" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-names.png" loading="lazy" />
   </Tab>
   <Tab label="Step 2">
-    Una volta posizionato sul dominio interessato, clicca sulla scheda <code className="action">Hosts</code>.
+    Una volta posizionato sul dominio interessato, clicca sulla scheda <code className="action">Host</code>.
 
     Nella tabella visualizzata, se presenti, troverai i record host attualmente configurati in OVHcloud per il tuo dominio. Per aggiungere un nuovo record, clicca sul pulsante <code className="action">Aggiungi</code>.
 

--- a/docs/it/guides/web-cloud/domains/redirect-domain-name.mdx
+++ b/docs/it/guides/web-cloud/domains/redirect-domain-name.mdx
@@ -106,28 +106,28 @@ Clicca sulle schede qui sotto per visualizzare i **7** step in sequenza.
 
     <img className="thumbnail" alt="Step 1" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-1.png" loading="lazy" />
 
-Clicca su <code className="action">Avanti</code>.
+Clicca su <code className="action">Continua</code>.
   </Tab>
   <Tab label="Step 4">
     Seleziona <code className="action">Verso un indirizzo Web</code>.
 
     <img className="thumbnail" alt="Step 4" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-2-to-a-web-adress.png" loading="lazy" />
 
-Clicca su <code className="action">Avanti</code>.
+Clicca su <code className="action">Continua</code>.
   </Tab>
   <Tab label="Step 5">
     Seleziona <code className="action">Con un reindirizzamento visibile</code> tra le due opzioni indicate.
 
     <img className="thumbnail" alt="Step 5" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-3-a-visible-redirection.png" loading="lazy" />
 
-Clicca su <code className="action">Avanti</code>.
+Clicca su <code className="action">Continua</code>.
   </Tab>
   <Tab label="Step 6">
     Seleziona <code className="action">Permanente (301)</code> tra le due opzioni indicate, poi inserisci il dominio o l'URL di destinazione del reindirizzamento nel campo <code className="action">Indirizzo web</code> che appare.
 
     <img className="thumbnail" alt="Step 6" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-4-permanent.png" loading="lazy" />
 
-Clicca su <code className="action">Avanti</code>.
+Clicca su <code className="action">Continua</code>.
   </Tab>
   <Tab label="Step 7">
     In quest'ultimo step, assicurati che le informazioni mostrate siano corrette.
@@ -184,28 +184,28 @@ Clicca sulle schede qui sotto per visualizzare i **7** step in sequenza.
 
     <img className="thumbnail" alt="Step 3" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-1.png" loading="lazy" />
 
-Clicca su <code className="action">Avanti</code>.
+Clicca su <code className="action">Continua</code>.
   </Tab>
   <Tab label="Step 4">
     Seleziona <code className="action">Verso un indirizzo Web</code>.
 
     <img className="thumbnail" alt="Step 4" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-2-to-a-web-adress.png" loading="lazy" />
 
-Clicca su <code className="action">Avanti</code>.
+Clicca su <code className="action">Continua</code>.
   </Tab>
   <Tab label="Step 5">
     Seleziona <code className="action">Con un reindirizzamento visibile</code> tra le due opzioni indicate.
 
     <img className="thumbnail" alt="Step 5" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-3-a-visible-redirection.png" loading="lazy" />
 
-Clicca su <code className="action">Avanti</code>.
+Clicca su <code className="action">Continua</code>.
   </Tab>
   <Tab label="Step 6">
     Seleziona <code className="action">Temporaneo (302)</code> tra le due opzioni indicate, poi inserisci il dominio o l'URL di destinazione del reindirizzamento nel campo <code className="action">Indirizzo web</code> che appare.
 
     <img className="thumbnail" alt="Step 6" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-4-temporary.png" loading="lazy" />
 
-Clicca su <code className="action">Avanti</code>.
+Clicca su <code className="action">Continua</code>.
   </Tab>
   <Tab label="Step 7">
     In quest'ultimo step, assicurati che le informazioni mostrate siano corrette.
@@ -269,21 +269,21 @@ Clicca sulle schede qui sotto per visualizzare i **7** step in sequenza.
 
     <img className="thumbnail" alt="Step 3" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-1.png" loading="lazy" />
 
-Clicca su <code className="action">Avanti</code>.
+Clicca su <code className="action">Continua</code>.
   </Tab>
   <Tab label="Step 4">
     Seleziona <code className="action">Verso un indirizzo Web</code>.
 
     <img className="thumbnail" alt="Step 4" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-2-to-a-web-adress.png" loading="lazy" />
 
-Clicca su <code className="action">Avanti</code>.
+Clicca su <code className="action">Continua</code>.
   </Tab>
   <Tab label="Step 5">
     Seleziona <code className="action">Con un reindirizzamento invisibile</code> tra le due opzioni indicate.
 
     <img className="thumbnail" alt="Step 5" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-3-with-an-invisible-redirection.png" loading="lazy" />
 
-Clicca su <code className="action">Avanti</code>.
+Clicca su <code className="action">Continua</code>.
   </Tab>
   <Tab label="Step 6">
     Seleziona <code className="action">Temporaneo (iframe)</code> tra le due opzioni indicate, poi inserisci il dominio o l'URL di destinazione del reindirizzamento nel campo <code className="action">Indirizzo web</code> che appare.
@@ -296,7 +296,7 @@ Tre parametri opzionali sono disponibili in questo step:
     - **Parole chiave**: possono essere utilizzate dai motori di ricerca per indicizzare parzialmente la pagina.
     - **Descrizione**: relativa al sito Internet. Verrà utilizzata dai motori di ricerca nei loro risultati.
 
-    Clicca su <code className="action">Avanti</code>.
+    Clicca su <code className="action">Continua</code>.
   </Tab>
   <Tab label="Step 7">
     In quest'ultimo step, assicurati che le informazioni mostrate siano corrette.

--- a/docs/it/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/configure-your-web-hosting.mdx
@@ -261,7 +261,7 @@ A destra della voce **Versione PHP**, situata quasi al centro della pagina, clic
 
   </Tab>
   <Tab label="Passaggio 3">
-    Nella nuova finestra, sono disponibili due opzioni. Seleziona quella che corrisponde all’azione che vuoi effettuare e clicca su <code className="action">Seguente</code>.
+    Nella nuova finestra, sono disponibili due opzioni. Seleziona quella che corrisponde all’azione che vuoi effettuare e clicca su <code className="action">Continua</code>.
 
     |Scelta|Dettaglio|
     |---|---|

--- a/docs/it/guides/web-cloud/web-hosting/copy-database.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/copy-database.mdx
@@ -64,7 +64,7 @@ Clicca sulle schede qui sotto per visualizzare ciascuno dei **6** passaggi.
     <img className="thumbnail" alt="Web Hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/hosting-plans.png" loading="lazy" />
   </Tab>
   <Tab label="Passaggio 2">
-    Clicca sulla scheda <code className="action">Databases</code>. La tabella elenca i database creati sul tuo piano di hosting Web.
+    Clicca sulla scheda <code className="action">Database</code>. La tabella elenca i database creati sul tuo piano di hosting Web.
 
     <img className="thumbnail" alt="Lista dei BDD Start SQL" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png" loading="lazy" />
   </Tab>
@@ -117,7 +117,7 @@ Clicca sulle schede qui sotto per visualizzare ciascuno dei **6** passaggi.
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases.png" loading="lazy" />
   </Tab>
   <Tab label="Passaggio 2">
-    Clicca sulla scheda <code className="action">Databases</code>. La lista dei database presenti sul server Web Cloud Databases viene visualizzata.
+    Clicca sulla scheda <code className="action">Database</code>. La lista dei database presenti sul server Web Cloud Databases viene visualizzata.
 
     <img className="thumbnail" alt="Lista dei database WCD" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png" loading="lazy" />
   </Tab>

--- a/docs/it/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
@@ -139,7 +139,7 @@ Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **2**
     <img className="thumbnail" alt="Hosting plans" src="/images/assets/screens/control-panel/product-selection/web-cloud/hosting-plans.png" loading="lazy" />
   </Tab>
   <Tab label="Passaggio 2">
-    Clicca sulla scheda <code className="action">Databases</code> e verifica la corrispondenza tra gli elementi visualizzati e quelli presenti nel file `wp-config.php`:
+    Clicca sulla scheda <code className="action">Database</code> e verifica la corrispondenza tra gli elementi visualizzati e quelli presenti nel file `wp-config.php`:
 
     - **my_database** deve corrispondere a quanto indicato in `Nome del database`;
     - **my_user** deve corrispondere a quanto riportato in `Nome utente`;
@@ -217,7 +217,7 @@ Per ricalcolare la quota, clicca sulle schede qui sotto per visualizzare in succ
     <img className="thumbnail" alt="Hosting plans" src="/images/assets/screens/control-panel/product-selection/web-cloud/hosting-plans.png" loading="lazy" />
   </Tab>
   <Tab label="Passaggio 2">
-    Clicca sulla scheda <code className="action">Databases</code>, poi sul pulsante <code className="action">...</code> accanto al database interessato.
+    Clicca sulla scheda <code className="action">Database</code>, poi sul pulsante <code className="action">...</code> accanto al database interessato.
   </Tab>
   <Tab label="Passaggio 3">
     Clicca su <code className="action">Ricalcola la quota</code>.
@@ -241,7 +241,7 @@ Per ricalcolare la quota, clicca sulle schede qui sotto per visualizzare in succ
     <img className="thumbnail" alt="Hosting plans" src="/images/assets/screens/control-panel/product-selection/web-cloud/hosting-plans.png" loading="lazy" />
   </Tab>
   <Tab label="Passaggio 2">
-    Clicca sulla scheda <code className="action">Databases</code>, poi sul pulsante <code className="action">...</code> accanto al database interessato.
+    Clicca sulla scheda <code className="action">Database</code>, poi sul pulsante <code className="action">...</code> accanto al database interessato.
   </Tab>
   <Tab label="Passaggio 3">
     Clicca su <code className="action">Ricalcola la quota</code>.
@@ -305,7 +305,7 @@ Per prima cosa, assicurati che il database sia vuoto. Per farlo, clicca sulle sc
     <img className="thumbnail" alt="Hosting plans" src="/images/assets/screens/control-panel/product-selection/web-cloud/hosting-plans.png" loading="lazy" />
   </Tab>
   <Tab label="Passaggio 2">
-    Clicca sulla scheda <code className="action">Databases</code>, poi sul pulsante <code className="action">...</code> accanto al database interessato e su <code className="action">Ricalcola la quota</code>.
+    Clicca sulla scheda <code className="action">Database</code>, poi sul pulsante <code className="action">...</code> accanto al database interessato e su <code className="action">Ricalcola la quota</code>.
   </Tab>
   <Tab label="Passaggio 3">
     Se il database non è vuoto, [salva i dati presenti](/guides/web-cloud/web-hosting/sql-database-export) e poi eliminali prima di riavviare l'operazione di importazione.
@@ -426,7 +426,7 @@ Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **2**
     <img className="thumbnail" alt="Hosting plans" src="/images/assets/screens/control-panel/product-selection/web-cloud/hosting-plans.png" loading="lazy" />
   </Tab>
   <Tab label="Passaggio 2">
-    Clicca sulla scheda <code className="action">Databases</code>. Il nome del server da inserire è indicato nella colonna `Indirizzo del server`.
+    Clicca sulla scheda <code className="action">Database</code>. Il nome del server da inserire è indicato nella colonna `Indirizzo del server`.
   </Tab>
 </Tabs>
 

--- a/docs/it/guides/web-cloud/web-hosting/enable-ldp-web-hosting.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/enable-ldp-web-hosting.mdx
@@ -68,16 +68,16 @@ Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **2**
     <img className="thumbnail" alt="Web Hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/hosting-plans.png" loading="lazy" />
   </Tab>
   <Tab label="Step 2">
-    Clicca sulla scheda <code className="action">Logs</code>.
+    Clicca sulla scheda <code className="action">Log</code>.
 
     <img className="thumbnail" alt="Logs" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/logs/tab.png" loading="lazy" />
 
     Questa console integrata visualizza i log in tempo reale della tua offerta di hosting web.
 
     :::info
-    I log sono disponibili solo in tempo reale. Appaiono soltanto se vengono generati nel momento in cui ti trovi sulla scheda <code className="action">Logs</code>.
+    I log sono disponibili solo in tempo reale. Appaiono soltanto se vengono generati nel momento in cui ti trovi sulla scheda <code className="action">Log</code>.
 
-    Se esci dalla scheda <code className="action">Logs</code> e vi ritorni in seguito, la cronologia precedente sarà scomparsa.
+    Se esci dalla scheda <code className="action">Log</code> e vi ritorni in seguito, la cronologia precedente sarà scomparsa.
     :::
   </Tab>
 </Tabs>
@@ -131,7 +131,7 @@ Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **5**
     <img className="thumbnail" alt="Web Hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/hosting-plans.png" loading="lazy" />
   </Tab>
   <Tab label="Step 2">
-    Clicca sulla scheda <code className="action">Logs</code>.
+    Clicca sulla scheda <code className="action">Log</code>.
 
     <img className="thumbnail" alt="Logs" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/logs/tab.png" loading="lazy" />
   </Tab>
@@ -171,7 +171,7 @@ Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **6**
     <img className="thumbnail" alt="Web Hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/hosting-plans.png" loading="lazy" />
   </Tab>
   <Tab label="Step 2">
-    Clicca sulla scheda <code className="action">Logs</code>.
+    Clicca sulla scheda <code className="action">Log</code>.
 
     <img className="thumbnail" alt="Logs" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/logs/tab.png" loading="lazy" />
   </Tab>
@@ -203,7 +203,7 @@ Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **6**
 
     Non ti resta che sottoscrivere il tuo hosting web al tuo flusso appena creato sulla tua soluzione Logs Data Platform.
 
-    Per farlo, torna alla scheda <code className="action">Logs</code> della tua offerta di hosting web, come spiegato [in precedenza](#webhosting-ldp), per sottoscrivere questo nuovo flusso di dati, quindi segui questa volta il [Caso n. 1](#webhosting-ldp-case1) descritto sopra.
+    Per farlo, torna alla scheda <code className="action">Log</code> della tua offerta di hosting web, come spiegato [in precedenza](#webhosting-ldp), per sottoscrivere questo nuovo flusso di dati, quindi segui questa volta il [Caso n. 1](#webhosting-ldp-case1) descritto sopra.
   </Tab>
 </Tabs>
 

--- a/docs/it/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ftp-save-and-backup.mdx
@@ -145,7 +145,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **5** pa
     |1 settimana|La domenica precedente alle 01:00|
     |2 settimane|La domenica di due settimane prima alle 01:00|
 
-    Una volta selezionata la data, clicca su <code className="action">Seguente</code>. 
+    Una volta selezionata la data, clicca su <code className="action">Continua</code>. 
   </Tab>
   <Tab label="Passaggio 5">
     <img className="thumbnail" alt="backupftp" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/restore-backup-step-1.png" loading="lazy" />

--- a/docs/it/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/how-to-upgrade-web-hosting-offer.mdx
@@ -191,7 +191,7 @@ Per conservare lo stesso numero di caselle email **prima di passare l'hosting We
     Accedi alla pagina <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> e seleziona il dominio interessato.
   </Tab>
   <Tab label="Passaggio 2">
-    Nel riquadro **Abbonamento** e a destra di **Servizio**, clicca sul pulsante <code className="action">...</code> e poi su <code className="action">Modifica soluzione</code>.
+    Nel riquadro **Abbonamento** e a destra di **Servizio**, clicca sul pulsante <code className="action">...</code> e poi su <code className="action">Modificare soluzione</code>.
 
     <img className="thumbnail" alt="Modifica offerta MX Plan" src="/images/assets/screens/control-panel/product-selection/web-cloud/emails/general-information/change-solution.png" loading="lazy" />
   </Tab>
@@ -221,7 +221,7 @@ Per attivare l'hosting Web su una soluzione [Personale](/links/web/hosting), è 
     Accedi alla pagina <ManagerLink to="/#/web/web/email_domain">MX Plan</ManagerLink> e seleziona il dominio interessato.
   </Tab>
   <Tab label="Passaggio 2">
-    Nel riquadro **Abbonamento** e a destra di **Servizio**, clicca sul pulsante <code className="action">...</code> e poi su <code className="action">Modifica soluzione</code>.
+    Nel riquadro **Abbonamento** e a destra di **Servizio**, clicca sul pulsante <code className="action">...</code> e poi su <code className="action">Modificare soluzione</code>.
   </Tab>
 </Tabs>
 

--- a/docs/it/guides/web-cloud/web-hosting/resolve-anomalous-activity.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/resolve-anomalous-activity.mdx
@@ -97,10 +97,10 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** pa
     Una **finestra di allerta** appare: `"Attività anomala sul tuo hosting"`. Se clicchi sul pulsante <code className="action">Più tardi</code>, una **bandiera di allerta** `"Attività anomala rilevata"` appare in alto sulla pagina. Clicca su <code className="action">Scopri di più</code> per riaprire la finestra di allerta.
   </Tab>
   <Tab label="Passaggio 3">
-    **Seleziona** la casella: `Confermo di aver eseguito tutte le azioni necessarie per risolvere il problema`, poi clicca su <code className="action">Rimuovere le misure di sicurezza</code>.
+    **Seleziona** la casella: `Confermo di aver eseguito tutte le azioni necessarie per risolvere il problema`, poi clicca su <code className="action">Rimozione delle misure di sicurezza</code>.
   </Tab>
   <Tab label="Passaggio 4">
-    Una **bandiera di conferma** appare in alto sulla pagina: `Il tuo hosting è in analisi per rimuovere le misure di sicurezza.` Segui il progresso cliccando sul link <code className="action">Vedi le attività in corso</code> o direttamente dall'etichetta <code className="action">Attività in corso</code>.
+    Una **bandiera di conferma** appare in alto sulla pagina: `Il tuo hosting è in analisi per rimuovere le misure di sicurezza.` Segui il progresso cliccando sul link <code className="action">Visualizza le operazioni in corso</code> o direttamente dall'etichetta <code className="action">Attività in corso</code>.
   </Tab>
 </Tabs>
 

--- a/docs/it/guides/web-cloud/web-hosting/sql-create-database.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/sql-create-database.mdx
@@ -189,7 +189,7 @@ OVHcloud fornisce uno strumento online per la gestione dei database, "phpMyAdmin
     Nella tabella che appare, clicca sul pulsante <code className="action">...</code> a destra del database interessato e poi su <code className="action">Accedi a phpMyAdmin</code> nel menu a tendina.
   </Tab>
   <Tab label="Passaggio 4">
-    Inserisci le informazioni di accesso al database e clicca su <code className="action">Accedi</code>.
+    Inserisci le informazioni di accesso al database e clicca su <code className="action">Connetti</code>.
 
     <img className="thumbnail" alt="Pagina di accesso a phpMyAdmin" src="/images/assets/screens/other/web-tools/phpmyadmin/pma-interface-login.png" loading="lazy" />
 

--- a/docs/it/guides/web-cloud/web-hosting/sql-database-export.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/sql-database-export.mdx
@@ -97,7 +97,7 @@ Per effettuare un nuovo backup, clicca sulle schede qui sotto per visualizzare i
     <img className="thumbnail" alt="databasedump" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/databases/create-a-backup.png" loading="lazy" />
   </Tab>
   <Tab label="Passaggio 4">
-    Nella nuova finestra, seleziona la data in cui effettuare il backup e clicca sul pulsante <code className="action">Avanti</code>. Verifica la correttezza delle informazioni e clicca su <code className="action">Conferma</code> per avviare l'operazione.
+    Nella nuova finestra, seleziona la data in cui effettuare il backup e clicca sul pulsante <code className="action">Continua</code>. Verifica la correttezza delle informazioni e clicca su <code className="action">Conferma</code> per avviare l'operazione.
 
     <img className="thumbnail" alt="databasedump" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/databases/create-a-database-backup-step-1.png" loading="lazy" />
 

--- a/docs/pl/guides/web-cloud/databases/db-backup-export-database-server.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-backup-export-database-server.mdx
@@ -63,7 +63,7 @@ Kliknij poniższe zakładki, aby wyświetlić kolejno każdy z **3** kroków.
     W kolumnie **Kopie zapasowe** liczba odpowiada liczbie kopii zapasowych dostępnych dla Twojej bazy danych.
   </Tab>
   <Tab label="Krok 3">
-    Kliknij przycisk <code className="action">...</code> po prawej stronie bazy danych, a następnie <code className="action">Zapisz teraz</code>.
+    Kliknij przycisk <code className="action">...</code> po prawej stronie bazy danych, a następnie <code className="action">Stwórz teraz kopię zapasową</code>.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/databases/back-up-now.png" loading="lazy" />
   </Tab>

--- a/docs/pl/guides/web-cloud/databases/db-create-databases-users.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-create-databases-users.mdx
@@ -108,7 +108,7 @@ Kliknij poniższe karty, aby wyświetlić kolejne **4** kroki.
     Kliknij kartę <code className="action">Użytkownicy i uprawnienia</code>.
   </Tab>
   <Tab label="Krok 3">
-    Kliknij przycisk <code className="action">...</code> po prawej stronie odpowiedniego użytkownika, a następnie <code className="action">Zarządzaj uprawnieniami</code>.
+    Kliknij przycisk <code className="action">...</code> po prawej stronie odpowiedniego użytkownika, a następnie <code className="action">Zarządzanie uprawnieniami</code>.
 
     <img className="thumbnail" alt="web-cloud-databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/users-and-rights/manage-rights.png" loading="lazy" />
   </Tab>

--- a/docs/pl/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-getting-started.mdx
@@ -195,7 +195,7 @@ W tym celu kliknij poniższe karty, aby wyświetlić kolejne **4** kroki.
     <img className="thumbnail" alt="Interfejs autoryzowanych adresów IP" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/tab-0000-sftp-hosting-enabled.png" loading="lazy" />
 
     :::tip
-    Jeśli chcesz zmienić już autoryzowany adres IP lub zakres adresów IP, kliknij przycisk <code className="action">...</code> po prawej stronie odpowiedniego wiersza w tabeli, a następnie <code className="action">Edytuj whitelist</code>.
+    Jeśli chcesz zmienić już autoryzowany adres IP lub zakres adresów IP, kliknij przycisk <code className="action">...</code> po prawej stronie odpowiedniego wiersza w tabeli, a następnie <code className="action">Edytuj białą listę</code>.
 
     :::
 

--- a/docs/pl/guides/web-cloud/databases/db-restore-import-database.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-restore-import-database.mdx
@@ -84,7 +84,7 @@ Kliknij na poniższe karty, aby wyświetlić kolejno każdy z **4** kroków.
     Kliknij kartę <code className="action">Bazy danych</code>.
   </Tab>
   <Tab label="Krok 3">
-    Kliknij przycisk <code className="action">...</code> po prawej stronie bazy danych, a następnie <code className="action">Importuj plik</code>.
+    Kliknij przycisk <code className="action">...</code> po prawej stronie bazy danych, a następnie <code className="action">Zaimportuj plik</code>.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/databases/import-file.png" loading="lazy" />
   </Tab>

--- a/docs/pl/guides/web-cloud/domains/dns-dynhost.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-dynhost.mdx
@@ -96,7 +96,7 @@ W tym celu kliknij poniższe zakładki, aby wyświetlić kolejne **5** kroki.
     <img className="thumbnail" alt="DynHost" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dynhost.png" loading="lazy" />
   </Tab>
   <Tab label="Krok 3">
-    Kliknij przycisk <code className="action">Zarządzaj dostępami</code>, a następnie kliknij <code className="action">Utwórz identyfikator</code>. 
+    Kliknij przycisk <code className="action">Zarządzanie dostępami</code>, a następnie kliknij <code className="action">Utwórz identyfikator</code>. 
 
     <img className="thumbnail" alt="DynHost tab empty" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/dynhost/tab-empty.png" loading="lazy" />
   </Tab>

--- a/docs/pl/guides/web-cloud/domains/redirect-domain-name.mdx
+++ b/docs/pl/guides/web-cloud/domains/redirect-domain-name.mdx
@@ -123,7 +123,7 @@ Kliknij <code className="action">Dalej</code>.
 Kliknij <code className="action">Dalej</code>.
   </Tab>
   <Tab label="Krok 6">
-    Wybierz <code className="action">Permanentne (301)</code> spośród dwóch wyświetlonych opcji, a następnie wprowadź docelową nazwę domeny lub adres URL przekierowania w polu <code className="action">Adres www</code>.
+    Wybierz <code className="action">stałe (301)</code> spośród dwóch wyświetlonych opcji, a następnie wprowadź docelową nazwę domeny lub adres URL przekierowania w polu <code className="action">Adres www</code>.
 
     <img className="thumbnail" alt="Step 6" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/redirection/add-a-redirection-step-4-permanent.png" loading="lazy" />
 
@@ -137,7 +137,7 @@ Kliknij <code className="action">Dalej</code>.
 Kliknij <code className="action">Potwierdź</code>, aby zatwierdzić konfigurację.
 
     :::info
-    Jeśli wyświetla się komunikat "*Istnieją przekierowania z nazw domen, które chcesz przekierować, kolidujące z przekierowaniami, które chcesz dodać*", możesz zaznaczyć pole <code className="action">Potwierdź usunięcie istniejącego przekierowania</code>, aby wymusić zastosowanie przekierowania.
+    Jeśli wyświetla się komunikat "*Istnieją przekierowania z nazw domen, które chcesz przekierować, kolidujące z przekierowaniami, które chcesz dodać*", możesz zaznaczyć pole <code className="action">Potwierdzenie usunięcia istniejącego przekierowania</code>, aby wymusić zastosowanie przekierowania.
 
     Uwaga: poprzednia konfiguracja zostanie wyłączona i usunięta.
 
@@ -215,7 +215,7 @@ Kliknij <code className="action">Dalej</code>.
 Kliknij <code className="action">Potwierdź</code>, aby zatwierdzić konfigurację.
 
     :::info
-    Jeśli wyświetla się komunikat "*Istnieją przekierowania z nazw domen, które chcesz przekierować, kolidujące z przekierowaniami, które chcesz dodać*", możesz zaznaczyć pole <code className="action">Potwierdź usunięcie istniejącego przekierowania</code>, aby wymusić zastosowanie przekierowania.
+    Jeśli wyświetla się komunikat "*Istnieją przekierowania z nazw domen, które chcesz przekierować, kolidujące z przekierowaniami, które chcesz dodać*", możesz zaznaczyć pole <code className="action">Potwierdzenie usunięcia istniejącego przekierowania</code>, aby wymusić zastosowanie przekierowania.
 
     Uwaga: poprzednia konfiguracja zostanie wyłączona i usunięta.
 
@@ -306,7 +306,7 @@ Na tym etapie dostępne są trzy opcjonalne ustawienia:
 Kliknij <code className="action">Potwierdź</code>, aby zatwierdzić konfigurację.
 
     :::info
-    Jeśli wyświetla się komunikat "*Istnieją przekierowania z nazw domen, które chcesz przekierować, kolidujące z przekierowaniami, które chcesz dodać*", możesz zaznaczyć pole <code className="action">Potwierdź usunięcie istniejącego przekierowania</code>, aby wymusić zastosowanie przekierowania.
+    Jeśli wyświetla się komunikat "*Istnieją przekierowania z nazw domen, które chcesz przekierować, kolidujące z przekierowaniami, które chcesz dodać*", możesz zaznaczyć pole <code className="action">Potwierdzenie usunięcia istniejącego przekierowania</code>, aby wymusić zastosowanie przekierowania.
 
     Uwaga: poprzednia konfiguracja zostanie wyłączona i usunięta.
 

--- a/docs/pl/guides/web-cloud/web-hosting/enable-ldp-web-hosting.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/enable-ldp-web-hosting.mdx
@@ -68,16 +68,16 @@ Kliknij poniższe zakładki, aby kolejno wyświetlić każdy z **2** etapów.
     <img className="thumbnail" alt="Web Hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/hosting-plans.png" loading="lazy" />
   </Tab>
   <Tab label="Etap 2">
-    Kliknij zakładkę <code className="action">Logs</code>.
+    Kliknij zakładkę <code className="action">Logi</code>.
 
     <img className="thumbnail" alt="Logs" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/logs/tab.png" loading="lazy" />
 
     Ta wbudowana konsola wyświetla logi w czasie rzeczywistym Twojego hostingu.
 
     :::info
-    Logi są dostępne wyłącznie w czasie rzeczywistym. Pojawiają się tylko wtedy, gdy są generowane w momencie, gdy znajdujesz się w zakładce <code className="action">Logs</code>.
+    Logi są dostępne wyłącznie w czasie rzeczywistym. Pojawiają się tylko wtedy, gdy są generowane w momencie, gdy znajdujesz się w zakładce <code className="action">Logi</code>.
 
-    Jeśli opuścisz zakładkę <code className="action">Logs</code>, a następnie wrócisz do niej później, poprzednia historia zniknie.
+    Jeśli opuścisz zakładkę <code className="action">Logi</code>, a następnie wrócisz do niej później, poprzednia historia zniknie.
     :::
   </Tab>
 </Tabs>
@@ -131,7 +131,7 @@ Kliknij poniższe zakładki, aby kolejno wyświetlić każdy z **5** etapów.
     <img className="thumbnail" alt="Web Hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/hosting-plans.png" loading="lazy" />
   </Tab>
   <Tab label="Etap 2">
-    Kliknij zakładkę <code className="action">Logs</code>.
+    Kliknij zakładkę <code className="action">Logi</code>.
 
     <img className="thumbnail" alt="Logs" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/logs/tab.png" loading="lazy" />
   </Tab>
@@ -171,7 +171,7 @@ Kliknij poniższe zakładki, aby kolejno wyświetlić każdy z **6** etapów.
     <img className="thumbnail" alt="Web Hosting" src="/images/assets/screens/control-panel/product-selection/web-cloud/hosting-plans.png" loading="lazy" />
   </Tab>
   <Tab label="Etap 2">
-    Kliknij zakładkę <code className="action">Logs</code>.
+    Kliknij zakładkę <code className="action">Logi</code>.
 
     <img className="thumbnail" alt="Logs" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/logs/tab.png" loading="lazy" />
   </Tab>
@@ -203,7 +203,7 @@ Kliknij poniższe zakładki, aby kolejno wyświetlić każdy z **6** etapów.
 
     Pozostaje już tylko subskrybować Twój hosting do nowo utworzonego strumienia w Twoim rozwiązaniu Logs Data Platform.
 
-    Aby to zrobić, wróć do zakładki <code className="action">Logs</code> Twojego hostingu, jak wyjaśniono [wcześniej](#webhosting-ldp), aby subskrybować ten nowy strumień danych, a następnie tym razem postępuj zgodnie z opisanym powyżej [Przypadkiem nr 1](#webhosting-ldp-case1).
+    Aby to zrobić, wróć do zakładki <code className="action">Logi</code> Twojego hostingu, jak wyjaśniono [wcześniej](#webhosting-ldp), aby subskrybować ten nowy strumień danych, a następnie tym razem postępuj zgodnie z opisanym powyżej [Przypadkiem nr 1](#webhosting-ldp-case1).
   </Tab>
 </Tabs>
 

--- a/docs/pl/guides/web-cloud/web-hosting/ftp-connection.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ftp-connection.mdx
@@ -71,7 +71,7 @@ Jeśli nie posiadasz tych elementów, kliknij poniższe zakładki, aby wyświetl
 
     :::info
     Jeśli chcesz utworzyć nowego użytkownika FTP/SSH z tej samej strony, kliknij przycisk <code className="action">Utwórz użytkownika</code> z prawej strony.
-    Zdefiniuj rozszerzenie nazwy nowego <code className="action">Użytkownik</code> i <code className="action">Folder główny</code>, w którym użytkownik będzie mógł działać, a następnie kliknij <code className="action">Dalej</code>.
+    Zdefiniuj rozszerzenie nazwy nowego <code className="action">Użytkownik</code> i <code className="action">Katalog główny</code>, w którym użytkownik będzie mógł działać, a następnie kliknij <code className="action">Dalej</code>.
     Wybierz hasło dla tego nowego konta użytkownika, kliknij na <code className="action">Dalej</code>, następnie kliknij na <code className="action">Potwierdź</code>.
     :::
 

--- a/docs/pl/guides/web-cloud/web-hosting/logs-and-statistics.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/logs-and-statistics.mdx
@@ -168,7 +168,7 @@ Link dostępowy do statystyk / logów możesz również sprawdzić bezpośrednio
     Na stronie, która się wyświetli kliknij zakładkę <code className="action">Statystyki i logi</code>, a następnie przejdź do sekcji **Statystyki odwiedzin**.
   </Tab>
   <Tab label="Krok 3">
-    Kliknij przycisk <code className="action">Zobacz statystyki</code>.
+    Kliknij przycisk <code className="action">Wyświetl statystyki</code>.
 
     <img className="thumbnail" alt="Statystyki odwiedzin strony WWW" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/statistics-and-logs/view-statistics.png" loading="lazy" />
 

--- a/docs/pl/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -70,7 +70,7 @@ Aby uzyskać dostęp do sekcji «Skrypty e-mail», kliknij poniższe zakładki, 
 
         W zależności od tego stanu, zarządzanie wysyłkami będzie inne.
 
-    - **Raport błędów do**: otrzymuj go codziennie na wybrany adres e-mail. Ustaw go za pomocą przycisku <code className="action">Zmień odbiorcę</code>. Raport zawiera wiadomości e-mail wysłane z Twojego hostingu, które wróciły z błędem do OVHcloud. Przycisk <code className="action">E-maile w błędzie</code> umożliwia również przeglądanie tych raportów w dowolnym momencie po prawej stronie strony <code className="action">Skrypty e-mail</code>.
+    - **Raport błędów do**: otrzymuj go codziennie na wybrany adres e-mail. Ustaw go za pomocą przycisku <code className="action">Zmień odbiorcę</code>. Raport zawiera wiadomości e-mail wysłane z Twojego hostingu, które wróciły z błędem do OVHcloud. Przycisk <code className="action">E-maile z błędami</code> umożliwia również przeglądanie tych raportów w dowolnym momencie po prawej stronie strony <code className="action">Skrypty e-mail</code>.
     - **Łączna liczba wysłanych e-maili**: łączna liczba automatycznych wiadomości e-mail wysłanych od czasu utworzenia Twojego hostingu OVHcloud.
     - **E-maile wysłane dzisiaj**: łączna liczba automatycznych wiadomości e-mail wysłanych tylko dzisiaj.
     - **Łączna liczba e-maili w błędzie**: łączna liczba automatycznych wiadomości e-mail wysłanych od czasu utworzenia Twojego hostingu, które wróciły z błędem do OVHcloud.
@@ -79,7 +79,7 @@ Aby uzyskać dostęp do sekcji «Skrypty e-mail», kliknij poniższe zakładki, 
     Po prawej stronie kilka przycisków umożliwia zarządzanie wysyłkami automatycznych wiadomości e-mail z Twojego hostingu. W zależności od stanu usługi, niektóre przyciski mogą być niedostępne.
 
     - **Usuń e-maile**: usuwa e-maile z kolejki i odblokowuje wysyłkę. Ze względu na poufność, e-maile w kolejce są niedostępne po stronie OVHcloud. Możesz wyświetlić te e-maile tylko jeśli zostały wcześniej zapisane w bazie danych Twojej strony WWW przed wysłaniem.
-    - **E-maile w błędzie**: umożliwia dostęp do logów ostatnich wiadomości e-mail, które nie zostały wysłane z powodu błędu. Znajdziesz tam zainteresowane adresy e-mail z powiązanym błędem. Uwaga, historia ta nie zostanie zresetowana, nawet jeśli zdecydujesz się <code className="action">Usuń e-maile</code> lub <code className="action">Odblokuj wysyłkę</code>.
+    - **E-maile w błędzie**: umożliwia dostęp do logów ostatnich wiadomości e-mail, które nie zostały wysłane z powodu błędu. Znajdziesz tam zainteresowane adresy e-mail z powiązanym błędem. Uwaga, historia ta nie zostanie zresetowana, nawet jeśli zdecydujesz się <code className="action">Usuń wiadomości e-mail</code> lub <code className="action">Odblokuj wysyłkę</code>.
     - **Zablokuj wysyłkę**: blokuje dystrybucję automatycznych wysyłek wiadomości e-mail z Twojego hostingu. Wiadomości e-mail generowane przez Twoje skrypty po zablokowaniu nie będą wysyłane, lecz przechowywane w kolejce przez maksymalnie 72 godziny.
     - **Odblokuj wysyłkę**: odblokowuje wysyłkę automatycznych wiadomości e-mail z Twojego hostingu. Wiadomości e-mail w kolejce zostaną również wznowione.
 
@@ -175,7 +175,7 @@ Aby odblokować sytuację, kliknij poniższe zakładki, aby wyświetlić kolejne
     Możliwe są dwie opcje:
 
     - Jeśli klikniesz <code className="action">Odblokuj wysyłkę</code>, stan usługi zmieni się na *«Force»*. Dozwolony stosunek **wiadomości e-mail zwróconych z błędem / łączna liczba wysłanych wiadomości e-mail** przed zablokowaniem zostanie podwojony. Wysyłka będzie ponownie aktywna kilka minut po odblokowaniu.
-    - Jeśli klikniesz <code className="action">Usuń e-maile</code>, wszystkie wiadomości e-mail z kolejki zostaną usunięte, a stan usługi wróci do *«Aktywny»* bez podwajania stosunku.
+    - Jeśli klikniesz <code className="action">Usuń wiadomości e-mail</code>, wszystkie wiadomości e-mail z kolejki zostaną usunięte, a stan usługi wróci do *«Aktywny»* bez podwajania stosunku.
   </Tab>
 </Tabs>
 
@@ -203,7 +203,7 @@ Następnie przejdź do sekcji «Skrypty e-mail» Twojego hostingu. W tym celu kl
     Na stronie, która się wyświetla, kliknij zakładkę <code className="action">Więcej</code>, a następnie kliknij <code className="action">Skrypty e-mail</code>.
   </Tab>
   <Tab label="Krok 3">
-    Kliknij <code className="action">Usuń e-maile</code>: wszystkie wiadomości e-mail z kolejki zostaną usunięte, a stan usługi wróci do *«Aktywny»*. W tym przypadku usunięcie jest obowiązkowe, aby usunąć spam oczekujący na wysyłkę.
+    Kliknij <code className="action">Usuń wiadomości e-mail</code>: wszystkie wiadomości e-mail z kolejki zostaną usunięte, a stan usługi wróci do *«Aktywny»*. W tym przypadku usunięcie jest obowiązkowe, aby usunąć spam oczekujący na wysyłkę.
   </Tab>
 </Tabs>
 
@@ -229,7 +229,7 @@ Po zabezpieczeniu hostingu kliknij poniższe zakładki, aby wyświetlić kolejne
     Na stronie, która się wyświetla, kliknij zakładkę <code className="action">Więcej</code>, a następnie kliknij <code className="action">Skrypty e-mail</code>.
   </Tab>
   <Tab label="Krok 3">
-    Kliknij <code className="action">Usuń e-maile</code>: wszystkie wiadomości e-mail z kolejki zostaną usunięte, a stan usługi wróci do *«Aktywny»*.
+    Kliknij <code className="action">Usuń wiadomości e-mail</code>: wszystkie wiadomości e-mail z kolejki zostaną usunięte, a stan usługi wróci do *«Aktywny»*.
   </Tab>
 </Tabs>
 

--- a/docs/pl/guides/web-cloud/web-hosting/resolve-anomalous-activity.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/resolve-anomalous-activity.mdx
@@ -99,7 +99,7 @@ Kliknij poniższe zakładki, aby wyświetlić kolejne **4** kroki.
     **Zaznacz** pole: `Potwierdzam, że wykonałem wszystkie niezbędne działania, aby rozwiązać problem`, a następnie kliknij <code className="action">Uniknięcie środków bezpieczeństwa</code>.
   </Tab>
   <Tab label="Krok 4">
-    Pojawia się **baner potwierdzenia** na górze strony: `Twój hosting jest analizowany, aby uniknąć środków bezpieczeństwa.` Śledź postęp klikając w link <code className="action">Zobacz bieżące zadania</code> lub bezpośrednio z zakładki <code className="action">Bieżące zadania</code>.
+    Pojawia się **baner potwierdzenia** na górze strony: `Twój hosting jest analizowany, aby uniknąć środków bezpieczeństwa.` Śledź postęp klikając w link <code className="action">Zobacz bieżące zadania</code> lub bezpośrednio z zakładki <code className="action">Zadania w toku</code>.
   </Tab>
 </Tabs>
 

--- a/docs/pl/guides/web-cloud/web-hosting/sql-create-database.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/sql-create-database.mdx
@@ -74,8 +74,8 @@ Aby utworzyć bazę danych, kliknij poniższe zakładki, aby wyświetlić kolejn
   <Tab label="Krok 2">
     Na stronie, która się wyświetli, kliknij zakładkę <code className="action">Bazy danych</code>, a następnie:
 
-    - **Jeśli jeszcze nie utworzyłeś bazy danych**: kliknij przycisk <code className="action">Utwórz bazę danych</code>.
-    - **Jeśli już utworzyłeś bazę danych**: kliknij przycisk <code className="action">Operacje</code>, a następnie <code className="action">Utwórz bazę danych</code>.
+    - **Jeśli jeszcze nie utworzyłeś bazy danych**: kliknij przycisk <code className="action">Tworzenie bazy danych</code>.
+    - **Jeśli już utworzyłeś bazę danych**: kliknij przycisk <code className="action">Operacje</code>, a następnie <code className="action">Tworzenie bazy danych</code>.
   </Tab>
   <Tab label="Krok 3">
     W wyświetlonym oknie wybierz następujące informacje i kliknij <code className="action">Dalej</code>:
@@ -189,7 +189,7 @@ OVHcloud udostępnia narzędzie online do zarządzania bazami danych "phpMyAdmin
     W tabeli, która się wyświetli kliknij przycisk <code className="action">...</code> po prawej stronie odpowiedniej bazy danych, a następnie z menu rozwijanego kliknij <code className="action">Dostęp do phpMyAdmin</code>.
   </Tab>
   <Tab label="Krok 4">
-    Wprowadź dane dostępowe do Twojej bazy danych, a następnie kliknij <code className="action">Zaloguj się</code>.
+    Wprowadź dane dostępowe do Twojej bazy danych, a następnie kliknij <code className="action">Login</code>.
 
     <img className="thumbnail" alt="Strona logowania do phpMyAdmin" src="/images/assets/screens/other/web-tools/phpmyadmin/pma-interface-login.png" loading="lazy" />
 

--- a/docs/pt/guides/web-cloud/databases/db-backup-export-database-server.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-backup-export-database-server.mdx
@@ -63,7 +63,7 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
     Na coluna **Backups**, o número corresponde ao número de backups disponíveis para a sua base de dados.
   </Tab>
   <Tab label="Etapa 3">
-    Clique no botão <code className="action">...</code> à direita da base de dados e, a seguir, em <code className="action">Fazer backup agora</code>.
+    Clique no botão <code className="action">...</code> à direita da base de dados e, a seguir, em <code className="action">Efetuar um backup agora</code>.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/databases/back-up-now.png" loading="lazy" />
   </Tab>
@@ -85,12 +85,12 @@ Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
     Na coluna **Backups**, o número corresponde ao número de backups disponíveis para a sua base de dados.
   </Tab>
   <Tab label="Etapa 3">
-    Clique no botão <code className="action">...</code> à direita da base de dados e, a seguir, em <code className="action">Exibir os backups</code>.
+    Clique no botão <code className="action">...</code> à direita da base de dados e, a seguir, em <code className="action">Apresentar backups</code>.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/databases/show-backups.png" loading="lazy" />
   </Tab>
   <Tab label="Etapa 4">
-    Surge a lista dos backups disponíveis. Clique no botão <code className="action">...</code> à direita do backup pretendido e, a seguir, em <code className="action">Descarregar o backup</code>.
+    Surge a lista dos backups disponíveis. Clique no botão <code className="action">...</code> à direita do backup pretendido e, a seguir, em <code className="action">Transferir backup</code>.
   </Tab>
 </Tabs>
 

--- a/docs/pt/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -80,7 +80,7 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases.png" loading="lazy" />
   </Tab>
   <Tab label="Passo 2">
-    Clique no separador <code className="action">IPs autorizados</code> e, em seguida, no botão <code className="action">Adicionar um endereço IP / máscara</code>.
+    Clique no separador <code className="action">Endereços IP autorizados</code> e, em seguida, no botão <code className="action">Adicionar um endereço IP / máscara</code>.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask.png" loading="lazy" />
   </Tab>
@@ -106,7 +106,7 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases.png" loading="lazy" />
   </Tab>
   <Tab label="Passo 2">
-    Clique no separador <code className="action">IPs autorizados</code>.
+    Clique no separador <code className="action">Endereços IP autorizados</code>.
   </Tab>
   <Tab label="Passo 3">
     Selecione <code className="action">Autorizar os alojamentos web OVHcloud a aceder à base de dados</code>.
@@ -281,7 +281,7 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
     No separador **Informações gerais**, a versão atual aparece na linha **Versão**.
   </Tab>
   <Tab label="Passo 3">
-    Para modificar esta versão, clique em <code className="action">Modificar a versão</code>.
+    Para modificar esta versão, clique em <code className="action">Alterar versão</code>.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/general-information/postgre-12-update-version.png" loading="lazy" />
   </Tab>

--- a/docs/pt/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-getting-started.mdx
@@ -185,7 +185,7 @@ Para isso, clique nos separadores abaixo para ver cada um dos **4** passos.
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases.png" loading="lazy" />
   </Tab>
   <Tab label="Passo 2">
-    Na página apresentada, clique no separador <code className="action">IPs autorizados</code>.
+    Na página apresentada, clique no separador <code className="action">Endereços IP autorizados</code>.
 
     <img className="thumbnail" alt="IPs autorizados" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/authorised-ips.png" loading="lazy" />
   </Tab>

--- a/docs/pt/guides/web-cloud/databases/db-restore-import-database.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-restore-import-database.mdx
@@ -55,7 +55,7 @@ Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
     Na coluna **"Backups"**, o algarismo corresponde ao número de backups disponíveis para a sua base de dados.
   </Tab>
   <Tab label="Etapa 3">
-    Clique no botão <code className="action">...</code> à direita da base de dados e, a seguir, em <code className="action">Exibir os backups</code>.
+    Clique no botão <code className="action">...</code> à direita da base de dados e, a seguir, em <code className="action">Apresentar backups</code>.
   </Tab>
   <Tab label="Etapa 4">
     A lista dos backups disponíveis é apresentada. Clique no botão <code className="action">...</code> à direita do backup escolhido e em <code className="action">Restaurar o backup</code>.

--- a/docs/pt/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -468,7 +468,7 @@ Siga os **5 passos** clicando sucessivamente em cada um dos 5 separadores seguin
     Os valores `"status": "toSet"` e `"status": "disabled"` significam que os registos CNAME devem ser configurados. Guarde os 2 valores `cname` num ficheiro de texto e passe à etapa seguinte.
   </Tab>
   <Tab label="4. Configurar o registo DNS">
-    A partir de <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, na qual está alojado o nome de domínio do seu serviço de e-mail, no separador <code className="action">Web Cloud</code>, clique em <code className="action">Domínios</code> na coluna da esquerda e selecione o domínio em causa.<br/>
+    A partir de <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, na qual está alojado o nome de domínio do seu serviço de e-mail, no separador <code className="action">Web Cloud</code>, clique em <code className="action">Nomes de domínio</code> na coluna da esquerda e selecione o domínio em causa.<br/>
     Aceda ao separador <code className="action">Zona DNS</code> e clique em <code className="action">Adicionar uma entrada</code> acima da tabela. No formulário que se abre, selecione o tipo `CNAME` e preencha os campos de acordo com os valores que obteve.
 
     Decompõe-se os valores do exemplo na etapa "**3. Obter o registo DNS**":

--- a/docs/pt/guides/web-cloud/domains/transfer-outgoing-couk.mdx
+++ b/docs/pt/guides/web-cloud/domains/transfer-outgoing-couk.mdx
@@ -78,7 +78,7 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
     <img className="thumbnail" alt="Área de Cliente OVHcloud - lista de nomes de domínio" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-names.png" loading="lazy" />
   </Tab>
   <Tab label="Etapa 2">
-    Na secção **Configuração**, clique no link <code className="action">Tag de transferência que sai</code>.
+    Na secção **Configuração**, clique no link <code className="action">Tag da transferência de saída</code>.
 
     <img className="thumbnail" alt="transferência de saída" src="/images/assets/screens/control-panel/product-selection/web-cloud/domain-dns/general-information/outgoing-transfer-tag.png" loading="lazy" />
   </Tab>

--- a/docs/pt/guides/web-cloud/web-hosting/copy-database.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/copy-database.mdx
@@ -94,7 +94,7 @@ Clique nos separadores abaixo para visualizar cada uma das **6** etapas.
 
     <img className="thumbnail" alt="Mensagem de confirmação copiar BDD" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png" loading="lazy" />
 
-    Se não pretender substituir a base de dados de destino escolhida, clique em <code className="action">Anterior</code> para alterar a sua escolha ou em <code className="action">Cancelar</code> para cancelar tudo. Caso contrário, clique em <code className="action">Confirmar</code> para confirmar a duplicação.
+    Se não pretender substituir a base de dados de destino escolhida, clique em <code className="action">Anterior</code> para alterar a sua escolha ou em <code className="action">Cancelar</code> para cancelar tudo. Caso contrário, clique em <code className="action">Validar</code> para confirmar a duplicação.
   </Tab>
   <Tab label="Etapa 6">
     A cópia pode demorar alguns minutos. No separador <code className="action">Operações em curso</code>, é apresentada uma nova linha para a cópia com um estado "planeado". Quando a operação for concluída, a linha desaparece.
@@ -147,7 +147,7 @@ Clique nos separadores abaixo para visualizar cada uma das **6** etapas.
 
     <img className="thumbnail" alt="Mensagem de confirmação copiar BDD" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png" loading="lazy" />
 
-    Se não pretender substituir a base de dados de destino escolhida, clique em <code className="action">Anterior</code> para alterar a sua escolha ou em <code className="action">Cancelar</code> para cancelar tudo. Caso contrário, clique em <code className="action">Confirmar</code> para confirmar a duplicação.
+    Se não pretender substituir a base de dados de destino escolhida, clique em <code className="action">Anterior</code> para alterar a sua escolha ou em <code className="action">Cancelar</code> para cancelar tudo. Caso contrário, clique em <code className="action">Validar</code> para confirmar a duplicação.
   </Tab>
   <Tab label="Etapa 6">
     A cópia pode demorar alguns minutos. No separador <code className="action">Operações em curso</code>, é apresentada uma nova linha para a cópia com um estado "planeado". Quando a operação for concluída, a linha desaparece.

--- a/docs/pt/guides/web-cloud/web-hosting/cron-tasks.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cron-tasks.mdx
@@ -90,7 +90,7 @@ Clique nos separadores abaixo para visualizar cada uma das **5** etapas.
     Clique em <code className="action">Seguinte</code>.
   </Tab>
   <Tab label="Etapa 5">
-    O resumo lembra-lhe os parâmetros configurados, incluindo a notação *crontab* da frequência de execução. Se tudo estiver correto, clique em <code className="action">Confirmar</code>.
+    O resumo lembra-lhe os parâmetros configurados, incluindo a notação *crontab* da frequência de execução. Se tudo estiver correto, clique em <code className="action">Validar</code>.
 
     <img className="thumbnail" alt="cron confirmation" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png" loading="lazy" />
 

--- a/docs/pt/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -98,7 +98,7 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
     <img className="thumbnail" alt="FTP - SSH" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh.png" loading="lazy" />
   </Tab>
   <Tab label="Etapa 3">
-    Um quadro apresenta os *utilizadores FTP* criados no seu alojamento web. Clique no botão <code className="action">...</code> à direita do utilizador FTP em questão e depois em <code className="action">Alterar palavra-passe</code>. Na nova janela, introduza a nova palavra-passe pretendida **seguindo a política de palavras-passe**, confirme introduzindo-a uma segunda vez e clique no botão <code className="action">Confirmar</code>.
+    Um quadro apresenta os *utilizadores FTP* criados no seu alojamento web. Clique no botão <code className="action">...</code> à direita do utilizador FTP em questão e depois em <code className="action">Alterar palavra-passe</code>. Na nova janela, introduza a nova palavra-passe pretendida **seguindo a política de palavras-passe**, confirme introduzindo-a uma segunda vez e clique no botão <code className="action">Validar</code>.
 
     <img className="thumbnail" alt="change-ftp-password-pro" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png" loading="lazy" />
   </Tab>

--- a/docs/pt/guides/web-cloud/web-hosting/resolve-anomalous-activity.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/resolve-anomalous-activity.mdx
@@ -92,7 +92,7 @@ Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
     Aceda à página <ManagerLink to="/#/web/hosting">Alojamentos</ManagerLink> e selecione o alojamento web em causa.
   </Tab>
   <Tab label="Etapa 2">
-    Uma **janela de alerta** aparece: `"Atividade anormal no seu alojamento"`. Se clicar no botão <code className="action">Mais tarde</code>, uma **bandeira de alerta** `"Atividade anormal detectada"` aparece no topo da página. Clique em <code className="action">Saiba mais</code> para reabrir a janela de alerta.
+    Uma **janela de alerta** aparece: `"Atividade anormal no seu alojamento"`. Se clicar no botão <code className="action">Mais tarde</code>, uma **bandeira de alerta** `"Atividade anormal detectada"` aparece no topo da página. Clique em <code className="action">Saber mais</code> para reabrir a janela de alerta.
   </Tab>
   <Tab label="Etapa 3">
     **Marque** a caixa: `Confirmo ter realizado todas as ações necessárias para resolver o problema`, depois clique em <code className="action">Levantar as medidas de segurança</code>.

--- a/docs/pt/guides/web-cloud/web-hosting/sql-overquota-database.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/sql-overquota-database.mdx
@@ -94,7 +94,7 @@ Tome nota do `Nome de utilizador` e do`Endereço do servidor` **da sua base de d
   <Tab label="Etapa 4">
     <img className="thumbnail" alt="phpMyAdmin Login interface" src="/images/assets/screens/other/web-tools/phpmyadmin/pma-interface-login.png" loading="lazy" />
 
-Introduza as informações de acesso à sua base de dados e depois clique em <code className="action">Entrada</code>.
+Introduza as informações de acesso à sua base de dados e depois clique em <code className="action">Iniciar sessão</code>.
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

Audit and correction of action-button labels (`<code className="action">`) located inside `<Tabs>` blocks across the Web Cloud guides, checked against the official OVHcloud Manager translations.

**Scope:** `docs/{locale}/guides/web-cloud/{databases,domains,web-hosting}` for all 6 non-default locales: **de, en, es, it, pl, pt**.

**Method:** each FR button was mapped to its Manager translation key, the expected per-locale label was read from the Manager repo, and compared against the label actually written in each locale's guide (position-aligned within the same file). The Manager is the source of truth.

## What changed

- Fixed all **severe "dashboard" mismatches** where the guide's button label did not match the Manager UI (wrong wording, untranslated English left in place, inconsistent casing/spacing).
- Aligned recurring buttons across locales (e.g. `Next` → `Continua`/`Kontynuuj`/`Weiter`, `Databases`/`Logs` tabs left untranslated, `Confirmer`/`Valider` swaps, phpMyAdmin login labels).
- 60 guide files updated across 4 commits (DE/EN/IT/PL, then PT, then ES).

## Out of scope (intentionally not changed)

- **Non-dashboard contexts** (phpMyAdmin, order/checkout tunnels) where the Manager translation does not apply.
- **Minor/trivial variants** (verb form, articles, singular/plural, punctuation) — flagged but not corrected.

## Notes

- No structural/JSX changes; only text inside `<code className="action">` tags was edited.
- IDE may show spurious `<Tabs>` JSX warnings on `.mdx` files (MDX parser limitation) — not introduced by this PR.
