### PR TITLE
VoIP - Phone troubleshoot reset

### DIFF
--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: Dépanner son téléphone OVHcloud
 description: Apprenez à dépanner votre téléphone OVHcloud
-lastUpdated: 2026-07-28
+lastUpdated: 2026-08-12
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -95,12 +95,13 @@ La réinitialisation d'un téléphone s'effectue généralement via son menu lor
 
 Les manipulations pour réinitialiser nos téléphones sont décrites ci-dessous.
 
-**Sélectionnez la marque de votre téléphone, puis l'onglet correspondant à votre modèle.**
+**Sélectionnez la marque de votre téléphone, puis référez-vous à votre modèle.**
+
+<details>
+<summary>Fanvil</summary>
 
 <Tabs noSync>
-  <Tab label="Fanvil">
-<Tabs noSync>
-  <Tab label="Standard">
+<Tab label="Standard">
 Modèles **V65** et **V66 Pro**.
 
 Il existe 3 méthodes pour réinitialiser le téléphone :
@@ -119,7 +120,7 @@ Il existe 3 méthodes pour réinitialiser le téléphone :
     3. Lorsque l'écran affiche `Post Mode`, composez successivement `*`, `#`, `1`, `6`, `8`.
 
 </Tab>
-  <Tab label="Sans fil (Wi-Fi)">
+<Tab label="Sans fil (Wi-Fi)">
 Modèle **W620W**.
 
 Il existe 2 méthodes pour réinitialiser le téléphone :
@@ -133,22 +134,26 @@ Il existe 2 méthodes pour réinitialiser le téléphone :
 
 </Tab>
 </Tabs>
-  </Tab>
-  <Tab label="Yealink">
+
+</details>
+
+<details>
+<summary>Yealink</summary>
+
 <Tabs noSync>
-  <Tab label="Standard (non tactile)">
+<Tab label="Standard (non tactile)">
 Modèles **T41P**, **T41S**, **T46S**, **T53**, **T53W**, **T54W**, **T73W** et **T85W**.
 
 - Appuyez pendant 10 secondes sur le bouton `OK` du téléphone, puis confirmez la réinitialisation.
 
 </Tab>
-  <Tab label="Standard (tactile)">
+<Tab label="Standard (tactile)">
 Modèles **T58W Pro** et **T88W Pro**.
 
 - Maintenez enfoncée la touche `Redial` 🔄, puis validez la demande de réinitialisation affichée à l'écran du téléphone.
 
 </Tab>
-  <Tab label="Sans fil (DECT)">
+<Tab label="Sans fil (DECT)">
 Modèles **W73P** et **W79P**.
 
 Les manipulations sont à effectuer sur **la base émettrice/réceptrice**, et non sur le socle de rechargement du combiné.
@@ -162,7 +167,7 @@ Les manipulations sont à effectuer sur **la base émettrice/réceptrice**, et n
     6. Pour associer le **combiné** à la **base**, appuyez sur le bouton `REGISTER` en bas à gauche de l'écran du **combiné**. Dans la foulée, maintenez enfoncé le bouton au centre de la **base** pendant 3 à 4 secondes.
 
 </Tab>
-  <Tab label="Sans fil (Wi-Fi)">
+<Tab label="Sans fil (Wi-Fi)">
 Modèles **AX83H** et **AX86R**.
 
 - Suivez les instructions ci-dessous pour déclencher la réinitialisation :
@@ -172,16 +177,23 @@ Modèles **AX83H** et **AX86R**.
 
 </Tab>
 </Tabs>
-  </Tab>
-  <Tab label="Grandstream">
+
+</details>
+
+<details>
+<summary>Grandstream</summary>
+
 Modèle **HT802**.
 
 - À l'aide d'un objet pointu, appuyez pendant environ 7 secondes dans le trou `Reset` situé à l'arrière du boîtier, puis relâchez. L'adaptateur redémarre et retrouve automatiquement sa configuration d'usine.
 
-</Tab>
-  <Tab label="Cisco">
+</details>
+
+<details>
+<summary>Cisco</summary>
+
 <Tabs noSync>
-  <Tab label="Standard">
+<Tab label="Standard">
 Modèles **CP7841** et **CP8851**.
 
 - Suivez les instructions ci-dessous pour déclencher la réinitialisation :
@@ -191,17 +203,21 @@ Modèles **CP7841** et **CP8851**.
     4. Validez la réinitialisation.
 
 </Tab>
