### PR TITLE
docs: migrate legacy support disclaimers to the support-scope fragment

### DIFF
--- a/docs/de/guides/web-cloud/domains/_transfer-incoming-o2switch.mdx
+++ b/docs/de/guides/web-cloud/domains/_transfer-incoming-o2switch.mdx
@@ -32,11 +32,7 @@ Wenn auch der **Inhaber des Domainnamens** geändert werden muss, sollte dies er
 - Sie besitzen die Verfügungsberechtigung, um den Transfer des Domainnamens zu veranlassen.
 - Der Domaininhaber und/oder dessen Administratoren sind über den Transfer informiert.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihren aktuellen Registrar zu kontaktieren. Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## In der praktischen Anwendung
 

--- a/docs/de/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -11,12 +11,7 @@ Der Eintrag **D**omain-based **M**essage **A**uthentication, **R**eporting, and 
 
 **Diese Anleitung erklärt, wie DMARC funktioniert und wie Sie es für Ihren E-Mail-Dienst einrichten.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](/links/partner) oder stellen Ihre Fragen in der OVHcloud Community. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/de/guides/web-cloud/domains/domain-icloud.mdx
@@ -5,11 +5,7 @@ lastUpdated: 2025-08-27
 availableIn: [eu, ca, apac]
 ---
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Objective
 

--- a/docs/de/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
+++ b/docs/de/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
@@ -13,11 +13,12 @@ Sie sind Inhaber eines Domainnamens bei OVHcloud und möchten diesen mit einem G
 
 **Erfahren Sie hier, wie Sie Ihren OVHcloud Domainnamen mit einem GoDaddy Hosting verbinden.**
 
-:::warning
-- Der GoDaddy Support hat keinen Zugriff auf die Einstellungen Ihrer OVHcloud Domainnamen und kann Sie deshalb nicht diesbezüglich beraten.
-- OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.<br/><br/> Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) und/oder den Herausgeber der verwendeten Software zu kontaktieren, falls Sie auf Schwierigkeiten stoßen. Leider können wir Ihnen keine weitergehende technische Unterstützung hierzu anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+[[fragment:support-scope]]
 
+:::warning
+Der GoDaddy Support hat keinen Zugriff auf die Einstellungen Ihrer OVHcloud Domainnamen und kann Sie deshalb nicht diesbezüglich beraten.
 :::
+
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
+++ b/docs/de/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
@@ -13,11 +13,12 @@ Sie sind Inhaber eines Domainnamens bei OVHcloud und möchten diesen mit einer G
 
 **Erfahren Sie hier, wie Sie Ihren OVHcloud Domainnamen mit einer Google Site verbinden.**
 
-:::warning
-- Der Google Sites Support hat keinen Zugriff auf die Einstellungen Ihrer OVHcloud Domainnamen und kann Sie deshalb nicht diesbezüglich beraten.
-- OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.<br/><br/> Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) und/oder den Herausgeber der verwendeten Software zu kontaktieren, falls Sie auf Schwierigkeiten stoßen. Leider können wir Ihnen keine weitergehende technische Unterstützung hierzu anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+[[fragment:support-scope]]
 
+:::warning
+Der Google Sites Support hat keinen Zugriff auf die Einstellungen Ihrer OVHcloud Domainnamen und kann Sie deshalb nicht diesbezüglich beraten.
 :::
+
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
+++ b/docs/de/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
@@ -13,12 +13,12 @@ Sie sind Inhaber eines Domainnamens bei OVHcloud und möchten diesen mit einem S
 
 **Erfahren Sie hier, wie Sie Ihren OVHcloud Domainnamen mit einem Shopify Hosting verbinden.**
 
+[[fragment:support-scope]]
+
 :::warning
-- Der Shopify Support hat keinen Zugriff auf die Einstellungen Ihrer OVHcloud Domainnamen und kann Sie deshalb nicht diesbezüglich beraten.
-
-- OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.<br/><br/> Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) und/oder den Herausgeber der verwendeten Software zu kontaktieren, falls Sie auf Schwierigkeiten stoßen. Leider können wir Ihnen keine weitergehende technische Unterstützung hierzu anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
+Der Shopify Support hat keinen Zugriff auf die Einstellungen Ihrer OVHcloud Domainnamen und kann Sie deshalb nicht diesbezüglich beraten.
 :::
+
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
+++ b/docs/de/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
@@ -13,12 +13,12 @@ Sie sind Inhaber eines Domainnamens bei OVHcloud und möchten diesen mit einem S
 
 **Erfahren Sie hier, wie Sie Ihren OVHcloud Domainnamen mit einem SquareSpace Hosting verbinden.**
 
+[[fragment:support-scope]]
+
 :::warning
-- Der SquareSpace Support hat keinen Zugriff auf die Einstellungen Ihrer OVHcloud Domainnamen und kann Sie deshalb nicht diesbezüglich beraten.
-
-- OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.<br/><br/> Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) und/oder den Herausgeber der verwendeten Software zu kontaktieren, falls Sie auf Schwierigkeiten stoßen. Leider können wir Ihnen keine weitergehende technische Unterstützung hierzu anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
+Der SquareSpace Support hat keinen Zugriff auf die Einstellungen Ihrer OVHcloud Domainnamen und kann Sie deshalb nicht diesbezüglich beraten.
 :::
+
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
+++ b/docs/de/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
@@ -13,11 +13,12 @@ Sie sind Inhaber eines Domainnamens bei OVHcloud und möchten diesen mit einem W
 
 **Erfahren Sie hier, wie Sie Ihren OVHcloud Domainnamen mit einem Webflow Hosting verbinden.**
 
-:::warning
-- Der Webflow Support hat keinen Zugriff auf die Einstellungen Ihrer OVHcloud Domainnamen und kann Sie deshalb nicht diesbezüglich beraten.
-- OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.<br/><br/> Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) und/oder den Herausgeber der verwendeten Software zu kontaktieren, falls Sie auf Schwierigkeiten stoßen. Leider können wir Ihnen keine weitergehende technische Unterstützung hierzu anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+[[fragment:support-scope]]
 
+:::warning
+Der Webflow Support hat keinen Zugriff auf die Einstellungen Ihrer OVHcloud Domainnamen und kann Sie deshalb nicht diesbezüglich beraten.
 :::
+
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
+++ b/docs/de/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
@@ -13,12 +13,12 @@ Sie sind Inhaber eines Domainnamens bei OVHcloud und möchten diesen mit einem W
 
 **Erfahren Sie hier, wie Sie Ihren OVHcloud Domainnamen mit einem Wix Hosting verbinden.**
 
+[[fragment:support-scope]]
+
 :::warning
-- Der Wix Support hat keinen Zugriff auf die Einstellungen Ihrer OVHcloud Domainnamen und kann Sie deshalb nicht diesbezüglich beraten.
-
-- OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.<br/><br/> Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) und/oder den Herausgeber der verwendeten Software zu kontaktieren, falls Sie auf Schwierigkeiten stoßen. Leider können wir Ihnen keine weitergehende technische Unterstützung hierzu anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
+Der Wix Support hat keinen Zugriff auf die Einstellungen Ihrer OVHcloud Domainnamen und kann Sie deshalb nicht diesbezüglich beraten.
 :::
