### PR TITLE
docs(web-cloud): document configurable value ranges for Web Cloud Databases MySQL/MariaDB parameters

### DIFF
--- a/docs/de/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/de/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfigurieren Ihres Datenbankservers
 description: Erfahren Sie, wie Sie Ihren Datenbankserver konfigurieren und optimieren
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-17
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -183,18 +183,22 @@ Klicken Sie auf die unten stehenden Tabs, um die **3** Schritte nacheinander anz
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png" loading="lazy" />
 
-    - **MaxAllowedPacket**: Maximale Paketgröße.
-    - **Max_user_connections**: Anzahl der erlaubten gleichzeitigen Verbindungen pro Benutzer.
-    - **AutoCommit**: Legt fest, ob die Anfragen automatisch bestätigt werden oder nicht.
-    - **Interactive_timeout**: Zeit (in Sekunden), die der Server auf eine Aktivität auf einer interaktiven Verbindung wartet, bevor er diese schließt.
-    - **InnodbBufferPoolSize**: Größe des ausgewählten Pufferspeichers.
-    - **MaxConnections:** Anzahl der erlaubten gleichzeitigen Verbindungen auf dem Datenbankserver.
-    - **Wait_timeout**: Zeit (in Sekunden), die der Server auf eine Aktivität auf einer nicht interaktiven Verbindung wartet, bevor er diese schließt.
-    - **Event_scheduler**: Löst die Ausführung von programmierten Anfragen direkt auf dem MySQL-Server aus.
-    - **sql_mode**: Die Option **sql_mode** beeinflusst die unterstützte SQL-Syntax und die Datenvalidierungsprüfungen durch MySQL/MariaDB.
+    Die folgende Tabelle enthält alle Parameter, die Sie bearbeiten können, sowie die Werte, die Sie diesen zuweisen können.
+
+    |Parameter|Beschreibung|Konfigurierbare Werte|
+    |---|---|---|
+    |`max_allowed_packet`|Maximale Paketgröße.|Von 1 bis 64 MB|
+    |`max_user_connections`|Anzahl der erlaubten gleichzeitigen Verbindungen pro Benutzer.|Von 50 bis 200|
+    |`autocommit`|Legt fest, ob die Anfragen automatisch bestätigt werden oder nicht.|ON oder OFF|
+    |`interactive_timeout`|Zeit (in Sekunden), die der Server auf eine Aktivität auf einer interaktiven Verbindung wartet, bevor er diese schließt.|Von 60 bis 28800 Sekunden|
+    |`innodb_buffer_pool_size`|Größe des Pufferspeichers in Megabyte.|Von 128 MB bis 50% des gesamten RAM Ihrer Instanz|
+    |`max_connections`|Anzahl der erlaubten gleichzeitigen Verbindungen auf dem Datenbankserver.|Von 100 bis 200|
+    |`wait_timeout`|Zeit (in Sekunden), die der Server auf eine Aktivität auf einer nicht interaktiven Verbindung wartet, bevor er diese schließt.|Von 60 bis 28800 Sekunden|
+    |`event_scheduler`|Löst die Ausführung von programmierten Anfragen direkt auf dem MySQL-Server aus.|ON oder OFF|
+    |`sql_mode`|Beeinflusst die unterstützte SQL-Syntax und die Datenvalidierungsprüfungen durch MySQL/MariaDB.|Siehe die untenstehenden Standardmodi|
 
     :::info
-    Wenn auf Ihrer Website der Fehler **"Too many connections"** angezeigt wird, ist dies auf die Überschreitung der gleichzeitigen Verbindungen auf Ihrem Datenbankserver zurückzuführen. Sie können dann die Variable **"MaxConnections"** erhöhen, wenn sie nicht bereits den Maximalwert erreicht hat.
+    Wenn auf Ihrer Website der Fehler `Too many connections` angezeigt wird, ist dies auf die Überschreitung der gleichzeitigen Verbindungen auf Ihrem Datenbankserver zurückzuführen. Sie können dann die Variable `max_connections` erhöhen, wenn sie nicht bereits den Maximalwert erreicht hat.
 
     :::
 

--- a/docs/en/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/en/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring your database server
 description: Find out how to configure and optimise your database server
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-17
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -183,18 +183,22 @@ Click on the tabs below to view each of the **3** steps.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png" loading="lazy" />
 