-  <Tab label="Adaptateur">
+<Tab label="Adaptateur">
 Modèle **ATA191**.
 
 - Appuyez pendant 10 secondes, avec un objet pointu, dans le trou `Reset` situé à l'arrière du boîtier Cisco. Le voyant **Power** va clignoter durant la procédure de réinitialisation. Les voyants **Power** puis **Internet** vont ensuite rester allumés, puis le voyant **Line 1** (ou **Line 2**) s'allumera.
 
 </Tab>
 </Tabs>
-  </Tab>
-  <Tab label="Gigaset">
+
+</details>
+
+<details>
+<summary>Gigaset</summary>
+
 <Tabs noSync>
-  <Tab label="Standard">
+<Tab label="Standard">
 Modèle **Maxwell 3**.
 
 - Suivez les instructions ci-dessous pour déclencher la réinitialisation :
@@ -210,7 +226,7 @@ Modèle **Maxwell 3**.
     3. Appuyez sur `OK` et confirmez la réinitialisation.
 
 </Tab>
-  <Tab label="Sans fil (DECT)">
+<Tab label="Sans fil (DECT)">
 Modèles **C530 IP** et **N510 IP PRO**.
 
 Les manipulations sont à effectuer sur **la base émettrice/réceptrice**, et non sur le socle de rechargement du combiné.
@@ -222,8 +238,8 @@ Les manipulations sont à effectuer sur **la base émettrice/réceptrice**, et n
 
 </Tab>
 </Tabs>
-  </Tab>
-</Tabs>
+
+</details>
 
 **Une fois le téléphone réinitialisé, la date et l'heure affichées sur son écran sont-elles exactes ?**
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel.mdx
@@ -97,23 +97,23 @@ Les manipulations pour réinitialiser nos téléphones sont décrites ci-dessous
 
 **Sélectionnez la marque de votre téléphone, puis l'onglet correspondant à votre modèle.**
 
-<Tabs>
+<Tabs noSync>
   <Tab label="Fanvil">
-<Tabs>
+<Tabs noSync>
   <Tab label="Standard">
 Modèles **V65** et **V66 Pro**.
 
-Il existe 3 méthodes pour effectuer la réinitialisation :
+Il existe 3 méthodes pour réinitialiser le téléphone :
 
 - Maintenez enfoncée la touche `OK` du téléphone pendant environ 10 secondes, puis validez la demande de réinitialisation affichée à l'écran.
 
-- La réinitialisation est également accessible depuis le menu du téléphone :
+- Vous pouvez également réinitialiser le téléphone depuis son menu :
     1. Depuis l'écran d'accueil, rendez-vous dans le `Menu`.
-    2. Ouvrez `Avancé`, puis renseignez le mot de passe par défaut : `123`.
+    2. Ouvrez `Avancé`, puis renseignez le mot de passe par défaut : `123`.
     3. Allez dans `Maintenance`, puis sélectionnez `Retour aux paramètres d'usine`.
     4. Positionnez l'option `Tout effacer` sur `Activé`, puis appuyez sur `OK` pour finaliser.
 
-- Si le téléphone ne répond plus ou n'affiche pas le menu, effectuez une réinitialisation forcée (« reset hard ») :
+- Si le téléphone ne répond plus ou n'affiche pas le menu, effectuez une réinitialisation forcée (« reset hard ») :
     1. Éteignez le téléphone, puis rallumez-le.
     2. Dès que le pavé numérique se met à clignoter, appuyez sur la touche `#`.
     3. Lorsque l'écran affiche `Post Mode`, composez successivement `*`, `#`, `1`, `6`, `8`.
@@ -122,20 +122,20 @@ Il existe 3 méthodes pour effectuer la réinitialisation :
   <Tab label="Sans fil (Wi-Fi)">
 Modèle **W620W**.
 
-Il existe 2 méthodes pour effectuer la réinitialisation :
+Il existe 2 méthodes pour réinitialiser le téléphone :
 
 - Depuis l'écran de veille du combiné, maintenez enfoncée la touche `OK` pendant environ 6 secondes, puis appuyez sur `OK` pour valider la demande de réinitialisation affichée à l'écran.
 
-- La réinitialisation est également accessible depuis le menu du combiné :
+- Vous pouvez également réinitialiser le combiné depuis son menu :
     1. Rendez-vous dans le `Menu`.
