### PR TITLE
fix(voip): restore content wrongly replaced by the support-scope fragment

### DIFF
--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/deroulement-d-un-rma.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/deroulement-d-un-rma.mdx
@@ -60,9 +60,102 @@ Retrouvez plus d'informations sur la gestion des contacts dans notre guide « [G
 
 :::
 
-[[fragment:support-scope]]
+<details>
 
-[[fragment:support-scope]]
+<summary>E-mail pour un échange de matériel</summary>
+
+<Tabs>
+  <Tab label="Échange de téléphone">
+    > Objet : [OVH-TELECOM] Bon de retour pour votre matériel : #MODEL# #IDENT#
+    > Bonjour,
+    > Vous avez demandé, en date du #DATE#, un matériel de remplacement à celui correspondant au modèle #MODEL# (Référence : #REFERENCE#).<br/>
+    > Voici le bon de retour, au format PDF, pour le renvoi de ce matériel : #Lien vers le PDF du RMA#.<br/>
+    > Veuillez imprimer ce bon svp, puis joindre la partie basse à votre colis, tandis que la partie haute devra être collée dessus, à l'extérieur.<br/>
+    > Merci de bien vérifier que votre colis contienne tous les éléments d'origine. Vous disposez de 15 jours pour nous renvoyer ce matériel.<br/>
+    > Après ce délai, vous pourrez être facturé de la caution et/ou des frais de pénalités.<br/>
+    > Votre numéro de retour (RMA) est : #RMA#. Il vous sera demandé en cas d'échange avec notre support concernant ce dossier. <br/>
+    > Adresse de retour : OVH SAS - 155, avenue Georges Hannart 59170 CROIX.
+  </Tab>
+  <Tab label="Échange de modem">
+    > Objet : [OVH-TELECOM] Bon de retour pour votre matériel : #MODEL# #LINE# (#DESCRIPTION#)
+    > Bonjour,
+    > Vous avez demandé, en date du #DATE#, un matériel de remplacement à celui correspondant au modèle #MODEL# (Référence : #REFERENCE#).<br/>
+    > Voici le bon de retour, au format PDF, pour le renvoi de ce matériel : #Lien vers le PDF du RMA#.<br/>
+    > Veuillez imprimer ce bon svp, puis joindre la partie basse à votre colis, tandis que la partie haute devra être collée dessus, à l'extérieur.<br/>
+    > Merci de bien vérifier que votre matériel contienne tous les éléments d'origine. Vous disposez de 15 jours pour nous renvoyer ce matériel.
+    > Après ce délai, vous serez facturé de la caution de ce dernier #AMOUNT#.<br/>
+    > La société OVH décline toute responsabilité en cas de non réception ou de perte du colis par le transporteur choisi.<br/>
+    > Votre numéro de retour (RMA) est : #RMA#. Il vous sera demandé en cas d'échange avec notre support concernant ce dossier.<br/>
+    > Adresse de retour : OVH SAS - Service Après Vente - 155, avenue Georges Hannart 59170 CROIX.
+  </Tab>
+</Tabs>
+
+</details>
+
+<details>
+
+<summary>E-mail pour une résiliation</summary>
+
+<Tabs>
+  <Tab label="Résiliation d'une ligne VoIP">
+    > Objet : [OVH-TELECOM] Bon de retour pour votre matériel : #MODEL# #IDENT# 
+    > Bonjour,
+    > En date du #DATE#, un bon de renvoi du matériel, fourni par OVHcloud, a été créé.
+    > Modèle : #MODEL# Référence/Mac : #REFERENCE#
+    > Cette demande de retour a pu être générée, non sur votre demande, dans les cas suivants :
+    > - Résiliation d'un abonnement
+    > - Suspension prolongée d'un abonnement
+    > - Impayé d'un abonnement <sup>\*</sup>
+    > Voici le bon de retour, au format PDF, pour le renvoi de ce matériel : #Lien vers le PDF du RMA#.<br/>
+    > Veuillez imprimer ce bon svp, puis joindre la partie basse à votre colis, tandis que la partie haute devra être collée dessus, à l'extérieur.<br/>
+    > Merci de bien vérifier que votre colis contienne tous les éléments d'origine.<br/>
+    > Vous disposez de 15 jours pour nous renvoyer ce matériel. Après ce délai, vous pourrez être facturé de la caution et/ou des frais de pénalités.<br/>
+    > Votre numéro de retour (RMA) est : #RMA#. Il vous sera demandé en cas d'échange avec notre support concernant ce dossier.<br/>
+    > Adresse de retour : OVH SAS - Service Après Vente - 155, avenue Georges Hannart 59170 CROIX
+    > <sup>\*</sup> Cette demande de retour sera automatiquement annulée en cas de régularisation de votre situation dans les délais. À défaut, votre abonnement sera définitivement supprimé et les frais éventuels restants appliqués.
+  </Tab>
+  <Tab label="Résiliation d'un accès Internet xDSL">
+    > Objet : [OVH] Demande de résiliation de l'accès Internet #PACKADSL# (#LINE# - #ACCESS#)
+    > Bonjour,
+    > La demande de résiliation de l'accès internet #LINE# (#ACCESS#) au nom de #NAME# a bien été prise en compte.<br/>
+    > La résiliation sera effective au #DATE#. Votre accès internet reste opérationnel jusqu'à cette date.<br/>
+    > Nous vous informons que vous serez redevable du mois en cours.<br/>
+    > Vous avez la possibilité, si vous le souhaitez, d'annuler votre demande de résiliation. Pour ce faire, rendez-vous sur votre Espace Client par le biais de ce lien : #LINK#.<br/>
+    > Vous recevrez un nouveau mail lorsque la résiliation sera effective.<br/>
+    > Un bon de renvoi du modem #MODEL# a été créé avec la référence #RMA#.<br/>
+    > Vous disposez de X jours, soit jusqu'au #DATE+15jours#, pour nous renvoyer ce matériel. Après ce délai, vous pourrez être facturé de la caution et/ou des frais de pénalités.<br/>
+    > Vous pouvez retrouver le bon de retour pour le modem au format PDF à l'adresse suivante : #Lien vers le PDF du RMA#.<br/>
+    > Après avoir imprimé votre bon, coupez la partie basse. Joignez-la au matériel, à l'intérieur du colis. La partie haute doit être collée à l'extérieur du colis et doit rester visible.<br/>
+    > Nous vous prions de joindre l'intégralité des éléments d'origine du matériel.<br/>
+    > Attention : Nous vous prions de bien vouloir retirer du matériel et de son emballage tout effet personnel, information ou élément qui n'aurait aucun lien avec le matériel retourné. Dans le cas contraire, OVHcloud tentera de prendre attache avec le client par courriel pour restituer les biens n'appartenant pas à OVHcloud. À compter de l'envoi de ce courriel et sans retour de la part du client dans un délai de 30 jours calendaires, OVHcloud procédera à la destruction dudit matériel.<br/>
+    > La société OVH décline toute responsabilité en cas de non réception ou de perte du colis par le transporteur choisi.<br/>
+    > L'adresse de retour est la suivante : OVH SAS - Service Après Vente - 155, avenue Georges Hannart 59170 CROIX
+  </Tab>
+  <Tab label="Résiliation d'un accès Internet Fibre">
+    Deux RMA sont générés, pour le retour du modem et pour le retour du boîtier fibre (ONT).
+    
+    > Objet : [OVH] Demande de résiliation de l'accès Internet #PACKADSL# (#PTO-REF# - #DESCRIPTION#)
+    > Bonjour,
+    > La demande de résiliation de l'accès internet #PTO-REF# (#DESCRIPTION#) au nom de #NAME# a bien été prise en compte.<br/>
+    > La résiliation sera effective au #DATE#. Votre accès internet reste opérationnel jusqu'à cette date.<br/>
+    > Nous vous informons que vous serez redevable du mois en cours.<br/>
+    > Vous avez la possibilité, si vous le souhaitez, d'annuler votre demande de résiliation. Pour ce faire, rendez-vous sur votre Espace Client par le biais de ce lien : #LINK#.<br/>
+    > Vous recevrez un nouveau mail lorsque la résiliation sera effective.<br/>
+    > Un bon de renvoi du modem #MODEL# a été créé avec la référence #RMA#.<br/>
+    > Ainsi qu'un bon de renvoi pour l'ONT avec la référence #RMA-ONT#.<br/>
+    > Vous disposez de X jours, soit jusqu'au #DATE+15jours#, pour nous renvoyer ce matériel. Après ce délai, vous pourrez être facturé de la caution et/ou des frais de pénalités.<br/>
+    > Vous pouvez retrouver le bon de retour pour le modem au format PDF à l'adresse suivante : #Lien vers le PDF du RMA#.<br/>
+    > Celui de l'ONT au format PDF est à l'adresse suivante : #Lien vers le PDF du RMA-ONT#.<br/>
+    > Vous avez la possibilité de renvoyer l'ONT et le modem dans le même colis, pensez bien à y joindre les deux bons de retour.<br/>
+    > Après avoir imprimé votre bon, coupez la partie basse. Joignez-la au matériel, à l'intérieur du colis. La partie haute doit être collée à l'extérieur du colis et doit rester visible.<br/>
+    > Nous vous prions de joindre l'intégralité des éléments d'origine du matériel.<br/>
+    > Attention : Nous vous prions de bien vouloir retirer du matériel et de son emballage tout effet personnel, information ou élément qui n'aurait aucun lien avec le matériel retourné. Dans le cas contraire, OVHcloud tentera de prendre attache avec le client par courriel pour restituer les biens n'appartenant pas à OVHcloud. À compter de l'envoi de ce courriel et sans retour de la part du client dans un délai de 30 jours calendaires, OVHcloud procédera à la destruction dudit matériel.<br/>
+    > La société OVH décline toute responsabilité en cas de non réception ou de perte du colis par le transporteur choisi.<br/>
+    > L'adresse de retour est la suivante : OVH SAS - Service Après Vente - 155, avenue Georges Hannart 59170 CROIX
+  </Tab>
+</Tabs>
+
+</details>
 
 Lorsque vous recevez cet e-mail, le lien vers le bon de retour au format PDF est disponible dans le corps de l'e-mail.
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/les-files-d-appels.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/les-files-d-appels.mdx
@@ -183,10 +183,11 @@ Dans le menu « Configuration », cliquez sur <code className="action">Gestion d
 [[fragment:support-scope]]
 
 :::warning