-    - **MaxAllowedPacket**: Maximum packet size.
-    - **Max_user_connections**: Number of concurrent connections authorised per user.
-    - **AutoCommit**: Defines whether requests are automatically committed or not.
-    - **Interactive_timeout**: Time (in seconds) for which the server will wait for activity on an interactive connection before closing it.
-    - **InnodbBufferPoolSize**: Selected buffer memory size.
-    - **MaxConnections:** Number of concurrent connections authorised on the database server.
-    - **Wait_timeout**: Time (in seconds) for which the server will wait for activity on a non-interactive connection before closing it.
-    - **Event_scheduler**: Triggers the execution of requests programmed directly on the MySQL server.
-    - **sql_mode**: The **sql_mode** option affects the supported SQL syntax and the data validation checks performed by MySQL/MariaDB.
+    The table below details each parameter you can modify, along with the values you can assign to it.
+
+    |Parameter|Description|Configurable values|
+    |---|---|---|
+    |`max_allowed_packet`|Maximum packet size.|From 1 to 64 MB|
+    |`max_user_connections`|Number of concurrent connections authorised per user.|From 50 to 200|
+    |`autocommit`|Defines whether requests are automatically committed or not.|ON or OFF|
+    |`interactive_timeout`|Time (in seconds) for which the server will wait for activity on an interactive connection before closing it.|From 60 to 28800 seconds|
+    |`innodb_buffer_pool_size`|Buffer memory size, expressed in megabytes.|From 128 MB to 50% of your instance's total RAM|
+    |`max_connections`|Number of concurrent connections authorised on the database server.|From 100 to 200|
+    |`wait_timeout`|Time (in seconds) for which the server will wait for activity on a non-interactive connection before closing it.|From 60 to 28800 seconds|
+    |`event_scheduler`|Triggers the execution of requests programmed directly on the MySQL server.|ON or OFF|
+    |`sql_mode`|Affects the supported SQL syntax and the data validation checks performed by MySQL/MariaDB.|See the default modes below|
 
     :::info
-    When you encounter an error on your website stating **"Too many connections"**, this is due to the number of simultaneous connections on your database server being exceeded. You can then increase the **"MaxConnections"** variable if it is not at its maximum.
+    When you encounter an error on your website stating `Too many connections`, this is due to the number of simultaneous connections on your database server being exceeded. You can then increase the `max_connections` variable if it is not at its maximum.
 
     :::
 

--- a/docs/es/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/es/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar el servidor de bases de datos
 description: Cómo configurar y optimizar el servidor de bases de datos
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-17
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -183,18 +183,22 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png" loading="lazy" />
 
-    - **MaxAllowedPacket**: Tamaño máximo de los paquetes.
-    - **Max_user_connections**: Número de conexiones simultáneas autorizadas por usuario.
-    - **AutoCommit**: Define si las peticiones se validan automáticamente (committed) o no.
-    - **Interactive_timeout**: Tiempo (en segundos) que el servidor espera actividad en una conexión interactiva antes de cerrarla.
-    - **InnodbBufferPoolSize**: Tamaño de la memoria intermedia seleccionada.
-    - **MaxConnections:** Número de conexiones simultáneas autorizadas en el servidor de bases de datos.
-    - **Wait_timeout**: Tiempo (en segundos) que el servidor espera actividad en una conexión no interactiva antes de cerrarla.
-    - **Event_scheduler**: Permite activar la ejecución de consultas programadas directamente en el servidor MySQL.
-    - **sql_mode**: La opción **sql_mode** afecta a la sintaxis SQL soportada y a las verificaciones de validación de datos realizadas por MySQL/MariaDB.
+    La siguiente tabla detalla cada parámetro modificable, así como los valores que puede asignarle.
+
+    |Parámetro|Descripción|Valores configurables|
+    |---|---|---|
+    |`max_allowed_packet`|Tamaño máximo de los paquetes.|De 1 a 64 MB|
+    |`max_user_connections`|Número de conexiones simultáneas autorizadas por usuario.|De 50 a 200|
+    |`autocommit`|Define si las peticiones se validan automáticamente (committed) o no.|ON u OFF|
+    |`interactive_timeout`|Tiempo (en segundos) que el servidor espera actividad en una conexión interactiva antes de cerrarla.|De 60 a 28800 segundos|
+    |`innodb_buffer_pool_size`|Tamaño de la memoria intermedia, expresado en megabytes.|De 128 MB al 50% de la RAM total de su instancia|
+    |`max_connections`|Número de conexiones simultáneas autorizadas en el servidor de bases de datos.|De 100 a 200|
+    |`wait_timeout`|Tiempo (en segundos) que el servidor espera actividad en una conexión no interactiva antes de cerrarla.|De 60 a 28800 segundos|
+    |`event_scheduler`|Permite activar la ejecución de consultas programadas directamente en el servidor MySQL.|ON u OFF|
+    |`sql_mode`|Afecta a la sintaxis SQL soportada y a las verificaciones de validación de datos realizadas por MySQL/MariaDB.|Consulte los modos predeterminados que figuran a continuación|
 
     :::info