-    2. Ouvrez `Avancé`, puis renseignez le mot de passe par défaut : `123`.
+    2. Ouvrez `Avancé`, puis renseignez le mot de passe par défaut : `123`.
     3. Sélectionnez `Retour aux paramètres d'usine`.
 
 </Tab>
 </Tabs>
   </Tab>
   <Tab label="Yealink">
-<Tabs>
+<Tabs noSync>
   <Tab label="Standard (non tactile)">
 Modèles **T41P**, **T41S**, **T46S**, **T53**, **T53W**, **T54W**, **T73W** et **T85W**.
 
@@ -153,7 +153,7 @@ Modèles **W73P** et **W79P**.
 
 Les manipulations sont à effectuer sur **la base émettrice/réceptrice**, et non sur le socle de rechargement du combiné.
 
-- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
+- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
     1. Débranchez l'alimentation électrique de **la base émettrice/réceptrice** du téléphone.
     2. Rebranchez l'alimentation électrique en **maintenant enfoncé le bouton au centre de la base**.
     3. Relâchez le bouton quand les 3 voyants sont allumés et fixes.
@@ -165,9 +165,9 @@ Les manipulations sont à effectuer sur **la base émettrice/réceptrice**, et n
   <Tab label="Sans fil (Wi-Fi)">
 Modèles **AX83H** et **AX86R**.
 
-- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
+- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
     1. Appuyez sur la touche `OK` pour accéder au menu.
-    2. Rendez-vous dans `Avancé` (mot de passe par défaut : `123456`), puis dans `Réinitialisation config.`.
+    2. Rendez-vous dans `Avancé` (mot de passe par défaut : `123456`), puis dans `Réinitialisation config.`.
     3. Sélectionnez `Réinitialisation aux paramètres d'usine` et validez avec `OK`.
 
 </Tab>
@@ -180,11 +180,11 @@ Modèle **HT802**.
 
 </Tab>
   <Tab label="Cisco">
-<Tabs>
+<Tabs noSync>
   <Tab label="Standard">
 Modèles **CP7841** et **CP8851**.
 
-- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
+- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
     1. Appuyez sur le bouton `Engrenage` pour accéder au menu principal.
     2. Allez dans le sous-menu `Admin. Appareil`.
     3. Sélectionnez l'option `Réinit. Usine`.
@@ -200,22 +200,22 @@ Modèle **ATA191**.
 </Tabs>
   </Tab>
   <Tab label="Gigaset">
-<Tabs>
+<Tabs noSync>
   <Tab label="Standard">
 Modèle **Maxwell 3**.
 
-- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
+- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
     1. Dans le menu principal, sélectionnez le sous-menu `Réglages`.
     2. Sélectionnez `Réinitialisation`.
     3. Appuyez sur `OK` et confirmez la réinitialisation.
 
 </Tab>
   <Tab label="Sans fil (DECT)">
-Modèles **C530IP** et **N510 IP PRO**.
+Modèles **C530 IP** et **N510 IP PRO**.
 
 Les manipulations sont à effectuer sur **la base émettrice/réceptrice**, et non sur le socle de rechargement du combiné.
 
-- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
+- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
     1. Débranchez l'alimentation électrique de la base émettrice/réceptrice.
     2. Rebranchez l'alimentation électrique en **maintenant enfoncé le bouton unique de la base** (en façade de celle-ci).
     3. Relâchez le bouton au bout de 30 secondes après avoir rebranché l'alimentation.

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: Dépanner son téléphone OVHcloud
 description: Apprenez à dépanner votre téléphone OVHcloud
-lastUpdated: 2026-07-27
+lastUpdated: 2026-07-28
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -95,142 +95,132 @@ La réinitialisation d'un téléphone s'effectue généralement via son menu lor
 
 Les manipulations pour réinitialiser nos téléphones sont décrites ci-dessous.
 
-**Sélectionnez la marque de votre téléphone, puis repérez votre modèle dans la liste.**
+**Sélectionnez la marque de votre téléphone, puis l'onglet correspondant à votre modèle.**
 
 <Tabs>
   <Tab label="Fanvil">
 <Tabs>
-  <Tab label="Standard (V65, V66 Pro)">
-1\. Depuis l'écran d'accueil, rendez-vous dans le `Menu`.
+  <Tab label="Standard">
+Modèles **V65** et **V66 Pro**.
 
