### PR TITLE
docs(dedicated-servers): reword the Hyper-V network guide scope

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
 title: Netzwerk auf Windows Server 2016/2019 mit Hyper-V konfigurieren
 description: Erfahren Sie, wie Sie das Netzwerk auf Windows Server 2016 und 2019 mit Hyper-V konfigurieren, inklusive NIC Teaming, virtuellem Switch und Additional IP
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-11
 ---
 
 :::info
@@ -15,7 +15,7 @@ Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In 
 **Diese Anleitung erklärt, wie Sie das Netzwerk mit Hyper-V auf Windows Server 2016 und 2019 konfigurieren.**
 
 :::warning
-Diese Anleitung gilt ausschließlich für die **Hyper-V**-Images von **Windows Server 2016** und **Windows Server 2019**. Das hier beschriebene NIC Teaming basiert auf LBFO, dessen Verwendung mit einem virtuellen Hyper-V-Switch ab Windows Server 2022 veraltet ist.
+Diese Anleitung gilt ausschließlich für **Hyper-V** 2016 und 2019. Das hier beschriebene NIC Teaming basiert auf LBFO, dessen Verwendung mit einem virtuellen Hyper-V-Switch ab Windows Server 2022 veraltet ist.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
@@ -9,7 +9,7 @@ lastUpdated: 2026-08-06
 **This guide explains how to configure the network on Windows Server 2016 and 2019 with Hyper-V.**
 
 :::warning
-This guide only applies to the **Hyper-V** images for **Windows Server 2016** and **Windows Server 2019**. The NIC teaming it describes relies on LBFO, whose use with a Hyper-V virtual switch is deprecated from Windows Server 2022 onwards.
+This guide only applies to **Hyper-V** 2016 and 2019. The NIC teaming it describes relies on LBFO, whose use with a Hyper-V virtual switch is deprecated from Windows Server 2022 onwards.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring the network on Windows Server 2016/2019 with Hyper-V
 description: Find out how to configure the network on Windows Server 2016 and 2019 with Hyper-V, including NIC teaming, the virtual switch and Additional IPs
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-11
 ---
 
 ## Objective

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar la red en Windows Server 2016/2019 con Hyper-V
 description: Cómo configurar la red en Windows Server 2016 y 2019 con Hyper-V, incluidos el NIC Teaming, el switch virtual y las direcciones Additional IP
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-11
 ---
 
 :::info
@@ -15,7 +15,7 @@ Esta traducción ha sido generada de forma automática por nuestro partner SYSTR
 **Esta guía explica cómo configurar la red en Windows Server 2016 y 2019 con Hyper-V.**
 
 :::warning
-Esta guía solo se aplica a las imágenes **Hyper-V** de **Windows Server 2016** y **Windows Server 2019**. El NIC Teaming que describe se basa en LBFO, cuyo uso con un switch virtual de Hyper-V está obsoleto a partir de Windows Server 2022.
+Esta guía solo se aplica a **Hyper-V** 2016 y 2019. El NIC Teaming que describe se basa en LBFO, cuyo uso con un switch virtual de Hyper-V está obsoleto a partir de Windows Server 2022.
 
 :::
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer le réseau sur Windows Server 2016/2019 avec Hyper-V
 description: Découvrez comment configurer le réseau sur Windows Server 2016 et 2019 avec Hyper-V, dont le NIC Teaming, le switch virtuel et les adresses Additional IP
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-11
 ---
 
 ## Objectif
@@ -9,7 +9,7 @@ lastUpdated: 2026-08-06
 **Ce guide explique comment configurer le réseau sur Windows Server 2016 et 2019 avec Hyper-V.**
 
 :::warning
-Ce guide s'applique uniquement aux images **Hyper-V** de **Windows Server 2016** et **Windows Server 2019**. Le NIC Teaming qu'il décrit repose sur LBFO, dont l'utilisation avec un switch virtuel Hyper-V est obsolète à partir de Windows Server 2022.
+Ce guide s'applique uniquement à **Hyper-V** 2016 et 2019. Le NIC Teaming qu'il décrit repose sur LBFO, dont l'utilisation avec un switch virtuel Hyper-V est obsolète à partir de Windows Server 2022.
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurare la rete su Windows Server 2016/2019 con Hyper-V
 description: Come configurare la rete su Windows Server 2016 e 2019 con Hyper-V, compresi il NIC Teaming, lo switch virtuale e gli indirizzi Additional IP
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-11
 ---
 
 :::info
@@ -15,7 +15,7 @@ Questa traduzione è stata generata automaticamente dal nostro partner SYSTRAN. 
 **Questa guida ti mostra come configurare la rete su Windows Server 2016 e 2019 con Hyper-V.**
 
 :::warning
-Questa guida si applica esclusivamente alle immagini **Hyper-V** di **Windows Server 2016** e **Windows Server 2019**. Il NIC Teaming descritto si basa su LBFO, il cui utilizzo con uno switch virtuale Hyper-V è obsoleto a partire da Windows Server 2022.
+Questa guida si applica esclusivamente a **Hyper-V** 2016 e 2019. Il NIC Teaming descritto si basa su LBFO, il cui utilizzo con uno switch virtuale Hyper-V è obsoleto a partire da Windows Server 2022.
 
 :::
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja sieci w systemie Windows Server 2016/2019 z Hyper-V
 description: Dowiedz się, jak skonfigurować sieć w systemie Windows Server 2016 i 2019 z Hyper-V, w tym NIC Teaming, wirtualny switch i adresy Additional IP
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-11
 ---
 
 :::info
@@ -15,7 +15,7 @@ Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera S
 **Ten przewodnik wyjaśnia, jak skonfigurować sieć w systemie Windows Server 2016 i 2019 przy użyciu Hyper-V.**
 
 :::warning
-Ten przewodnik dotyczy wyłącznie obrazów **Hyper-V** dla systemów **Windows Server 2016** i **Windows Server 2019**. Opisany w nim NIC Teaming opiera się na LBFO, którego użycie z wirtualnym switchem Hyper-V jest przestarzałe począwszy od systemu Windows Server 2022.
+Ten przewodnik dotyczy wyłącznie **Hyper-V** 2016 i 2019. Opisany w nim NIC Teaming opiera się na LBFO, którego użycie z wirtualnym switchem Hyper-V jest przestarzałe począwszy od systemu Windows Server 2022.
 
 :::
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/hyperv-network-hg-scale.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar a rede em Windows Server 2016/2019 com Hyper-V
 description: Descubra como configurar a rede no Windows Server 2016 e 2019 com Hyper-V, incluindo o NIC Teaming, o switch virtual e os endereços Additional IP
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-11
 ---
 
 :::info
@@ -15,7 +15,7 @@ Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certo
 **Este guia explica como configurar a rede em Windows Server 2016 e 2019 com Hyper-V.**
 
 :::warning
-Este guia aplica-se exclusivamente às imagens **Hyper-V** do **Windows Server 2016** e do **Windows Server 2019**. O NIC Teaming aqui descrito baseia-se em LBFO, cuja utilização com um switch virtual Hyper-V está obsoleta a partir do Windows Server 2022.
+Este guia aplica-se exclusivamente ao **Hyper-V** 2016 e 2019. O NIC Teaming aqui descrito baseia-se em LBFO, cuja utilização com um switch virtual Hyper-V está obsoleta a partir do Windows Server 2022.
 
 :::
 


### PR DESCRIPTION
"The Hyper-V images" read as the OVHcloud templates only, whereas the guide applies to Hyper-V 2016 and 2019 however Hyper-V was installed.