-    Cuando aparece un error en su sitio web que indica **"Too many connections"**, se debe a que se ha superado el número de conexiones simultáneas en su servidor de bases de datos. Puede aumentar la variable **"MaxConnections"** si no está al máximo.
+    Cuando aparece un error en su sitio web que indica `Too many connections`, se debe a que se ha superado el número de conexiones simultáneas en su servidor de bases de datos. Puede aumentar la variable `max_connections` si no está al máximo.
 
     :::
 

--- a/docs/fr/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer votre serveur de bases de données
 description: Découvrez comment configurer et optimiser votre serveur de base de données
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-17
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -183,18 +183,22 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png" loading="lazy" />
 
-    - **MaxAllowedPacket** : Taille maximum des paquets.
-    - **Max_user_connections** : Nombre de connexions simultanées autorisées par utilisateur.
-    - **AutoCommit** : Définit si les requêtes sont automatiquement validées (committed) ou non.
-    - **Interactive_timeout** : Temps en secondes pendant lequel le serveur attend l’activité sur une connexion interactive avant de la fermer.
-    - **InnodbBufferPoolSize** : Choix de la taille de la mémoire tampon.
-    - **MaxConnections :** Nombre de connexions simultanées autorisées sur le serveur de bases de données.
-    - **Wait_timeout** : Temps en secondes pendant lequel le serveur attend l’activité sur une connexion non interactive avant de la fermer.
-    - **Event_scheduler** : Permet de déclencher l’exécution de requêtes programmées directement dans le serveur MySQL.
-    - **sql_mode** : L’option **sql_mode** affecte la syntaxe SQL prise en charge et les vérifications de validation des données effectuées par MySQL/MariaDB.
+    Le tableau ci-dessous détaille chaque paramètre modifiable ainsi que les valeurs que vous pouvez lui attribuer.
+
+    |Paramètre|Description|Valeurs configurables|
+    |---|---|---|
+    |`max_allowed_packet`|Taille maximum des paquets.|De 1 à 64 Mo|
+    |`max_user_connections`|Nombre de connexions simultanées autorisées par utilisateur.|De 50 à 200|
+    |`autocommit`|Définit si les requêtes sont automatiquement validées (committed) ou non.|ON ou OFF|
+    |`interactive_timeout`|Temps en secondes pendant lequel le serveur attend l’activité sur une connexion interactive avant de la fermer.|De 60 à 28800 secondes|
+    |`innodb_buffer_pool_size`|Choix de la taille de la mémoire tampon, exprimée en mégaoctets.|De 128 Mo à 50% de la RAM totale de votre instance|
+    |`max_connections`|Nombre de connexions simultanées autorisées sur le serveur de bases de données.|De 100 à 200|
+    |`wait_timeout`|Temps en secondes pendant lequel le serveur attend l’activité sur une connexion non interactive avant de la fermer.|De 60 à 28800 secondes|
+    |`event_scheduler`|Permet de déclencher l’exécution de requêtes programmées directement dans le serveur MySQL.|ON ou OFF|
+    |`sql_mode`|Affecte la syntaxe SQL prise en charge et les vérifications de validation des données effectuées par MySQL/MariaDB.|Voir les modes par défaut ci-dessous|
 
     :::info
-    Lorsque vous rencontrez une erreur sur votre site indiquant **« Too many connections »**, cela est dû au dépassement du nombre de connexions simultanées sur votre serveur de bases de données. Vous pouvez alors augmenter la variable **« MaxConnections »** si elle n’est pas à son maximum.
+    Lorsque vous rencontrez une erreur sur votre site indiquant `Too many connections`, cela est dû au dépassement du nombre de connexions simultanées sur votre serveur de bases de données. Vous pouvez alors augmenter la variable `max_connections` si elle n’est pas à son maximum.
 
     :::
 