-2\. Ouvrez `Avancé`, puis renseignez le mot de passe par défaut : `123`.
+Il existe 3 méthodes pour effectuer la réinitialisation :
 
-3\. Allez dans `Maintenance`, puis sélectionnez `Retour aux paramètres d'usine`.
+- Maintenez enfoncée la touche `OK` du téléphone pendant environ 10 secondes, puis validez la demande de réinitialisation affichée à l'écran.
 
-4\. Positionnez l'option `Tout effacer` sur `Activé`, puis appuyez sur `OK` pour finaliser.
+- La réinitialisation est également accessible depuis le menu du téléphone :
+    1. Depuis l'écran d'accueil, rendez-vous dans le `Menu`.
+    2. Ouvrez `Avancé`, puis renseignez le mot de passe par défaut : `123`.
+    3. Allez dans `Maintenance`, puis sélectionnez `Retour aux paramètres d'usine`.
+    4. Positionnez l'option `Tout effacer` sur `Activé`, puis appuyez sur `OK` pour finaliser.
 
-Si le téléphone ne répond plus ou n'affiche pas le menu, effectuez une réinitialisation forcée (« reset hard ») :
+- Si le téléphone ne répond plus ou n'affiche pas le menu, effectuez une réinitialisation forcée (« reset hard ») :
+    1. Éteignez le téléphone, puis rallumez-le.
+    2. Dès que le pavé numérique se met à clignoter, appuyez sur la touche `#`.
+    3. Lorsque l'écran affiche `Post Mode`, composez successivement `*`, `#`, `1`, `6`, `8`.
 
-1\. Éteignez le téléphone, puis rallumez-le.
+</Tab>
+  <Tab label="Sans fil (Wi-Fi)">
+Modèle **W620W**.
 
-2\. Dès que le pavé numérique se met à clignoter, appuyez sur la touche `#`.
+Il existe 2 méthodes pour effectuer la réinitialisation :
 
-3\. Lorsque l'écran affiche `Post Mode`, composez successivement `*`, `#`, `1`, `6`, `8`.
-  </Tab>
-  <Tab label="Sans fil Wi-Fi (W620W)">
-1\. Depuis l'écran de veille du combiné, maintenez enfoncée la touche `OK` pendant environ 6 secondes.
+- Depuis l'écran de veille du combiné, maintenez enfoncée la touche `OK` pendant environ 6 secondes, puis appuyez sur `OK` pour valider la demande de réinitialisation affichée à l'écran.
 
-2\. Lorsque la demande de réinitialisation s'affiche à l'écran, appuyez sur `OK` pour la valider.
+- La réinitialisation est également accessible depuis le menu du combiné :
+    1. Rendez-vous dans le `Menu`.
+    2. Ouvrez `Avancé`, puis renseignez le mot de passe par défaut : `123`.
+    3. Sélectionnez `Retour aux paramètres d'usine`.
 
-La réinitialisation est également accessible depuis le menu du combiné, via `Menu` > `Avancé` (mot de passe par défaut : `123`) > `Retour aux paramètres d'usine`.
-  </Tab>
+</Tab>
 </Tabs>
   </Tab>
   <Tab label="Yealink">
 <Tabs>
-  <Tab label="Standard">
-<Tabs>
-  <Tab label="Non tactiles (T4x, T5x, T73W)">
-1\. Appuyez pendant 10 secondes sur le bouton `OK` du téléphone.
+  <Tab label="Standard (non tactile)">
+Modèles **T41P**, **T41S**, **T46S**, **T53**, **T53W**, **T54W**, **T73W** et **T85W**.
 
-2\. Confirmez la réinitialisation.
-  </Tab>
-  <Tab label="Tactiles">
-- **T58 W Pro**
+- Appuyez pendant 10 secondes sur le bouton `OK` du téléphone, puis confirmez la réinitialisation.
 
-1\. Maintenez enfoncée la touche `Redial` 🔄 .
+</Tab>
+  <Tab label="Standard (tactile)">
+Modèles **T58W Pro** et **T88W Pro**.
 
-<img className="thumbnail" alt="touche redial" src="/images/web-cloud/phone-and-fax/voip/troubleshoot-02-fix-control-panel/t58wpro-redial.png" loading="lazy" />
+- Maintenez enfoncée la touche `Redial` 🔄, puis validez la demande de réinitialisation affichée à l'écran du téléphone.
 