+La création des annonces sonores est de votre responsabilité. En cas de difficultés, nous vous conseillons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/) car OVHcloud ne sera pas en mesure de créer ces fichiers pour vous.
+
 Sachez qu'il est possible de créer des fichiers-sons via le logiciel open source et gratuit [Audacity](https://www.audacityteam.org/).
 Nous vous rappelons que l'utilisation d'une musique non libre d'utilisation commerciale nécessite de s'acquitter de droits de diffusion auprès des sociétés d'auteurs/compositeurs/producteurs.
 :::
-
 
 Vous pouvez ajouter deux sons :
 

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-local-network.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/troubleshoot-local-network.mdx
@@ -41,7 +41,12 @@ Les causes d'un dysfonctionnement d'un téléphone VoIP sont variées :
 
 ## En pratique
 
-[[fragment:support-scope]]
+:::warning
+Les équipes de support OVHcloud ne pourront pas vous fournir d'assistance quant à la configuration matérielle et logicielle de votre réseau local, celui-ci étant de votre responsabilité.
+
+En cas de difficultés, nous vous recommandons de faire appel à l'un de [nos partenaires](https://partner.ovhcloud.com/fr/directory/) ou à vous faire aider par la communauté des utilisateurs OVHcloud. Pour plus d'informations, reportez-vous à la section « [Aller plus loin](#gofurther) » de ce guide
+
+:::
 
 Ce tutoriel détaille les causes principales, liées au réseau local, d'un défaut d'enregistrement de la ligne SIP associée à votre téléphone, suivant un ordre logique. 
 Nous vous conseillons donc de **suivre l'ordre des étapes de vérification** ci-dessous afin de dépanner votre téléphone.

--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/verification-identite-numeros-sva.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/verification-identite-numeros-sva.mdx
@@ -212,7 +212,19 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-[[fragment:support-scope]]
+<details>
+
+<summary>Fonds de dotation</summary>
+
+- Une **pièce d'identité** en cours de validité de la personne physique responsable de gérer le compte OVHcloud du fonds de dotation : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
+- Un **document officiel** certifiant que la personne physique identifiée est bien autorisée à représenter le fonds de dotation et à gérer le compte OVHcloud.
+- Les **statuts datés et signés** du fonds de dotation titulaire du compte OVHcloud.
+- Une **copie de moins d'un an du procès-verbal de la dernière assemblée générale** ou la liste des membres du conseil d'administration du fonds de dotation titulaire du compte OVHcloud.
+- Une **vérification d’identité par vidéo** du responsable. Si votre appareil ne possède pas de caméra, poursuivez depuis un autre appareil doté d'une caméra (ordinateur, smartphone ou tablette).
+- La **signature électronique** du responsable.
+- Un **Relevé d'Identité Bancaire**.
+
+</details>
 
 <details>
 
@@ -226,7 +238,20 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-[[fragment:support-scope]]
+<details>
+
+<summary>Exploitation agricole à responsabilité limitée</summary>
+
+- Une **pièce d'identité** en cours de validité du président ou trésorier de l'EARL titulaire du compte OVHcloud : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
+- Une **pièce d'identité** en cours de validité de chacun des **bénéficiaires effectifs** de l'EARL : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
+- Un **certificat d'immatriculation au Registre du Commerce et des Sociétés** de moins de 3 mois au nom de l'EARL titulaire du compte OVHcloud.
+- Les **statuts datés et signés** de l'EARL titulaire du compte OVHcloud.
+- Une copie de la parution de l'acte dans le **Bulletin officiel des annonces civiles et commerciales** (BODACC).
+- Une **vérification d’identité par vidéo** du président ou trésorier. Si votre appareil ne possède pas de caméra, poursuivez depuis un autre appareil doté d'une caméra (ordinateur, smartphone ou tablette).
+- La **signature électronique** du président ou trésorier.
+- Un **Relevé d'Identité Bancaire**.
+
+</details>
 
 <details>
 
@@ -241,13 +266,58 @@ Si votre compte OVHcloud correspond à **un projet de financement participatif (
 
 </details>
 
-[[fragment:support-scope]]
+<details>
 
-[[fragment:support-scope]]
+<summary>Comité social et économique (CSE)</summary>
 
-[[fragment:support-scope]]
+- Une **pièce d'identité** en cours de validité de la personne physique responsable de gérer le compte OVHcloud au nom du CSE : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
+- Une **copie de moins d'un an du procès-verbal de la dernière assemblée générale** ou la liste des membres du conseil d'administration du CSE titulaire du compte OVHcloud.
+- Une **vérification d’identité par vidéo** du responsable. Si votre appareil ne possède pas de caméra, poursuivez depuis un autre appareil doté d'une caméra (ordinateur, smartphone ou tablette).
+- La **signature électronique** du responsable.
+- Un **Relevé d'Identité Bancaire**.
 
-[[fragment:support-scope]]
+</details>
+
+<details>
+
+<summary>Groupement d'intérêt public, Centre hospitalier universitaire, Établissement public d'intérêt général, Société d'investissement immobilier, Établissements de santé privés d'intérêt collectif</summary>
+
+- Une **pièce d'identité** en cours de validité de la personne physique responsable de gérer le compte OVHcloud au nom de l'agence publique : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
+- Un **document officiel** certifiant que la personne physique identifiée est bien autorisée à **représenter l'agence publique** et à gérer le compte OVHcloud.
+- Une **vérification d’identité par vidéo** du responsable. Si votre appareil ne possède pas de caméra, poursuivez depuis un autre appareil doté d'une caméra (ordinateur, smartphone ou tablette).
+- La **signature électronique** du responsable.
+- Un **Relevé d'Identité Bancaire**.
+
+</details>
+
+<details>
+
+<summary>Compagnie d'assurance</summary>
+
+- Une **pièce d'identité** en cours de validité de la personne physique responsable de gérer le compte OVHcloud au nom de la compagnie d'assurance : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
+- Une **décision** (extrait de la délibération ou mandat) désignant la ou **les mandataire(s)** (non exécutifs) autorisés à gérer le compte OVHcloud au nom de la compagnie d'assurance.
+- Un **extrait des délibérations** désignant les directeurs et précisant leurs capacités.
+- Un **extrait de la publication dans le Journal officiel des associations et fondations d'entreprise** (JOAFE) ou, à défaut, l'extrait de l'enregistrement de compagnies d'assurance mutuelle attestant de l'immatriculation de la compagnie d'assurance titulaire du compte OVHcloud.
+- Les **statuts finaux et/ou certifiés conformes**, datés et signés, de la compagnie d'assurance titulaire du compte OVHcloud.
+- Une **vérification d’identité par vidéo** du responsable. Si votre appareil ne possède pas de caméra, poursuivez depuis un autre appareil doté d'une caméra (ordinateur, smartphone ou tablette).
+- La **signature électronique** du responsable.
+- Un **Relevé d'Identité Bancaire**.
+
+</details>
+
+<details>
+
+<summary>Paroisse ou église</summary>
+
+- Une **pièce d'identité** en cours de validité de la personne physique responsable de gérer le compte OVHcloud au nom de la paroisse ou de l'église : carte d'identité (recto et verso), passeport, titre de séjour (recto et verso), permis de conduire biométrique (recto et verso).
+- Une copie de moins d'un an du **procès-verbal de la dernière assemblée générale** de l'association diocésaine autorisant l'ouverture du compte et désignant les personnes autorisées à le gérer.
+- Un **extrait de la publication dans le Journal officiel des associations et fondations d'entreprise** (JOAFE) au nom de l'association diocésaine ou du diocèse.
+- Les **statuts datés et signés** au nom de l'association diocésaine ou du diocèse.
+- Une **vérification d’identité par vidéo** du responsable. Si votre appareil ne possède pas de caméra, poursuivez depuis un autre appareil doté d'une caméra (ordinateur, smartphone ou tablette).
+- La **signature électronique** du responsable.
+- Un **Relevé d'Identité Bancaire**.
+
+</details>
 
 ##### Fonds d'investissement
 


### PR DESCRIPTION
PR #569 replaced legacy support callouts with [[fragment:support-scope]], but its second pass matched on `<details>` structure rather than on disclaimer text. Four FR telecom guides lost content the fragment does not carry.

- deroulement-d-un-rma: restore 2 blocks of RMA email templates (return addresses, 15-day deadlines, deposit/penalty terms) across 5 tabs.
- verification-identite-numeros-sva: restore 6 blocks listing the KYC identity documents required per legal entity type (fonds de dotation, EARL, CSE, GIP/CHU, compagnie d'assurance, paroisse).
- troubleshoot-local-network: restore the callout scoped to local network hardware and software configuration, which is not generic support boilerplate.
- les-files-d-appels: reinstate the sound-file responsibility sentence into the reduced warning; the generic half correctly stays as the fragment.

Neither of the first three guides ever contained a support disclaimer.

The rest of PR #569 was verified and left untouched: the other 5 FR VoIP guides and all 38 email and web-hosting guides replaced genuine boilerplate only.