--- a/docs/it/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/it/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configura il tuo database server
 description: Come configurare e ottimizzare il tuo database server
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-17
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -183,18 +183,22 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png" loading="lazy" />
 
-    - **MaxAllowedPacket**: Dimensione massima dei pacchetti.
-    - **Max_user_connections**: Numero di connessioni simultanee autorizzate per utente.
-    - **AutoCommit**: Definisce se le richieste sono automaticamente confermate (committed) o meno.
-    - **Interactive_timeout**: Tempo (in secondi) durante il quale il server attende l'attività su una connessione interattiva prima di chiuderla.
-    - **InnodbBufferPoolSize**: Dimensione della memoria buffer selezionata.
-    - **MaxConnections**: Numero di connessioni simultanee autorizzate sul database server.
-    - **Wait_timeout**: Tempo (in secondi) durante il quale il server attende l'attività su una connessione non interattiva prima di chiuderla.
-    - **Event_scheduler**: Consente di avviare l'esecuzione di richieste programmate direttamente sul server MySQL.
-    - **sql_mode**: L'opzione **sql_mode** influisce sulla sintassi SQL supportata e sulle verifiche di convalida dei dati eseguite da MySQL/MariaDB.
+    La tabella seguente descrive ogni parametro modificabile e i valori che puoi attribuirgli.
+
+    |Parametro|Descrizione|Valori configurabili|
+    |---|---|---|
+    |`max_allowed_packet`|Dimensione massima dei pacchetti.|Da 1 a 64 MB|
+    |`max_user_connections`|Numero di connessioni simultanee autorizzate per utente.|Da 50 a 200|
+    |`autocommit`|Definisce se le richieste sono automaticamente confermate (committed) o meno.|ON o OFF|
+    |`interactive_timeout`|Tempo (in secondi) durante il quale il server attende l'attività su una connessione interattiva prima di chiuderla.|Da 60 a 28800 secondi|
+    |`innodb_buffer_pool_size`|Dimensione della memoria buffer, espressa in megabyte.|Da 128 MB al 50% della RAM totale della tua istanza|
+    |`max_connections`|Numero di connessioni simultanee autorizzate sul database server.|Da 100 a 200|
+    |`wait_timeout`|Tempo (in secondi) durante il quale il server attende l'attività su una connessione non interattiva prima di chiuderla.|Da 60 a 28800 secondi|
+    |`event_scheduler`|Consente di avviare l'esecuzione di richieste programmate direttamente sul server MySQL.|ON o OFF|
+    |`sql_mode`|Influisce sulla sintassi SQL supportata e sulle verifiche di convalida dei dati eseguite da MySQL/MariaDB.|Consulta le modalità predefinite qui sotto|
 
     :::info
-    Quando si verifica un errore sul tuo sito indicando **"Too many connections"**, è dovuto al superamento del numero di connessioni simultanee sul database server. In questo caso, puoi aumentare la variabile **"MaxConnections"** se non è al massimo.
+    Quando si verifica un errore sul tuo sito indicando `Too many connections`, è dovuto al superamento del numero di connessioni simultanee sul database server. In questo caso, puoi aumentare la variabile `max_connections` se non è al massimo.
 
     :::
 

--- a/docs/pl/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja serwera baz danych
 description: Dowiedz się, jak skonfigurować i zoptymalizować serwer bazy danych
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-17
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -183,18 +183,22 @@ Kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png" loading="lazy" />
 