-2\. Validez la demande de réinitialisation affichée à l'écran du téléphone.
+</Tab>
+  <Tab label="Sans fil (DECT)">
+Modèles **W73P** et **W79P**.
 
-- **T85W**
-
-1\. Ouvrez `Menu`, puis `Avancé` (mot de passe par défaut : `admin`).
-
-2\. Sélectionnez `Réinit. config.`, puis `Réinitialisation aux paramètres d'usine`.
-
-3\. Validez la réinitialisation.
-
-- **T88W Pro**
-
-1\. Depuis l'écran d'accueil, ouvrez le menu `Paramètres`.
-
-2\. Rendez-vous dans `Avancé` (un mot de passe administrateur peut être demandé), puis dans `Système`.
-
-3\. Sélectionnez `Réinitialisation aux paramètres d'usine`, puis validez.
-  </Tab>
-</Tabs>
-  </Tab>
-  <Tab label="Sans fil DECT (W73P, W79P)">
 Les manipulations sont à effectuer sur **la base émettrice/réceptrice**, et non sur le socle de rechargement du combiné.
 
-1\. Débranchez l'alimentation électrique de **la base émettrice/réceptrice** du téléphone.
+- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
+    1. Débranchez l'alimentation électrique de **la base émettrice/réceptrice** du téléphone.
+    2. Rebranchez l'alimentation électrique en **maintenant enfoncé le bouton au centre de la base**.
+    3. Relâchez le bouton quand les 3 voyants sont allumés et fixes.
+    4. Débranchez l'alimentation électrique de **la base** du téléphone et rebranchez-la juste après.
+    5. Patientez environ 5 minutes le temps que la base se mette à jour.
+    6. Pour associer le **combiné** à la **base**, appuyez sur le bouton `REGISTER` en bas à gauche de l'écran du **combiné**. Dans la foulée, maintenez enfoncé le bouton au centre de la **base** pendant 3 à 4 secondes.
 
-2\. Rebranchez l'alimentation électrique en **maintenant enfoncé le bouton au centre de la base**.
+</Tab>
+  <Tab label="Sans fil (Wi-Fi)">
+Modèles **AX83H** et **AX86R**.
 
-3\. Relâchez le bouton quand les 3 voyants sont allumés et fixes.
+- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
+    1. Appuyez sur la touche `OK` pour accéder au menu.
+    2. Rendez-vous dans `Avancé` (mot de passe par défaut : `123456`), puis dans `Réinitialisation config.`.
+    3. Sélectionnez `Réinitialisation aux paramètres d'usine` et validez avec `OK`.
 
-4\. Débranchez l'alimentation électrique de **la base** du téléphone et rebranchez-la juste après.
-
-5\. Patientez environ 5 minutes le temps que la base se mette à jour.
-
-6\. Pour associer le **combiné** à la **base**, appuyez sur le bouton `REGISTER` en bas à gauche de l'écran du **combiné**. Dans la foulée, maintenez enfoncé le bouton au centre de la **base** pendant 3 à 4 secondes.
-  </Tab>
-  <Tab label="Sans fil Wi-Fi (AX83H, AX86R)">
-1\. Appuyez sur la touche `OK` pour accéder au menu.
-
-2\. Rendez-vous dans `Avancé` (mot de passe par défaut : `123456`), puis dans `Réinitialisation config.`.
-
-3\. Sélectionnez `Réinitialisation aux paramètres d'usine` et validez avec `OK`.
-  </Tab>
+</Tab>
 </Tabs>
   </Tab>
   <Tab label="Grandstream">
-**Adaptateur HT802**
+Modèle **HT802**.
 
-1\. À l'aide d'un objet pointu, appuyez pendant environ 7 secondes dans le trou `Reset` situé à l'arrière du boîtier, puis relâchez.
+- À l'aide d'un objet pointu, appuyez pendant environ 7 secondes dans le trou `Reset` situé à l'arrière du boîtier, puis relâchez. L'adaptateur redémarre et retrouve automatiquement sa configuration d'usine.
 
-2\. L'adaptateur redémarre et retrouve automatiquement sa configuration d'usine.
-  </Tab>
+</Tab>
   <Tab label="Cisco">
 <Tabs>
   <Tab label="Standard">
-1\. Appuyez sur le bouton `Engrenage` pour accéder au menu principal.
+Modèles **CP7841** et **CP8851**.
 