+
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/domains/redirect-domain-name.mdx
+++ b/docs/de/guides/web-cloud/domains/redirect-domain-name.mdx
@@ -317,12 +317,7 @@ Klicken Sie auf <code className="action">Bestätigen</code>, um Ihre Konfigurati
 
 ### Einen Domainnamen über eine ".htaccess"-Datei weiterleiten <a name="htaccess_rewrite"></a>
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren, wenn Sie Schwierigkeiten haben. Wir werden Ihnen bei den unten dokumentierten Schritten keine weitergehende Unterstützung anbieten können. Weitere Informationen finden Sie im Abschnitt [Weiterführende Informationen](#go-further) dieser Anleitung.
-
-:::
+[[fragment:support-scope]]
 
 ".htaccess"-Dateien sind Konfigurationsdateien, in denen Befehle angegeben werden können. Wenn der Webserver (Apache) den Code Ihrer Website ausführt, werden die Befehle interpretiert und ausgeführt.
 

--- a/docs/de/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/de/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -9,12 +9,7 @@ availableIn: [eu, ca, apac]
 
 Für den Transfer einer .uk-Domainname (oder einer ähnlichen Domainname) ist ein spezifischer Vorgang erforderlich.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-:::
+[[fragment:support-scope]]
 
 **In dieser Anleitung erfahren Sie, wie Sie .uk-Domainnamen zu OVHcloud transferieren.**
 

--- a/docs/de/guides/web-cloud/domains/transfer-incoming-gandi.mdx
+++ b/docs/de/guides/web-cloud/domains/transfer-incoming-gandi.mdx
@@ -40,11 +40,7 @@ Es ist daher wichtig, dass Sie Ihre Inhalte sichern, bevor Sie mit dem Transfer 
 - Sie besitzen die Verfügungsberechtigung, um den Transfer des Domainnamens zu veranlassen.
 - Der Domaininhaber und/oder dessen Administratoren sind über den Transfer informiert.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihren aktuellen Registrar zu kontaktieren. Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## In der praktischen Anwendung
 

--- a/docs/de/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
+++ b/docs/de/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
@@ -32,11 +32,7 @@ Wenn auch der **Inhaber des Domainnamens** geändert werden muss, sollte dies er
 - Sie besitzen die Verfügungsberechtigung, um den Transfer des Domainnamens zu veranlassen.
 - Der Domaininhaber und/oder dessen Administratoren sind über den Transfer informiert.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihren aktuellen Registrar zu kontaktieren. Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## In der praktischen Anwendung
 

--- a/docs/de/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
+++ b/docs/de/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
@@ -32,11 +32,7 @@ Wenn auch der **Inhaber des Domainnamens** geändert werden muss, sollte dies er
 - Sie besitzen die Verfügungsberechtigung, um den Transfer des Domainnamens zu veranlassen.
 - Der Domaininhaber und/oder dessen Administratoren sind über den Transfer informiert.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihren aktuellen Registrar zu kontaktieren. Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## In der praktischen Anwendung
 

--- a/docs/de/guides/web-cloud/domains/transfer-incoming-ionos.mdx
+++ b/docs/de/guides/web-cloud/domains/transfer-incoming-ionos.mdx
@@ -32,11 +32,7 @@ Wenn auch der **Inhaber des Domainnamens** geändert werden muss, sollte dies er
 - Sie besitzen die Verfügungsberechtigung, um den Transfer des Domainnamens zu veranlassen.
 - Der Domaininhaber und/oder dessen Administratoren sind über den Transfer informiert.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihren aktuellen Registrar zu kontaktieren. Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## In der praktischen Anwendung
 

--- a/docs/de/guides/web-cloud/domains/transfer-incoming-wix.mdx
+++ b/docs/de/guides/web-cloud/domains/transfer-incoming-wix.mdx
@@ -32,11 +32,7 @@ Wenn auch der **Inhaber des Domainnamens** geändert werden muss, sollte dies er
 - Sie besitzen die Verfügungsberechtigung, um den Transfer des Domainnamens zu veranlassen.
 - Der Domaininhaber und/oder dessen Administratoren sind über den Transfer informiert.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihren aktuellen Registrar zu kontaktieren. Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## In der praktischen Anwendung
 

--- a/docs/de/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -14,12 +14,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 **Diese Anleitung erklärt, wie Sie Ihr 1-Klick-Modul über Ihr OVHcloud Kundencenter verwalten.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -9,13 +9,10 @@ availableIn: [eu, ca, apac]
 
 Dieses Tutorial hilft Ihnen Schritt für Schritt bei der manuellen Installation des Content Management System (CMS) Drupal.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den [Herausgeber von Drupal](https://www.drupal.org/support) zu kontaktieren. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-Wenn Sie ein vorhandenes Drupal CMS aktualisieren möchten oder Fragen zur Verwendung von Drupal haben, wenden Sie sich direkt an [den Herausgeber des Drupal CMS](https://www.drupal.org/support).
-
+Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den [Herausgeber von Drupal](https://www.drupal.org/support) zu kontaktieren. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 :::tip

--- a/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Hier finden Sie alle Elemente, um das Content Management System (CMS) Joomla! in wenigen Schritten manuell zu installieren.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den [Herausgeber von Joomla!](https://www.joomla.org/) zu kontaktieren. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
+Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den [Herausgeber von Joomla!](https://www.joomla.org/) zu kontaktieren. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 :::tip

--- a/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Hier finden Sie alle Elemente, um das Content Management System (CMS) PrestaShop in wenigen Schritten manuell zu installieren.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den [Herausgeber von PrestaShop](https://www.prestashop.com/en/support) zu kontaktieren. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
+Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den [Herausgeber von PrestaShop](https://www.prestashop.com/en/support) zu kontaktieren. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 :::tip

--- a/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Dieses Tutorial hilft Ihnen Schritt für Schritt bei der manuellen Installation eines WordPress CMS (Content Management System).
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
+Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 :::tip

--- a/docs/de/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -12,22 +12,10 @@ import { Region } from '@components/Zone';
 
 Dieses Tutorial hilft Ihnen Schritt für Schritt bei der manuellen Installation eines CMS (Content Management System) auf Ihrem Webhosting.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den Herausgeber des CMS zu kontaktieren. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-Um die verschiedenen Herausgeber der oben genannten CMS zu kontaktieren, finden Sie hier die Links zu ihren offiziellen Seiten:
-
-- [WordPress](https://wordpress.com/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-- [Pico](https://picocms.org/)
-- [Grav](https://getgrav.org/)
-- [Typo3](https://typo3.com/)
-- [SPIP](https://www.spip.net/en_rubrique25.html)
-
+Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den Herausgeber des CMS zu kontaktieren. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 :::tip

--- a/docs/de/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -37,18 +37,10 @@ Es gibt mehrere Möglichkeiten, das Administratorpasswort Ihres CMS anzupassen:
 - [Verwaltungsinterface Ihres CMS](#via-cms)
 - [phpMyAdmin in Ihrem OVHcloud Kundencenter](#via-phpmyadmin)
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Wir stellen Ihnen dieses Tutorial zur Verfügung, um Ihnen bei der Bewältigung genereller Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) oder den Herausgeber des CMS zu kontaktieren, wenn Sie bei der Administration Ihrer Dienste Hilfe benötigen. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-Um den Herausgeber eines der oben genannten CMS zu kontaktieren, finden Sie hier die Links zu deren offiziellen Seiten:
-
-- [WordPress](https://wordpress.com/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-
+Wir stellen Ihnen dieses Tutorial zur Verfügung, um Ihnen bei der Bewältigung genereller Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) oder den Herausgeber des CMS zu kontaktieren, wenn Sie bei der Administration Ihrer Dienste Hilfe benötigen.
 :::
 
 ### Administratorpasswort per automatischer E-Mail ändern ("Passwort vergessen") <a name="via-email"></a>

--- a/docs/de/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
@@ -19,12 +19,7 @@ Ein Hack kann diverse Folgen haben (nicht erschöpfende Liste):
 
 **Dieses Tutorial erklärt, wie Sie Ihre gehackte Website wiederherstellen können.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/composer-install-composer.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/composer-install-composer.mdx
@@ -11,11 +11,7 @@ availableIn: [eu, ca, apac]
 
 **Diese Anleitung erklärt, wie Sie Composer installieren und gibt ein Anwendungsbeispiel.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/configure-ipv6.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/configure-ipv6.mdx
@@ -39,12 +39,7 @@ Unsere Webhostings sind seit 2011 mit IPv6 kompatibel, doch die Aktivierung dies
 
 ## In der praktischen Anwendung
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Wir empfehlen Ihnen jedoch, bei Schwierigkeiten einen [spezialisierten Dienstleister](/links/partner) oder den Herausgeber des Dienstes zu kontaktieren. Für externe Dienstleistungen bieten wir leider keine Unterstützung. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-:::
+[[fragment:support-scope]]
 
 Wenn Ihre Website nicht bereits mit IPv6 funktioniert, können Sie die [IPv6-Adresse Ihres OVHcloud Webhostings](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip) der aktiven DNS-Zone Ihres Domainnamens hinzufügen. Ziel ist es, dass Webbrowser eine IPv6-Adresse finden, die mit Ihrer Website über Ihren Domainnamen verknüpft ist.
 

--- a/docs/de/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
@@ -9,11 +9,7 @@ availableIn: [eu]
 
 Hier erfahren Sie, wie Sie die Homepage einer Website mit *Kostenloses Hosting* erstellen, das Sie kostenlos zu einem Domainnamen bei OVHcloud erhalten.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/cron-tasks.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cron-tasks.mdx
@@ -13,10 +13,10 @@ Auf Ihrem OVHcloud Webhosting können Sie Skripte verwenden, um bestimmte Operat
 
 **Hier erfahren Sie, wie Sie CRON-Tasks erstellen, um Ihre geplanten Tasks auf einem Webhosting zu automatisieren.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
+[[fragment:support-scope]]
 
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+:::warning
+Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 ## Voraussetzungen

--- a/docs/de/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
@@ -13,11 +13,7 @@ Bei der Nutzung von Datenbanken können Unregelmäßigkeiten auftreten. Fehler b
 
 **Diese Anleitung erklärt, wie Sie Fehler bei der Verwendung von Datenbanken mit OVHcloud Webhostings beheben können.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie im Abschnitt [Weiterführende Informationen](#go-further) dieser Anleitung.
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -33,11 +33,10 @@ Mit der automatisierten Sperrung werden Sie auch vor möglichen rechtlichen Kons
 
 **Diese Anleitung erklärt, wie Sie im Fall einer Anzeige von “403 forbidden“ den Zugang zu Ihrer Seite entsperren.**
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [OVHcloud Community](/links/community) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
+Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [OVHcloud Community](/links/community) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 ## Voraussetzungen

--- a/docs/de/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -12,13 +12,7 @@ Wenn diese jedoch nicht korrekt konfiguriert sind, kann die Installation des 1-K
 
 **Diese Anleitung erklärt, wie Sie die häufigsten Fehler bei der Erstellung eines 1-Klick-Moduls diagnostizieren**
 
-
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den Herausgeber des Dienstes zu kontaktieren. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
@@ -15,11 +15,10 @@ Diese Fehler können auch durch Updates entstehen, die **automatisch** von Kompo
 
 **Diese Anleitung erklärt, wie Sie die häufigsten "Fehler 500" diagnostizieren.**
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
 Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](/links/partner) und/oder stellen Ihre Fragen in der [OVHcloud Community](/links/community) (Englisch). Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
-
 :::
 
 ## Voraussetzungen

--- a/docs/de/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
@@ -16,13 +16,7 @@ Eine **Index of**-Seite erscheint in mindestens einem der folgenden Fälle:
 
 **Diese Anleitung erklärt, wie Sie die Anzeige einer "Index of"-Seite korrigieren.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-:::
-
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
@@ -20,11 +20,7 @@ Es können verschiedene Fehlermeldungen auftreten, wenn Ihre Website nicht errei
 
 **Diese Anleitung erklärt, wie Sie Fehler der Art "Keine sichere Verbindung" beheben.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -52,11 +52,10 @@ Darüber hinaus wird die Performance der Hosting-Infrastruktur von OVHcloud perm
 
 ## In der praktischen Anwendung
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten, sofern die **Ausfälle nicht auf Ebene der Hosting-Infrastruktur verursacht werden**. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
+Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten, sofern die **Ausfälle nicht auf Ebene der Hosting-Infrastruktur verursacht werden**.
 :::
 
 :::tip

--- a/docs/de/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
@@ -20,11 +20,7 @@ Wenn Ihre Website nicht erreichbar ist, können in Ihrem Browser mehrere Fehlerm
 
 **Diese Anleitung erklärt, wie Sie Fehler der Art "Website nicht erreichbar" beheben.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -18,11 +18,7 @@ Dieser Zugang erlaubt unter anderem [Ihre Website online zu stellen](/guides/web
 
 **Diese Anleitung erklärt, wie Sie das Passwort eines auf Ihrem OVHcloud Webhosting erstellten FTP-Benutzers ändern.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
@@ -19,11 +19,7 @@ Um Cyberduck herunterzuladen, gehen Sie auf die [offizielle Website](https://cyb
 
 :::
 
-:::warning
-OVHcloud stellt Ihnen Dienste zur Verfügung, für deren Konfiguration, Verwaltung und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit in Ihrer Verantwortung, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Sie bei gängigen Aufgaben bestmöglich zu begleiten. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) und/oder den Herausgeber des Dienstes zu kontaktieren. Für externe Dienstleistungen bieten wir leider keine Unterstützung. Weitere Informationen finden Sie im Abschnitt [Weiterführende Informationen](#go-further) dieser Anleitung.
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
@@ -13,12 +13,7 @@ Die Verwendung von FTP-Software beim Login auf Ihr [Hosting-Pakete](/links/web/h
 
 **Diese Anleitung erklärt, wie Sie gängige Fehler im Zusammenhang mit FTP-Programmen beheben.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -35,10 +35,10 @@ Wenn Sie Ihre Website ohne Visual Studio Code verwalten möchten, können Sie de
 
 ## In der praktischen Anwendung
 
-:::warning
-OVHcloud stellt Ihnen Dienste zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit in Ihrer Verantwortung, sicherzustellen, dass diese ordnungsgemäß funktionieren.
+[[fragment:support-scope]]
 
-Wir stellen Ihnen dieses Tutorial zur Verfügung, um Sie bestmöglich bei gängigen Aufgaben zu begleiten. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Anbieter](/links/partner) oder den Herausgeber von [Visual Studio Code IDE](https://code.visualstudio.com/) zu kontaktieren. Für externe Dienstleistungen bieten wir leider keine Unterstützung. Weitere Informationen finden Sie im Abschnitt [„Weiterführende Informationen“](#go-further) dieser Anleitung.
+:::warning
+Wir stellen Ihnen dieses Tutorial zur Verfügung, um Sie bestmöglich bei gängigen Aufgaben zu begleiten. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Anbieter](/links/partner) oder den Herausgeber von [Visual Studio Code IDE](https://code.visualstudio.com/) zu kontaktieren. Für externe Dienstleistungen bieten wir leider keine Unterstützung.
 :::
 
 ### SFTP-Erweiterung für Visual Studio Code installieren

--- a/docs/de/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
@@ -53,13 +53,7 @@ Nachdem Sie eine der Möglichkeiten ausgewählt haben, ergeben sich die folgende
 - **Sie möchten keine 1-Klick-Module verwenden**: Stellen Sie Ihre Website manuell auf Ihrem Hosting online. In dieser Anleitung geben wir Ihnen einige Informationen, die Ihnen hierbei helfen. Sie ersetzen jedoch nicht die Unterstützung eines Webmasters.
  
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) und/oder den Herausgeber des Dienstes zu kontaktieren. Für externe Dienstleistungen bietet OVHcloud leider keine Unterstützung. Genauere Informationen finden Sie im Teil „Weiterführende Informationen" dieser Anleitung.
-
-:::
-
+[[fragment:support-scope]]
 
 ### 2 - Websitedateien im Speicherplatz online stellen
 

--- a/docs/de/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
@@ -12,12 +12,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 In dieser Anleitung werden die verschiedenen Aktionen beschrieben, die notwendig sind, um Ihre gesamte Website, Domainnamen und E-Mail-Adressen ohne Dienstunterbrechung zu OVHcloud zu migrieren.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
@@ -30,12 +30,7 @@ Die OVHcloud Webhosting-Angebote basieren auf einer geteilten Infrastruktur (*sh
 
 ## In der praktischen Anwendung
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den Herausgeber der verwendeten Software zu kontaktieren, falls Sie auf Schwierigkeiten stoßen. Leider können wir Ihnen keine weitergehende technische Unterstützung hierzu anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-:::
+[[fragment:support-scope]]
 
 ### FTP
 

--- a/docs/de/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -12,10 +12,10 @@ Die regelmäßige Sicherung Ihrer Website ist eine gute Vorgehensweise. So könn
 
 Sie sind für Backups von auf Webhostings gehosteten Websites alleine verantwortlich. Neben den von OVHcloud automatisch erzeugten Backups (nicht garantiert) empfehlen wir, eigene Sicherungen regelmäßig anzulegen und mithilfe geeigneter Backup-Medien (Festplatte, USB-Laufwerk etc.) zu verwalten.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
+[[fragment:support-scope]]
 
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+:::warning
+Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 **Dieses Tutorial erklärt, wie Sie Ihre WordPress Website und deren Datenbank sichern.**

--- a/docs/de/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -13,13 +13,7 @@ In diesem Tutorial erklären wir Ihnen die wichtigsten Schritte, die Sie bei der
 
 **Diese Anleitung erklärt, wie Sie eine Website auf einen neuen Domainnamen umstellen.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-:::
-
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -15,11 +15,7 @@ Sie können mehrere ".htaccess"-Dateien in [FTP-Bereich](/guides/web-cloud/web-h
 
 **Diese Anleitung erklärt, wie Sie den Zugang zu Ihrer Seite für bestimmte IP-Adressen über eine ".htaccess"-Datei blockieren.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -11,10 +11,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 In dieser Anleitung erfahren Sie, wie Sie bestimmte Funktionen Ihres Webhostings mit **.htaccess**-Dateien konfigurieren, insbesondere um die Einstellungen Ihrer Website teilweise oder vollständig zu ändern (Weiterleitungen, Zugangsbeschränkungen, Datei-Berechtigungen, Cache-Kontrolle etc.).
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
+[[fragment:support-scope]]
 
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+:::warning
+Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 **Dieses Tutorial erklärt, wie Sie Ihr WordPress mit .htaccess-Dateien absichern.**

--- a/docs/de/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
@@ -14,13 +14,7 @@ Verwenden Sie hierzu zwei Apache-Konfigurationsdateien (HTTP), die im [FTP-Berei
 - "**.htaccess**": Weitere Informationen zu den Funktionen dieser Datei finden Sie in unserem Tutorial zu den möglichen [Operationen mit einer .htaccess Datei](/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do).
 - "**.htpasswd**": Als Ergänzung zu dieser Anleitung finden Sie mehr Informationen in der [offiziellen Apache Dokumentation](https://httpd.apache.org/docs/2.4/en/programs/htpasswd.html) zu dieser Datei.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-Die folgenden Beispiele sind in eine ".htaccess" Datei oder eine ".htpasswd" Datei einzufügen. Achtung, die Regeln, die Sie in diesen Dateien festlegen, haben direkte Auswirkungen auf Ihre Website. Überprüfen Sie systematisch die Regeln, die Sie hinzufügen, bevor Sie sie auf Ihrer Website anwenden. 
-:::
+[[fragment:support-scope]]
 
 **Diese Anleitung erklärt, wie Sie ein Verzeichnis oder den Zugang zum Adminbereich Ihrer Website durch Authentifizierung mit den Dateien ".htaccess" und ".htpasswd" schützen.**
 

--- a/docs/de/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -33,14 +33,7 @@ Wenn Sie Ihr Wissen über die Verwendung von Apache "**mod_rewrite**" vertiefen 
 
 ## In der praktischen Anwendung
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-Die nachfolgenden Code-Beispiele werden in einer ".htaccess"-Datei implementiert. Achtung: Die Regeln, die Sie in dieser Datei festlegen, haben direkte Auswirkungen auf Ihre Website. Überprüfen Sie Ihre Regeln deshalb systematisch, bevor Sie sie auf Ihre Website anwenden.
-
-:::
+[[fragment:support-scope]]
 
 Die Datei ".htaccess", in der Apache "**mod_rewrite**" konfiguriert wird, kann in mehreren Ordnern abgelegt werden. Beachten Sie aber unbedingt die Regel, dass nur **eine einzige** ".htaccess"-Datei pro Ordner oder Unterordner vorhanden sein darf.
 

--- a/docs/de/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
@@ -19,13 +19,7 @@ Um die Datei ".htaccess" korrekt zu verwenden müssen Sie folgende Regeln kennen
 - Die Datei ".htaccess" ist für Besucher Ihrer Website unsichtbar.
 - Die in einer ".htaccess" Datei befindlichen Regeln gelten für das gesamte Verzeichnis, in dem die ".htaccess" Datei liegt, sowie für alle Unterverzeichnisse desselben Verzeichnisses.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Wenn Sie Schwierigkeiten haben, die Schritte in diesem Tutorial durchzuführen, empfehlen wir, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-Die folgenden Beispiele sind in eine ".htaccess" Datei einzufügen. Achtung, die Regeln, die Sie in dieser Datei festlegen, haben direkte Auswirkungen auf Ihre Website. Überprüfen Sie systematisch die Regeln, die Sie hinzufügen, bevor Sie sie auf Ihre Website anwenden. 
-:::
+[[fragment:support-scope]]
 
 **Dieses Tutorial erklärt die wichtigsten Operationen, die mithilfe einer ".htaccess" Datei durchgeführt werden können.**
 

--- a/docs/de/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -259,11 +259,7 @@ Unser Anti-Spam-Dienst wird die Situation analysieren und unser Support kann Ihn
 
 ### Versand von E-Mails mit einem "SMTP" Skript <a name="SMTP"></a>
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Jedoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren, falls Sie Schwierigkeiten haben. Leider können wir Ihnen keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 Wir empfehlen Ihnen dringend, die "mail()"-Funktion von PHP bevorzugt zu nutzen. Ein Webhosting erlaubt es Ihnen jedoch, E-Mails über ein Skript mit SMTP (Simple Mail Transfer Protocol) zu versenden. Die Gesamtgröße Ihrer E-Mail darf nicht größer sein als **10 MB** (d.h. **7-8 MB ohne Kapselung**).
 

--- a/docs/de/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -23,10 +23,10 @@ MainWP offers several extensions for backing up your websites.
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/de/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -16,10 +16,10 @@ Retaining customers is vital to your company's development. Whether you have one
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard. For more information, please read our guide on [Managing multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general).
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/de/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -26,10 +26,10 @@ In this guide, we have chosen the MainWP plugin. Other similar solutions exist, 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, in the `Web Cloud` section.
 - Access to the WordPress administration interface.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/de/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -16,10 +16,10 @@ Maintaining the security of your websites is crucial for the development of your
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/de/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
@@ -20,10 +20,10 @@ Ihre Website entwickelt sich weiter, und der Ressourcenverbrauch wird immer stä
 
 ## In der praktischen Anwendung
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
+[[fragment:support-scope]]
 
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+:::warning
+Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 ### Schritt 1 - Sicherung der Dateien und der Datenbank Ihrer Website <a name="step1"></a>

--- a/docs/de/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 In dieser Anleitung erfahren Sie Schritt für Schritt, wie Sie Ihre WordPress Website und alle zugehörigen Dienste zu OVHcloud migrieren.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
+[[fragment:support-scope]]
 
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+:::warning
+Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 **Diese Anleitung erklärt, wie Sie Ihre WordPress Website und zugehörige Dienste zu OVHcloud migrieren.**

--- a/docs/de/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 In dieser Anleitung erfahren Sie Schritt für Schritt, wie Sie Ihre Xara Website und alle zugehörigen Dienste zu OVHcloud migrieren.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
+[[fragment:support-scope]]
 
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder die [offizielle Website von Xara Web Designer](https://www.xara.com/de/webdesigner-plus/) zu besuchen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+:::warning
+Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder die [offizielle Website von Xara Web Designer](https://www.xara.com/de/webdesigner-plus/) zu besuchen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 **Diese Anleitung erklärt, wie Sie Ihre Xara Website und zugehörige Dienste zu OVHcloud migrieren.**

--- a/docs/de/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
@@ -16,11 +16,10 @@ Möglicherweise wird in Ihrem Webbrowser die Fehlerseite "**Seite nicht installi
 
 **Diese Anleitung erklärt, wie Sie den Fehler "Seite nicht installiert" beheben.**
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
+Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 

--- a/docs/de/guides/web-cloud/web-hosting/secure-your-website.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/secure-your-website.mdx
@@ -15,11 +15,7 @@ Sollten Sie jedoch Schwierigkeiten haben, einige der hier beschriebenen Operatio
 
 **Diese Anleitung erklärt, wie Sie Ihre Website schützen.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/sql-change-password.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/sql-change-password.mdx
@@ -33,13 +33,7 @@ Die Änderung des Passworts der Datenbank Ihrer Website erfolgt in vier Teilen:
 
 **Diese Anleitung erklärt, wie Sie das Passwort einer Datenbank sicher ändern.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-:::
-
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/sql-database-export.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/sql-database-export.mdx
@@ -49,10 +49,10 @@ Einige der oben aufgeführten Methoden lassen sich nicht über ein OVHcloud Inte
 
 Folgen Sie dieser Anleitung nun entsprechend der von Ihnen ausgewählten Backup-Methode.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
+[[fragment:support-scope]]
 
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+:::warning
+Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten.
 :::
 
 ### Backup mit dem OVHcloud Backup-Tool exportieren

--- a/docs/de/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
@@ -49,11 +49,7 @@ Einige der oben aufgeführten Methoden lassen sich nicht über ein OVHcloud Inte
 
 Folgen Sie dieser Anleitung nun entsprechend der von Ihnen gewählten Import-Methode.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) und/oder den Herausgeber des Dienstes zu kontaktieren. Für externe Dienstleistungen bietet OVHcloud leider keine Unterstützung. Genauere Informationen finden Sie im Teil "Weiterführende Informationen" dieser Anleitung.
-:::
+[[fragment:support-scope]]
 
 ### Backup über das Kundencenter wiederherstellen
 

--- a/docs/de/guides/web-cloud/web-hosting/sql-overquota-database.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/sql-overquota-database.mdx
@@ -36,12 +36,7 @@ Dieses Tutorial zeigt anhand von Beispielen die möglichen Aktionen, wenn eine O
 
 ## In der praktischen Anwendung
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Wenn Sie Schwierigkeiten haben, die Schritte in diesem Tutorial durchzuführen, empfehlen wir, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
-:::
+[[fragment:support-scope]]
 
 Wenn Ihre OVHcloud Webhosting-Datenbank (*shared database*) eine bestimmte Sättigung (**overquota**) erreicht, senden unsere Bots eine Benachrichtigung an die E-Mail-Adresse des [Administratorkontakts](/guides/account-and-service-management/account-information/managing-contacts) der Datenbank. 
 

--- a/docs/de/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
@@ -14,10 +14,10 @@ Die meisten unserer [Webhosting](/links/web/hosting) Angebote beinhalten Datenba
 
 **Diese Anleitung erklärt, wie Sie über die OVHcloud API das Backup einer Datenbank abrufen können, wenn diese über Ihr OVHcloud Kundencenter gelöscht wurde.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
+[[fragment:support-scope]]
 
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen zur API-Verwendung keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+:::warning
+Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen zur API-Verwendung keine weitergehende technische Unterstützung anbieten.
 :::
 
 ## Voraussetzungen

--- a/docs/de/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
@@ -35,11 +35,7 @@ Es wird dadurch leicht überprüfbar, ob Ihre Website über eine sichere Verbind
 
 **Die Umstellung Ihrer Website auf *HTTPS* kann ein heikler Vorgang sein**. Die meisten Aktionen werden im Quellcode der Website ausgeführt. Wenn diese nicht korrekt durchgeführt werden, kann es zu negativen SEO-Auswirkungen für Suchmaschinen (Google, Yahoo!, Bing, etc.) oder sogar zu einer völligen Nichterreichbarkeit Ihrer Website kommen.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Wenn Sie Schwierigkeiten haben, die Schritte in diesem Tutorial durchzuführen, empfehlen wir, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 Im Folgenden finden Sie die wichtigsten Schritte, um Ihre Website auf *HTTPS* umzustellen:
 

--- a/docs/de/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -9,11 +9,7 @@ availableIn: [eu, ca, apac]
 
 In dieser Anleitung finden Sie einige Beispiele für mögliche Problemsituationen wenn Sie Ihre Website mit SSL absichern.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Wenn Sie Schwierigkeiten haben, die Schritte in diesem Tutorial durchzuführen, empfehlen wir, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 **Diese Anleitung erklärt, wie Sie häufige Fehler bei der Sicherung Ihrer Website mit SSL vermeiden.**
 

--- a/docs/de/guides/web-cloud/web-hosting/ssl-custom.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/ssl-custom.mdx
@@ -36,11 +36,10 @@ Je nach Ihrer Situation kann es sein, dass Sie ein anderes SSL-Zertifikat als da
 
 ## In der praktischen Anwendung
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung genereller Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren. **Bei der Installation oder Bestellung eines anderen SSL-Zertifikats als [den von OVHcloud angebotenen](/links/web/hosting-options-ssl)** können wir Ihnen keine Unterstützung anbieten. Weitere Informationen finden Sie im Abschnitt „[Weiterführende Informationen](#go-further)“ in dieser Anleitung.
-
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung genereller Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren. **Bei der Installation oder Bestellung eines anderen SSL-Zertifikats als [den von OVHcloud angebotenen](/links/web/hosting-options-ssl)** können wir Ihnen keine Unterstützung anbieten.
 :::
 
 ### 1 - SSL Certificate Signing Request (CSR) erstellen <a name="step-1"></a>

--- a/docs/de/guides/web-cloud/web-hosting/ssl-ev.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/ssl-ev.mdx
@@ -59,11 +59,10 @@ Sie können über [diese Adresse](https://help.sectigostore.com/support/solution
 
 ## In der praktischen Anwendung
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen keine Unterstützung **für jegliche von der Zertifizierungsstelle Sectigo durchgeführten Verifizierungen** anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-
+Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen keine Unterstützung **für jegliche von der Zertifizierungsstelle Sectigo durchgeführten Verifizierungen** anbieten.
 :::
 
 ### 1: Sectigo EV SSL-Zertifikat bestellen

--- a/docs/de/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
@@ -11,11 +11,7 @@ In dieser Anleitung erfahren Sie, wie Sie das Web-Entwicklungstool [Cecil](https
 
 **In diesem Tutorial wird erläutert, wie Sie API-Aufrufe von Ihrer statischen Webseite aus hinzufügen.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Wenn Sie Schwierigkeiten haben, den Schritten dieses Tutorials zu folgen, empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/static-website-installation-cecil.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/static-website-installation-cecil.mdx
@@ -13,11 +13,7 @@ Eine im Wesentlichen aus statischen Seiten bestehende Website garantiert Ihren B
 
 **In diesem Tutorial wird erläutert, wie Sie mit Cecil Ihre statische Website mit einer modernen Template-Engine (Jamstack) erstellen können.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Wenn Sie Schwierigkeiten haben, die Schritte in diesem Tutorial durchzuführen, empfehlen wir, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/svn.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/svn.mdx
@@ -11,11 +11,7 @@ SVN, die Abkürzung für "Subversion", ist ein Versionsverwaltungssystem.
 
 **Diese Anleitung erklärt, wie Sie SVN über eine SSH-Verbindung auf Ihrem Webhosting nutzen können.**
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) und/oder den Herausgeber des Dienstes zu kontaktieren. Für externe Dienstleistungen bietet OVHcloud leider keine Unterstützung. Genauere Informationen finden Sie im Teil „[Weiterführende Informationen](#go-further)" dieser Anleitung.
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/using-scp-command.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/using-scp-command.mdx
@@ -15,11 +15,7 @@ Das Secure Copy Protocol (SCP) ermöglicht das sichere Kopieren von Daten (über
 
 Es ermöglicht über ein Terminal mit einem Linux-Befehl das Kopieren von Dateien und Ordnern.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-
-Wenn Sie Schwierigkeiten haben, die Schritte in diesem Tutorial durchzuführen, empfehlen wir, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
-:::
+[[fragment:support-scope]]
 
 **Diese Anleitung erklärt, wie Sie den Befehl Secure Copy Protocol (SCP) per SSH verwenden, um Dateien von oder auf Ihr Webhosting zu kopieren.**
 

--- a/docs/de/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Mithilfe dieser Anleitung können Sie Ihre ersten Inhalte erstellen, organisieren, online stellen und das Thema Ihrer Website mit dem Content Management System (CMS) **WordPress** ändern. Sie können Ihre Website ohne besondere Kenntnisse in Programmierung erstellen, mit einer breiten Palette an Themes wie Unternehmens-Website, Blog oder Website, um Ihre Aktivitäten oder Leidenschaften bekannt zu machen.
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
+[[fragment:support-scope]]
 
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+:::warning
+Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 **Dieses Tutorial erklärt, wie Sie eine Website mit dem CMS WordPress erstellen.**

--- a/docs/de/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Dieses Tutorial erklärt, wie Sie einen Onlineshop mit der Open-Source-Anwendung **WooCommerce** für das Content Management System (CMS) **WordPress** einrichten. 
 
-:::warning
-OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
+[[fragment:support-scope]]
 
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) oder dem [Herausgeber von WooCommerce](https://woocommerce.com/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+:::warning
+Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) oder dem [Herausgeber von WooCommerce](https://woocommerce.com/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 :::
 
 ## Voraussetzungen

--- a/docs/en/guides/web-cloud/domains/_transfer-incoming-homepl.mdx
+++ b/docs/en/guides/web-cloud/domains/_transfer-incoming-homepl.mdx
@@ -32,11 +32,7 @@ If you also need to change the **domain name holder**, you should do so **before
 - You have the authority to request a transfer for the domain name.
 - The domain name owner and/or its administrators must be informed of the transfer request.
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or your current domain name registrar if you encounter any difficulties. OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Instructions
 

--- a/docs/en/guides/web-cloud/domains/_transfer-incoming-o2switch.mdx
+++ b/docs/en/guides/web-cloud/domains/_transfer-incoming-o2switch.mdx
@@ -32,11 +32,7 @@ If you also need to change the **domain name holder**, you should do so **before
 - You have the authority to request a transfer for the domain name.
 - The domain name owner and/or its administrators must be informed of the transfer request.
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or your current domain name registrar if you encounter any difficulties. OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Instructions
 

--- a/docs/en/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -11,13 +11,7 @@ The **D**omain-based **M**essage **A**uthentication, **R**eporting, and **C**omp
 
 **Find out how DMARC works, and how to set it up for your email service.**
 
-:::warning
-OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This tutorial is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) if you experience any issues. OVHcloud cannot provide you with technical support in this regard.
-You can find more information in the [Go further](#gofurther) section of this tutorial.
-
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -4,11 +4,7 @@ lastUpdated: 2026-02-10
 availableIn: [eu, ca, apac]
 ---
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you face difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Objective
 

--- a/docs/en/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/en/guides/web-cloud/domains/domain-icloud.mdx
@@ -7,12 +7,7 @@ availableIn: [eu, ca, apac]
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) if you encounter any difficulties. We will not be able to assist you. You can find more information in the "[Go further](#go-further)" section of this guide.
-
-:::
+[[fragment:support-scope]]
 
 ## Objective
 

--- a/docs/en/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
+++ b/docs/en/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
@@ -13,11 +13,12 @@ You are the holder of a domain name with OVHcloud and want to connect it to a Go
 
 **Find out how to connect your OVHcloud domain name to a GoDaddy hosting plan.**
 
-:::warning
-- GoDaddy support does not have access to your OVHcloud domain name settings and therefore cannot advise you on the information you will need to provide.
-- OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore up to you to ensure that they function correctly.<br/><br/> We have provided you with this guide in order to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) and/or the service's publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+[[fragment:support-scope]]
 
+:::warning
+GoDaddy support does not have access to your OVHcloud domain name settings and therefore cannot advise you on the information you will need to provide.
 :::
+
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
+++ b/docs/en/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
@@ -13,11 +13,12 @@ You are the holder of a domain name with OVHcloud and want to connect it to a Go
 
 **Find out how to connect your OVHcloud domain name to a Google Site.**
 
-:::warning
-- Google Site support does not have access to your OVHcloud domain name settings and therefore cannot advise you on the information you will need to provide.
-- OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore up to you to ensure that they function correctly.<br/><br/> We have provided you with this guide in order to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) and/or the service's publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+[[fragment:support-scope]]
 
+:::warning
+Google Site support does not have access to your OVHcloud domain name settings and therefore cannot advise you on the information you will need to provide.
 :::
+
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
+++ b/docs/en/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
@@ -13,12 +13,12 @@ You are the holder of a domain name with OVHcloud and want to connect it to a Sh
 
 **Find out how to connect your OVHcloud domain name to a Shopify hosting plan.**
 
+[[fragment:support-scope]]
+
 :::warning
-- Shopify support does not have access to your OVHcloud domain name settings and therefore cannot advise you on the information you will need to provide.
-
-- OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore up to you to ensure that they function correctly.<br/><br/> We have provided you with this guide in order to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) and/or the service's publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
-
+Shopify support does not have access to your OVHcloud domain name settings and therefore cannot advise you on the information you will need to provide.
 :::
+
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
+++ b/docs/en/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
@@ -13,12 +13,12 @@ You are the holder of a domain name with OVHcloud and want to connect it to a Sq
 
 **Find out how to connect your OVHcloud domain name to a SquareSpace hosting plan.**
 
+[[fragment:support-scope]]
+
 :::warning
-- SquareSpace support does not have access to your OVHcloud domain name settings and therefore cannot advise you on the information you will need to provide.
-
-- OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore up to you to ensure that they function correctly.<br/><br/> We have provided you with this guide in order to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) and/or the service's publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
-
+SquareSpace support does not have access to your OVHcloud domain name settings and therefore cannot advise you on the information you will need to provide.
 :::
+
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
+++ b/docs/en/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
@@ -13,11 +13,12 @@ You are the holder of a domain name with OVHcloud and want to connect it to a We
 
 **Find out how to connect your OVHcloud domain name to a Webflow hosting plan.**
 
-:::warning
-- Webflow support does not have access to your OVHcloud domain name settings and therefore cannot advise you on the information you will need to provide.
-- OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore up to you to ensure that they function correctly.<br/><br/> We have provided you with this guide in order to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) and/or the service's publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+[[fragment:support-scope]]
 
+:::warning
+Webflow support does not have access to your OVHcloud domain name settings and therefore cannot advise you on the information you will need to provide.
 :::
+
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
+++ b/docs/en/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
@@ -13,12 +13,12 @@ You are the holder of a domain name with OVHcloud and want to connect it to a Wi
 
 **Find out how to connect your OVHcloud domain name to a Wix hosting plan.**
 
+[[fragment:support-scope]]
+
 :::warning
-- Wix support does not have access to your OVHcloud domain name settings and therefore cannot advise you on the information you will need to provide.
-
-- OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore up to you to ensure that they function correctly.<br/><br/> We have provided you with this guide in order to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) and/or the service's publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
-
+Wix support does not have access to your OVHcloud domain name settings and therefore cannot advise you on the information you will need to provide.
 :::
+
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/domains/redirect-domain-name.mdx
+++ b/docs/en/guides/web-cloud/domains/redirect-domain-name.mdx
@@ -317,12 +317,7 @@ Click <code className="action">Confirm</code> to confirm your configuration.
 
 ### Redirecting a domain name via a ".htaccess" file <a name="htaccess_rewrite"></a>
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) if you experience any difficulties. We will not be able to assist you with the steps documented below. You can find more information in the [Go further](#go-further) section of this guide.
-
-:::
+[[fragment:support-scope]]
 
 ".htaccess" files are configuration files in which commands can be specified. When the web server (Apache) runs your website's code, the commands are interpreted and executed.
 

--- a/docs/en/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/en/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -9,12 +9,7 @@ availableIn: [eu, ca, apac]
 
 Transferring a .uk (or similar) domain name requires a specific approach.
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you face difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
-
-:::
+[[fragment:support-scope]]
 
 **This guide explains how to transfer a .uk (or similar) domain name to OVHcloud.**
 

--- a/docs/en/guides/web-cloud/domains/transfer-incoming-gandi.mdx
+++ b/docs/en/guides/web-cloud/domains/transfer-incoming-gandi.mdx
@@ -40,11 +40,7 @@ It is therefore essential to back up their content before starting the domain na
 - You have the authority to request a transfer for the domain name.
 - The domain name holder and/or its administrators must be informed of the transfer request.
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or your current domain name registrar if you encounter any difficulties. OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Instructions
 

--- a/docs/en/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
+++ b/docs/en/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
@@ -32,11 +32,7 @@ If you also need to change the **domain name holder**, you should do so **before
 - You have the authority to request a transfer for the domain name.
 - The domain name holder and/or its administrators must be informed of the transfer request.
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or your current domain name registrar if you encounter any difficulties. OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Instructions
 

--- a/docs/en/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
+++ b/docs/en/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
@@ -32,11 +32,7 @@ If you also need to change the **domain name holder**, you should do so **before
 - You have the authority to request a transfer for the domain name.
 - The domain name holder and/or its administrators must be informed of the transfer request.
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or your current domain name registrar if you encounter any difficulties. OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Instructions
 

--- a/docs/en/guides/web-cloud/domains/transfer-incoming-ionos.mdx
+++ b/docs/en/guides/web-cloud/domains/transfer-incoming-ionos.mdx
@@ -32,11 +32,7 @@ If you also need to change the **domain name holder**, you should do so **before
 - You have the authority to request a transfer for the domain name.
 - The domain name holder and/or its administrators must be informed of the transfer request.
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or your current domain name registrar if you encounter any difficulties. OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Instructions
 

--- a/docs/en/guides/web-cloud/domains/transfer-incoming-wix.mdx
+++ b/docs/en/guides/web-cloud/domains/transfer-incoming-wix.mdx
@@ -32,11 +32,7 @@ If you also need to change the **domain name holder**, you should do so **before
 - You have the authority to request a transfer for the domain name.
 - The domain name holder and/or its administrators must be informed of the transfer request.
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or your current domain name registrar if you encounter any difficulties. OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Instructions
 

--- a/docs/en/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -14,12 +14,7 @@ The 1-click modules are a quick and easy way to install an online website creati
 
 **Find out how to manage your 1-click module through the OVHcloud Control Panel.**
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you face difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
-
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -9,13 +9,10 @@ availableIn: [eu, ca, apac]
 
 This tutorial will help you install Drupal CMS (Content Management System) manually in just a few steps.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [Drupal support](https://www.drupal.org/support) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-
-If you would like to update an existing Drupal CMS, or have any questions on how to use the Drupal CMS, please contact [the Drupal CMS publisher](https://www.drupal.org/support) directly.
-
+This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [Drupal support](https://www.drupal.org/support) if you encounter any difficulties. We will not be able to assist you.
 :::
 
 :::tip

--- a/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 This tutorial will help you install Joomla! CMS (Content Management System) manually in just a few steps.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [Joomla! support](https://www.joomla.org/) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+:::warning
+This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [Joomla! support](https://www.joomla.org/) if you encounter any difficulties. We will not be able to assist you.
 :::
 
 :::tip

--- a/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 This tutorial will help you install PrestaShop CMS (Content Management System) manually in just a few steps.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [PrestaShop support](https://www.prestashop.com/en/support) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+:::warning
+This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [PrestaShop support](https://www.prestashop.com/en/support) if you encounter any difficulties. We will not be able to assist you.
 :::
 
 :::tip

--- a/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 This tutorial will help you install the WordPress CMS (Content Management System) manually in just a few steps.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-
+This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) if you encounter any difficulties. We will not be able to assist you.
 :::
 
 :::tip

--- a/docs/en/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -12,22 +12,10 @@ import { Region } from '@components/Zone';
 
 This tutorial will help you install a CMS (Content Management System) like WordPress, Joomla!, Drupal, PrestaShop, Pico, Grav, Typo3 or SPIP manually in just a few steps.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
-
-Find below the links to the respective official pages of the CMS mentioned above:
-
-- [WordPress](https://wordpress.com/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-- [Pico](https://picocms.org/)
-- [Grav](https://getgrav.org/)
-- [Typo3](https://typo3.com/)
-- [SPIP](https://www.spip.net/en_rubrique25.html)
-
+This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you.
 :::
 
 :::tip

--- a/docs/en/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -37,18 +37,10 @@ There are several ways of changing the admin password for your CMS, depending on
 - [via your CMS administration interface](#via-cms)
 - [via phpMyAdmin via the OVHcloud Control Panel](#via-phpmyadmin)
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
-
-Find below the links to the respective official pages of the CMS mentioned above:
-
-- [WordPress](https://wordpress.com/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-
+This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you.
 :::
 
 ### Change your admin password via automatic email (forgotten password) <a name="via-email"></a>

--- a/docs/en/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
@@ -19,12 +19,7 @@ Hacking can occur in several ways (non-exhaustive list):
 
 **This tutorial explains some tips for repairing your hacked website.**
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the OVHcloud community if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/composer-install-composer.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/composer-install-composer.mdx
@@ -11,11 +11,7 @@ availableIn: [eu, ca, apac]
 
 **This guide explains how to install Composer and provides an example of usage with a Web Hosting plan.**
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the OVHcloud community if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/configure-ipv6.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/configure-ipv6.mdx
@@ -39,12 +39,7 @@ Our web hosting plans have been compatible with IPv6 since 2011. However, enabli
 
 ## Instructions
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This guide is designed to help you with common tasks. If you encounter any difficulties, we recommend contacting a [specialist provider](/links/partner) and/or the service’s publisher. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-
-:::
+[[fragment:support-scope]]
 
 If your website is not configured to work with an IPv6 address, you can add [the IPv6 address of your OVHcloud web hosting](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip) in your domain name’s active DNS zone. The goal is for web browsers to find an IPv6 address associated with your website via your domain name.
 

--- a/docs/en/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
@@ -9,10 +9,7 @@ availableIn: [eu]
 
 Find out how to create the first page of a website on a free hosting plan, available for free with every domain name purchase from OVHcloud.
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/cron-tasks.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cron-tasks.mdx
@@ -13,10 +13,10 @@ On your OVHcloud web hosting, you can use scripts to automate certain operations
 
 **This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+:::warning
+This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you.
 :::
 
 ## Requirements

--- a/docs/en/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
@@ -13,11 +13,7 @@ Your database usage may result in anomalies on your website or error messages in
 
 **Find out how to troubleshoot database errors with OVHcloud Web Hosting plans.**
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-This guide is designed to assist you in common tasks as much as possible. However, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -33,11 +33,10 @@ This device also legally protects you from actions resulting from a possible hac
 
 **Find out how to unblock access to your website if you see a "403 forbidden" page.**
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-
+This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you.
 :::
 
 ## Requirements

--- a/docs/en/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -12,13 +12,7 @@ However, if they are not configured correctly, the 1-click module installation m
 
 **Find out how to diagnose the most common errors associated with 1-click module creations**
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the software publisher if you encounter any difficulties. OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
@@ -15,12 +15,7 @@ These errors may also come from updates carried out **automatically** by compone
 
 **Learn how to diagnose the most common cases of "500" type errors.**
 
-:::warning
-OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
-
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
@@ -16,11 +16,7 @@ An "**Index of**" page appears in at least one of the following cases:
 
 **This guide explains how to troubleshoot the display of an "Index of" page.**
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
@@ -20,11 +20,7 @@ Several error messages may appear if your website is inaccessible. The examples 
 
 **Find out how to solve SSL-related error messages on your website.**
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -53,11 +53,10 @@ Furthermore, the performance of OVHcloud shared hosting infrastructures is monit
 
 ## Instructions
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the OVHcloud community if you encounter any difficulties. We will not be able to assist you with issues **not caused by the relevant hosting infrastructure itself**. You can find more information in the [Go further](#go-further) section of this guide.
-
+This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the OVHcloud community if you encounter any difficulties. We will not be able to assist you with issues **not caused by the relevant hosting infrastructure itself**.
 :::
 
 :::tip

--- a/docs/en/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
@@ -20,11 +20,7 @@ Several error returns may appear on your browser if your website becomes inacces
 
 **This guide explains how to resolve common "This site can't be reached" type errors.**
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -18,11 +18,7 @@ This access allows you to [put your website online](/guides/web-cloud/web-hostin
 
 **This guide explains how to change the password for an FTP user created on your OVHcloud Web Hosting plan.**
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you have difficulties or doubts. You can find more information in the ["Go further"](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
@@ -19,11 +19,7 @@ To download Cyberduck, go to the [official website](https://cyberduck.io/) of th
 
 :::
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the software publisher if you encounter any difficulties. OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
@@ -13,11 +13,7 @@ Using FTP software when logging in to your [Web Hosting plan](/links/web/hosting
 
 **Find out how to resolve the most common FTP software related issues.**
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -35,10 +35,10 @@ If you want to administer your website remotely without using Visual Studio Code
 
 ## Instructions
 
-:::warning
-OVHcloud provides services that you are responsible for configuring, managing and managing. It is therefore up to you to ensure that it works properly.
+[[fragment:support-scope]]
 
-We offer this tutorial to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the Visual Studio Code IDE](https://code.visualstudio.com/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+We offer this tutorial to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the Visual Studio Code IDE](https://code.visualstudio.com/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ### Install the SFTP extension for Visual Studio Code

--- a/docs/en/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
@@ -52,12 +52,7 @@ Once you have considered the possibilities above, you can choose one of two opti
 
 - **If you do not want to use our 1-click modules**, you can set up your website manually on your Web Hosting plan. You may find the information in our guide helpful, but it is not a substitute for the support of a webmaster.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-
-:::
+[[fragment:support-scope]]
 
  
 ### 2 - Put your website files online in your storage space

--- a/docs/en/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
@@ -12,11 +12,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 This guide will outline the steps you need to take to migrate your entire website, folders, domain name, database, and email addresses to OVHcloud, without any service interruptions.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the OVHcloud community if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
@@ -30,12 +30,7 @@ OVHcloud Web Hosting plans are shared. As a result, the configuration of these s
 
 ## Instructions
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the software publisher if you encounter any difficulties. OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
-
-:::
+[[fragment:support-scope]]
 
 ### FTP
 

--- a/docs/en/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -12,10 +12,10 @@ Regular backups of your website is a good practice. This will enable you to reve
 
 On a web hosting plan, you are responsible for your website’s backups. Although OVHcloud offers automated backups (non-contractual), we recommend to carry out regular backups yourself, and to manage them using appropriate backup media (hard disk, USB drive, etc.) as an added precaution.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+:::warning
+This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) if you encounter any difficulties. We will not be able to assist you.
 :::
 
 **This tutorial explains how to back up the content of your WordPress website and its database.**

--- a/docs/en/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -13,13 +13,7 @@ The aim of this tutorial is to explain the main steps you need to follow when yo
 
 **This guide explains how to change the domain name of an existing website.**
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the OVHcloud community if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -15,11 +15,7 @@ You can create multiple ".htaccess" files in [the FTP space](/guides/web-cloud/w
 
 **Find out how to block access to your website for certain IP addresses via a ".htaccess" file.**
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -11,10 +11,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 This tutorial will show you how to configure certain features of your web hosting plan with one or more **.htaccess** files, namely to modify settings for part or all of your website (redirections, access bans, restricted permissions, cache control, etc.).
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+:::warning
+This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) if you encounter any difficulties. We will not be able to assist you.
 :::
 
 **This tutorial explains how to secure your WordPress with one or more .htaccess files.**

--- a/docs/en/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
@@ -14,13 +14,7 @@ You can do this by using two Apache configuration files (HTTP) to place in [the 
 - "**.htaccess**": For more information on the functionalities of this file, please read our tutorial on [Operations achievable with a .htaccess file](/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do).
 - "**.htpasswd**": In addition to this tutorial, please refer to the [official Apache documentation](https://httpd.apache.org/docs/2.4/en/programs/htpasswd.html) for this file.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you. You can find more information in the ["Go further"](#go-further) section of this guide.
-
-The following examples should be set up in files named ".htaccess" and ".htpasswd". Please note that the rules you define in this file have a direct impact on your website. Always check the rules you add before applying them to your website. 
-:::
+[[fragment:support-scope]]
 
 **Find out how to protect a directory or the administration part of your website by authenticating with the .htaccess and .htpasswd files.**
 

--- a/docs/en/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -34,14 +34,7 @@ If you would like to learn more about how to use the Apache **mod_rewrite** modu
 
 ## Instructions
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-
-The following examples should be set up in a ".htaccess" file. Please note that the rules you define in this file have a direct impact on your website. Always verify the rules you add before applying them to your website.
-
-:::
+[[fragment:support-scope]]
 
 The ".htaccess" file in which you are going to configure the Apache **mod_rewrite** can be placed in several different folders. Be sure to follow the rule of **only one** ".htaccess" file per folder or subfolder.
 

--- a/docs/en/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
@@ -19,13 +19,7 @@ To use the .htaccess file correctly, you need to know and follow the following r
 - The .htaccess file is invisible to users visiting your website.
 - The rules declared in a .htaccess file apply to the entire directory where the ".htaccess" file is installed, as well as to all subdirectories in that same directory.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you. You can find more information in the ["Go further"](#go-further) section of this guide.
-
-The following examples should be set up in a ".htaccess" file. Please note that the rules you define in this file have a direct impact on your website. Always check the rules you add before applying them to your website. 
-:::
+[[fragment:support-scope]]
 
 **Find out the main operations you can do with a .htaccess file.**
 

--- a/docs/en/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -269,11 +269,7 @@ Our antispam service will analyse the situation, and our support team will get b
 
 ### Sending emails using an "SMTP" script <a name="SMTP"></a>
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 Although we strongly recommend using PHP's "mail()" function, shared hosting allows you to send emails via a script that uses Simple Mail Transfer Protocol (SMTP). The total size of your email can not exceed **10 MB** (i.e. **7/8 MB excluding encapsulation**).
 

--- a/docs/en/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -23,10 +23,10 @@ MainWP offers several extensions for backing up your websites.
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/en/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -16,10 +16,10 @@ Retaining customers is vital to your company’s development. Whether you have o
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard. For more information, please read our guide on [Managing multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general).
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/en/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -26,11 +26,10 @@ In this guide, we have chosen the MainWP plugin. Other similar solutions exist, 
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to the WordPress administration interface.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
-
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/en/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -16,10 +16,10 @@ Maintaining the security of your websites is crucial for the development of your
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/en/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
@@ -20,11 +20,7 @@ As your website evolves, its resource consumption becomes so high that your web 
 
 ## Instructions
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ### Step 1 - Back up your website files and database <a name="step1"></a>
 

--- a/docs/en/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 This tutorial will show you step by step how to migrate your WordPress website and all its associated services to OVHcloud.
 
-:::warning
-OVHcloud provides services that you are responsible for configuring and managing. It is therefore up to you to ensure that it works properly.
+[[fragment:support-scope]]
 
-We offer this tutorial to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the WordPress CMS editor](https://wordpress.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+We offer this tutorial to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the WordPress CMS editor](https://wordpress.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 **Find out how to migrate your WordPress website and associated services to OVHcloud.**

--- a/docs/en/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 This tutorial will show you step by step how to migrate your Xara website and all its associated services to OVHcloud.
 
-:::warning
-OVHcloud provides services that you are responsible for configuring and managing. It is therefore up to you to ensure that it works properly.
+[[fragment:support-scope]]
 
-We offer this tutorial to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or the [official website of Xara Web designer](https://www.xara.com/webdesigner-plus/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+We offer this tutorial to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or the [official website of Xara Web designer](https://www.xara.com/webdesigner-plus/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 **Find out how to migrate your Xara website and associated services to OVHcloud.**

--- a/docs/en/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
@@ -15,11 +15,10 @@ You may see the error page “**Site not installed**” displayed on your web br
 
 **This guide explains how to identify and resolve the "Site not installed" error page.**
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-
+This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you.
 :::
 
 ## Requirements

--- a/docs/en/guides/web-cloud/web-hosting/secure-your-website.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/secure-your-website.mdx
@@ -15,10 +15,7 @@ However, if you experience any difficulties carrying out some of them, please do
 
 **This guide explains how to improve the security your website.**
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/sql-change-password.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/sql-change-password.mdx
@@ -33,11 +33,7 @@ Changing your website’s database password involves four parts:
 
 **This guide explains how to change a database password securely.**
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/sql-database-export.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/sql-database-export.mdx
@@ -50,11 +50,7 @@ Some of the methods above are not inherent to an OVHcloud interface. You will th
 
 We recommend reading this guide, and focusing on the backup method you wish to use.
 
-:::warning
-OVHcloud provides services that you are responsible for configuring, managing and managing. It is up to you to ensure that it works properly.
-
-We have provided you with this guide in order to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) if you experience any difficulties. We will not be able to assist you. You can find more information in the ["Go further"](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ### Retrieve a backup via the OVHcloud tool
 

--- a/docs/en/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
@@ -49,11 +49,7 @@ Some of the methods listed above are not included in the OVHcloud interface. You
 
 We recommend reading this guide, and focusing on the import method you wish to use.
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-This guide is designed to assist you in common tasks as much as possible. However, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the "Go further" section of this guide.
-:::
+[[fragment:support-scope]]
 
 ### Restore a backup from the Control Panel
 

--- a/docs/en/guides/web-cloud/web-hosting/sql-overquota-database.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/sql-overquota-database.mdx
@@ -36,12 +36,7 @@ This tutorial will show you the actions you can take when your OVHcloud shared d
 
 ## Instructions
 
-:::warning
-OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-If you experience any difficulties following the steps in this tutorial, we recommend contacting a [specialist provider](/links/partner) or reach out to the OVHcloud community. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-
-:::
+[[fragment:support-scope]]
 
 When your OVHcloud shared database reaches a certain saturation level (**overquota**), our robots will send a notification to the email address of the database’s [administrator contact](/guides/account-and-service-management/account-information/managing-contacts). 
 

--- a/docs/en/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
@@ -14,11 +14,7 @@ Databases are included in most of our [web hosting plans](/links/web/hosting). I
  
 **This guide explains how to retrieve a database backup via the OVHcloud API once it has been deleted via the OVHcloud Control Panel.**
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. However, we recommend contacting a [specialist service provider](/links/partner) if you encounter any difficulties. We will not be able to provide you with any additional API support. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
@@ -18,12 +18,12 @@ import { Tab, Tabs } from '@rspress/core/theme';
 - [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) installed on your local device
 - A basic understanding of the [SSH protocol and its usage](/guides/bare-metal-cloud/dedicated-servers/ssh-introduction)
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. This tutorial will illustrate how to use OVHcloud solutions with external tools. You may need to adapt some specific instructions to the operating system of your local device or your server.
-
-We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](/links/community) if you experience any issues.
-
+This tutorial will illustrate how to use OVHcloud solutions with external tools. You may need to adapt some specific instructions to the operating system of your local device or your server.
 :::
+
 
 {/* CP-NAV-START:web-hosting */}
 ---

--- a/docs/en/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
@@ -35,11 +35,7 @@ These indicators help to determine whether your website has a secure connection 
 
 **Changing your website to *HTTPS* may be a tricky task.**. Most of the actions you need to perform will be carried out in your website’s source code. If they are not carried out correctly, you run the risk of your website's SEO (Google, Yahoo!, bing, etc.) dropping, or becoming completely inaccessible.
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 Below are the main steps described in the rest of this guide to switch your website to *HTTPS*:
 

--- a/docs/en/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -9,11 +9,7 @@ availableIn: [eu, ca, apac]
 
 In this tutorial, you will find some examples of situations you may encounter when securing your website with SSL.
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to the OVHcloud community if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 **This guide explains how to avoid common website security errors with SSL.**
 

--- a/docs/en/guides/web-cloud/web-hosting/ssl-custom.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ssl-custom.mdx
@@ -36,11 +36,10 @@ Depending on your situation, you may want to install a different SSL certificate
 
 ## Instructions
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) if you encounter any difficulties. We will not be able to assist you with the **installation or subscription of an SSL certificate other than [those offered by OVHcloud](/links/web/hosting-options-ssl)**. You can find more information in the "[Go further](#go-further)" section of this guide.
-
+This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) if you encounter any difficulties. We will not be able to assist you with the **installation or subscription of an SSL certificate other than [those offered by OVHcloud](/links/web/hosting-options-ssl)**.
 :::
 
 ### 1 - Obtain an SSL Certificate Signing Request (CSR) <a name="step-1"></a>

--- a/docs/en/guides/web-cloud/web-hosting/ssl-ev.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ssl-ev.mdx
@@ -59,11 +59,10 @@ To check if you are eligible to subscribe to a Sectigo EV SSL certificate, go to
 
 ## Instructions
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) if you encounter any difficulties. We will not be able to assist you with **all verification steps of the Sectigo certification authority**. You can find more information in the [Go further](#go-further) section of this guide.
-
+This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) if you encounter any difficulties. We will not be able to assist you with **all verification steps of the Sectigo certification authority**.
 :::
 
 ### 1 - Order the Sectigo EV SSL certificate

--- a/docs/en/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
@@ -11,11 +11,7 @@ This tutorial describes how to use the [Cecil](https://cecil.app) site builder t
 
 **Find out how to add a call to an external API from your static web page.**
 
-:::warning
-OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-If you experience any difficulties following the steps in this tutorial, we recommend contacting a [specialist provider](/links/partner) or reach out to the OVHcloud community. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/static-website-installation-cecil.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/static-website-installation-cecil.mdx
@@ -13,11 +13,7 @@ A website essentially composed of static web pages guarantees a better loading t
 
 **This tutorial explains how Cecil allows you to create your static website using a modern template engine (Jamstack).**
 
-:::warning
-OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-If you experience any difficulties following the steps in this tutorial, we recommend contacting a [specialist provider](/links/partner) or reach out to the OVHcloud community. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/svn.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/svn.mdx
@@ -11,11 +11,7 @@ SVN, which stands for "subversion," is a version management system.
 
 **This guide explains how to use SVN over an SSH connection on your Web Hosting plan.**
 
-:::warning
-OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
-
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the “[Go further](#go-further)” section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/web-hosting/using-scp-command.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/using-scp-command.mdx
@@ -15,11 +15,7 @@ With the Secure Copy Protocol (SCP), you can securely copy data between two devi
 
 It allows you to copy a file or folder containing one or more files from a terminal using a Linux command.
 
-:::warning
-OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
-
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 **This guide explains how to use the Secure Copy Protocol (SCP) command in SSH to copy files to and from your Web Hosting plan.**
 

--- a/docs/en/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 This tutorial will help you create your first content, organise it, put it online and change the theme of your website with the Content Management System (CMS) **WordPress**. You can build your website without any particular knowledge of programming, with a wide range of topics such as a company website, a blog, or even a website to publicise your activity or passion.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+:::warning
+This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) if you encounter any difficulties. We will not be able to assist you.
 :::
 
 **This tutorial explains how to create a website with WordPress CMS.**

--- a/docs/en/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 This tutorial explains how to create an online store with the open-source plugin **WooCommerce** for the Content Management System (CMS) **WordPress**. 
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) or [the publisher of WooCommerce](https://woocommerce.com/) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+:::warning
+This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) or [the publisher of WooCommerce](https://woocommerce.com/) if you encounter any difficulties. We will not be able to assist you.
 :::
 
 ## Requirements

--- a/docs/es/guides/web-cloud/domains/_transfer-incoming-o2switch.mdx
+++ b/docs/es/guides/web-cloud/domains/_transfer-incoming-o2switch.mdx
@@ -35,11 +35,7 @@ También debe:
 - Estar facultado para solicitar la transferencia del dominio.
 - Haber informado al propietario del dominio y/o a sus administradores de la solicitud de transferencia.
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con su actual agente registrador. Nosotros no podremos asistirle. Para más información, consulte la sección [Más información](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Procedimiento
 

--- a/docs/es/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -11,12 +11,7 @@ El registro **D**omain-based **M**essage **A**uthentication, **R**eporting, and 
 
 **Esta guía explica cómo funciona DMARC y cómo implementarlo para su servicio de correo.**
 
-:::warning
-OVHcloud ofrece servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle al respecto. Para más información, consulte la sección [«Más información»](#go-further) de este tutorial.
-
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -4,11 +4,7 @@ lastUpdated: 2026-02-10
 availableIn: [eu, ca, apac]
 ---
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle al respecto. Para más información, consulte el apartado ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Objetivo
 

--- a/docs/es/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/es/guides/web-cloud/domains/domain-icloud.mdx
@@ -5,11 +5,7 @@ lastUpdated: 2025-08-27
 availableIn: [eu, ca, apac]
 ---
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Objective
 

--- a/docs/es/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
+++ b/docs/es/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
@@ -13,11 +13,12 @@ Si es titular de un nombre de dominio en OVHcloud y quiere conectarlo a un aloja
 
 **Cómo conectar un nombre de dominio de OVHcloud a un alojamiento GoDaddy**
 
-:::warning
-- El servicio de asistencia de GoDaddy no tiene acceso a los parámetros de su nombre de dominio de OVHcloud y, por lo tanto, no puede aconsejarle sobre la información que deba proporcionarle.
-- La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.<br/><br/> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle al respecto. Para más información, consulte la sección [Más información](#go-further) de esta guía.
+[[fragment:support-scope]]
 
+:::warning
+El servicio de asistencia de GoDaddy no tiene acceso a los parámetros de su nombre de dominio de OVHcloud y, por lo tanto, no puede aconsejarle sobre la información que deba proporcionarle.
 :::
+
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
+++ b/docs/es/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
@@ -13,11 +13,12 @@ Si es titular de un nombre de dominio en OVHcloud y quiere conectarlo a un Googl
 
 **Cómo conectar un nombre de dominio de OVHcloud a un Google Site.**
 
-:::warning
-- El servicio de asistencia de Google Site no tiene acceso a los parámetros de su nombre de dominio de OVHcloud y, por lo tanto, no puede aconsejarle sobre la información que deba proporcionarle.
-- La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.<br/><br/> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle al respecto. Para más información, consulte la sección [Más información](#go-further) de esta guía.
+[[fragment:support-scope]]
 
+:::warning
+El servicio de asistencia de Google Site no tiene acceso a los parámetros de su nombre de dominio de OVHcloud y, por lo tanto, no puede aconsejarle sobre la información que deba proporcionarle.
 :::
+
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
+++ b/docs/es/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
@@ -13,12 +13,12 @@ Si es titular de un nombre de dominio en OVHcloud y quiere conectarlo a un aloja
 
 **Cómo conectar un nombre de dominio de OVHcloud a un alojamiento Shopify**
 
+[[fragment:support-scope]]
+
 :::warning
-- El servicio de asistencia de Shopify no tiene acceso a los parámetros de su nombre de dominio de OVHcloud y, por lo tanto, no puede aconsejarle sobre la información que deba proporcionarle.
-
-- La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.<br/><br/> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle al respecto. Para más información, consulte la sección [Más información](#go-further) de esta guía.
-
+El servicio de asistencia de Shopify no tiene acceso a los parámetros de su nombre de dominio de OVHcloud y, por lo tanto, no puede aconsejarle sobre la información que deba proporcionarle.
 :::
+
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
+++ b/docs/es/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
@@ -13,12 +13,12 @@ Si es titular de un nombre de dominio en OVHcloud y quiere conectarlo a un aloja
 
 **Cómo conectar un nombre de dominio de OVHcloud a un alojamiento SquareSpace**
 
+[[fragment:support-scope]]
+
 :::warning
-- El servicio de asistencia de SquareSpace no tiene acceso a los parámetros de su nombre de dominio de OVHcloud y, por lo tanto, no puede aconsejarle sobre la información que deba proporcionarle.
-
-- La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.<br/><br/> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle al respecto. Para más información, consulte la sección [Más información](#go-further) de esta guía.
-
+El servicio de asistencia de SquareSpace no tiene acceso a los parámetros de su nombre de dominio de OVHcloud y, por lo tanto, no puede aconsejarle sobre la información que deba proporcionarle.
 :::
+
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
+++ b/docs/es/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
@@ -13,11 +13,12 @@ Si es titular de un nombre de dominio en OVHcloud y quiere conectarlo a un aloja
 
 **Cómo conectar un nombre de dominio de OVHcloud a un alojamiento Webflow**
 
-:::warning
-- El servicio de asistencia de Webflow no tiene acceso a los parámetros de su nombre de dominio de OVHcloud y, por lo tanto, no puede aconsejarle sobre la información que deba proporcionarle.
-- La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.<br/><br/> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle al respecto. Para más información, consulte la sección [Más información](#go-further) de esta guía.
+[[fragment:support-scope]]
 
+:::warning
+El servicio de asistencia de Webflow no tiene acceso a los parámetros de su nombre de dominio de OVHcloud y, por lo tanto, no puede aconsejarle sobre la información que deba proporcionarle.
 :::
+
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
+++ b/docs/es/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
@@ -13,12 +13,12 @@ Si es titular de un nombre de dominio en OVHcloud y quiere conectarlo a un aloja
 
 **Cómo conectar un nombre de dominio de OVHcloud a un alojamiento Wix**
 
+[[fragment:support-scope]]
+
 :::warning
-- El servicio de asistencia de Wix no tiene acceso a los parámetros de su nombre de dominio de OVHcloud y, por lo tanto, no puede aconsejarle sobre la información que deba proporcionarle.
-
-- La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.<br/><br/> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle al respecto. Para más información, consulte la sección [Más información](#go-further) de esta guía.
-
+El servicio de asistencia de Wix no tiene acceso a los parámetros de su nombre de dominio de OVHcloud y, por lo tanto, no puede aconsejarle sobre la información que deba proporcionarle.
 :::
+
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/domains/redirect-domain-name.mdx
+++ b/docs/es/guides/web-cloud/domains/redirect-domain-name.mdx
@@ -317,12 +317,7 @@ Haga clic en <code className="action">Confirmar</code> para validar la configura
 
 ### Redirigir un nombre de dominio a través de un archivo ".htaccess" <a name="htaccess_rewrite"></a>
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad le incumben. Es su responsabilidad garantizar su correcto funcionamiento.
-
-Ponemos a su disposición esta parte de la guía para ayudarle con las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](/links/partner) si tiene dificultades. Nosotros no podremos proporcionarle asistencia en los pasos documentados a continuación. Más información en la sección "[Más información](#go-further)" de esta guía.
-
-:::
+[[fragment:support-scope]]
 
 Los archivos ".htaccess" son archivos de configuración en los que se pueden especificar comandos. Cuando el servidor web (Apache) ejecuta el código del sitio web, los comandos son interpretados y ejecutados.
 

--- a/docs/es/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/es/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -9,12 +9,7 @@ availableIn: [eu, ca, apac]
 
 La transferencia de un nombre de dominio .uk (o asimilado) debe respetar un procedimiento específico.
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle al respecto. Para más información, consulte el apartado [Más información](#go-further) de esta guía.
-
-:::
+[[fragment:support-scope]]
 
 **Cómo transferir un nombre de dominio .uk (o asimilado) a OVHcloud**
 

--- a/docs/es/guides/web-cloud/domains/transfer-incoming-gandi.mdx
+++ b/docs/es/guides/web-cloud/domains/transfer-incoming-gandi.mdx
@@ -43,11 +43,7 @@ También debe:
 - Estar facultado para solicitar la transferencia del nombre de dominio.
 - Haber informado al titular del nombre de dominio y/o a sus administradores de la solicitud de transferencia.
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con su actual agente registrador. Nosotros no podremos asistirle. Para más información, consulte la sección [Más información](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Procedimiento
 

--- a/docs/es/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
+++ b/docs/es/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
@@ -35,11 +35,7 @@ También debe:
 - Estar facultado para solicitar la transferencia del nombre de dominio.
 - Haber informado al titular del nombre de dominio y/o a sus administradores de la solicitud de transferencia.
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con su actual agente registrador. Nosotros no podremos asistirle. Para más información, consulte la sección [Más información](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Procedimiento
 

--- a/docs/es/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
+++ b/docs/es/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
@@ -35,11 +35,7 @@ También debe:
 - Estar facultado para solicitar la transferencia del nombre de dominio.
 - Haber informado al titular del nombre de dominio y/o a sus administradores de la solicitud de transferencia.
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con su actual agente registrador. Nosotros no podremos asistirle. Para más información, consulte la sección [Más información](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Procedimiento
 

--- a/docs/es/guides/web-cloud/domains/transfer-incoming-ionos.mdx
+++ b/docs/es/guides/web-cloud/domains/transfer-incoming-ionos.mdx
@@ -35,11 +35,7 @@ También debe:
 - Estar facultado para solicitar la transferencia del nombre de dominio.
 - Haber informado al titular del nombre de dominio y/o a sus administradores de la solicitud de transferencia.
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con su actual agente registrador. Nosotros no podremos asistirle. Para más información, consulte la sección [Más información](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Procedimiento
 

--- a/docs/es/guides/web-cloud/domains/transfer-incoming-wix.mdx
+++ b/docs/es/guides/web-cloud/domains/transfer-incoming-wix.mdx
@@ -35,11 +35,7 @@ También debe:
 - Estar facultado para solicitar la transferencia del nombre de dominio.
 - Haber informado al titular del nombre de dominio y/o a sus administradores de la solicitud de transferencia.
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con su actual agente registrador. Nosotros no podremos asistirle. Para más información, consulte la sección [Más información](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Procedimiento
 

--- a/docs/es/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -13,12 +13,7 @@ Los módulos en 1 clic permiten la instalación fácil y rápida de un programa 
 
 **Descubra cómo gestionar el módulo en 1 clic desde el área de cliente de OVHcloud.**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle al respecto. Para más información, consulte el apartado [Más información](#go-further) de esta guía.
-
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -9,12 +9,10 @@ availableIn: [eu, ca, apac]
 
 Aquí encontrará todos los elementos necesarios para instalar manualmente el CMS (Content Management System) Drupal en pocos pasos.
 
+[[fragment:support-scope]]
+
 :::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS Drupal](https://www.drupal.org/support). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de este tutorial.
-
-Si desea actualizar un CMS Drupal existente o tiene alguna pregunta sobre el uso del CMS Drupal, póngase en contacto directamente con el [editor del CMS Drupal](https://www.drupal.org/support).
+Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS Drupal](https://www.drupal.org/support). Nosotros no podremos asistirle.
 :::
 
 :::tip

--- a/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Aquí encontrará todos los elementos necesarios para instalar manualmente el CMS (content management system) Joomla! en pocos pasos.
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
+[[fragment:support-scope]]
 
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS Joomla!](https://www.joomla.org/). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de este tutorial.
+:::warning
+Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS Joomla!](https://www.joomla.org/). Nosotros no podremos asistirle.
 :::
 
 :::tip

--- a/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Aquí encontrará todos los elementos necesarios para instalar manualmente el CMS (Content Management System) PrestaShop en pocos pasos.
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
+[[fragment:support-scope]]
 
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS PrestaShop](https://www.prestashop.com/en/support). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de esta guía.
+:::warning
+Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS PrestaShop](https://www.prestashop.com/en/support). Nosotros no podremos asistirle.
 :::
 
 :::tip

--- a/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Este tutorial le ayudará a instalar manualmente el CMS (Content Management System) WordPress en pocos etapas.
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
+[[fragment:support-scope]]
 
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS WordPress](https://wordpress.com/es/support/). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de esta guía.
+:::warning
+Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS WordPress](https://wordpress.com/es/support/). Nosotros no podremos asistirle.
 :::
 
 :::tip

--- a/docs/es/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -12,22 +12,10 @@ import { Region } from '@components/Zone';
 
 Esta guía explica cómo instalar manualmente un CMS (del inglés content management system), como WordPress, Joomla!, Drupal, PrestaShop, Pico, Grav, Typo3 o SPIP en pocos pasos.
 
+[[fragment:support-scope]]
+
 :::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del CMS que haya elegido instalar. Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de este tutorial.
-
-Para contactar con los diferentes editores de los CMS mencionados, consulte los enlaces a sus páginas oficiales respectivas:
-
-- [WordPress](https://wordpress.com/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-- [Pico](https://picocms.org/)
-- [Grav](https://getgrav.org/)
-- [Typo3](https://typo3.com/)
-- [SPIP](https://www.spip.net/en_rubrique25.html)
-
+Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del CMS que haya elegido instalar. Nosotros no podremos asistirle.
 :::
 
 :::tip

--- a/docs/es/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -37,18 +37,10 @@ Existen diversas formas de cambiar la contraseña de administrador del CMS en fu
 - [a través del panel de administración del CMS](#via-cms)
 - [mediante phpMyAdmin desde el área de cliente de OVHcloud](#via-phpmyadmin)
 
+[[fragment:support-scope]]
+
 :::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del CMS que haya elegido instalar. Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de este tutorial.
-
-Para contactar con los diferentes editores de los CMS mencionados, consulte los enlaces a sus páginas oficiales respectivas:
-
-- [WordPress](https://wordpress.com/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-
+Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del CMS que haya elegido instalar. Nosotros no podremos asistirle.
 :::
 
 ### Cambiar la contraseña del administrador por correo electrónico automático (olvidado) <a name="vía email"></a>

--- a/docs/es/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
@@ -19,11 +19,7 @@ La piratería informática puede manifestarse de varias maneras (lista no exhaus
 
 **Descubra nuestros consejos para reparar su sitio web pirateado.**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/composer-install-composer.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/composer-install-composer.mdx
@@ -11,11 +11,7 @@ availableIn: [eu, ca, apac]
 
 **Cómo instalar y dar los primeros pasos en Composer**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de este tutorial.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/configure-ipv6.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/configure-ipv6.mdx
@@ -38,11 +38,7 @@ Nuestros planes de hosting son compatibles con IPv6 desde 2011. Sin embargo, la 
 
 ## Procedimiento
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de este tutorial.
-:::
+[[fragment:support-scope]]
 
 Si su sitio no está configurado para funcionar con una dirección IPv6, puede añadir [la dirección IPv6 de su alojamiento compartido OVHcloud](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip) a la zona DNS activa de su nombre de dominio. El objetivo es que los navegadores puedan encontrar una dirección IPv6 asociada a su sitio web a través de su nombre de dominio.
 

--- a/docs/es/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
@@ -9,11 +9,7 @@ availableIn: [eu]
 
 Esta guía explica cómo crear la primera página de un sitio web en un Alojamiento gratuito para la adquisición de un dominio en OVHcloud.
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/cron-tasks.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cron-tasks.mdx
@@ -13,11 +13,7 @@ En su alojamiento web de OVHcloud, puede utilizar scripts para automatizar deter
 
 **Esta guía explica cómo crear tareas CRON para automatizar las tareas programadas en un alojamiento web.**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor de servicios especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
@@ -13,11 +13,7 @@ El uso de sus bases de datos puede dar lugar a una serie de anomalías en su sit
 
 **Descubra cómo solucionar los errores relacionados con las bases de datos de los alojamientos compartidos de OVHcloud.**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Le ofrecemos esta guía para ayudarle a completar mejor las tareas más comunes. Sin embargo, le recomendamos que, si necesita ayuda, contacte con un [proveedor de servicios especializado](/links/partner) o con el editor del programa o la interfaz. Nosotros no podremos asistirle. Más información en la sección [Más información](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -33,10 +33,10 @@ Tras la detección de un funcionamiento sospechoso, nuestros robots de seguridad
 
 **Descubra cómo desbloquear el acceso a su sitio web en caso de que aparezca "403 forbidden".**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
+[[fragment:support-scope]]
 
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) y/o con nuestra [comunidad de usuarios](/links/community). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de esta guía.
+:::warning
+Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) y/o con nuestra [comunidad de usuarios](/links/community). Nosotros no podremos asistirle.
 :::
 
 ## Requisitos

--- a/docs/es/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -12,13 +12,7 @@ No obstante, si la configuración de estos últimos no se realiza correctamente,
 
 **Descubra cómo diagnosticar los casos más comunes de errores relacionados con la creación de "módulos en un clic"**
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte la sección "[Más información](#go-further)" de esta guía.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
@@ -15,12 +15,7 @@ A veces también se actualizan **automáticamente** en un componente del sitio w
 
 **Esta guía explica cómo diagnosticar los casos más comunes de errores 500.**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle al respecto. Para más información, consulte el apartado [Más información](#go-further) de esta guía.
-
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
@@ -16,11 +16,7 @@ En al menos uno de los siguientes casos aparece una página **"Index of"**:
 
 **Esta guía explica cómo corregir la visualización de una página "Index of".**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado [Más información](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
@@ -20,11 +20,7 @@ En caso de que su sitio web no sea accesible, pueden aparecer varios mensajes de
 
 **Descubra cómo resolver los errores del tipo "La conexión no es privada".**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -52,10 +52,10 @@ Por otro lado, el rendimiento de la infraestructura de alojamientos compartidos 
 
 ## Procedimiento
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
+[[fragment:support-scope]]
 
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. **Siempre que la infraestructura en la que está alojado su plan de hosting no sea válida**. Más información en la sección ["Más información"](#go-further) de esta guía.
+:::warning
+Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. **Siempre que la infraestructura en la que está alojado su plan de hosting no sea válida**.
 :::
 
 :::tip

--- a/docs/es/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
@@ -20,11 +20,7 @@ En caso de que su sitio web no sea accesible, pueden aparecer varios errores en 
 
 **Cómo solucionar los errores del tipo "No se puede acceder a este sitio web"**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle al respecto. Para más información, consulte el apartado [Más información](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -18,11 +18,7 @@ Este acceso permite, entre otras cosas, [publicar el sitio web](/guides/web-clou
 
 **Descubra cómo cambiar la contraseña de un usuario FTP en un alojamiento de OVHcloud.**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
@@ -19,11 +19,7 @@ Para descargar Cyberduck, acceda al [sitio web oficial](https://cyberduck.io/) d
 
 :::
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, le recomendamos que, si necesita ayuda, contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte la sección [Más información](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
@@ -13,12 +13,7 @@ El uso de software FTP durante la conexión a su [hosting Web Cloud](/links/web/
 
 **Esta guía explica cómo solucionar los errores relacionados con el software FTP.**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle al respecto. Para más información, consulte el apartado [Más información](#go-further) de esta guía.
-
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -35,10 +35,10 @@ Si desea administrar su sitio web de forma remota sin utilizar Visual Studio Cod
 
 ## Procedimiento
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
+[[fragment:support-scope]]
 
-Este tutorial le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el [editor del IDE de Visual Studio Code](https://code.visualstudio.com/). Nosotros no podremos asistirle. Para más información, consulte la sección ["Más información"](#go-further) de este tutorial.
+:::warning
+Este tutorial le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el [editor del IDE de Visual Studio Code](https://code.visualstudio.com/). Nosotros no podremos asistirle.
 :::
 
 ### Instalar la extensión SFTP para Visual Studio Code

--- a/docs/es/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
@@ -53,13 +53,7 @@ Según el método elegido para llevar a cabo su proyecto, tendrá dos posibilida
 - **No utilizar nuestros módulos en un clic**: En ese caso, deberá instalar el sitio web en su alojamiento manualmente. La información que ofrece esta guía puede serle útil. No obstante, si necesita ayuda, puede ponerse en contacto con un webmaster.
  
 
-:::warning
-La responsabilidad sobre la configuración y la gestión de los servicios que OVHcloud pone a su disposición recae íntegramente en usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado «Más información» de esta guía.
-
-:::
-
+[[fragment:support-scope]]
 
 ### 2 - Colocar los archivos del sitio web en el espacio de almacenamiento
 

--- a/docs/es/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
@@ -12,11 +12,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Esta guía explica las diferentes acciones que debe realizar para migrar su sitio web, sus carpetas, su dominio, su base de datos y sus direcciones de correo electrónico a OVHcloud, sin interrupción del servicio.
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. Más información en la sección [Más información](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
@@ -30,12 +30,7 @@ Los planes de hosting de OVHcloud son compartidos. Por lo tanto, la configuraci�
 
 ## Procedimiento
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte la sección "[Más información](#go-further)" de esta guía.
-
-:::
+[[fragment:support-scope]]
 
 ### FTP
 

--- a/docs/es/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -12,10 +12,10 @@ Una buena práctica consiste en guardar regularmente la información de su sitio
 
 En un alojamiento web compartido, usted es responsable de las copias de seguridad de su sitio web. Aunque OVHcloud ofrece copias de seguridad (no contractuales), también le recomendamos que realice usted mismo las copias de seguridad regulares y gestione sus propios soportes de backup (disco duro, memoria USB, etc.) para mayor precaución.
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
+[[fragment:support-scope]]
 
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del CMS WordPress](https://wordpress.com/support/). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de este tutorial.
+:::warning
+Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del CMS WordPress](https://wordpress.com/support/). Nosotros no podremos asistirle.
 :::
 
 **Descubra cómo guardar copia de seguridad del contenido de su sitio web WordPress y su base de datos.**

--- a/docs/es/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -13,13 +13,7 @@ Este tutorial explica los pasos que debe seguir para cambiar el dominio de su si
 
 **Descubra cómo cambiar el dominio de un sitio existente.**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de esta guía.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -15,11 +15,7 @@ Puede crear varios archivos ".htaccess" en [el espacio FTP](/guides/web-cloud/we
 
 **Descubra cómo bloquear el acceso a su sitio web para algunas direcciones IP a través de un archivo ".htaccess".**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -11,10 +11,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Este tutorial explica cómo configurar algunas funcionalidades de su alojamiento web con uno o varios archivos **.htaccess**, especialmente para modificar los parámetros de una parte o del conjunto de su sitio web (redirecciones, prohibiciones de acceso, autorizaciones restringidas, control de caché, etc.).
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
+[[fragment:support-scope]]
 
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS WordPress](https://wordpress.com/es/support/). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de este tutorial.
+:::warning
+Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS WordPress](https://wordpress.com/es/support/). Nosotros no podremos asistirle.
 :::
 
 **Descubra cómo proteger su WordPress con uno o más archivos htaccess.**

--- a/docs/es/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
@@ -14,13 +14,7 @@ Utilizando dos archivos de configuración (HTTP) Apache que quiere situar en [el
 - "**.htaccess**": para más información sobre las funcionalidades de este fichero, consulte nuestro tutorial sobre ["Operaciones realizables con un fichero ".htaccess"](/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do).
 - "**.htpasswd**": además de este tutorial, consulte la [documentación oficial de Apache](https://httpd.apache.org/docs/2.4/en/programs/htpasswd.html) relativa a este archivo.
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de esta guía.
-
-Deberá configurar los siguientes ejemplos en archivos con los nombres ".htaccess" y ".htpasswd". Atención: Las reglas que usted establezca en estos archivos tienen consecuencias directas en su sitio web. Compruebe sistemáticamente las reglas que añade antes de aplicarlas a su sitio web. 
-:::
+[[fragment:support-scope]]
 
 **Descubra cómo proteger un repertorio o el acceso a la parte de administrador de su sitio web mediante autenticación con los archivos ".htaccess" y ".htpasswd".**
 

--- a/docs/es/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -33,13 +33,7 @@ Si desea más información sobre el uso de la "**mod_rewrite**" de Apache o el e
 
 ## Procedimiento
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de esta guía.
-
-Deberá configurar los siguientes ejemplos en un archivo ".htaccess". Atención: Las reglas que usted establezca en este fichero tienen consecuencias directas en su sitio web. Compruebe sistemáticamente las reglas que añade antes de aplicarlas a su sitio web.
-:::
+[[fragment:support-scope]]
 
 El archivo ".htaccess" en el que va a configurar el "**mod_rewrite**" de Apache puede ser colocado en varias carpetas diferentes. Solo debe respetar la regla de un **solo** fichero ".htaccess" por carpeta o subcarpeta.
 

--- a/docs/es/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
@@ -19,13 +19,7 @@ Para utilizar correctamente el archivo ".htaccess", debe conocer y respetar las 
 - el archivo ".htaccess" es invisible para los internautas que visitan su sitio web;
 - las reglas declaradas en un archivo ".htaccess" se aplican a todo el directorio en el que está instalado el archivo ".htaccess", así como a todos los subdirectorios del mismo directorio.
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de esta guía.
-
-Deberá configurar los siguientes ejemplos en un archivo ".htaccess". Atención: Las reglas que usted establezca en este fichero tienen consecuencias directas en su sitio web. Compruebe sistemáticamente las reglas que añade antes de aplicarlas a su sitio web. 
-:::
+[[fragment:support-scope]]
 
 **Descubra las principales operaciones que se pueden realizar con un archivo ".htaccess".**
 

--- a/docs/es/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -259,11 +259,7 @@ Nuestro servicio antispam analizará la situación y nuestro soporte volverá a 
 
 ### Envío de emails mediante un script «SMTP» <a name="SMTP"></a>
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Sin embargo, le recomendamos que contacte con un [proveedor especializado](/links/partner) si tiene alguna duda. Nosotros no podremos asistirle. Más información en la sección [«Más información»](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 Aunque le recomendamos encarecidamente que prefiera utilizar la función "mail()" de PHP, los alojamientos compartidos permiten enviar emails pasando por un script que utiliza el protocolo SMTP (Simple Mail Transfer Protocol). El tamaño total del mensaje de correo electrónico no podrá ser superior a **10 MB** (es decir, **7/8 MB sin encapsular**).
 

--- a/docs/es/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -23,10 +23,10 @@ MainWP offers several extensions for backing up your websites.
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/es/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -16,10 +16,10 @@ Retaining customers is vital to your company's development. Whether you have one
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard. For more information, please read our guide on [Managing multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general).
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/es/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -26,10 +26,10 @@ In this guide, we have chosen the MainWP plugin. Other similar solutions exist, 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, in the `Web Cloud` section.
 - Access to the WordPress administration interface.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/es/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -16,10 +16,10 @@ Maintaining the security of your websites is crucial for the development of your
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/es/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
@@ -20,11 +20,7 @@ A medida que su sitio web evoluciona, su consumo de recursos se vuelve tal que s
 
 ## Procedimiento
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. Para más información, consulte la sección ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ### Etapa 1 - Realizar una copia de seguridad de los archivos y la base de datos de su sitio web <a name="step1"></a>
 

--- a/docs/es/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Este tutorial explica paso a paso cómo migrar un sitio web WordPress y todos sus servicios asociados a OVHcloud.
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
+[[fragment:support-scope]]
 
-Este tutorial le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el [editor del CMS WordPress](https://wordpress.com/es/support/). Nosotros no podremos asistirle. Para más información, consulte la sección ["Más información"](#go-further) de este tutorial.
+:::warning
+Este tutorial le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el [editor del CMS WordPress](https://wordpress.com/es/support/). Nosotros no podremos asistirle.
 :::
 
 **Descubra cómo migrar su sitio web WordPress y los servicios asociados a OVHcloud.**

--- a/docs/es/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Este tutorial explica paso a paso cómo migrar un sitio web Xara y todos sus servicios asociados a OVHcloud.
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
+[[fragment:support-scope]]
 
-Este tutorial le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el [sitio oficial de Xara Web designer](https://www.xara.com/webdesigner-plus/). Nosotros no podremos asistirle. Para más información, consulte la sección ["Más información"](#go-further) de este tutorial.
+:::warning
+Este tutorial le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el [sitio oficial de Xara Web designer](https://www.xara.com/webdesigner-plus/). Nosotros no podremos asistirle.
 :::
 
 **Descubra cómo migrar su sitio web Xara y los servicios asociados a OVHcloud.**

--- a/docs/es/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
@@ -16,13 +16,7 @@ Es posible que aparezca en su navegador de internet la página de error "**Sitio
 
 **Descubra cómo identificar y resolver la página de error "Sitio no instalado"**
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte la sección "[Más información](#go-further)" de esta guía.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/secure-your-website.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/secure-your-website.mdx
@@ -13,11 +13,7 @@ Se organiza por etapas en un orden creciente de importancia y dificultad técnic
 
 **Esta guía explica cómo proteger un sitio web.**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Le ofrecemos esta guía para ayudarle a completar mejor las tareas más comunes. Sin embargo, le recomendamos que, si necesita ayuda, contacte con un proveedor de servicios especializado o con el editor del programa o la interfaz. Nosotros no podremos asistirle. Para más información, consulte la sección [Más información](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/sql-change-password.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/sql-change-password.mdx
@@ -33,13 +33,7 @@ La modificación de la contraseña de la base de datos del sitio web se realiza 
 
 **Esta guía explica cómo cambiar la contraseña de una base de datos de forma segura.**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle al respecto. Para más información, consulte el apartado [Más información](#go-further) de esta guía.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/sql-database-export.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/sql-database-export.mdx
@@ -50,11 +50,7 @@ Algunos de los métodos anteriores no son inherentes a una interfaz de OVHcloud.
 
 Continúe leyendo esta guía en el apartado correspondiente al método de backup elegido.
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. Para más información, consulte la sección ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ### Obtener una copia de seguridad a través de la herramienta de OVHcloud
 

--- a/docs/es/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
@@ -49,11 +49,7 @@ Algunas de las operaciones anteriores se realizan en interfaces que no pertenece
 
 Continúe leyendo esta guía en el apartado correspondiente al método de importación elegido.
 
-:::warning
-La responsabilidad sobre la configuración y la gestión de los servicios que OVHcloud pone a su disposición recae íntegramente en usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado "Más información" de esta guía.
-:::
+[[fragment:support-scope]]
 
 ### Restaurar una copia de seguridad desde el área de cliente
 

--- a/docs/es/guides/web-cloud/web-hosting/sql-overquota-database.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/sql-overquota-database.mdx
@@ -36,11 +36,7 @@ Este tutorial explica las acciones que debe realizar cuando la base de datos en 
 
 ## Procedimiento
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
-
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 Cuando su base de datos en alojamiento compartido OVHcloud se satura (**overquota**), nuestros robots le advierten por correo electrónico en la dirección de correo electrónico del [contacto "Administrador"](/guides/account-and-service-management/account-information/managing-contacts) de la base de datos. 
 

--- a/docs/es/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
@@ -14,11 +14,7 @@ La mayoría de nuestros [planes de hosting](/links/web/hosting) incluyen bases d
 
 **Descubra cómo, a través de las API de OVHcloud, recuperar una copia de seguridad de una base de datos eliminada desde el área de cliente de OVHcloud.**
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. Sin embargo, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner), ya que no podremos proporcionarle ayuda adicional sobre las API. Para más información, consulte la sección ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
@@ -18,12 +18,12 @@ import { Tab, Tabs } from '@rspress/core/theme';
 - [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) instalado en el dispositivo local
 - Conocimientos básicos del [protocolo SSH y de su uso](/guides/bare-metal-cloud/dedicated-servers/ssh-introduction)
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud ofrece servicios cuya configuración y gestión son responsabilidad suya. Este tutorial explica cómo utilizar las soluciones de OVHcloud con herramientas externas. Es posible que tenga que adaptar algunas instrucciones específicas para el sistema operativo de su estación de trabajo local o servidor.
-
-Le recomendamos que, si necesita ayuda, contacte con un [proveedor de servicios especializado](/links/partner) o [nuestra comunidad](/links/community).
-
+Este tutorial explica cómo utilizar las soluciones de OVHcloud con herramientas externas. Es posible que tenga que adaptar algunas instrucciones específicas para el sistema operativo de su estación de trabajo local o servidor.
 :::
+
 
 {/* CP-NAV-START:web-hosting */}
 ---

--- a/docs/es/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
@@ -35,11 +35,7 @@ Cada vez es más fácil ver si un sitio web dispone o no de una conexión segura
 
 **Habilitar HTTPS en un sitio web puede ser una operación delicada**. En efecto, la mayoría de las acciones a realizar se realizarán en el código fuente de su sitio web. Si no se efectúan correctamente, existe el riesgo de que los resultados de los motores de búsqueda (Google, Yahoo!, bing...) muestren un nivel de SEO inferior o, incluso, de que el sitio web deje de estar disponible.
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. Para más información, consulte la sección "[Más información](#go-further)" de esta guía.
-:::
+[[fragment:support-scope]]
 
 A continuación le ofrecemos los Etapas principales para activar el protocolo HTTPS en su sitio web:
 

--- a/docs/es/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -9,11 +9,7 @@ availableIn: [eu, ca, apac]
 
 En este tutorial encontrará algunos ejemplos de situaciones relativas a la seguridad de su sitio web con el SSL.
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. Para más información, consulte la sección ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 **Descubra cómo evitar los errores habituales de seguridad de su sitio web con el SSL**
 

--- a/docs/es/guides/web-cloud/web-hosting/ssl-custom.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ssl-custom.mdx
@@ -36,11 +36,10 @@ En función de su situación, es posible que quiera instalar un certificado SSL 
 
 ## Procedimiento
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner). OVHcloud no podrá asistirle en **la instalación o contratación de un certificado SSL que no sea [los que ofrece OVHcloud](/links/web/hosting-options-ssl)**. Para más información, consulte la sección "[Más información](#go-further)" de esta guía.
-
+Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner). OVHcloud no podrá asistirle en **la instalación o contratación de un certificado SSL que no sea [los que ofrece OVHcloud](/links/web/hosting-options-ssl)**.
 :::
 
 ### 1 - Obtener una solicitud de firma de certificados (CSR) SSL <a name="step-1"></a>

--- a/docs/es/guides/web-cloud/web-hosting/ssl-ev.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ssl-ev.mdx
@@ -59,10 +59,10 @@ Para comprobar si puede contratar un certificado SSL Sectigo EV, acceda a [este 
 
 ## Procedimiento
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
+[[fragment:support-scope]]
 
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner). En efecto, no podremos asistirle en **todas las etapas de verificación directamente efectuada con la autoridad de certificación Sectigo**. Más información en la sección [Más información](#go-further) de esta guía.
+:::warning
+Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner). En efecto, no podremos asistirle en **todas las etapas de verificación directamente efectuada con la autoridad de certificación Sectigo**.
 :::
 
 ### 1 - Contratar el certificado SSL Sectigo EV

--- a/docs/es/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
@@ -11,11 +11,7 @@ Este tutorial explica cómo utilizar el generador de sitios web [Cecil](https://
 
 **Esta guía explica cómo añadir una llamada a una API externa desde su página web estática.**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Si necesita ayuda para seguir los pasos de este tutorial, le recomendamos que contacte con un [proveedor especializado](/links/partner) . Nosotros no podremos asistirle al respecto. Para más información, consulte el apartado ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/svn.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/svn.mdx
@@ -11,11 +11,7 @@ SVN, abreviación de "subversion", es un sistema de gestión de versiones.
 
 **Cómo utilizar SVN por SSH en un alojamiento web**
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado "[Más información](#go-further)" de esta guía.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/es/guides/web-cloud/web-hosting/using-scp-command.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/using-scp-command.mdx
@@ -15,11 +15,7 @@ El Secure Copy Protocol (SCP) permite copiar datos de forma segura (gracias al p
 
 Permite copiar un archivo o una carpeta que contiene uno o varios archivos desde un terminal y utilizando un comando Linux.
 
-:::warning
-OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
-
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. Para más información, consulte la sección ["Más información"](#go-further) de esta guía.
-:::
+[[fragment:support-scope]]
 
 **Descubra cómo utilizar el comando Secure Copy Protocol (SCP) por SSH para copiar archivos desde o hacia su alojamiento web.**
 

--- a/docs/es/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Este tutorial le permitirá crear sus primeros contenidos, organizarlos, publicarlos y cambiar el tema de su sitio web con el Content Management System (CMS) **WordPress**. Podrá crear su sitio web sin conocimientos de programación específicos, con una gran variedad de temas como un sitio web corporativo, un blog o incluso un sitio web para dar a conocer su actividad o su pasión.
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
+[[fragment:support-scope]]
 
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del CMS WordPress](https://wordpress.com/support/). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de este tutorial.
+:::warning
+Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del CMS WordPress](https://wordpress.com/support/). Nosotros no podremos asistirle.
 :::
 
 **Descubra cómo crear un sitio web con el CMS WordPress.**

--- a/docs/es/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Esta guía explica cómo crear una tienda online con la extensión open source **WooCommerce** con el Content Management System (CMS) **WordPress**. 
 
-:::warning
-La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
+[[fragment:support-scope]]
 
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](/links/partner), [el editor del CMS WordPress](https://wordpress.com/support/) o con [el editor de WooCommerce](https://woocommerce.com/) si tiene alguna dificultad. Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de este tutorial.
+:::warning
+Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](/links/partner), [el editor del CMS WordPress](https://wordpress.com/support/) o con [el editor de WooCommerce](https://woocommerce.com/) si tiene alguna dificultad. Nosotros no podremos asistirle.
 :::
 
 ## Requisitos

--- a/docs/fr/guides/web-cloud/domains/_transfer-incoming-homepl.mdx
+++ b/docs/fr/guides/web-cloud/domains/_transfer-incoming-homepl.mdx
@@ -35,11 +35,7 @@ Vous devez aussi :
 - Être habilité à demander le transfert du nom de domaine.
 - Avoir prévenu le propriétaire du nom de domaine et/ou ses administrateurs de la demande de transfert.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter votre bureau d’enregistrement actuel si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## En pratique
 

--- a/docs/fr/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -11,12 +11,7 @@ L’enregistrement **D**omain-based **M**essage **A**uthentication, **R**eportin
 
 **Découvrez comment fonctionne DMARC et comment le mettre en place pour votre service e-mail.**
 
-:::warning
-OVHcloud propose des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
-
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -4,11 +4,7 @@ lastUpdated: 2026-02-10
 availableIn: [eu, ca, apac]
 ---
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
-:::
+[[fragment:support-scope]]
 
 ## Objectif
 

--- a/docs/fr/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/fr/guides/web-cloud/domains/domain-icloud.mdx
@@ -7,12 +7,7 @@ availableIn: [eu, ca, apac]
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section « [Aller plus loin](#go-further) » de ce tutoriel.
-
-:::
+[[fragment:support-scope]]
 
 ## Objectif
 

--- a/docs/fr/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
+++ b/docs/fr/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
@@ -13,11 +13,12 @@ Vous êtes titulaire d’un nom de domaine chez OVHcloud et vous souhaitez le co
 
 **Découvrez comment connecter votre nom de domaine OVHcloud à un hébergement GoDaddy**
 
-:::warning
-- L’assistance GoDaddy n’a pas accès aux paramètres de votre nom de domaine OVHcloud et ne peut donc pas vous conseiller sur les informations que vous devrez lui fournir.
-- OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.<br/><br/> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
+[[fragment:support-scope]]
 
+:::warning
+L’assistance GoDaddy n’a pas accès aux paramètres de votre nom de domaine OVHcloud et ne peut donc pas vous conseiller sur les informations que vous devrez lui fournir.
 :::
+
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
+++ b/docs/fr/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
@@ -13,11 +13,12 @@ Vous êtes titulaire d’un nom de domaine chez OVHcloud et vous souhaitez le co
 
 **Découvrez comment connecter votre nom de domaine OVHcloud à un Google Site.**
 
-:::warning
-- L’assistance Google Site n’a pas accès aux paramètres de votre nom de domaine OVHcloud et ne peut donc pas vous conseiller sur les informations que vous devrez lui fournir.
-- OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.<br/><br/> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
+[[fragment:support-scope]]
 
+:::warning
+L’assistance Google Site n’a pas accès aux paramètres de votre nom de domaine OVHcloud et ne peut donc pas vous conseiller sur les informations que vous devrez lui fournir.
 :::
+
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
+++ b/docs/fr/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
@@ -13,12 +13,12 @@ Vous êtes titulaire d’un nom de domaine chez OVHcloud et vous souhaitez le co
 
 **Découvrez comment connecter votre nom de domaine OVHcloud à un hébergement Shopify**
 
+[[fragment:support-scope]]
+
 :::warning
-- L’assistance Shopify n’a pas accès aux paramètres de votre nom de domaine OVHcloud et ne peut donc pas vous conseiller sur les informations que vous devrez lui fournir.
-
-- OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.<br/><br/> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-
+L’assistance Shopify n’a pas accès aux paramètres de votre nom de domaine OVHcloud et ne peut donc pas vous conseiller sur les informations que vous devrez lui fournir.
 :::
+
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
+++ b/docs/fr/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
@@ -13,12 +13,12 @@ Vous êtes titulaire d’un nom de domaine chez OVHcloud et vous souhaitez le co
 
 **Découvrez comment connecter votre nom de domaine OVHcloud à un hébergement SquareSpace**
 
+[[fragment:support-scope]]
+
 :::warning
-- L’assistance SquareSpace n’a pas accès aux paramètres de votre nom de domaine OVHcloud et ne peut donc pas vous conseiller sur les informations que vous devrez lui fournir.
-
-- OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.<br/><br/> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-
+L’assistance SquareSpace n’a pas accès aux paramètres de votre nom de domaine OVHcloud et ne peut donc pas vous conseiller sur les informations que vous devrez lui fournir.
 :::
+
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
+++ b/docs/fr/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
@@ -13,11 +13,12 @@ Vous êtes titulaire d’un nom de domaine chez OVHcloud et vous souhaitez le co
 
 **Découvrez comment connecter votre nom de domaine OVHcloud à un hébergement Webflow**
 
-:::warning
-- L’assistance Webflow n’a pas accès aux paramètres de votre nom de domaine OVHcloud et ne peut donc pas vous conseiller sur les informations que vous devrez lui fournir.
-- OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.<br/><br/> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
+[[fragment:support-scope]]
 
+:::warning
+L’assistance Webflow n’a pas accès aux paramètres de votre nom de domaine OVHcloud et ne peut donc pas vous conseiller sur les informations que vous devrez lui fournir.
 :::
+
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
+++ b/docs/fr/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
@@ -13,12 +13,12 @@ Vous êtes titulaire d’un nom de domaine chez OVHcloud et vous souhaitez le co
 
 **Découvrez comment connecter votre nom de domaine OVHcloud à un hébergement Wix**
 
+[[fragment:support-scope]]
+
 :::warning
-- L’assistance Wix n’a pas accès aux paramètres de votre nom de domaine OVHcloud et ne peut donc pas vous conseiller sur les informations que vous devrez lui fournir.
-
-- OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.<br/><br/> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-
+L’assistance Wix n’a pas accès aux paramètres de votre nom de domaine OVHcloud et ne peut donc pas vous conseiller sur les informations que vous devrez lui fournir.
 :::
+
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/domains/redirect-domain-name.mdx
+++ b/docs/fr/guides/web-cloud/domains/redirect-domain-name.mdx
@@ -317,12 +317,7 @@ Cliquez sur <code className="action">Confirmer</code> pour valider votre configu
 
 ### Rediriger un nom de domaine via un fichier « .htaccess » <a name="htaccess_rewrite"></a>
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition cette partie du guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance sur les étapes documentées ci-dessous. Retrouvez plus d’informations dans la section « [Aller plus loin](#go-further) » de ce guide.
-
-:::
+[[fragment:support-scope]]
 
 Les fichiers « .htaccess » sont des fichiers de configuration dans lesquels des commandes peuvent être spécifiées. Lors de l’exécution du code de votre site internet par le serveur web (Apache), les commandes seront interprétées et ainsi exécutées.
 

--- a/docs/fr/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/fr/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -26,12 +26,7 @@ Cela vous évitera d’interrompre l’association entre votre nom de domaine et
 
 :::
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#aller-plus-loin) de ce guide.
-
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/domains/transfer-incoming-gandi.mdx
+++ b/docs/fr/guides/web-cloud/domains/transfer-incoming-gandi.mdx
@@ -43,11 +43,7 @@ Vous devez aussi :
 - Être habilité à demander le transfert du nom de domaine.
 - Avoir prévenu le titulaire du nom de domaine et/ou ses administrateurs de la demande de transfert.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter votre bureau d’enregistrement actuel si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## En pratique
 

--- a/docs/fr/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
+++ b/docs/fr/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
@@ -35,11 +35,7 @@ Vous devez aussi :
 - Être habilité à demander le transfert du nom de domaine.
 - Avoir prévenu le titulaire du nom de domaine et/ou ses administrateurs de la demande de transfert.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter votre bureau d’enregistrement actuel si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## En pratique
 

--- a/docs/fr/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
+++ b/docs/fr/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
@@ -35,11 +35,7 @@ Vous devez aussi :
 - Être habilité à demander le transfert du nom de domaine.
 - Avoir prévenu le titulaire du nom de domaine et/ou ses administrateurs de la demande de transfert.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter votre bureau d’enregistrement actuel si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## En pratique
 

--- a/docs/fr/guides/web-cloud/domains/transfer-incoming-ionos.mdx
+++ b/docs/fr/guides/web-cloud/domains/transfer-incoming-ionos.mdx
@@ -35,11 +35,7 @@ Vous devez aussi :
 - Être habilité à demander le transfert du nom de domaine.
 - Avoir prévenu le titulaire du nom de domaine et/ou ses administrateurs de la demande de transfert.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter votre bureau d’enregistrement actuel si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## En pratique
 

--- a/docs/fr/guides/web-cloud/domains/transfer-incoming-wix.mdx
+++ b/docs/fr/guides/web-cloud/domains/transfer-incoming-wix.mdx
@@ -35,11 +35,7 @@ Vous devez aussi :
 - Être habilité à demander le transfert du nom de domaine.
 - Avoir prévenu le titulaire du nom de domaine et/ou ses administrateurs de la demande de transfert.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter votre bureau d’enregistrement actuel si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## En pratique
 

--- a/docs/fr/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -14,12 +14,7 @@ Les modules en 1 clic permettent l’installation facile et rapide d’un logici
 
 **Découvrez comment gérer votre module en 1 clic depuis votre espace client OVHcloud.**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce guide.
-
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -9,13 +9,10 @@ availableIn: [eu, ca, apac]
 
 Vous trouverez ici tous les éléments pour installer manuellement le CMS (Content Management System) Drupal en quelques étapes.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS Drupal](https://www.drupal.org/support) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Retrouvez plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
-
-Si vous souhaitez mettre à jour un CMS Drupal existant ou si vous avez des questions sur l’utilisation du CMS Drupal, contactez directement [l’éditeur du CMS Drupal](https://www.drupal.org/support).
-
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS Drupal](https://www.drupal.org/support) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 :::tip

--- a/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Vous trouverez ici tous les éléments pour installer manuellement le CMS (Content Management System) Joomla! en quelques étapes.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS Joomla!](https://www.joomla.org/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Retrouvez plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
-
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS Joomla!](https://www.joomla.org/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 :::tip

--- a/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Vous trouverez ici tous les éléments pour installer manuellement le CMS (Content Management System) PrestaShop en quelques étapes.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS PrestaShop](https://www.prestashop.com/en/support) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-
+Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS PrestaShop](https://www.prestashop.com/en/support) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 :::tip

--- a/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Ce tutoriel a pour objectif de vous aider à installer manuellement le CMS (Content Management System) WordPress en quelques étapes.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
-
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 :::tip

--- a/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -12,22 +12,10 @@ import { Region } from '@components/Zone';
 
 Ce tutoriel a pour objectif de vous aider à installer manuellement un CMS (Content Management System) tel que WordPress, Joomla!, Drupal, PrestaShop, Pico, Grav, Typo3 ou SPIP en quelques étapes.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou l’éditeur du CMS que vous aurez choisi d’installer si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section « [Aller plus loin](#go-further) » de ce tutoriel.
-
-Pour contacter les différents éditeurs des CMS cités ci-dessus, retrouvez ci-après les liens vers leurs pages officielles respectives :
-
-- [WordPress](https://wordpress.com/fr/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-- [Pico](https://picocms.org/)
-- [Grav](https://getgrav.org/)
-- [Typo3](https://typo3.fr/)
-- [SPIP](https://www.spip.net/en_rubrique25.html)
-
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou l’éditeur du CMS que vous aurez choisi d’installer si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 :::tip

--- a/docs/fr/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -37,18 +37,10 @@ Plusieurs méthodes existent pour modifier le mot de passe administrateur de vot
 - [via l’interface d’administration de votre CMS](#via-cms)
 - [via phpMyAdmin depuis votre espace client OVHcloud](#via-phpmyadmin)
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Cependant, si vous éprouvez des difficultés, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à l’éditeur du CMS que vous aurez choisi d’installer. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section « [Aller plus loin](#go-further) » de ce tutoriel.
-
-Pour contacter les différents éditeurs des CMS cités ci-dessus, retrouvez ci-dessous les liens vers leurs pages officielles respectives :
-
-- [WordPress](https://wordpress.com/fr/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Cependant, si vous éprouvez des difficultés, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à l’éditeur du CMS que vous aurez choisi d’installer. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 ### Modifier son mot de passe administrateur via l’e-mail automatique (mot de passe oublié) <a name="via-email"></a>

--- a/docs/fr/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
@@ -19,12 +19,7 @@ Un piratage peut se manifester de plusieurs manières (liste non exhaustive) :
 
 **Découvrez nos conseils pour réparer votre site Web piraté.**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/composer-install-composer.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/composer-install-composer.mdx
@@ -11,11 +11,7 @@ availableIn: [eu, ca, apac]
 
 **Découvrez comment installer et faire vos premiers pas sur Composer**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/configure-ipv6.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/configure-ipv6.mdx
@@ -39,12 +39,7 @@ Nos hébergements web sont compatibles IPv6 depuis 2011. Mais l’activation de 
 
 ## En pratique
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Si vous éprouvez des difficultés, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
-
-:::
+[[fragment:support-scope]]
 
 Si votre site n’est pas configuré pour fonctionner avec une adresse IPv6, vous pouvez ajouter [l’adresse IPv6 de votre hébergement mutualisé OVHcloud](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip) dans la zone DNS active de votre nom de domaine. L’objectif est de permettre aux navigateurs web de trouver une adresse IPv6 associée à votre site web via votre nom de domaine.
 

--- a/docs/fr/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
@@ -9,11 +9,7 @@ availableIn: [eu]
 
 Découvrez comment créer la première page d’un site web sur un hébergement gratuit proposé gratuitement pour tout achat d’un nom de domaine chez OVHcloud.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/cron-tasks.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cron-tasks.mdx
@@ -13,11 +13,7 @@ Sur votre hébergement web OVHcloud, vous pouvez utiliser des scripts pour autom
 
 **Découvrez comment créer des tâches CRON pour automatiser vos tâches planifiées sur un hébergement web.**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
@@ -13,11 +13,7 @@ L’utilisation de vos bases de données peut entraîner un certain nombre d’a
 
 **Découvrez comment résoudre les erreurs liées aux bases de données sur les hébergements mutualisés OVHcloud.**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Ce guide vous accompagne sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -33,11 +33,10 @@ Suite à la détection d’un fonctionnement suspect, nos robots de sécurité p
 
 **Découvrez comment débloquer l’accès à votre site web en cas d’affichage d’une page « 403 forbidden ».**
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou d’échanger avec notre [communauté d’utilisateurs](/links/community) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-
+Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou d’échanger avec notre [communauté d’utilisateurs](/links/community) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 ## Prérequis

--- a/docs/fr/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -12,13 +12,7 @@ Cependant, si la configuration de ces derniers n'est pas correctement réalisée
 
 **Découvrez comment diagnostiquer les cas les plus courants d'erreurs liées aux créations de « module en 1 clic »**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « [Aller plus loin](#go-further) » de ce guide.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
@@ -15,12 +15,7 @@ Elles proviennent parfois aussi d’une mise à jour effectuée **automatiquemen
 
 **Découvrez comment diagnostiquer les cas les plus courants d’erreurs 500.**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
@@ -16,13 +16,7 @@ Une page **« Index of »** apparaît dans au moins l'un des cas suivants :
 
 **Découvrez comment corriger l’affichage d’une page « Index of ».**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce guide.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
@@ -20,11 +20,7 @@ Plusieurs messages d’erreur peuvent apparaître en cas d’inaccessibilité de
 
 **Découvrez comment résoudre les erreurs du type « Votre connexion n’est pas privée ».**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section « [Aller plus loin](#go-further) » de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -52,11 +52,10 @@ Par ailleurs, les performances de l’infrastructure d’hébergements mutualis�
 
 ## En pratique
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance **dès lors que l’infrastructure où votre offre d’hébergement mutualisé est présente n’est pas en cause**. Plus d’informations dans la section « [Aller plus loin](#go-further) » de ce guide.
-
+Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance **dès lors que l’infrastructure où votre offre d’hébergement mutualisé est présente n’est pas en cause**.
 :::
 
 :::tip

--- a/docs/fr/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
@@ -20,11 +20,7 @@ Plusieurs retours d’erreur peuvent apparaître sur votre navigateur en cas d�
 
 **Découvrez comment résoudre les erreurs du type « Ce site est inaccessible »**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -18,11 +18,7 @@ Cet accès permet notamment de [mettre en ligne votre site](/guides/web-cloud/we
 
 **Découvrez comment modifier le mot de passe d’un utilisateur FTP créé sur votre hébergement web OVHcloud.**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
@@ -19,11 +19,7 @@ Pour télécharger Cyberduck, rendez-vous sur le [site officiel](https://cyberdu
 
 :::
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous rencontrez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Consultez la section [Aller plus loin](#go-further) de ce guide pour plus d’informations.
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
@@ -13,12 +13,7 @@ L’utilisation de logiciels FTP lors de la connexion à votre [hébergement Web
 
 **Découvrez comment résoudre les erreurs liées aux logiciels FTP.**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -35,10 +35,10 @@ Si vous souhaitez administrer votre site web à distance sans utiliser Visual St
 
 ## En pratique
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
+[[fragment:support-scope]]
 
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur de l’IDE Visual Studio Code](https://code.visualstudio.com/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
+:::warning
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur de l’IDE Visual Studio Code](https://code.visualstudio.com/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 ### Installer l’extension SFTP pour Visual Studio Code

--- a/docs/fr/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
@@ -53,13 +53,7 @@ Après avoir évalué les différentes possibilités ci-dessus, deux choix s'off
 - **vous ne souhaitez pas utiliser nos modules en 1 clic** : vous devrez réaliser l'installation de votre site manuellement sur votre hébergement. Pour cela, les informations présentes dans cette documentation pourront vous aider dans vos démarches, mais elles ne se substituent pas à l'aide d'un webmaster.
  
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « Aller plus loin » de ce guide.
-
-:::
-
+[[fragment:support-scope]]
 
 ### 2 - Mise en ligne des fichiers du site sur l'espace de stockage
 

--- a/docs/fr/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
@@ -12,12 +12,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Ce guide vous présente les différentes actions à réaliser pour migrer l’ensemble de votre site web, vos dossiers, votre nom de domaine, votre base de données et vos adresses e-mail chez OVHcloud, sans interruption de services.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
@@ -30,12 +30,7 @@ Les offres d’hébergement web OVHcloud sont mutualisées. Par conséquent, la 
 
 ## En pratique
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section « [Aller plus loin](#go-further) » de ce guide.
-
-:::
+[[fragment:support-scope]]
 
 ### FTP
 

--- a/docs/fr/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -12,10 +12,10 @@ La sauvegarde régulière des informations de votre site web est une bonne prati
 
 Sur un hébergement web mutualisé, vous êtes responsable des sauvegardes de votre site web. Même si OVHcloud propose des sauvegardes (non contractuelles), nous vous recommandons de réaliser également vous-même des sauvegardes régulières et de gérer vos propres supports de sauvegarde (disque dur, clé USB, etc.) pour plus de précautions.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
+[[fragment:support-scope]]
 
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
+:::warning
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 **Découvrez comment sauvegarder le contenu de votre site WordPress et sa base de données.**

--- a/docs/fr/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -13,13 +13,7 @@ Ce tutoriel a pour objectif de vous expliquer les principales étapes à suivre 
 
 **Découvrez comment changer le nom de domaine d'un site existant.**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -15,11 +15,7 @@ Vous pouvez créer plusieurs fichiers « .htaccess » dans [l’espace FTP](/g
 
 **Découvrez comment bloquer l’accès à votre site pour certaines adresses IP via un fichier « .htaccess ».**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section « [Aller plus loin](#go-further) » de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -11,10 +11,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Ce tutoriel vous explique comment configurer certaines fonctionnalités de votre hébergement web avec un ou plusieurs fichiers **.htaccess**, notamment pour modifier les paramètres d’une partie ou de l’ensemble de votre site web (redirections, interdictions d’accès, autorisations restreintes, contrôle du cache, etc.).
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
+[[fragment:support-scope]]
 
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
+:::warning
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 **Découvrez comment sécuriser votre WordPress avec un ou plusieurs fichiers htaccess.**

--- a/docs/fr/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
@@ -14,13 +14,7 @@ Ceci en utilisant deux fichiers de configuration (HTTP) Apache à placer dans [l
 - « **.htaccess** » : pour plus d’informations sur les fonctionnalités de ce fichier, consultez notre tutoriel sur les [« Opérations réalisables avec un fichier « .htaccess » »](/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do).
 - « **.htpasswd** » : en complément de ce tutoriel, consultez la [documentation officielle Apache](https://httpd.apache.org/docs/2.4/fr/programs/htpasswd.html) relative à ce fichier.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-
-Les exemples qui vont suivre sont à mettre en place dans des fichiers nommés « .htaccess » et « .htpasswd ». Attention, les règles que vous définissez dans ces fichiers ont des conséquences directes sur votre site web. Vérifiez systématiquement les règles que vous ajoutez avant de les appliquer à votre site web. 
-:::
+[[fragment:support-scope]]
 
 **Découvrez comment protéger un répertoire ou l’accès à la partie administrateur de votre site web via une authentification avec les fichiers « .htaccess » et « .htpasswd ».**
 

--- a/docs/fr/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -32,14 +32,7 @@ Si vous souhaitez approfondir vos connaissances sur l'utilisation du « **mod_re
 
 ## En pratique
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
-
-Ce tutoriel est mis à votre disposition afin de vous aider au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-
-Les exemples qui vont suivre sont à mettre en place dans un fichier « .htaccess ». Attention, les règles que vous définissez dans ce fichier ont des conséquences directes sur votre site web. Vérifiez systématiquement les règles que vous ajoutez avant de les appliquer à votre site web.
-
-:::
+[[fragment:support-scope]]
 
 Le fichier « .htaccess » dans lequel vous allez configurer le « **mod_rewrite** » d'Apache peut être placé dans plusieurs dossiers différents. Vous devez uniquement respecter la règle d'un **seul** fichier « .htaccess » par dossier ou sous-dossier.
 

--- a/docs/fr/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
@@ -19,13 +19,7 @@ Pour utiliser correctement le fichier « .htaccess », vous devez connaître et 
 - le fichier « .htaccess » est invisible pour les internautes qui visitent votre site Web ;
 - les règles déclarées dans un fichier « .htaccess » s’appliquent à l’ensemble du répertoire où le fichier « .htaccess » est installé, ainsi qu’à tous les sous-répertoires de ce même répertoire.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-
-Les exemples qui vont suivre sont à mettre en place dans un fichier « .htaccess ». Attention, les règles que vous définissez dans ce fichier ont des conséquences directes sur votre site web. Vérifiez systématiquement les règles que vous ajoutez avant de les appliquer à votre site web. 
-:::
+[[fragment:support-scope]]
 
 **Découvrez les principales opérations réalisables à l’aide d’un fichier « .htaccess ».**
 

--- a/docs/fr/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -259,11 +259,7 @@ Notre service anti-spam analysera la situation et notre support reviendra vers v
 
 ### Envoi d’e-mails à l’aide d’un script « SMTP » <a name="SMTP"></a>
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition la partie qui va suivre afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 Même si nous vous recommandons vivement de privilégier l’utilisation de la fonction « mail() » de PHP, les hébergements mutualisés permettent d’envoyer des e-mails en passant par un script utilisant le protocole SMTP (Simple Mail Transfer Protocol). La taille totale de votre e-mail ne pourra pas dépasser les **10 Mo** (soit **7/8 Mo hors encapsulation**).
 

--- a/docs/fr/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -23,10 +23,10 @@ MainWP propose plusieurs extensions permettant de sauvegarder vos sites web.
 - Disposer d’une [offre d’hébergement Web Cloud](/links/web/hosting).
 - Être connecté à votre dashboard MainWP.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
+[[fragment:support-scope]]
 
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du plugin MainWP](https://mainwp.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
+:::warning
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du plugin MainWP](https://mainwp.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 ## En pratique

--- a/docs/fr/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -16,10 +16,10 @@ La fidélisation de vos clients est primordiale pour le développement de votre 
 - Disposer d’une [offre d’hébergement Web Cloud](/links/web/hosting).
 - Être connecté à votre dashboard MainWP. Pour plus d’informations, consultez notre guide « [Administrer plusieurs sites web WordPress avec le plugin MainWP](/guides/web-cloud/web-hosting/mainwp-general) ».
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
+[[fragment:support-scope]]
 
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du plugin MainWP](https://mainwp.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
+:::warning
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du plugin MainWP](https://mainwp.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 ## En pratique

--- a/docs/fr/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -26,11 +26,10 @@ Dans ce guide, nous avons choisi le plugin MainWP. D’autres solutions analogue
 - Disposer d’une [offre d’hébergement Web Cloud](/links/web/hosting).
 - Être connecté à l’interface d’administration de WordPress.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du plugin MainWP](https://mainwp.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
-
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du plugin MainWP](https://mainwp.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/fr/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -16,10 +16,10 @@ Maintenir la sécurité de vos sites web est crucial pour le développement de v
 - Disposer d’une [offre d’hébergement Web Cloud](/links/web/hosting).
 - Être connecté à votre dashboard MainWP.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
+[[fragment:support-scope]]
 
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du plugin MainWP](https://mainwp.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
+:::warning
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du plugin MainWP](https://mainwp.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 ## En pratique

--- a/docs/fr/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
@@ -20,11 +20,7 @@ Votre site web évolue, sa consommation de ressources devient telle que votre h�
 
 ## En pratique
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ### Étape 1 - Sauvegarder les fichiers et la base de données de votre site web <a name="step1"></a>
 

--- a/docs/fr/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Ce tutoriel vous explique pas à pas comment migrer votre site web WordPress et tous ses services associés vers OVHcloud.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
+[[fragment:support-scope]]
 
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
+:::warning
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 **Découvrez comment migrer votre site web WordPress et ses services associés vers OVHcloud.**

--- a/docs/fr/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Ce tutoriel vous explique pas à pas comment migrer votre site web Xara et tous ses services associés vers OVHcloud.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
+[[fragment:support-scope]]
 
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou au [site officiel de Xara Web designer](https://www.xara.com/webdesigner-plus/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
+:::warning
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou au [site officiel de Xara Web designer](https://www.xara.com/webdesigner-plus/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 **Découvrez comment migrer votre site web Xara et ses services associés vers OVHcloud.**

--- a/docs/fr/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
@@ -16,13 +16,7 @@ Il est possible de voir apparaître sur votre navigateur Internet la page d'erre
 
 **Découvrez comment identifier et résoudre la page d'erreur « Site non installé »**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Retrouvez plus d'informations dans la section « [Aller plus loin](#go-further) » de ce guide.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/secure-your-website.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/secure-your-website.mdx
@@ -14,11 +14,7 @@ Toutefois, si vous rencontrez des difficultés à réaliser certaines d’entre 
 
 **Découvrez comment sécuriser votre site Web.**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [Aller plus loin](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/sql-change-password.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/sql-change-password.mdx
@@ -33,13 +33,7 @@ La modification du mot de passe de la base de données de votre site nécessite 
 
 **Découvrez comment changer le mot de passe d'une base de données de façon sécurisée.**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce guide.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/sql-database-export.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/sql-database-export.mdx
@@ -50,11 +50,7 @@ Certaines des méthodes ci-dessus ne sont pas inhérentes à une interface OVHcl
 
 Poursuivez la lecture de cette documentation selon la méthode de sauvegarde souhaitée.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ### Récupérer une sauvegarde via l’outil d’OVHcloud
 

--- a/docs/fr/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
@@ -49,11 +49,7 @@ Certaines des méthodes ci-dessus ne sont pas inhérentes à une interface OVHcl
 
 Poursuivez la lecture de cette documentation selon la méthode d’importation souhaitée.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section « Aller plus loin » de ce guide.
-:::
+[[fragment:support-scope]]
 
 ### Restaurer une sauvegarde depuis l’espace client
 

--- a/docs/fr/guides/web-cloud/web-hosting/sql-overquota-database.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/sql-overquota-database.mdx
@@ -37,12 +37,7 @@ Ce tutoriel vous propose des actions à entreprendre lorsque votre base de donn�
 
 ## En pratique
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-
-:::
+[[fragment:support-scope]]
 
 Lorsque votre base de données mutualisée OVHcloud arrive à saturation (**overquota**), nos robots vous avertissent par e-mail sur l’adresse e-mail du [contact « Administrateur »](/guides/account-and-service-management/account-information/managing-contacts) de la base de données. 
 

--- a/docs/fr/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
@@ -14,11 +14,7 @@ La plupart de nos offres d’[hébergement web](/links/web/hosting) comprennent 
 
 **Découvrez comment retrouver, via les API OVHcloud, la sauvegarde d’une base de données lorsque celle-ci a été supprimée depuis votre espace client OVHcloud.**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance complémentaire sur les API. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
@@ -18,12 +18,12 @@ import { Tab, Tabs } from '@rspress/core/theme';
 - [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) installé sur votre équipement local
 - Des connaissances de base du [protocole SSH et de son utilisation](/guides/bare-metal-cloud/dedicated-servers/ssh-introduction)
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud fournit des services dont la configuration et la gestion relèvent de votre responsabilité. Ce tutoriel va illustrer comment utiliser les solutions OVHcloud avec des outils externes. Vous devrez peut-être adapter certaines instructions spécifiques au système d’exploitation de votre poste de travail local ou de votre serveur.
-
-Nous vous recommandons de contacter un [prestataire de services spécialisé](/links/partner) ou [notre communauté](/links/community) si vous rencontrez des difficultés.
-
+Ce tutoriel va illustrer comment utiliser les solutions OVHcloud avec des outils externes. Vous devrez peut-être adapter certaines instructions spécifiques au système d’exploitation de votre poste de travail local ou de votre serveur.
 :::
+
 
 {/* CP-NAV-START:web-hosting */}
 ---

--- a/docs/fr/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
@@ -35,11 +35,7 @@ Le fait que votre site web possède ou non une connexion sécurisée devient de 
 
 **Passer son site web en *HTTPS* peut être une manipulation sensible**. En effet, l’essentiel des actions à réaliser s’effectueront dans le code source de votre site web. Si elles ne sont pas effectuées correctement, vous risquez une baisse de référencement (SEO) dans les résultats proposés par les moteurs de recherche (Google, Yahoo!, bing, etc.), voire une inaccessibilité totale de votre site web.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 Retrouvez ci-dessous les principales étapes décrites dans la suite de ce guide pour passer votre site web en *HTTPS* :
 

--- a/docs/fr/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -9,11 +9,7 @@ availableIn: [eu, ca, apac]
 
 Retrouvez, dans ce tutoriel, quelques exemples de situations concernant la sécurisation de votre site web avec le SSL.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 **Découvrez comment éviter les erreurs courantes de sécurisation de son site web avec le SSL**
 

--- a/docs/fr/guides/web-cloud/web-hosting/ssl-custom.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ssl-custom.mdx
@@ -36,11 +36,10 @@ En fonction de votre situation, il est possible que vous souhaitiez installer un
 
 ## En pratique
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance sur **l’installation ou la souscription d’un certificat SSL autre que [ceux proposés par OVHcloud](/links/web/hosting-options-ssl)**. Plus d’informations dans la section « [Aller plus loin](#go-further) » de ce guide.
-
+Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance sur **l’installation ou la souscription d’un certificat SSL autre que [ceux proposés par OVHcloud](/links/web/hosting-options-ssl)**.
 :::
 
 ### 1 - Obtenir une Certificate Signing Request (CSR) SSL <a name="step-1"></a>

--- a/docs/fr/guides/web-cloud/web-hosting/ssl-ev.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ssl-ev.mdx
@@ -59,11 +59,10 @@ Pour vérifier si vous êtes éligible à la souscription d’un certificat SSL 
 
 ## En pratique
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance **pour toutes les étapes de vérifications directement réalisées avec l’autorité de certification Sectigo**. Plus d’informations dans la section « [Aller plus loin](#go-further) » de ce guide.
-
+Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance **pour toutes les étapes de vérifications directement réalisées avec l’autorité de certification Sectigo**.
 :::
 
 ### 1 - Commander le certificat SSL Sectigo EV

--- a/docs/fr/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
@@ -11,11 +11,7 @@ Ce tutoriel vous décrit comment utiliser le générateur de site [Cecil](https:
 
 **Découvrez comment ajouter un appel vers une API externe depuis votre page web statique.**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Si vous éprouvez des difficultés à suivre les étapes de ce tutoriel, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) . En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/svn.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/svn.mdx
@@ -11,11 +11,7 @@ SVN, qui est l’abréviation de « subversion », est un système de gestion de
 
 **Découvrez comment utiliser SVN en SSH sur votre hébergement web**
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section « [Aller plus loin](#go-further) » de ce guide.
-:::
+[[fragment:support-scope]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/web-hosting/using-scp-command.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/using-scp-command.mdx
@@ -15,11 +15,7 @@ Le Secure Copy Protocol (SCP) permet de copier de manière sécurisée (grâce a
 
 Il permet, depuis un terminal et à l’aide d’une commande Linux, de copier un fichier ou un dossier contenant un ou plusieurs fichiers.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
-
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
-:::
+[[fragment:support-scope]]
 
 **Découvrez comment utiliser la commande Secure Copy Protocol (SCP) en SSH pour copier des fichiers depuis ou vers votre hébergement web.**
 

--- a/docs/fr/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Ce tutoriel va vous permettre de créer vos premiers contenus, les organiser, les mettre en ligne et changer le thème de votre site web avec le Content Management System (CMS) **WordPress**. Vous pourrez réaliser votre site web sans connaissances particulières en programmation, avec un large choix de thématiques comme un site web d’entreprise, un blog, ou encore un site pour faire connaître votre activité ou votre passion.
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
+[[fragment:support-scope]]
 
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du CMS WordPress](https://wordpress.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
+:::warning
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du CMS WordPress](https://wordpress.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 **Découvrez comment créer un site web avec le CMS WordPress.**

--- a/docs/fr/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Découvrez comment créer une boutique en ligne avec l’extension open source **WooCommerce** avec le Content Management System (CMS) **WordPress**. 
 
-:::warning
-OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
+[[fragment:support-scope]]
 
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner), à [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) ou à [l’éditeur de WooCommerce](https://woocommerce.com/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
+:::warning
+Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner), à [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) ou à [l’éditeur de WooCommerce](https://woocommerce.com/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
 :::
 
 ## Prérequis

--- a/docs/it/guides/web-cloud/domains/_transfer-incoming-o2switch.mdx
+++ b/docs/it/guides/web-cloud/domains/_transfer-incoming-o2switch.mdx
@@ -36,11 +36,7 @@ Se è necessario modificare il **proprietario** del dominio, è necessario farlo
 - Essere abilitato a richiedere il trasferimento del dominio.
 - Aver informato il proprietario del dominio e/o i suoi amministratori della richiesta di trasferimento.
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o il tuo attuale provider. OVHcloud non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Procedura
 

--- a/docs/it/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -11,12 +11,7 @@ Il record **D**omain-based **M**essage **A**uthentication, **R**eporting, and **
 
 **Come funziona DMARC e come configurarlo per il tuo servizio di posta elettronica.**
 
-:::warning
-OVHcloud propone servizi di cui l’utente è responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a realizzare le operazioni più ricorrenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [fornitore specializzato](/links/partner). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -4,11 +4,7 @@ lastUpdated: 2026-02-10
 availableIn: [eu, ca, apac]
 ---
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a realizzare le operazioni più ricorrenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a un [fornitore specializzato](/links/partner). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Obiettivo
 

--- a/docs/it/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/it/guides/web-cloud/domains/domain-icloud.mdx
@@ -5,11 +5,7 @@ lastUpdated: 2025-08-27
 availableIn: [eu, ca, apac]
 ---
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Objective
 

--- a/docs/it/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
+++ b/docs/it/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
@@ -13,11 +13,12 @@ Sei titolare di un nome di dominio presso OVHcloud e desideri connetterlo a un h
 
 **Scopri come connettere il tuo nome di dominio OVHcloud a un hosting GoDaddy**
 
-:::warning
-- L'assistenza GoDaddy non ha accesso ai parametri del tuo nome di dominio OVHcloud e non può quindi consigliarti sulle informazioni che dovrai fornire.
-- OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione, la gestione e la responsabilità. Garantirne il corretto funzionamento è quindi responsabilità dell'utente.<br/><br/> Questa guida ti aiuta a realizzare le operazioni più ricorrenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [fornitore specializzato](/links/partner) e/o il fornitore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
+[[fragment:support-scope]]
 
+:::warning
+L'assistenza GoDaddy non ha accesso ai parametri del tuo nome di dominio OVHcloud e non può quindi consigliarti sulle informazioni che dovrai fornire.
 :::
+
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
+++ b/docs/it/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
@@ -13,11 +13,12 @@ Sei titolare di un nome di dominio presso OVHcloud e desideri connetterlo a un G
 
 **Scopri come connettere il tuo nome di dominio OVHcloud a un Google Site.**
 
-:::warning
-- L'assistenza Google Site non ha accesso ai parametri del tuo nome di dominio OVHcloud e non può quindi consigliarti sulle informazioni che dovrai fornire.
-- OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione, la gestione e la responsabilità. Garantirne il corretto funzionamento è quindi responsabilità dell'utente.<br/><br/> Questa guida ti aiuta a realizzare le operazioni più ricorrenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [fornitore specializzato](/links/partner) e/o il fornitore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
+[[fragment:support-scope]]
 
+:::warning
+L'assistenza Google Site non ha accesso ai parametri del tuo nome di dominio OVHcloud e non può quindi consigliarti sulle informazioni che dovrai fornire.
 :::
+
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
+++ b/docs/it/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
@@ -13,12 +13,12 @@ Sei titolare di un nome di dominio presso OVHcloud e desideri connetterlo a un h
 
 **Scopri come connettere il tuo nome di dominio OVHcloud a un hosting Shopify**
 
+[[fragment:support-scope]]
+
 :::warning
-- L'assistenza Shopify non ha accesso ai parametri del tuo nome di dominio OVHcloud e non può quindi consigliarti sulle informazioni che dovrai fornire.
-
-- OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione, la gestione e la responsabilità. Garantirne il corretto funzionamento è quindi responsabilità dell'utente.<br/><br/> Questa guida ti aiuta a realizzare le operazioni più ricorrenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [fornitore specializzato](/links/partner) e/o il fornitore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-
+L'assistenza Shopify non ha accesso ai parametri del tuo nome di dominio OVHcloud e non può quindi consigliarti sulle informazioni che dovrai fornire.
 :::
+
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
+++ b/docs/it/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
@@ -13,12 +13,12 @@ Sei titolare di un nome di dominio presso OVHcloud e desideri connetterlo a un h
 
 **Scopri come connettere il tuo nome di dominio OVHcloud a un hosting SquareSpace**
 
+[[fragment:support-scope]]
+
 :::warning
-- L'assistenza SquareSpace non ha accesso ai parametri del tuo nome di dominio OVHcloud e non può quindi consigliarti sulle informazioni che dovrai fornire.
-
-- OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione, la gestione e la responsabilità. Garantirne il corretto funzionamento è quindi responsabilità dell'utente.<br/><br/> Questa guida ti aiuta a realizzare le operazioni più ricorrenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [fornitore specializzato](/links/partner) e/o il fornitore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-
+L'assistenza SquareSpace non ha accesso ai parametri del tuo nome di dominio OVHcloud e non può quindi consigliarti sulle informazioni che dovrai fornire.
 :::
+
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
+++ b/docs/it/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
@@ -13,11 +13,12 @@ Sei titolare di un nome di dominio presso OVHcloud e desideri connetterlo a un h
 
 **Scopri come connettere il tuo nome di dominio OVHcloud a un hosting Webflow**
 
-:::warning
-- L'assistenza Webflow non ha accesso ai parametri del tuo nome di dominio OVHcloud e non può quindi consigliarti sulle informazioni che dovrai fornire.
-- OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione, la gestione e la responsabilità. Garantirne il corretto funzionamento è quindi responsabilità dell'utente.<br/><br/> Questa guida ti aiuta a realizzare le operazioni più ricorrenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [fornitore specializzato](/links/partner) e/o il fornitore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
+[[fragment:support-scope]]
 
+:::warning
+L'assistenza Webflow non ha accesso ai parametri del tuo nome di dominio OVHcloud e non può quindi consigliarti sulle informazioni che dovrai fornire.
 :::
+
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
+++ b/docs/it/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
@@ -13,12 +13,12 @@ Sei titolare di un nome di dominio presso OVHcloud e desideri connetterlo a un h
 
 **Scopri come connettere il tuo nome di dominio OVHcloud a un hosting Wix**
 
+[[fragment:support-scope]]
+
 :::warning
-- L'assistenza Wix non ha accesso ai parametri del tuo nome di dominio OVHcloud e non può quindi consigliarti sulle informazioni che dovrai fornire.
-
-- OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione, la gestione e la responsabilità. Garantirne il corretto funzionamento è quindi responsabilità dell'utente.<br/><br/> Questa guida ti aiuta a realizzare le operazioni più ricorrenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [fornitore specializzato](/links/partner) e/o il fornitore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-
+L'assistenza Wix non ha accesso ai parametri del tuo nome di dominio OVHcloud e non può quindi consigliarti sulle informazioni che dovrai fornire.
 :::
+
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/domains/redirect-domain-name.mdx
+++ b/docs/it/guides/web-cloud/domains/redirect-domain-name.mdx
@@ -317,12 +317,7 @@ Clicca su <code className="action">Conferma</code> per confermare la configurazi
 
 ### Reindirizzare un dominio tramite un file ".htaccess" <a name="htaccess_rewrite"></a>
 
-:::warning
-OVHcloud mette a disposizione i servizi la cui configurazione, gestione e responsabilità spettano a te. Spetta a te assicurarne il corretto funzionamento.
-
-Mettiamo a tua disposizione questa parte della guida per assisterti nelle operazioni più comuni. Tuttavia, ti consigliamo di rivolgerti a un [provider specializzato](/links/partner) in caso di difficoltà. Non saremo in grado di fornirti assistenza per i passaggi documentati qui sotto. Trovi maggiori informazioni nella sezione "[Per saperne di più](#go-further)" di questa guida.
-
-:::
+[[fragment:support-scope]]
 
 I file ".htaccess" sono file di configurazione in cui è possibile specificare dei comandi. Quando il server web (Apache) esegue il codice del sito Internet, i comandi vengono interpretati e quindi eseguiti.
 

--- a/docs/it/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/it/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -9,12 +9,7 @@ availableIn: [eu, ca, apac]
 
 Il trasferimento di un nome di dominio.uk (o assimilato) richiede una procedura specifica.
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato o l’amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) su questa guida.
-
-:::
+[[fragment:support-scope]]
 
 **Come trasferire un nome di dominio.uk (o equivalente) in OVHcloud**
 

--- a/docs/it/guides/web-cloud/domains/transfer-incoming-gandi.mdx
+++ b/docs/it/guides/web-cloud/domains/transfer-incoming-gandi.mdx
@@ -44,11 +44,7 @@ Prima di iniziare il trasferimento del nome di dominio è quindi fondamentale ef
 - essere abilitato a richiedere il trasferimento del nome di dominio.
 - Aver informato l'intestatario del nome di dominio e/o i suoi amministratori della richiesta di trasferimento.
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o il tuo attuale provider. OVH non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Procedura
 

--- a/docs/it/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
+++ b/docs/it/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
@@ -36,11 +36,7 @@ Se è necessario modificare l'**intestatario** del nome di dominio, è necessari
 - essere abilitato a richiedere il trasferimento del nome di dominio.
 - Aver informato l'intestatario del nome di dominio e/o i suoi amministratori della richiesta di trasferimento.
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o il tuo attuale provider. OVH non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Procedura
 

--- a/docs/it/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
+++ b/docs/it/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
@@ -36,11 +36,7 @@ Se è necessario modificare l'**intestatario** del nome di dominio, è necessari
 - Essere abilitato a richiedere il trasferimento del nome di dominio.
 - Aver informato l'intestatario del nome di dominio e/o i suoi amministratori della richiesta di trasferimento.
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o il tuo attuale provider. OVH non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Procedura
 

--- a/docs/it/guides/web-cloud/domains/transfer-incoming-ionos.mdx
+++ b/docs/it/guides/web-cloud/domains/transfer-incoming-ionos.mdx
@@ -36,11 +36,7 @@ Se è necessario modificare l'**intestatario** del nome di dominio, è necessari
 - essere abilitato a richiedere il trasferimento del nome di dominio.
 - Aver informato l'intestatario del nome di dominio e/o i suoi amministratori della richiesta di trasferimento.
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o il tuo attuale provider. OVH non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Procedura
 

--- a/docs/it/guides/web-cloud/domains/transfer-incoming-wix.mdx
+++ b/docs/it/guides/web-cloud/domains/transfer-incoming-wix.mdx
@@ -36,11 +36,7 @@ Se è necessario modificare l'**intestatario** del nome di dominio, è necessari
 - Essere abilitato a richiedere il trasferimento del nome di dominio.
 - Aver informato l'**intestatario** del nome di dominio e/o i suoi amministratori della richiesta di trasferimento.
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o il tuo attuale provider. OVHcloud non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Procedura
 

--- a/docs/it/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -13,12 +13,7 @@ I moduli in 1 click permettono di installare facilmente e rapidamente un softwar
 
 **Questa guida ti mostra come gestire il tuo modulo in 1 click dallo Spazio Cliente OVHcloud.**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato o l'amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) su questa guida.
-
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -9,13 +9,10 @@ availableIn: [eu, ca, apac]
 
 Qui trovi tutti gli elementi per installare manualmente il CMS (Content Management System) Drupal in pochi step.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o [amministratore del CMS Drupal](https://www.drupal.org/support). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni, consulta la sezione ["Per saperne di più"](#go-further) di questo tutorial.
-
-Per aggiornare un CMS Drupal esistente o avere domande sull'utilizzo del CMS Drupal, contatta direttamente [l'editor del CMS Drupal](https://www.drupal.org/support).
-
+Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o [amministratore del CMS Drupal](https://www.drupal.org/support). OVHcloud non potrà fornirti alcuna assistenza.
 :::
 
 :::tip

--- a/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Qui trovi tutti gli elementi per installare manualmente il CMS (Content Management System) Joomla! in pochi step.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o [amministratore del CMS Joomla!](https://www.joomla.org/). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni, consulta la sezione ["Per saperne di più"](#go-further) di questo tutorial.
-
+Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o [amministratore del CMS Joomla!](https://www.joomla.org/). OVHcloud non potrà fornirti alcuna assistenza.
 :::
 
 :::tip

--- a/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Qui trovi tutti gli elementi per installare manualmente il CMS (Content Management System) PrestaShop in pochi step.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a un [provider specializzato](/links/partner) o [amministratore del CMS PrestaShop](https://www.prestashop.com/en/support). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-
+Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a un [provider specializzato](/links/partner) o [amministratore del CMS PrestaShop](https://www.prestashop.com/en/support). OVHcloud non potrà fornirti alcuna assistenza.
 :::
 
 :::tip

--- a/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Questa guida ti mostra come installare manualmente il CMS (Content Management System) WordPress in pochi step.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o [l'amministratore del CMS WordPress](https://wordpress.com/it/support/). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più](#go-further) di questa guida.
-
+Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o [l'amministratore del CMS WordPress](https://wordpress.com/it/support/). OVHcloud non potrà fornirti alcuna assistenza.
 :::
 
 :::tip

--- a/docs/it/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -12,22 +12,10 @@ import { Region } from '@components/Zone';
 
 Questa guida ti mostra come installare manualmente un CMS (Content Management System) come WordPress, Joomla!, Drupal, PrestaShop, Pico, Grav, Typo3 o SPIP.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o all'amministratore del CMS che hai scelto di installare. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questo tutorial.
-
-Per contattare gli editori dei CMS di cui sopra, clicca qui di seguito sui link alle rispettive pagine ufficiali:
-
-- [WordPress](https://wordpress.com/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-- [Pico](https://picocms.org/)
-- [Grav](https://getgrav.org/)
-- [Typo3](https://typo3.com/)
-- [SPIP](https://www.spip.net/en_rubrique25.html)
-
+Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o all'amministratore del CMS che hai scelto di installare. OVHcloud non potrà fornirti alcuna assistenza.
 :::
 
 :::tip

--- a/docs/it/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -37,18 +37,10 @@ Esistono diversi metodi per modificare la password amministratore del CMS in bas
 - [tramite l'interfaccia di amministrazione del CMS](#via-cms)
 - [via phpMyAdmin dal tuo Spazio Cliente OVHcloud](#via-phpmyadmin)
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o all'amministratore del CMS che hai scelto di installare. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questo tutorial.
-
-Per contattare gli editori dei CMS di cui sopra, clicca qui di seguito sui link alle rispettive pagine ufficiali:
-
-- [WordPress](https://wordpress.com/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-
+Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o all'amministratore del CMS che hai scelto di installare. OVHcloud non potrà fornirti alcuna assistenza.
 :::
 
 ### Modificare la password amministratore tramite l'email automatica (password dimenticata) <a name="via-email"></a>

--- a/docs/it/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
@@ -19,12 +19,7 @@ La pirateria può manifestarsi in diversi modi (elenco non esaustivo):
 
 **Scopri i nostri consigli per riparare il tuo sito Web pirata.**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/composer-install-composer.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/composer-install-composer.mdx
@@ -11,11 +11,7 @@ availableIn: [eu, ca, apac]
 
 **Questa guida ti mostra come installare e fare i primi passi su Composer**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o di contattare l'amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questo tutorial.
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/configure-ipv6.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/configure-ipv6.mdx
@@ -38,12 +38,7 @@ I nostri hosting Web sono compatibili con IPv6 dal 2011. L'attivazione di questo
 
 ## Procedura
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. In caso di difficoltà, ti consigliamo di contattare un [provider specializzato](/links/partner) e/o il fornitore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questo tutorial.
-
-:::
+[[fragment:support-scope]]
 
 Se il tuo sito non è configurato per funzionare con un indirizzo IPv6, puoi aggiungere [l'indirizzo IPv6 del tuo hosting condiviso OVHcloud](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip) nella zona DNS attiva del tuo dominio. L'obiettivo è permettere ai browser di trovare un indirizzo IPv6 associato al tuo sito Web tramite il tuo dominio.
 

--- a/docs/it/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
@@ -11,11 +11,7 @@ Questa guida ti mostra come creare la prima pagina di un sito Web su un Hosting 
 
 **Scoprire come creare la tua prima pagina Web su un Hosting gratuito**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/cron-tasks.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cron-tasks.mdx
@@ -13,11 +13,7 @@ Sull'hosting web OVHcloud è possibile utilizzare script per automatizzare alcun
 
 **Questa guida ti mostra come creare task CRON per automatizzare le operazioni pianificate su un hosting web.**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Spetta quindi a te garantirne il buon funzionamento.
-
-Questa guida ti aiuta a realizzare le operazioni più ricorrenti. Per questo, ti suggeriamo di rivolgerti a un [provider specializzato](/links/partner) o di contattare l'amministratore del servizio nel caso in cui dovessi incontrare delle difficoltà. Non saremo effettivamente in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
@@ -13,11 +13,7 @@ L'utilizzo dei database può provocare alcune anomalie sul tuo sito o sul tuo <M
 
 **Scopri come risolvere gli errori associati ai database sugli hosting condivisi OVHcloud.**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [fornitore specializzato](/links/partner) o l'amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) su questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -33,11 +33,10 @@ In seguito al rilevamento di un funzionamento sospetto, i nostri sistemi di sicu
 
 **Questa guida ti mostra come sbloccare l'accesso al tuo sito in caso di visualizzazione "403 forbidden".**
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a un [provider specializzato](/links/partner) e/o di contattare la nostra [Community di utenti](/links/community). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-
+Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a un [provider specializzato](/links/partner) e/o di contattare la nostra [Community di utenti](/links/community). OVHcloud non potrà fornirti alcuna assistenza.
 :::
 
 ## Prerequisiti

--- a/docs/it/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -12,13 +12,7 @@ Tuttavia, se la configurazione non viene effettuata correttamente, l’installaz
 
 **Questa guida ti mostra come diagnosticare i casi più comuni di errori legati alla creazione di "moduli in 1 click"**
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o il fornitore del servizio. OVH non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione "[Per saperne di più](#go-further)" di questa guida.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
@@ -15,12 +15,7 @@ A volte provengono anche da un aggiornamento effettuato **automaticamente** da u
 
 **Scopri come diagnosticare i casi di errore più comuni 500.**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato o l’amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) su questa guida.
-
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
@@ -16,14 +16,7 @@ Una pagina **"Index of"** compare in almeno uno dei seguenti casi:
 
 **Questa guida ti mostra come correggere la visualizzazione di una pagina "Index of"**.
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o di contattare l'amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-
-:::
-
-
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
@@ -20,11 +20,7 @@ In caso di inaccessibilità del sito, potrebbero comparire diversi messaggi di e
 
 **Scopri come risolvere errori di tipo "La tua connessione non è privata".**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a un [provider specializzato](/links/partner) o contattare l'amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -52,11 +52,10 @@ Inoltre, le prestazioni dell'infrastruttura di hosting condivisi OVHcloud sono m
 
 ## Procedura
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner). OVHcloud non sarà infatti in grado di fornirti assistenza **se l'infrastruttura in cui è presente la tua offerta di hosting condiviso non è interessata**. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-
+Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner). OVHcloud non sarà infatti in grado di fornirti assistenza **se l'infrastruttura in cui è presente la tua offerta di hosting condiviso non è interessata**.
 :::
 
 :::tip

--- a/docs/it/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
@@ -20,11 +20,7 @@ Se il tuo sito non è raggiungibile, sul tuo browser potrebbero comparire divers
 
 **Scopri come risolvere gli errori del tipo "Impossibile raggiungere il sito"**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato o l'amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) su questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -18,11 +18,7 @@ Questo accesso permette in particolare di [pubblicare il vostro sito](/guides/we
 
 **Questa guida ti mostra come modificare la password di un utente FTP creata sul tuo hosting Web OVHcloud.**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
@@ -19,11 +19,7 @@ Per scaricare Cyberduck, accedi al [sito ufficiale](https://cyberduck.io/) dell�
 
 :::
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o il fornitore del servizio. OVHcloud non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni, consulta la sezione [Per saperne di più](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
@@ -13,12 +13,7 @@ L'utilizzo di software FTP durante la connessione al tuo [hosting Web Cloud](/li
 
 **Questa guida ti mostra come risolvere gli errori associati ai software FTP.**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato o l’amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) su questa guida.
-
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -35,10 +35,10 @@ Per gestire il sito Web in remoto senza utilizzare Visual Studio Code, installa 
 
 ## Procedura
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
+[[fragment:support-scope]]
 
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o [l’editor dell’IDE Visual Studio Code](https://code.visualstudio.com/). OVHcloud non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
+:::warning
+Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o [l’editor dell’IDE Visual Studio Code](https://code.visualstudio.com/). OVHcloud non sarà infatti in grado di fornirti assistenza.
 :::
 
 ### Installare l'estensione SFTP per Visual Studio Code

--- a/docs/it/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
@@ -53,13 +53,7 @@ In base all’opzione scelta, hai quindi due possibilità:
 - **non utilizzare i nostri moduli in 1 click**: in questo caso, l’installazione del sito deve essere eseguita manualmente sull’hosting. Questa guida contiene informazioni utili per effettuare questa operazione ma, in caso di necessità, ti consigliamo di rivolgerti a un webmaster.
  
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione; garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente. 
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla pubblicazione dei tuoi contenuti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato.  Per maggiori informazioni consulta la sezione “Per saperne di più”.
-
-:::
-
+[[fragment:support-scope]]
 
 ### 2 - Carica i file del sito nello spazio di storage
 

--- a/docs/it/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
@@ -12,12 +12,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Questa guida ti mostra le operazioni da effettuare per migrare in OVHcloud siti Web, cartelle, domini, database e indirizzi email, senza interruzioni di servizio.
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore ](/links/partner). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
@@ -30,12 +30,7 @@ I pacchetti di web hosting OVHcloud sono condivisi. Di conseguenza, la configura
 
 ## Procedura
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o il fornitore del servizio. OVH non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione "[Per saperne di più](#go-further)" di questa guida.
-
-:::
+[[fragment:support-scope]]
 
 ### FTP
 

--- a/docs/it/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -12,10 +12,10 @@ Backup regolare delle informazioni del tuo sito Web è una buona prassi da adott
 
 Su un hosting Web condiviso, sei responsabile dei backup del tuo sito Web. Anche se OVHcloud offre backup (extracontrattuali), ti consigliamo di eseguire backup regolari e di gestire i tuoi supporti di backup (hard disk, penna USB, ecc...) per maggiore cautela.
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
+[[fragment:support-scope]]
 
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a [fornitore specializzato](/links/partner) o [amministratore del CMS WordPress](https://wordpress.com/support/). OVH non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questo tutorial.
+:::warning
+Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a [fornitore specializzato](/links/partner) o [amministratore del CMS WordPress](https://wordpress.com/support/). OVH non potrà fornirti alcuna assistenza.
 :::
 
 **Questa guida ti mostra come salvare il contenuto del tuo sito WordPress e del suo database.**

--- a/docs/it/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -13,13 +13,7 @@ Questa guida ti mostra le operazioni da effettuare per modificare il dominio di 
 
 **Questa guida ti mostra come modificare il dominio di un sito esistente.**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -15,11 +15,7 @@ Puoi creare diversi file ".htaccess" in [lo spazio FTP](/guides/web-cloud/web-ho
 
 **Questa guida ti mostra come bloccare l'accesso al tuo sito per alcuni indirizzi IP tramite un file.htaccess.**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -11,10 +11,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Questa guida ti mostra come configurare alcune funzionalità del tuo hosting Web con uno o più file **.htaccess**, in particolare per modificare i parametri di una parte o dell'insieme del tuo sito Web (reindirizzamenti, divieti di accesso, autorizzazioni limitate, controllo della cache, ecc...).
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
+[[fragment:support-scope]]
 
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o [l'amministratore del CMS WordPress](https://wordpress.com/it/support/). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questo tutorial.
+:::warning
+Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o [l'amministratore del CMS WordPress](https://wordpress.com/it/support/). OVHcloud non potrà fornirti alcuna assistenza.
 :::
 
 **Questa guida ti mostra come proteggere il tuo WordPress con uno o più file htaccess.**

--- a/docs/it/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
@@ -14,13 +14,7 @@ utilizzando due file di configurazione (HTTP) Apache da inserire nello [spazio F
 - "**.htaccess**": per maggiori informazioni sulle funzionalità di questo file, consulta il nostro tutorial sulle ["Operazioni realizzabili con un file ".htaccess"](/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do).
 - "**.htpasswd**": in aggiunta a questo tutorial, consulta la [documentazione ufficiale Apache](https://httpd.apache.org/docs/2.4/en/programs/htpasswd.html) relativa a questo file.
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o di contattare l'amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-
-Gli esempi che seguiranno devono essere salvati in file denominati ".htaccess" e ".htpasswd". Attenzione, le regole definite in questi file hanno conseguenze dirette sul tuo sito web. Prima di applicarle al tuo sito, verifica sistematicamente le regole che aggiungi. 
-:::
+[[fragment:support-scope]]
 
 **Questa guida ti mostra come proteggere una directory o l'accesso alla sezione amministratore del tuo sito Web tramite un'autenticazione con i file ".htaccess" e ".htpasswd".**
 

--- a/docs/it/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -33,14 +33,7 @@ Per approfondire le tue conoscenze sull'utilizzo del "**mod_rewrite**" di Apache
 
 ## Procedura
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-
-Gli esempi che seguiranno dovranno essere inseriti in un file ".htaccess". Attenzione, le regole definite in questo file hanno conseguenze dirette sul tuo sito Web. Prima di applicarle al tuo sito, verifica sistematicamente le regole che aggiungi.
-
-:::
+[[fragment:support-scope]]
 
 Il file ".htaccess" nel quale configura il "**mod_rewrite**" di Apache può essere inserito in diverse cartelle. Dovrai rispettare solo la regola di un **solo** file ".htaccess" per cartella o sottocartella.
 

--- a/docs/it/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
@@ -19,13 +19,7 @@ Per utilizzare correttamente il file ".htaccess", è necessario conoscere e risp
 - il file ".htaccess" è invisibile agli utenti che visitano il tuo sito Web;
 - le regole dichiarate in un file ".htaccess" si applicano all'intera directory in cui è installato il file ".htaccess", nonché a tutte le sottodirectory della stessa directory.
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o di contattare l'amministratore del servizio. OVH non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-
-Gli esempi che seguiranno devono essere inseriti in un file ".htaccess". Attenzione, le regole definite in questo file hanno conseguenze dirette sul tuo sito Web. Prima di applicarle al tuo sito, verifica sistematicamente le regole che aggiungi. 
-:::
+[[fragment:support-scope]]
 
 **Questa guida ti mostra le principali operazioni realizzabili con un file ".htaccess".**
 

--- a/docs/it/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -259,11 +259,7 @@ Il nostro servizio antispam analizzerà la situazione e il nostro supporto ti ri
 
 ### Invio di email tramite uno script «SMTP» <a name="SMTP"></a>
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui sei responsabile per la configurazione e la gestione. Spetta quindi a te garantirne il corretto funzionamento.
-
-Tuttavia, ti raccomandiamo di rivolgerti a un [provider specializzato](/links/partner) se incontri delle difficoltà. Noi non saremo in grado di fornirti assistenza. Per maggiori informazioni, consulta la sezione [«Per saperne di più»](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 Pur raccomandando vivamente di privilegiare l'utilizzo della funzione "mail()" di PHP, gli hosting condivisi permettono di inviare email tramite uno script che utilizza il protocollo SMTP (Simple Mail Transfer Protocol). La dimensione totale della tua email non può superare **10 MB** (cioè **7/8 MB senza incapsulamento**).
 

--- a/docs/it/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -23,10 +23,10 @@ MainWP offers several extensions for backing up your websites.
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/it/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -16,10 +16,10 @@ Retaining customers is vital to your company's development. Whether you have one
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard. For more information, please read our guide on [Managing multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general).
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/it/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -26,10 +26,10 @@ In this guide, we have chosen the MainWP plugin. Other similar solutions exist, 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, in the `Web Cloud` section.
 - Access to the WordPress administration interface.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/it/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -16,10 +16,10 @@ Maintaining the security of your websites is crucial for the development of your
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/it/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
@@ -20,11 +20,7 @@ Il tuo sito Web si evolve, il suo consumo di risorse diventa tale che il tuo hos
 
 ## Procedura
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. In caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner). OVH non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ### Step 1 - Eseguire il backup dei file e del database del sito Web <a name="step1"></a>
 

--- a/docs/it/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Questa guida ti mostra come migrare passo per passo il sito Web WordPress e tutti i servizi associati a OVHcloud.
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
+[[fragment:support-scope]]
 
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. In caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o [l’editor del CMS WordPress](https://wordpress.com/it/support/). OVH non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
+:::warning
+Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. In caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o [l’editor del CMS WordPress](https://wordpress.com/it/support/). OVH non sarà infatti in grado di fornirti assistenza.
 :::
 
 **Questa guida ti mostra come migrare il tuo sito Web WordPress e i servizi associati in OVHcloud.**

--- a/docs/it/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Questa guida ti mostra come migrare passo per passo il sito Web Xara e tutti i servizi associati a OVHcloud.
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
+[[fragment:support-scope]]
 
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. In caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o [sito ufficiale di Xara Web designer](https://www.xara.com/webdesigner-plus/). OVH non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
+:::warning
+Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. In caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o [sito ufficiale di Xara Web designer](https://www.xara.com/webdesigner-plus/). OVH non sarà infatti in grado di fornirti assistenza.
 :::
 
 **Questa guida ti mostra come migrare il tuo sito Web Xara e i servizi associati in OVHcloud.**

--- a/docs/it/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
@@ -16,13 +16,7 @@ La pagina di errore "**Sito non installato**" può essere visualizzata sul brows
 
 **Questa guida ti mostra come individuare e risolvere la pagina di errore "Sito non installato"**
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o il fornitore del servizio. OVH non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione "[Per saperne di più](#go-further)" di questa guida.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/secure-your-website.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/secure-your-website.mdx
@@ -13,11 +13,7 @@ Il progetto è organizzato gradualmente in ordine crescente di importanza e diff
 
 **Questa guida ti mostra come proteggere il tuo sito Web.**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie sul tuo VPS. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a un [provider specializzato](/links/partner) o contattare l'amministratore del servizio. OVHcloud non potrà fornirti assistenza. Per maggiori informazioni consulta la sezione "Per saperne di più" di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/sql-change-password.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/sql-change-password.mdx
@@ -33,13 +33,7 @@ Per modificare la password del database del tuo sito sono necessarie quattro azi
 
 **Questa guida ti mostra come modificare la password di un database in modo sicuro.**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato o l’amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) su questa guida.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/sql-database-export.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/sql-database-export.mdx
@@ -50,11 +50,7 @@ Alcuni dei metodi indicati non sono relativi a un'interfaccia OVHcloud. E, in ba
 
 Continua la lettura in base al metodo di backup scelto.
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner). OVHcloud non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) della guida.
-:::
+[[fragment:support-scope]]
 
 ### Recuperare un backup tramite lo strumento di OVHcloud
 

--- a/docs/it/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
@@ -49,11 +49,7 @@ Alcune delle opzioni elencate non vengono eseguite in un'interfaccia OVHcloud e 
 
 Continua la lettura in base al metodo di importazione scelto.
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione; garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie per importare il backup di un database. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare uno specialista del settore o il fornitore del servizio. Per maggiori informazioni consulta la sezione "Per saperne di più".
-:::
+[[fragment:support-scope]]
 
 ### Ripristino dallo Spazio Cliente
 

--- a/docs/it/guides/web-cloud/web-hosting/sql-overquota-database.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/sql-overquota-database.mdx
@@ -36,12 +36,7 @@ Questa guida ti mostra le operazioni da effettuare quando il tuo database condiv
 
 ## Procedura
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner). OVH non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-
-:::
+[[fragment:support-scope]]
 
 Quando il database condiviso OVHcloud raggiunge la saturazione (**overquota**), i nostri robot ti avvertono via email all'indirizzo del [contatto "amministratore"](/guides/account-and-service-management/account-information/managing-contacts) del database. 
 

--- a/docs/it/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
@@ -14,11 +14,7 @@ La maggior parte delle nostre soluzioni di [hosting Web](/links/web/hosting) inc
 
 **Questa guida ti mostra come recuperare il backup di un database dallo Spazio Cliente OVHcloud utilizzando le API OVHcloud.**
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. In caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner). OVHcloud non sarà infatti in grado di fornirti un'assistenza aggiuntiva sulle API. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
@@ -18,12 +18,12 @@ import { Tab, Tabs } from '@rspress/core/theme';
 - [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) installato sul dispositivo locale
 - Conoscenze di base del [protocollo SSH e del suo utilizzo](/guides/bare-metal-cloud/dedicated-servers/ssh-introduction)
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud fornisce servizi la cui configurazione e gestione sono di vostra responsabilità. Questa guida ti mostra come utilizzare le soluzioni OVHcloud con tool esterni. Potrebbe essere necessario adattare alcune istruzioni specifiche al sistema operativo della workstation locale o del server.
-
-In caso di difficoltà o dubbi, ti consigliamo di contattare un [provider di servizi specializzato](/links/partner) o [la nostra Community](/links/community).
-
+Questa guida ti mostra come utilizzare le soluzioni OVHcloud con tool esterni. Potrebbe essere necessario adattare alcune istruzioni specifiche al sistema operativo della workstation locale o del server.
 :::
+
 
 {/* CP-NAV-START:web-hosting */}
 ---

--- a/docs/it/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
@@ -35,11 +35,7 @@ Riconoscere a colpo d’occhio se un sito è sicuro è sempre più facile.
 
 **Attivare il protocollo HTTPS su un sito Web è un’operazione delicata**. In effetti, la maggior parte delle azioni da effettuare si effettueranno nel codice sorgente del tuo sito Web. Se non vengono effettuate correttamente, rischi un calo di referenziazione (SEO) nei risultati proposti dai motori di ricerca (Google, Yahoo!, bing, ecc.), oppure un’inaccessibilità totale del tuo sito Web.
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner). OVH non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 Segui i passaggi descritti in questa guida per cambiare il tuo sito Web in *HTTPS*:
 

--- a/docs/it/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -9,11 +9,7 @@ availableIn: [eu, ca, apac]
 
 Questo tutorial contiene alcuni esempi di situazioni in cui proteggere il sito Web con l’SSL.
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner). OVHcloud non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 **Questa guida ti mostra come evitare i comuni errori di protezione del tuo sito Web con SSL**
 

--- a/docs/it/guides/web-cloud/web-hosting/ssl-custom.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ssl-custom.mdx
@@ -36,11 +36,10 @@ OVHcloud propone diversi tipi di certificati SSL sulle offerte di [hosting condi
 
 ## Procedura
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. In caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner). OVHcloud non sarà infatti in grado di fornirti assistenza per **l'installazione o la sottoscrizione di un certificato SSL diverso da [quelli proposti da OVHcloud](/links/web/hosting-options-ssl)**. Per maggiori informazioni consulta la sezione "[Per saperne di più](#go-further)" di questa guida.
-
+Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. In caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner). OVHcloud non sarà infatti in grado di fornirti assistenza per **l'installazione o la sottoscrizione di un certificato SSL diverso da [quelli proposti da OVHcloud](/links/web/hosting-options-ssl)**.
 :::
 
 ### 1 - Ottieni un Certificate Signing Request (CSR) SSL <a name="step-1"></a>

--- a/docs/it/guides/web-cloud/web-hosting/ssl-ev.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ssl-ev.mdx
@@ -59,11 +59,10 @@ Per verificare se hai diritto alla sottoscrizione di un certificato SSL Sectigo 
 
 ## Procedura
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner). OVHcloud non sarà infatti in grado di fornirti assistenza **per tutte le fasi di verifica direttamente realizzata con l'autorità di certificazione Sectigo**. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) di questa guida.
-
+Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner). OVHcloud non sarà infatti in grado di fornirti assistenza **per tutte le fasi di verifica direttamente realizzata con l'autorità di certificazione Sectigo**.
 :::
 
 ### 1 - ordina il certificato SSL Sectigo EV

--- a/docs/it/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
@@ -11,11 +11,7 @@ Questa guida ti mostra come utilizzare il generatore del sito [Cecil](https://ce
 
 **Questa guida ti mostra come aggiungere una chiamata verso un'API esterna dalla tua pagina Web statica.**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente.
-
-Se hai difficoltà a seguire gli step di questo tutorial, ti consigliamo di rivolgerti a un [professionista specializzato](/links/partner). OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 ## Prerequisiti
 

--- a/docs/it/guides/web-cloud/web-hosting/svn.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/svn.mdx
@@ -11,11 +11,7 @@ SVN, che è l'abbreviazione di "sovversione", è un sistema di gestione delle ve
 
 **Scopri come utilizzare SVN in SSH sul tuo hosting Web**
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato o l’amministratore del servizio. OVHcloud non può fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione “[Per saperne di più](#go-further)”.
-:::
+[[fragment:support-scope]]
 
 ## Pre-obbligatorio
 

--- a/docs/it/guides/web-cloud/web-hosting/using-scp-command.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/using-scp-command.mdx
@@ -15,11 +15,7 @@ Il Secure Copy Protocol (SCP) permette di copiare dati in modo sicuro (grazie al
 
 Permette, da un terminale e con l’aiuto di un comando Linux, di copiare un file o una cartella che contiene uno o più file.
 
-:::warning
-OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. Garantirne il corretto funzionamento è quindi responsabilità dell’utente.
-
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner). OVHcloud non sarà infatti in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
-:::
+[[fragment:support-scope]]
 
 **Questa guida ti mostra come utilizzare il comando Secure Copy Protocol (SCP) in SSH per copiare file da o verso un hosting Web.**
 

--- a/docs/it/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Questa guida ti mostra come creare i tuoi primi contenuti, organizzarli, metterli online e modificare il tema del tuo sito Web con il Content Management System (CMS) **WordPress**. È possibile realizzare il tuo sito senza particolari conoscenze di programmazione, con una vasta scelta di tematiche come siti web aziendali, blog o siti per diffondere la tua attività o passione.
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
+[[fragment:support-scope]]
 
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a [fornitore specializzato](/links/partner) o [amministratore del CMS WordPress](https://wordpress.com/support/). OVH non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questo tutorial.
+:::warning
+Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a [fornitore specializzato](/links/partner) o [amministratore del CMS WordPress](https://wordpress.com/support/). OVH non potrà fornirti alcuna assistenza.
 :::
 
 **Questa guida ti mostra come creare un sito Web con CMS WordPress.**

--- a/docs/it/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Scopri come creare un negozio online con l'estensione open source **WooCommerce** con il Content Management System (CMS) **WordPress**. 
 
-:::warning
-OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
+[[fragment:support-scope]]
 
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a [uno specialista del settore](/links/partner), [amministratore del CMS WordPress](https://wordpress.com/support/) o [amministratore delegato di WooCommerce](https://woocommerce.com/). OVH non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questo tutorial.
+:::warning
+Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a [uno specialista del settore](/links/partner), [amministratore del CMS WordPress](https://wordpress.com/support/) o [amministratore delegato di WooCommerce](https://woocommerce.com/). OVH non potrà fornirti alcuna assistenza.
 :::
 
 ## Prerequisiti

--- a/docs/pl/guides/web-cloud/domains/_transfer-incoming-o2switch.mdx
+++ b/docs/pl/guides/web-cloud/domains/_transfer-incoming-o2switch.mdx
@@ -35,11 +35,7 @@ Musisz również:
 - Posiadanie uprawnień do złożenia wniosku o transfer domeny.
 - Właściciel i/lub administratorzy domeny zostali poinformowani o wszczęciu procedury transferu domeny.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner) lub kontakt z aktualnym operatorem. Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ## W praktyce
 

--- a/docs/pl/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -11,12 +11,7 @@ Rekord **D**omain-based **M**essage **A**uthentication, **R**eporting, and **C**
 
 **Dowiedz się, jak działa DMARC i jak wdrożyć go dla Twojej usługi e-mail.**
 
-:::warning
-OVHcloud oferuje usługi, ale to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. Jeśli jednak napotkasz trudności, zalecamy skontaktowanie się z [wyspecjalizowanym](/links/partner) dostawcą usług hostingowych. Niestety firma OVH nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) tego tutoriala.
-
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/pl/guides/web-cloud/domains/domain-icloud.mdx
@@ -5,11 +5,7 @@ lastUpdated: 2025-08-27
 availableIn: [eu, ca, apac]
 ---
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Objective
 

--- a/docs/pl/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
+++ b/docs/pl/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
@@ -13,11 +13,12 @@ Jesteś posiadaczem nazwy domeny w OVHcloud i chcesz połączyć ją z hostingie
 
 **Dowiedz się, jak powiązać nazwę domeny OVHcloud z hostingiem GoDaddy.**
 
-:::warning
-- Pomoc techniczna GoDaddy nie ma dostępu do ustawień Twojej nazwy domeny OVHcloud i nie może udzielić Ci porad dotyczących informacji, które należy jej dostarczyć.
-- OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.<br/><br/> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skontaktowanie się z wyspecjalizowanym [usługodawcą](/links/partner) i/lub wydawcą usługi. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
+[[fragment:support-scope]]
 
+:::warning
+Pomoc techniczna GoDaddy nie ma dostępu do ustawień Twojej nazwy domeny OVHcloud i nie może udzielić Ci porad dotyczących informacji, które należy jej dostarczyć.
 :::
+
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
+++ b/docs/pl/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
@@ -13,11 +13,12 @@ Jesteś posiadaczem nazwy domeny w OVHcloud i chcesz połączyć ją z Google Si
 
 **Dowiedz się, jak powiązać nazwę domeny OVHcloud z Google Site.**
 
-:::warning
-- Pomoc techniczna Google Site nie ma dostępu do ustawień Twojej nazwy domeny OVHcloud i nie może udzielić Ci porad dotyczących informacji, które należy jej dostarczyć.
-- OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.<br/><br/> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skontaktowanie się z wyspecjalizowanym [usługodawcą](/links/partner) i/lub wydawcą usługi. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
+[[fragment:support-scope]]
 
+:::warning
+Pomoc techniczna Google Site nie ma dostępu do ustawień Twojej nazwy domeny OVHcloud i nie może udzielić Ci porad dotyczących informacji, które należy jej dostarczyć.
 :::
+
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
+++ b/docs/pl/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
@@ -13,12 +13,12 @@ Jesteś posiadaczem nazwy domeny w OVHcloud i chcesz połączyć ją z hostingie
 
 **Dowiedz się, jak powiązać nazwę domeny OVHcloud z hostingiem Shopify.**
 
+[[fragment:support-scope]]
+
 :::warning
-- Pomoc techniczna Shopify nie ma dostępu do ustawień Twojej nazwy domeny OVHcloud i nie może udzielić Ci porad dotyczących informacji, które należy jej dostarczyć.
-
-- OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.<br/><br/> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skontaktowanie się z wyspecjalizowanym [usługodawcą](/links/partner) i/lub wydawcą usługi. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-
+Pomoc techniczna Shopify nie ma dostępu do ustawień Twojej nazwy domeny OVHcloud i nie może udzielić Ci porad dotyczących informacji, które należy jej dostarczyć.
 :::
+
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
+++ b/docs/pl/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
@@ -13,12 +13,12 @@ Jesteś posiadaczem nazwy domeny w OVHcloud i chcesz połączyć ją z hostingie
 
 **Dowiedz się, jak powiązać nazwę domeny OVHcloud z hostingiem SquareSpace.**
 
+[[fragment:support-scope]]
+
 :::warning
-- Pomoc techniczna SquareSpace nie ma dostępu do ustawień Twojej nazwy domeny OVHcloud i nie może udzielić Ci porad dotyczących informacji, które należy jej dostarczyć.
-
-- OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.<br/><br/> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skontaktowanie się z wyspecjalizowanym [usługodawcą](/links/partner) i/lub wydawcą usługi. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-
+Pomoc techniczna SquareSpace nie ma dostępu do ustawień Twojej nazwy domeny OVHcloud i nie może udzielić Ci porad dotyczących informacji, które należy jej dostarczyć.
 :::
+
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
+++ b/docs/pl/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
@@ -13,11 +13,12 @@ Jesteś posiadaczem nazwy domeny w OVHcloud i chcesz połączyć ją z hostingie
 
 **Dowiedz się, jak powiązać nazwę domeny OVHcloud z hostingiem Webflow.**
 
-:::warning
-- Pomoc techniczna Webflow nie ma dostępu do ustawień Twojej nazwy domeny OVHcloud i nie może udzielić Ci porad dotyczących informacji, które należy jej dostarczyć.
-- OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.<br/><br/> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skontaktowanie się z wyspecjalizowanym [usługodawcą](/links/partner) i/lub wydawcą usługi. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
+[[fragment:support-scope]]
 
+:::warning
+Pomoc techniczna Webflow nie ma dostępu do ustawień Twojej nazwy domeny OVHcloud i nie może udzielić Ci porad dotyczących informacji, które należy jej dostarczyć.
 :::
+
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
+++ b/docs/pl/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
@@ -13,12 +13,12 @@ Jesteś posiadaczem nazwy domeny w OVHcloud i chcesz połączyć ją z hostingie
 
 **Dowiedz się, jak powiązać nazwę domeny OVHcloud z hostingiem Wix.**
 
+[[fragment:support-scope]]
+
 :::warning
-- Pomoc techniczna Wix nie ma dostępu do ustawień Twojej nazwy domeny OVHcloud i nie może udzielić Ci porad dotyczących informacji, które należy jej dostarczyć.
-
-- OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.<br/><br/> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skontaktowanie się z wyspecjalizowanym [usługodawcą](/links/partner) i/lub wydawcą usługi. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-
+Pomoc techniczna Wix nie ma dostępu do ustawień Twojej nazwy domeny OVHcloud i nie może udzielić Ci porad dotyczących informacji, które należy jej dostarczyć.
 :::
+
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/domains/redirect-domain-name.mdx
+++ b/docs/pl/guides/web-cloud/domains/redirect-domain-name.mdx
@@ -317,12 +317,7 @@ Kliknij <code className="action">Potwierdź</code>, aby zatwierdzić konfiguracj
 
 ### Przekierowanie nazwy domeny za pomocą pliku ".htaccess" <a name="htaccess_rewrite"></a>
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Tobie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Niniejszy przewodnik ma na celu pomoc w realizacji bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w zakresie opisanych poniżej kroków. Więcej informacji znajdziesz w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-
-:::
+[[fragment:support-scope]]
 
 Pliki ".htaccess" to pliki konfiguracyjne, w których można określić polecenia. Podczas wykonywania kodu Twojej strony WWW na serwerze (Apache) polecenia te zostaną zinterpretowane i wykonane.
 

--- a/docs/pl/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/pl/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -9,12 +9,7 @@ availableIn: [eu, ca, apac]
 
 Transfer nazwy domeny .uk (lub podobnej) wymaga zastosowania specjalnego podejścia.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) ten przewodnik.
-
-:::
+[[fragment:support-scope]]
 
 **Dowiedz się, jak przenieść nazwę domeny .uk (lub podobną) na OVHcloud**
 

--- a/docs/pl/guides/web-cloud/domains/transfer-incoming-gandi.mdx
+++ b/docs/pl/guides/web-cloud/domains/transfer-incoming-gandi.mdx
@@ -43,11 +43,7 @@ Musisz również:
 - Posiadanie uprawnień do złożenia wniosku o transfer nazwy domeny.
 - Abonent i/lub administratorzy nazwy domeny zostali poinformowani o wszczęciu procedury transferu nazwy domeny.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner) lub kontakt z aktualnym operatorem. Niestety firma OVH nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ## W praktyce
 

--- a/docs/pl/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
+++ b/docs/pl/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
@@ -35,11 +35,7 @@ Musisz również:
 - Posiadanie uprawnień do złożenia wniosku o transfer nazwy domeny.
 - Abonent i/lub administratorzy nazwy domeny zostali poinformowani o wszczęciu procedury transferu nazwy domeny.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner) lub kontakt z aktualnym operatorem. Niestety firma OVH nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ## W praktyce
 

--- a/docs/pl/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
+++ b/docs/pl/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
@@ -35,11 +35,7 @@ Musisz również:
 - Posiadanie uprawnień do złożenia wniosku o transfer nazwy domeny.
 - Abonent i/lub administratorzy nazwy domeny zostali poinformowani o wszczęciu procedury transferu nazwy domeny.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner) lub kontakt z aktualnym operatorem. Niestety firma OVH nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ## W praktyce
 

--- a/docs/pl/guides/web-cloud/domains/transfer-incoming-ionos.mdx
+++ b/docs/pl/guides/web-cloud/domains/transfer-incoming-ionos.mdx
@@ -35,11 +35,7 @@ Musisz również:
 - Posiadanie uprawnień do złożenia wniosku o transfer nazwy domeny.
 - Abonent i/lub administratorzy nazwy domeny zostali poinformowani o wszczęciu procedury transferu nazwy domeny.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner) lub kontakt z aktualnym operatorem. Niestety firma OVH nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ## W praktyce
 

--- a/docs/pl/guides/web-cloud/domains/transfer-incoming-wix.mdx
+++ b/docs/pl/guides/web-cloud/domains/transfer-incoming-wix.mdx
@@ -35,11 +35,7 @@ Musisz również:
 - Posiadanie uprawnień do złożenia wniosku o transfer nazwy domeny.
 - Abonent i/lub administratorzy nazwy domeny zostali poinformowani o wszczęciu procedury transferu nazwy domeny.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner) lub kontakt z aktualnym operatorem. Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ## W praktyce
 

--- a/docs/pl/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -13,12 +13,7 @@ Moduły za 1 kliknięciem pozwalają na szybką i prostą instalację internetow
 
 **Dowiedz się, jak zarządzać modułem za pomocą 1 kliknięcia w Panelu klienta OVHcloud.**
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) ten przewodnik.
-
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -9,13 +9,10 @@ availableIn: [eu, ca, apac]
 
 Tutaj znajdziesz wszystkie elementy, które pozwolą Ci ręcznie zainstalować CMS (Content Management System) Drupal.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywają na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [producenta CMS Drupal](https://www.drupal.org/support). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego tutoriala.
-
-Jeśli chcesz zaktualizować istniejący CMS Drupal lub masz pytania dotyczące korzystania z tego CMS, skontaktuj się bezpośrednio z [wydawcą CMS Drupal](https://www.drupal.org/support).
-
+Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [producenta CMS Drupal](https://www.drupal.org/support). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
 :::
 
 :::tip

--- a/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Znajdziesz tutaj wszystkie elementy do ręcznego zainstalowania systemu CMS (Content Management System) Joomla! w kilku krokach.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywają na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS Joomla!](https://www.joomla.org/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również"](#go-further) niniejszego tutoriala.
-
+Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS Joomla!](https://www.joomla.org/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
 :::
 
 :::tip

--- a/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Tutaj znajdziesz wszystkie elementy do ręcznego zainstalowania systemu CMS (Content Management System) PrestaShop.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywają na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS PrestaShop](https://www.prestashop.com/en/support). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-
+Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS PrestaShop](https://www.prestashop.com/en/support). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
 :::
 
 :::tip

--- a/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Tutorial ten pomoże Ci ręcznie zainstalować CMS (Content Management System) WordPress w kilku etapach.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-
+Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
 :::
 
 :::tip

--- a/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -12,22 +12,10 @@ import { Region } from '@components/Zone';
 
 Tutorial ten pomoże Ci ręcznie zainstalować CMS (Content Management System), np. WordPress, Joomla!, Drupal, PrestaShop, Pico, Grav, Typo3 lub SPIP.
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywają na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego webmastera](/links/partner) lub producenta systemu CMS, który wybrałeś. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Idź dalej"](#go-further) niniejszego tutoriala.
-
-Aby skontaktować się z poszczególnymi edytorami systemów zarządzania treścią, zapoznaj się z poniższymi linkami do ich odpowiednich oficjalnych stron:
-
-- [WordPress](https://wordpress.com/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-- [Pico](https://picocms.org/)
-- [Grav](https://getgrav.org/)
-- [Typo3](https://typo3.com/)
-- [SPIP](https://www.spip.net/en_rubrique25.html)
-
+Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego webmastera](/links/partner) lub producenta systemu CMS, który wybrałeś. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
 :::
 
 :::tip

--- a/docs/pl/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -37,18 +37,10 @@ Istnieje kilka metod zmiany hasła administratora CMS w zależności od Twojego 
 - [w interfejsie zarządzania CMS](#via-cms)
 - [via phpMyAdmin w Panelu klienta OVHcloud](#via-phpMyAdmin)
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywają na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego webmastera](/links/partner) lub producenta systemu CMS, który wybrałeś. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego tutoriala.
-
-Aby skontaktować się z poszczególnymi edytorami systemów zarządzania treścią, zapoznaj się z poniższymi linkami do ich odpowiednich oficjalnych stron:
-
-- [WordPress](https://wordpress.com/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-
+Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego webmastera](/links/partner) lub producenta systemu CMS, który wybrałeś. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
 :::
 
 ### Zmiana hasła administratora za pomocą automatycznego konta e-mail (zapomniane hasło) <a name="via-email"></a>

--- a/docs/pl/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
@@ -19,12 +19,7 @@ Piractwo może pojawić się na kilka sposobów (niewyczerpująca lista):
 
 **Odkryj nasze porady dotyczące naprawy zhakowanej strony WWW.**
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/composer-install-composer.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/composer-install-composer.mdx
@@ -11,11 +11,7 @@ availableIn: [eu, ca, apac]
 
 **Dowiedz się, jak zainstalować i zrobić pierwsze kroki z Composer**
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) i/lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego tutoriala.
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/configure-ipv6.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/configure-ipv6.mdx
@@ -39,12 +39,7 @@ Nasze pakiety hostingowe są kompatybilne z IPv6 od 2011 roku. Aktywacja tego pr
 
 ## W praktyce
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) i/lub kontakt z wydawcą usługi. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego tutoriala.
-
-:::
+[[fragment:support-scope]]
 
 Jeśli Twoja strona nie jest skonfigurowana tak, aby działała z adresem IPv6, możesz dodać [adres IPv6 Twojego hostingu OVHcloud](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip) do strefy DNS aktywnej domeny. Celem jest umożliwienie przeglądarkom internetowym znalezienia adresu IPv6 powiązanego z Twoją stroną WWW za pomocą Twojej domeny.
 

--- a/docs/pl/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
@@ -9,11 +9,7 @@ availableIn: [eu]
 
 Dowiedz się, jak utworzyć pierwszą stronę internetową na darmowy hosting oferowanym bezpłatnie w przypadku zakupu domeny od OVHcloud.
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/cron-tasks.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cron-tasks.mdx
@@ -13,11 +13,7 @@ Na Twoim hostingu OVHcloud możesz użyć skryptów do automatyzacji niektórych
 
 **Dowiedz się, jak tworzyć zadania CRON do automatyzacji zaplanowanych zadań na hostingu.**
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Jesteś tym samym odpowiedzialny za ich prawidłowe funkcjonowanie.
-
-Oddajemy w twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego webmastera](/links/partner) lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
@@ -13,11 +13,7 @@ Korzystanie z baz danych może spowodować pewne nieprawidłowości na Twojej st
 
 **Dowiedz się, jak usunąć błędy związane z bazami danych na hostingu www OVHcloud.**
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. Jednakże w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) tego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -33,11 +33,10 @@ Po wykryciu podejrzanego działania nasze roboty związane z bezpieczeństwem mo
 
 **Dowiedz się, jak odblokować dostęp do Twojej strony w przypadku wyświetlenia "403 forbidden".**
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywają na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) i/lub kontakt z [społecznością użytkowników](/links/community). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-
+Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) i/lub kontakt z [społecznością użytkowników](/links/community). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
 :::
 
 ## Wymagania początkowe

--- a/docs/pl/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -12,13 +12,7 @@ Jeśli konfiguracja modułu nie zostanie przeprowadzona prawidłowo, instalacja 
 
 **Dowiedz się, jak zdiagnozować najczęstsze przypadki błędów podczas tworzenia "modułu za 1 kliknięciem"**
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner) i/lub skontaktowanie się z dostawcą usługi. Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji "[Sprawdź również](#go-further)" tego przewodnika.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
@@ -15,12 +15,7 @@ Zdarza się to również w wyniku aktualizacji przeprowadzonej **automatycznie**
 
 **Dowiedz się, jak zdiagnozować najczęstsze przypadki błędów 500.**
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź](#go-further) ten przewodnik.
-
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
@@ -16,13 +16,7 @@ Pojawi się strona **"Index of"** w przynajmniej jednym z następujących przypa
 
 **Dowiedz się, jak naprawić wyświetlanie strony "Index of".**
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywają na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) i lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) ten przewodnik.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
@@ -20,11 +20,7 @@ W przypadku niedostępności Twojej strony może wystąpić kilka komunikatów o
 
 **Dowiedz się, jak usunąć błędy związane z komunikatem "Połączenie nie jest prywatne".**
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji "[Sprawdź również](#go-further)" niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -57,11 +57,10 @@ Niniejszy przewodnik zostanie wkrótce zaktualizowany. W razie jakichkolwiek tru
 
 :::
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety nie będziemy w stanie udzielić Ci wsparcia **w przypadku, gdy infrastruktura, na której hostowana jest Twoja oferta hostingu współdzielonego, nie jest istotna**. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-
+Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety nie będziemy w stanie udzielić Ci wsparcia **w przypadku, gdy infrastruktura, na której hostowana jest Twoja oferta hostingu współdzielonego, nie jest istotna**.
 :::
 
 :::tip

--- a/docs/pl/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
@@ -20,11 +20,7 @@ W przypadku niedostępności Twojej strony WWW może pojawić się kilka zwrotó
 
 **Dowiedz się, jak usunąć błędy związane z plikiem "Ta witryna jest nieosiągalna"**
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) ten przewodnik.
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -18,11 +18,7 @@ W szczególności dostęp ten umożliwia [umieszczenie strony w Internecie](/gui
 
 **Dowiedz się, jak zmienić hasło do konta FTP utworzonego na Twoim hostingu.**
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywają na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
@@ -19,11 +19,7 @@ Aby pobrać Cyberduck, przejdź do [oficjalnej strony](https://cyberduck.io/) ap
 
 :::
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner) lub skontaktowanie się z wydawcą usługi. Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji zawiera sekcja [Sprawdź również](#go-further) w tym przewodniku.
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
@@ -13,12 +13,7 @@ Korzystanie z oprogramowania FTP podczas logowania do [hostingu Cloud](/links/we
 
 **Dowiedz się, jak usunąć błędy związane z oprogramowaniem FTP.**
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) ten przewodnik.
-
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -35,10 +35,10 @@ Jeśli chcesz zdalnie zarządzać swoją witryną internetową bez użycia Visua
 
 ## W praktyce
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
+[[fragment:support-scope]]
 
-Oddajemy w Twoje ręce tutorial, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego dostawcy](/links/partner) lub [Visual Studio Code](https://code.visualstudio.com/) IDE. Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) tego tutoriala.
+:::warning
+Oddajemy w Twoje ręce tutorial, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego dostawcy](/links/partner) lub [Visual Studio Code](https://code.visualstudio.com/) IDE. Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie.
 :::
 
 ### Zainstaluj rozszerzenie SFTP dla Visual Studio Code

--- a/docs/pl/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
@@ -54,13 +54,7 @@ Po przeanalizowaniu powyższych opcji, masz dwie możliwości:
 - **nie chcesz użyć gotowego modułu OVHcloud**: przeprowadź ręczną instalację Twojej strony WWW na hostingu OVHcloud. Informacje zawarte w przewodniku pomogą Ci w przeprowadzeniu operacji, nie zastąpią jednak wsparcia wyspecjalizowanego webmastera.
  
 
-:::warning
-OVHcloud świadczy usługi, za których konfigurację i zarządzanie odpowiada użytkownik. W związku z tym na Tobie spoczywa odpowiedzialność za zapewnienie prawidłowego funkcjonowania stron i aplikacji WWW.
-
-W tym przewodniku znajdziesz pomoc w zakresie podstawowych zadań związanych z uruchomieniem strony WWW. Zalecamy jednak skorzystanie z usług wyspecjalizowanego webmastera i/lub skontaktowanie się z nim w przypadku jakichkolwiek trudności. OVHcloud nie będzie w stanie w tym zakresie zapewnić dodatkowego wsparcia. Więcej informacji znajduje się w sekcji „Sprawdź również”.
-
-:::
-
+[[fragment:support-scope]]
 
 ### 2 - Wgranie plików strony WWW na przestrzeń dyskową
 

--- a/docs/pl/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
@@ -12,12 +12,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Niniejszy przewodnik prezentuje różne działania, jakie należy przeprowadzić, aby bez przerwy w dostępie do usług przenieść całą stronę WWW, foldery, nazwę domeny, bazę danych oraz konta e-mail do OVHcloud.
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Idź dalej"](#go-further) niniejszego przewodnika.
-
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
@@ -30,12 +30,7 @@ Pakiety hostingowe OVHcloud są współdzielone. W związku z tym konfiguracja t
 
 ## W praktyce
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner) i/lub skontaktowanie się z dostawcą usługi. Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji "[Sprawdź również](#go-further)" tego przewodnika.
-
-:::
+[[fragment:support-scope]]
 
 ### FTP
 

--- a/docs/pl/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -12,10 +12,10 @@ Regularne tworzenie kopii zapasowych danych umieszczonych na Twojej stronie WWW 
 
 Na hostingu możesz zarządzać kopiami zapasowymi Twojej strony WWW. Nawet jeśli OVHcloud oferuje kopie zapasowe (nieobjęte umową), zalecamy wykonywanie również regularnych kopii zapasowych oraz zarządzanie własnymi nośnikami kopii zapasowych (dysk twardy, klucz USB, itp.), aby zachować szczególną ostrożność.
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
+[[fragment:support-scope]]
 
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego tutoriala.
+:::warning
+Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
 :::
 
 **Dowiedz się, jak zapisać zawartość strony WordPress i jej bazy danych.**

--- a/docs/pl/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -13,13 +13,7 @@ Tutorial wyjaśnia, jakie kroki należy podjąć w przypadku zmiany domeny dost�
 
 **Dowiedz się, jak zmienić nazwę domeny na istniejącej stronie.**
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -15,11 +15,7 @@ Możesz utworzyć kilka plików ".htaccess" w [przestrzeni FTP](/guides/web-clou
 
 **Dowiedz się, jak zablokować dostęp do Twojej strony WWW dla niektórych adresów IP poprzez plik ".htaccess".**
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -11,10 +11,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Tutorial wyjaśnia, jak skonfigurować niektóre funkcjonalności hostingu za pomocą jednego lub kilku plików **.htaccess**, zwłaszcza w celu zmiany ustawień niektórych lub wszystkich Twoich stron WWW (przekierowania, zakazy dostępu, ograniczone uprawnienia, kontrola cache, itp.).
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
+[[fragment:support-scope]]
 
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego tutoriala.
+:::warning
+Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
 :::
 
 **Dowiedz się, jak zabezpieczyć moduł WordPress korzystając z jednego lub kilku plików htaccess.**

--- a/docs/pl/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
@@ -14,13 +14,7 @@ Używając dwóch plików konfiguracyjnych (HTTP) Apache do umieszczenia w [prze
 - "**.htaccess**": aby uzyskać więcej informacji na temat funkcjonalności tego pliku, zapoznaj się z naszym tutorial ["Operacje możliwe do wykonania za pomocą pliku ".htaccess"](/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do).
 - "**.htpasswd**": oprócz tego tutoriala, zapoznaj się z [oficjalną dokumentacją Apache](https://httpd.apache.org/docs/2.4/en/programs/htpasswd.html) dotyczącą tego pliku.
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywają na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) i/lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-
-Przykłady, które zostaną następnie wyświetlone, znajdują się w plikach o nazwie ".htaccess" i ".htpasswd". Uwaga, reguły, które określiłeś w tych plikach, mają bezpośrednie konsekwencje dla Twojej strony WWW. Sprawdź systematycznie dodawanie reguł przed ich wdrożeniem na Twojej stronie WWW. 
-:::
+[[fragment:support-scope]]
 
 **Dowiedz się, jak zabezpieczyć katalog lub dostęp do administratora Twojej strony WWW za pomocą uwierzytelnienia za pomocą plików ".htaccess" i ".htpasswd".**
 

--- a/docs/pl/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -33,14 +33,7 @@ Jeśli chcesz pogłębić swoją wiedzę na temat korzystania z Apache "**mod_re
 
 ## W praktyce
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-
-Kolejne przykłady zostaną wprowadzone do pliku .htaccess. Uwaga, reguły, które określiłeś w tym pliku, mają bezpośrednie konsekwencje dla Twojej strony WWW. Sprawdź systematycznie dodawanie reguł przed ich wdrożeniem na Twojej stronie WWW.
-
-:::
+[[fragment:support-scope]]
 
 Plik ".htaccess", w którym skonfigurujesz "**mod_rewrite**" Apache może być umieszczony w kilku różnych folderach. Należy przestrzegać wyłącznie zasady jednego **tylko** pliku ".htaccess" dla każdego katalogu lub podkatalogu.
 

--- a/docs/pl/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
@@ -19,13 +19,7 @@ Aby poprawnie korzystać z pliku ".htaccess", musisz znać i przestrzegać nast�
 - plik ".htaccess" jest niewidoczny dla użytkowników odwiedzających Twoją stronę;
 - reguły zadeklarowane w pliku ".htaccess" mają zastosowanie do całego katalogu, w którym zainstalowany jest plik ".htaccess", oraz do wszystkich podkatalogów tego katalogu.
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywają na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) i/lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Idź dalej"](#go-further) niniejszego przewodnika.
-
-Przykłady, które będą następnie wyświetlane są wprowadzane do pliku ".htaccess". Uwaga, reguły, które określiłeś w tym pliku, mają bezpośrednie konsekwencje dla Twojej strony WWW. Sprawdź systematycznie dodawanie reguł przed ich wdrożeniem na Twojej stronie WWW. 
-:::
+[[fragment:support-scope]]
 
 **Poznaj najważniejsze operacje wykonywane za pomocą pliku ".htaccess".**
 

--- a/docs/pl/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -259,11 +259,7 @@ Nasza usługa antyspamowa przeanalizuje sytuację, a nasz dział wsparcia skonta
 
 ### Wysyłka wiadomości e-mail za pomocą skryptu «SMTP» <a name="SMTP"></a>
 
-:::warning
-OVHcloud udostępnia Ci usługi, za których konfigurację i zarządzanie odpowiadasz. To Ty odpowiadasz za ich prawidłowe funkcjonowanie.
-
-Jednak zachęcamy do kontaktu z [wyspecjalizowanym dostawcą](/links/partner) w przypadku napotkania trudności. Niestety nie będziemy w stanie udzielić Ci wsparcia. Więcej informacji znajdziesz w sekcji [«Sprawdź również»](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 Chociaż zdecydowanie zalecamy korzystanie z funkcji "mail()" PHP, hosting współdzielony umożliwia wysyłanie wiadomości e-mail za pomocą skryptu korzystającego z protokołu SMTP (Simple Mail Transfer Protocol). Całkowity rozmiar Twojej wiadomości e-mail nie może przekraczać **10 MB** (tj. **7/8 MB bez enkapsulacji**).
 

--- a/docs/pl/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -23,10 +23,10 @@ MainWP offers several extensions for backing up your websites.
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/pl/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -16,10 +16,10 @@ Retaining customers is vital to your company's development. Whether you have one
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard. For more information, please read our guide on [Managing multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general).
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/pl/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -26,10 +26,10 @@ In this guide, we have chosen the MainWP plugin. Other similar solutions exist, 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, in the `Web Cloud` section.
 - Access to the WordPress administration interface.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/pl/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -16,10 +16,10 @@ Maintaining the security of your websites is crucial for the development of your
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/pl/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
@@ -20,11 +20,7 @@ Twoja strona WWW zmienia się, a zużycie zasobów zmienia się w taki sposób, 
 
 ## W praktyce
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Jednak w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner). Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ### Etap 1 - Wykonaj kopię zapasową plików i bazy danych Twojej strony WWW <a name="step1"></a>
 

--- a/docs/pl/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Tutorial ten krok po kroku wyjaśnia, jak migrować Twoją stronę WWW WordPress i wszystkie powiązane z nią usługi do OVHcloud.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
+[[fragment:support-scope]]
 
-Oddajemy w Twoje ręce tutorial, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego dostawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) tego tutoriala.
+:::warning
+Oddajemy w Twoje ręce tutorial, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego dostawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie.
 :::
 
 **Dowiedz się, jak przenieść Twoją stronę WWW WordPress i powiązane z nią usługi do OVHcloud.**

--- a/docs/pl/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Tutorial ten krok po kroku wyjaśnia, jak migrować Twoją stronę WWW Xara i wszystkie powiązane z nią usługi do OVHcloud.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
+[[fragment:support-scope]]
 
-Oddajemy w Twoje ręce tutorial, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego dostawcy](/links/partner) lub [oficjalna strona Xara Web designer](https://www.xara.com/webdesigner-plus/). Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) tego tutoriala.
+:::warning
+Oddajemy w Twoje ręce tutorial, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego dostawcy](/links/partner) lub [oficjalna strona Xara Web designer](https://www.xara.com/webdesigner-plus/). Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie.
 :::
 
 **Dowiedz się, jak przenieść Twoją stronę WWW Xara i powiązane z nią usługi do OVHcloud.**

--- a/docs/pl/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
@@ -16,13 +16,7 @@ W przeglądarce internetowej może pojawić się komunikat o błędzie "**Niezai
 
 **Dowiedz się, jak zidentyfikować i usunąć stronę błędu "Strona nie została zainstalowana"**
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner) lub skontaktowanie się z wydawcą usługi. Niestety firma OVH nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji "[Sprawdź również](#go-further)" tego przewodnika.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/secure-your-website.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/secure-your-website.mdx
@@ -13,11 +13,7 @@ Jest on organizowany etapami w coraz większym stopniu w zakresie znaczenia i tr
 
 **Dowiedz się, jak zabezpieczyć Twoją stronę WWW.**
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Tobie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy specjalisty lub kontakt z producentem programu lub interfejsu. Niestety OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) ten przewodnik.
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/sql-change-password.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/sql-change-password.mdx
@@ -33,13 +33,7 @@ Zmiana hasła do bazy danych składa się z czterech częściach:
 
 **Dowiedz się, jak zmienić hasło do bazy danych w bezpieczny sposób.**
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź](#go-further) ten przewodnik.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/sql-database-export.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/sql-database-export.mdx
@@ -50,11 +50,7 @@ Niektóre z powyższych metod nie są powiązane z interfejsem OVHcloud. W przyp
 
 Przejdź do metody tworzenia kopii zapasowej, która Cię interesuje opisanej w dalszej części dokumentacji.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Jeśli jednak napotkasz trudności, zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner). Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ### Pobierz kopię zapasową, korzystając z narzędzia OVHcloud
 

--- a/docs/pl/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
@@ -49,11 +49,7 @@ Niektóre z powyższych metod nie są powiązane z interfejsem OVHcloud. W takic
 
 Przejdź do metody importu, która Cię interesuje opisanej w dalszej części dokumentacji.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak ich konfiguracja, zarządzanie oraz utrzymanie należy do Ciebie. Jesteś tym samym odpowiedzialny za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji "Sprawdź również".
-:::
+[[fragment:support-scope]]
 
 ### Przywracanie kopii zapasowej w Panelu klienta
 

--- a/docs/pl/guides/web-cloud/web-hosting/sql-overquota-database.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/sql-overquota-database.mdx
@@ -36,12 +36,7 @@ Tutorial ten wyjaśnia, jakie działania należy podjąć, gdy wirtualna baza da
 
 ## W praktyce
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-
-:::
+[[fragment:support-scope]]
 
 Gdy baza danych współdzielona OVHcloud zostanie przeciążona (**overquota**), nasze roboty prześlą do Ciebie e-mail na adres e-mail [kontaktu administratora](/guides/account-and-service-management/account-information/managing-contacts) bazy danych. 
 

--- a/docs/pl/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
@@ -14,11 +14,7 @@ Większość naszych pakietów hostingowych [hosting](/links/web/hosting) zawier
 
 **Dowiedz się, jak odnaleźć, za pośrednictwem interfejsów API OVHcloud, kopię zapasową bazy danych po jej usunięciu z Panelu klienta OVHcloud.**
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Jednak w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym usługodawcą](/links/partner). Niestety OVHcloud nie jest w stanie udzielić Ci dalszego wsparcia w zakresie API. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
@@ -18,12 +18,12 @@ import { Tab, Tabs } from '@rspress/core/theme';
 - [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) zainstalowany na lokalnym sprzęcie
 - Podstawowa znajomość [protokołu SSH i jego zastosowania](/guides/bare-metal-cloud/dedicated-servers/ssh-introduction)
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud zapewnia usługi, ale to użytkownik ponosi odpowiedzialność za zarządzanie nimi oraz ich konfigurację. Tutorial ten wyjaśnia, jak korzystać z rozwiązań OVHcloud przy użyciu narzędzi zewnętrznych. Może być konieczne dostosowanie niektórych instrukcji specyficznych dla systemu operacyjnego lokalnego komputera lub serwera.
-
-W przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner) lub [naszą społecznością](/links/community).
-
+Tutorial ten wyjaśnia, jak korzystać z rozwiązań OVHcloud przy użyciu narzędzi zewnętrznych. Może być konieczne dostosowanie niektórych instrukcji specyficznych dla systemu operacyjnego lokalnego komputera lub serwera.
 :::
+
 
 {/* CP-NAV-START:web-hosting */}
 ---

--- a/docs/pl/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
@@ -35,11 +35,7 @@ A zatem, czy Twoja strona WWW używa bezpiecznego połączenia czy też nie, sta
 
 **Przełączenie strony WWW na *HTTPS* może być wrażliwą operacją**. Większość operacji, które należy wykonać, zostanie wykonana w kodzie źródłowym Twojej strony WWW. Jeśli działania nie zostaną przeprowadzone prawidłowo, istnieje ryzyko, że w wynikach wyszukiwania (Google, Yahoo!, bing, etc.) tracisz pozycjonowanie (SEO), a Twoja strona WWW będzie całkowicie niedostępna.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Jeśli jednak napotkasz trudności, zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner). Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 Poniżej znajdziesz najważniejsze kroki opisane w dalszej części tego przewodnika, aby aktywować Twoją stronę WWW przy użyciu *HTTPS*:
 

--- a/docs/pl/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -9,11 +9,7 @@ availableIn: [eu, ca, apac]
 
 W tym tutorialu znajdziesz przykłady sytuacji dotyczących zabezpieczenia Twojej strony WWW za pomocą certyfikatu SSL.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Jeśli jednak napotkasz trudności, zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner). Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 **Dowiedz się, jak uniknąć typowych błędów podczas zabezpieczania strony WWW za pomocą certyfikatu SSL**
 

--- a/docs/pl/guides/web-cloud/web-hosting/ssl-custom.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ssl-custom.mdx
@@ -36,11 +36,10 @@ Możliwe, że w zależności od Twojej sytuacji będziesz chciał zainstalować 
 
 ## W praktyce
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Jednak w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner). OVHcloud nie może udzielić Ci wsparcia w zakresie **instalacji lub subskrypcji certyfikatu SSL innego niż [ten proponowany przez OVHcloud](/links/web/hosting-options-ssl)**. Więcej informacji znajduje się w sekcji "[Sprawdź również](#go-further)" tego przewodnika.
-
+Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Jednak w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner). OVHcloud nie może udzielić Ci wsparcia w zakresie **instalacji lub subskrypcji certyfikatu SSL innego niż [ten proponowany przez OVHcloud](/links/web/hosting-options-ssl)**.
 :::
 
 ### 1 - Uzyskanie certyfikatu Signing Request (CSR) SSL <a name="step-1"></a>

--- a/docs/pl/guides/web-cloud/web-hosting/ssl-ev.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ssl-ev.mdx
@@ -59,11 +59,10 @@ Aby sprawdzić, czy możesz zamówić certyfikat SSL Sectigo EV, przejdź do [li
 
 ## W praktyce
 
+[[fragment:support-scope]]
+
 :::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety nie będziemy w stanie udzielić wsparcia **na wszystkich etapach weryfikacji bezpośrednio z organem certyfikującym Sectigo**. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) niniejszego przewodnika.
-
+Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety nie będziemy w stanie udzielić wsparcia **na wszystkich etapach weryfikacji bezpośrednio z organem certyfikującym Sectigo**.
 :::
 
 ### 1 - Zamów certyfikat SSL Sectigo EV

--- a/docs/pl/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
@@ -11,11 +11,7 @@ Tutorial wyjaśnia, jak używać generatora strony [Cecil](https://cecil.app) do
 
 **Dowiedz się, jak dodać połączenie do zewnętrznego API na stronie statycznej.**
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Jeśli masz trudności z postępowaniem zgodnie z instrukcjami zawartymi w tym przewodniku, zalecamy skorzystanie z [pomocy specjalisty](/links/partner). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/svn.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/svn.mdx
@@ -11,11 +11,7 @@ SVN, który jest skrótem od "subwersji", jest systemem zarządzania wersjami.
 
 **Dowiedz się, jak korzystać z SVN przez SSH na Twoim hostingu**
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji „[Sprawdź również](#go-further)”.
-:::
+[[fragment:support-scope]]
 
 ## Wymagania początkowe
 

--- a/docs/pl/guides/web-cloud/web-hosting/using-scp-command.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/using-scp-command.mdx
@@ -15,11 +15,7 @@ Secure Copy Protocol (SCP) umożliwia bezpieczne kopiowanie (przy użyciu protok
 
 Za pomocą terminala i polecenia Linux można skopiować plik lub folder zawierający jeden lub więcej plików.
 
-:::warning
-OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
-
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Jeśli jednak napotkasz trudności, zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner). Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego przewodnika.
-:::
+[[fragment:support-scope]]
 
 **Dowiedz się, jak używać polecenia Secure Copy Protocol (SCP) przez SSH do kopiowania plików z lub na Twój hosting.**
 

--- a/docs/pl/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Tutorial ten pozwoli Ci na tworzenie pierwszych treści, ich organizację, umieszczenie w Internecie i zmianę motywu Twojej strony WWW za pomocą Content Management System (CMS) **WordPress**. Możesz uruchomić Twoją stronę WWW bez konieczności posiadania wiedzy z zakresu programowania, z szerokim wachlarzem tematów, takich jak firmowa strona WWW, blog czy strona internetowa, która pozwoli Ci poznać Twoją działalność i pasję.
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
+[[fragment:support-scope]]
 
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego tutoriala.
+:::warning
+Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
 :::
 
 **Dowiedz się, jak utworzyć stronę WWW przy użyciu CMS WordPress.**

--- a/docs/pl/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Dowiedz się, jak utworzyć sklep internetowy z rozszerzeniem open source **WooCommerce** przy użyciu Content Management System (CMS) **WordPress**. 
 
-:::warning
-OVHcloud oddaje do Twojej dyspozycji usługi, których konfiguracja, zarządzanie i odpowiedzialność spoczywa na Ciebie. W związku z tym należy zapewnić ich prawidłowe funkcjonowanie.
+[[fragment:support-scope]]
 
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner), [edytora CMS WordPress](https://wordpress.com/support/) lub [edytora WooCommerce](https://woocommerce.com/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further) niniejszego tutoriala.
+:::warning
+Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner), [edytora CMS WordPress](https://wordpress.com/support/) lub [edytora WooCommerce](https://woocommerce.com/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
 :::
 
 ## Wymagania początkowe

--- a/docs/pt/guides/web-cloud/domains/_transfer-incoming-o2switch.mdx
+++ b/docs/pt/guides/web-cloud/domains/_transfer-incoming-o2switch.mdx
@@ -35,11 +35,7 @@ Deve também:
 - Ter a possibilidade de solicitar a transferência do nome de domínio.
 - Ter informado o proprietário do nome de domínio e/ou os seus administradores do pedido de transferência.
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. Contudo, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que contacte o seu agente de registo atual. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte [Quer saber mais?](#go-further) deste guia.
-:::
+[[fragment:support-scope]]
 
 ## Instruções
 

--- a/docs/pt/guides/web-cloud/domains/dns-zone-dmarc.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zone-dmarc.mdx
@@ -11,12 +11,7 @@ O registo **D**omain-based **M**essage **A**uthentication, **R**eporting, and **
 
 **Saiba como o DMARC funciona e como configurá-lo para o seu serviço de e-mail.**
 
-:::warning
-A OVHcloud oferece serviços cuja configuração, gestão e responsabilidade são da sua responsabilidade. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Mais informações na secção [Quer saber mais?](#go-further) deste tutorial.
-
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -4,11 +4,7 @@ lastUpdated: 2026-02-10
 availableIn: [eu, ca, apac]
 ---
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste manual.
-:::
+[[fragment:support-scope]]
 
 ## Objetivo
 

--- a/docs/pt/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/pt/guides/web-cloud/domains/domain-icloud.mdx
@@ -5,11 +5,7 @@ lastUpdated: 2025-08-27
 availableIn: [eu, ca, apac]
 ---
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
-
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
-:::
+[[fragment:support-scope]]
 
 ## Objective
 

--- a/docs/pt/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
+++ b/docs/pt/guides/web-cloud/domains/how-to-connect-domain-to-godaddy.mdx
@@ -13,11 +13,12 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 **Saiba como ligar o seu nome de domínio OVHcloud a um alojamento GoDaddy**
 
-:::warning
-- O suporte GoDaddy não tem acesso aos parâmetros do seu nome de domínio OVHcloud e não pode, por isso, aconselhá-lo sobre as informações que deverá fornecer.
-- A OVHcloud disponibiliza-lhe serviços cuja configuração, gestão e responsabilidade é da sua competência. Assim, deverá certificar-se de que estes funcionam corretamente.<br/><br/> Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte a secção [Quer saber mais?](#go-further) deste guia.
+[[fragment:support-scope]]
 
+:::warning
+O suporte GoDaddy não tem acesso aos parâmetros do seu nome de domínio OVHcloud e não pode, por isso, aconselhá-lo sobre as informações que deverá fornecer.
 :::
+
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
+++ b/docs/pt/guides/web-cloud/domains/how-to-connect-domain-to-google-site.mdx
@@ -13,11 +13,12 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 **Saiba como ligar o seu nome de domínio OVHcloud a um Google Site.**
 
-:::warning
-- O suporte Google Site não tem acesso aos parâmetros do seu nome de domínio OVHcloud e não pode, por isso, aconselhá-lo sobre as informações que deverá fornecer.
-- A OVHcloud disponibiliza-lhe serviços cuja configuração, gestão e responsabilidade é da sua competência. Assim, deverá certificar-se de que estes funcionam corretamente.<br/><br/> Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte a secção [Quer saber mais?](#go-further) deste guia.
+[[fragment:support-scope]]
 
+:::warning
+O suporte Google Site não tem acesso aos parâmetros do seu nome de domínio OVHcloud e não pode, por isso, aconselhá-lo sobre as informações que deverá fornecer.
 :::
+
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
+++ b/docs/pt/guides/web-cloud/domains/how-to-connect-domain-to-shopify.mdx
@@ -13,12 +13,12 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 **Saiba como ligar o seu nome de domínio OVHcloud a um alojamento Shopify**
 
+[[fragment:support-scope]]
+
 :::warning
-- O suporte Shopify não tem acesso aos parâmetros do seu nome de domínio OVHcloud e não pode, por isso, aconselhá-lo sobre as informações que deverá fornecer.
-
-- A OVHcloud disponibiliza-lhe serviços cuja configuração, gestão e responsabilidade é da sua competência. Assim, deverá certificar-se de que estes funcionam corretamente.<br/><br/> Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte a secção [Quer saber mais?](#go-further) deste guia.
-
+O suporte Shopify não tem acesso aos parâmetros do seu nome de domínio OVHcloud e não pode, por isso, aconselhá-lo sobre as informações que deverá fornecer.
 :::
+
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
+++ b/docs/pt/guides/web-cloud/domains/how-to-connect-domain-to-squarespace.mdx
@@ -13,12 +13,12 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 **Saiba como ligar o seu nome de domínio OVHcloud a um alojamento SquareSpace**
 
+[[fragment:support-scope]]
+
 :::warning
-- O suporte SquareSpace não tem acesso aos parâmetros do seu nome de domínio OVHcloud e não pode, por isso, aconselhá-lo sobre as informações que deverá fornecer.
-
-- A OVHcloud disponibiliza-lhe serviços cuja configuração, gestão e responsabilidade é da sua competência. Assim, deverá certificar-se de que estes funcionam corretamente.<br/><br/> Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte a secção [Quer saber mais?](#go-further) deste guia.
-
+O suporte SquareSpace não tem acesso aos parâmetros do seu nome de domínio OVHcloud e não pode, por isso, aconselhá-lo sobre as informações que deverá fornecer.
 :::
+
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
+++ b/docs/pt/guides/web-cloud/domains/how-to-connect-domain-to-webflow.mdx
@@ -13,11 +13,12 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 **Saiba como ligar o seu nome de domínio OVHcloud a um alojamento Webflow**
 
-:::warning
-- O suporte Webflow não tem acesso aos parâmetros do seu nome de domínio OVHcloud e não pode, por isso, aconselhá-lo sobre as informações que deverá fornecer.
-- A OVHcloud disponibiliza-lhe serviços cuja configuração, gestão e responsabilidade é da sua competência. Assim, deverá certificar-se de que estes funcionam corretamente.<br/><br/> Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte a secção [Quer saber mais?](#go-further) deste guia.
+[[fragment:support-scope]]
 
+:::warning
+O suporte Webflow não tem acesso aos parâmetros do seu nome de domínio OVHcloud e não pode, por isso, aconselhá-lo sobre as informações que deverá fornecer.
 :::
+
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
+++ b/docs/pt/guides/web-cloud/domains/how-to-connect-domain-to-wix.mdx
@@ -13,12 +13,12 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 **Saiba como ligar o seu nome de domínio OVHcloud a um alojamento Wix**
 
+[[fragment:support-scope]]
+
 :::warning
-- O suporte Wix não tem acesso aos parâmetros do seu nome de domínio OVHcloud e não pode, por isso, aconselhá-lo sobre as informações que deverá fornecer.
-
-- A OVHcloud disponibiliza-lhe serviços cuja configuração, gestão e responsabilidade é da sua competência. Assim, deverá certificar-se de que estes funcionam corretamente.<br/><br/> Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte a secção [Quer saber mais?](#go-further) deste guia.
-
+O suporte Wix não tem acesso aos parâmetros do seu nome de domínio OVHcloud e não pode, por isso, aconselhá-lo sobre as informações que deverá fornecer.
 :::
+
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/domains/redirect-domain-name.mdx
+++ b/docs/pt/guides/web-cloud/domains/redirect-domain-name.mdx
@@ -317,12 +317,7 @@ Clique em <code className="action">Confirmar</code> para validar a configuraçã
 
 ### Reencaminhar um domínio através de um ficheiro ".htaccess" <a name="htaccess_rewrite"></a>
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade são da sua responsabilidade. Cabe-lhe a si assegurar o seu bom funcionamento.
-
-Disponibilizamos esta parte do guia para o acompanhar nas tarefas mais habituais. No entanto, recomendamos que contacte um [prestador especializado](/links/partner) se encontrar dificuldades. Não poderemos prestar-lhe assistência nos passos documentados abaixo. Encontre mais informações na secção "[Quer saber mais?](#go-further)" deste guia.
-
-:::
+[[fragment:support-scope]]
 
 Os ficheiros ".htaccess" são ficheiros de configuração nos quais podem ser especificados comandos. Quando o código do website é executado pelo servidor web (Apache), os comandos são interpretados e executados.
 

--- a/docs/pt/guides/web-cloud/domains/transfer-incoming-couk.mdx
+++ b/docs/pt/guides/web-cloud/domains/transfer-incoming-couk.mdx
@@ -9,12 +9,7 @@ availableIn: [eu, ca, apac]
 
 A transferência de um nome de domínio .uk (ou equiparado) requer uma abordagem específica.
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais?](#go-further)?
-
-:::
+[[fragment:support-scope]]
 
 ***Descubra como transferir um nome de domínio .uk (ou equiparado) para a OVHcloud**
 

--- a/docs/pt/guides/web-cloud/domains/transfer-incoming-gandi.mdx
+++ b/docs/pt/guides/web-cloud/domains/transfer-incoming-gandi.mdx
@@ -43,11 +43,7 @@ Deve também:
 - Ter a possibilidade de solicitar a transferência do nome de domínio.
 - Ter informado o titular do nome de domínio e/ou os seus administradores do pedido de transferência.
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. Contudo, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que contacte o seu agente de registo atual. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte [Quer saber mais?](#go-further) deste guia.
-:::
+[[fragment:support-scope]]
 
 ## Instruções
 

--- a/docs/pt/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
+++ b/docs/pt/guides/web-cloud/domains/transfer-incoming-godaddy.mdx
@@ -35,11 +35,7 @@ Deve também:
 - Ter a possibilidade de solicitar a transferência do nome de domínio.
 - Ter informado o titular do nome de domínio e/ou os seus administradores do pedido de transferência.
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. Contudo, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que contacte o seu agente de registo atual. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte [Quer saber mais?](#go-further) deste guia.
-:::
+[[fragment:support-scope]]
 
 ## Instruções
 

--- a/docs/pt/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
+++ b/docs/pt/guides/web-cloud/domains/transfer-incoming-hostinger.mdx
@@ -35,11 +35,7 @@ Deve também:
 - Ter a possibilidade de solicitar a transferência do nome de domínio.
 - Ter informado o titular do nome de domínio e/ou os seus administradores do pedido de transferência.
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. Contudo, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que contacte o seu agente de registo atual. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte [Quer saber mais?](#go-further) deste guia.
-:::
+[[fragment:support-scope]]
 
 ## Instruções
 

--- a/docs/pt/guides/web-cloud/domains/transfer-incoming-ionos.mdx
+++ b/docs/pt/guides/web-cloud/domains/transfer-incoming-ionos.mdx
@@ -35,11 +35,7 @@ Deve também:
 - Ter a possibilidade de solicitar a transferência do nome de domínio.
 - Ter informado o titular do nome de domínio e/ou os seus administradores do pedido de transferência.
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. Contudo, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que contacte o seu agente de registo atual. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte [Quer saber mais?](#go-further) deste guia.
-:::
+[[fragment:support-scope]]
 
 ## Instruções
 

--- a/docs/pt/guides/web-cloud/domains/transfer-incoming-wix.mdx
+++ b/docs/pt/guides/web-cloud/domains/transfer-incoming-wix.mdx
@@ -35,11 +35,7 @@ Deve também:
 - Ter a possibilidade de solicitar a transferência do nome de domínio.
 - Ter informado o titular do nome de domínio e/ou os seus administradores do pedido de transferência.
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. Contudo, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que contacte o seu agente de registo atual. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte [Quer saber mais?](#go-further) deste guia.
-:::
+[[fragment:support-scope]]
 
 ## Instruções
 

--- a/docs/pt/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-manage-1-click-module.mdx
@@ -13,12 +13,7 @@ Os módulos 1 clique permitem a instalação fácil e rápida de um software on-
 
 **Saiba como gerir o módulo 1 clique na Área de Cliente OVHcloud.**
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais](#go-further)?
-
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -9,13 +9,10 @@ availableIn: [eu, ca, apac]
 
 Aqui, poderá encontrar todos os elementos para instalar manualmente o CMS (Content Management System) Drupal em apenas alguns passos.
 
+[[fragment:support-scope]]
+
 :::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS Drupal](https://www.drupal.org/support). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais?](#go-further) deste tutorial.
-
-Se pretender atualizar um CMS Drupal existente ou se tiver dúvidas sobre a utilização do CMS Drupal, contacte diretamente o [editor do CMS Drupal](https://www.drupal.org/support).
-
+Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS Drupal](https://www.drupal.org/support). Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 :::tip

--- a/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Aqui, poderá encontrar todos os elementos para instalar manualmente o CMS (Content Management System) Joomla! em apenas alguns passos.
 
+[[fragment:support-scope]]
+
 :::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS Joomla!](https://www.joomla.org/). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste tutorial.
-
+Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS Joomla!](https://www.joomla.org/). Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 :::tip

--- a/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Aqui, poderá encontrar todos os elementos para instalar manualmente o CMS (Content Management System) PrestaShop em algumas etapas.
 
+[[fragment:support-scope]]
+
 :::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS PrestaShop](https://www.prestashop.com/en/support). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste manual.
-
+Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS PrestaShop](https://www.prestashop.com/en/support). Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 :::tip

--- a/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -9,11 +9,10 @@ availableIn: [eu, ca, apac]
 
 Este tutorial tem como objetivo ajudá-lo a instalar manualmente o CMS (Content Management System) WordPress em apenas alguns Etapas.
 
+[[fragment:support-scope]]
+
 :::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste manual.
-
+Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 :::tip

--- a/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -12,22 +12,10 @@ import { Region } from '@components/Zone';
 
 Este tutorial tem como objetivo ajudá-lo a instalar manualmente um CMS (Content Management System) como WordPress, Joomla!, Drupal, PrestaShop, Pico, Grav, Typo3 ou SPIP em algumas etapas.
 
+[[fragment:support-scope]]
+
 :::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou ao editor do CMS. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais?](#go-further) deste tutorial.
-
-Para contactar os diferentes editores dos CMS acima mencionados, consulte as ligações às respetivas páginas oficiais:
-
-- [WordPress](https://wordpress.com/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-- [Pico](https://picocms.org/)
-- [Grav](https://getgrav.org/)
-- [Typo3](https://typo3.com/)
-- [SPIP](https://www.spip.net/en_rubrique25.html)
-
+Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou ao editor do CMS. Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 :::tip

--- a/docs/pt/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -37,18 +37,10 @@ Existem vários métodos para alterar a palavra-passe de administrador do seu CM
 - [através da interface de administração do seu CMS](#via-cms)
 - [via phpMyAdmin a partir da Área de Cliente OVHcloud](#via-phpmyadmin)
 
+[[fragment:support-scope]]
+
 :::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou ao editor do CMS. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais?](#go-further) deste tutorial.
-
-Para contactar os diferentes editores dos CMS acima mencionados, consulte as ligações às respetivas páginas oficiais:
-
-- [WordPress](https://wordpress.com/support/)
-- [Joomla!](https://www.joomla.org/)
-- [Drupal](https://www.drupal.org/)
-- [PrestaShop](https://www.prestashop.com/en/support)
-
+Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou ao editor do CMS. Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 ### Alterar a palavra-passe de administrador através do e-mail automático (palavra-passe esquecida) <a name="via-email"></a>

--- a/docs/pt/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-what-to-do-if-your-site-is-hacked.mdx
@@ -19,12 +19,7 @@ A pirataria pode manifestar-se de várias formas (lista não exaustiva):
 
 **Saiba os nossos conselhos para reparar o seu website pirateado**
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais?](#go-further) deste manual.
-
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/composer-install-composer.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/composer-install-composer.mdx
@@ -11,11 +11,7 @@ availableIn: [eu, ca, apac]
 
 **Descubra como instalar e dar os primeiros passos em Composer**
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais?](#go-further) deste tutorial.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/configure-ipv6.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/configure-ipv6.mdx
@@ -38,12 +38,7 @@ Os nossos alojamentos web são compatíveis com IPv6 desde 2011. Mas a ativaçã
 
 ## Instruções
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. Se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais?](#go-further) deste tutorial.
-
-:::
+[[fragment:support-scope]]
 
 Se o seu site não estiver configurado para funcionar com um endereço IPv6, pode adicionar [o endereço IPv6 do seu alojamento partilhado OVHcloud](/guides/web-cloud/web-hosting/clusters-and-shared-hosting-ip) na zona DNS ativa do seu nome de domínio. O objetivo é permitir aos browsers encontrar um endereço IPv6 associado ao seu website através do seu domínio.
 

--- a/docs/pt/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/create-your-personal-webpage.mdx
@@ -9,11 +9,7 @@ availableIn: [eu]
 
 Saiba como criar a primeira página de um site num alojamento gratuito grátis para qualquer compra de um domínio na OVHcloud.
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais?](#go-further) deste manual.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/cron-tasks.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cron-tasks.mdx
@@ -13,11 +13,7 @@ No seu alojamento web OVHcloud, pode utilizar scripts para automatizar certas op
 
 **Saiba como criar tarefas CRON para automatizar as tarefas planeadas num alojamento web.**
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se tiver alguma dúvida, recomendamos que recorra a um [fornecedor de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste manual.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/diagnosis-database-errors.mdx
@@ -13,11 +13,7 @@ A utilização das suas bases de dados pode dar origem a um certo número de ano
 
 **Descubra como resolver os erros associados às bases de dados sobre os alojamentos partilhados OVHcloud.**
 
-:::warning
-A OVHcloud disponibiliza-lhe serviços cuja configuração e gestão são da responsabilidade do cliente. O cliente é o único responsável pelo seu bom funcionamento.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais](#go-further)?
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -33,11 +33,10 @@ Após a deteção de um funcionamento suspeito, os nossos robôs de segurança p
 
 **Descubra como desbloquear o acesso ao seu site em caso de apresentação "403 forbidden".**
 
+[[fragment:support-scope]]
+
 :::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que troque informações com a nossa [comunidade de utilizadores](/links/community). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais?](#go-further) deste manual.
-
+Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que troque informações com a nossa [comunidade de utilizadores](/links/community). Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 ## Requisitos

--- a/docs/pt/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/diagnostic-errors-module1clic.mdx
@@ -12,13 +12,7 @@ No entanto, se a configuração destes últimos não for realizada corretamente,
 
 **Saiba como diagnosticar os casos mais comuns de erros relacionados com a criação de "módulo 1 clique"**
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Mais informações na secção "[Quer saber mais?](#go-further)" deste guia.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
@@ -15,12 +15,7 @@ Por vezes, provêm também de uma atualização efetuada **automaticamente** por
 
 **Saiba como diagnosticar os casos mais comuns de erros 500.**
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais](#go-further) ?
-
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/diagnostic-index-of.mdx
@@ -16,13 +16,7 @@ Uma página **"Index of"** aparece pelo menos num dos casos seguintes:
 
 **Descubra como corrigir a apresentação de uma página "Index of".**
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais](#go-further)?
-
-:::
-
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/diagnostic-not-secured.mdx
@@ -20,11 +20,7 @@ Em caso de inacessibilidade do seu site, podem surgir várias mensagens de erro.
 
 **Descubra como resolver os erros do tipo "Sua conexão não é particular".**
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção deste manual intitulada: "[Quer saber mais?](#go-further)".
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -57,11 +57,10 @@ Este guia será atualizado em breve. Em caso de dificuldades, consulte a versão
 
 :::
 
+[[fragment:support-scope]]
+
 :::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). De facto, não poderemos fornecer-lhe assistência **a partir do momento em que a infraestrutura em que o seu alojamento partilhado está presente não esteja em causa**. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste manual.
-
+Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). De facto, não poderemos fornecer-lhe assistência **a partir do momento em que a infraestrutura em que o seu alojamento partilhado está presente não esteja em causa**.
 :::
 
 :::tip

--- a/docs/pt/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/diagnostic-website-not-accessible.mdx
@@ -20,11 +20,7 @@ Vários feedbacks de erro podem aparecer no seu navegador em caso de inacessibil
 
 **Saiba como corrigir erros do tipo "Não é possível acessar esse site"**
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais?](#go-further).
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/ftp-change-password.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ftp-change-password.mdx
@@ -18,11 +18,7 @@ Este acesso permite nomeadamente [publicar o seu site](/guides/web-cloud/web-hos
 
 **Descubra como alterar a palavra-passe de um utilizador FTP criado no seu alojamento web da OVHcloud.**
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner), não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais"](#go-further)?
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ftp-cyberduck-user-guide-on-mac.mdx
@@ -19,11 +19,7 @@ Para transferir o Cyberduck, aceda a [site oficial](https://cyberduck.io/) da ap
 
 :::
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Consulte [Quer saber mais?](#go-further) deste guia para mais informações.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ftp-recurring-ftp-problems.mdx
@@ -13,12 +13,7 @@ A utilização de software FTP durante a ligação ao seu [alojamento Web Cloud]
 
 **Descubra como corrigir os erros relacionados com o software FTP.**
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais](#go-further)?
-
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -35,10 +35,10 @@ Se pretender administrar o seu website remotamente sem utilizar o Visual Studio 
 
 ## Instruções
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
+[[fragment:support-scope]]
 
-Nós disponibilizamos-lhe este tutorial a fim de o acompanhar nas tarefas mais comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou a [editor do IDE Visual Studio Code](https://code.visualstudio.com/). Não poderemos proporcionar-lhe assistência técnica. Mais informações na secção ["Quer saber mais?"](#go-further) deste tutorial.
+:::warning
+Nós disponibilizamos-lhe este tutorial a fim de o acompanhar nas tarefas mais comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou a [editor do IDE Visual Studio Code](https://code.visualstudio.com/). Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 ### Instalar a extensão SFTP para o Visual Studio Code

--- a/docs/pt/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/hosting-how-to-get-my-website-online.mdx
@@ -54,13 +54,7 @@ Depois de ter avaliado as diferentes possibilidades descritas acima, pode escolh
 - **Não pretende utilizar os módulos 1 clique**: terá de efetuar manualmente a instalação do site no alojamento. As informações presentes neste manual poderão ser úteis. No entanto, se precisar de ajuda, pode contactar um webmaster.
  
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção “Quer saber mais?” deste manual.
-
-:::
-
+[[fragment:support-scope]]
 
 ### 2 - Colocar os ficheiros do site no espaço de armazenamento
 

--- a/docs/pt/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/hosting-migrating-to-ovh.mdx
@@ -12,12 +12,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Este guia apresenta-lhe as diferentes ações a realizar para migrar o conjunto do seu website, as suas pastas, o seu nome de domínio, a sua base de dados e os seus endereços de e-mail para a OVHcloud, sem interrupção de serviços.
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste manual.
-
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/hosting-technical-specificities.mdx
@@ -30,12 +30,7 @@ As ofertas de alojamento web da OVHcloud são partilhadas. Por conseguinte, a co
 
 ## Instruções
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção "[Quer saber mais?](#go-further)" deste guia.
-
-:::
+[[fragment:support-scope]]
 
 ### FTP
 

--- a/docs/pt/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -12,10 +12,10 @@ O backup regular das informações do seu website é uma boa prática a adotar. 
 
 Num alojamento web partilhado, é responsável pelos backups do seu website. Mesmo que a OVHcloud proponha backups (não contratuais), recomendamos que realize também si backups regulares e que gira os seus próprios suportes de backup (disco rígido, pen USB, etc.) para uma maior precaução.
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
+[[fragment:support-scope]]
 
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou ao [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste tutorial.
+:::warning
+Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou ao [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 **Descubra como guardar o conteúdo do seu site WordPress e a sua base de dados.**

--- a/docs/pt/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -13,13 +13,7 @@ Este tutorial tem como objetivo explicar os principais passos a seguir quando de
 
 **Descubra como mudar o nome de domínio de um site existente.**
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste manual.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-block-a-specific-ip-address-from-accessing-your-website.mdx
@@ -15,11 +15,7 @@ Pode criar vários ficheiros ".htaccess" no [espaço FTP](/guides/web-cloud/web-
 
 **Descubra como bloquear o acesso ao seu site para certos endereços IP através de um ficheiro ".htaccess".**
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais?](#go-further) deste manual.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -11,10 +11,10 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Este tutorial explica-lhe como configurar certas funcionalidades do seu alojamento web com um ou vários ficheiros **.htaccess**, nomeadamente para modificar os parâmetros de uma parte ou do conjunto do seu website (reencaminhamentos, proibições de acesso, autorizações restritas, controlo da cache, etc.).
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
+[[fragment:support-scope]]
 
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais?](#go-further) deste tutorial.
+:::warning
+Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 **Descubra como proteger o seu WordPress com um ou vários ficheiros htaccess.**

--- a/docs/pt/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/htaccess-protect-directory-by-password.mdx
@@ -14,13 +14,7 @@ Isto utilizando dois ficheiros de configuração (HTTP) Apache que pretende colo
 - "**.htaccess**": para mais informações sobre as funcionalidades deste ficheiro, consulte o nosso tutorial sobre as ["Operações possíveis com um ficheiro ".htaccess"](/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do).
 - "**.htpasswd**": para além deste tutorial, consulte a [documentação oficial Apache](https://httpd.apache.org/docs/2.4/en/programs/htpasswd.html) relativa a este ficheiro.
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste manual.
-
-Os exemplos que se seguem são implementados em ficheiros denominados ".htaccess" e ".htpasswd". Atenção, as regras que define nestes ficheiros têm consequências diretas no seu website. Verifique sempre as regras que adicionou antes de as aplicar ao seu website. 
-:::
+[[fragment:support-scope]]
 
 **Descubra como proteger um diretório ou o acesso à parte administrador do seu website através de uma autenticação com os ficheiros ".htaccess" e ".htpasswd".**
 

--- a/docs/pt/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite.mdx
@@ -33,14 +33,7 @@ Se pretender aprofundar os seus conhecimentos sobre a utilização do "**mod_rew
 
 ## Instruções
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais?](#go-further) deste manual.
-
-Os exemplos que se seguem são colocados num ficheiro ".htaccess". Atenção, as regras que define neste ficheiro têm consequências diretas no seu website. Verifique sempre as regras que adicionou antes de as aplicar ao seu website.
-
-:::
+[[fragment:support-scope]]
 
 O ficheiro ".htaccess" no qual vai configurar o "**mod_rewrite**" do Apache pode ser colocado em várias pastas diferentes. Deve apenas respeitar a regra de **um** ficheiro ".htaccess" por pasta ou sub-pasta.
 

--- a/docs/pt/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/htaccess-what-else-can-you-do.mdx
@@ -19,13 +19,7 @@ Para utilizar corretamente o ficheiro ".htaccess", deve conhecer e respeitar as 
 - o ficheiro ".htaccess" é invisível para os internautas que visitam o seu website;
 - as regras declaradas num ficheiro ".htaccess" aplicam-se a todo o diretório onde o ficheiro ".htaccess" está instalado, bem como a todos os subdiretórios desse mesmo diretório.
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste manual.
-
-Os exemplos que se seguirão serão colocados num ficheiro ".htaccess". Atenção, as regras que define neste ficheiro têm consequências diretas no seu website. Verifique sempre as regras que adicionou antes de as aplicar ao seu website. 
-:::
+[[fragment:support-scope]]
 
 **Descubra as principais operações que podem ser realizadas com um ficheiro ".htaccess".**
 

--- a/docs/pt/guides/web-cloud/web-hosting/mail-function-script-records.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mail-function-script-records.mdx
@@ -259,11 +259,7 @@ O nosso serviço antispam analisará a situação e o nosso suporte entrará em 
 
 ### Envio de e-mails com a ajuda de um script «SMTP» <a name="SMTP"></a>
 
-:::warning
-A OVHcloud disponibiliza-lhe serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-No entanto, recomendamos que recorra a um [fornecedor especializado](/links/partner) se encontrar dificuldades. Não lhe poderemos prestar assistência. Para mais informações, aceda à secção [«Quer saber mais?»](#go-further) deste guia.
-:::
+[[fragment:support-scope]]
 
 Embora recomendemos vivamente privilegiar a utilização da função "mail()" de PHP, os alojamentos partilhados permitem enviar e-mails através de um script que utiliza o protocolo SMTP (Simple Mail Transfer Protocol). O tamanho total do seu e-mail não poderá ultrapassar **10 MB** (ou seja, **7/8 MB sem encapsulamento**).
 

--- a/docs/pt/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -23,10 +23,10 @@ MainWP offers several extensions for backing up your websites.
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/pt/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -16,10 +16,10 @@ Retaining customers is vital to your company's development. Whether you have one
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard. For more information, please read our guide on [Managing multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general).
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/pt/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -26,10 +26,10 @@ In this guide, we have chosen the MainWP plugin. Other similar solutions exist, 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, in the `Web Cloud` section.
 - Access to the WordPress administration interface.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/pt/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -16,10 +16,10 @@ Maintaining the security of your websites is crucial for the development of your
 - A [Web Cloud hosting plan](/links/web/hosting).
 - Access to your MainWP dashboard.
 
-:::warning
-OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
+[[fragment:support-scope]]
 
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
+:::warning
+This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
 :::
 
 ## Instructions

--- a/docs/pt/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
@@ -20,11 +20,7 @@ O seu website evolui e o seu consumo de recursos é tal que o seu alojamento web
 
 ## Instruções
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. Se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte a secção ["Quer saber mais?"](#go-further) deste guia.
-:::
+[[fragment:support-scope]]
 
 ### Etapa 1 - Efetuar o backup dos ficheiros e da base de dados do seu website <a name="step1"></a>
 

--- a/docs/pt/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Este tutorial explica passo a passo como migrar o seu website WordPress e todos os seus serviços associados para a OVHcloud.
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
+[[fragment:support-scope]]
 
-Nós disponibilizamos-lhe este tutorial a fim de o acompanhar nas tarefas mais comuns. Contudo, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou a [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica. Mais informações na secção ["Quer saber mais?"](#go-further) deste tutorial.
+:::warning
+Nós disponibilizamos-lhe este tutorial a fim de o acompanhar nas tarefas mais comuns. Contudo, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou a [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 **Descubra como migrar o seu website WordPress e os seus serviços associados para a OVHcloud.**

--- a/docs/pt/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Este tutorial explica passo a passo como migrar o seu website Xara e todos os seus serviços associados para a OVHcloud.
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
+[[fragment:support-scope]]
 
-Nós disponibilizamos-lhe este tutorial a fim de o acompanhar nas tarefas mais comuns. Contudo, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou a [site oficial do Xara Web designer](https://www.xara.com/webdesigner-plus/). Não poderemos proporcionar-lhe assistência técnica. Mais informações na secção ["Quer saber mais?"](#go-further) deste tutorial.
+:::warning
+Nós disponibilizamos-lhe este tutorial a fim de o acompanhar nas tarefas mais comuns. Contudo, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou a [site oficial do Xara Web designer](https://www.xara.com/webdesigner-plus/). Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 **Descubra como migrar o seu website Xara e os seus serviços associados para a OVHcloud.**

--- a/docs/pt/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
@@ -16,13 +16,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 **Saiba como identificar e resolver a página de erro "Site não instalado"**
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Mais informações na secção "[Quer saber mais?](#go-further)" deste guia.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/secure-your-website.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/secure-your-website.mdx
@@ -13,11 +13,7 @@ Este guia permite-lhe adquirir conhecimentos fundamentais para assegurar a dispo
 
 **Descubra como proteger o seu website.**
 
-:::warning
-A OVHcloud disponibiliza-lhe serviços cuja configuração e gestão são da responsabilidade do cliente. O cliente é o único responsável pelo seu bom funcionamento.
-
-Este manual fornece as instruções necessárias para usar as funcionalidades básicas de um servidor. No entanto, caso encontre dificuldades, recomendamos que contacte um fornecedor especializado e/ou o editor do serviço. De facto, a OVHcloud não lhe poderá fornecer assistência. Para mais informações, aceda à secção deste manual intitulada: [Quer saber mais?](#go-further)
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/sql-change-password.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/sql-change-password.mdx
@@ -33,13 +33,7 @@ A alteração da palavra-passe da base de dados do seu site faz-se em quatro par
 
 **Descubra como alterar a palavra-passe de uma base de dados de forma segura.**
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [Quer saber mais](#go-further)?
-
-:::
-
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/sql-database-export.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/sql-database-export.mdx
@@ -50,11 +50,7 @@ Alguns dos métodos acima indicados não são inerentes a uma interface OVHcloud
 
 Consulte este manual de acordo com o método de backup pretendido.
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Mais informações na secção [Quer saber mais?](#go-further) deste guia.
-:::
+[[fragment:support-scope]]
 
 ### Recuperar um backup através da ferramenta da OVHcloud
 

--- a/docs/pt/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/sql-importing-mysql-database.mdx
@@ -49,11 +49,7 @@ Tenha em conta que algumas destas operações se realizam fora da interface da O
 
 Consulte a documentação correspondente ao método de importação pretendido.
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, recomendamos que recorra a um fornecedor especializado e/ou que contacte o editor do serviço se encontrar dificuldades. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção deste guia intitulada: "Quer saber mais?"
-:::
+[[fragment:support-scope]]
 
 ### Restaurar um backup a partir da Área de Cliente
 

--- a/docs/pt/guides/web-cloud/web-hosting/sql-overquota-database.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/sql-overquota-database.mdx
@@ -36,12 +36,7 @@ Este tutorial propõe-lhe as ações a empreender quando a sua base de dados par
 
 ## Instruções
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste manual.
-
-:::
+[[fragment:support-scope]]
 
 Quando a sua base de dados partilhada da OVHcloud chega a saturação (**overquota**), os nossos robôs avisam-no por e-mail no endereço de e-mail do [contacto "Administrador"](/guides/account-and-service-management/account-information/managing-contacts) da base de dados. 
 

--- a/docs/pt/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
@@ -14,11 +14,7 @@ A maioria dos nossos serviços de [alojamento web](/links/web/hosting) incluem b
 
 **Saiba como recuperar, através das API OVHcloud, o backup de uma base de dados quando esta foi eliminada a partir da Área de Cliente OVHcloud.**
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos fornecer-lhe assistência complementar a nível das API. Para mais informações, consulte a secção ["Quer saber mais?"](#go-further) deste guia.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
@@ -18,12 +18,12 @@ O [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) é um 
 - [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) instalado no seu equipamento local
 - Conhecimentos de base do [protocolo SSH e da sua utilização](/guides/bare-metal-cloud/dedicated-servers/ssh-introduction)
 
+[[fragment:support-scope]]
+
 :::warning
-A OVHcloud fornece serviços cuja configuração e gestão são da sua responsabilidade. Este tutorial explica como utilizar as soluções da OVHcloud com ferramentas externas. Poderá ser necessário adaptar algumas instruções específicas ao sistema operativo da estação de trabalho local ou do servidor.
-
-Recomendamos que entre em contacto com um [fornecedor de serviços especializado](/links/partner) ou [nossa comunidade](/links/community) se encontrar dificuldades.
-
+Este tutorial explica como utilizar as soluções da OVHcloud com ferramentas externas. Poderá ser necessário adaptar algumas instruções específicas ao sistema operativo da estação de trabalho local ou do servidor.
 :::
+
 
 {/* CP-NAV-START:web-hosting */}
 ---

--- a/docs/pt/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ssl-activate-https-website.mdx
@@ -35,11 +35,7 @@ O facto de o seu website possuir ou não uma ligação segura torna-se cada vez 
 
 **Tornar o website em *HTTPS* pode ser uma operação sensível**. De facto, a maior parte das ações a realizar serão efetuadas no código fonte do seu website. Se não forem efetuadas corretamente, poderá verificar uma diminuição do referenciamento (SEO) nos resultados propostos pelos motores de pesquisa (Google, Yahoo!, bing, etc.), ou mesmo uma inacessibilidade total do seu website.
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte a secção ["Quer saber mais?"](#go-further) deste guia.
-:::
+[[fragment:support-scope]]
 
 Encontre aqui as principais etapas descritas no resto deste guia para passar o seu website em *HTTPS*:
 

--- a/docs/pt/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ssl-avoid-common-pitfalls-of-making-website-secure.mdx
@@ -9,11 +9,7 @@ availableIn: [eu, ca, apac]
 
 Encontre, neste tutorial, alguns exemplos de situações relativas à segurança do seu website com o SSL.
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte a secção ["Quer saber mais?"](#go-further) deste guia.
-:::
+[[fragment:support-scope]]
 
 **Descubra como evitar os erros comuns de segurança do seu website com o SSL**
 

--- a/docs/pt/guides/web-cloud/web-hosting/ssl-custom.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ssl-custom.mdx
@@ -36,11 +36,10 @@ Em função da sua situação, é possível que pretenda instalar um certificado
 
 ## Instruções
 
+[[fragment:support-scope]]
+
 :::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. Se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). De facto, não poderemos fornecer-lhe assistência no **instalação ou subscrição de um certificado SSL que não seja o [certificado SSL proposto pela OVHcloud](/links/web/hosting-options-ssl)**. Mais informações na secção "[Quer saber mais?](#go-further)" deste guia.
-
+Este guia fornece as instruções necessárias para realizar as operações mais habituais. Se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). De facto, não poderemos fornecer-lhe assistência no **instalação ou subscrição de um certificado SSL que não seja o [certificado SSL proposto pela OVHcloud](/links/web/hosting-options-ssl)**.
 :::
 
 ### 1 - Obter um Certificate Signing Request (CSR) SSL <a name="step-1"></a>

--- a/docs/pt/guides/web-cloud/web-hosting/ssl-ev.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ssl-ev.mdx
@@ -59,11 +59,10 @@ Para verificar se é elegível para a subscrição de um certificado SSL Sectigo
 
 ## Instruções
 
+[[fragment:support-scope]]
+
 :::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). De facto, não poderemos prestar-lhe assistência **para todas as etapas de verificação diretamente realizadas com a autoridade de certificação Sectigo**. Para mais informações, aceda à secção [Quer saber mais?](#go-further) deste manual.
-
+Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). De facto, não poderemos prestar-lhe assistência **para todas as etapas de verificação diretamente realizadas com a autoridade de certificação Sectigo**.
 :::
 
 ### 1 - Encomendar o certificado SSL Sectigo EV

--- a/docs/pt/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/static-website-installation-cecil-api-call.mdx
@@ -11,11 +11,7 @@ Este tutorial explica como utilizar o gerador de site [Cecil](https://cecil.app)
 
 **Saiba como adicionar uma chamada a uma API externa a partir da sua página web estática.**
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Se tiver dificuldades em seguir os passos deste tutorial, recomendamos que recorra a um [prestador de serviços especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste manual.
-:::
+[[fragment:support-scope]]
 
 ## Requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/svn.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/svn.mdx
@@ -11,11 +11,7 @@ SVN, que é a abreviação de "subversion", é um sistema de gestão de versões
 
 **Saiba como utilizar o SVN em SSH no seu alojamento web**
 
-:::warning
-A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
-
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção "[Quer saber mais?](#go-further)" deste guia.
-:::
+[[fragment:support-scope]]
 
 ## Pré-requisitos
 

--- a/docs/pt/guides/web-cloud/web-hosting/using-scp-command.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/using-scp-command.mdx
@@ -15,11 +15,7 @@ O Secure Copy Protocol (SCP) permite a cópia segura (através do protocolo SSH)
 
 Permite, a partir de um terminal e graças a um comando Linux, copiar um ficheiro ou uma pasta que contenha um ou vários ficheiros.
 
-:::warning
-A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
-
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, consulte a secção ["Ir mais longe"](#go-further) deste guia.
-:::
+[[fragment:support-scope]]
 
 **Saiba como utilizar o comando Secure Copy Protocol (SCP) em SSH para copiar ficheiros de ou para o seu alojamento web.**
 

--- a/docs/pt/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Este tutorial vai permitir-lhe criar os seus primeiros conteúdos, organizá-los, publicá-los e alterar o tema do seu website com o Content Management System (CMS) **WordPress**. Poderá realizar o seu website sem conhecimentos específicos em programação, com uma vasta escolha de temas como um website de empresa, um blogue ou ainda um site para dar a conhecer a sua atividade ou paixão.
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
+[[fragment:support-scope]]
 
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou ao [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste tutorial.
+:::warning
+Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou ao [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 **Descubra como criar um website com o CMS WordPress.**

--- a/docs/pt/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -9,10 +9,10 @@ availableIn: [eu, ca, apac]
 
 Saiba como criar uma loja online com a extensão open source **WooCommerce** com o Content Management System (CMS) **WordPress**. 
 
-:::warning
-A OVHcloud disponibiliza serviços cuja configuração, gestão e responsabilidade lhe incumbem. Assim, deverá certificar-se de que estes funcionam corretamente.
+[[fragment:support-scope]]
 
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner), ao [editor do CMS WordPress](https://wordpress.com/support/) ou ao [editor do WooCommerce](https://woocommerce.com/). Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste tutorial.
+:::warning
+Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner), ao [editor do CMS WordPress](https://wordpress.com/support/) ou ao [editor do WooCommerce](https://woocommerce.com/). Não poderemos proporcionar-lhe assistência técnica.
 :::
 
 ## Requisitos


### PR DESCRIPTION
## What

Replaces the hand-written support/responsibility `:::warning` blocks with the centralised
`[[fragment:support-scope]]` token introduced in #488, across **Web Hosting** and **Domains**,
in all 7 locales.

**532 files changed** (`+985 / −2679`).

| Product | Guides | Files |
|---|---|---|
| Web Hosting | 60 | 414 |
| Domains | 18 | 118 |
| Databases | — | 0 (analysed: this product carries no such disclaimer) |

## How the blocks were handled

Each legacy block held a generic responsibility paragraph plus a recommendation paragraph that
was sometimes guide-specific. The generic parts are dropped — the fragment already covers them —
and anything specific is kept in a reduced `:::warning` right below the token.

| Outcome | Files |
|---|---|
| Fragment only | 329 |
| Fragment + preserved guide-specific warning | 203 |

Preserved content includes:

- third-party publisher links (WordPress, MainWP, Drupal, Joomla, PrestaShop, Xara, VS Code…);
- scope exclusions (`ssl-custom`: SSL certificates not sold by OVHcloud; `ssl-ev`; `diagnostic-slownesses`);
- the third-party support bullet of the six `how-to-connect-domain-to-*` guides
  ("GoDaddy support does not have access to your OVHcloud domain name settings…"),
  whose warning mixed a specific bullet with a `<br/><br/>`-fused generic one;
- the OS-adaptation notice of `ssh-using-putty-on-windows`, where the generic sentence was fused
  mid-paragraph with guide-specific prose.

Guides that carried no disclaimer were deliberately left untouched — this is a migration of
existing content, not a harmonisation.

## Notes for reviewers

- Detection is semantic (OVHcloud + a responsibility stem in any of the 7 languages) rather than
  based on a list of known phrasings: **14+ distinct wordings** are in use, and several `de/es/it/pl/pt`
  files still carry the English source text untranslated.
- Blocks on other topics are intentionally kept: backup policy and PHP updates
  (`hosting-technical-specificities`), service renewal and deletion (`diagnostic-website-not-accessible`),
  CMS configuration files (`diagnosis-database-errors`).
- `de/dns-zonemaster.mdx` and `pl/dns-zonemaster.mdx` are symlinks to the English file, so the
  migration reaches them through the `en/` target — this is why the Domains total is 118 and not 126.

## Validation

- `pnpm content:lint` — all checks passed
- All 532 changed files compiled through the real MDX pipeline (`replaceRules` for fragments + links,
  plus the `remarkNoUnresolvedFragments` guard): **532/532 OK**
- No legacy disclaimer left in the three folders; token is unique per file, alone on its line and
  surrounded by blank lines

## Out of scope

The same disclaimer is still present in other Web Cloud products — Email (Outlook, Gmail, Zimbra,
MX Plan), 3CX and VoIP guides — and would be a natural follow-up.