-    - **MaxAllowedPacket**: Maksymalny rozmiar pakietu.
-    - **Max_user_connections**: Liczba jednoczesnych połączeń autoryzowanych na użytkownika.
-    - **AutoCommit**: Określa, czy zapytania są automatycznie zatwierdzane (committed), czy nie.
-    - **Interactive_timeout**: Czas (w sekundach), przez który serwer czeka na działanie w połączeniu interaktywnym przed jego zamknięciem.
-    - **InnodbBufferPoolSize**: Wybrany rozmiar pamięci buforowej.
-    - **MaxConnections:** Liczba jednoczesnych połączeń autoryzowanych na serwerze baz danych.
-    - **Wait_timeout**: Czas (w sekundach), przez który serwer czeka na działanie w połączeniu nieinteraktywnym przed jego zamknięciem.
-    - **Event_scheduler**: Uruchamia wykonywanie zapytań zaprogramowanych bezpośrednio na serwerze MySQL.
-    - **sql_mode**: Opcja **sql_mode** wpływa na obsługiwaną składnię SQL oraz sprawdzanie poprawności danych przez MySQL/MariaDB.
+    Poniższa tabela przedstawia każdy parametr, który możesz zmienić, oraz wartości, jakie możesz mu przypisać.
+
+    |Parametr|Opis|Wartości konfigurowalne|
+    |---|---|---|
+    |`max_allowed_packet`|Maksymalny rozmiar pakietu.|Od 1 do 64 MB|
+    |`max_user_connections`|Liczba jednoczesnych połączeń autoryzowanych na użytkownika.|Od 50 do 200|
+    |`autocommit`|Określa, czy zapytania są automatycznie zatwierdzane (committed), czy nie.|ON lub OFF|
+    |`interactive_timeout`|Czas (w sekundach), przez który serwer czeka na działanie w połączeniu interaktywnym przed jego zamknięciem.|Od 60 do 28800 sekund|
+    |`innodb_buffer_pool_size`|Rozmiar pamięci buforowej wyrażony w megabajtach.|Od 128 MB do 50% całkowitej pamięci RAM Twojej instancji|
+    |`max_connections`|Liczba jednoczesnych połączeń autoryzowanych na serwerze baz danych.|Od 100 do 200|
+    |`wait_timeout`|Czas (w sekundach), przez który serwer czeka na działanie w połączeniu nieinteraktywnym przed jego zamknięciem.|Od 60 do 28800 sekund|
+    |`event_scheduler`|Uruchamia wykonywanie zapytań zaprogramowanych bezpośrednio na serwerze MySQL.|ON lub OFF|
+    |`sql_mode`|Wpływa na obsługiwaną składnię SQL oraz sprawdzanie poprawności danych przez MySQL/MariaDB.|Patrz tryby domyślne poniżej|
 
     :::info
-    Jeśli na Twojej stronie pojawi się błąd wskazujący **"Too many connections"**, jest to spowodowane przekroczeniem liczby jednoczesnych połączeń do serwera baz danych. Możesz wówczas zwiększyć zmienną **"MaxConnections"**, jeśli nie osiągnęła jeszcze wartości maksymalnej.
+    Jeśli na Twojej stronie pojawi się błąd wskazujący `Too many connections`, jest to spowodowane przekroczeniem liczby jednoczesnych połączeń do serwera baz danych. Możesz wówczas zwiększyć zmienną `max_connections`, jeśli nie osiągnęła jeszcze wartości maksymalnej.
 
     :::
 

--- a/docs/pt/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-configure-optimise-database-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar o servidor de bases de dados
 description: Descubra como configurar e otimizar o servidor de bases de dados
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-17
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -183,18 +183,22 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
 
     <img className="thumbnail" alt="Web Cloud Databases" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png" loading="lazy" />
 