-2\. Allez dans le sous-menu `Admin. Appareil`.
+- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
+    1. Appuyez sur le bouton `Engrenage` pour accéder au menu principal.
+    2. Allez dans le sous-menu `Admin. Appareil`.
+    3. Sélectionnez l'option `Réinit. Usine`.
+    4. Validez la réinitialisation.
 
-3\. Sélectionnez l'option `Réinit. Usine`.
+</Tab>
+  <Tab label="Adaptateur">
+Modèle **ATA191**.
 
-4\. Validez la réinitialisation.
-  </Tab>
-  <Tab label="Adaptateur (ATA191)">
-1\. Appuyez pendant 10 secondes, avec un objet pointu, dans le trou `Reset` situé à l'arrière du boîtier Cisco.
+- Appuyez pendant 10 secondes, avec un objet pointu, dans le trou `Reset` situé à l'arrière du boîtier Cisco. Le voyant **Power** va clignoter durant la procédure de réinitialisation. Les voyants **Power** puis **Internet** vont ensuite rester allumés, puis le voyant **Line 1** (ou **Line 2**) s'allumera.
 
-2\. Le voyant **Power** va clignoter durant la procédure de réinitialisation.
-
-3\. Les voyants **Power** puis **Internet** vont ensuite rester allumés, puis le voyant **Line 1** (ou **Line 2**) s'allumera.
-  </Tab>
+</Tab>
 </Tabs>
   </Tab>
   <Tab label="Gigaset">
 <Tabs>
   <Tab label="Standard">
-1\. Dans le menu principal, sélectionnez le sous-menu `Réglages`.
+Modèle **Maxwell 3**.
 
-2\. Sélectionnez `Réinitialisation`.
+- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
+    1. Dans le menu principal, sélectionnez le sous-menu `Réglages`.
+    2. Sélectionnez `Réinitialisation`.
+    3. Appuyez sur `OK` et confirmez la réinitialisation.
 
-3\. Appuyez sur `OK` et confirmez la réinitialisation.
-  </Tab>
-  <Tab label="Sans fil DECT">
+</Tab>
+  <Tab label="Sans fil (DECT)">
+Modèles **C530IP** et **N510 IP PRO**.
+
 Les manipulations sont à effectuer sur **la base émettrice/réceptrice**, et non sur le socle de rechargement du combiné.
 
-1\. Débranchez l'alimentation électrique de la base émettrice/réceptrice.
+- Suivez les instructions ci-dessous pour déclencher la réinitialisation :
+    1. Débranchez l'alimentation électrique de la base émettrice/réceptrice.
+    2. Rebranchez l'alimentation électrique en **maintenant enfoncé le bouton unique de la base** (en façade de celle-ci).
+    3. Relâchez le bouton au bout de 30 secondes après avoir rebranché l'alimentation.
 
-2\. Rebranchez l'alimentation électrique en **maintenant enfoncé le bouton unique de la base** (en façade de celle-ci).
-
-3\. Relâchez le bouton au bout de 30 secondes après avoir rebranché l'alimentation.
-  </Tab>
+</Tab>
 </Tabs>
   </Tab>
 </Tabs>

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: Dépanner son téléphone OVHcloud
 description: Apprenez à dépanner votre téléphone OVHcloud
-lastUpdated: 2025-04-28
+lastUpdated: 2026-07-27
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -95,56 +95,76 @@ La réinitialisation d'un téléphone s'effectue généralement via son menu lor
 
 Les manipulations pour réinitialiser nos téléphones sont décrites ci-dessous.
 
-**Cliquez sur l'onglet correspondant au modèle de votre téléphone.**
+**Sélectionnez la marque de votre téléphone, puis repérez votre modèle dans la liste.**
 
 <Tabs>
-  <Tab label="Cisco standard">
-1\. Appuyez sur le bouton `Engrenage` pour accéder au menu principal.
+  <Tab label="Fanvil">
+<Tabs>
+  <Tab label="Standard (V65, V66 Pro)">
+1\. Depuis l'écran d'accueil, rendez-vous dans le `Menu`.
 
-2\. Allez dans le sous-menu `Admin. Appareil`.
+2\. Ouvrez `Avancé`, puis renseignez le mot de passe par défaut : `123`.
 
-3\. Sélectionnez l'option `Réinit. Usine`.
+3\. Allez dans `Maintenance`, puis sélectionnez `Retour aux paramètres d'usine`.
 
