### PR TITLE
fix(components): prevent explorer card arrow overlap on tablet/mobile

### DIFF
--- a/components/LinkCard/LinkCard.css
+++ b/components/LinkCard/LinkCard.css
@@ -55,6 +55,12 @@
   line-height: 1.4;
 }
 
+.link-card__title-text {
+  min-width: 0;
+  overflow-wrap: normal;
+  word-break: keep-all;
+}
+
 .link-card__arrow {
   flex-shrink: 0;
   color: #6696e7; /*var(--rp-c-brand);*/

--- a/components/LinkCard/LinkCard.tsx
+++ b/components/LinkCard/LinkCard.tsx
@@ -71,7 +71,7 @@ export function LinkCard({
       )}
       <div className="link-card__content">
         <h3 className="link-card__title">
-          {title}
+          <span className="link-card__title-text">{title}</span>
           <span className="link-card__arrow">→</span>
         </h3>
         {description && <p className="link-card__description">{description}</p>}

--- a/theme/components/HomeExplore/index.scss
+++ b/theme/components/HomeExplore/index.scss
@@ -38,11 +38,11 @@
       min-width: 0;
     }
 
-    @media (max-width: 768px) {
+    @media (max-width: 900px) {
       flex-wrap: wrap;
 
       > * {
-        flex: 1 1 calc(33.33% - 1rem);
+        flex: 1 1 calc(50% - 0.5rem);
       }
     }
 


### PR DESCRIPTION
Long card titles (e.g. "Hébergements web") forced the flex title row wider than the card, pushing the flex-shrink:0 arrow past the right edge into the neighbouring card. Wrap the title in a shrinkable span with min-width:0 so it can wrap instead of overflowing, and give the home explore rows a 2-column stage at tablet width instead of cramming three.

## Problem
On the docs home page, the "Explorer" cards showed a misplaced arrow overlapping the
neighbouring card at tablet width — reproducible in Firefox responsive mode with the
iPad 10th/11th Gen preset (820 px): "Hébergements web"'s arrow spilled into "E-mails".

## Root cause
Title + arrow share one flex <h3> (arrow flex-shrink:0). The title was a bare text node
(min-width:auto), so a long title forced the flex row wider than the card and pushed the
non-shrinking arrow past the right edge. Only surfaced at tablet width because the home
explore rows crammed 3 columns down to 480 px.

## Fix
- LinkCard.tsx: wrap title in `.link-card__title-text` span (shrinkable flex item)
- LinkCard.css: min-width:0 (the fix) + word-break:keep-all (no mid-word splits)
- HomeExplore/index.scss: rows drop to 2 columns at ≤900 px instead of cramming 3

## Verification
Measured arrow-edge vs card-edge across breakpoints. Before: +27 px past the edge at
820 px (overlap). After: −25 px inside at 1440/950/820/375. No mid-word splits.