-    - **MaxAllowedPacket**: Tamanho máximo dos pacotes.
-    - **Max_user_connections**: Número de ligações simultâneas autorizadas por utilizador.
-    - **AutoCommit**: Define se os pedidos são automaticamente validados (committed) ou não.
-    - **Interactive_timeout**: Tempo (em segundos) durante o qual o servidor aguarda atividade numa ligação interativa antes de a fechar.
-    - **InnodbBufferPoolSize**: Escolha da dimensão da memória tampão.
-    - **MaxConnections:** Número de ligações simultâneas autorizadas no servidor de bases de dados.
-    - **Wait_timeout**: Tempo (em segundos) durante o qual o servidor aguarda atividade numa ligação não interativa antes de a fechar.
-    - **Event_scheduler**: Permite acionar a execução de pedidos programados diretamente no servidor MySQL.
-    - **sql_mode**: A opção **sql_mode** afeta a sintaxe SQL suportada e as verificações de validação de dados efetuadas por MySQL/MariaDB.
+    A tabela abaixo detalha cada parâmetro modificável, assim como os valores que lhe pode atribuir.
+
+    |Parâmetro|Descrição|Valores configuráveis|
+    |---|---|---|
+    |`max_allowed_packet`|Tamanho máximo dos pacotes.|De 1 a 64 MB|
+    |`max_user_connections`|Número de ligações simultâneas autorizadas por utilizador.|De 50 a 200|
+    |`autocommit`|Define se os pedidos são automaticamente validados (committed) ou não.|ON ou OFF|
+    |`interactive_timeout`|Tempo (em segundos) durante o qual o servidor aguarda atividade numa ligação interativa antes de a fechar.|De 60 a 28800 segundos|
+    |`innodb_buffer_pool_size`|Dimensão da memória tampão, expressa em megabytes.|De 128 MB a 50% da RAM total da sua instância|
+    |`max_connections`|Número de ligações simultâneas autorizadas no servidor de bases de dados.|De 100 a 200|
+    |`wait_timeout`|Tempo (em segundos) durante o qual o servidor aguarda atividade numa ligação não interativa antes de a fechar.|De 60 a 28800 segundos|
+    |`event_scheduler`|Permite acionar a execução de pedidos programados diretamente no servidor MySQL.|ON ou OFF|
+    |`sql_mode`|Afeta a sintaxe SQL suportada e as verificações de validação de dados efetuadas por MySQL/MariaDB.|Consulte os modos predefinidos abaixo|
 
     :::info
-    Quando encontra um erro no seu site a indicar **"Too many connections"**, isso deve-se à ultrapassagem do número de ligações simultâneas no servidor de bases de dados. Pode então aumentar a variável **"MaxConnections"** se esta não estiver no máximo.
+    Quando encontra um erro no seu site a indicar `Too many connections`, isso deve-se à ultrapassagem do número de ligações simultâneas no servidor de bases de dados. Pode então aumentar a variável `max_connections` se esta não estiver no máximo.
 
     :::
 


### PR DESCRIPTION
## Context

SK2637 — The MySQL/MariaDB configuration section of the "Configure your database server"
guide listed the nine editable parameters without their allowed values, so readers could
not tell what they were free to set before opening the Manager. The parameter names were
also written in CamelCase (`MaxAllowedPacket`, `MaxConnections`…), which never matched the
Manager, where the fields are labelled with the raw API keys in snake_case — as the
screenshot in the guide itself shows.

## What changed

- The bullet list is now a table with three columns: **Parameter / Description /
  Configurable values**, which keeps nine entries readable and aligns the ranges in a
  single column.
- The nine parameters are renamed to their real Manager keys: `max_allowed_packet`,
  `max_user_connections`, `autocommit`, `interactive_timeout`, `innodb_buffer_pool_size`,
  `max_connections`, `wait_timeout`, `event_scheduler`, `sql_mode`.
- Minimum and maximum values are documented for each parameter. `autocommit` and
  `event_scheduler` are toggles (ON/OFF), not ranges. `innodb_buffer_pool_size` has a
  relative upper bound — 50% of the instance's total RAM — not a fixed one.
- `sql_mode` moves to the last row and points to the existing callout listing the default
  modes per engine version (MariaDB 10.1 / 10.2+, MySQL 5.6 / 5.7+), instead of duplicating
  that information in the table.
- The "Too many connections" callout referred to a `MaxConnections` variable that no longer
  matched any row; it now refers to `max_connections`.
- Parameter names and command output use backticks instead of bold and quotes, per the
  repository convention for technical identifiers.
- Applied to all 7 locales (fr, en, de, es, it, pl, pt). `lastUpdated` bumped to 2026-08-17
  everywhere.

## Sources

Values were provided by the product side. The parameter keys and the rendering logic
(dropdown vs toggle, 50%-of-RAM cap on the buffer pool) were cross-checked against the
Manager codebase — `private-database-configuration.controller.js` and the
`privateDatabase_configuration_field_*` translation keys — and against the guide's own
screenshot. Note that the ranges are not in the API schema: the endpoint
`GET /hosting/privateDatabase/{serviceName}/config` returns `availableValues` computed
per instance, so they cannot be verified from a static snapshot.

## Known gaps (not addressed here)

- The screenshot shows a fifth dropdown, `tmpdir`, which the table does not document,
  while the introduction claims it covers every editable parameter.
- The screenshot predates `sql_mode` and does not show it.
- The screenshot is in English in all 7 locales.