-4\. Validez la réinitialisation.
+4\. Positionnez l'option `Tout effacer` sur `Activé`, puis appuyez sur `OK` pour finaliser.
+
+Si le téléphone ne répond plus ou n'affiche pas le menu, effectuez une réinitialisation forcée (« reset hard ») :
+
+1\. Éteignez le téléphone, puis rallumez-le.
+
+2\. Dès que le pavé numérique se met à clignoter, appuyez sur la touche `#`.
+
+3\. Lorsque l'écran affiche `Post Mode`, composez successivement `*`, `#`, `1`, `6`, `8`.
   </Tab>
-  <Tab label="Cisco sans écran (modèle ATA191)">
-1\. Appuyez pendant 10 secondes, avec un objet pointu, dans le trou `Reset` situé à l'arrière du boîtier Cisco.
+  <Tab label="Sans fil Wi-Fi (W620W)">
+1\. Depuis l'écran de veille du combiné, maintenez enfoncée la touche `OK` pendant environ 6 secondes.
 
-2\. Le voyant **Power** va clignoter durant la procédure de réinitialisation.
+2\. Lorsque la demande de réinitialisation s'affiche à l'écran, appuyez sur `OK` pour la valider.
 
-3\. Les voyants **Power** puis **Internet** vont ensuite rester allumés, puis le voyant **Line 1** (ou **Line 2**) s'allumera.
+La réinitialisation est également accessible depuis le menu du combiné, via `Menu` > `Avancé` (mot de passe par défaut : `123`) > `Retour aux paramètres d'usine`.
   </Tab>
-  <Tab label="Gigaset DECT (sans-fil)">
-Les manipulations sont à effectuer sur **la base émettrice/réceptrice** et non sur le socle de rechargement du combiné.
-
-Consultez des [modèles de bases émettrices/réceptrices Gigaset](https://raw.githubusercontent.com/ovh/docs/develop/pages/web_cloud/phone_and_fax/voip/troubleshoot-02-fix-control-panel/images/gigaset-dect.png).
-
-1\. Débranchez l'alimentation électrique de la base émettrice/réceptrice.
-
-2\. Rebranchez l'alimentation électrique en **maintenant enfoncé le bouton unique de la base** (en façade de celle-ci).
-
-3\. Relâchez le bouton au bout de 30 secondes après avoir rebranché l'alimentation.
+</Tabs>
   </Tab>
-  <Tab label="Gigaset standard">
-1\. Dans le menu principal, sélectionnez le sous-menu `Réglages`.
-
-2\. Sélectionnez `Réinitialisation`.
-
-3\. Appuyez sur `OK` et confirmez la réinitialisation.
-  </Tab>
-  <Tab label="Yealink standard">
+  <Tab label="Yealink">
+<Tabs>
+  <Tab label="Standard">
+<Tabs>
+  <Tab label="Non tactiles (T4x, T5x, T73W)">
 1\. Appuyez pendant 10 secondes sur le bouton `OK` du téléphone.
 
 2\. Confirmez la réinitialisation.
   </Tab>
-  <Tab label="Yealink T58 W Pro">
+  <Tab label="Tactiles">
+- **T58 W Pro**
+
 1\. Maintenez enfoncée la touche `Redial` 🔄 .
 
-<img className="thumbnail" alt="touche redial" src="/images/web-cloud/phone-and-fax/voip/troubleshoot-02-fix-control-panel/t58wpro-redial.png" loading="lazy" />.
+<img className="thumbnail" alt="touche redial" src="/images/web-cloud/phone-and-fax/voip/troubleshoot-02-fix-control-panel/t58wpro-redial.png" loading="lazy" />
 
 2\. Validez la demande de réinitialisation affichée à l'écran du téléphone.
+
+- **T85W**
+
+1\. Ouvrez `Menu`, puis `Avancé` (mot de passe par défaut : `admin`).
+
+2\. Sélectionnez `Réinit. config.`, puis `Réinitialisation aux paramètres d'usine`.
+
+3\. Validez la réinitialisation.
+
+- **T88W Pro**
+
+1\. Depuis l'écran d'accueil, ouvrez le menu `Paramètres`.
+
+2\. Rendez-vous dans `Avancé` (un mot de passe administrateur peut être demandé), puis dans `Système`.
+
+3\. Sélectionnez `Réinitialisation aux paramètres d'usine`, puis validez.
   </Tab>
-  <Tab label="Yealink DECT (sans fil)">
+</Tabs>
+  </Tab>
+  <Tab label="Sans fil DECT (W73P, W79P)">
+Les manipulations sont à effectuer sur **la base émettrice/réceptrice**, et non sur le socle de rechargement du combiné.
+
 1\. Débranchez l'alimentation électrique de **la base émettrice/réceptrice** du téléphone.
 
 2\. Rebranchez l'alimentation électrique en **maintenant enfoncé le bouton au centre de la base**.
@@ -156,6 +176,62 @@ Consultez des [modèles de bases émettrices/réceptrices Gigaset](https://raw.g
 5\. Patientez environ 5 minutes le temps que la base se mette à jour.
 
 6\. Pour associer le **combiné** à la **base**, appuyez sur le bouton `REGISTER` en bas à gauche de l'écran du **combiné**. Dans la foulée, maintenez enfoncé le bouton au centre de la **base** pendant 3 à 4 secondes.
+  </Tab>
+  <Tab label="Sans fil Wi-Fi (AX83H, AX86R)">
+1\. Appuyez sur la touche `OK` pour accéder au menu.
+
+2\. Rendez-vous dans `Avancé` (mot de passe par défaut : `123456`), puis dans `Réinitialisation config.`.
+
+3\. Sélectionnez `Réinitialisation aux paramètres d'usine` et validez avec `OK`.
+  </Tab>
+</Tabs>
+  </Tab>
+  <Tab label="Grandstream">
+**Adaptateur HT802**
+
+1\. À l'aide d'un objet pointu, appuyez pendant environ 7 secondes dans le trou `Reset` situé à l'arrière du boîtier, puis relâchez.
+
+2\. L'adaptateur redémarre et retrouve automatiquement sa configuration d'usine.
+  </Tab>
+  <Tab label="Cisco">
+<Tabs>
+  <Tab label="Standard">
+1\. Appuyez sur le bouton `Engrenage` pour accéder au menu principal.
+
+2\. Allez dans le sous-menu `Admin. Appareil`.
+
+3\. Sélectionnez l'option `Réinit. Usine`.
+
+4\. Validez la réinitialisation.
+  </Tab>
+  <Tab label="Adaptateur (ATA191)">
+1\. Appuyez pendant 10 secondes, avec un objet pointu, dans le trou `Reset` situé à l'arrière du boîtier Cisco.
+
+2\. Le voyant **Power** va clignoter durant la procédure de réinitialisation.
+
+3\. Les voyants **Power** puis **Internet** vont ensuite rester allumés, puis le voyant **Line 1** (ou **Line 2**) s'allumera.
+  </Tab>
+</Tabs>
+  </Tab>
+  <Tab label="Gigaset">
+<Tabs>
+  <Tab label="Standard">
+1\. Dans le menu principal, sélectionnez le sous-menu `Réglages`.
+
+2\. Sélectionnez `Réinitialisation`.
+
+3\. Appuyez sur `OK` et confirmez la réinitialisation.
+  </Tab>
+  <Tab label="Sans fil DECT">
+Les manipulations sont à effectuer sur **la base émettrice/réceptrice**, et non sur le socle de rechargement du combiné.
+
+1\. Débranchez l'alimentation électrique de la base émettrice/réceptrice.
+
+2\. Rebranchez l'alimentation électrique en **maintenant enfoncé le bouton unique de la base** (en façade de celle-ci).
+
+3\. Relâchez le bouton au bout de 30 secondes après avoir rebranché l'alimentation.
+  </Tab>
+</Tabs>
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
Refonte de l'étape 2 « Réinitialiser le téléphone » du guide FR
« Dépanner son téléphone OVHcloud ».

**Modèles ajoutés** : Fanvil V65, V66 Pro, W620W · Yealink T73W, T85W,
T88W Pro, AX83H, AX86R · Grandstream HT802.

**Changements**
- Une section repliable par marque, puis des onglets par type d'équipement
  (standard tactile / non tactile, DECT, Wi-Fi, adaptateur).
- Procédures complétées (menu et « reset hard » Fanvil, association
  combiné/base Yealink DECT) et réécrites en listes Markdown natives.
- Terminologie « téléphone standard » ; ATA191 et HT802 désignés comme
  adaptateurs.
- Suppression du lien mort `gigaset-dect.png` (404, image absente des deux
  dépôts).